### PR TITLE
fix: Add Kafka log retention policies to prevent stress test disk exhaustion

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -59,6 +59,11 @@ jobs:
             -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1 \
             -e KAFKA_LOG_DIRS=/var/lib/kafka/data \
             -e CLUSTER_ID=stress-test-cluster-001 \
+            -e KAFKA_LOG_RETENTION_MS=300000 \
+            -e KAFKA_LOG_RETENTION_BYTES=2147483648 \
+            -e KAFKA_LOG_SEGMENT_BYTES=134217728 \
+            -e KAFKA_LOG_SEGMENT_DELETE_DELAY_MS=1000 \
+            -e KAFKA_LOG_CLEANUP_POLICY=delete \
             apache/kafka:latest
 
           echo "Waiting for Kafka to be ready..."
@@ -71,6 +76,13 @@ jobs:
             sleep 2
           done
 
+      - name: Check Initial Disk Space
+        run: |
+          echo "=== Initial Disk Space ==="
+          df -h
+          echo "=== Docker Disk Usage ==="
+          docker system df
+
       - name: Run Stress Tests
         env:
           KAFKA_BOOTSTRAP_SERVERS: localhost:9092
@@ -82,6 +94,16 @@ jobs:
             --scenario ${{ github.event.inputs.scenario || 'all' }} \
             --client ${{ github.event.inputs.client || 'all' }} \
             --output ./results
+
+      - name: Check Final Disk Space
+        if: always()
+        run: |
+          echo "=== Final Disk Space ==="
+          df -h
+          echo "=== Docker Disk Usage ==="
+          docker system df
+          echo "=== Kafka Container Stats ==="
+          docker stats kafka --no-stream || true
 
       - name: Upload Results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fixes the "No space left on device" error in stress tests by adding aggressive Kafka log retention policies to prevent unbounded disk growth on GitHub Actions runners.

## Problem

Stress tests were failing when Kafka accumulated ~200GB of message data during 15-minute runs, exceeding the ~14GB available disk space on GitHub Actions runners.

**Root cause analysis:**
- Test generates 85GB raw message data (500K seed messages + 90M test messages at 1KB each)
- Kafka overhead (indexes, logs, segment files) multiplies this 2-3x to ~200GB total
- No retention policies meant infinite message accumulation
- GitHub Actions Ubuntu runner has only ~14GB available disk

## Solution

Added aggressive Kafka log retention policies to the stress test workflow:

```yaml
KAFKA_LOG_RETENTION_MS=300000           # 5 minutes - delete old messages quickly
KAFKA_LOG_RETENTION_BYTES=2147483648    # 2GB per partition maximum
KAFKA_LOG_SEGMENT_BYTES=134217728       # 128MB segments for faster rotation
KAFKA_LOG_SEGMENT_DELETE_DELAY_MS=1000  # Near-immediate deletion after rotation
KAFKA_LOG_CLEANUP_POLICY=delete         # Explicit delete policy
```

This caps maximum disk usage at ~12GB (6 partitions × 2GB), leaving ~2GB headroom.

## Additional Changes

Added disk space monitoring steps:
- Check initial disk space before tests
- Check final disk space after tests (even if tests fail)
- Report Docker disk usage and Kafka container stats

This helps track disk usage patterns and catch future issues early.

## Test Plan

- [ ] Workflow runs to completion without disk space errors
- [ ] Disk monitoring shows usage stays under 12GB
- [ ] Stress test results remain valid despite aggressive retention
- [ ] 15-minute test duration still exercises sustained performance

## Related Issues

Resolves the recurring "No space left on device" failures in the stress test workflow.