### PR TITLE
feat: Add MaxBlockMs producer configuration

### DIFF
--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -110,6 +110,23 @@ public sealed class ProducerOptions
     public int CloseTimeoutMs { get; init; } = 30000;
 
     /// <summary>
+    /// Maximum time in milliseconds that <see cref="KafkaProducer{TKey,TValue}.ProduceAsync"/>
+    /// and <see cref="KafkaProducer{TKey,TValue}.Send"/> will block when the producer's buffer
+    /// is full or metadata is unavailable.
+    /// <para>
+    /// This controls how long the producer waits for buffer space (backpressure) and for
+    /// initial metadata when producing to a new topic for the first time.
+    /// </para>
+    /// <para>
+    /// If the timeout expires, a <see cref="TimeoutException"/> is thrown with a descriptive message.
+    /// </para>
+    /// <para>
+    /// Equivalent to Kafka's <c>max.block.ms</c> configuration. Default is 60000ms (60 seconds).
+    /// </para>
+    /// </summary>
+    public int MaxBlockMs { get; init; } = 60000;
+
+    /// <summary>
     /// Maximum request size in bytes.
     /// </summary>
     public int MaxRequestSize { get; init; } = 1048576;

--- a/tests/Dekaf.Tests.Unit/Producer/BufferMemoryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BufferMemoryTests.cs
@@ -255,7 +255,7 @@ public class BufferMemoryTests
             BufferMemory = 1000, // Very small buffer - 1KB
             BatchSize = 16384,
             LingerMs = 100,
-            DeliveryTimeoutMs = 500 // Short timeout - 500ms
+            MaxBlockMs = 500 // Short timeout - 500ms (controls buffer wait timeout)
         };
 
         var accumulator = new RecordAccumulator(options);
@@ -352,8 +352,8 @@ public class BufferMemoryTests
                     await Task.CompletedTask.ConfigureAwait(false);
                 });
 
-                // Assert: Should throw immediately, not wait for timeout
-                await Assert.That(exception!.Message).Contains("buffer memory");
+                // Assert: Should throw with descriptive message about max.block.ms
+                await Assert.That(exception!.Message).Contains("max.block.ms");
             }
             finally
             {

--- a/tests/Dekaf.Tests.Unit/Producer/MaxBlockMsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/MaxBlockMsTests.cs
@@ -1,0 +1,234 @@
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public sealed class MaxBlockMsTests
+{
+    #region ProducerOptions
+
+    [Test]
+    public async Task MaxBlockMs_DefaultValue_Is60000()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"]
+        };
+
+        await Assert.That(options.MaxBlockMs).IsEqualTo(60000);
+    }
+
+    [Test]
+    public async Task MaxBlockMs_CanBeSetToCustomValue()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            MaxBlockMs = 5000
+        };
+
+        await Assert.That(options.MaxBlockMs).IsEqualTo(5000);
+    }
+
+    [Test]
+    public async Task MaxBlockMs_CanBeSetToLargeValue()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            MaxBlockMs = 300000
+        };
+
+        await Assert.That(options.MaxBlockMs).IsEqualTo(300000);
+    }
+
+    [Test]
+    public async Task MaxBlockMs_CanBeSetToOne()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            MaxBlockMs = 1
+        };
+
+        await Assert.That(options.MaxBlockMs).IsEqualTo(1);
+    }
+
+    #endregion
+
+    #region Builder - WithMaxBlockMs
+
+    [Test]
+    public async Task WithMaxBlockMs_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+        var result = builder.WithMaxBlockMs(5000);
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithMaxBlockMs_BuildSucceeds()
+    {
+        var act = () => Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithMaxBlockMs(5000)
+            .Build();
+
+        await Assert.That(act).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task WithMaxBlockMs_Zero_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithMaxBlockMs(0);
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithMaxBlockMs_Negative_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithMaxBlockMs(-1);
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithMaxBlockMs_NegativeLargeValue_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithMaxBlockMs(-60000);
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    #endregion
+
+    #region Builder - WithMaxBlock (TimeSpan)
+
+    [Test]
+    public async Task WithMaxBlock_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+        var result = builder.WithMaxBlock(TimeSpan.FromSeconds(5));
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithMaxBlock_BuildSucceeds()
+    {
+        var act = () => Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithMaxBlock(TimeSpan.FromSeconds(30))
+            .Build();
+
+        await Assert.That(act).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task WithMaxBlock_Zero_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithMaxBlock(TimeSpan.Zero);
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithMaxBlock_Negative_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithMaxBlock(TimeSpan.FromSeconds(-1));
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    #endregion
+
+    #region Builder chaining
+
+    [Test]
+    public async Task WithMaxBlockMs_ChainsWithOtherBuilderMethods()
+    {
+        var act = () => Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithMaxBlockMs(10000)
+            .WithBufferMemory(1024 * 1024)
+            .WithLingerMs(5)
+            .Build();
+
+        await Assert.That(act).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task WithMaxBlock_ChainsWithOtherBuilderMethods()
+    {
+        var act = () => Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithMaxBlock(TimeSpan.FromSeconds(10))
+            .WithBufferMemory(1024 * 1024)
+            .WithLinger(TimeSpan.FromMilliseconds(5))
+            .Build();
+
+        await Assert.That(act).ThrowsNothing();
+    }
+
+    #endregion
+
+    #region RecordAccumulator timeout uses MaxBlockMs
+
+    [Test]
+    public async Task RecordAccumulator_UsesMaxBlockMs_ForBufferTimeout()
+    {
+        // Create options with a very small buffer and very short MaxBlockMs
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BufferMemory = 1, // 1 byte - effectively always full
+            MaxBlockMs = 50   // 50ms timeout
+        };
+
+        await using var accumulator = new RecordAccumulator(options);
+
+        // Try to reserve more memory than available - should timeout with MaxBlockMs
+        var act = async () => await accumulator.ReserveMemoryAsyncForBackpressure(1024, CancellationToken.None)
+            .ConfigureAwait(false);
+
+        await Assert.That(act).Throws<TimeoutException>();
+    }
+
+    [Test]
+    public async Task RecordAccumulator_TimeoutMessage_ContainsMaxBlockMs()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BufferMemory = 1,
+            MaxBlockMs = 50
+        };
+
+        await using var accumulator = new RecordAccumulator(options);
+
+        try
+        {
+            await accumulator.ReserveMemoryAsyncForBackpressure(1024, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Should not reach here
+            throw new InvalidOperationException("Expected TimeoutException was not thrown");
+        }
+        catch (TimeoutException ex)
+        {
+            await Assert.That(ex.Message).Contains("max.block.ms");
+            await Assert.That(ex.Message).Contains("50");
+        }
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
@@ -209,6 +209,13 @@ public class ProducerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task MaxBlockMs_DefaultsTo_60000()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.MaxBlockMs).IsEqualTo(60000);
+    }
+
+    [Test]
     public async Task SocketSendBufferBytes_DefaultsTo_0()
     {
         var options = CreateOptions();


### PR DESCRIPTION
## Summary
- Add `MaxBlockMs` config (default 60s) to limit how long `ProduceAsync`/`Send` block when buffer is full or metadata is unavailable
- Applied when waiting for buffer space (backpressure), initial metadata, and topic metadata fetching
- Throws `TimeoutException` with clear, actionable messages when exceeded
- Prevents indefinite producer hangs under memory pressure or when cluster is unreachable
- Equivalent to Kafka's `max.block.ms` configuration

## Test plan
- [x] Unit tests for `MaxBlockMs` default value (60000ms)
- [x] Unit tests for `ProducerOptions.MaxBlockMs` config storage
- [x] Unit tests for `WithMaxBlockMs(int)` builder method with validation
- [x] Unit tests for `WithMaxBlock(TimeSpan)` builder method with validation
- [x] Unit tests for builder method chaining
- [x] Unit tests verifying `RecordAccumulator` uses `MaxBlockMs` for buffer timeout
- [x] Unit tests verifying timeout message contains `max.block.ms`
- [x] Existing producer tests pass (94 tests, no regressions)
- [x] Existing buffer memory tests pass (16 tests, updated to use `MaxBlockMs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)