### PR TITLE
Add ListOffsetsAsync and ElectLeadersAsync admin APIs

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -351,6 +351,200 @@ public sealed class AdminClient : IAdminClient
         throw new NotImplementedException("CreatePartitions not yet implemented");
     }
 
+    public async ValueTask<IReadOnlyDictionary<TopicPartition, ListOffsetsResultInfo>> ListOffsetsAsync(
+        IEnumerable<TopicPartitionOffsetSpec> specs,
+        ListOffsetsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var opts = options ?? new ListOffsetsOptions();
+        var specList = specs.ToList();
+
+        // Group specs by topic for the request
+        var topicGroups = specList
+            .GroupBy(s => s.TopicPartition.Topic)
+            .Select(g => new ListOffsetsRequestTopic
+            {
+                Name = g.Key,
+                Partitions = g.Select(s => new ListOffsetsRequestPartition
+                {
+                    PartitionIndex = s.TopicPartition.Partition,
+                    Timestamp = GetTimestampForSpec(s)
+                }).ToList()
+            })
+            .ToList();
+
+        // Get partition leaders from metadata and group specs by leader
+        var partitionsByLeader = new Dictionary<int, List<ListOffsetsRequestTopic>>();
+
+        foreach (var spec in specList)
+        {
+            var leaderNode = _metadataManager.Metadata.GetPartitionLeader(spec.TopicPartition.Topic, spec.TopicPartition.Partition);
+            if (leaderNode is null)
+            {
+                throw new KafkaException(Protocol.ErrorCode.LeaderNotAvailable,
+                    $"No leader available for {spec.TopicPartition.Topic}-{spec.TopicPartition.Partition}");
+            }
+
+            var leaderId = leaderNode.NodeId;
+
+            if (!partitionsByLeader.TryGetValue(leaderId, out var leaderTopics))
+            {
+                leaderTopics = [];
+                partitionsByLeader[leaderId] = leaderTopics;
+            }
+
+            var topicEntry = leaderTopics.FirstOrDefault(t => t.Name == spec.TopicPartition.Topic);
+            if (topicEntry is null)
+            {
+                topicEntry = new ListOffsetsRequestTopic
+                {
+                    Name = spec.TopicPartition.Topic,
+                    Partitions = new List<ListOffsetsRequestPartition>()
+                };
+                leaderTopics.Add(topicEntry);
+            }
+
+            ((List<ListOffsetsRequestPartition>)topicEntry.Partitions).Add(new ListOffsetsRequestPartition
+            {
+                PartitionIndex = spec.TopicPartition.Partition,
+                Timestamp = GetTimestampForSpec(spec)
+            });
+        }
+
+        var result = new Dictionary<TopicPartition, ListOffsetsResultInfo>();
+
+        // Send requests to each leader
+        foreach (var (leaderId, topics) in partitionsByLeader)
+        {
+            var connection = await _connectionPool.GetConnectionAsync(leaderId, cancellationToken).ConfigureAwait(false);
+
+            var request = new ListOffsetsRequest
+            {
+                ReplicaId = -1, // Consumer request
+                IsolationLevel = opts.IsolationLevel,
+                Topics = topics
+            };
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.ListOffsets,
+                ListOffsetsRequest.LowestSupportedVersion,
+                ListOffsetsRequest.HighestSupportedVersion);
+
+            var response = await connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                request,
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (var topic in response.Topics)
+            {
+                foreach (var partition in topic.Partitions)
+                {
+                    var tp = new TopicPartition(topic.Name, partition.PartitionIndex);
+
+                    if (partition.ErrorCode != Protocol.ErrorCode.None)
+                    {
+                        throw new KafkaException(partition.ErrorCode,
+                            $"ListOffsets failed for {tp.Topic}-{tp.Partition}: {partition.ErrorCode}");
+                    }
+
+                    result[tp] = new ListOffsetsResultInfo
+                    {
+                        Offset = partition.Offset,
+                        Timestamp = partition.Timestamp,
+                        LeaderEpoch = partition.LeaderEpoch >= 0 ? partition.LeaderEpoch : null
+                    };
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static long GetTimestampForSpec(TopicPartitionOffsetSpec spec)
+    {
+        return spec.Spec switch
+        {
+            OffsetSpec.Earliest => -2,
+            OffsetSpec.Latest => -1,
+            OffsetSpec.MaxTimestamp => -3,
+            OffsetSpec.Timestamp => spec.Timestamp ?? throw new ArgumentException("Timestamp must be specified when using OffsetSpec.Timestamp"),
+            _ => throw new ArgumentOutOfRangeException(nameof(spec), spec.Spec, "Unknown OffsetSpec")
+        };
+    }
+
+    public async ValueTask<IReadOnlyList<ElectLeadersResultInfo>> ElectLeadersAsync(
+        ElectionType electionType,
+        IEnumerable<TopicPartition>? partitions = null,
+        ElectLeadersOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+
+        var opts = options ?? new ElectLeadersOptions();
+
+        // Build topic partitions array if specified
+        IReadOnlyList<ElectLeadersRequestTopic>? topicPartitions = null;
+        if (partitions is not null)
+        {
+            var partitionList = partitions.ToList();
+            if (partitionList.Count > 0)
+            {
+                topicPartitions = partitionList
+                    .GroupBy(p => p.Topic)
+                    .Select(g => new ElectLeadersRequestTopic
+                    {
+                        Topic = g.Key,
+                        Partitions = g.Select(p => p.Partition).ToList()
+                    })
+                    .ToList();
+            }
+        }
+
+        var request = new ElectLeadersRequest
+        {
+            ElectionType = (byte)electionType,
+            TopicPartitions = topicPartitions,
+            TimeoutMs = opts.TimeoutMs
+        };
+
+        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            Protocol.ApiKey.ElectLeaders,
+            ElectLeadersRequest.LowestSupportedVersion,
+            ElectLeadersRequest.HighestSupportedVersion);
+
+        var response = await controller.SendAsync<ElectLeadersRequest, ElectLeadersResponse>(
+            request,
+            apiVersion,
+            cancellationToken).ConfigureAwait(false);
+
+        // Check top-level error
+        if (response.ErrorCode != Protocol.ErrorCode.None)
+        {
+            throw new KafkaException(response.ErrorCode, $"ElectLeaders failed: {response.ErrorCode}");
+        }
+
+        // Build results
+        var results = new List<ElectLeadersResultInfo>();
+        foreach (var topic in response.ReplicaElectionResults)
+        {
+            foreach (var partition in topic.PartitionResult)
+            {
+                results.Add(new ElectLeadersResultInfo
+                {
+                    TopicPartition = new TopicPartition(topic.Topic, partition.PartitionId),
+                    ErrorCode = partition.ErrorCode,
+                    ErrorMessage = partition.ErrorMessage
+                });
+            }
+        }
+
+        return results;
+    }
+
     private async ValueTask EnsureInitializedAsync(CancellationToken cancellationToken)
     {
         if (_metadataManager.Metadata.LastRefreshed == default)

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -69,6 +69,32 @@ public interface IAdminClient : IAsyncDisposable
     ValueTask CreatePartitionsAsync(IReadOnlyDictionary<string, int> newPartitionCounts, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Lists offsets for the specified topic partitions.
+    /// </summary>
+    /// <param name="specs">The topic partition offset specifications.</param>
+    /// <param name="options">Optional settings for the request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A dictionary mapping topic partitions to their offset information.</returns>
+    ValueTask<IReadOnlyDictionary<TopicPartition, ListOffsetsResultInfo>> ListOffsetsAsync(
+        IEnumerable<TopicPartitionOffsetSpec> specs,
+        ListOffsetsOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Triggers leader election for partitions.
+    /// </summary>
+    /// <param name="electionType">The type of election (Preferred or Unclean).</param>
+    /// <param name="partitions">Partitions to elect leaders for. If null, all partitions are elected.</param>
+    /// <param name="options">Optional settings for the request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Results for each partition.</returns>
+    ValueTask<IReadOnlyList<ElectLeadersResultInfo>> ElectLeadersAsync(
+        ElectionType electionType,
+        IEnumerable<TopicPartition>? partitions = null,
+        ElectLeadersOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the cluster metadata.
     /// </summary>
     ClusterMetadata Metadata { get; }
@@ -185,4 +211,136 @@ public sealed class MemberDescription
     public string? ClientId { get; init; }
     public string? ClientHost { get; init; }
     public IReadOnlyList<TopicPartition>? Assignment { get; init; }
+}
+
+/// <summary>
+/// Specifies a topic partition and the offset spec for ListOffsets.
+/// </summary>
+public sealed class TopicPartitionOffsetSpec
+{
+    /// <summary>
+    /// The topic partition.
+    /// </summary>
+    public required TopicPartition TopicPartition { get; init; }
+
+    /// <summary>
+    /// The offset specification.
+    /// </summary>
+    public required OffsetSpec Spec { get; init; }
+
+    /// <summary>
+    /// Timestamp to query when Spec is Timestamp.
+    /// </summary>
+    public long? Timestamp { get; init; }
+}
+
+/// <summary>
+/// Specification for which offset to retrieve.
+/// </summary>
+public enum OffsetSpec
+{
+    /// <summary>
+    /// The earliest available offset.
+    /// </summary>
+    Earliest,
+
+    /// <summary>
+    /// The latest available offset (end of log).
+    /// </summary>
+    Latest,
+
+    /// <summary>
+    /// The offset of the record with the maximum timestamp.
+    /// </summary>
+    MaxTimestamp,
+
+    /// <summary>
+    /// Query by timestamp. Use with TopicPartitionOffsetSpec.Timestamp.
+    /// </summary>
+    Timestamp
+}
+
+/// <summary>
+/// Result of a ListOffsets query for a single partition.
+/// </summary>
+public sealed class ListOffsetsResultInfo
+{
+    /// <summary>
+    /// The offset.
+    /// </summary>
+    public required long Offset { get; init; }
+
+    /// <summary>
+    /// The timestamp associated with the offset (-1 if not available).
+    /// </summary>
+    public long Timestamp { get; init; } = -1;
+
+    /// <summary>
+    /// The leader epoch, or null if not available.
+    /// </summary>
+    public int? LeaderEpoch { get; init; }
+}
+
+/// <summary>
+/// Options for ListOffsets.
+/// </summary>
+public sealed class ListOffsetsOptions
+{
+    /// <summary>
+    /// Timeout in milliseconds.
+    /// </summary>
+    public int TimeoutMs { get; init; } = 30000;
+
+    /// <summary>
+    /// Isolation level for the request.
+    /// </summary>
+    public Protocol.Messages.IsolationLevel IsolationLevel { get; init; } = Protocol.Messages.IsolationLevel.ReadUncommitted;
+}
+
+/// <summary>
+/// Type of leader election.
+/// </summary>
+public enum ElectionType : byte
+{
+    /// <summary>
+    /// Elect the preferred replica as leader if possible.
+    /// </summary>
+    Preferred = 0,
+
+    /// <summary>
+    /// Elect an unclean leader (may cause data loss).
+    /// </summary>
+    Unclean = 1
+}
+
+/// <summary>
+/// Options for ElectLeaders.
+/// </summary>
+public sealed class ElectLeadersOptions
+{
+    /// <summary>
+    /// Timeout in milliseconds.
+    /// </summary>
+    public int TimeoutMs { get; init; } = 30000;
+}
+
+/// <summary>
+/// Result of ElectLeaders for a single partition.
+/// </summary>
+public sealed class ElectLeadersResultInfo
+{
+    /// <summary>
+    /// The topic partition.
+    /// </summary>
+    public required TopicPartition TopicPartition { get; init; }
+
+    /// <summary>
+    /// Error code for this partition (None if successful).
+    /// </summary>
+    public Protocol.ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// Error message, if any.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
 }

--- a/src/Dekaf/Protocol/Messages/ElectLeadersRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ElectLeadersRequest.cs
@@ -1,0 +1,115 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ElectLeaders request (API key 43).
+/// Triggers leader election for partitions.
+/// </summary>
+public sealed class ElectLeadersRequest : IKafkaRequest<ElectLeadersResponse>
+{
+    public static ApiKey ApiKey => ApiKey.ElectLeaders;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 2;
+
+    /// <summary>
+    /// Type of election: 0 = Preferred, 1 = Unclean.
+    /// Only supported in v1+.
+    /// </summary>
+    public byte ElectionType { get; init; }
+
+    /// <summary>
+    /// Topics with partitions to elect leaders for.
+    /// Null means elect leaders for all partitions.
+    /// </summary>
+    public IReadOnlyList<ElectLeadersRequestTopic>? TopicPartitions { get; init; }
+
+    /// <summary>
+    /// Timeout in milliseconds.
+    /// </summary>
+    public int TimeoutMs { get; init; } = 30000;
+
+    public static bool IsFlexibleVersion(short version) => version >= 2;
+    public static short GetRequestHeaderVersion(short version) => version >= 2 ? (short)2 : (short)1;
+    public static short GetResponseHeaderVersion(short version) => version >= 2 ? (short)1 : (short)0;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 2;
+
+        // ElectionType is only in v1+
+        if (version >= 1)
+        {
+            writer.WriteInt8((sbyte)ElectionType);
+        }
+
+        // TopicPartitions (nullable array)
+        if (TopicPartitions is null)
+        {
+            if (isFlexible)
+                writer.WriteUnsignedVarInt(0); // 0 means null for compact nullable arrays
+            else
+                writer.WriteInt32(-1);
+        }
+        else
+        {
+            if (isFlexible)
+            {
+                writer.WriteCompactArray(
+                    TopicPartitions,
+                    (ref KafkaProtocolWriter w, ElectLeadersRequestTopic t) => t.Write(ref w, version));
+            }
+            else
+            {
+                writer.WriteArray(
+                    TopicPartitions,
+                    (ref KafkaProtocolWriter w, ElectLeadersRequestTopic t) => t.Write(ref w, version));
+            }
+        }
+
+        writer.WriteInt32(TimeoutMs);
+
+        if (isFlexible)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+    }
+}
+
+/// <summary>
+/// Topic in an ElectLeaders request.
+/// </summary>
+public sealed class ElectLeadersRequestTopic
+{
+    /// <summary>
+    /// The topic name.
+    /// </summary>
+    public required string Topic { get; init; }
+
+    /// <summary>
+    /// The partition indexes.
+    /// </summary>
+    public required IReadOnlyList<int> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        var isFlexible = version >= 2;
+
+        if (isFlexible)
+            writer.WriteCompactString(Topic);
+        else
+            writer.WriteString(Topic);
+
+        if (isFlexible)
+        {
+            writer.WriteCompactArray(
+                Partitions,
+                (ref KafkaProtocolWriter w, int p) => w.WriteInt32(p));
+            writer.WriteEmptyTaggedFields();
+        }
+        else
+        {
+            writer.WriteArray(
+                Partitions,
+                (ref KafkaProtocolWriter w, int p) => w.WriteInt32(p));
+        }
+    }
+}

--- a/src/Dekaf/Protocol/Messages/ElectLeadersResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ElectLeadersResponse.cs
@@ -1,0 +1,150 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ElectLeaders response (API key 43).
+/// Contains results of leader election requests.
+/// </summary>
+public sealed class ElectLeadersResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.ElectLeaders;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 2;
+
+    /// <summary>
+    /// Throttle time in milliseconds.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// Top-level error code.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// Results for each topic.
+    /// </summary>
+    public required IReadOnlyList<ElectLeadersResponseTopic> ReplicaElectionResults { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        var throttleTimeMs = reader.ReadInt32();
+
+        // ErrorCode is only in v1+
+        var errorCode = version >= 1 ? (ErrorCode)reader.ReadInt16() : ErrorCode.None;
+
+        IReadOnlyList<ElectLeadersResponseTopic> results;
+        if (isFlexible)
+        {
+            results = reader.ReadCompactArray(
+                (ref KafkaProtocolReader r) => ElectLeadersResponseTopic.Read(ref r, version)) ?? [];
+            reader.SkipTaggedFields();
+        }
+        else
+        {
+            results = reader.ReadArray(
+                (ref KafkaProtocolReader r) => ElectLeadersResponseTopic.Read(ref r, version)) ?? [];
+        }
+
+        return new ElectLeadersResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ReplicaElectionResults = results
+        };
+    }
+}
+
+/// <summary>
+/// Per-topic results in an ElectLeaders response.
+/// </summary>
+public sealed class ElectLeadersResponseTopic
+{
+    /// <summary>
+    /// The topic name.
+    /// </summary>
+    public required string Topic { get; init; }
+
+    /// <summary>
+    /// Results for each partition.
+    /// </summary>
+    public required IReadOnlyList<ElectLeadersResponsePartition> PartitionResult { get; init; }
+
+    public static ElectLeadersResponseTopic Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        var topic = isFlexible
+            ? reader.ReadCompactString() ?? string.Empty
+            : reader.ReadString() ?? string.Empty;
+
+        IReadOnlyList<ElectLeadersResponsePartition> partitions;
+        if (isFlexible)
+        {
+            partitions = reader.ReadCompactArray(
+                (ref KafkaProtocolReader r) => ElectLeadersResponsePartition.Read(ref r, version)) ?? [];
+            reader.SkipTaggedFields();
+        }
+        else
+        {
+            partitions = reader.ReadArray(
+                (ref KafkaProtocolReader r) => ElectLeadersResponsePartition.Read(ref r, version)) ?? [];
+        }
+
+        return new ElectLeadersResponseTopic
+        {
+            Topic = topic,
+            PartitionResult = partitions
+        };
+    }
+}
+
+/// <summary>
+/// Per-partition results in an ElectLeaders response.
+/// </summary>
+public sealed class ElectLeadersResponsePartition
+{
+    /// <summary>
+    /// The partition index.
+    /// </summary>
+    public int PartitionId { get; init; }
+
+    /// <summary>
+    /// Error code for this partition.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// Error message (v1+).
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    public static ElectLeadersResponsePartition Read(ref KafkaProtocolReader reader, short version)
+    {
+        var isFlexible = version >= 2;
+
+        var partitionId = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        string? errorMessage = null;
+        if (version >= 1)
+        {
+            errorMessage = isFlexible
+                ? reader.ReadCompactString()
+                : reader.ReadString();
+        }
+
+        if (isFlexible)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new ElectLeadersResponsePartition
+        {
+            PartitionId = partitionId,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminTypesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminTypesTests.cs
@@ -1,0 +1,189 @@
+using Dekaf.Admin;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+/// <summary>
+/// Tests for admin API types.
+/// </summary>
+public class AdminTypesTests
+{
+    #region TopicPartitionOffsetSpec Tests
+
+    [Test]
+    public async Task TopicPartitionOffsetSpec_CanBeCreated()
+    {
+        var spec = new TopicPartitionOffsetSpec
+        {
+            TopicPartition = new TopicPartition("test-topic", 0),
+            Spec = OffsetSpec.Latest
+        };
+
+        await Assert.That(spec.TopicPartition.Topic).IsEqualTo("test-topic");
+        await Assert.That(spec.TopicPartition.Partition).IsEqualTo(0);
+        await Assert.That(spec.Spec).IsEqualTo(OffsetSpec.Latest);
+        await Assert.That(spec.Timestamp).IsNull();
+    }
+
+    [Test]
+    public async Task TopicPartitionOffsetSpec_WithTimestamp()
+    {
+        var spec = new TopicPartitionOffsetSpec
+        {
+            TopicPartition = new TopicPartition("test-topic", 1),
+            Spec = OffsetSpec.Timestamp,
+            Timestamp = 1234567890L
+        };
+
+        await Assert.That(spec.Spec).IsEqualTo(OffsetSpec.Timestamp);
+        await Assert.That(spec.Timestamp).IsEqualTo(1234567890L);
+    }
+
+    [Test]
+    public async Task TopicPartitionOffsetSpec_AllOffsetSpecs()
+    {
+        var specEarliest = new TopicPartitionOffsetSpec
+        {
+            TopicPartition = new TopicPartition("test", 0),
+            Spec = OffsetSpec.Earliest
+        };
+        var specLatest = new TopicPartitionOffsetSpec
+        {
+            TopicPartition = new TopicPartition("test", 0),
+            Spec = OffsetSpec.Latest
+        };
+        var specMaxTimestamp = new TopicPartitionOffsetSpec
+        {
+            TopicPartition = new TopicPartition("test", 0),
+            Spec = OffsetSpec.MaxTimestamp
+        };
+
+        await Assert.That(specEarliest.Spec).IsEqualTo(OffsetSpec.Earliest);
+        await Assert.That(specLatest.Spec).IsEqualTo(OffsetSpec.Latest);
+        await Assert.That(specMaxTimestamp.Spec).IsEqualTo(OffsetSpec.MaxTimestamp);
+    }
+
+    #endregion
+
+    #region ListOffsetsResultInfo Tests
+
+    [Test]
+    public async Task ListOffsetsResultInfo_CanBeCreated()
+    {
+        var result = new ListOffsetsResultInfo
+        {
+            Offset = 100,
+            Timestamp = 1234567890L,
+            LeaderEpoch = 5
+        };
+
+        await Assert.That(result.Offset).IsEqualTo(100L);
+        await Assert.That(result.Timestamp).IsEqualTo(1234567890L);
+        await Assert.That(result.LeaderEpoch).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task ListOffsetsResultInfo_DefaultTimestamp()
+    {
+        var result = new ListOffsetsResultInfo
+        {
+            Offset = 100
+        };
+
+        await Assert.That(result.Timestamp).IsEqualTo(-1L);
+        await Assert.That(result.LeaderEpoch).IsNull();
+    }
+
+    #endregion
+
+    #region ListOffsetsOptions Tests
+
+    [Test]
+    public async Task ListOffsetsOptions_Defaults()
+    {
+        var options = new ListOffsetsOptions();
+
+        await Assert.That(options.TimeoutMs).IsEqualTo(30000);
+        await Assert.That(options.IsolationLevel).IsEqualTo(IsolationLevel.ReadUncommitted);
+    }
+
+    [Test]
+    public async Task ListOffsetsOptions_CanBeConfigured()
+    {
+        var options = new ListOffsetsOptions
+        {
+            TimeoutMs = 60000,
+            IsolationLevel = IsolationLevel.ReadCommitted
+        };
+
+        await Assert.That(options.TimeoutMs).IsEqualTo(60000);
+        await Assert.That(options.IsolationLevel).IsEqualTo(IsolationLevel.ReadCommitted);
+    }
+
+    #endregion
+
+    #region ElectLeadersOptions Tests
+
+    [Test]
+    public async Task ElectLeadersOptions_Defaults()
+    {
+        var options = new ElectLeadersOptions();
+
+        await Assert.That(options.TimeoutMs).IsEqualTo(30000);
+    }
+
+    #endregion
+
+    #region ElectLeadersResultInfo Tests
+
+    [Test]
+    public async Task ElectLeadersResultInfo_Success()
+    {
+        var result = new ElectLeadersResultInfo
+        {
+            TopicPartition = new TopicPartition("test-topic", 0),
+            ErrorCode = ErrorCode.None
+        };
+
+        await Assert.That(result.TopicPartition.Topic).IsEqualTo("test-topic");
+        await Assert.That(result.TopicPartition.Partition).IsEqualTo(0);
+        await Assert.That(result.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(result.ErrorMessage).IsNull();
+    }
+
+    [Test]
+    public async Task ElectLeadersResultInfo_WithError()
+    {
+        var result = new ElectLeadersResultInfo
+        {
+            TopicPartition = new TopicPartition("test-topic", 1),
+            ErrorCode = ErrorCode.PreferredLeaderNotAvailable,
+            ErrorMessage = "Preferred leader not available"
+        };
+
+        await Assert.That(result.ErrorCode).IsEqualTo(ErrorCode.PreferredLeaderNotAvailable);
+        await Assert.That(result.ErrorMessage).IsEqualTo("Preferred leader not available");
+    }
+
+    #endregion
+
+    #region ElectionType Tests
+
+    [Test]
+    public async Task ElectionType_Preferred()
+    {
+        var electionType = ElectionType.Preferred;
+        await Assert.That(electionType).IsEqualTo(ElectionType.Preferred);
+    }
+
+    [Test]
+    public async Task ElectionType_Unclean()
+    {
+        var electionType = ElectionType.Unclean;
+        await Assert.That(electionType).IsEqualTo(ElectionType.Unclean);
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ElectLeadersMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ElectLeadersMessageTests.cs
@@ -1,0 +1,284 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+/// <summary>
+/// Tests for ElectLeaders request/response encoding and decoding.
+/// </summary>
+public class ElectLeadersMessageTests
+{
+    #region ElectLeadersRequest Tests
+
+    [Test]
+    public async Task ElectLeadersRequest_V0_WithPartitions()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ElectLeadersRequest
+        {
+            TopicPartitions =
+            [
+                new ElectLeadersRequestTopic
+                {
+                    Topic = "test",
+                    Partitions = [0, 1]
+                }
+            ],
+            TimeoutMs = 30000
+        };
+        request.Write(ref writer, version: 0);
+
+        var expected = new List<byte>();
+        // TopicPartitions array length (INT32)
+        expected.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // 1 topic
+        // Topic (STRING)
+        expected.AddRange(new byte[] { 0x00, 0x04 }); // length = 4
+        expected.AddRange("test"u8.ToArray());
+        // Partitions array (INT32 length)
+        expected.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x02 }); // 2 partitions
+        expected.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 }); // partition 0
+        expected.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // partition 1
+        // TimeoutMs (INT32)
+        expected.AddRange(new byte[] { 0x00, 0x00, 0x75, 0x30 }); // 30000
+
+        await Assert.That(buffer.WrittenSpan.ToArray()).IsEquivalentTo(expected.ToArray());
+    }
+
+    [Test]
+    public async Task ElectLeadersRequest_V0_NullPartitions_AllPartitions()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ElectLeadersRequest
+        {
+            TopicPartitions = null,
+            TimeoutMs = 30000
+        };
+        request.Write(ref writer, version: 0);
+
+        var expected = new List<byte>();
+        // Null array (INT32 = -1)
+        expected.AddRange(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF });
+        // TimeoutMs (INT32)
+        expected.AddRange(new byte[] { 0x00, 0x00, 0x75, 0x30 }); // 30000
+
+        await Assert.That(buffer.WrittenSpan.ToArray()).IsEquivalentTo(expected.ToArray());
+    }
+
+    [Test]
+    public async Task ElectLeadersRequest_V1_WithElectionType()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ElectLeadersRequest
+        {
+            ElectionType = 1, // Unclean
+            TopicPartitions =
+            [
+                new ElectLeadersRequestTopic
+                {
+                    Topic = "test",
+                    Partitions = [0]
+                }
+            ],
+            TimeoutMs = 30000
+        };
+        request.Write(ref writer, version: 1);
+
+        // Read synchronously before await
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var electionType = reader.ReadInt8();
+
+        await Assert.That(electionType).IsEqualTo((sbyte)1);
+    }
+
+    [Test]
+    public async Task ElectLeadersRequest_V2_Flexible_WithPartitions()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ElectLeadersRequest
+        {
+            ElectionType = 0, // Preferred
+            TopicPartitions =
+            [
+                new ElectLeadersRequestTopic
+                {
+                    Topic = "test",
+                    Partitions = [0]
+                }
+            ],
+            TimeoutMs = 30000
+        };
+        request.Write(ref writer, version: 2);
+
+        // Read synchronously before await
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var electionType = reader.ReadInt8();
+        var topicsLength = reader.ReadUnsignedVarInt();
+
+        await Assert.That(electionType).IsEqualTo((sbyte)0);
+        await Assert.That(topicsLength).IsEqualTo(2); // 1 topic + 1
+    }
+
+    [Test]
+    public async Task ElectLeadersRequest_V2_NullPartitions()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ElectLeadersRequest
+        {
+            ElectionType = 0,
+            TopicPartitions = null,
+            TimeoutMs = 30000
+        };
+        request.Write(ref writer, version: 2);
+
+        // Read synchronously before await
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        reader.ReadInt8(); // ElectionType
+        var topicsLength = reader.ReadUnsignedVarInt();
+
+        await Assert.That(topicsLength).IsEqualTo(0); // null
+    }
+
+    #endregion
+
+    #region ElectLeadersResponse Tests
+
+    [Test]
+    public async Task ElectLeadersResponse_V0_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // ReplicaElectionResults array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // 1 topic
+        // Topic (STRING)
+        data.AddRange(new byte[] { 0x00, 0x04 }); // length = 4
+        data.AddRange("test"u8.ToArray());
+        // PartitionResult array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // 1 partition
+        // PartitionId (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (ElectLeadersResponse)ElectLeadersResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ReplicaElectionResults.Count).IsEqualTo(1);
+        await Assert.That(response.ReplicaElectionResults[0].Topic).IsEqualTo("test");
+        await Assert.That(response.ReplicaElectionResults[0].PartitionResult.Count).IsEqualTo(1);
+        await Assert.That(response.ReplicaElectionResults[0].PartitionResult[0].PartitionId).IsEqualTo(0);
+        await Assert.That(response.ReplicaElectionResults[0].PartitionResult[0].ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
+    public async Task ElectLeadersResponse_V1_WithErrorCodeAndMessage()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // ErrorCode (INT16) - v1+ top-level error
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ReplicaElectionResults array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // 1 topic
+        // Topic (STRING)
+        data.AddRange(new byte[] { 0x00, 0x04 }); // length = 4
+        data.AddRange("test"u8.ToArray());
+        // PartitionResult array (INT32 length)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // 1 partition
+        // PartitionId (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x50 }); // PreferredLeaderNotAvailable = 80
+        // ErrorMessage (NULLABLE_STRING)
+        data.AddRange(new byte[] { 0x00, 0x04 }); // length = 4
+        data.AddRange("test"u8.ToArray());
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (ElectLeadersResponse)ElectLeadersResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ReplicaElectionResults[0].PartitionResult[0].ErrorCode)
+            .IsEqualTo(ErrorCode.PreferredLeaderNotAvailable);
+        await Assert.That(response.ReplicaElectionResults[0].PartitionResult[0].ErrorMessage)
+            .IsEqualTo("test");
+    }
+
+    [Test]
+    public async Task ElectLeadersResponse_V2_Flexible_CanBeParsed()
+    {
+        var data = new List<byte>();
+        // ThrottleTimeMs (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x64 }); // 100ms
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ReplicaElectionResults COMPACT_ARRAY (length+1 = 2)
+        data.Add(0x02);
+        // Topic (COMPACT_STRING length+1 = 5)
+        data.Add(0x05);
+        data.AddRange("test"u8.ToArray());
+        // PartitionResult COMPACT_ARRAY (length+1 = 2)
+        data.Add(0x02);
+        // PartitionId (INT32)
+        data.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x00 });
+        // ErrorCode (INT16)
+        data.AddRange(new byte[] { 0x00, 0x00 }); // None
+        // ErrorMessage (COMPACT_NULLABLE_STRING)
+        data.Add(0x00); // null
+        // Partition tagged fields
+        data.Add(0x00);
+        // Topic tagged fields
+        data.Add(0x00);
+        // Response tagged fields
+        data.Add(0x00);
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (ElectLeadersResponse)ElectLeadersResponse.Read(ref reader, version: 2);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(100);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ReplicaElectionResults.Count).IsEqualTo(1);
+        await Assert.That(response.ReplicaElectionResults[0].Topic).IsEqualTo("test");
+    }
+
+    #endregion
+
+    #region Version Flexibility Tests
+
+    [Test]
+    [Arguments((short)0, false)]
+    [Arguments((short)1, false)]
+    [Arguments((short)2, true)]
+    public async Task ElectLeadersRequest_FlexibilityDetection(short version, bool expectedFlexible)
+    {
+        var isFlexible = ElectLeadersRequest.IsFlexibleVersion(version);
+        await Assert.That(isFlexible).IsEqualTo(expectedFlexible);
+    }
+
+    [Test]
+    [Arguments((short)0, (short)1, (short)0)]
+    [Arguments((short)1, (short)1, (short)0)]
+    [Arguments((short)2, (short)2, (short)1)]
+    public async Task ElectLeadersRequest_HeaderVersions(short apiVersion, short expectedRequestHeader, short expectedResponseHeader)
+    {
+        var requestHeaderVersion = ElectLeadersRequest.GetRequestHeaderVersion(apiVersion);
+        var responseHeaderVersion = ElectLeadersRequest.GetResponseHeaderVersion(apiVersion);
+
+        await Assert.That(requestHeaderVersion).IsEqualTo(expectedRequestHeader);
+        await Assert.That(responseHeaderVersion).IsEqualTo(expectedResponseHeader);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Add `ListOffsetsAsync` to query offsets for topic partitions using various offset specifications (Earliest, Latest, MaxTimestamp, or specific Timestamp)
- Add `ElectLeadersAsync` to trigger preferred or unclean leader election for partitions
- Create supporting types: `TopicPartitionOffsetSpec`, `OffsetSpec`, `ListOffsetsResultInfo`, `ElectionType`, `ListOffsetsOptions`, `ElectLeadersOptions`, `ElectLeadersResultInfo`
- Implement `ElectLeadersRequest`/`ElectLeadersResponse` protocol messages (API key 43, versions 0-2)

## Test plan

- [x] Unit tests for all new admin types (`AdminTypesTests.cs`)
- [x] Protocol encoding/decoding tests for ElectLeaders messages (`ElectLeadersMessageTests.cs`)
- [x] All 221 unit tests pass

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)