### PR TITLE
perf: Optimize VarInt encoding and configurable batch capacity

### DIFF
--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -192,6 +192,14 @@ public sealed class ProducerOptions
     /// Set to 0 to use BatchSize as the arena capacity.
     /// </summary>
     public int ArenaCapacity { get; init; } = 65536;
+
+    /// <summary>
+    /// Initial capacity for record arrays in partition batches.
+    /// Lower values reduce memory for applications with many small batches.
+    /// Higher values reduce array resizing for high-throughput scenarios.
+    /// Default is 64, balancing memory usage and resize frequency.
+    /// </summary>
+    public int InitialBatchRecordCapacity { get; init; } = 64;
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- **VarInt fast-path optimization**: Added specialized fast paths for single-byte (0-127) and two-byte (128-16383) VarInt values in both `KafkaProtocolWriter` and `KafkaProtocolReader`. These are the most common cases and now avoid the loop-based slow path entirely.
- **UTF-8 header key sizing fix**: Fixed `EstimateRecordSize` to use `Encoding.UTF8.GetByteCount()` instead of `string.Length` for accurate byte-length estimation with multi-byte characters.
- **Configurable batch initial capacity**: Added `InitialBatchRecordCapacity` option to `ProducerOptions` with default of 64 (reduced from hardcoded 256), reducing memory allocation for applications with many small batches.

## Test plan

- [x] All 44 VarInt-related unit tests pass
- [x] All 28 KafkaProtocol unit tests pass
- [x] All 13 Producer unit tests pass
- [ ] Run benchmarks to measure VarInt performance improvement
- [ ] Run benchmarks to measure batch memory reduction