### PR TITLE
Fix: Specify dictionary capacity in StickyPartitioner

### DIFF
--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -36,7 +36,7 @@ public sealed class DefaultPartitioner : IPartitioner
 /// </summary>
 public sealed class StickyPartitioner : IPartitioner
 {
-    private readonly Dictionary<string, int> _stickyPartitions = [];
+    private readonly Dictionary<string, int> _stickyPartitions = new(capacity: 16);
     private readonly object _lock = new();
     private int _counter;
 


### PR DESCRIPTION
## Summary
- Pre-allocates `StickyPartitioner` dictionary with capacity of 16
- Prevents resizing allocations and rehashing as topics are added
- Minor performance optimization aligning with zero-allocation principles

## Changes
Modified `src/Dekaf/Producer/Partitioner.cs`:
- Changed `_stickyPartitions` initialization from collection expression `[]` to explicit constructor with `capacity: 16`

## Testing
- All 611 unit tests pass
- No behavioral changes, only initialization optimization

## References
Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)