### PR TITLE
feat: KIP-848 new consumer group protocol foundation

### DIFF
--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -49,6 +49,21 @@ public sealed class ConsumerOptions
     public string? GroupInstanceId { get; init; }
 
     /// <summary>
+    /// The consumer group protocol to use for group coordination.
+    /// Default is <see cref="GroupProtocol.Classic"/> for backward compatibility.
+    /// Set to <see cref="GroupProtocol.Consumer"/> to use the KIP-848 protocol (Kafka 4.0+).
+    /// </summary>
+    public GroupProtocol GroupProtocol { get; init; } = GroupProtocol.Classic;
+
+    /// <summary>
+    /// The server-side partition assignor to use when <see cref="GroupProtocol"/> is
+    /// <see cref="GroupProtocol.Consumer"/>. Common values are "uniform" and "range".
+    /// When null, the broker uses its default assignor.
+    /// This setting is only applicable with the Consumer group protocol (KIP-848).
+    /// </summary>
+    public string? GroupRemoteAssignor { get; init; }
+
+    /// <summary>
     /// Offset commit mode controlling how offsets are stored and committed.
     /// Default is <see cref="OffsetCommitMode.Auto"/>.
     /// </summary>
@@ -234,6 +249,27 @@ public sealed class ConsumerOptions
     /// Handler for statistics events. Called periodically based on StatisticsInterval.
     /// </summary>
     public Action<Statistics.ConsumerStatistics>? StatisticsHandler { get; init; }
+}
+
+/// <summary>
+/// Specifies the consumer group protocol to use for group coordination.
+/// </summary>
+public enum GroupProtocol
+{
+    /// <summary>
+    /// Classic consumer group protocol using JoinGroup/SyncGroup/Heartbeat APIs.
+    /// This is the traditional protocol used in Kafka versions prior to 4.0.
+    /// Partition assignment is performed client-side by the group leader.
+    /// </summary>
+    Classic,
+
+    /// <summary>
+    /// New consumer group protocol introduced in KIP-848 (Kafka 4.0+).
+    /// Uses the ConsumerGroupHeartbeat API for group coordination.
+    /// Partition assignment is performed server-side by the group coordinator,
+    /// providing up to 20x faster rebalancing.
+    /// </summary>
+    Consumer
 }
 
 /// <summary>

--- a/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatRequest.cs
@@ -1,0 +1,131 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ConsumerGroupHeartbeat request (API key 68).
+/// Used by the KIP-848 consumer group protocol for group coordination.
+/// The broker handles partition assignment server-side instead of the client.
+/// </summary>
+public sealed class ConsumerGroupHeartbeatRequest : IKafkaRequest<ConsumerGroupHeartbeatResponse>
+{
+    public static ApiKey ApiKey => ApiKey.ConsumerGroupHeartbeat;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// The group ID.
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// The member ID. Empty string for new members joining the group.
+    /// </summary>
+    public required string MemberId { get; init; }
+
+    /// <summary>
+    /// The member epoch. 0 for new members, -1 to leave the group, -2 for a static member rejoining.
+    /// </summary>
+    public required int MemberEpoch { get; init; }
+
+    /// <summary>
+    /// The group instance ID for static membership.
+    /// </summary>
+    public string? InstanceId { get; init; }
+
+    /// <summary>
+    /// The rack ID of the consumer, used for rack-aware assignment.
+    /// </summary>
+    public string? RackId { get; init; }
+
+    /// <summary>
+    /// The maximum time in milliseconds that the coordinator will wait for the member to revoke
+    /// partitions. Only provided when joining or rejoining the group.
+    /// </summary>
+    public int RebalanceTimeoutMs { get; init; } = -1;
+
+    /// <summary>
+    /// The list of topic names the consumer is subscribed to.
+    /// Null if not changed since the last heartbeat.
+    /// </summary>
+    public IReadOnlyList<string>? SubscribedTopicNames { get; init; }
+
+    /// <summary>
+    /// The server-side assignor to use. Null to use the broker default.
+    /// </summary>
+    public string? ServerAssignor { get; init; }
+
+    /// <summary>
+    /// The topic partitions currently owned by this member.
+    /// Null if not changed since the last heartbeat.
+    /// </summary>
+    public IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? TopicPartitions { get; init; }
+
+    // ConsumerGroupHeartbeat is only v0, which is always flexible
+    public static bool IsFlexibleVersion(short version) => true;
+    public static short GetRequestHeaderVersion(short version) => 2;
+    public static short GetResponseHeaderVersion(short version) => 1;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactString(GroupId);
+        writer.WriteCompactString(MemberId);
+        writer.WriteInt32(MemberEpoch);
+        writer.WriteCompactNullableString(InstanceId);
+        writer.WriteCompactNullableString(RackId);
+        writer.WriteInt32(RebalanceTimeoutMs);
+
+        writer.WriteCompactNullableArray(
+            SubscribedTopicNames,
+            static (ref KafkaProtocolWriter w, string topic) =>
+            {
+                w.WriteCompactString(topic);
+            });
+
+        writer.WriteCompactNullableString(ServerAssignor);
+
+        writer.WriteCompactNullableArray(
+            TopicPartitions,
+            static (ref KafkaProtocolWriter w, ConsumerGroupHeartbeatTopicPartitions tp) => tp.Write(ref w));
+
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// Topic partitions in a ConsumerGroupHeartbeat request/response.
+/// </summary>
+public sealed class ConsumerGroupHeartbeatTopicPartitions
+{
+    /// <summary>
+    /// The topic ID (UUID).
+    /// </summary>
+    public required Guid TopicId { get; init; }
+
+    /// <summary>
+    /// The partition indexes.
+    /// </summary>
+    public required IReadOnlyList<int> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteUuid(TopicId);
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, int partition) => w.WriteInt32(partition));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ConsumerGroupHeartbeatTopicPartitions Read(ref KafkaProtocolReader reader)
+    {
+        var topicId = reader.ReadUuid();
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32());
+
+        reader.SkipTaggedFields();
+
+        return new ConsumerGroupHeartbeatTopicPartitions
+        {
+            TopicId = topicId,
+            Partitions = partitions
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatResponse.cs
@@ -1,0 +1,121 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ConsumerGroupHeartbeat response (API key 68).
+/// Contains the group coordination state from the broker, including
+/// the assigned partitions (server-side assignment per KIP-848).
+/// </summary>
+public sealed class ConsumerGroupHeartbeatResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.ConsumerGroupHeartbeat;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// Throttle time in milliseconds.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The top-level error code, or 0 if there was no error.
+    /// </summary>
+    public required ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The member ID assigned by the coordinator.
+    /// Only set when the member first joins the group (MemberEpoch == 0).
+    /// </summary>
+    public string? MemberId { get; init; }
+
+    /// <summary>
+    /// The current member epoch. The member must use this epoch for subsequent heartbeats.
+    /// </summary>
+    public int MemberEpoch { get; init; }
+
+    /// <summary>
+    /// The heartbeat interval in milliseconds.
+    /// The member should send the next heartbeat before this interval expires.
+    /// </summary>
+    public int HeartbeatIntervalMs { get; init; }
+
+    /// <summary>
+    /// The assignment for this member, or null if the assignment has not changed.
+    /// Contains both immediately usable partitions and pending partitions
+    /// that are still being revoked from other members.
+    /// </summary>
+    public ConsumerGroupHeartbeatAssignment? Assignment { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+        var memberId = reader.ReadCompactString();
+        var memberEpoch = reader.ReadInt32();
+        var heartbeatIntervalMs = reader.ReadInt32();
+
+        // Assignment is a nullable struct encoded with a tag-like presence indicator
+        // In the Kafka protocol, the assignment is present if the next varint is > 0
+        var assignmentPresent = reader.ReadUnsignedVarInt();
+        ConsumerGroupHeartbeatAssignment? assignment = null;
+        if (assignmentPresent > 0)
+        {
+            assignment = ConsumerGroupHeartbeatAssignment.Read(ref reader);
+        }
+
+        // Response tagged fields
+        reader.SkipTaggedFields();
+
+        return new ConsumerGroupHeartbeatResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            MemberId = memberId,
+            MemberEpoch = memberEpoch,
+            HeartbeatIntervalMs = heartbeatIntervalMs,
+            Assignment = assignment
+        };
+    }
+}
+
+/// <summary>
+/// Assignment information in a ConsumerGroupHeartbeat response.
+/// Contains the partitions assigned to this member by the server.
+/// </summary>
+public sealed class ConsumerGroupHeartbeatAssignment
+{
+    /// <summary>
+    /// The partitions assigned to this member that are immediately usable.
+    /// </summary>
+    public required IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions> AssignedTopicPartitions { get; init; }
+
+    /// <summary>
+    /// The partitions assigned to this member that are not yet released by their former owners.
+    /// The member should not start consuming from these partitions until they appear in
+    /// <see cref="AssignedTopicPartitions"/> in a subsequent heartbeat response.
+    /// </summary>
+    public required IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions> PendingTopicPartitions { get; init; }
+
+    public static ConsumerGroupHeartbeatAssignment Read(ref KafkaProtocolReader reader)
+    {
+        var assignedTopicPartitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ConsumerGroupHeartbeatTopicPartitions.Read(ref r));
+
+        var pendingTopicPartitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ConsumerGroupHeartbeatTopicPartitions.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new ConsumerGroupHeartbeatAssignment
+        {
+            AssignedTopicPartitions = assignedTopicPartitions,
+            PendingTopicPartitions = pendingTopicPartitions
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/GroupProtocolConfigTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/GroupProtocolConfigTests.cs
@@ -1,0 +1,231 @@
+using Dekaf.Consumer;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+/// <summary>
+/// Tests for GroupProtocol enum and ConsumerOptions configuration related to KIP-848.
+/// </summary>
+public sealed class GroupProtocolConfigTests
+{
+    private static ConsumerOptions CreateOptions() => new()
+    {
+        BootstrapServers = ["localhost:9092"]
+    };
+
+    #region GroupProtocol Enum
+
+    [Test]
+    public async Task GroupProtocol_HasClassicValue()
+    {
+        var protocol = GroupProtocol.Classic;
+        await Assert.That(protocol).IsEqualTo(GroupProtocol.Classic);
+    }
+
+    [Test]
+    public async Task GroupProtocol_HasConsumerValue()
+    {
+        var protocol = GroupProtocol.Consumer;
+        await Assert.That(protocol).IsEqualTo(GroupProtocol.Consumer);
+    }
+
+    [Test]
+    public async Task GroupProtocol_ClassicAndConsumer_AreDifferent()
+    {
+        GroupProtocol classic = GroupProtocol.Classic;
+        GroupProtocol consumer = GroupProtocol.Consumer;
+        await Assert.That(classic).IsNotEqualTo(consumer);
+    }
+
+    #endregion
+
+    #region ConsumerOptions Defaults
+
+    [Test]
+    public async Task GroupProtocol_DefaultsTo_Classic()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.GroupProtocol).IsEqualTo(GroupProtocol.Classic);
+    }
+
+    [Test]
+    public async Task GroupRemoteAssignor_DefaultsTo_Null()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.GroupRemoteAssignor).IsNull();
+    }
+
+    #endregion
+
+    #region ConsumerOptions with Consumer Protocol
+
+    [Test]
+    public async Task GroupProtocol_CanBeSetTo_Consumer()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            GroupProtocol = GroupProtocol.Consumer
+        };
+        await Assert.That(options.GroupProtocol).IsEqualTo(GroupProtocol.Consumer);
+    }
+
+    [Test]
+    public async Task GroupRemoteAssignor_CanBeSetTo_Uniform()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            GroupProtocol = GroupProtocol.Consumer,
+            GroupRemoteAssignor = "uniform"
+        };
+        await Assert.That(options.GroupRemoteAssignor).IsEqualTo("uniform");
+    }
+
+    [Test]
+    public async Task GroupRemoteAssignor_CanBeSetTo_Range()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            GroupProtocol = GroupProtocol.Consumer,
+            GroupRemoteAssignor = "range"
+        };
+        await Assert.That(options.GroupRemoteAssignor).IsEqualTo("range");
+    }
+
+    #endregion
+
+    #region Builder Methods
+
+    [Test]
+    public async Task WithGroupProtocol_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+        var result = builder.WithGroupProtocol(GroupProtocol.Consumer);
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithGroupRemoteAssignor_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+        var result = builder.WithGroupRemoteAssignor("uniform");
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithGroupProtocol_Classic_ThenBuild_Succeeds()
+    {
+        var act = () => Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupProtocol(GroupProtocol.Classic)
+            .Build();
+
+        await Assert.That(act).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task WithGroupProtocol_Consumer_ThenBuild_Succeeds()
+    {
+        var act = () => Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupProtocol(GroupProtocol.Consumer)
+            .Build();
+
+        await Assert.That(act).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task WithGroupProtocol_Consumer_WithRemoteAssignor_ThenBuild_Succeeds()
+    {
+        var act = () => Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupProtocol(GroupProtocol.Consumer)
+            .WithGroupRemoteAssignor("uniform")
+            .Build();
+
+        await Assert.That(act).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task WithGroupRemoteAssignor_Null_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var act = () => builder.WithGroupRemoteAssignor(null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    #endregion
+
+    #region Validation
+
+    [Test]
+    public async Task Build_WithGroupRemoteAssignor_WithoutConsumerProtocol_Throws()
+    {
+        var act = () => Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupRemoteAssignor("uniform")
+            .Build();
+
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Build_WithGroupRemoteAssignor_WithClassicProtocol_Throws()
+    {
+        var act = () => Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupProtocol(GroupProtocol.Classic)
+            .WithGroupRemoteAssignor("uniform")
+            .Build();
+
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Build_WithGroupRemoteAssignor_WithConsumerProtocol_Succeeds()
+    {
+        var act = () => Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupProtocol(GroupProtocol.Consumer)
+            .WithGroupRemoteAssignor("uniform")
+            .Build();
+
+        await Assert.That(act).ThrowsNothing();
+    }
+
+    #endregion
+
+    #region Builder Chaining
+
+    [Test]
+    public async Task FullChain_WithConsumerProtocol_Succeeds()
+    {
+        var act = () => Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("my-group")
+            .WithGroupProtocol(GroupProtocol.Consumer)
+            .WithGroupRemoteAssignor("uniform")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .Build();
+
+        await Assert.That(act).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task FullChain_WithClassicProtocol_Succeeds()
+    {
+        var act = () => Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("my-group")
+            .WithGroupProtocol(GroupProtocol.Classic)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .Build();
+
+        await Assert.That(act).ThrowsNothing();
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ConsumerGroupHeartbeatMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ConsumerGroupHeartbeatMessageTests.cs
@@ -1,0 +1,454 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+/// <summary>
+/// Tests for ConsumerGroupHeartbeat request and response message encoding/decoding (KIP-848).
+/// </summary>
+public sealed class ConsumerGroupHeartbeatMessageTests
+{
+    #region Request Construction
+
+    [Test]
+    public async Task Request_CanBeConstructed_WithRequiredFields()
+    {
+        var request = new ConsumerGroupHeartbeatRequest
+        {
+            GroupId = "my-group",
+            MemberId = "",
+            MemberEpoch = 0
+        };
+
+        await Assert.That(request.GroupId).IsEqualTo("my-group");
+        await Assert.That(request.MemberId).IsEqualTo("");
+        await Assert.That(request.MemberEpoch).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Request_CanBeConstructed_WithAllFields()
+    {
+        var topicId = Guid.NewGuid();
+        var request = new ConsumerGroupHeartbeatRequest
+        {
+            GroupId = "my-group",
+            MemberId = "member-1",
+            MemberEpoch = 5,
+            InstanceId = "instance-1",
+            RackId = "rack-a",
+            RebalanceTimeoutMs = 30000,
+            SubscribedTopicNames = ["topic-1", "topic-2"],
+            ServerAssignor = "uniform",
+            TopicPartitions =
+            [
+                new ConsumerGroupHeartbeatTopicPartitions
+                {
+                    TopicId = topicId,
+                    Partitions = [0, 1, 2]
+                }
+            ]
+        };
+
+        await Assert.That(request.GroupId).IsEqualTo("my-group");
+        await Assert.That(request.MemberId).IsEqualTo("member-1");
+        await Assert.That(request.MemberEpoch).IsEqualTo(5);
+        await Assert.That(request.InstanceId).IsEqualTo("instance-1");
+        await Assert.That(request.RackId).IsEqualTo("rack-a");
+        await Assert.That(request.RebalanceTimeoutMs).IsEqualTo(30000);
+        await Assert.That(request.SubscribedTopicNames!.Count).IsEqualTo(2);
+        await Assert.That(request.ServerAssignor).IsEqualTo("uniform");
+        await Assert.That(request.TopicPartitions!.Count).IsEqualTo(1);
+        await Assert.That(request.TopicPartitions[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(request.TopicPartitions[0].Partitions.Count).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Request_NullableFields_DefaultToNull()
+    {
+        var request = new ConsumerGroupHeartbeatRequest
+        {
+            GroupId = "my-group",
+            MemberId = "",
+            MemberEpoch = 0
+        };
+
+        await Assert.That(request.InstanceId).IsNull();
+        await Assert.That(request.RackId).IsNull();
+        await Assert.That(request.SubscribedTopicNames).IsNull();
+        await Assert.That(request.ServerAssignor).IsNull();
+        await Assert.That(request.TopicPartitions).IsNull();
+    }
+
+    [Test]
+    public async Task Request_RebalanceTimeoutMs_DefaultsToNegativeOne()
+    {
+        var request = new ConsumerGroupHeartbeatRequest
+        {
+            GroupId = "my-group",
+            MemberId = "",
+            MemberEpoch = 0
+        };
+
+        await Assert.That(request.RebalanceTimeoutMs).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task Request_MemberEpoch_NegativeOne_MeansLeave()
+    {
+        var request = new ConsumerGroupHeartbeatRequest
+        {
+            GroupId = "my-group",
+            MemberId = "member-1",
+            MemberEpoch = -1
+        };
+
+        await Assert.That(request.MemberEpoch).IsEqualTo(-1);
+    }
+
+    #endregion
+
+    #region Request API Metadata
+
+    [Test]
+    public async Task Request_ApiKey_IsConsumerGroupHeartbeat()
+    {
+        await Assert.That(ConsumerGroupHeartbeatRequest.ApiKey).IsEqualTo(ApiKey.ConsumerGroupHeartbeat);
+    }
+
+    [Test]
+    public async Task Request_LowestSupportedVersion_Is0()
+    {
+        await Assert.That(ConsumerGroupHeartbeatRequest.LowestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task Request_HighestSupportedVersion_Is0()
+    {
+        await Assert.That(ConsumerGroupHeartbeatRequest.HighestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task Request_IsAlwaysFlexible()
+    {
+        await Assert.That(ConsumerGroupHeartbeatRequest.IsFlexibleVersion(0)).IsTrue();
+    }
+
+    [Test]
+    public async Task Request_RequestHeaderVersion_Is2()
+    {
+        await Assert.That(ConsumerGroupHeartbeatRequest.GetRequestHeaderVersion(0)).IsEqualTo((short)2);
+    }
+
+    [Test]
+    public async Task Request_ResponseHeaderVersion_Is1()
+    {
+        await Assert.That(ConsumerGroupHeartbeatRequest.GetResponseHeaderVersion(0)).IsEqualTo((short)1);
+    }
+
+    #endregion
+
+    #region Request Encoding
+
+    [Test]
+    public async Task Request_Write_JoinGroup_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ConsumerGroupHeartbeatRequest
+        {
+            GroupId = "test",
+            MemberId = "",
+            MemberEpoch = 0,
+            RebalanceTimeoutMs = 60000,
+            SubscribedTopicNames = ["my-topic"],
+            ServerAssignor = "uniform"
+        };
+        request.Write(ref writer, version: 0);
+
+        // Verify the output is non-empty and can be produced without error
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_WithNullOptionalFields_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ConsumerGroupHeartbeatRequest
+        {
+            GroupId = "test",
+            MemberId = "",
+            MemberEpoch = 0
+        };
+        request.Write(ref writer, version: 0);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_WithTopicPartitions_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var topicId = Guid.NewGuid();
+        var request = new ConsumerGroupHeartbeatRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            MemberEpoch = 3,
+            TopicPartitions =
+            [
+                new ConsumerGroupHeartbeatTopicPartitions
+                {
+                    TopicId = topicId,
+                    Partitions = [0, 1]
+                }
+            ]
+        };
+        request.Write(ref writer, version: 0);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    #endregion
+
+    #region Response Construction
+
+    [Test]
+    public async Task Response_CanBeConstructed_WithRequiredFields()
+    {
+        var response = new ConsumerGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.None
+        };
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.MemberEpoch).IsEqualTo(0);
+        await Assert.That(response.HeartbeatIntervalMs).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_CanBeConstructed_WithAllFields()
+    {
+        var topicId = Guid.NewGuid();
+        var response = new ConsumerGroupHeartbeatResponse
+        {
+            ThrottleTimeMs = 100,
+            ErrorCode = ErrorCode.None,
+            ErrorMessage = null,
+            MemberId = "member-1",
+            MemberEpoch = 5,
+            HeartbeatIntervalMs = 5000,
+            Assignment = new ConsumerGroupHeartbeatAssignment
+            {
+                AssignedTopicPartitions =
+                [
+                    new ConsumerGroupHeartbeatTopicPartitions
+                    {
+                        TopicId = topicId,
+                        Partitions = [0, 1, 2]
+                    }
+                ],
+                PendingTopicPartitions = []
+            }
+        };
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(100);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.MemberId).IsEqualTo("member-1");
+        await Assert.That(response.MemberEpoch).IsEqualTo(5);
+        await Assert.That(response.HeartbeatIntervalMs).IsEqualTo(5000);
+        await Assert.That(response.Assignment).IsNotNull();
+        await Assert.That(response.Assignment!.AssignedTopicPartitions.Count).IsEqualTo(1);
+        await Assert.That(response.Assignment.PendingTopicPartitions.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_Assignment_CanBeNull()
+    {
+        var response = new ConsumerGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.None,
+            MemberId = "member-1",
+            MemberEpoch = 3,
+            HeartbeatIntervalMs = 5000,
+            Assignment = null
+        };
+
+        await Assert.That(response.Assignment).IsNull();
+    }
+
+    [Test]
+    public async Task Response_WithError_HasErrorMessage()
+    {
+        var response = new ConsumerGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.GroupAuthorizationFailed,
+            ErrorMessage = "Not authorized"
+        };
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.GroupAuthorizationFailed);
+        await Assert.That(response.ErrorMessage).IsEqualTo("Not authorized");
+    }
+
+    #endregion
+
+    #region Response API Metadata
+
+    [Test]
+    public async Task Response_ApiKey_IsConsumerGroupHeartbeat()
+    {
+        await Assert.That(ConsumerGroupHeartbeatResponse.ApiKey).IsEqualTo(ApiKey.ConsumerGroupHeartbeat);
+    }
+
+    [Test]
+    public async Task Response_LowestSupportedVersion_Is0()
+    {
+        await Assert.That(ConsumerGroupHeartbeatResponse.LowestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task Response_HighestSupportedVersion_Is0()
+    {
+        await Assert.That(ConsumerGroupHeartbeatResponse.HighestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    #endregion
+
+    #region TopicPartitions
+
+    [Test]
+    public async Task TopicPartitions_CanBeConstructed()
+    {
+        var topicId = Guid.NewGuid();
+        var tp = new ConsumerGroupHeartbeatTopicPartitions
+        {
+            TopicId = topicId,
+            Partitions = [0, 1, 2]
+        };
+
+        await Assert.That(tp.TopicId).IsEqualTo(topicId);
+        await Assert.That(tp.Partitions.Count).IsEqualTo(3);
+        await Assert.That(tp.Partitions[0]).IsEqualTo(0);
+        await Assert.That(tp.Partitions[1]).IsEqualTo(1);
+        await Assert.That(tp.Partitions[2]).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task TopicPartitions_Write_ProducesOutput()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var tp = new ConsumerGroupHeartbeatTopicPartitions
+        {
+            TopicId = Guid.NewGuid(),
+            Partitions = [0, 1]
+        };
+        tp.Write(ref writer);
+
+        // UUID (16 bytes) + compact array header + 2 * INT32 (8 bytes) + tagged fields
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task TopicPartitions_WriteAndRead_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var topicId = Guid.NewGuid();
+        var original = new ConsumerGroupHeartbeatTopicPartitions
+        {
+            TopicId = topicId,
+            Partitions = [0, 3, 7]
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ConsumerGroupHeartbeatTopicPartitions.Read(ref reader);
+
+        await Assert.That(deserialized.TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.Partitions.Count).IsEqualTo(3);
+        await Assert.That(deserialized.Partitions[0]).IsEqualTo(0);
+        await Assert.That(deserialized.Partitions[1]).IsEqualTo(3);
+        await Assert.That(deserialized.Partitions[2]).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task TopicPartitions_EmptyPartitions_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var topicId = Guid.NewGuid();
+        var original = new ConsumerGroupHeartbeatTopicPartitions
+        {
+            TopicId = topicId,
+            Partitions = []
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ConsumerGroupHeartbeatTopicPartitions.Read(ref reader);
+
+        await Assert.That(deserialized.TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.Partitions.Count).IsEqualTo(0);
+    }
+
+    #endregion
+
+    #region Assignment
+
+    [Test]
+    public async Task Assignment_CanBeConstructed_WithEmptyLists()
+    {
+        var assignment = new ConsumerGroupHeartbeatAssignment
+        {
+            AssignedTopicPartitions = [],
+            PendingTopicPartitions = []
+        };
+
+        await Assert.That(assignment.AssignedTopicPartitions.Count).IsEqualTo(0);
+        await Assert.That(assignment.PendingTopicPartitions.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Assignment_CanBeConstructed_WithAssignedAndPending()
+    {
+        var topicId1 = Guid.NewGuid();
+        var topicId2 = Guid.NewGuid();
+
+        var assignment = new ConsumerGroupHeartbeatAssignment
+        {
+            AssignedTopicPartitions =
+            [
+                new ConsumerGroupHeartbeatTopicPartitions
+                {
+                    TopicId = topicId1,
+                    Partitions = [0, 1]
+                }
+            ],
+            PendingTopicPartitions =
+            [
+                new ConsumerGroupHeartbeatTopicPartitions
+                {
+                    TopicId = topicId2,
+                    Partitions = [2]
+                }
+            ]
+        };
+
+        await Assert.That(assignment.AssignedTopicPartitions.Count).IsEqualTo(1);
+        await Assert.That(assignment.AssignedTopicPartitions[0].TopicId).IsEqualTo(topicId1);
+        await Assert.That(assignment.PendingTopicPartitions.Count).IsEqualTo(1);
+        await Assert.That(assignment.PendingTopicPartitions[0].TopicId).IsEqualTo(topicId2);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Add `GroupProtocol` enum (`Classic`, `Consumer`) and config option to `ConsumerOptions`
- Add `GroupRemoteAssignor` config for server-side assignor selection (e.g., "uniform", "range")
- Add `ConsumerGroupHeartbeatRequest`/`Response` protocol messages (API key 68) following existing message patterns
- Add `ConsumerGroupHeartbeatAssignment` with `AssignedTopicPartitions` and `PendingTopicPartitions` for incremental assignment
- Add builder methods: `WithGroupProtocol()`, `WithGroupRemoteAssignor()`
- Add validation: `GroupRemoteAssignor` requires `GroupProtocol.Consumer`
- Foundation for full KIP-848 implementation (server-side assignment, Kafka 4.0+)

## Test plan
- [x] Unit tests for `GroupProtocol` enum values and `ConsumerOptions` defaults (19 tests)
- [x] Unit tests for builder methods and chaining
- [x] Unit tests for validation rules (remote assignor requires Consumer protocol)
- [x] Unit tests for `ConsumerGroupHeartbeatRequest`/`Response` construction and encoding (27 tests)
- [x] Unit tests for `ConsumerGroupHeartbeatTopicPartitions` write/read round-trip
- [x] All existing consumer tests pass (135 tests, regression check)
- [x] Full unit test suite passes (1332 tests, zero failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)