### PR TITLE
Add DescribeConfigs and AlterConfigs admin APIs

### DIFF
--- a/src/Dekaf/Admin/ConfigTypes.cs
+++ b/src/Dekaf/Admin/ConfigTypes.cs
@@ -1,0 +1,312 @@
+namespace Dekaf.Admin;
+
+/// <summary>
+/// Type of configuration resource.
+/// </summary>
+public enum ConfigResourceType : sbyte
+{
+    /// <summary>
+    /// Unknown resource type.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Topic configuration.
+    /// </summary>
+    Topic = 2,
+
+    /// <summary>
+    /// Broker configuration.
+    /// </summary>
+    Broker = 4,
+
+    /// <summary>
+    /// Broker logger configuration.
+    /// </summary>
+    BrokerLogger = 8
+}
+
+/// <summary>
+/// Source of a configuration value.
+/// </summary>
+public enum ConfigSource : sbyte
+{
+    /// <summary>
+    /// Unknown source.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The configuration is a dynamic topic config that is configured for a specific topic.
+    /// </summary>
+    DynamicTopicConfig = 1,
+
+    /// <summary>
+    /// The configuration is a dynamic broker config that is configured for a specific broker.
+    /// </summary>
+    DynamicBrokerConfig = 2,
+
+    /// <summary>
+    /// The configuration is a dynamic broker config that is configured as default for all brokers.
+    /// </summary>
+    DynamicDefaultBrokerConfig = 3,
+
+    /// <summary>
+    /// The configuration is a static broker config provided as broker properties at start up.
+    /// </summary>
+    StaticBrokerConfig = 4,
+
+    /// <summary>
+    /// The configuration is a built-in default value.
+    /// </summary>
+    DefaultConfig = 5,
+
+    /// <summary>
+    /// The configuration is a dynamic broker logger config.
+    /// </summary>
+    DynamicBrokerLoggerConfig = 6
+}
+
+/// <summary>
+/// Operation type for incremental config alterations.
+/// </summary>
+public enum ConfigAlterOperation : sbyte
+{
+    /// <summary>
+    /// Set the configuration value.
+    /// </summary>
+    Set = 0,
+
+    /// <summary>
+    /// Delete/unset the configuration value.
+    /// </summary>
+    Delete = 1,
+
+    /// <summary>
+    /// Append to a list configuration value.
+    /// </summary>
+    Append = 2,
+
+    /// <summary>
+    /// Subtract from a list configuration value.
+    /// </summary>
+    Subtract = 3
+}
+
+/// <summary>
+/// Identifies a Kafka configuration resource (topic, broker, etc.).
+/// </summary>
+public sealed class ConfigResource : IEquatable<ConfigResource>
+{
+    /// <summary>
+    /// The type of resource.
+    /// </summary>
+    public required ConfigResourceType Type { get; init; }
+
+    /// <summary>
+    /// The name of the resource. For topics, this is the topic name.
+    /// For brokers, this is the broker ID as a string, or empty for cluster-wide config.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Creates a ConfigResource for a topic.
+    /// </summary>
+    public static ConfigResource Topic(string topicName) =>
+        new() { Type = ConfigResourceType.Topic, Name = topicName };
+
+    /// <summary>
+    /// Creates a ConfigResource for a specific broker.
+    /// </summary>
+    public static ConfigResource Broker(int brokerId) =>
+        new() { Type = ConfigResourceType.Broker, Name = brokerId.ToString() };
+
+    /// <summary>
+    /// Creates a ConfigResource for cluster-wide broker configuration.
+    /// </summary>
+    public static ConfigResource ClusterBroker() =>
+        new() { Type = ConfigResourceType.Broker, Name = string.Empty };
+
+    /// <summary>
+    /// Creates a ConfigResource for a broker logger.
+    /// </summary>
+    public static ConfigResource BrokerLogger(int brokerId) =>
+        new() { Type = ConfigResourceType.BrokerLogger, Name = brokerId.ToString() };
+
+    public bool Equals(ConfigResource? other)
+    {
+        if (other is null) return false;
+        return Type == other.Type && Name == other.Name;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as ConfigResource);
+
+    public override int GetHashCode() => HashCode.Combine(Type, Name);
+
+    public override string ToString() => $"{Type}:{Name}";
+}
+
+/// <summary>
+/// A configuration entry returned by DescribeConfigs.
+/// </summary>
+public sealed class ConfigEntry
+{
+    /// <summary>
+    /// The configuration name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The configuration value, or null if sensitive.
+    /// </summary>
+    public string? Value { get; init; }
+
+    /// <summary>
+    /// Whether the config value is read-only.
+    /// </summary>
+    public bool IsReadOnly { get; init; }
+
+    /// <summary>
+    /// Whether the config value is set to a non-default value.
+    /// </summary>
+    public bool IsDefault { get; init; }
+
+    /// <summary>
+    /// Whether the config value is sensitive.
+    /// </summary>
+    public bool IsSensitive { get; init; }
+
+    /// <summary>
+    /// The source of this configuration entry.
+    /// </summary>
+    public ConfigSource Source { get; init; } = ConfigSource.Unknown;
+
+    /// <summary>
+    /// Configuration synonyms (if requested).
+    /// </summary>
+    public IReadOnlyList<ConfigSynonym>? Synonyms { get; init; }
+
+    /// <summary>
+    /// The documentation for this config (if requested).
+    /// </summary>
+    public string? Documentation { get; init; }
+}
+
+/// <summary>
+/// A synonym for a configuration entry.
+/// </summary>
+public sealed class ConfigSynonym
+{
+    /// <summary>
+    /// The synonym name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The synonym value.
+    /// </summary>
+    public string? Value { get; init; }
+
+    /// <summary>
+    /// The source of this synonym.
+    /// </summary>
+    public ConfigSource Source { get; init; } = ConfigSource.Unknown;
+}
+
+/// <summary>
+/// A configuration alteration for IncrementalAlterConfigs.
+/// </summary>
+public sealed class ConfigAlter
+{
+    /// <summary>
+    /// The configuration name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The configuration value, or null for delete operation.
+    /// </summary>
+    public string? Value { get; init; }
+
+    /// <summary>
+    /// The operation to perform.
+    /// </summary>
+    public ConfigAlterOperation Operation { get; init; } = ConfigAlterOperation.Set;
+
+    /// <summary>
+    /// Creates a Set operation.
+    /// </summary>
+    public static ConfigAlter Set(string name, string? value) =>
+        new() { Name = name, Value = value, Operation = ConfigAlterOperation.Set };
+
+    /// <summary>
+    /// Creates a Delete operation.
+    /// </summary>
+    public static ConfigAlter Delete(string name) =>
+        new() { Name = name, Value = null, Operation = ConfigAlterOperation.Delete };
+
+    /// <summary>
+    /// Creates an Append operation.
+    /// </summary>
+    public static ConfigAlter Append(string name, string value) =>
+        new() { Name = name, Value = value, Operation = ConfigAlterOperation.Append };
+
+    /// <summary>
+    /// Creates a Subtract operation.
+    /// </summary>
+    public static ConfigAlter Subtract(string name, string value) =>
+        new() { Name = name, Value = value, Operation = ConfigAlterOperation.Subtract };
+}
+
+/// <summary>
+/// Options for DescribeConfigs.
+/// </summary>
+public sealed class DescribeConfigsOptions
+{
+    /// <summary>
+    /// Timeout in milliseconds.
+    /// </summary>
+    public int TimeoutMs { get; init; } = 30000;
+
+    /// <summary>
+    /// Whether to include synonyms in the response.
+    /// </summary>
+    public bool IncludeSynonyms { get; init; }
+
+    /// <summary>
+    /// Whether to include documentation in the response.
+    /// </summary>
+    public bool IncludeDocumentation { get; init; }
+}
+
+/// <summary>
+/// Options for AlterConfigs.
+/// </summary>
+public sealed class AlterConfigsOptions
+{
+    /// <summary>
+    /// Timeout in milliseconds.
+    /// </summary>
+    public int TimeoutMs { get; init; } = 30000;
+
+    /// <summary>
+    /// If true, the broker will validate the request, but not change the configuration.
+    /// </summary>
+    public bool ValidateOnly { get; init; }
+}
+
+/// <summary>
+/// Options for IncrementalAlterConfigs.
+/// </summary>
+public sealed class IncrementalAlterConfigsOptions
+{
+    /// <summary>
+    /// Timeout in milliseconds.
+    /// </summary>
+    public int TimeoutMs { get; init; } = 30000;
+
+    /// <summary>
+    /// If true, the broker will validate the request, but not change the configuration.
+    /// </summary>
+    public bool ValidateOnly { get; init; }
+}

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -69,6 +69,43 @@ public interface IAdminClient : IAsyncDisposable
     ValueTask CreatePartitionsAsync(IReadOnlyDictionary<string, int> newPartitionCounts, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Describes configurations for the specified resources.
+    /// </summary>
+    /// <param name="resources">The resources to describe configurations for.</param>
+    /// <param name="options">Optional configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A dictionary mapping each resource to its configuration entries.</returns>
+    ValueTask<IReadOnlyDictionary<ConfigResource, IReadOnlyList<ConfigEntry>>> DescribeConfigsAsync(
+        IEnumerable<ConfigResource> resources,
+        DescribeConfigsOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Alters configurations for the specified resources.
+    /// This replaces the entire configuration for each resource.
+    /// Consider using IncrementalAlterConfigsAsync for partial updates.
+    /// </summary>
+    /// <param name="configs">The configurations to set for each resource.</param>
+    /// <param name="options">Optional configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask AlterConfigsAsync(
+        IReadOnlyDictionary<ConfigResource, IReadOnlyList<ConfigEntry>> configs,
+        AlterConfigsOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Incrementally alters configurations for the specified resources.
+    /// This allows setting, deleting, appending to, or subtracting from individual configuration values.
+    /// </summary>
+    /// <param name="configs">The configuration alterations for each resource.</param>
+    /// <param name="options">Optional configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask IncrementalAlterConfigsAsync(
+        IReadOnlyDictionary<ConfigResource, IReadOnlyList<ConfigAlter>> configs,
+        IncrementalAlterConfigsOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the cluster metadata.
     /// </summary>
     ClusterMetadata Metadata { get; }

--- a/src/Dekaf/Protocol/Messages/AlterConfigsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/AlterConfigsRequest.cs
@@ -1,0 +1,137 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// AlterConfigs request (API key 33).
+/// Alters the configuration of the specified resources.
+/// This is a deprecated API - use IncrementalAlterConfigs instead.
+/// </summary>
+public sealed class AlterConfigsRequest : IKafkaRequest<AlterConfigsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.AlterConfigs;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 2;
+
+    /// <summary>
+    /// The updates for each resource.
+    /// </summary>
+    public required IReadOnlyList<AlterConfigsResource> Resources { get; init; }
+
+    /// <summary>
+    /// True if we should validate the request, but not change the configuration.
+    /// </summary>
+    public bool ValidateOnly { get; init; }
+
+    public static bool IsFlexibleVersion(short version) => version >= 2;
+    public static short GetRequestHeaderVersion(short version) => version >= 2 ? (short)2 : (short)1;
+    public static short GetResponseHeaderVersion(short version) => version >= 2 ? (short)1 : (short)0;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 2;
+
+        if (isFlexible)
+        {
+            writer.WriteCompactArray(
+                Resources,
+                (ref KafkaProtocolWriter w, AlterConfigsResource r) => r.Write(ref w, version));
+        }
+        else
+        {
+            writer.WriteArray(
+                Resources,
+                (ref KafkaProtocolWriter w, AlterConfigsResource r) => r.Write(ref w, version));
+        }
+
+        writer.WriteBoolean(ValidateOnly);
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}
+
+/// <summary>
+/// A resource to alter configuration for.
+/// </summary>
+public sealed class AlterConfigsResource
+{
+    /// <summary>
+    /// The resource type (2=TOPIC, 4=BROKER, 8=BROKER_LOGGER).
+    /// </summary>
+    public required sbyte ResourceType { get; init; }
+
+    /// <summary>
+    /// The resource name.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>
+    /// The configurations to set.
+    /// </summary>
+    public required IReadOnlyList<AlterableConfig> Configs { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 2;
+
+        writer.WriteInt8(ResourceType);
+
+        if (isFlexible)
+        {
+            writer.WriteCompactString(ResourceName);
+            writer.WriteCompactArray(
+                Configs,
+                (ref KafkaProtocolWriter w, AlterableConfig c) => c.Write(ref w, version));
+        }
+        else
+        {
+            writer.WriteString(ResourceName);
+            writer.WriteArray(
+                Configs,
+                (ref KafkaProtocolWriter w, AlterableConfig c) => c.Write(ref w, version));
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}
+
+/// <summary>
+/// A configuration to alter.
+/// </summary>
+public sealed class AlterableConfig
+{
+    /// <summary>
+    /// The configuration key name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The value to set for the configuration key.
+    /// </summary>
+    public string? Value { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 2;
+
+        if (isFlexible)
+        {
+            writer.WriteCompactString(Name);
+            writer.WriteCompactNullableString(Value);
+        }
+        else
+        {
+            writer.WriteString(Name);
+            writer.WriteString(Value);
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}

--- a/src/Dekaf/Protocol/Messages/AlterConfigsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/AlterConfigsResponse.cs
@@ -1,0 +1,120 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// AlterConfigs response (API key 33).
+/// Contains the results of altering the configuration for resources.
+/// </summary>
+public sealed class AlterConfigsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.AlterConfigs;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 2;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The responses for each resource.
+    /// </summary>
+    public required IReadOnlyList<AlterConfigsResourceResponse> Responses { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        var throttleTimeMs = reader.ReadInt32();
+
+        IReadOnlyList<AlterConfigsResourceResponse> responses;
+        if (isFlexible)
+        {
+            responses = reader.ReadCompactArray(
+                (ref KafkaProtocolReader r) => AlterConfigsResourceResponse.Read(ref r, version)) ?? [];
+        }
+        else
+        {
+            responses = reader.ReadArray(
+                (ref KafkaProtocolReader r) => AlterConfigsResourceResponse.Read(ref r, version)) ?? [];
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new AlterConfigsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            Responses = responses
+        };
+    }
+}
+
+/// <summary>
+/// Per-resource response for AlterConfigs.
+/// </summary>
+public sealed class AlterConfigsResourceResponse
+{
+    /// <summary>
+    /// The error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The resource type.
+    /// </summary>
+    public sbyte ResourceType { get; init; }
+
+    /// <summary>
+    /// The resource name.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    public static AlterConfigsResourceResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        string? errorMessage;
+        if (isFlexible)
+        {
+            errorMessage = reader.ReadCompactString();
+        }
+        else
+        {
+            errorMessage = reader.ReadString();
+        }
+
+        var resourceType = reader.ReadInt8();
+
+        string resourceName;
+        if (isFlexible)
+        {
+            resourceName = reader.ReadCompactString() ?? string.Empty;
+        }
+        else
+        {
+            resourceName = reader.ReadString() ?? string.Empty;
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new AlterConfigsResourceResponse
+        {
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            ResourceType = resourceType,
+            ResourceName = resourceName
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DescribeConfigsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeConfigsRequest.cs
@@ -1,0 +1,119 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DescribeConfigs request (API key 32).
+/// Describes the configuration of the specified resources.
+/// </summary>
+public sealed class DescribeConfigsRequest : IKafkaRequest<DescribeConfigsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.DescribeConfigs;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 4;
+
+    /// <summary>
+    /// The resources whose configurations we want to describe.
+    /// </summary>
+    public required IReadOnlyList<DescribeConfigsResource> Resources { get; init; }
+
+    /// <summary>
+    /// True if we should include all synonyms (v1+).
+    /// </summary>
+    public bool IncludeSynonyms { get; init; }
+
+    /// <summary>
+    /// True if we should include configuration documentation (v3+).
+    /// </summary>
+    public bool IncludeDocumentation { get; init; }
+
+    public static bool IsFlexibleVersion(short version) => version >= 4;
+    public static short GetRequestHeaderVersion(short version) => version >= 4 ? (short)2 : (short)1;
+    public static short GetResponseHeaderVersion(short version) => version >= 4 ? (short)1 : (short)0;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 4;
+
+        if (isFlexible)
+        {
+            writer.WriteCompactArray(
+                Resources,
+                (ref KafkaProtocolWriter w, DescribeConfigsResource r) => r.Write(ref w, version));
+        }
+        else
+        {
+            writer.WriteArray(
+                Resources,
+                (ref KafkaProtocolWriter w, DescribeConfigsResource r) => r.Write(ref w, version));
+        }
+
+        if (version >= 1)
+        {
+            writer.WriteBoolean(IncludeSynonyms);
+        }
+
+        if (version >= 3)
+        {
+            writer.WriteBoolean(IncludeDocumentation);
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}
+
+/// <summary>
+/// A resource to describe configuration for.
+/// </summary>
+public sealed class DescribeConfigsResource
+{
+    /// <summary>
+    /// The resource type (2=TOPIC, 4=BROKER, 8=BROKER_LOGGER).
+    /// </summary>
+    public required sbyte ResourceType { get; init; }
+
+    /// <summary>
+    /// The resource name.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>
+    /// The configuration keys to list, or null to list all.
+    /// </summary>
+    public IReadOnlyList<string>? ConfigurationKeys { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 4;
+
+        writer.WriteInt8(ResourceType);
+
+        if (isFlexible)
+        {
+            writer.WriteCompactString(ResourceName);
+        }
+        else
+        {
+            writer.WriteString(ResourceName);
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteCompactNullableArray(
+                ConfigurationKeys,
+                (ref KafkaProtocolWriter w, string s) => w.WriteCompactString(s));
+        }
+        else
+        {
+            writer.WriteNullableArray(
+                ConfigurationKeys,
+                (ref KafkaProtocolWriter w, string s) => w.WriteString(s));
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DescribeConfigsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeConfigsResponse.cs
@@ -1,0 +1,329 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DescribeConfigs response (API key 32).
+/// Contains the configuration for the requested resources.
+/// </summary>
+public sealed class DescribeConfigsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.DescribeConfigs;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 4;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The results for each resource.
+    /// </summary>
+    public required IReadOnlyList<DescribeConfigsResult> Results { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 4;
+
+        var throttleTimeMs = reader.ReadInt32();
+
+        IReadOnlyList<DescribeConfigsResult> results;
+        if (isFlexible)
+        {
+            results = reader.ReadCompactArray(
+                (ref KafkaProtocolReader r) => DescribeConfigsResult.Read(ref r, version)) ?? [];
+        }
+        else
+        {
+            results = reader.ReadArray(
+                (ref KafkaProtocolReader r) => DescribeConfigsResult.Read(ref r, version)) ?? [];
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DescribeConfigsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            Results = results
+        };
+    }
+}
+
+/// <summary>
+/// Per-resource result for DescribeConfigs.
+/// </summary>
+public sealed class DescribeConfigsResult
+{
+    /// <summary>
+    /// The error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The resource type.
+    /// </summary>
+    public sbyte ResourceType { get; init; }
+
+    /// <summary>
+    /// The resource name.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>
+    /// Each listed configuration.
+    /// </summary>
+    public required IReadOnlyList<DescribeConfigsResourceResult> Configs { get; init; }
+
+    public static DescribeConfigsResult Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 4;
+
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        string? errorMessage;
+        if (isFlexible)
+        {
+            errorMessage = reader.ReadCompactString();
+        }
+        else
+        {
+            errorMessage = reader.ReadString();
+        }
+
+        var resourceType = reader.ReadInt8();
+
+        string resourceName;
+        if (isFlexible)
+        {
+            resourceName = reader.ReadCompactString() ?? string.Empty;
+        }
+        else
+        {
+            resourceName = reader.ReadString() ?? string.Empty;
+        }
+
+        IReadOnlyList<DescribeConfigsResourceResult> configs;
+        if (isFlexible)
+        {
+            configs = reader.ReadCompactArray(
+                (ref KafkaProtocolReader r) => DescribeConfigsResourceResult.Read(ref r, version)) ?? [];
+        }
+        else
+        {
+            configs = reader.ReadArray(
+                (ref KafkaProtocolReader r) => DescribeConfigsResourceResult.Read(ref r, version)) ?? [];
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DescribeConfigsResult
+        {
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            ResourceType = resourceType,
+            ResourceName = resourceName,
+            Configs = configs
+        };
+    }
+}
+
+/// <summary>
+/// A configuration entry in the DescribeConfigs response.
+/// </summary>
+public sealed class DescribeConfigsResourceResult
+{
+    /// <summary>
+    /// The configuration name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The configuration value.
+    /// </summary>
+    public string? Value { get; init; }
+
+    /// <summary>
+    /// True if the configuration is read-only.
+    /// </summary>
+    public bool ReadOnly { get; init; }
+
+    /// <summary>
+    /// True if the configuration is not set (v0 only, deprecated).
+    /// </summary>
+    public bool IsDefault { get; init; }
+
+    /// <summary>
+    /// The configuration source (v1+).
+    /// </summary>
+    public sbyte ConfigSource { get; init; } = -1;
+
+    /// <summary>
+    /// True if this configuration is sensitive.
+    /// </summary>
+    public bool IsSensitive { get; init; }
+
+    /// <summary>
+    /// The synonyms for this configuration key (v1+).
+    /// </summary>
+    public IReadOnlyList<DescribeConfigsSynonym>? Synonyms { get; init; }
+
+    /// <summary>
+    /// The configuration data type (v3+).
+    /// </summary>
+    public sbyte ConfigType { get; init; }
+
+    /// <summary>
+    /// The configuration documentation (v3+).
+    /// </summary>
+    public string? Documentation { get; init; }
+
+    public static DescribeConfigsResourceResult Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 4;
+
+        string name;
+        if (isFlexible)
+        {
+            name = reader.ReadCompactString() ?? string.Empty;
+        }
+        else
+        {
+            name = reader.ReadString() ?? string.Empty;
+        }
+
+        string? value;
+        if (isFlexible)
+        {
+            value = reader.ReadCompactString();
+        }
+        else
+        {
+            value = reader.ReadString();
+        }
+
+        var readOnly = reader.ReadBoolean();
+
+        // v0 has IsDefault; v1+ uses ConfigSource instead
+        var isDefault = version == 0 && reader.ReadBoolean();
+
+        sbyte configSource = -1;
+        if (version >= 1)
+        {
+            configSource = reader.ReadInt8();
+        }
+
+        var isSensitive = reader.ReadBoolean();
+
+        IReadOnlyList<DescribeConfigsSynonym>? synonyms = null;
+        if (version >= 1)
+        {
+            if (isFlexible)
+            {
+                synonyms = reader.ReadCompactArray(
+                    (ref KafkaProtocolReader r) => DescribeConfigsSynonym.Read(ref r, version));
+            }
+            else
+            {
+                synonyms = reader.ReadArray(
+                    (ref KafkaProtocolReader r) => DescribeConfigsSynonym.Read(ref r, version));
+            }
+        }
+
+        sbyte configType = 0;
+        string? documentation = null;
+        if (version >= 3)
+        {
+            configType = reader.ReadInt8();
+            if (isFlexible)
+            {
+                documentation = reader.ReadCompactString();
+            }
+            else
+            {
+                documentation = reader.ReadString();
+            }
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DescribeConfigsResourceResult
+        {
+            Name = name,
+            Value = value,
+            ReadOnly = readOnly,
+            IsDefault = isDefault,
+            ConfigSource = configSource,
+            IsSensitive = isSensitive,
+            Synonyms = synonyms,
+            ConfigType = configType,
+            Documentation = documentation
+        };
+    }
+}
+
+/// <summary>
+/// A configuration synonym in the DescribeConfigs response.
+/// </summary>
+public sealed class DescribeConfigsSynonym
+{
+    /// <summary>
+    /// The synonym name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The synonym value.
+    /// </summary>
+    public string? Value { get; init; }
+
+    /// <summary>
+    /// The source of this configuration.
+    /// </summary>
+    public sbyte Source { get; init; }
+
+    public static DescribeConfigsSynonym Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 4;
+
+        string name;
+        string? value;
+
+        if (isFlexible)
+        {
+            name = reader.ReadCompactString() ?? string.Empty;
+            value = reader.ReadCompactString();
+        }
+        else
+        {
+            name = reader.ReadString() ?? string.Empty;
+            value = reader.ReadString();
+        }
+
+        var source = reader.ReadInt8();
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DescribeConfigsSynonym
+        {
+            Name = name,
+            Value = value,
+            Source = source
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/IncrementalAlterConfigsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/IncrementalAlterConfigsRequest.cs
@@ -1,0 +1,150 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// IncrementalAlterConfigs request (API key 44).
+/// Incrementally alters the configuration of the specified resources.
+/// </summary>
+public sealed class IncrementalAlterConfigsRequest : IKafkaRequest<IncrementalAlterConfigsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.IncrementalAlterConfigs;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 1;
+
+    /// <summary>
+    /// The incremental updates for each resource.
+    /// </summary>
+    public required IReadOnlyList<IncrementalAlterConfigsResource> Resources { get; init; }
+
+    /// <summary>
+    /// True if we should validate the request, but not change the configuration.
+    /// </summary>
+    public bool ValidateOnly { get; init; }
+
+    public static bool IsFlexibleVersion(short version) => version >= 1;
+    public static short GetRequestHeaderVersion(short version) => version >= 1 ? (short)2 : (short)1;
+    public static short GetResponseHeaderVersion(short version) => version >= 1 ? (short)1 : (short)0;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 1;
+
+        if (isFlexible)
+        {
+            writer.WriteCompactArray(
+                Resources,
+                (ref KafkaProtocolWriter w, IncrementalAlterConfigsResource r) => r.Write(ref w, version));
+        }
+        else
+        {
+            writer.WriteArray(
+                Resources,
+                (ref KafkaProtocolWriter w, IncrementalAlterConfigsResource r) => r.Write(ref w, version));
+        }
+
+        writer.WriteBoolean(ValidateOnly);
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}
+
+/// <summary>
+/// A resource for incremental config alteration.
+/// </summary>
+public sealed class IncrementalAlterConfigsResource
+{
+    /// <summary>
+    /// The resource type (2=TOPIC, 4=BROKER, 8=BROKER_LOGGER).
+    /// </summary>
+    public required sbyte ResourceType { get; init; }
+
+    /// <summary>
+    /// The resource name.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>
+    /// The configurations to alter.
+    /// </summary>
+    public required IReadOnlyList<IncrementalAlterableConfig> Configs { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 1;
+
+        writer.WriteInt8(ResourceType);
+
+        if (isFlexible)
+        {
+            writer.WriteCompactString(ResourceName);
+            writer.WriteCompactArray(
+                Configs,
+                (ref KafkaProtocolWriter w, IncrementalAlterableConfig c) => c.Write(ref w, version));
+        }
+        else
+        {
+            writer.WriteString(ResourceName);
+            writer.WriteArray(
+                Configs,
+                (ref KafkaProtocolWriter w, IncrementalAlterableConfig c) => c.Write(ref w, version));
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}
+
+/// <summary>
+/// A configuration to incrementally alter.
+/// </summary>
+public sealed class IncrementalAlterableConfig
+{
+    /// <summary>
+    /// The configuration key name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The type (Set, Delete, Append, Subtract) of operation.
+    /// </summary>
+    public sbyte ConfigOperation { get; init; }
+
+    /// <summary>
+    /// The value to set for the configuration key.
+    /// </summary>
+    public string? Value { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 1;
+
+        if (isFlexible)
+        {
+            writer.WriteCompactString(Name);
+        }
+        else
+        {
+            writer.WriteString(Name);
+        }
+
+        writer.WriteInt8(ConfigOperation);
+
+        if (isFlexible)
+        {
+            writer.WriteCompactNullableString(Value);
+        }
+        else
+        {
+            writer.WriteString(Value);
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}

--- a/src/Dekaf/Protocol/Messages/IncrementalAlterConfigsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/IncrementalAlterConfigsResponse.cs
@@ -1,0 +1,120 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// IncrementalAlterConfigs response (API key 44).
+/// Contains the results of incrementally altering the configuration for resources.
+/// </summary>
+public sealed class IncrementalAlterConfigsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.IncrementalAlterConfigs;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 1;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The responses for each resource.
+    /// </summary>
+    public required IReadOnlyList<IncrementalAlterConfigsResourceResponse> Responses { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 1;
+
+        var throttleTimeMs = reader.ReadInt32();
+
+        IReadOnlyList<IncrementalAlterConfigsResourceResponse> responses;
+        if (isFlexible)
+        {
+            responses = reader.ReadCompactArray(
+                (ref KafkaProtocolReader r) => IncrementalAlterConfigsResourceResponse.Read(ref r, version)) ?? [];
+        }
+        else
+        {
+            responses = reader.ReadArray(
+                (ref KafkaProtocolReader r) => IncrementalAlterConfigsResourceResponse.Read(ref r, version)) ?? [];
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new IncrementalAlterConfigsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            Responses = responses
+        };
+    }
+}
+
+/// <summary>
+/// Per-resource response for IncrementalAlterConfigs.
+/// </summary>
+public sealed class IncrementalAlterConfigsResourceResponse
+{
+    /// <summary>
+    /// The error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The resource type.
+    /// </summary>
+    public sbyte ResourceType { get; init; }
+
+    /// <summary>
+    /// The resource name.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    public static IncrementalAlterConfigsResourceResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 1;
+
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        string? errorMessage;
+        if (isFlexible)
+        {
+            errorMessage = reader.ReadCompactString();
+        }
+        else
+        {
+            errorMessage = reader.ReadString();
+        }
+
+        var resourceType = reader.ReadInt8();
+
+        string resourceName;
+        if (isFlexible)
+        {
+            resourceName = reader.ReadCompactString() ?? string.Empty;
+        }
+        else
+        {
+            resourceName = reader.ReadString() ?? string.Empty;
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new IncrementalAlterConfigsResourceResponse
+        {
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            ResourceType = resourceType,
+            ResourceName = resourceName
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/ConfigTypesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/ConfigTypesTests.cs
@@ -1,0 +1,288 @@
+using Dekaf.Admin;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+/// <summary>
+/// Tests for config admin API types.
+/// </summary>
+public class ConfigTypesTests
+{
+    #region ConfigResource Tests
+
+    [Test]
+    public async Task ConfigResource_Topic_CreatesCorrectType()
+    {
+        var resource = ConfigResource.Topic("my-topic");
+
+        await Assert.That(resource.Type).IsEqualTo(ConfigResourceType.Topic);
+        await Assert.That(resource.Name).IsEqualTo("my-topic");
+    }
+
+    [Test]
+    public async Task ConfigResource_Broker_CreatesCorrectType()
+    {
+        var resource = ConfigResource.Broker(1);
+
+        await Assert.That(resource.Type).IsEqualTo(ConfigResourceType.Broker);
+        await Assert.That(resource.Name).IsEqualTo("1");
+    }
+
+    [Test]
+    public async Task ConfigResource_ClusterBroker_CreatesCorrectType()
+    {
+        var resource = ConfigResource.ClusterBroker();
+
+        await Assert.That(resource.Type).IsEqualTo(ConfigResourceType.Broker);
+        await Assert.That(resource.Name).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task ConfigResource_BrokerLogger_CreatesCorrectType()
+    {
+        var resource = ConfigResource.BrokerLogger(2);
+
+        await Assert.That(resource.Type).IsEqualTo(ConfigResourceType.BrokerLogger);
+        await Assert.That(resource.Name).IsEqualTo("2");
+    }
+
+    [Test]
+    public async Task ConfigResource_Equality_SameTypeAndName_AreEqual()
+    {
+        var resource1 = ConfigResource.Topic("test");
+        var resource2 = ConfigResource.Topic("test");
+
+        await Assert.That(resource1.Equals(resource2)).IsTrue();
+        await Assert.That(resource1.GetHashCode()).IsEqualTo(resource2.GetHashCode());
+    }
+
+    [Test]
+    public async Task ConfigResource_Equality_DifferentType_AreNotEqual()
+    {
+        var resource1 = ConfigResource.Topic("test");
+        var resource2 = new ConfigResource { Type = ConfigResourceType.Broker, Name = "test" };
+
+        await Assert.That(resource1.Equals(resource2)).IsFalse();
+    }
+
+    [Test]
+    public async Task ConfigResource_Equality_DifferentName_AreNotEqual()
+    {
+        var resource1 = ConfigResource.Topic("test1");
+        var resource2 = ConfigResource.Topic("test2");
+
+        await Assert.That(resource1.Equals(resource2)).IsFalse();
+    }
+
+    [Test]
+    public async Task ConfigResource_ToString_ReturnsExpectedFormat()
+    {
+        var resource = ConfigResource.Topic("my-topic");
+
+        await Assert.That(resource.ToString()).IsEqualTo("Topic:my-topic");
+    }
+
+    [Test]
+    public async Task ConfigResource_Equality_WithNull_ReturnsFalse()
+    {
+        var resource = ConfigResource.Topic("test");
+
+        await Assert.That(resource.Equals(null)).IsFalse();
+    }
+
+    [Test]
+    public async Task ConfigResource_CanBeUsedAsDictionaryKey()
+    {
+        var dict = new Dictionary<ConfigResource, string>
+        {
+            [ConfigResource.Topic("topic1")] = "value1",
+            [ConfigResource.Topic("topic2")] = "value2",
+            [ConfigResource.Broker(1)] = "value3"
+        };
+
+        await Assert.That(dict[ConfigResource.Topic("topic1")]).IsEqualTo("value1");
+        await Assert.That(dict[ConfigResource.Topic("topic2")]).IsEqualTo("value2");
+        await Assert.That(dict[ConfigResource.Broker(1)]).IsEqualTo("value3");
+    }
+
+    #endregion
+
+    #region ConfigAlter Tests
+
+    [Test]
+    public async Task ConfigAlter_Set_CreatesCorrectOperation()
+    {
+        var alter = ConfigAlter.Set("retention.ms", "3600000");
+
+        await Assert.That(alter.Name).IsEqualTo("retention.ms");
+        await Assert.That(alter.Value).IsEqualTo("3600000");
+        await Assert.That(alter.Operation).IsEqualTo(ConfigAlterOperation.Set);
+    }
+
+    [Test]
+    public async Task ConfigAlter_Delete_CreatesCorrectOperation()
+    {
+        var alter = ConfigAlter.Delete("retention.ms");
+
+        await Assert.That(alter.Name).IsEqualTo("retention.ms");
+        await Assert.That(alter.Value).IsNull();
+        await Assert.That(alter.Operation).IsEqualTo(ConfigAlterOperation.Delete);
+    }
+
+    [Test]
+    public async Task ConfigAlter_Append_CreatesCorrectOperation()
+    {
+        var alter = ConfigAlter.Append("follower.replication.throttled.replicas", "0:1");
+
+        await Assert.That(alter.Name).IsEqualTo("follower.replication.throttled.replicas");
+        await Assert.That(alter.Value).IsEqualTo("0:1");
+        await Assert.That(alter.Operation).IsEqualTo(ConfigAlterOperation.Append);
+    }
+
+    [Test]
+    public async Task ConfigAlter_Subtract_CreatesCorrectOperation()
+    {
+        var alter = ConfigAlter.Subtract("follower.replication.throttled.replicas", "0:1");
+
+        await Assert.That(alter.Name).IsEqualTo("follower.replication.throttled.replicas");
+        await Assert.That(alter.Value).IsEqualTo("0:1");
+        await Assert.That(alter.Operation).IsEqualTo(ConfigAlterOperation.Subtract);
+    }
+
+    #endregion
+
+    #region ConfigEntry Tests
+
+    [Test]
+    public async Task ConfigEntry_DefaultValues_AreCorrect()
+    {
+        var entry = new ConfigEntry
+        {
+            Name = "test.config"
+        };
+
+        await Assert.That(entry.Name).IsEqualTo("test.config");
+        await Assert.That(entry.Value).IsNull();
+        await Assert.That(entry.IsReadOnly).IsFalse();
+        await Assert.That(entry.IsDefault).IsFalse();
+        await Assert.That(entry.IsSensitive).IsFalse();
+        await Assert.That(entry.Source).IsEqualTo(ConfigSource.Unknown);
+        await Assert.That(entry.Synonyms).IsNull();
+        await Assert.That(entry.Documentation).IsNull();
+    }
+
+    [Test]
+    public async Task ConfigEntry_WithAllProperties_SetsCorrectly()
+    {
+        var synonyms = new List<ConfigSynonym>
+        {
+            new() { Name = "synonym1", Value = "value1", Source = ConfigSource.DefaultConfig }
+        };
+
+        var entry = new ConfigEntry
+        {
+            Name = "retention.ms",
+            Value = "604800000",
+            IsReadOnly = false,
+            IsDefault = true,
+            IsSensitive = false,
+            Source = ConfigSource.DefaultConfig,
+            Synonyms = synonyms,
+            Documentation = "The retention time for logs"
+        };
+
+        await Assert.That(entry.Name).IsEqualTo("retention.ms");
+        await Assert.That(entry.Value).IsEqualTo("604800000");
+        await Assert.That(entry.IsDefault).IsTrue();
+        await Assert.That(entry.Source).IsEqualTo(ConfigSource.DefaultConfig);
+        await Assert.That(entry.Synonyms).IsNotNull();
+        await Assert.That(entry.Synonyms!.Count).IsEqualTo(1);
+        await Assert.That(entry.Documentation).IsEqualTo("The retention time for logs");
+    }
+
+    #endregion
+
+    #region Options Tests
+
+    [Test]
+    public async Task DescribeConfigsOptions_DefaultValues_AreCorrect()
+    {
+        var options = new DescribeConfigsOptions();
+
+        await Assert.That(options.TimeoutMs).IsEqualTo(30000);
+        await Assert.That(options.IncludeSynonyms).IsFalse();
+        await Assert.That(options.IncludeDocumentation).IsFalse();
+    }
+
+    [Test]
+    public async Task AlterConfigsOptions_DefaultValues_AreCorrect()
+    {
+        var options = new AlterConfigsOptions();
+
+        await Assert.That(options.TimeoutMs).IsEqualTo(30000);
+        await Assert.That(options.ValidateOnly).IsFalse();
+    }
+
+    [Test]
+    public async Task IncrementalAlterConfigsOptions_DefaultValues_AreCorrect()
+    {
+        var options = new IncrementalAlterConfigsOptions();
+
+        await Assert.That(options.TimeoutMs).IsEqualTo(30000);
+        await Assert.That(options.ValidateOnly).IsFalse();
+    }
+
+    #endregion
+
+    #region Enum Values Tests
+
+    [Test]
+    public async Task ConfigResourceType_HasCorrectValues()
+    {
+        // Cast to sbyte and store in variables to avoid constant value assertions
+        var unknown = (sbyte)ConfigResourceType.Unknown;
+        var topic = (sbyte)ConfigResourceType.Topic;
+        var broker = (sbyte)ConfigResourceType.Broker;
+        var brokerLogger = (sbyte)ConfigResourceType.BrokerLogger;
+
+        await Assert.That(unknown).IsEqualTo((sbyte)0);
+        await Assert.That(topic).IsEqualTo((sbyte)2);
+        await Assert.That(broker).IsEqualTo((sbyte)4);
+        await Assert.That(brokerLogger).IsEqualTo((sbyte)8);
+    }
+
+    [Test]
+    public async Task ConfigSource_HasCorrectValues()
+    {
+        var unknown = (sbyte)ConfigSource.Unknown;
+        var dynamicTopicConfig = (sbyte)ConfigSource.DynamicTopicConfig;
+        var dynamicBrokerConfig = (sbyte)ConfigSource.DynamicBrokerConfig;
+        var dynamicDefaultBrokerConfig = (sbyte)ConfigSource.DynamicDefaultBrokerConfig;
+        var staticBrokerConfig = (sbyte)ConfigSource.StaticBrokerConfig;
+        var defaultConfig = (sbyte)ConfigSource.DefaultConfig;
+        var dynamicBrokerLoggerConfig = (sbyte)ConfigSource.DynamicBrokerLoggerConfig;
+
+        await Assert.That(unknown).IsEqualTo((sbyte)0);
+        await Assert.That(dynamicTopicConfig).IsEqualTo((sbyte)1);
+        await Assert.That(dynamicBrokerConfig).IsEqualTo((sbyte)2);
+        await Assert.That(dynamicDefaultBrokerConfig).IsEqualTo((sbyte)3);
+        await Assert.That(staticBrokerConfig).IsEqualTo((sbyte)4);
+        await Assert.That(defaultConfig).IsEqualTo((sbyte)5);
+        await Assert.That(dynamicBrokerLoggerConfig).IsEqualTo((sbyte)6);
+    }
+
+    [Test]
+    public async Task ConfigAlterOperation_HasCorrectValues()
+    {
+        var set = (sbyte)ConfigAlterOperation.Set;
+        var delete = (sbyte)ConfigAlterOperation.Delete;
+        var append = (sbyte)ConfigAlterOperation.Append;
+        var subtract = (sbyte)ConfigAlterOperation.Subtract;
+
+        await Assert.That(set).IsEqualTo((sbyte)0);
+        await Assert.That(delete).IsEqualTo((sbyte)1);
+        await Assert.That(append).IsEqualTo((sbyte)2);
+        await Assert.That(subtract).IsEqualTo((sbyte)3);
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ConfigMessageEncodingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ConfigMessageEncodingTests.cs
@@ -1,0 +1,675 @@
+using System.Buffers;
+using Dekaf.Admin;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+/// <summary>
+/// Tests for config admin API protocol message encoding/decoding.
+/// </summary>
+public class ConfigMessageEncodingTests
+{
+    #region DescribeConfigs Request Tests
+
+    [Test]
+    public async Task DescribeConfigsRequest_V0_SingleTopic_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new DescribeConfigsRequest
+        {
+            Resources =
+            [
+                new DescribeConfigsResource
+                {
+                    ResourceType = (sbyte)ConfigResourceType.Topic,
+                    ResourceName = "test-topic",
+                    ConfigurationKeys = null
+                }
+            ]
+        };
+        request.Write(ref writer, version: 0);
+
+        var expected = new List<byte>();
+        // Resources array (INT32 length)
+        expected.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 });
+        // ResourceType (INT8) = 2 (Topic)
+        expected.Add(0x02);
+        // ResourceName (STRING with INT16 length prefix)
+        expected.AddRange(new byte[] { 0x00, 0x0A }); // length = 10
+        expected.AddRange("test-topic"u8.ToArray());
+        // ConfigurationKeys (nullable array, -1 for null)
+        expected.AddRange(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF });
+
+        await Assert.That(buffer.WrittenSpan.ToArray()).IsEquivalentTo(expected.ToArray());
+    }
+
+    [Test]
+    public async Task DescribeConfigsRequest_V1_WithIncludeSynonyms_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new DescribeConfigsRequest
+        {
+            Resources =
+            [
+                new DescribeConfigsResource
+                {
+                    ResourceType = (sbyte)ConfigResourceType.Broker,
+                    ResourceName = "0",
+                    ConfigurationKeys = ["log.retention.ms"]
+                }
+            ],
+            IncludeSynonyms = true
+        };
+        request.Write(ref writer, version: 1);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        // Read all values first
+        var arrayLength = reader.ReadInt32();
+        var resourceType = reader.ReadInt8();
+        var resourceName = reader.ReadString();
+        var keysLength = reader.ReadInt32();
+        var keyName = reader.ReadString();
+        var includeSynonyms = reader.ReadBoolean();
+
+        // Now do all asserts
+        await Assert.That(arrayLength).IsEqualTo(1);
+        await Assert.That(resourceType).IsEqualTo((sbyte)4); // Broker
+        await Assert.That(resourceName).IsEqualTo("0");
+        await Assert.That(keysLength).IsEqualTo(1);
+        await Assert.That(keyName).IsEqualTo("log.retention.ms");
+        await Assert.That(includeSynonyms).IsTrue();
+    }
+
+    [Test]
+    public async Task DescribeConfigsRequest_V4_Flexible_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new DescribeConfigsRequest
+        {
+            Resources =
+            [
+                new DescribeConfigsResource
+                {
+                    ResourceType = (sbyte)ConfigResourceType.Topic,
+                    ResourceName = "test",
+                    ConfigurationKeys = null
+                }
+            ],
+            IncludeSynonyms = true,
+            IncludeDocumentation = true
+        };
+        request.Write(ref writer, version: 4);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        // Read all values first
+        var arrayLength = reader.ReadUnsignedVarInt() - 1;
+        var resourceType = reader.ReadInt8();
+        var resourceName = reader.ReadCompactString();
+        var keysLength = reader.ReadUnsignedVarInt();
+        reader.SkipTaggedFields();
+        var includeSynonyms = reader.ReadBoolean();
+        var includeDocumentation = reader.ReadBoolean();
+
+        // Now do all asserts
+        await Assert.That(arrayLength).IsEqualTo(1);
+        await Assert.That(resourceType).IsEqualTo((sbyte)2); // Topic
+        await Assert.That(resourceName).IsEqualTo("test");
+        await Assert.That(keysLength).IsEqualTo(0); // null
+        await Assert.That(includeSynonyms).IsTrue();
+        await Assert.That(includeDocumentation).IsTrue();
+    }
+
+    #endregion
+
+    #region DescribeConfigs Response Tests
+
+    [Test]
+    public async Task DescribeConfigsResponse_V0_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // Results array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 });
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (STRING, null)
+        data.AddRange(new byte[] { 0xFF, 0xFF });
+        // ResourceType (INT8)
+        data.Add(0x02); // Topic
+        // ResourceName (STRING)
+        data.AddRange(new byte[] { 0x00, 0x04 }); // length = 4
+        data.AddRange("test"u8.ToArray());
+        // Configs array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 });
+        // Config entry
+        // Name (STRING)
+        data.AddRange(new byte[] { 0x00, 0x0C }); // length = 12
+        data.AddRange("retention.ms"u8.ToArray());
+        // Value (STRING)
+        data.AddRange(new byte[] { 0x00, 0x07 }); // length = 7
+        data.AddRange("6048000"u8.ToArray());
+        // ReadOnly (BOOLEAN)
+        data.Add(0x00); // false
+        // IsDefault (BOOLEAN) - v0 only
+        data.Add(0x01); // true
+        // IsSensitive (BOOLEAN)
+        data.Add(0x00); // false
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (DescribeConfigsResponse)DescribeConfigsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.Results.Count).IsEqualTo(1);
+        await Assert.That(response.Results[0].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Results[0].ResourceType).IsEqualTo((sbyte)2);
+        await Assert.That(response.Results[0].ResourceName).IsEqualTo("test");
+        await Assert.That(response.Results[0].Configs.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task DescribeConfigsResponse_V1_WithSynonyms_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x64 }); // 100ms
+        // Results array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 });
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (STRING, null)
+        data.AddRange(new byte[] { 0xFF, 0xFF });
+        // ResourceType (INT8)
+        data.Add(0x02); // Topic
+        // ResourceName (STRING)
+        data.AddRange(new byte[] { 0x00, 0x04 }); // length = 4
+        data.AddRange("test"u8.ToArray());
+        // Configs array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 });
+        // Config entry
+        // Name (STRING)
+        data.AddRange(new byte[] { 0x00, 0x0C }); // length = 12
+        data.AddRange("retention.ms"u8.ToArray());
+        // Value (STRING)
+        data.AddRange(new byte[] { 0x00, 0x07 }); // length = 7
+        data.AddRange("6048000"u8.ToArray());
+        // ReadOnly (BOOLEAN)
+        data.Add(0x00); // false
+        // ConfigSource (INT8) - v1+
+        data.Add(0x01); // DynamicTopicConfig
+        // IsSensitive (BOOLEAN)
+        data.Add(0x00); // false
+        // Synonyms array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 });
+        // Synonym entry
+        // Name (STRING)
+        data.AddRange(new byte[] { 0x00, 0x0C }); // length = 12
+        data.AddRange("retention.ms"u8.ToArray());
+        // Value (STRING)
+        data.AddRange(new byte[] { 0x00, 0x07 }); // length = 7
+        data.AddRange("6048000"u8.ToArray());
+        // Source (INT8)
+        data.Add(0x01); // DynamicTopicConfig
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (DescribeConfigsResponse)DescribeConfigsResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(100);
+        await Assert.That(response.Results[0].Configs[0].ConfigSource).IsEqualTo((sbyte)1);
+        await Assert.That(response.Results[0].Configs[0].Synonyms).IsNotNull();
+        await Assert.That(response.Results[0].Configs[0].Synonyms!.Count).IsEqualTo(1);
+        await Assert.That(response.Results[0].Configs[0].Synonyms![0].Name).IsEqualTo("retention.ms");
+    }
+
+    #endregion
+
+    #region AlterConfigs Request Tests
+
+    [Test]
+    public async Task AlterConfigsRequest_V0_SingleTopicConfig_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new AlterConfigsRequest
+        {
+            Resources =
+            [
+                new AlterConfigsResource
+                {
+                    ResourceType = (sbyte)ConfigResourceType.Topic,
+                    ResourceName = "test-topic",
+                    Configs =
+                    [
+                        new AlterableConfig { Name = "retention.ms", Value = "3600000" }
+                    ]
+                }
+            ],
+            ValidateOnly = false
+        };
+        request.Write(ref writer, version: 0);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        // Read all values first
+        var arrayLength = reader.ReadInt32();
+        var resourceType = reader.ReadInt8();
+        var resourceName = reader.ReadString();
+        var configsLength = reader.ReadInt32();
+        var configName = reader.ReadString();
+        var configValue = reader.ReadString();
+        var validateOnly = reader.ReadBoolean();
+
+        // Now do all asserts
+        await Assert.That(arrayLength).IsEqualTo(1);
+        await Assert.That(resourceType).IsEqualTo((sbyte)2); // Topic
+        await Assert.That(resourceName).IsEqualTo("test-topic");
+        await Assert.That(configsLength).IsEqualTo(1);
+        await Assert.That(configName).IsEqualTo("retention.ms");
+        await Assert.That(configValue).IsEqualTo("3600000");
+        await Assert.That(validateOnly).IsFalse();
+    }
+
+    [Test]
+    public async Task AlterConfigsRequest_V2_Flexible_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new AlterConfigsRequest
+        {
+            Resources =
+            [
+                new AlterConfigsResource
+                {
+                    ResourceType = (sbyte)ConfigResourceType.Topic,
+                    ResourceName = "test",
+                    Configs =
+                    [
+                        new AlterableConfig { Name = "cleanup.policy", Value = "compact" }
+                    ]
+                }
+            ],
+            ValidateOnly = true
+        };
+        request.Write(ref writer, version: 2);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        // Read all values first
+        var arrayLength = reader.ReadUnsignedVarInt() - 1;
+        var resourceType = reader.ReadInt8();
+        var resourceName = reader.ReadCompactString();
+        var configsLength = reader.ReadUnsignedVarInt() - 1;
+        var configName = reader.ReadCompactString();
+        var configValue = reader.ReadCompactString();
+
+        // Now do all asserts
+        await Assert.That(arrayLength).IsEqualTo(1);
+        await Assert.That(resourceType).IsEqualTo((sbyte)2); // Topic
+        await Assert.That(resourceName).IsEqualTo("test");
+        await Assert.That(configsLength).IsEqualTo(1);
+        await Assert.That(configName).IsEqualTo("cleanup.policy");
+        await Assert.That(configValue).IsEqualTo("compact");
+    }
+
+    #endregion
+
+    #region AlterConfigs Response Tests
+
+    [Test]
+    public async Task AlterConfigsResponse_V0_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // Responses array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 });
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (STRING, null)
+        data.AddRange(new byte[] { 0xFF, 0xFF });
+        // ResourceType (INT8)
+        data.Add(0x02); // Topic
+        // ResourceName (STRING)
+        data.AddRange(new byte[] { 0x00, 0x04 }); // length = 4
+        data.AddRange("test"u8.ToArray());
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (AlterConfigsResponse)AlterConfigsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.Responses.Count).IsEqualTo(1);
+        await Assert.That(response.Responses[0].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Responses[0].ResourceType).IsEqualTo((sbyte)2);
+        await Assert.That(response.Responses[0].ResourceName).IsEqualTo("test");
+    }
+
+    [Test]
+    public async Task AlterConfigsResponse_V0_WithError_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // Responses array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 });
+        // ErrorCode (INT16) - InvalidConfig = 40
+        data.AddRange(new byte[] { 0x00, 0x28 });
+        // ErrorMessage (STRING)
+        data.AddRange(new byte[] { 0x00, 0x0E }); // length = 14
+        data.AddRange("Invalid config"u8.ToArray());
+        // ResourceType (INT8)
+        data.Add(0x02); // Topic
+        // ResourceName (STRING)
+        data.AddRange(new byte[] { 0x00, 0x04 }); // length = 4
+        data.AddRange("test"u8.ToArray());
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (AlterConfigsResponse)AlterConfigsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.Responses[0].ErrorCode).IsEqualTo(ErrorCode.InvalidConfig);
+        await Assert.That(response.Responses[0].ErrorMessage).IsEqualTo("Invalid config");
+    }
+
+    #endregion
+
+    #region IncrementalAlterConfigs Request Tests
+
+    [Test]
+    public async Task IncrementalAlterConfigsRequest_V0_SetOperation_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new IncrementalAlterConfigsRequest
+        {
+            Resources =
+            [
+                new IncrementalAlterConfigsResource
+                {
+                    ResourceType = (sbyte)ConfigResourceType.Topic,
+                    ResourceName = "test-topic",
+                    Configs =
+                    [
+                        new IncrementalAlterableConfig
+                        {
+                            Name = "retention.ms",
+                            ConfigOperation = (sbyte)ConfigAlterOperation.Set,
+                            Value = "3600000"
+                        }
+                    ]
+                }
+            ],
+            ValidateOnly = false
+        };
+        request.Write(ref writer, version: 0);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        // Read all values first
+        var arrayLength = reader.ReadInt32();
+        var resourceType = reader.ReadInt8();
+        var resourceName = reader.ReadString();
+        var configsLength = reader.ReadInt32();
+        var configName = reader.ReadString();
+        var configOperation = reader.ReadInt8();
+        var configValue = reader.ReadString();
+        var validateOnly = reader.ReadBoolean();
+
+        // Now do all asserts
+        await Assert.That(arrayLength).IsEqualTo(1);
+        await Assert.That(resourceType).IsEqualTo((sbyte)2); // Topic
+        await Assert.That(resourceName).IsEqualTo("test-topic");
+        await Assert.That(configsLength).IsEqualTo(1);
+        await Assert.That(configName).IsEqualTo("retention.ms");
+        await Assert.That(configOperation).IsEqualTo((sbyte)0); // Set
+        await Assert.That(configValue).IsEqualTo("3600000");
+        await Assert.That(validateOnly).IsFalse();
+    }
+
+    [Test]
+    public async Task IncrementalAlterConfigsRequest_V0_DeleteOperation_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new IncrementalAlterConfigsRequest
+        {
+            Resources =
+            [
+                new IncrementalAlterConfigsResource
+                {
+                    ResourceType = (sbyte)ConfigResourceType.Topic,
+                    ResourceName = "test",
+                    Configs =
+                    [
+                        new IncrementalAlterableConfig
+                        {
+                            Name = "retention.ms",
+                            ConfigOperation = (sbyte)ConfigAlterOperation.Delete,
+                            Value = null
+                        }
+                    ]
+                }
+            ],
+            ValidateOnly = false
+        };
+        request.Write(ref writer, version: 0);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        // Skip to config operation and read values
+        reader.ReadInt32(); // array length
+        reader.ReadInt8(); // resource type
+        reader.ReadString(); // resource name
+        reader.ReadInt32(); // configs array length
+        reader.ReadString(); // config name
+        var configOperation = reader.ReadInt8();
+        var configValue = reader.ReadString();
+
+        // Now do all asserts
+        await Assert.That(configOperation).IsEqualTo((sbyte)1); // Delete
+        await Assert.That(configValue).IsNull();
+    }
+
+    [Test]
+    public async Task IncrementalAlterConfigsRequest_V1_Flexible_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new IncrementalAlterConfigsRequest
+        {
+            Resources =
+            [
+                new IncrementalAlterConfigsResource
+                {
+                    ResourceType = (sbyte)ConfigResourceType.Topic,
+                    ResourceName = "test",
+                    Configs =
+                    [
+                        new IncrementalAlterableConfig
+                        {
+                            Name = "cleanup.policy",
+                            ConfigOperation = (sbyte)ConfigAlterOperation.Set,
+                            Value = "compact"
+                        }
+                    ]
+                }
+            ],
+            ValidateOnly = true
+        };
+        request.Write(ref writer, version: 1);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        // Read all values first
+        var arrayLength = reader.ReadUnsignedVarInt() - 1;
+        var resourceType = reader.ReadInt8();
+        var resourceName = reader.ReadCompactString();
+        var configsLength = reader.ReadUnsignedVarInt() - 1;
+        var configName = reader.ReadCompactString();
+        var configOperation = reader.ReadInt8();
+        var configValue = reader.ReadCompactString();
+
+        // Now do all asserts
+        await Assert.That(arrayLength).IsEqualTo(1);
+        await Assert.That(resourceType).IsEqualTo((sbyte)2); // Topic
+        await Assert.That(resourceName).IsEqualTo("test");
+        await Assert.That(configsLength).IsEqualTo(1);
+        await Assert.That(configName).IsEqualTo("cleanup.policy");
+        await Assert.That(configOperation).IsEqualTo((sbyte)0); // Set
+        await Assert.That(configValue).IsEqualTo("compact");
+    }
+
+    #endregion
+
+    #region IncrementalAlterConfigs Response Tests
+
+    [Test]
+    public async Task IncrementalAlterConfigsResponse_V0_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // Responses array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 });
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (STRING, null)
+        data.AddRange(new byte[] { 0xFF, 0xFF });
+        // ResourceType (INT8)
+        data.Add(0x02); // Topic
+        // ResourceName (STRING)
+        data.AddRange(new byte[] { 0x00, 0x04 }); // length = 4
+        data.AddRange("test"u8.ToArray());
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (IncrementalAlterConfigsResponse)IncrementalAlterConfigsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.Responses.Count).IsEqualTo(1);
+        await Assert.That(response.Responses[0].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Responses[0].ResourceType).IsEqualTo((sbyte)2);
+        await Assert.That(response.Responses[0].ResourceName).IsEqualTo("test");
+    }
+
+    [Test]
+    public async Task IncrementalAlterConfigsResponse_V1_Flexible_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x32 }); // 50ms
+        // Responses COMPACT_ARRAY (length+1 = 2)
+        data.Add(0x02);
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (COMPACT_NULLABLE_STRING, null = 0)
+        data.Add(0x00);
+        // ResourceType (INT8)
+        data.Add(0x02); // Topic
+        // ResourceName (COMPACT_STRING)
+        data.Add(0x05); // length+1 = 5
+        data.AddRange("test"u8.ToArray());
+        // Tagged fields
+        data.Add(0x00);
+        // Response tagged fields
+        data.Add(0x00);
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (IncrementalAlterConfigsResponse)IncrementalAlterConfigsResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(50);
+        await Assert.That(response.Responses.Count).IsEqualTo(1);
+        await Assert.That(response.Responses[0].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Responses[0].ResourceName).IsEqualTo("test");
+    }
+
+    #endregion
+
+    #region Version Flexibility Tests
+
+    [Test]
+    [Arguments((short)0, false)]
+    [Arguments((short)1, false)]
+    [Arguments((short)2, false)]
+    [Arguments((short)3, false)]
+    [Arguments((short)4, true)]
+    public async Task DescribeConfigsRequest_FlexibilityDetection(short version, bool expectedFlexible)
+    {
+        var isFlexible = DescribeConfigsRequest.IsFlexibleVersion(version);
+        await Assert.That(isFlexible).IsEqualTo(expectedFlexible);
+    }
+
+    [Test]
+    [Arguments((short)0, false)]
+    [Arguments((short)1, false)]
+    [Arguments((short)2, true)]
+    public async Task AlterConfigsRequest_FlexibilityDetection(short version, bool expectedFlexible)
+    {
+        var isFlexible = AlterConfigsRequest.IsFlexibleVersion(version);
+        await Assert.That(isFlexible).IsEqualTo(expectedFlexible);
+    }
+
+    [Test]
+    [Arguments((short)0, false)]
+    [Arguments((short)1, true)]
+    public async Task IncrementalAlterConfigsRequest_FlexibilityDetection(short version, bool expectedFlexible)
+    {
+        var isFlexible = IncrementalAlterConfigsRequest.IsFlexibleVersion(version);
+        await Assert.That(isFlexible).IsEqualTo(expectedFlexible);
+    }
+
+    #endregion
+
+    #region Header Version Tests
+
+    [Test]
+    [Arguments((short)0, (short)1, (short)0)]
+    [Arguments((short)3, (short)1, (short)0)]
+    [Arguments((short)4, (short)2, (short)1)]
+    public async Task DescribeConfigsRequest_HeaderVersions(short apiVersion, short expectedRequestHeader, short expectedResponseHeader)
+    {
+        var requestHeaderVersion = DescribeConfigsRequest.GetRequestHeaderVersion(apiVersion);
+        var responseHeaderVersion = DescribeConfigsRequest.GetResponseHeaderVersion(apiVersion);
+
+        await Assert.That(requestHeaderVersion).IsEqualTo(expectedRequestHeader);
+        await Assert.That(responseHeaderVersion).IsEqualTo(expectedResponseHeader);
+    }
+
+    [Test]
+    [Arguments((short)0, (short)1, (short)0)]
+    [Arguments((short)1, (short)1, (short)0)]
+    [Arguments((short)2, (short)2, (short)1)]
+    public async Task AlterConfigsRequest_HeaderVersions(short apiVersion, short expectedRequestHeader, short expectedResponseHeader)
+    {
+        var requestHeaderVersion = AlterConfigsRequest.GetRequestHeaderVersion(apiVersion);
+        var responseHeaderVersion = AlterConfigsRequest.GetResponseHeaderVersion(apiVersion);
+
+        await Assert.That(requestHeaderVersion).IsEqualTo(expectedRequestHeader);
+        await Assert.That(responseHeaderVersion).IsEqualTo(expectedResponseHeader);
+    }
+
+    [Test]
+    [Arguments((short)0, (short)1, (short)0)]
+    [Arguments((short)1, (short)2, (short)1)]
+    public async Task IncrementalAlterConfigsRequest_HeaderVersions(short apiVersion, short expectedRequestHeader, short expectedResponseHeader)
+    {
+        var requestHeaderVersion = IncrementalAlterConfigsRequest.GetRequestHeaderVersion(apiVersion);
+        var responseHeaderVersion = IncrementalAlterConfigsRequest.GetResponseHeaderVersion(apiVersion);
+
+        await Assert.That(requestHeaderVersion).IsEqualTo(expectedRequestHeader);
+        await Assert.That(responseHeaderVersion).IsEqualTo(expectedResponseHeader);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Implements `DescribeConfigsAsync`, `AlterConfigsAsync`, and `IncrementalAlterConfigsAsync` in `IAdminClient`
- Adds supporting types: `ConfigResource`, `ConfigEntry`, `ConfigAlter`, and related enums
- Implements protocol request/response types for API Keys 32, 33, 44

## Changes
- New file: `src/Dekaf/Admin/ConfigTypes.cs` - Supporting types for config admin APIs
- New files: Protocol messages for DescribeConfigs, AlterConfigs, IncrementalAlterConfigs
- Modified: `src/Dekaf/Admin/IAdminClient.cs` - Added interface methods
- Modified: `src/Dekaf/Admin/AdminClient.cs` - Implemented the APIs
- New test files: Unit tests for config types and protocol message encoding

## Test plan
- [x] Unit tests for config admin API types (ConfigTypesTests.cs)
- [x] Unit tests for protocol message encoding/decoding (ConfigMessageEncodingTests.cs)
- [x] All 249 unit tests pass
- [x] Build succeeds

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)