### PR TITLE
Add ACL management admin APIs

### DIFF
--- a/src/Dekaf/Admin/Acl.cs
+++ b/src/Dekaf/Admin/Acl.cs
@@ -1,0 +1,386 @@
+namespace Dekaf.Admin;
+
+/// <summary>
+/// Represents a Kafka ACL resource type.
+/// </summary>
+public enum ResourceType : sbyte
+{
+    /// <summary>
+    /// Resource type is not known.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Matches any resource type.
+    /// </summary>
+    Any = 1,
+
+    /// <summary>
+    /// A topic resource.
+    /// </summary>
+    Topic = 2,
+
+    /// <summary>
+    /// A consumer group resource.
+    /// </summary>
+    Group = 3,
+
+    /// <summary>
+    /// The cluster resource.
+    /// </summary>
+    Cluster = 4,
+
+    /// <summary>
+    /// A transactional ID resource.
+    /// </summary>
+    TransactionalId = 5,
+
+    /// <summary>
+    /// A delegation token resource.
+    /// </summary>
+    DelegationToken = 6
+}
+
+/// <summary>
+/// Represents a Kafka ACL resource pattern type.
+/// </summary>
+public enum PatternType : sbyte
+{
+    /// <summary>
+    /// Pattern type is not known.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Matches any pattern type.
+    /// </summary>
+    Any = 1,
+
+    /// <summary>
+    /// Match patterns to find ACLs that would affect the resource.
+    /// </summary>
+    Match = 2,
+
+    /// <summary>
+    /// The resource name must match exactly.
+    /// </summary>
+    Literal = 3,
+
+    /// <summary>
+    /// The resource name is a prefix.
+    /// </summary>
+    Prefixed = 4
+}
+
+/// <summary>
+/// Represents a Kafka ACL operation.
+/// </summary>
+public enum AclOperation : sbyte
+{
+    /// <summary>
+    /// Operation is not known.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Matches any operation.
+    /// </summary>
+    Any = 1,
+
+    /// <summary>
+    /// Matches all operations.
+    /// </summary>
+    All = 2,
+
+    /// <summary>
+    /// Read operation.
+    /// </summary>
+    Read = 3,
+
+    /// <summary>
+    /// Write operation.
+    /// </summary>
+    Write = 4,
+
+    /// <summary>
+    /// Create operation.
+    /// </summary>
+    Create = 5,
+
+    /// <summary>
+    /// Delete operation.
+    /// </summary>
+    Delete = 6,
+
+    /// <summary>
+    /// Alter operation.
+    /// </summary>
+    Alter = 7,
+
+    /// <summary>
+    /// Describe operation.
+    /// </summary>
+    Describe = 8,
+
+    /// <summary>
+    /// Cluster action operation.
+    /// </summary>
+    ClusterAction = 9,
+
+    /// <summary>
+    /// Describe configs operation.
+    /// </summary>
+    DescribeConfigs = 10,
+
+    /// <summary>
+    /// Alter configs operation.
+    /// </summary>
+    AlterConfigs = 11,
+
+    /// <summary>
+    /// Idempotent write operation.
+    /// </summary>
+    IdempotentWrite = 12
+}
+
+/// <summary>
+/// Represents a Kafka ACL permission type.
+/// </summary>
+public enum AclPermissionType : sbyte
+{
+    /// <summary>
+    /// Permission type is not known.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Matches any permission type.
+    /// </summary>
+    Any = 1,
+
+    /// <summary>
+    /// Deny permission.
+    /// </summary>
+    Deny = 2,
+
+    /// <summary>
+    /// Allow permission.
+    /// </summary>
+    Allow = 3
+}
+
+/// <summary>
+/// Represents a Kafka resource pattern for ACL bindings.
+/// </summary>
+public sealed class ResourcePattern
+{
+    /// <summary>
+    /// The resource type.
+    /// </summary>
+    public required ResourceType Type { get; init; }
+
+    /// <summary>
+    /// The resource name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The pattern type.
+    /// </summary>
+    public PatternType PatternType { get; init; } = PatternType.Literal;
+
+    /// <summary>
+    /// Creates a resource pattern for a topic.
+    /// </summary>
+    public static ResourcePattern Topic(string name, PatternType patternType = PatternType.Literal) =>
+        new() { Type = ResourceType.Topic, Name = name, PatternType = patternType };
+
+    /// <summary>
+    /// Creates a resource pattern for a consumer group.
+    /// </summary>
+    public static ResourcePattern Group(string name, PatternType patternType = PatternType.Literal) =>
+        new() { Type = ResourceType.Group, Name = name, PatternType = patternType };
+
+    /// <summary>
+    /// Creates a resource pattern for the cluster.
+    /// </summary>
+    public static ResourcePattern Cluster() =>
+        new() { Type = ResourceType.Cluster, Name = "kafka-cluster", PatternType = PatternType.Literal };
+
+    /// <summary>
+    /// Creates a resource pattern for a transactional ID.
+    /// </summary>
+    public static ResourcePattern TransactionalId(string name, PatternType patternType = PatternType.Literal) =>
+        new() { Type = ResourceType.TransactionalId, Name = name, PatternType = patternType };
+}
+
+/// <summary>
+/// Represents an access control entry for ACL bindings.
+/// </summary>
+public sealed class AccessControlEntry
+{
+    /// <summary>
+    /// The principal (e.g., "User:alice").
+    /// </summary>
+    public required string Principal { get; init; }
+
+    /// <summary>
+    /// The host from which the principal is allowed/denied access.
+    /// Use "*" for all hosts.
+    /// </summary>
+    public string Host { get; init; } = "*";
+
+    /// <summary>
+    /// The operation being allowed or denied.
+    /// </summary>
+    public required AclOperation Operation { get; init; }
+
+    /// <summary>
+    /// The permission type (Allow or Deny).
+    /// </summary>
+    public required AclPermissionType Permission { get; init; }
+}
+
+/// <summary>
+/// Represents a binding of an ACL to a resource pattern.
+/// </summary>
+public sealed class AclBinding
+{
+    /// <summary>
+    /// The resource pattern this ACL applies to.
+    /// </summary>
+    public required ResourcePattern Pattern { get; init; }
+
+    /// <summary>
+    /// The access control entry.
+    /// </summary>
+    public required AccessControlEntry Entry { get; init; }
+
+    /// <summary>
+    /// Creates an ACL binding that allows the specified operation.
+    /// </summary>
+    public static AclBinding Allow(ResourcePattern pattern, string principal, AclOperation operation, string host = "*") =>
+        new()
+        {
+            Pattern = pattern,
+            Entry = new AccessControlEntry
+            {
+                Principal = principal,
+                Host = host,
+                Operation = operation,
+                Permission = AclPermissionType.Allow
+            }
+        };
+
+    /// <summary>
+    /// Creates an ACL binding that denies the specified operation.
+    /// </summary>
+    public static AclBinding Deny(ResourcePattern pattern, string principal, AclOperation operation, string host = "*") =>
+        new()
+        {
+            Pattern = pattern,
+            Entry = new AccessControlEntry
+            {
+                Principal = principal,
+                Host = host,
+                Operation = operation,
+                Permission = AclPermissionType.Deny
+            }
+        };
+}
+
+/// <summary>
+/// Filter for matching ACL bindings.
+/// </summary>
+public sealed class AclBindingFilter
+{
+    /// <summary>
+    /// The resource type to filter on, or Any to match all.
+    /// </summary>
+    public ResourceType ResourceType { get; init; } = ResourceType.Any;
+
+    /// <summary>
+    /// The resource name to filter on, or null to match all.
+    /// </summary>
+    public string? ResourceName { get; init; }
+
+    /// <summary>
+    /// The pattern type to filter on, or Any to match all.
+    /// </summary>
+    public PatternType PatternType { get; init; } = PatternType.Any;
+
+    /// <summary>
+    /// The principal to filter on, or null to match all.
+    /// </summary>
+    public string? Principal { get; init; }
+
+    /// <summary>
+    /// The host to filter on, or null to match all.
+    /// </summary>
+    public string? Host { get; init; }
+
+    /// <summary>
+    /// The operation to filter on, or Any to match all.
+    /// </summary>
+    public AclOperation Operation { get; init; } = AclOperation.Any;
+
+    /// <summary>
+    /// The permission type to filter on, or Any to match all.
+    /// </summary>
+    public AclPermissionType Permission { get; init; } = AclPermissionType.Any;
+
+    /// <summary>
+    /// Creates a filter that matches all ACLs.
+    /// </summary>
+    public static AclBindingFilter MatchAll() => new();
+
+    /// <summary>
+    /// Creates a filter for ACLs on a specific resource.
+    /// </summary>
+    public static AclBindingFilter ForResource(ResourceType resourceType, string resourceName, PatternType patternType = PatternType.Any) =>
+        new()
+        {
+            ResourceType = resourceType,
+            ResourceName = resourceName,
+            PatternType = patternType
+        };
+
+    /// <summary>
+    /// Creates a filter for ACLs for a specific principal.
+    /// </summary>
+    public static AclBindingFilter ForPrincipal(string principal) =>
+        new() { Principal = principal };
+}
+
+/// <summary>
+/// Options for CreateAcls operation.
+/// </summary>
+public sealed class CreateAclsOptions
+{
+    /// <summary>
+    /// The timeout in milliseconds for the request.
+    /// </summary>
+    public int TimeoutMs { get; init; } = 30000;
+}
+
+/// <summary>
+/// Options for DeleteAcls operation.
+/// </summary>
+public sealed class DeleteAclsOptions
+{
+    /// <summary>
+    /// The timeout in milliseconds for the request.
+    /// </summary>
+    public int TimeoutMs { get; init; } = 30000;
+}
+
+/// <summary>
+/// Options for DescribeAcls operation.
+/// </summary>
+public sealed class DescribeAclsOptions
+{
+    /// <summary>
+    /// The timeout in milliseconds for the request.
+    /// </summary>
+    public int TimeoutMs { get; init; } = 30000;
+}

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -69,6 +69,21 @@ public interface IAdminClient : IAsyncDisposable
     ValueTask CreatePartitionsAsync(IReadOnlyDictionary<string, int> newPartitionCounts, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Creates ACLs.
+    /// </summary>
+    ValueTask CreateAclsAsync(IEnumerable<AclBinding> aclBindings, CreateAclsOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes ACLs matching the specified filters.
+    /// </summary>
+    ValueTask<IReadOnlyList<AclBinding>> DeleteAclsAsync(IEnumerable<AclBindingFilter> filters, DeleteAclsOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Describes ACLs matching the specified filter.
+    /// </summary>
+    ValueTask<IReadOnlyList<AclBinding>> DescribeAclsAsync(AclBindingFilter filter, DescribeAclsOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the cluster metadata.
     /// </summary>
     ClusterMetadata Metadata { get; }

--- a/src/Dekaf/Protocol/Messages/CreateAclsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/CreateAclsRequest.cs
@@ -1,0 +1,121 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// CreateAcls request (API key 30).
+/// Creates one or more ACLs.
+/// </summary>
+public sealed class CreateAclsRequest : IKafkaRequest<CreateAclsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.CreateAcls;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 3;
+
+    /// <summary>
+    /// The ACLs to create.
+    /// </summary>
+    public required IReadOnlyList<AclCreation> Creations { get; init; }
+
+    public static bool IsFlexibleVersion(short version) => version >= 2;
+    public static short GetRequestHeaderVersion(short version) => version >= 2 ? (short)2 : (short)1;
+    public static short GetResponseHeaderVersion(short version) => version >= 2 ? (short)1 : (short)0;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 2;
+
+        if (isFlexible)
+        {
+            writer.WriteCompactArray(
+                Creations,
+                (ref KafkaProtocolWriter w, AclCreation c) => c.Write(ref w, version));
+        }
+        else
+        {
+            writer.WriteArray(
+                Creations,
+                (ref KafkaProtocolWriter w, AclCreation c) => c.Write(ref w, version));
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}
+
+/// <summary>
+/// An ACL creation entry.
+/// </summary>
+public sealed class AclCreation
+{
+    /// <summary>
+    /// The resource type.
+    /// </summary>
+    public sbyte ResourceType { get; init; }
+
+    /// <summary>
+    /// The resource name.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>
+    /// The resource pattern type (v1+).
+    /// </summary>
+    public sbyte ResourcePatternType { get; init; } = 3; // Literal
+
+    /// <summary>
+    /// The principal.
+    /// </summary>
+    public required string Principal { get; init; }
+
+    /// <summary>
+    /// The host.
+    /// </summary>
+    public required string Host { get; init; }
+
+    /// <summary>
+    /// The operation.
+    /// </summary>
+    public sbyte Operation { get; init; }
+
+    /// <summary>
+    /// The permission type.
+    /// </summary>
+    public sbyte PermissionType { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 2;
+
+        writer.WriteInt8(ResourceType);
+
+        if (isFlexible)
+            writer.WriteCompactString(ResourceName);
+        else
+            writer.WriteString(ResourceName);
+
+        if (version >= 1)
+        {
+            writer.WriteInt8(ResourcePatternType);
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteCompactString(Principal);
+            writer.WriteCompactString(Host);
+        }
+        else
+        {
+            writer.WriteString(Principal);
+            writer.WriteString(Host);
+        }
+
+        writer.WriteInt8(Operation);
+        writer.WriteInt8(PermissionType);
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}

--- a/src/Dekaf/Protocol/Messages/CreateAclsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/CreateAclsResponse.cs
@@ -1,0 +1,92 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// CreateAcls response (API key 30).
+/// Contains the results of ACL creation requests.
+/// </summary>
+public sealed class CreateAclsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.CreateAcls;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 3;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The results for each ACL creation.
+    /// </summary>
+    public required IReadOnlyList<AclCreationResult> Results { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        var throttleTimeMs = reader.ReadInt32();
+
+        IReadOnlyList<AclCreationResult> results;
+        if (isFlexible)
+        {
+            results = reader.ReadCompactArray(
+                (ref KafkaProtocolReader r) => AclCreationResult.Read(ref r, version)) ?? [];
+        }
+        else
+        {
+            results = reader.ReadArray(
+                (ref KafkaProtocolReader r) => AclCreationResult.Read(ref r, version)) ?? [];
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new CreateAclsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            Results = results
+        };
+    }
+}
+
+/// <summary>
+/// The result of an ACL creation.
+/// </summary>
+public sealed class AclCreationResult
+{
+    /// <summary>
+    /// The error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    public static AclCreationResult Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        string? errorMessage;
+        if (isFlexible)
+            errorMessage = reader.ReadCompactString();
+        else
+            errorMessage = reader.ReadString();
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new AclCreationResult
+        {
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DeleteAclsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/DeleteAclsRequest.cs
@@ -1,0 +1,121 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DeleteAcls request (API key 31).
+/// Deletes ACLs matching the specified filters.
+/// </summary>
+public sealed class DeleteAclsRequest : IKafkaRequest<DeleteAclsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.DeleteAcls;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 3;
+
+    /// <summary>
+    /// The filters to use when deleting ACLs.
+    /// </summary>
+    public required IReadOnlyList<DeleteAclsFilter> Filters { get; init; }
+
+    public static bool IsFlexibleVersion(short version) => version >= 2;
+    public static short GetRequestHeaderVersion(short version) => version >= 2 ? (short)2 : (short)1;
+    public static short GetResponseHeaderVersion(short version) => version >= 2 ? (short)1 : (short)0;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 2;
+
+        if (isFlexible)
+        {
+            writer.WriteCompactArray(
+                Filters,
+                (ref KafkaProtocolWriter w, DeleteAclsFilter f) => f.Write(ref w, version));
+        }
+        else
+        {
+            writer.WriteArray(
+                Filters,
+                (ref KafkaProtocolWriter w, DeleteAclsFilter f) => f.Write(ref w, version));
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}
+
+/// <summary>
+/// A filter for deleting ACLs.
+/// </summary>
+public sealed class DeleteAclsFilter
+{
+    /// <summary>
+    /// The resource type to filter on.
+    /// </summary>
+    public sbyte ResourceTypeFilter { get; init; }
+
+    /// <summary>
+    /// The resource name to filter on, or null for any.
+    /// </summary>
+    public string? ResourceNameFilter { get; init; }
+
+    /// <summary>
+    /// The pattern type to filter on (v1+).
+    /// </summary>
+    public sbyte PatternTypeFilter { get; init; } = 1; // Any
+
+    /// <summary>
+    /// The principal to filter on, or null for any.
+    /// </summary>
+    public string? PrincipalFilter { get; init; }
+
+    /// <summary>
+    /// The host to filter on, or null for any.
+    /// </summary>
+    public string? HostFilter { get; init; }
+
+    /// <summary>
+    /// The operation to filter on.
+    /// </summary>
+    public sbyte Operation { get; init; }
+
+    /// <summary>
+    /// The permission type to filter on.
+    /// </summary>
+    public sbyte PermissionType { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 2;
+
+        writer.WriteInt8(ResourceTypeFilter);
+
+        if (isFlexible)
+            writer.WriteCompactNullableString(ResourceNameFilter);
+        else
+            writer.WriteString(ResourceNameFilter);
+
+        if (version >= 1)
+        {
+            writer.WriteInt8(PatternTypeFilter);
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteCompactNullableString(PrincipalFilter);
+            writer.WriteCompactNullableString(HostFilter);
+        }
+        else
+        {
+            writer.WriteString(PrincipalFilter);
+            writer.WriteString(HostFilter);
+        }
+
+        writer.WriteInt8(Operation);
+        writer.WriteInt8(PermissionType);
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DeleteAclsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DeleteAclsResponse.cs
@@ -1,0 +1,218 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DeleteAcls response (API key 31).
+/// Contains the results of ACL deletion requests.
+/// </summary>
+public sealed class DeleteAclsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.DeleteAcls;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 3;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The results for each filter.
+    /// </summary>
+    public required IReadOnlyList<DeleteAclsFilterResult> FilterResults { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        var throttleTimeMs = reader.ReadInt32();
+
+        IReadOnlyList<DeleteAclsFilterResult> filterResults;
+        if (isFlexible)
+        {
+            filterResults = reader.ReadCompactArray(
+                (ref KafkaProtocolReader r) => DeleteAclsFilterResult.Read(ref r, version)) ?? [];
+        }
+        else
+        {
+            filterResults = reader.ReadArray(
+                (ref KafkaProtocolReader r) => DeleteAclsFilterResult.Read(ref r, version)) ?? [];
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DeleteAclsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            FilterResults = filterResults
+        };
+    }
+}
+
+/// <summary>
+/// The result of a delete ACL filter.
+/// </summary>
+public sealed class DeleteAclsFilterResult
+{
+    /// <summary>
+    /// The error code, or 0 if the filter was a success.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if the filter was a success.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The ACLs that were deleted.
+    /// </summary>
+    public required IReadOnlyList<DeleteAclsMatchingAcl> MatchingAcls { get; init; }
+
+    public static DeleteAclsFilterResult Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        string? errorMessage;
+        if (isFlexible)
+            errorMessage = reader.ReadCompactString();
+        else
+            errorMessage = reader.ReadString();
+
+        IReadOnlyList<DeleteAclsMatchingAcl> matchingAcls;
+        if (isFlexible)
+        {
+            matchingAcls = reader.ReadCompactArray(
+                (ref KafkaProtocolReader r) => DeleteAclsMatchingAcl.Read(ref r, version)) ?? [];
+        }
+        else
+        {
+            matchingAcls = reader.ReadArray(
+                (ref KafkaProtocolReader r) => DeleteAclsMatchingAcl.Read(ref r, version)) ?? [];
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DeleteAclsFilterResult
+        {
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            MatchingAcls = matchingAcls
+        };
+    }
+}
+
+/// <summary>
+/// An ACL that was deleted by a filter.
+/// </summary>
+public sealed class DeleteAclsMatchingAcl
+{
+    /// <summary>
+    /// The deletion error code, or 0 if the deletion succeeded.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The deletion error message, or null if the deletion succeeded.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The resource type.
+    /// </summary>
+    public sbyte ResourceType { get; init; }
+
+    /// <summary>
+    /// The resource name.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>
+    /// The resource pattern type (v1+).
+    /// </summary>
+    public sbyte PatternType { get; init; } = 3; // Literal
+
+    /// <summary>
+    /// The principal.
+    /// </summary>
+    public required string Principal { get; init; }
+
+    /// <summary>
+    /// The host.
+    /// </summary>
+    public required string Host { get; init; }
+
+    /// <summary>
+    /// The operation.
+    /// </summary>
+    public sbyte Operation { get; init; }
+
+    /// <summary>
+    /// The permission type.
+    /// </summary>
+    public sbyte PermissionType { get; init; }
+
+    public static DeleteAclsMatchingAcl Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        string? errorMessage;
+        if (isFlexible)
+            errorMessage = reader.ReadCompactString();
+        else
+            errorMessage = reader.ReadString();
+
+        var resourceType = reader.ReadInt8();
+
+        string resourceName;
+        if (isFlexible)
+            resourceName = reader.ReadCompactString() ?? string.Empty;
+        else
+            resourceName = reader.ReadString() ?? string.Empty;
+
+        var patternType = version >= 1 ? reader.ReadInt8() : (sbyte)3;
+
+        string principal;
+        string host;
+        if (isFlexible)
+        {
+            principal = reader.ReadCompactString() ?? string.Empty;
+            host = reader.ReadCompactString() ?? string.Empty;
+        }
+        else
+        {
+            principal = reader.ReadString() ?? string.Empty;
+            host = reader.ReadString() ?? string.Empty;
+        }
+
+        var operation = reader.ReadInt8();
+        var permissionType = reader.ReadInt8();
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DeleteAclsMatchingAcl
+        {
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            ResourceType = resourceType,
+            ResourceName = resourceName,
+            PatternType = patternType,
+            Principal = principal,
+            Host = host,
+            Operation = operation,
+            PermissionType = permissionType
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DescribeAclsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeAclsRequest.cs
@@ -1,0 +1,87 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DescribeAcls request (API key 29).
+/// Describes ACLs matching the specified filter.
+/// </summary>
+public sealed class DescribeAclsRequest : IKafkaRequest<DescribeAclsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.DescribeAcls;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 3;
+
+    /// <summary>
+    /// The resource type to filter on.
+    /// </summary>
+    public sbyte ResourceTypeFilter { get; init; }
+
+    /// <summary>
+    /// The resource name to filter on, or null for any.
+    /// </summary>
+    public string? ResourceNameFilter { get; init; }
+
+    /// <summary>
+    /// The pattern type to filter on (v1+).
+    /// </summary>
+    public sbyte PatternTypeFilter { get; init; } = 3; // Literal
+
+    /// <summary>
+    /// The principal to filter on, or null for any.
+    /// </summary>
+    public string? PrincipalFilter { get; init; }
+
+    /// <summary>
+    /// The host to filter on, or null for any.
+    /// </summary>
+    public string? HostFilter { get; init; }
+
+    /// <summary>
+    /// The operation to filter on.
+    /// </summary>
+    public sbyte Operation { get; init; }
+
+    /// <summary>
+    /// The permission type to filter on.
+    /// </summary>
+    public sbyte PermissionType { get; init; }
+
+    public static bool IsFlexibleVersion(short version) => version >= 2;
+    public static short GetRequestHeaderVersion(short version) => version >= 2 ? (short)2 : (short)1;
+    public static short GetResponseHeaderVersion(short version) => version >= 2 ? (short)1 : (short)0;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 2;
+
+        writer.WriteInt8(ResourceTypeFilter);
+
+        if (isFlexible)
+            writer.WriteCompactNullableString(ResourceNameFilter);
+        else
+            writer.WriteString(ResourceNameFilter);
+
+        if (version >= 1)
+        {
+            writer.WriteInt8(PatternTypeFilter);
+        }
+
+        if (isFlexible)
+        {
+            writer.WriteCompactNullableString(PrincipalFilter);
+            writer.WriteCompactNullableString(HostFilter);
+        }
+        else
+        {
+            writer.WriteString(PrincipalFilter);
+            writer.WriteString(HostFilter);
+        }
+
+        writer.WriteInt8(Operation);
+        writer.WriteInt8(PermissionType);
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DescribeAclsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeAclsResponse.cs
@@ -1,0 +1,198 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DescribeAcls response (API key 29).
+/// Contains the ACLs matching the filter.
+/// </summary>
+public sealed class DescribeAclsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.DescribeAcls;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 3;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The resources and their associated ACLs.
+    /// </summary>
+    public required IReadOnlyList<DescribeAclsResource> Resources { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        string? errorMessage;
+        if (isFlexible)
+            errorMessage = reader.ReadCompactString();
+        else
+            errorMessage = reader.ReadString();
+
+        IReadOnlyList<DescribeAclsResource> resources;
+        if (isFlexible)
+        {
+            resources = reader.ReadCompactArray(
+                (ref KafkaProtocolReader r) => DescribeAclsResource.Read(ref r, version)) ?? [];
+        }
+        else
+        {
+            resources = reader.ReadArray(
+                (ref KafkaProtocolReader r) => DescribeAclsResource.Read(ref r, version)) ?? [];
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DescribeAclsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            Resources = resources
+        };
+    }
+}
+
+/// <summary>
+/// A resource with its associated ACLs.
+/// </summary>
+public sealed class DescribeAclsResource
+{
+    /// <summary>
+    /// The resource type.
+    /// </summary>
+    public sbyte ResourceType { get; init; }
+
+    /// <summary>
+    /// The resource name.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>
+    /// The resource pattern type (v1+).
+    /// </summary>
+    public sbyte PatternType { get; init; } = 3; // Literal
+
+    /// <summary>
+    /// The ACLs associated with this resource.
+    /// </summary>
+    public required IReadOnlyList<AclDescription> Acls { get; init; }
+
+    public static DescribeAclsResource Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        var resourceType = reader.ReadInt8();
+
+        string resourceName;
+        if (isFlexible)
+            resourceName = reader.ReadCompactString() ?? string.Empty;
+        else
+            resourceName = reader.ReadString() ?? string.Empty;
+
+        var patternType = version >= 1 ? reader.ReadInt8() : (sbyte)3;
+
+        IReadOnlyList<AclDescription> acls;
+        if (isFlexible)
+        {
+            acls = reader.ReadCompactArray(
+                (ref KafkaProtocolReader r) => AclDescription.Read(ref r, version)) ?? [];
+        }
+        else
+        {
+            acls = reader.ReadArray(
+                (ref KafkaProtocolReader r) => AclDescription.Read(ref r, version)) ?? [];
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DescribeAclsResource
+        {
+            ResourceType = resourceType,
+            ResourceName = resourceName,
+            PatternType = patternType,
+            Acls = acls
+        };
+    }
+}
+
+/// <summary>
+/// An ACL description.
+/// </summary>
+public sealed class AclDescription
+{
+    /// <summary>
+    /// The principal.
+    /// </summary>
+    public required string Principal { get; init; }
+
+    /// <summary>
+    /// The host.
+    /// </summary>
+    public required string Host { get; init; }
+
+    /// <summary>
+    /// The operation.
+    /// </summary>
+    public sbyte Operation { get; init; }
+
+    /// <summary>
+    /// The permission type.
+    /// </summary>
+    public sbyte PermissionType { get; init; }
+
+    public static AclDescription Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        string principal;
+        string host;
+
+        if (isFlexible)
+        {
+            principal = reader.ReadCompactString() ?? string.Empty;
+            host = reader.ReadCompactString() ?? string.Empty;
+        }
+        else
+        {
+            principal = reader.ReadString() ?? string.Empty;
+            host = reader.ReadString() ?? string.Empty;
+        }
+
+        var operation = reader.ReadInt8();
+        var permissionType = reader.ReadInt8();
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new AclDescription
+        {
+            Principal = principal,
+            Host = host,
+            Operation = operation,
+            PermissionType = permissionType
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AclTypesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AclTypesTests.cs
@@ -1,0 +1,263 @@
+using Dekaf.Admin;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+/// <summary>
+/// Tests for ACL types and helper methods.
+/// </summary>
+public class AclTypesTests
+{
+    #region ResourcePattern Tests
+
+    [Test]
+    public async Task ResourcePattern_Topic_CreatesCorrectPattern()
+    {
+        var pattern = ResourcePattern.Topic("my-topic");
+
+        await Assert.That(pattern.Type).IsEqualTo(ResourceType.Topic);
+        await Assert.That(pattern.Name).IsEqualTo("my-topic");
+        await Assert.That(pattern.PatternType).IsEqualTo(PatternType.Literal);
+    }
+
+    [Test]
+    public async Task ResourcePattern_Topic_WithPrefixedPattern()
+    {
+        var pattern = ResourcePattern.Topic("my-prefix", PatternType.Prefixed);
+
+        await Assert.That(pattern.Type).IsEqualTo(ResourceType.Topic);
+        await Assert.That(pattern.Name).IsEqualTo("my-prefix");
+        await Assert.That(pattern.PatternType).IsEqualTo(PatternType.Prefixed);
+    }
+
+    [Test]
+    public async Task ResourcePattern_Group_CreatesCorrectPattern()
+    {
+        var pattern = ResourcePattern.Group("my-group");
+
+        await Assert.That(pattern.Type).IsEqualTo(ResourceType.Group);
+        await Assert.That(pattern.Name).IsEqualTo("my-group");
+        await Assert.That(pattern.PatternType).IsEqualTo(PatternType.Literal);
+    }
+
+    [Test]
+    public async Task ResourcePattern_Cluster_CreatesCorrectPattern()
+    {
+        var pattern = ResourcePattern.Cluster();
+
+        await Assert.That(pattern.Type).IsEqualTo(ResourceType.Cluster);
+        await Assert.That(pattern.Name).IsEqualTo("kafka-cluster");
+        await Assert.That(pattern.PatternType).IsEqualTo(PatternType.Literal);
+    }
+
+    [Test]
+    public async Task ResourcePattern_TransactionalId_CreatesCorrectPattern()
+    {
+        var pattern = ResourcePattern.TransactionalId("my-tx-id");
+
+        await Assert.That(pattern.Type).IsEqualTo(ResourceType.TransactionalId);
+        await Assert.That(pattern.Name).IsEqualTo("my-tx-id");
+        await Assert.That(pattern.PatternType).IsEqualTo(PatternType.Literal);
+    }
+
+    #endregion
+
+    #region AclBinding Tests
+
+    [Test]
+    public async Task AclBinding_Allow_CreatesAllowBinding()
+    {
+        var binding = AclBinding.Allow(
+            ResourcePattern.Topic("my-topic"),
+            "User:alice",
+            AclOperation.Read);
+
+        await Assert.That(binding.Pattern.Type).IsEqualTo(ResourceType.Topic);
+        await Assert.That(binding.Pattern.Name).IsEqualTo("my-topic");
+        await Assert.That(binding.Entry.Principal).IsEqualTo("User:alice");
+        await Assert.That(binding.Entry.Host).IsEqualTo("*");
+        await Assert.That(binding.Entry.Operation).IsEqualTo(AclOperation.Read);
+        await Assert.That(binding.Entry.Permission).IsEqualTo(AclPermissionType.Allow);
+    }
+
+    [Test]
+    public async Task AclBinding_Allow_WithCustomHost()
+    {
+        var binding = AclBinding.Allow(
+            ResourcePattern.Topic("my-topic"),
+            "User:alice",
+            AclOperation.Write,
+            "192.168.1.100");
+
+        await Assert.That(binding.Entry.Host).IsEqualTo("192.168.1.100");
+    }
+
+    [Test]
+    public async Task AclBinding_Deny_CreatesDenyBinding()
+    {
+        var binding = AclBinding.Deny(
+            ResourcePattern.Topic("sensitive-topic"),
+            "User:bob",
+            AclOperation.Read);
+
+        await Assert.That(binding.Entry.Permission).IsEqualTo(AclPermissionType.Deny);
+        await Assert.That(binding.Entry.Operation).IsEqualTo(AclOperation.Read);
+    }
+
+    #endregion
+
+    #region AclBindingFilter Tests
+
+    [Test]
+    public async Task AclBindingFilter_MatchAll_CreatesDefaultFilter()
+    {
+        var filter = AclBindingFilter.MatchAll();
+
+        await Assert.That(filter.ResourceType).IsEqualTo(ResourceType.Any);
+        await Assert.That(filter.ResourceName).IsNull();
+        await Assert.That(filter.PatternType).IsEqualTo(PatternType.Any);
+        await Assert.That(filter.Principal).IsNull();
+        await Assert.That(filter.Host).IsNull();
+        await Assert.That(filter.Operation).IsEqualTo(AclOperation.Any);
+        await Assert.That(filter.Permission).IsEqualTo(AclPermissionType.Any);
+    }
+
+    [Test]
+    public async Task AclBindingFilter_ForResource_CreatesResourceFilter()
+    {
+        var filter = AclBindingFilter.ForResource(ResourceType.Topic, "my-topic");
+
+        await Assert.That(filter.ResourceType).IsEqualTo(ResourceType.Topic);
+        await Assert.That(filter.ResourceName).IsEqualTo("my-topic");
+        await Assert.That(filter.PatternType).IsEqualTo(PatternType.Any);
+    }
+
+    [Test]
+    public async Task AclBindingFilter_ForResource_WithPatternType()
+    {
+        var filter = AclBindingFilter.ForResource(ResourceType.Topic, "my-prefix", PatternType.Prefixed);
+
+        await Assert.That(filter.PatternType).IsEqualTo(PatternType.Prefixed);
+    }
+
+    [Test]
+    public async Task AclBindingFilter_ForPrincipal_CreatesPrincipalFilter()
+    {
+        var filter = AclBindingFilter.ForPrincipal("User:alice");
+
+        await Assert.That(filter.Principal).IsEqualTo("User:alice");
+        await Assert.That(filter.ResourceType).IsEqualTo(ResourceType.Any);
+    }
+
+    #endregion
+
+    #region Enum Value Tests
+
+    [Test]
+    public async Task ResourceType_EnumValues_AreCorrect()
+    {
+        var unknown = ResourceType.Unknown;
+        var any = ResourceType.Any;
+        var topic = ResourceType.Topic;
+        var group = ResourceType.Group;
+        var cluster = ResourceType.Cluster;
+        var transactionalId = ResourceType.TransactionalId;
+        var delegationToken = ResourceType.DelegationToken;
+
+        await Assert.That((sbyte)unknown).IsEqualTo((sbyte)0);
+        await Assert.That((sbyte)any).IsEqualTo((sbyte)1);
+        await Assert.That((sbyte)topic).IsEqualTo((sbyte)2);
+        await Assert.That((sbyte)group).IsEqualTo((sbyte)3);
+        await Assert.That((sbyte)cluster).IsEqualTo((sbyte)4);
+        await Assert.That((sbyte)transactionalId).IsEqualTo((sbyte)5);
+        await Assert.That((sbyte)delegationToken).IsEqualTo((sbyte)6);
+    }
+
+    [Test]
+    public async Task PatternType_EnumValues_AreCorrect()
+    {
+        var unknown = PatternType.Unknown;
+        var any = PatternType.Any;
+        var match = PatternType.Match;
+        var literal = PatternType.Literal;
+        var prefixed = PatternType.Prefixed;
+
+        await Assert.That((sbyte)unknown).IsEqualTo((sbyte)0);
+        await Assert.That((sbyte)any).IsEqualTo((sbyte)1);
+        await Assert.That((sbyte)match).IsEqualTo((sbyte)2);
+        await Assert.That((sbyte)literal).IsEqualTo((sbyte)3);
+        await Assert.That((sbyte)prefixed).IsEqualTo((sbyte)4);
+    }
+
+    [Test]
+    public async Task AclOperation_EnumValues_AreCorrect()
+    {
+        var unknown = AclOperation.Unknown;
+        var any = AclOperation.Any;
+        var all = AclOperation.All;
+        var read = AclOperation.Read;
+        var write = AclOperation.Write;
+        var create = AclOperation.Create;
+        var delete = AclOperation.Delete;
+        var alter = AclOperation.Alter;
+        var describe = AclOperation.Describe;
+        var clusterAction = AclOperation.ClusterAction;
+        var describeConfigs = AclOperation.DescribeConfigs;
+        var alterConfigs = AclOperation.AlterConfigs;
+        var idempotentWrite = AclOperation.IdempotentWrite;
+
+        await Assert.That((sbyte)unknown).IsEqualTo((sbyte)0);
+        await Assert.That((sbyte)any).IsEqualTo((sbyte)1);
+        await Assert.That((sbyte)all).IsEqualTo((sbyte)2);
+        await Assert.That((sbyte)read).IsEqualTo((sbyte)3);
+        await Assert.That((sbyte)write).IsEqualTo((sbyte)4);
+        await Assert.That((sbyte)create).IsEqualTo((sbyte)5);
+        await Assert.That((sbyte)delete).IsEqualTo((sbyte)6);
+        await Assert.That((sbyte)alter).IsEqualTo((sbyte)7);
+        await Assert.That((sbyte)describe).IsEqualTo((sbyte)8);
+        await Assert.That((sbyte)clusterAction).IsEqualTo((sbyte)9);
+        await Assert.That((sbyte)describeConfigs).IsEqualTo((sbyte)10);
+        await Assert.That((sbyte)alterConfigs).IsEqualTo((sbyte)11);
+        await Assert.That((sbyte)idempotentWrite).IsEqualTo((sbyte)12);
+    }
+
+    [Test]
+    public async Task AclPermissionType_EnumValues_AreCorrect()
+    {
+        var unknown = AclPermissionType.Unknown;
+        var any = AclPermissionType.Any;
+        var deny = AclPermissionType.Deny;
+        var allow = AclPermissionType.Allow;
+
+        await Assert.That((sbyte)unknown).IsEqualTo((sbyte)0);
+        await Assert.That((sbyte)any).IsEqualTo((sbyte)1);
+        await Assert.That((sbyte)deny).IsEqualTo((sbyte)2);
+        await Assert.That((sbyte)allow).IsEqualTo((sbyte)3);
+    }
+
+    #endregion
+
+    #region Options Tests
+
+    [Test]
+    public async Task CreateAclsOptions_HasDefaultTimeout()
+    {
+        var options = new CreateAclsOptions();
+        await Assert.That(options.TimeoutMs).IsEqualTo(30000);
+    }
+
+    [Test]
+    public async Task DeleteAclsOptions_HasDefaultTimeout()
+    {
+        var options = new DeleteAclsOptions();
+        await Assert.That(options.TimeoutMs).IsEqualTo(30000);
+    }
+
+    [Test]
+    public async Task DescribeAclsOptions_HasDefaultTimeout()
+    {
+        var options = new DescribeAclsOptions();
+        await Assert.That(options.TimeoutMs).IsEqualTo(30000);
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/AclMessageEncodingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/AclMessageEncodingTests.cs
@@ -1,0 +1,703 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+/// <summary>
+/// Tests for ACL protocol message encoding/decoding.
+/// </summary>
+public class AclMessageEncodingTests
+{
+    #region DescribeAcls Request Tests
+
+    [Test]
+    public async Task DescribeAclsRequest_V0_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new DescribeAclsRequest
+        {
+            ResourceTypeFilter = 2, // Topic
+            ResourceNameFilter = "my-topic",
+            PrincipalFilter = "User:alice",
+            HostFilter = "*",
+            Operation = 3, // Read
+            PermissionType = 3 // Allow
+        };
+        request.Write(ref writer, version: 0);
+
+        var expected = new List<byte>();
+        // ResourceTypeFilter (INT8)
+        expected.Add(0x02);
+        // ResourceNameFilter (STRING with INT16 length prefix)
+        expected.AddRange(new byte[] { 0x00, 0x08 }); // length = 8
+        expected.AddRange("my-topic"u8.ToArray());
+        // PrincipalFilter (STRING)
+        expected.AddRange(new byte[] { 0x00, 0x0A }); // length = 10
+        expected.AddRange("User:alice"u8.ToArray());
+        // HostFilter (STRING)
+        expected.AddRange(new byte[] { 0x00, 0x01 }); // length = 1
+        expected.Add((byte)'*');
+        // Operation (INT8)
+        expected.Add(0x03);
+        // PermissionType (INT8)
+        expected.Add(0x03);
+
+        await Assert.That(buffer.WrittenSpan.ToArray()).IsEquivalentTo(expected.ToArray());
+    }
+
+    [Test]
+    public async Task DescribeAclsRequest_V1_WithPatternType()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new DescribeAclsRequest
+        {
+            ResourceTypeFilter = 2, // Topic
+            ResourceNameFilter = "my-topic",
+            PatternTypeFilter = 4, // Prefixed
+            PrincipalFilter = null,
+            HostFilter = null,
+            Operation = 1, // Any
+            PermissionType = 1 // Any
+        };
+        request.Write(ref writer, version: 1);
+
+        // Parse the written data to verify
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        var resourceType = reader.ReadInt8();
+        var resourceName = reader.ReadString();
+        var patternType = reader.ReadInt8();
+        var principal = reader.ReadString();
+        var host = reader.ReadString();
+        var operation = reader.ReadInt8();
+        var permissionType = reader.ReadInt8();
+
+        await Assert.That(resourceType).IsEqualTo((sbyte)2);
+        await Assert.That(resourceName).IsEqualTo("my-topic");
+        await Assert.That(patternType).IsEqualTo((sbyte)4);
+        await Assert.That(principal).IsNull();
+        await Assert.That(host).IsNull();
+        await Assert.That(operation).IsEqualTo((sbyte)1);
+        await Assert.That(permissionType).IsEqualTo((sbyte)1);
+    }
+
+    [Test]
+    public async Task DescribeAclsRequest_V2_Flexible()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new DescribeAclsRequest
+        {
+            ResourceTypeFilter = 3, // Group
+            ResourceNameFilter = "my-group",
+            PatternTypeFilter = 3, // Literal
+            PrincipalFilter = "User:bob",
+            HostFilter = "192.168.1.1",
+            Operation = 3, // Read
+            PermissionType = 3 // Allow
+        };
+        request.Write(ref writer, version: 2);
+
+        // Parse to verify
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        var resourceType = reader.ReadInt8();
+        var resourceName = reader.ReadCompactString();
+        var patternType = reader.ReadInt8();
+        var principal = reader.ReadCompactString();
+        var host = reader.ReadCompactString();
+        var operation = reader.ReadInt8();
+        var permissionType = reader.ReadInt8();
+        reader.SkipTaggedFields();
+
+        await Assert.That(resourceType).IsEqualTo((sbyte)3);
+        await Assert.That(resourceName).IsEqualTo("my-group");
+        await Assert.That(patternType).IsEqualTo((sbyte)3);
+        await Assert.That(principal).IsEqualTo("User:bob");
+        await Assert.That(host).IsEqualTo("192.168.1.1");
+        await Assert.That(operation).IsEqualTo((sbyte)3);
+        await Assert.That(permissionType).IsEqualTo((sbyte)3);
+    }
+
+    #endregion
+
+    #region DescribeAcls Response Tests
+
+    [Test]
+    public async Task DescribeAclsResponse_V0_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (nullable STRING)
+        data.AddRange(new byte[] { 0xFF, 0xFF }); // null
+        // Resources array (INT32 length + entries)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // 1 entry
+        // Resource entry:
+        // ResourceType (INT8)
+        data.Add(0x02); // Topic
+        // ResourceName (STRING)
+        data.AddRange(new byte[] { 0x00, 0x05 });
+        data.AddRange("topic"u8.ToArray());
+        // ACLs array
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // 1 ACL
+        // ACL entry:
+        // Principal (STRING)
+        data.AddRange(new byte[] { 0x00, 0x0A });
+        data.AddRange("User:alice"u8.ToArray());
+        // Host (STRING)
+        data.AddRange(new byte[] { 0x00, 0x01 });
+        data.Add((byte)'*');
+        // Operation (INT8)
+        data.Add(0x03); // Read
+        // PermissionType (INT8)
+        data.Add(0x03); // Allow
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (DescribeAclsResponse)DescribeAclsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Resources.Count).IsEqualTo(1);
+        await Assert.That(response.Resources[0].ResourceType).IsEqualTo((sbyte)2);
+        await Assert.That(response.Resources[0].ResourceName).IsEqualTo("topic");
+        await Assert.That(response.Resources[0].Acls.Count).IsEqualTo(1);
+        await Assert.That(response.Resources[0].Acls[0].Principal).IsEqualTo("User:alice");
+        await Assert.That(response.Resources[0].Acls[0].Host).IsEqualTo("*");
+        await Assert.That(response.Resources[0].Acls[0].Operation).IsEqualTo((sbyte)3);
+        await Assert.That(response.Resources[0].Acls[0].PermissionType).IsEqualTo((sbyte)3);
+    }
+
+    [Test]
+    public async Task DescribeAclsResponse_V2_Flexible_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x64 }); // 100ms
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (COMPACT_NULLABLE_STRING)
+        data.Add(0x00); // null
+        // Resources COMPACT_ARRAY (length+1 = 2, so 1 entry)
+        data.Add(0x02);
+        // Resource entry:
+        // ResourceType (INT8)
+        data.Add(0x02); // Topic
+        // ResourceName (COMPACT_STRING)
+        data.Add(0x06); // length+1 = 6
+        data.AddRange("topic"u8.ToArray());
+        // PatternType (INT8) - v1+
+        data.Add(0x03); // Literal
+        // ACLs COMPACT_ARRAY
+        data.Add(0x02); // 1 ACL
+        // ACL entry:
+        // Principal (COMPACT_STRING)
+        data.Add(0x0B); // length+1 = 11
+        data.AddRange("User:alice"u8.ToArray());
+        // Host (COMPACT_STRING)
+        data.Add(0x02);
+        data.Add((byte)'*');
+        // Operation (INT8)
+        data.Add(0x03); // Read
+        // PermissionType (INT8)
+        data.Add(0x03); // Allow
+        // ACL tagged fields
+        data.Add(0x00);
+        // Resource tagged fields
+        data.Add(0x00);
+        // Response tagged fields
+        data.Add(0x00);
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (DescribeAclsResponse)DescribeAclsResponse.Read(ref reader, version: 2);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(100);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Resources.Count).IsEqualTo(1);
+        await Assert.That(response.Resources[0].ResourceType).IsEqualTo((sbyte)2);
+        await Assert.That(response.Resources[0].PatternType).IsEqualTo((sbyte)3);
+        await Assert.That(response.Resources[0].Acls[0].Principal).IsEqualTo("User:alice");
+    }
+
+    #endregion
+
+    #region CreateAcls Request Tests
+
+    [Test]
+    public async Task CreateAclsRequest_V0_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new CreateAclsRequest
+        {
+            Creations =
+            [
+                new AclCreation
+                {
+                    ResourceType = 2, // Topic
+                    ResourceName = "my-topic",
+                    Principal = "User:alice",
+                    Host = "*",
+                    Operation = 4, // Write
+                    PermissionType = 3 // Allow
+                }
+            ]
+        };
+        request.Write(ref writer, version: 0);
+
+        // Parse to verify
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        var arrayLength = reader.ReadInt32();
+        var resourceType = reader.ReadInt8();
+        var resourceName = reader.ReadString();
+        var principal = reader.ReadString();
+        var host = reader.ReadString();
+        var operation = reader.ReadInt8();
+        var permissionType = reader.ReadInt8();
+
+        await Assert.That(arrayLength).IsEqualTo(1);
+        await Assert.That(resourceType).IsEqualTo((sbyte)2);
+        await Assert.That(resourceName).IsEqualTo("my-topic");
+        await Assert.That(principal).IsEqualTo("User:alice");
+        await Assert.That(host).IsEqualTo("*");
+        await Assert.That(operation).IsEqualTo((sbyte)4);
+        await Assert.That(permissionType).IsEqualTo((sbyte)3);
+    }
+
+    [Test]
+    public async Task CreateAclsRequest_V1_WithPatternType()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new CreateAclsRequest
+        {
+            Creations =
+            [
+                new AclCreation
+                {
+                    ResourceType = 2, // Topic
+                    ResourceName = "my-prefix",
+                    ResourcePatternType = 4, // Prefixed
+                    Principal = "User:alice",
+                    Host = "*",
+                    Operation = 3, // Read
+                    PermissionType = 3 // Allow
+                }
+            ]
+        };
+        request.Write(ref writer, version: 1);
+
+        // Parse to verify
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        _ = reader.ReadInt32(); // array length
+        _ = reader.ReadInt8(); // resource type
+        _ = reader.ReadString(); // resource name
+        var resourcePatternType = reader.ReadInt8();
+
+        await Assert.That(resourcePatternType).IsEqualTo((sbyte)4);
+    }
+
+    [Test]
+    public async Task CreateAclsRequest_V2_Flexible()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new CreateAclsRequest
+        {
+            Creations =
+            [
+                new AclCreation
+                {
+                    ResourceType = 3, // Group
+                    ResourceName = "my-group",
+                    ResourcePatternType = 3, // Literal
+                    Principal = "User:bob",
+                    Host = "*",
+                    Operation = 3, // Read
+                    PermissionType = 3 // Allow
+                }
+            ]
+        };
+        request.Write(ref writer, version: 2);
+
+        // Parse to verify
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        var arrayLengthPlus1 = reader.ReadUnsignedVarInt();
+        var resourceType = reader.ReadInt8();
+        var resourceName = reader.ReadCompactString();
+        _ = reader.ReadInt8(); // pattern type
+        var principal = reader.ReadCompactString();
+
+        await Assert.That(arrayLengthPlus1).IsEqualTo(2); // length+1 = 2 means 1 element
+        await Assert.That(resourceType).IsEqualTo((sbyte)3);
+        await Assert.That(resourceName).IsEqualTo("my-group");
+        await Assert.That(principal).IsEqualTo("User:bob");
+    }
+
+    #endregion
+
+    #region CreateAcls Response Tests
+
+    [Test]
+    public async Task CreateAclsResponse_V0_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // Results array (INT32 length + entries)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // 1 result
+        // Result entry:
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (nullable STRING)
+        data.AddRange(new byte[] { 0xFF, 0xFF }); // null
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (CreateAclsResponse)CreateAclsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.Results.Count).IsEqualTo(1);
+        await Assert.That(response.Results[0].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Results[0].ErrorMessage).IsNull();
+    }
+
+    [Test]
+    public async Task CreateAclsResponse_V2_Flexible_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x32 }); // 50ms
+        // Results COMPACT_ARRAY (length+1 = 2, so 1 entry)
+        data.Add(0x02);
+        // Result entry:
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (COMPACT_NULLABLE_STRING)
+        data.Add(0x00); // null
+        // Result tagged fields
+        data.Add(0x00);
+        // Response tagged fields
+        data.Add(0x00);
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (CreateAclsResponse)CreateAclsResponse.Read(ref reader, version: 2);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(50);
+        await Assert.That(response.Results.Count).IsEqualTo(1);
+        await Assert.That(response.Results[0].ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
+    public async Task CreateAclsResponse_WithError_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // Results COMPACT_ARRAY
+        data.Add(0x02);
+        // Result entry:
+        // ErrorCode (INT16) - CLUSTER_AUTHORIZATION_FAILED = 31
+        data.AddRange(new byte[] { 0x00, 0x1F });
+        // ErrorMessage (COMPACT_NULLABLE_STRING)
+        data.Add(0x1B); // length+1 = 27
+        data.AddRange("Cluster authorization failed"u8.ToArray().AsSpan(0, 26).ToArray());
+        // Result tagged fields
+        data.Add(0x00);
+        // Response tagged fields
+        data.Add(0x00);
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (CreateAclsResponse)CreateAclsResponse.Read(ref reader, version: 2);
+
+        await Assert.That(response.Results[0].ErrorCode).IsEqualTo(ErrorCode.ClusterAuthorizationFailed);
+        await Assert.That(response.Results[0].ErrorMessage).IsNotNull();
+    }
+
+    #endregion
+
+    #region DeleteAcls Request Tests
+
+    [Test]
+    public async Task DeleteAclsRequest_V0_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new DeleteAclsRequest
+        {
+            Filters =
+            [
+                new DeleteAclsFilter
+                {
+                    ResourceTypeFilter = 2, // Topic
+                    ResourceNameFilter = "my-topic",
+                    PrincipalFilter = "User:alice",
+                    HostFilter = null,
+                    Operation = 1, // Any
+                    PermissionType = 1 // Any
+                }
+            ]
+        };
+        request.Write(ref writer, version: 0);
+
+        // Parse to verify
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        var arrayLength = reader.ReadInt32();
+        var resourceType = reader.ReadInt8();
+        var resourceName = reader.ReadString();
+        var principal = reader.ReadString();
+        var host = reader.ReadString();
+        var operation = reader.ReadInt8();
+        var permissionType = reader.ReadInt8();
+
+        await Assert.That(arrayLength).IsEqualTo(1);
+        await Assert.That(resourceType).IsEqualTo((sbyte)2);
+        await Assert.That(resourceName).IsEqualTo("my-topic");
+        await Assert.That(principal).IsEqualTo("User:alice");
+        await Assert.That(host).IsNull();
+        await Assert.That(operation).IsEqualTo((sbyte)1);
+        await Assert.That(permissionType).IsEqualTo((sbyte)1);
+    }
+
+    [Test]
+    public async Task DeleteAclsRequest_V2_Flexible()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new DeleteAclsRequest
+        {
+            Filters =
+            [
+                new DeleteAclsFilter
+                {
+                    ResourceTypeFilter = 1, // Any
+                    ResourceNameFilter = null,
+                    PatternTypeFilter = 1, // Any
+                    PrincipalFilter = "User:alice",
+                    HostFilter = null,
+                    Operation = 1, // Any
+                    PermissionType = 1 // Any
+                }
+            ]
+        };
+        request.Write(ref writer, version: 2);
+
+        // Parse to verify
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        var arrayLengthPlus1 = reader.ReadUnsignedVarInt();
+        var resourceType = reader.ReadInt8();
+        var resourceName = reader.ReadCompactString();
+        var patternType = reader.ReadInt8();
+        var principal = reader.ReadCompactString();
+        var host = reader.ReadCompactString();
+
+        await Assert.That(arrayLengthPlus1).IsEqualTo(2);
+        await Assert.That(resourceType).IsEqualTo((sbyte)1);
+        await Assert.That(resourceName).IsNull();
+        await Assert.That(patternType).IsEqualTo((sbyte)1);
+        await Assert.That(principal).IsEqualTo("User:alice");
+        await Assert.That(host).IsNull();
+    }
+
+    #endregion
+
+    #region DeleteAcls Response Tests
+
+    [Test]
+    public async Task DeleteAclsResponse_V0_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // FilterResults array (INT32 length + entries)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // 1 result
+        // FilterResult entry:
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (nullable STRING)
+        data.AddRange(new byte[] { 0xFF, 0xFF }); // null
+        // MatchingAcls array
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // 1 ACL
+        // MatchingAcl entry:
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (nullable STRING)
+        data.AddRange(new byte[] { 0xFF, 0xFF }); // null
+        // ResourceType (INT8)
+        data.Add(0x02); // Topic
+        // ResourceName (STRING)
+        data.AddRange(new byte[] { 0x00, 0x08 });
+        data.AddRange("my-topic"u8.ToArray());
+        // Principal (STRING)
+        data.AddRange(new byte[] { 0x00, 0x0A });
+        data.AddRange("User:alice"u8.ToArray());
+        // Host (STRING)
+        data.AddRange(new byte[] { 0x00, 0x01 });
+        data.Add((byte)'*');
+        // Operation (INT8)
+        data.Add(0x04); // Write
+        // PermissionType (INT8)
+        data.Add(0x03); // Allow
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (DeleteAclsResponse)DeleteAclsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.FilterResults.Count).IsEqualTo(1);
+        await Assert.That(response.FilterResults[0].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.FilterResults[0].MatchingAcls.Count).IsEqualTo(1);
+        await Assert.That(response.FilterResults[0].MatchingAcls[0].ResourceType).IsEqualTo((sbyte)2);
+        await Assert.That(response.FilterResults[0].MatchingAcls[0].ResourceName).IsEqualTo("my-topic");
+        await Assert.That(response.FilterResults[0].MatchingAcls[0].Principal).IsEqualTo("User:alice");
+    }
+
+    [Test]
+    public async Task DeleteAclsResponse_V2_Flexible_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // FilterResults COMPACT_ARRAY
+        data.Add(0x02); // 1 result
+        // FilterResult entry:
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (COMPACT_NULLABLE_STRING)
+        data.Add(0x00); // null
+        // MatchingAcls COMPACT_ARRAY
+        data.Add(0x02); // 1 ACL
+        // MatchingAcl entry:
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (COMPACT_NULLABLE_STRING)
+        data.Add(0x00); // null
+        // ResourceType (INT8)
+        data.Add(0x02); // Topic
+        // ResourceName (COMPACT_STRING)
+        data.Add(0x09); // length+1 = 9
+        data.AddRange("my-topic"u8.ToArray());
+        // PatternType (INT8) - v1+
+        data.Add(0x03); // Literal
+        // Principal (COMPACT_STRING)
+        data.Add(0x0B); // length+1 = 11
+        data.AddRange("User:alice"u8.ToArray());
+        // Host (COMPACT_STRING)
+        data.Add(0x02);
+        data.Add((byte)'*');
+        // Operation (INT8)
+        data.Add(0x04); // Write
+        // PermissionType (INT8)
+        data.Add(0x03); // Allow
+        // MatchingAcl tagged fields
+        data.Add(0x00);
+        // FilterResult tagged fields
+        data.Add(0x00);
+        // Response tagged fields
+        data.Add(0x00);
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (DeleteAclsResponse)DeleteAclsResponse.Read(ref reader, version: 2);
+
+        await Assert.That(response.FilterResults[0].MatchingAcls[0].PatternType).IsEqualTo((sbyte)3);
+        await Assert.That(response.FilterResults[0].MatchingAcls[0].Principal).IsEqualTo("User:alice");
+    }
+
+    #endregion
+
+    #region Version Flexibility Tests
+
+    [Test]
+    [Arguments((short)0, false)]
+    [Arguments((short)1, false)]
+    [Arguments((short)2, true)]
+    [Arguments((short)3, true)]
+    public async Task DescribeAclsRequest_FlexibilityDetection(short version, bool expectedFlexible)
+    {
+        var isFlexible = DescribeAclsRequest.IsFlexibleVersion(version);
+        await Assert.That(isFlexible).IsEqualTo(expectedFlexible);
+    }
+
+    [Test]
+    [Arguments((short)0, false)]
+    [Arguments((short)1, false)]
+    [Arguments((short)2, true)]
+    [Arguments((short)3, true)]
+    public async Task CreateAclsRequest_FlexibilityDetection(short version, bool expectedFlexible)
+    {
+        var isFlexible = CreateAclsRequest.IsFlexibleVersion(version);
+        await Assert.That(isFlexible).IsEqualTo(expectedFlexible);
+    }
+
+    [Test]
+    [Arguments((short)0, false)]
+    [Arguments((short)1, false)]
+    [Arguments((short)2, true)]
+    [Arguments((short)3, true)]
+    public async Task DeleteAclsRequest_FlexibilityDetection(short version, bool expectedFlexible)
+    {
+        var isFlexible = DeleteAclsRequest.IsFlexibleVersion(version);
+        await Assert.That(isFlexible).IsEqualTo(expectedFlexible);
+    }
+
+    #endregion
+
+    #region Header Version Tests
+
+    [Test]
+    [Arguments((short)0, (short)1, (short)0)]
+    [Arguments((short)1, (short)1, (short)0)]
+    [Arguments((short)2, (short)2, (short)1)]
+    [Arguments((short)3, (short)2, (short)1)]
+    public async Task DescribeAclsRequest_HeaderVersions(short apiVersion, short expectedRequestHeader, short expectedResponseHeader)
+    {
+        var requestHeaderVersion = DescribeAclsRequest.GetRequestHeaderVersion(apiVersion);
+        var responseHeaderVersion = DescribeAclsRequest.GetResponseHeaderVersion(apiVersion);
+
+        await Assert.That(requestHeaderVersion).IsEqualTo(expectedRequestHeader);
+        await Assert.That(responseHeaderVersion).IsEqualTo(expectedResponseHeader);
+    }
+
+    [Test]
+    [Arguments((short)0, (short)1, (short)0)]
+    [Arguments((short)1, (short)1, (short)0)]
+    [Arguments((short)2, (short)2, (short)1)]
+    [Arguments((short)3, (short)2, (short)1)]
+    public async Task CreateAclsRequest_HeaderVersions(short apiVersion, short expectedRequestHeader, short expectedResponseHeader)
+    {
+        var requestHeaderVersion = CreateAclsRequest.GetRequestHeaderVersion(apiVersion);
+        var responseHeaderVersion = CreateAclsRequest.GetResponseHeaderVersion(apiVersion);
+
+        await Assert.That(requestHeaderVersion).IsEqualTo(expectedRequestHeader);
+        await Assert.That(responseHeaderVersion).IsEqualTo(expectedResponseHeader);
+    }
+
+    [Test]
+    [Arguments((short)0, (short)1, (short)0)]
+    [Arguments((short)1, (short)1, (short)0)]
+    [Arguments((short)2, (short)2, (short)1)]
+    [Arguments((short)3, (short)2, (short)1)]
+    public async Task DeleteAclsRequest_HeaderVersions(short apiVersion, short expectedRequestHeader, short expectedResponseHeader)
+    {
+        var requestHeaderVersion = DeleteAclsRequest.GetRequestHeaderVersion(apiVersion);
+        var responseHeaderVersion = DeleteAclsRequest.GetResponseHeaderVersion(apiVersion);
+
+        await Assert.That(requestHeaderVersion).IsEqualTo(expectedRequestHeader);
+        await Assert.That(responseHeaderVersion).IsEqualTo(expectedResponseHeader);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Implement ACL (Access Control List) management APIs for Kafka security administration
- Add `CreateAclsAsync`, `DeleteAclsAsync`, and `DescribeAclsAsync` methods to `IAdminClient`
- Implement Kafka protocol messages for API keys 29 (DescribeAcls), 30 (CreateAcls), and 31 (DeleteAcls)
- Add comprehensive unit tests for protocol encoding/decoding and ACL types

## New Types
- **Enums**: `ResourceType`, `PatternType`, `AclOperation`, `AclPermissionType`
- **Classes**: `ResourcePattern`, `AccessControlEntry`, `AclBinding`, `AclBindingFilter`
- **Options**: `CreateAclsOptions`, `DeleteAclsOptions`, `DescribeAclsOptions`
- **Protocol Messages**: Request/Response types for all three ACL APIs

## API Usage Example
```csharp
// Create ACLs
await adminClient.CreateAclsAsync([
    AclBinding.Allow(
        ResourcePattern.Topic("my-topic"),
        "User:alice",
        AclOperation.Read)
]);

// Describe ACLs
var acls = await adminClient.DescribeAclsAsync(
    AclBindingFilter.ForPrincipal("User:alice"));

// Delete ACLs
var deleted = await adminClient.DeleteAclsAsync([
    AclBindingFilter.ForResource(ResourceType.Topic, "my-topic")
]);
```

## Test plan
- [x] Unit tests for protocol message encoding (v0, v1, v2 flexible versions)
- [x] Unit tests for protocol message decoding
- [x] Unit tests for ACL type helper methods
- [x] Unit tests for enum values match Kafka protocol spec
- [x] All 253 tests pass

Closes #8

Generated with [Claude Code](https://claude.com/claude-code)