### PR TITLE
Remove LINQ allocations from consumer offset queries

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1032,8 +1032,22 @@ public sealed class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, TValue>
             listOffsetsVersion,
             cancellationToken).ConfigureAwait(false);
 
-        var earliestTopicResponse = earliestResponse.Topics.FirstOrDefault(t => t.Name == topicPartition.Topic);
-        var earliestPartitionResponse = earliestTopicResponse?.Partitions.FirstOrDefault(p => p.PartitionIndex == topicPartition.Partition);
+        Protocol.Messages.ListOffsetsResponsePartition? earliestPartitionResponse = null;
+        foreach (var topic in earliestResponse.Topics)
+        {
+            if (topic.Name == topicPartition.Topic)
+            {
+                foreach (var partition in topic.Partitions)
+                {
+                    if (partition.PartitionIndex == topicPartition.Partition)
+                    {
+                        earliestPartitionResponse = partition;
+                        break;
+                    }
+                }
+                break;
+            }
+        }
 
         if (earliestPartitionResponse?.ErrorCode != ErrorCode.None)
         {
@@ -1071,8 +1085,22 @@ public sealed class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, TValue>
             listOffsetsVersion,
             cancellationToken).ConfigureAwait(false);
 
-        var latestTopicResponse = latestResponse.Topics.FirstOrDefault(t => t.Name == topicPartition.Topic);
-        var latestPartitionResponse = latestTopicResponse?.Partitions.FirstOrDefault(p => p.PartitionIndex == topicPartition.Partition);
+        Protocol.Messages.ListOffsetsResponsePartition? latestPartitionResponse = null;
+        foreach (var topic in latestResponse.Topics)
+        {
+            if (topic.Name == topicPartition.Topic)
+            {
+                foreach (var partition in topic.Partitions)
+                {
+                    if (partition.PartitionIndex == topicPartition.Partition)
+                    {
+                        latestPartitionResponse = partition;
+                        break;
+                    }
+                }
+                break;
+            }
+        }
 
         if (latestPartitionResponse?.ErrorCode != ErrorCode.None)
         {
@@ -1258,8 +1286,22 @@ public sealed class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, TValue>
             listOffsetsVersion,
             cancellationToken).ConfigureAwait(false);
 
-        var topicResponse = response.Topics.FirstOrDefault(t => t.Name == partition.Topic);
-        var partitionResponse = topicResponse?.Partitions.FirstOrDefault(p => p.PartitionIndex == partition.Partition);
+        Protocol.Messages.ListOffsetsResponsePartition? partitionResponse = null;
+        foreach (var topic in response.Topics)
+        {
+            if (topic.Name == partition.Topic)
+            {
+                foreach (var p in topic.Partitions)
+                {
+                    if (p.PartitionIndex == partition.Partition)
+                    {
+                        partitionResponse = p;
+                        break;
+                    }
+                }
+                break;
+            }
+        }
 
         return partitionResponse?.Offset ?? 0;
     }
@@ -1319,8 +1361,22 @@ public sealed class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, TValue>
             listOffsetsVersion,
             cancellationToken).ConfigureAwait(false);
 
-        var topicResponse = response.Topics.FirstOrDefault(t => t.Name == partition.Topic);
-        var partitionResponse = topicResponse?.Partitions.FirstOrDefault(p => p.PartitionIndex == partition.Partition);
+        Protocol.Messages.ListOffsetsResponsePartition? partitionResponse = null;
+        foreach (var topic in response.Topics)
+        {
+            if (topic.Name == partition.Topic)
+            {
+                foreach (var p in topic.Partitions)
+                {
+                    if (p.PartitionIndex == partition.Partition)
+                    {
+                        partitionResponse = p;
+                        break;
+                    }
+                }
+                break;
+            }
+        }
 
         return partitionResponse?.Offset ?? 0;
     }


### PR DESCRIPTION
## Summary
- Replaced all `FirstOrDefault()` LINQ calls with imperative foreach loops in consumer offset query methods
- Eliminated enumerator allocations in `GetWatermarkOffsetsAsync()` and offset resolution methods
- Maintains identical behavior while adhering to zero-allocation design principles

## Changes
Modified `/src/Dekaf/Consumer/KafkaConsumer.cs`:
- Lines 1035-1036: Replaced LINQ in earliest offset query (GetWatermarkOffsetsAsync)
- Lines 1074-1075: Replaced LINQ in latest offset query (GetWatermarkOffsetsAsync)
- Lines 1261-1262: Replaced LINQ in auto offset reset resolution
- Lines 1322-1323: Replaced LINQ in special offset resolution

All four instances now use nested foreach loops to find matching topic and partition responses without allocating enumerators.

## Test plan
- [x] All 611 unit tests pass
- [x] Build succeeds with no warnings
- [x] Code follows existing patterns in the codebase (see line 1795 for similar foreach usage)
- [ ] Integration tests with Testcontainers (if applicable)

## Performance Impact
- Eliminates 4 enumerator allocations per watermark query
- Reduces GC pressure for applications querying offsets frequently
- Aligns with CLAUDE.md zero-allocation requirements for hot paths

Fixes #50

Generated with [Claude Code](https://claude.com/claude-code)