### PR TITLE
Add DeleteConsumerGroupOffsetsAsync admin API

### DIFF
--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -59,6 +59,16 @@ public interface IAdminClient : IAsyncDisposable
     ValueTask AlterConsumerGroupOffsetsAsync(string groupId, IEnumerable<TopicPartitionOffset> offsets, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Deletes committed offsets for specific partitions in a consumer group.
+    /// The group must not be actively consuming from the specified partitions.
+    /// </summary>
+    ValueTask DeleteConsumerGroupOffsetsAsync(
+        string groupId,
+        IEnumerable<TopicPartition> partitions,
+        DeleteConsumerGroupOffsetsOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Deletes records up to the specified offset.
     /// </summary>
     ValueTask<IReadOnlyDictionary<TopicPartition, long>> DeleteRecordsAsync(IReadOnlyDictionary<TopicPartition, long> offsets, CancellationToken cancellationToken = default);
@@ -118,6 +128,14 @@ public sealed class ListTopicsOptions
 public sealed class ListConsumerGroupsOptions
 {
     public IReadOnlyList<string>? States { get; init; }
+    public int TimeoutMs { get; init; } = 30000;
+}
+
+/// <summary>
+/// Options for DeleteConsumerGroupOffsets.
+/// </summary>
+public sealed class DeleteConsumerGroupOffsetsOptions
+{
     public int TimeoutMs { get; init; } = 30000;
 }
 

--- a/src/Dekaf/Protocol/Messages/OffsetDeleteRequest.cs
+++ b/src/Dekaf/Protocol/Messages/OffsetDeleteRequest.cs
@@ -1,0 +1,74 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// OffsetDelete request (API key 47).
+/// Deletes committed offsets for specific partitions in a consumer group.
+/// </summary>
+public sealed class OffsetDeleteRequest : IKafkaRequest<OffsetDeleteResponse>
+{
+    public static ApiKey ApiKey => ApiKey.OffsetDelete;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// The unique group identifier.
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// The topics to delete offsets for.
+    /// </summary>
+    public required IReadOnlyList<OffsetDeleteRequestTopic> Topics { get; init; }
+
+    public static bool IsFlexibleVersion(short version) => false;
+    public static short GetRequestHeaderVersion(short version) => 1;
+    public static short GetResponseHeaderVersion(short version) => 0;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteString(GroupId);
+        writer.WriteArray(
+            Topics,
+            (ref KafkaProtocolWriter w, OffsetDeleteRequestTopic t) => t.Write(ref w, version));
+    }
+}
+
+/// <summary>
+/// Topic in an OffsetDelete request.
+/// </summary>
+public sealed class OffsetDeleteRequestTopic
+{
+    /// <summary>
+    /// The topic name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The partitions to delete offsets for.
+    /// </summary>
+    public required IReadOnlyList<OffsetDeleteRequestPartition> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteString(Name);
+        writer.WriteArray(
+            Partitions,
+            (ref KafkaProtocolWriter w, OffsetDeleteRequestPartition p) => p.Write(ref w, version));
+    }
+}
+
+/// <summary>
+/// Partition in an OffsetDelete request.
+/// </summary>
+public sealed class OffsetDeleteRequestPartition
+{
+    /// <summary>
+    /// The partition index.
+    /// </summary>
+    public required int PartitionIndex { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteInt32(PartitionIndex);
+    }
+}

--- a/src/Dekaf/Protocol/Messages/OffsetDeleteResponse.cs
+++ b/src/Dekaf/Protocol/Messages/OffsetDeleteResponse.cs
@@ -1,0 +1,102 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// OffsetDelete response (API key 47).
+/// Contains the results of offset deletion requests.
+/// </summary>
+public sealed class OffsetDeleteResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.OffsetDelete;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// The top-level error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation
+    /// (zero if not throttled).
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// Results for each topic.
+    /// </summary>
+    public required IReadOnlyList<OffsetDeleteResponseTopic> Topics { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var throttleTimeMs = reader.ReadInt32();
+
+        var topics = reader.ReadArray(
+            (ref KafkaProtocolReader r) => OffsetDeleteResponseTopic.Read(ref r, version)) ?? [];
+
+        return new OffsetDeleteResponse
+        {
+            ErrorCode = errorCode,
+            ThrottleTimeMs = throttleTimeMs,
+            Topics = topics
+        };
+    }
+}
+
+/// <summary>
+/// Per-topic response for OffsetDelete.
+/// </summary>
+public sealed class OffsetDeleteResponseTopic
+{
+    /// <summary>
+    /// The topic name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The responses for each partition in the topic.
+    /// </summary>
+    public required IReadOnlyList<OffsetDeleteResponsePartition> Partitions { get; init; }
+
+    public static OffsetDeleteResponseTopic Read(ref KafkaProtocolReader reader, short version)
+    {
+        var name = reader.ReadString() ?? string.Empty;
+
+        var partitions = reader.ReadArray(
+            (ref KafkaProtocolReader r) => OffsetDeleteResponsePartition.Read(ref r, version)) ?? [];
+
+        return new OffsetDeleteResponseTopic
+        {
+            Name = name,
+            Partitions = partitions
+        };
+    }
+}
+
+/// <summary>
+/// Per-partition response for OffsetDelete.
+/// </summary>
+public sealed class OffsetDeleteResponsePartition
+{
+    /// <summary>
+    /// The partition index.
+    /// </summary>
+    public required int PartitionIndex { get; init; }
+
+    /// <summary>
+    /// The error code, or 0 if there was no error.
+    /// </summary>
+    public required ErrorCode ErrorCode { get; init; }
+
+    public static OffsetDeleteResponsePartition Read(ref KafkaProtocolReader reader, short version)
+    {
+        var partitionIndex = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        return new OffsetDeleteResponsePartition
+        {
+            PartitionIndex = partitionIndex,
+            ErrorCode = errorCode
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Implements DeleteConsumerGroupOffsetsAsync on IAdminClient
- Uses OffsetDelete API (API Key 47)
- Adds DeleteConsumerGroupOffsetsOptions configuration class
- Includes OffsetDeleteRequest and OffsetDeleteResponse protocol messages

## Test plan
- [x] Unit tests for OffsetDelete request encoding
- [x] Unit tests for OffsetDelete response decoding
- [x] Verify build succeeds
- [x] All unit tests pass (203 tests)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)