### PR TITLE
Add Close() method for graceful consumer shutdown

### DIFF
--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -115,6 +115,15 @@ public interface IKafkaConsumer<TKey, TValue> : IAsyncDisposable
     /// Wakes up the consumer if it's blocked on a fetch.
     /// </summary>
     void Wakeup();
+
+    /// <summary>
+    /// Gracefully closes the consumer: commits pending offsets,
+    /// leaves the consumer group, and releases resources.
+    /// This method is idempotent and safe to call multiple times.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous close operation.</returns>
+    ValueTask CloseAsync(CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/Dekaf/Protocol/Messages/LeaveGroupRequest.cs
+++ b/src/Dekaf/Protocol/Messages/LeaveGroupRequest.cs
@@ -1,0 +1,120 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// LeaveGroup request (API key 13).
+/// Sent by a consumer to leave a consumer group.
+/// </summary>
+public sealed class LeaveGroupRequest : IKafkaRequest<LeaveGroupResponse>
+{
+    public static ApiKey ApiKey => ApiKey.LeaveGroup;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 5;
+
+    /// <summary>
+    /// The group ID.
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// Member ID (v0-v2).
+    /// </summary>
+    public string? MemberId { get; init; }
+
+    /// <summary>
+    /// List of members leaving the group (v3+).
+    /// </summary>
+    public IReadOnlyList<LeaveGroupRequestMember>? Members { get; init; }
+
+    public static bool IsFlexibleVersion(short version) => version >= 4;
+    public static short GetRequestHeaderVersion(short version) => version >= 4 ? (short)2 : (short)1;
+    public static short GetResponseHeaderVersion(short version) => version >= 4 ? (short)1 : (short)0;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 4;
+
+        if (isFlexible)
+            writer.WriteCompactString(GroupId);
+        else
+            writer.WriteString(GroupId);
+
+        if (version <= 2)
+        {
+            // v0-v2: single member ID
+            if (isFlexible)
+                writer.WriteCompactString(MemberId ?? string.Empty);
+            else
+                writer.WriteString(MemberId ?? string.Empty);
+        }
+        else
+        {
+            // v3+: members array
+            if (isFlexible)
+            {
+                writer.WriteCompactArray(
+                    Members ?? [],
+                    (ref KafkaProtocolWriter w, LeaveGroupRequestMember m) => m.Write(ref w, version));
+            }
+            else
+            {
+                writer.WriteArray(
+                    Members ?? [],
+                    (ref KafkaProtocolWriter w, LeaveGroupRequestMember m) => m.Write(ref w, version));
+            }
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}
+
+/// <summary>
+/// A member leaving the group.
+/// </summary>
+public sealed class LeaveGroupRequestMember
+{
+    /// <summary>
+    /// The member ID.
+    /// </summary>
+    public required string MemberId { get; init; }
+
+    /// <summary>
+    /// Group instance ID for static membership.
+    /// </summary>
+    public string? GroupInstanceId { get; init; }
+
+    /// <summary>
+    /// The reason for leaving the group (v5+).
+    /// </summary>
+    public string? Reason { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 4;
+
+        if (isFlexible)
+            writer.WriteCompactString(MemberId);
+        else
+            writer.WriteString(MemberId);
+
+        if (isFlexible)
+            writer.WriteCompactNullableString(GroupInstanceId);
+        else
+            writer.WriteString(GroupInstanceId);
+
+        if (version >= 5)
+        {
+            if (isFlexible)
+                writer.WriteCompactNullableString(Reason);
+            else
+                writer.WriteString(Reason);
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}

--- a/src/Dekaf/Protocol/Messages/LeaveGroupResponse.cs
+++ b/src/Dekaf/Protocol/Messages/LeaveGroupResponse.cs
@@ -1,0 +1,102 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// LeaveGroup response (API key 13).
+/// </summary>
+public sealed class LeaveGroupResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.LeaveGroup;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 5;
+
+    /// <summary>
+    /// Throttle time in milliseconds (v1+).
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// Error code.
+    /// </summary>
+    public required ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// Member responses (v3+).
+    /// </summary>
+    public IReadOnlyList<LeaveGroupResponseMember>? Members { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 4;
+
+        var throttleTimeMs = version >= 1 ? reader.ReadInt32() : 0;
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        IReadOnlyList<LeaveGroupResponseMember>? members = null;
+
+        if (version >= 3)
+        {
+            if (isFlexible)
+            {
+                members = reader.ReadCompactArray((ref KafkaProtocolReader r) => LeaveGroupResponseMember.Read(ref r, version));
+            }
+            else
+            {
+                members = reader.ReadArray((ref KafkaProtocolReader r) => LeaveGroupResponseMember.Read(ref r, version));
+            }
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new LeaveGroupResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            Members = members
+        };
+    }
+}
+
+/// <summary>
+/// Response for a member that attempted to leave the group.
+/// </summary>
+public sealed class LeaveGroupResponseMember
+{
+    /// <summary>
+    /// The member ID.
+    /// </summary>
+    public required string MemberId { get; init; }
+
+    /// <summary>
+    /// Group instance ID for static membership.
+    /// </summary>
+    public string? GroupInstanceId { get; init; }
+
+    /// <summary>
+    /// Error code for this member.
+    /// </summary>
+    public required ErrorCode ErrorCode { get; init; }
+
+    public static LeaveGroupResponseMember Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 4;
+
+        var memberId = isFlexible ? reader.ReadCompactString()! : reader.ReadString()!;
+        var groupInstanceId = isFlexible ? reader.ReadCompactString() : reader.ReadString();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new LeaveGroupResponseMember
+        {
+            MemberId = memberId,
+            GroupInstanceId = groupInstanceId,
+            ErrorCode = errorCode
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCloseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCloseTests.cs
@@ -1,0 +1,361 @@
+using System.Buffers;
+using Dekaf.Consumer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+/// <summary>
+/// Tests for consumer CloseAsync functionality.
+/// </summary>
+public class ConsumerCloseTests
+{
+    #region LeaveGroup Request Encoding Tests
+
+    [Test]
+    public async Task LeaveGroupRequest_V0_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new LeaveGroupRequest
+        {
+            GroupId = "test-group",
+            MemberId = "member-1"
+        };
+        request.Write(ref writer, version: 0);
+
+        var expected = new List<byte>();
+        // GroupId (STRING with INT16 length prefix)
+        expected.AddRange(new byte[] { 0x00, 0x0A }); // length = 10
+        expected.AddRange("test-group"u8.ToArray());
+        // MemberId (STRING with INT16 length prefix)
+        expected.AddRange(new byte[] { 0x00, 0x08 }); // length = 8
+        expected.AddRange("member-1"u8.ToArray());
+
+        await Assert.That(buffer.WrittenSpan.ToArray()).IsEquivalentTo(expected.ToArray());
+    }
+
+    [Test]
+    public async Task LeaveGroupRequest_V3_WithMembersArray()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new LeaveGroupRequest
+        {
+            GroupId = "test-group",
+            Members =
+            [
+                new LeaveGroupRequestMember
+                {
+                    MemberId = "member-1",
+                    GroupInstanceId = null
+                }
+            ]
+        };
+        request.Write(ref writer, version: 3);
+
+        // Verify it can be written without errors
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+
+        // Parse it back to verify structure (synchronous parsing)
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var groupId = reader.ReadString();
+        var arrayLen = reader.ReadInt32();
+
+        await Assert.That(groupId).IsEqualTo("test-group");
+        await Assert.That(arrayLen).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task LeaveGroupRequest_V4_Flexible_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new LeaveGroupRequest
+        {
+            GroupId = "mygroup",
+            Members =
+            [
+                new LeaveGroupRequestMember
+                {
+                    MemberId = "m1",
+                    GroupInstanceId = "instance-1"
+                }
+            ]
+        };
+        request.Write(ref writer, version: 4);
+
+        // Verify it can be written without errors (flexible encoding)
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+
+        // Parse it back - v4 uses compact strings (synchronous parsing)
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var groupId = reader.ReadCompactString();
+        var arrayLen = reader.ReadUnsignedVarInt() - 1;
+
+        await Assert.That(groupId).IsEqualTo("mygroup");
+        await Assert.That((int)arrayLen).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task LeaveGroupRequest_V5_WithReason()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new LeaveGroupRequest
+        {
+            GroupId = "group",
+            Members =
+            [
+                new LeaveGroupRequestMember
+                {
+                    MemberId = "member",
+                    GroupInstanceId = null,
+                    Reason = "Shutting down"
+                }
+            ]
+        };
+        request.Write(ref writer, version: 5);
+
+        // Verify it can be written without errors
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    #endregion
+
+    #region LeaveGroup Response Parsing Tests
+
+    [Test]
+    public async Task LeaveGroupResponse_V0_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (LeaveGroupResponse)LeaveGroupResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.Members).IsNull();
+    }
+
+    [Test]
+    public async Task LeaveGroupResponse_V1_WithThrottle()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x64 }); // 100ms
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (LeaveGroupResponse)LeaveGroupResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(100);
+    }
+
+    [Test]
+    public async Task LeaveGroupResponse_V3_WithMembers()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // Members array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // 1 member
+        // Member entry:
+        // MemberId (STRING)
+        data.AddRange(new byte[] { 0x00, 0x03 }); // length = 3
+        data.AddRange("m-1"u8.ToArray());
+        // GroupInstanceId (NULLABLE_STRING)
+        data.AddRange(new byte[] { 0xFF, 0xFF }); // null
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (LeaveGroupResponse)LeaveGroupResponse.Read(ref reader, version: 3);
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Members).IsNotNull();
+        await Assert.That(response.Members!.Count).IsEqualTo(1);
+        await Assert.That(response.Members[0].MemberId).IsEqualTo("m-1");
+        await Assert.That(response.Members[0].GroupInstanceId).IsNull();
+        await Assert.That(response.Members[0].ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
+    public async Task LeaveGroupResponse_V4_Flexible_WithMembers()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // Members COMPACT_ARRAY (varint length+1)
+        data.Add(0x02); // 1 member (length+1)
+        // Member entry:
+        // MemberId (COMPACT_STRING)
+        data.Add(0x04); // length+1 = 4
+        data.AddRange("m-1"u8.ToArray());
+        // GroupInstanceId (COMPACT_NULLABLE_STRING)
+        data.Add(0x00); // null
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // Member tagged fields
+        data.Add(0x00);
+        // Response tagged fields
+        data.Add(0x00);
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (LeaveGroupResponse)LeaveGroupResponse.Read(ref reader, version: 4);
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Members).IsNotNull();
+        await Assert.That(response.Members!.Count).IsEqualTo(1);
+        await Assert.That(response.Members[0].MemberId).IsEqualTo("m-1");
+    }
+
+    [Test]
+    public async Task LeaveGroupResponse_WithError_ParsedCorrectly()
+    {
+        var data = new List<byte>();
+        // ErrorCode (INT16) - UnknownMemberId = 25
+        data.AddRange(new byte[] { 0x00, 0x19 });
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (LeaveGroupResponse)LeaveGroupResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.UnknownMemberId);
+    }
+
+    #endregion
+
+    #region Version Flexibility Tests
+
+    [Test]
+    [Arguments((short)0, false)]
+    [Arguments((short)1, false)]
+    [Arguments((short)2, false)]
+    [Arguments((short)3, false)]
+    [Arguments((short)4, true)]
+    [Arguments((short)5, true)]
+    public async Task LeaveGroupRequest_FlexibilityDetection(short version, bool expectedFlexible)
+    {
+        var isFlexible = LeaveGroupRequest.IsFlexibleVersion(version);
+        await Assert.That(isFlexible).IsEqualTo(expectedFlexible);
+    }
+
+    [Test]
+    [Arguments((short)0, (short)1, (short)0)]
+    [Arguments((short)3, (short)1, (short)0)]
+    [Arguments((short)4, (short)2, (short)1)]
+    [Arguments((short)5, (short)2, (short)1)]
+    public async Task LeaveGroupRequest_HeaderVersions(short apiVersion, short expectedRequestHeader, short expectedResponseHeader)
+    {
+        var requestHeaderVersion = LeaveGroupRequest.GetRequestHeaderVersion(apiVersion);
+        var responseHeaderVersion = LeaveGroupRequest.GetResponseHeaderVersion(apiVersion);
+
+        await Assert.That(requestHeaderVersion).IsEqualTo(expectedRequestHeader);
+        await Assert.That(responseHeaderVersion).IsEqualTo(expectedResponseHeader);
+    }
+
+    #endregion
+
+    #region Consumer CloseAsync Idempotency Tests
+
+    [Test]
+    public async Task KafkaConsumer_CloseAsync_IsIdempotent()
+    {
+        // Create a minimal consumer for testing
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-consumer"
+            // Note: No GroupId, so no coordinator - tests basic close behavior
+        };
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        // First close should succeed
+        await consumer.CloseAsync();
+
+        // Second close should also succeed (idempotent)
+        await consumer.CloseAsync();
+
+        // If we got here without exceptions, the test passed
+        // Verify consumer state reflects closed status
+        var subscription = consumer.Subscription;
+        await Assert.That(subscription.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task KafkaConsumer_CloseAsync_HandlesCancellation()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-consumer"
+        };
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        // Close with already-cancelled token should still work
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Should complete without throwing (graceful handling of cancellation)
+        try
+        {
+            await consumer.CloseAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // This is acceptable - cancellation was respected
+        }
+
+        // Either graceful completion or caught cancellation is valid
+        var subscription = consumer.Subscription;
+        await Assert.That(subscription.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task KafkaConsumer_DisposeAsync_CallsCloseInternally()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-consumer"
+        };
+
+        var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        // Dispose should work without prior close
+        await consumer.DisposeAsync();
+
+        // Consumer should be disposed - calling close should do nothing (already closed)
+        await consumer.CloseAsync();
+
+        // If we got here without exceptions, the test passed
+        var subscription = consumer.Subscription;
+        await Assert.That(subscription.Count).IsEqualTo(0);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Implements `CloseAsync` method on `IKafkaConsumer` for graceful shutdown
- Graceful shutdown sequence: stops heartbeat, commits offsets, sends LeaveGroup, releases resources
- Idempotent implementation (safe to call multiple times)
- Proper cancellation handling throughout
- Adds `LeaveGroupRequest`/`LeaveGroupResponse` protocol messages (v0-v5)
- `DisposeAsync` now calls `CloseAsync` internally with 5s timeout

## Test plan
- [x] Unit tests for LeaveGroup protocol message encoding/decoding
- [x] Unit tests for CloseAsync idempotency
- [x] Unit tests for cancellation handling
- [x] Verify build succeeds
- [x] All 217 unit tests pass

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)