### PR TITLE
Implement LZ4 compression codec

### DIFF
--- a/Dekaf.sln
+++ b/Dekaf.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.SchemaRegistry.Protobuf", "src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj", "{231964F6-569F-4E34-86DF-BDAA21D27468}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Compression.Lz4", "src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj", "{D4294249-1660-4F97-9E8F-ABB90469EB11}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -161,6 +163,18 @@ Global
 		{231964F6-569F-4E34-86DF-BDAA21D27468}.Release|x64.Build.0 = Release|Any CPU
 		{231964F6-569F-4E34-86DF-BDAA21D27468}.Release|x86.ActiveCfg = Release|Any CPU
 		{231964F6-569F-4E34-86DF-BDAA21D27468}.Release|x86.Build.0 = Release|Any CPU
+		{D4294249-1660-4F97-9E8F-ABB90469EB11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4294249-1660-4F97-9E8F-ABB90469EB11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4294249-1660-4F97-9E8F-ABB90469EB11}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D4294249-1660-4F97-9E8F-ABB90469EB11}.Debug|x64.Build.0 = Debug|Any CPU
+		{D4294249-1660-4F97-9E8F-ABB90469EB11}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D4294249-1660-4F97-9E8F-ABB90469EB11}.Debug|x86.Build.0 = Debug|Any CPU
+		{D4294249-1660-4F97-9E8F-ABB90469EB11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4294249-1660-4F97-9E8F-ABB90469EB11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4294249-1660-4F97-9E8F-ABB90469EB11}.Release|x64.ActiveCfg = Release|Any CPU
+		{D4294249-1660-4F97-9E8F-ABB90469EB11}.Release|x64.Build.0 = Release|Any CPU
+		{D4294249-1660-4F97-9E8F-ABB90469EB11}.Release|x86.ActiveCfg = Release|Any CPU
+		{D4294249-1660-4F97-9E8F-ABB90469EB11}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -176,5 +190,6 @@ Global
 		{2B23AEC5-2064-46ED-B044-05BFA3CB140E} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 		{E7330FE7-5836-4CB2-AE26-BC08EC560B68} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{231964F6-569F-4E34-86DF-BDAA21D27468} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{D4294249-1660-4F97-9E8F-ABB90469EB11} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 EndGlobal

--- a/src/Dekaf.Compression.Lz4/Dekaf.Compression.Lz4.csproj
+++ b/src/Dekaf.Compression.Lz4/Dekaf.Compression.Lz4.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dekaf.Compression.Lz4</PackageId>
+    <Description>LZ4 compression codec for Dekaf Kafka client</Description>
+    <PackageTags>kafka;compression;lz4</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
+    <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.3.*" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dekaf.Compression.Lz4/Lz4CompressionCodec.cs
+++ b/src/Dekaf.Compression.Lz4/Lz4CompressionCodec.cs
@@ -1,0 +1,178 @@
+using System.Buffers;
+using Dekaf.Compression;
+using Dekaf.Protocol.Records;
+using K4os.Compression.LZ4;
+using K4os.Compression.LZ4.Streams;
+
+namespace Dekaf.Compression.Lz4;
+
+/// <summary>
+/// LZ4 compression codec using LZ4 frame format (LZ4F).
+/// Kafka requires LZ4 frame format (magic: 0x04 0x22 0x4D 0x18), not raw block format.
+/// </summary>
+public sealed class Lz4CompressionCodec : ICompressionCodec
+{
+    private readonly LZ4Level _compressionLevel;
+
+    /// <summary>
+    /// Creates a new LZ4 compression codec with the specified compression level.
+    /// </summary>
+    /// <param name="compressionLevel">The compression level to use. Default is LZ4Level.L00_FAST.</param>
+    public Lz4CompressionCodec(LZ4Level compressionLevel = LZ4Level.L00_FAST)
+    {
+        _compressionLevel = compressionLevel;
+    }
+
+    /// <inheritdoc />
+    public CompressionType Type => CompressionType.Lz4;
+
+    /// <inheritdoc />
+    public void Compress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+    {
+        // Use LZ4 frame format as required by Kafka
+        using var outputStream = new BufferWriterStream(destination);
+        using var lz4Stream = LZ4Stream.Encode(outputStream, _compressionLevel, leaveOpen: true);
+
+        foreach (var segment in source)
+        {
+            lz4Stream.Write(segment.Span);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Decompress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+    {
+        using var inputStream = new ReadOnlySequenceStream(source);
+        using var lz4Stream = LZ4Stream.Decode(inputStream, leaveOpen: true);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(8192);
+        try
+        {
+            int bytesRead;
+            while ((bytesRead = lz4Stream.Read(buffer)) > 0)
+            {
+                var span = destination.GetSpan(bytesRead);
+                buffer.AsSpan(0, bytesRead).CopyTo(span);
+                destination.Advance(bytesRead);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}
+
+/// <summary>
+/// Extension methods for registering LZ4 compression.
+/// </summary>
+public static class Lz4CompressionExtensions
+{
+    /// <summary>
+    /// Registers the LZ4 compression codec with the specified compression level.
+    /// </summary>
+    /// <param name="registry">The compression codec registry.</param>
+    /// <param name="compressionLevel">The compression level to use. Default is LZ4Level.L00_FAST.</param>
+    /// <returns>The registry for fluent chaining.</returns>
+    public static CompressionCodecRegistry AddLz4(this CompressionCodecRegistry registry, LZ4Level compressionLevel = LZ4Level.L00_FAST)
+    {
+        registry.Register(new Lz4CompressionCodec(compressionLevel));
+        return registry;
+    }
+}
+
+/// <summary>
+/// Stream wrapper for IBufferWriter.
+/// </summary>
+internal sealed class BufferWriterStream : Stream
+{
+    private readonly IBufferWriter<byte> _writer;
+
+    public BufferWriterStream(IBufferWriter<byte> writer)
+    {
+        _writer = writer;
+    }
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Length => throw new NotSupportedException();
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush() { }
+
+    public override int Read(byte[] buffer, int offset, int count)
+        => throw new NotSupportedException();
+
+    public override long Seek(long offset, SeekOrigin origin)
+        => throw new NotSupportedException();
+
+    public override void SetLength(long value)
+        => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        var span = _writer.GetSpan(count);
+        buffer.AsSpan(offset, count).CopyTo(span);
+        _writer.Advance(count);
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        var span = _writer.GetSpan(buffer.Length);
+        buffer.CopyTo(span);
+        _writer.Advance(buffer.Length);
+    }
+}
+
+/// <summary>
+/// Stream wrapper for ReadOnlySequence.
+/// </summary>
+internal sealed class ReadOnlySequenceStream : Stream
+{
+    private ReadOnlySequence<byte> _sequence;
+    private SequencePosition _position;
+
+    public ReadOnlySequenceStream(ReadOnlySequence<byte> sequence)
+    {
+        _sequence = sequence;
+        _position = sequence.Start;
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => _sequence.Length;
+    public override long Position
+    {
+        get => _sequence.Slice(_sequence.Start, _position).Length;
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush() { }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var remaining = _sequence.Slice(_position);
+        if (remaining.IsEmpty)
+            return 0;
+
+        var toRead = (int)Math.Min(count, remaining.Length);
+        remaining.Slice(0, toRead).CopyTo(buffer.AsSpan(offset));
+        _position = _sequence.GetPosition(toRead, _position);
+        return toRead;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+        => throw new NotSupportedException();
+
+    public override void SetLength(long value)
+        => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count)
+        => throw new NotSupportedException();
+}

--- a/tests/Dekaf.Tests.Unit/Compression/Lz4CompressionCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Compression/Lz4CompressionCodecTests.cs
@@ -1,0 +1,222 @@
+using System.Buffers;
+using System.Text;
+using Dekaf.Compression;
+using Dekaf.Compression.Lz4;
+using Dekaf.Protocol.Records;
+using K4os.Compression.LZ4;
+
+namespace Dekaf.Tests.Unit.Compression;
+
+/// <summary>
+/// Tests for LZ4 compression codec.
+/// </summary>
+public class Lz4CompressionCodecTests
+{
+    #region Basic Functionality Tests
+
+    [Test]
+    public async Task Lz4CompressionCodec_Type_ReturnsLz4()
+    {
+        var codec = new Lz4CompressionCodec();
+
+        await Assert.That(codec.Type).IsEqualTo(CompressionType.Lz4);
+    }
+
+    [Test]
+    public async Task Lz4CompressionCodec_RoundTrip_PreservesData()
+    {
+        var codec = new Lz4CompressionCodec();
+        var originalData = "Hello, Kafka! This is a test message for LZ4 compression."u8.ToArray();
+
+        var compressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Compress(new ReadOnlySequence<byte>(originalData), compressedBuffer);
+
+        var decompressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Decompress(new ReadOnlySequence<byte>(compressedBuffer.WrittenMemory), decompressedBuffer);
+
+        await Assert.That(decompressedBuffer.WrittenSpan.ToArray()).IsEquivalentTo(originalData);
+    }
+
+    [Test]
+    public async Task Lz4CompressionCodec_RoundTrip_EmptyData()
+    {
+        var codec = new Lz4CompressionCodec();
+        var originalData = Array.Empty<byte>();
+
+        var compressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Compress(new ReadOnlySequence<byte>(originalData), compressedBuffer);
+
+        var decompressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Decompress(new ReadOnlySequence<byte>(compressedBuffer.WrittenMemory), decompressedBuffer);
+
+        await Assert.That(decompressedBuffer.WrittenSpan.ToArray()).IsEquivalentTo(originalData);
+    }
+
+    [Test]
+    public async Task Lz4CompressionCodec_RoundTrip_LargeData()
+    {
+        var codec = new Lz4CompressionCodec();
+        var originalData = new byte[100_000];
+        Random.Shared.NextBytes(originalData);
+
+        var compressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Compress(new ReadOnlySequence<byte>(originalData), compressedBuffer);
+
+        var decompressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Decompress(new ReadOnlySequence<byte>(compressedBuffer.WrittenMemory), decompressedBuffer);
+
+        await Assert.That(decompressedBuffer.WrittenSpan.ToArray()).IsEquivalentTo(originalData);
+    }
+
+    [Test]
+    public async Task Lz4CompressionCodec_Compress_ProducesFrameFormat()
+    {
+        var codec = new Lz4CompressionCodec();
+        var data = "Test data for LZ4 frame format verification"u8.ToArray();
+
+        var compressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Compress(new ReadOnlySequence<byte>(data), compressedBuffer);
+
+        // LZ4 frame magic bytes: 0x04 0x22 0x4D 0x18
+        var magic = compressedBuffer.WrittenSpan[..4].ToArray();
+        await Assert.That(magic[0]).IsEqualTo((byte)0x04);
+        await Assert.That(magic[1]).IsEqualTo((byte)0x22);
+        await Assert.That(magic[2]).IsEqualTo((byte)0x4D);
+        await Assert.That(magic[3]).IsEqualTo((byte)0x18);
+    }
+
+    #endregion
+
+    #region Compression Level Tests
+
+    [Test]
+    public async Task Lz4CompressionCodec_WithHighCompression_ProducesSmallerOutput()
+    {
+        var fastCodec = new Lz4CompressionCodec(LZ4Level.L00_FAST);
+        var highCodec = new Lz4CompressionCodec(LZ4Level.L12_MAX);
+
+        // Create compressible data (repeated patterns compress well)
+        var originalData = Encoding.UTF8.GetBytes(string.Concat(Enumerable.Repeat("Kafka message ", 1000)));
+
+        var fastBuffer = new ArrayBufferWriter<byte>();
+        fastCodec.Compress(new ReadOnlySequence<byte>(originalData), fastBuffer);
+
+        var highBuffer = new ArrayBufferWriter<byte>();
+        highCodec.Compress(new ReadOnlySequence<byte>(originalData), highBuffer);
+
+        // High compression should produce smaller or equal output
+        await Assert.That(highBuffer.WrittenCount).IsLessThanOrEqualTo(fastBuffer.WrittenCount);
+
+        // Verify both decompress correctly
+        var fastDecompressed = new ArrayBufferWriter<byte>();
+        fastCodec.Decompress(new ReadOnlySequence<byte>(fastBuffer.WrittenMemory), fastDecompressed);
+        await Assert.That(fastDecompressed.WrittenSpan.ToArray()).IsEquivalentTo(originalData);
+
+        var highDecompressed = new ArrayBufferWriter<byte>();
+        highCodec.Decompress(new ReadOnlySequence<byte>(highBuffer.WrittenMemory), highDecompressed);
+        await Assert.That(highDecompressed.WrittenSpan.ToArray()).IsEquivalentTo(originalData);
+    }
+
+    #endregion
+
+    #region Multi-Segment Tests
+
+    [Test]
+    public async Task Lz4CompressionCodec_RoundTrip_MultiSegmentSequence()
+    {
+        var codec = new Lz4CompressionCodec();
+
+        // Create a multi-segment sequence
+        var segment1 = new byte[] { 1, 2, 3, 4, 5 };
+        var segment2 = new byte[] { 6, 7, 8, 9, 10 };
+        var segment3 = new byte[] { 11, 12, 13, 14, 15 };
+
+        var firstSegment = new TestMemorySegment(segment1);
+        var secondSegment = firstSegment.Append(segment2);
+        var thirdSegment = secondSegment.Append(segment3);
+
+        var sequence = new ReadOnlySequence<byte>(firstSegment, 0, thirdSegment, segment3.Length);
+
+        var compressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Compress(sequence, compressedBuffer);
+
+        var decompressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Decompress(new ReadOnlySequence<byte>(compressedBuffer.WrittenMemory), decompressedBuffer);
+
+        var expectedData = segment1.Concat(segment2).Concat(segment3).ToArray();
+        await Assert.That(decompressedBuffer.WrittenSpan.ToArray()).IsEquivalentTo(expectedData);
+    }
+
+    #endregion
+
+    #region Extension Methods Tests
+
+    [Test]
+    public async Task AddLz4Extension_RegistersCodec()
+    {
+        var registry = new CompressionCodecRegistry();
+        registry.AddLz4();
+
+        await Assert.That(registry.IsSupported(CompressionType.Lz4)).IsTrue();
+
+        var codec = registry.GetCodec(CompressionType.Lz4);
+        await Assert.That(codec).IsTypeOf<Lz4CompressionCodec>();
+    }
+
+    [Test]
+    public async Task AddLz4Extension_ReturnsSameRegistry_ForFluentChaining()
+    {
+        var registry = new CompressionCodecRegistry();
+        var result = registry.AddLz4();
+
+        await Assert.That(result).IsSameReferenceAs(registry);
+    }
+
+    [Test]
+    public async Task AddLz4Extension_WithCompressionLevel_RegistersCodecWithLevel()
+    {
+        var registry = new CompressionCodecRegistry();
+        registry.AddLz4(LZ4Level.L09_HC);
+
+        await Assert.That(registry.IsSupported(CompressionType.Lz4)).IsTrue();
+
+        // Verify it works by compressing and decompressing
+        var codec = registry.GetCodec(CompressionType.Lz4);
+        var data = "test"u8.ToArray();
+
+        var compressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Compress(new ReadOnlySequence<byte>(data), compressedBuffer);
+
+        var decompressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Decompress(new ReadOnlySequence<byte>(compressedBuffer.WrittenMemory), decompressedBuffer);
+
+        await Assert.That(decompressedBuffer.WrittenSpan.ToArray()).IsEquivalentTo(data);
+    }
+
+    #endregion
+
+    #region Helper Classes
+
+    /// <summary>
+    /// Helper class for creating multi-segment ReadOnlySequence for testing.
+    /// </summary>
+    private sealed class TestMemorySegment : ReadOnlySequenceSegment<byte>
+    {
+        public TestMemorySegment(ReadOnlyMemory<byte> memory)
+        {
+            Memory = memory;
+        }
+
+        public TestMemorySegment Append(ReadOnlyMemory<byte> memory)
+        {
+            var segment = new TestMemorySegment(memory)
+            {
+                RunningIndex = RunningIndex + Memory.Length
+            };
+            Next = segment;
+            return segment;
+        }
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Add `Dekaf.Compression.Lz4` package with LZ4 frame format support for Kafka message compression
- Implement `Lz4CompressionCodec` using K4os.Compression.LZ4.Streams library which provides the LZ4F format required by Kafka (magic bytes: `0x04 0x22 0x4D 0x18`)
- Add `AddLz4()` extension method for `CompressionCodecRegistry` with configurable compression levels (L00_FAST to L12_MAX)
- Include comprehensive unit tests (10 tests) covering round-trip compression, frame format verification, compression levels, and multi-segment sequences

## Test plan
- [x] Build succeeds with no warnings
- [x] All 205 unit tests pass (including 10 new LZ4 tests)
- [x] LZ4 frame format magic bytes verified in test
- [x] Round-trip compression/decompression preserves data integrity
- [x] Multi-segment ReadOnlySequence handling tested

Closes #15

🤖 Generated with [Claude Code](https://claude.ai/code)