### PR TITLE
test: Expand unit test coverage and fix certificate flakiness

### DIFF
--- a/tests/Dekaf.Tests.Unit/Builder/BuilderEdgeCaseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/BuilderEdgeCaseTests.cs
@@ -1,0 +1,311 @@
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.Builder;
+
+public sealed class ProducerBuilderEdgeCaseTests
+{
+    #region WithMaxBlock Validation
+
+    [Test]
+    public async Task WithMaxBlock_Zero_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithMaxBlock(TimeSpan.Zero);
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithMaxBlock_Negative_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithMaxBlock(TimeSpan.FromSeconds(-1));
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithMaxBlock_Positive_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+        var result = builder.WithMaxBlock(TimeSpan.FromSeconds(30));
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    #endregion
+
+    #region WithStatisticsInterval Validation
+
+    [Test]
+    public async Task WithStatisticsInterval_Zero_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithStatisticsInterval(TimeSpan.Zero);
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithStatisticsInterval_Negative_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithStatisticsInterval(TimeSpan.FromSeconds(-1));
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithStatisticsInterval_Positive_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+        var result = builder.WithStatisticsInterval(TimeSpan.FromSeconds(5));
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    #endregion
+
+    #region WithMetadataMaxAge Validation
+
+    [Test]
+    public async Task WithMetadataMaxAge_Zero_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithMetadataMaxAge(TimeSpan.Zero);
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithMetadataMaxAge_Negative_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithMetadataMaxAge(TimeSpan.FromMinutes(-1));
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithMetadataMaxAge_Positive_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+        var result = builder.WithMetadataMaxAge(TimeSpan.FromMinutes(5));
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    #endregion
+
+    #region WithGssapi Validation
+
+    [Test]
+    public async Task WithGssapi_Null_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithGssapi(null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    #endregion
+
+    #region WithOAuthBearer Validation
+
+    [Test]
+    public async Task WithOAuthBearer_NullConfig_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithOAuthBearer((OAuthBearerConfig)null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task WithOAuthBearer_NullTokenProvider_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithOAuthBearer((Func<CancellationToken, ValueTask<OAuthBearerToken>>)null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    #endregion
+
+    #region WithStatisticsHandler Validation
+
+    [Test]
+    public async Task WithStatisticsHandler_Null_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithStatisticsHandler(null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    #endregion
+
+    #region AddInterceptor Validation
+
+    [Test]
+    public async Task AddInterceptor_Null_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.AddInterceptor(null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    #endregion
+}
+
+public sealed class ConsumerBuilderEdgeCaseTests
+{
+    #region WithStatisticsInterval Validation
+
+    [Test]
+    public async Task WithStatisticsInterval_Zero_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var act = () => builder.WithStatisticsInterval(TimeSpan.Zero);
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithStatisticsInterval_Negative_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var act = () => builder.WithStatisticsInterval(TimeSpan.FromSeconds(-1));
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    #endregion
+
+    #region WithMetadataMaxAge Validation
+
+    [Test]
+    public async Task WithMetadataMaxAge_Zero_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var act = () => builder.WithMetadataMaxAge(TimeSpan.Zero);
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithMetadataMaxAge_Negative_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var act = () => builder.WithMetadataMaxAge(TimeSpan.FromMinutes(-1));
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    #endregion
+
+    #region WithGssapi Validation
+
+    [Test]
+    public async Task WithGssapi_Null_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var act = () => builder.WithGssapi(null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    #endregion
+
+    #region WithOAuthBearer Validation
+
+    [Test]
+    public async Task WithOAuthBearer_NullConfig_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var act = () => builder.WithOAuthBearer((OAuthBearerConfig)null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task WithOAuthBearer_NullTokenProvider_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var act = () => builder.WithOAuthBearer((Func<CancellationToken, ValueTask<OAuthBearerToken>>)null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    #endregion
+
+    #region WithStatisticsHandler Validation
+
+    [Test]
+    public async Task WithStatisticsHandler_Null_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var act = () => builder.WithStatisticsHandler(null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    #endregion
+
+    #region WithGroupRemoteAssignor Validation
+
+    [Test]
+    public async Task WithGroupRemoteAssignor_Null_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var act = () => builder.WithGroupRemoteAssignor(null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Build_WithGroupRemoteAssignor_WithoutConsumerProtocol_ThrowsInvalidOperationException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupRemoteAssignor("uniform");
+
+        var act = () => builder.Build();
+
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    #endregion
+
+    #region AddInterceptor Validation
+
+    [Test]
+    public async Task AddInterceptor_Null_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var act = () => builder.AddInterceptor(null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerExtensionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerExtensionsTests.cs
@@ -1,0 +1,340 @@
+using System.Runtime.CompilerServices;
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerExtensionsTests
+{
+    #region Where
+
+    [Test]
+    public async Task Where_FiltersMatchingItems()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1), ("topic", 0, 2));
+
+        var results = new List<ConsumeResult<string, string>>();
+        await foreach (var item in source.Where(r => r.Offset % 2 == 0))
+        {
+            results.Add(item);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(2);
+        await Assert.That(results[0].Offset).IsEqualTo(0);
+        await Assert.That(results[1].Offset).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Where_NoMatches_ReturnsEmpty()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1));
+
+        var results = new List<ConsumeResult<string, string>>();
+        await foreach (var item in source.Where(_ => false))
+        {
+            results.Add(item);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Where_NullSource_ThrowsArgumentNullException()
+    {
+        IAsyncEnumerable<ConsumeResult<string, string>>? source = null;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+        {
+            await foreach (var _ in source!.Where(_ => true)) { }
+        });
+    }
+
+    [Test]
+    public async Task Where_NullPredicate_ThrowsArgumentNullException()
+    {
+        var source = CreateResults(("topic", 0, 0));
+        Func<ConsumeResult<string, string>, bool> predicate = null!;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+        {
+            await foreach (var _ in source.Where(predicate)) { }
+        });
+    }
+
+    #endregion
+
+    #region Select
+
+    [Test]
+    public async Task Select_ProjectsItems()
+    {
+        var source = CreateResults(("topic", 0, 10), ("topic", 0, 20));
+
+        var results = new List<long>();
+        await foreach (var offset in source.Select(r => r.Offset))
+        {
+            results.Add(offset);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(2);
+        await Assert.That(results[0]).IsEqualTo(10);
+        await Assert.That(results[1]).IsEqualTo(20);
+    }
+
+    [Test]
+    public async Task Select_NullSource_ThrowsArgumentNullException()
+    {
+        IAsyncEnumerable<ConsumeResult<string, string>>? source = null;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+        {
+            await foreach (var _ in source!.Select(r => r.Offset)) { }
+        });
+    }
+
+    [Test]
+    public async Task Select_NullSelector_ThrowsArgumentNullException()
+    {
+        var source = CreateResults(("topic", 0, 0));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+        {
+            await foreach (var _ in source.Select<string, string, long>(null!)) { }
+        });
+    }
+
+    #endregion
+
+    #region Take
+
+    [Test]
+    public async Task Take_ReturnsFirstNItems()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1), ("topic", 0, 2), ("topic", 0, 3));
+
+        var results = new List<ConsumeResult<string, string>>();
+        await foreach (var item in source.Take(2))
+        {
+            results.Add(item);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(2);
+        await Assert.That(results[0].Offset).IsEqualTo(0);
+        await Assert.That(results[1].Offset).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Take_Zero_ReturnsEmpty()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1));
+
+        var results = new List<ConsumeResult<string, string>>();
+        await foreach (var item in source.Take(0))
+        {
+            results.Add(item);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Take_MoreThanAvailable_ReturnsAll()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1));
+
+        var results = new List<ConsumeResult<string, string>>();
+        await foreach (var item in source.Take(100))
+        {
+            results.Add(item);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Take_Negative_ThrowsArgumentOutOfRangeException()
+    {
+        var source = CreateResults(("topic", 0, 0));
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+        {
+            await foreach (var _ in ConsumerExtensions.Take<string, string>(source, -1)) { }
+        });
+    }
+
+    #endregion
+
+    #region Batch
+
+    [Test]
+    public async Task Batch_GroupsIntoCorrectSizes()
+    {
+        var source = CreateResults(
+            ("topic", 0, 0), ("topic", 0, 1), ("topic", 0, 2),
+            ("topic", 0, 3), ("topic", 0, 4));
+
+        var batches = new List<IReadOnlyList<ConsumeResult<string, string>>>();
+        await foreach (var batch in source.Batch(2))
+        {
+            batches.Add(batch);
+        }
+
+        await Assert.That(batches).Count().IsEqualTo(3);
+        await Assert.That(batches[0]).Count().IsEqualTo(2);
+        await Assert.That(batches[1]).Count().IsEqualTo(2);
+        await Assert.That(batches[2]).Count().IsEqualTo(1); // Remainder
+    }
+
+    [Test]
+    public async Task Batch_ExactMultiple_NoRemainder()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1), ("topic", 0, 2), ("topic", 0, 3));
+
+        var batches = new List<IReadOnlyList<ConsumeResult<string, string>>>();
+        await foreach (var batch in source.Batch(2))
+        {
+            batches.Add(batch);
+        }
+
+        await Assert.That(batches).Count().IsEqualTo(2);
+        await Assert.That(batches[0]).Count().IsEqualTo(2);
+        await Assert.That(batches[1]).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Batch_LessThan1_ThrowsArgumentOutOfRangeException()
+    {
+        var source = CreateResults(("topic", 0, 0));
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+        {
+            await foreach (var _ in source.Batch(0)) { }
+        });
+    }
+
+    #endregion
+
+    #region SkipWhile
+
+    [Test]
+    public async Task SkipWhile_SkipsMatchingItemsThenYieldsRest()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1), ("topic", 0, 2), ("topic", 0, 3));
+
+        var results = new List<ConsumeResult<string, string>>();
+        await foreach (var item in source.SkipWhile(r => r.Offset < 2))
+        {
+            results.Add(item);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(2);
+        await Assert.That(results[0].Offset).IsEqualTo(2);
+        await Assert.That(results[1].Offset).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task SkipWhile_AllMatch_ReturnsEmpty()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1));
+
+        var results = new List<ConsumeResult<string, string>>();
+        await foreach (var item in source.SkipWhile(_ => true))
+        {
+            results.Add(item);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SkipWhile_NoneMatch_ReturnsAll()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1));
+
+        var results = new List<ConsumeResult<string, string>>();
+        await foreach (var item in source.SkipWhile(_ => false))
+        {
+            results.Add(item);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(2);
+    }
+
+    #endregion
+
+    #region TakeWhile
+
+    [Test]
+    public async Task TakeWhile_TakesWhilePredicateIsTrue()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1), ("topic", 0, 2), ("topic", 0, 3));
+
+        var results = new List<ConsumeResult<string, string>>();
+        await foreach (var item in source.TakeWhile(r => r.Offset < 2))
+        {
+            results.Add(item);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(2);
+        await Assert.That(results[0].Offset).IsEqualTo(0);
+        await Assert.That(results[1].Offset).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TakeWhile_AllMatch_ReturnsAll()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1));
+
+        var results = new List<ConsumeResult<string, string>>();
+        await foreach (var item in source.TakeWhile(_ => true))
+        {
+            results.Add(item);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task TakeWhile_NoneMatch_ReturnsEmpty()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1));
+
+        var results = new List<ConsumeResult<string, string>>();
+        await foreach (var item in source.TakeWhile(_ => false))
+        {
+            results.Add(item);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static async IAsyncEnumerable<ConsumeResult<string, string>> CreateResults(
+        params (string Topic, int Partition, long Offset)[] items)
+    {
+        foreach (var (topic, partition, offset) in items)
+        {
+            yield return new ConsumeResult<string, string>(
+                topic: topic,
+                partition: partition,
+                offset: offset,
+                keyData: default,
+                isKeyNull: true,
+                valueData: default,
+                isValueNull: true,
+                headers: null,
+                timestamp: default,
+                timestampType: TimestampType.NotAvailable,
+                leaderEpoch: null,
+                keyDeserializer: null,
+                valueDeserializer: null);
+        }
+
+        await Task.CompletedTask; // Ensure truly async
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Serialization.Json\Dekaf.Serialization.Json.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Extensions.DependencyInjection\Dekaf.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Extensions.Hosting\Dekaf.Extensions.Hosting.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
@@ -1,0 +1,196 @@
+using System.Runtime.CompilerServices;
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Hosting;
+
+public sealed class KafkaConsumerServiceTests
+{
+    #region ExecuteAsync
+
+    [Test]
+    public async Task ExecuteAsync_SubscribesToTopics()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        consumer.ConsumeAsync(Arg.Any<CancellationToken>())
+            .Returns(callInfo => WaitForCancellation(callInfo.ArgAt<CancellationToken>(0)));
+
+        var service = new TestConsumerService(consumer, ["topic-a", "topic-b"]);
+
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+        await service.StopAsync(CancellationToken.None);
+
+        consumer.Received(1).Subscribe(Arg.Is<string[]>(t => t.Length == 2 && t[0] == "topic-a" && t[1] == "topic-b"));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ProcessesMessages()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        consumer.ConsumeAsync(Arg.Any<CancellationToken>())
+            .Returns(CreateResults(("topic-a", 0, 0), ("topic-a", 0, 1)));
+
+        var service = new TestConsumerService(consumer, ["topic-a"]);
+
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(200);
+        await service.StopAsync(CancellationToken.None);
+
+        await Assert.That(service.ProcessedMessages).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_OnProcessError_CallsOnErrorAsync()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        consumer.ConsumeAsync(Arg.Any<CancellationToken>())
+            .Returns(CreateResults(("topic-a", 0, 0)));
+
+        var service = new FailingConsumerService(consumer, ["topic-a"]);
+
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(200);
+        await service.StopAsync(CancellationToken.None);
+
+        await Assert.That(service.Errors).Count().IsGreaterThanOrEqualTo(1);
+    }
+
+    #endregion
+
+    #region StopAsync
+
+    [Test]
+    public async Task StopAsync_CommitsOffsets()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        consumer.ConsumeAsync(Arg.Any<CancellationToken>())
+            .Returns(callInfo => WaitForCancellation(callInfo.ArgAt<CancellationToken>(0)));
+
+        var service = new TestConsumerService(consumer, ["topic-a"]);
+
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(50);
+        await service.StopAsync(CancellationToken.None);
+
+        await consumer.Received(1).CommitAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task StopAsync_CommitFails_DoesNotThrow()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        consumer.ConsumeAsync(Arg.Any<CancellationToken>())
+            .Returns(callInfo => WaitForCancellation(callInfo.ArgAt<CancellationToken>(0)));
+        consumer.CommitAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => throw new InvalidOperationException("Commit failed"));
+
+        var service = new TestConsumerService(consumer, ["topic-a"]);
+
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(50);
+
+        // StopAsync should not throw even if commit fails
+        var act = async () => await service.StopAsync(CancellationToken.None);
+
+        await Assert.That(act).ThrowsNothing();
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static async IAsyncEnumerable<ConsumeResult<string, string>> WaitForCancellation(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected - service is stopping
+        }
+
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<ConsumeResult<string, string>> CreateResults(
+        params (string Topic, int Partition, long Offset)[] items)
+    {
+        foreach (var (topic, partition, offset) in items)
+        {
+            yield return new ConsumeResult<string, string>(
+                topic: topic,
+                partition: partition,
+                offset: offset,
+                keyData: default,
+                isKeyNull: true,
+                valueData: default,
+                isValueNull: true,
+                headers: null,
+                timestamp: default,
+                timestampType: TimestampType.NotAvailable,
+                leaderEpoch: null,
+                keyDeserializer: null,
+                valueDeserializer: null);
+        }
+
+        await Task.CompletedTask;
+    }
+
+    private sealed class TestConsumerService : TestableKafkaConsumerService
+    {
+        public List<ConsumeResult<string, string>> ProcessedMessages { get; } = [];
+
+        public TestConsumerService(IKafkaConsumer<string, string> consumer, string[] topics)
+            : base(consumer, topics)
+        {
+        }
+
+        protected override ValueTask ProcessAsync(ConsumeResult<string, string> result, CancellationToken cancellationToken)
+        {
+            ProcessedMessages.Add(result);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FailingConsumerService : TestableKafkaConsumerService
+    {
+        public List<Exception> Errors { get; } = [];
+
+        public FailingConsumerService(IKafkaConsumer<string, string> consumer, string[] topics)
+            : base(consumer, topics)
+        {
+        }
+
+        protected override ValueTask ProcessAsync(ConsumeResult<string, string> result, CancellationToken cancellationToken)
+        {
+            throw new InvalidOperationException("Processing failed");
+        }
+
+        protected override ValueTask OnErrorAsync(Exception exception, ConsumeResult<string, string>? result, CancellationToken cancellationToken)
+        {
+            Errors.Add(exception);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private abstract class TestableKafkaConsumerService : Dekaf.Extensions.Hosting.KafkaConsumerService<string, string>
+    {
+        private readonly string[] _topics;
+
+        protected TestableKafkaConsumerService(IKafkaConsumer<string, string> consumer, string[] topics)
+            : base(consumer, NullLogger.Instance)
+        {
+            _topics = topics;
+        }
+
+        protected override IEnumerable<string> Topics => _topics;
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/KafkaFactoryTests.cs
+++ b/tests/Dekaf.Tests.Unit/KafkaFactoryTests.cs
@@ -1,0 +1,105 @@
+using Dekaf.Consumer;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit;
+
+public sealed class KafkaFactoryTests
+{
+    #region CreateProducer
+
+    [Test]
+    public async Task CreateProducer_Generic_ReturnsBuilder()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+        await Assert.That(builder).IsNotNull();
+    }
+
+    [Test]
+    public async Task CreateProducer_WithBootstrapServers_ReturnsProducer()
+    {
+        var producer = Kafka.CreateProducer<string, string>("localhost:9092");
+        await Assert.That(producer).IsNotNull();
+        await producer.DisposeAsync();
+    }
+
+    [Test]
+    public async Task CreateProducer_ImplementsIKafkaProducer()
+    {
+        var producer = Kafka.CreateProducer<string, string>("localhost:9092");
+        await Assert.That(producer).IsAssignableTo<IKafkaProducer<string, string>>();
+        await producer.DisposeAsync();
+    }
+
+    #endregion
+
+    #region CreateTopicProducer
+
+    [Test]
+    public async Task CreateTopicProducer_ReturnsTopicProducer()
+    {
+        await using var producer = Kafka.CreateTopicProducer<string, string>("localhost:9092", "my-topic");
+        await Assert.That(producer).IsNotNull();
+        await Assert.That(producer.Topic).IsEqualTo("my-topic");
+    }
+
+    [Test]
+    public async Task CreateTopicProducer_ImplementsITopicProducer()
+    {
+        await using var producer = Kafka.CreateTopicProducer<string, string>("localhost:9092", "my-topic");
+        await Assert.That(producer).IsAssignableTo<ITopicProducer<string, string>>();
+    }
+
+    #endregion
+
+    #region CreateConsumer
+
+    [Test]
+    public async Task CreateConsumer_Generic_ReturnsBuilder()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+        await Assert.That(builder).IsNotNull();
+    }
+
+    [Test]
+    public async Task CreateConsumer_WithBootstrapAndGroupId_ReturnsConsumer()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>("localhost:9092", "my-group");
+        await Assert.That(consumer).IsNotNull();
+    }
+
+    [Test]
+    public async Task CreateConsumer_WithBootstrapAndGroupId_ImplementsIKafkaConsumer()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>("localhost:9092", "my-group");
+        await Assert.That(consumer).IsAssignableTo<IKafkaConsumer<string, string>>();
+    }
+
+    [Test]
+    public async Task CreateConsumer_WithTopics_ReturnsConsumerWithSubscription()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>("localhost:9092", "my-group", "topic-a", "topic-b");
+        await Assert.That(consumer).IsNotNull();
+        await Assert.That(consumer.Subscription).Contains("topic-a");
+        await Assert.That(consumer.Subscription).Contains("topic-b");
+    }
+
+    #endregion
+
+    #region CreateAdminClient
+
+    [Test]
+    public async Task CreateAdminClient_Generic_ReturnsBuilder()
+    {
+        var builder = Kafka.CreateAdminClient();
+        await Assert.That(builder).IsNotNull();
+    }
+
+    [Test]
+    public async Task CreateAdminClient_WithBootstrapServers_ReturnsAdminClient()
+    {
+        await using var admin = Kafka.CreateAdminClient("localhost:9092");
+        await Assert.That(admin).IsNotNull();
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Metadata/ClusterMetadataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/ClusterMetadataTests.cs
@@ -1,0 +1,409 @@
+using Dekaf.Metadata;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Metadata;
+
+public sealed class ClusterMetadataTests
+{
+    #region Initial State
+
+    [Test]
+    public async Task NewClusterMetadata_ClusterId_IsNull()
+    {
+        var metadata = new ClusterMetadata();
+        await Assert.That(metadata.ClusterId).IsNull();
+    }
+
+    [Test]
+    public async Task NewClusterMetadata_ControllerId_IsNegativeOne()
+    {
+        var metadata = new ClusterMetadata();
+        await Assert.That(metadata.ControllerId).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task NewClusterMetadata_GetBrokers_ReturnsEmpty()
+    {
+        var metadata = new ClusterMetadata();
+        await Assert.That(metadata.GetBrokers()).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task NewClusterMetadata_GetTopics_ReturnsEmpty()
+    {
+        var metadata = new ClusterMetadata();
+        await Assert.That(metadata.GetTopics()).Count().IsEqualTo(0);
+    }
+
+    #endregion
+
+    #region Update
+
+    [Test]
+    public async Task Update_SetsClusterId()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse(clusterId: "test-cluster"));
+
+        await Assert.That(metadata.ClusterId).IsEqualTo("test-cluster");
+    }
+
+    [Test]
+    public async Task Update_SetsControllerId()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse(controllerId: 42));
+
+        await Assert.That(metadata.ControllerId).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Update_SetsLastRefreshed()
+    {
+        var metadata = new ClusterMetadata();
+        var before = DateTimeOffset.UtcNow;
+        metadata.Update(CreateMetadataResponse());
+        var after = DateTimeOffset.UtcNow;
+
+        await Assert.That(metadata.LastRefreshed).IsGreaterThanOrEqualTo(before);
+        await Assert.That(metadata.LastRefreshed).IsLessThanOrEqualTo(after);
+    }
+
+    #endregion
+
+    #region GetBroker
+
+    [Test]
+    public async Task GetBroker_ExistingBroker_ReturnsBroker()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var broker = metadata.GetBroker(1);
+
+        await Assert.That(broker).IsNotNull();
+        await Assert.That(broker!.NodeId).IsEqualTo(1);
+        await Assert.That(broker.Host).IsEqualTo("broker1");
+        await Assert.That(broker.Port).IsEqualTo(9092);
+    }
+
+    [Test]
+    public async Task GetBroker_NonExistentBroker_ReturnsNull()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var broker = metadata.GetBroker(999);
+
+        await Assert.That(broker).IsNull();
+    }
+
+    #endregion
+
+    #region GetBrokers
+
+    [Test]
+    public async Task GetBrokers_ReturnsAllBrokers()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var brokers = metadata.GetBrokers();
+
+        await Assert.That(brokers).Count().IsEqualTo(3);
+    }
+
+    #endregion
+
+    #region GetTopic by Name
+
+    [Test]
+    public async Task GetTopic_ByName_ExistingTopic_ReturnsTopic()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var topic = metadata.GetTopic("test-topic");
+
+        await Assert.That(topic).IsNotNull();
+        await Assert.That(topic!.Name).IsEqualTo("test-topic");
+    }
+
+    [Test]
+    public async Task GetTopic_ByName_NonExistentTopic_ReturnsNull()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var topic = metadata.GetTopic("nonexistent");
+
+        await Assert.That(topic).IsNull();
+    }
+
+    [Test]
+    public async Task GetTopic_ByName_ReturnsCorrectPartitions()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var topic = metadata.GetTopic("test-topic");
+
+        await Assert.That(topic!.Partitions).Count().IsEqualTo(3);
+        await Assert.That(topic.PartitionCount).IsEqualTo(3);
+    }
+
+    #endregion
+
+    #region GetTopic by ID
+
+    [Test]
+    public async Task GetTopic_ById_ExistingTopic_ReturnsTopic()
+    {
+        var topicId = Guid.NewGuid();
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse(topicId: topicId));
+
+        var topic = metadata.GetTopic(topicId);
+
+        await Assert.That(topic).IsNotNull();
+        await Assert.That(topic!.TopicId).IsEqualTo(topicId);
+    }
+
+    [Test]
+    public async Task GetTopic_ById_NonExistentId_ReturnsNull()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var topic = metadata.GetTopic(Guid.NewGuid());
+
+        await Assert.That(topic).IsNull();
+    }
+
+    [Test]
+    public async Task GetTopic_ById_EmptyGuid_ReturnsNull()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var topic = metadata.GetTopic(Guid.Empty);
+
+        await Assert.That(topic).IsNull();
+    }
+
+    #endregion
+
+    #region GetTopics
+
+    [Test]
+    public async Task GetTopics_ReturnsAllTopics()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponseMultipleTopics());
+
+        var topics = metadata.GetTopics();
+
+        await Assert.That(topics).Count().IsEqualTo(2);
+    }
+
+    #endregion
+
+    #region GetPartitionLeader
+
+    [Test]
+    public async Task GetPartitionLeader_ValidPartition_ReturnsBroker()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var leader = metadata.GetPartitionLeader("test-topic", 0);
+
+        await Assert.That(leader).IsNotNull();
+        await Assert.That(leader!.NodeId).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task GetPartitionLeader_NonExistentTopic_ReturnsNull()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var leader = metadata.GetPartitionLeader("nonexistent", 0);
+
+        await Assert.That(leader).IsNull();
+    }
+
+    [Test]
+    public async Task GetPartitionLeader_NonExistentPartition_ReturnsNull()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var leader = metadata.GetPartitionLeader("test-topic", 999);
+
+        await Assert.That(leader).IsNull();
+    }
+
+    [Test]
+    public async Task GetPartitionLeader_LeaderBrokerNotInCluster_ReturnsNull()
+    {
+        var metadata = new ClusterMetadata();
+        // Create response where partition leader ID doesn't match any broker
+        var response = new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 1, Host = "broker1", Port = 9092 }],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "test-topic",
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 999, // Not in brokers
+                            ReplicaNodes = [999],
+                            IsrNodes = [999]
+                        }
+                    ]
+                }
+            ]
+        };
+        metadata.Update(response);
+
+        var leader = metadata.GetPartitionLeader("test-topic", 0);
+
+        await Assert.That(leader).IsNull();
+    }
+
+    #endregion
+
+    #region Update Replaces Previous State
+
+    [Test]
+    public async Task Update_ReplacesAllPreviousData()
+    {
+        var metadata = new ClusterMetadata();
+
+        // First update
+        metadata.Update(CreateMetadataResponse(clusterId: "cluster-1"));
+        await Assert.That(metadata.ClusterId).IsEqualTo("cluster-1");
+        await Assert.That(metadata.GetBrokers()).Count().IsEqualTo(3);
+
+        // Second update with different data
+        metadata.Update(new MetadataResponse
+        {
+            ClusterId = "cluster-2",
+            ControllerId = 10,
+            Brokers = [new BrokerMetadata { NodeId = 10, Host = "new-broker", Port = 9093 }],
+            Topics = []
+        });
+
+        await Assert.That(metadata.ClusterId).IsEqualTo("cluster-2");
+        await Assert.That(metadata.ControllerId).IsEqualTo(10);
+        await Assert.That(metadata.GetBrokers()).Count().IsEqualTo(1);
+        await Assert.That(metadata.GetTopics()).Count().IsEqualTo(0);
+        await Assert.That(metadata.GetBroker(1)).IsNull(); // Old broker gone
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static MetadataResponse CreateMetadataResponse(
+        string? clusterId = "test-cluster",
+        int controllerId = 1,
+        Guid topicId = default)
+    {
+        return new MetadataResponse
+        {
+            ClusterId = clusterId,
+            ControllerId = controllerId,
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker1", Port = 9092 },
+                new BrokerMetadata { NodeId = 2, Host = "broker2", Port = 9092 },
+                new BrokerMetadata { NodeId = 3, Host = "broker3", Port = 9092, Rack = "rack-a" }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "test-topic",
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 1,
+                            LeaderEpoch = 5,
+                            ReplicaNodes = [1, 2, 3],
+                            IsrNodes = [1, 2, 3]
+                        },
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 1,
+                            LeaderId = 2,
+                            LeaderEpoch = 5,
+                            ReplicaNodes = [1, 2, 3],
+                            IsrNodes = [1, 2]
+                        },
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 2,
+                            LeaderId = 3,
+                            LeaderEpoch = 5,
+                            ReplicaNodes = [1, 2, 3],
+                            IsrNodes = [1, 2, 3]
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    private static MetadataResponse CreateMetadataResponseMultipleTopics()
+    {
+        return new MetadataResponse
+        {
+            ClusterId = "test-cluster",
+            ControllerId = 1,
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker1", Port = 9092 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "topic-a",
+                    Partitions =
+                    [
+                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] }
+                    ]
+                },
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "topic-b",
+                    Partitions =
+                    [
+                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] }
+                    ]
+                }
+            ]
+        };
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Observability/ObservabilityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Observability/ObservabilityTests.cs
@@ -1,0 +1,181 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Dekaf.Observability;
+
+namespace Dekaf.Tests.Unit.Observability;
+
+public sealed class DekafMetricsTests
+{
+    [Test]
+    public async Task MeterName_IsDekaf()
+    {
+        var meterName = DekafMetrics.MeterName;
+        await Assert.That(meterName).IsEqualTo("Dekaf");
+    }
+
+    [Test]
+    public async Task ProducerMessagesSent_HasCorrectName()
+    {
+        await Assert.That(DekafMetrics.ProducerMessagesSent.Name).IsEqualTo("dekaf.producer.messages.sent");
+    }
+
+    [Test]
+    public async Task ProducerBytesSent_HasCorrectName()
+    {
+        await Assert.That(DekafMetrics.ProducerBytesSent.Name).IsEqualTo("dekaf.producer.bytes.sent");
+    }
+
+    [Test]
+    public async Task ProducerErrors_HasCorrectName()
+    {
+        await Assert.That(DekafMetrics.ProducerErrors.Name).IsEqualTo("dekaf.producer.errors");
+    }
+
+    [Test]
+    public async Task ProducerLatency_HasCorrectName()
+    {
+        await Assert.That(DekafMetrics.ProducerLatency.Name).IsEqualTo("dekaf.producer.latency");
+    }
+
+    [Test]
+    public async Task ConsumerMessagesReceived_HasCorrectName()
+    {
+        await Assert.That(DekafMetrics.ConsumerMessagesReceived.Name).IsEqualTo("dekaf.consumer.messages.received");
+    }
+
+    [Test]
+    public async Task ConsumerBytesReceived_HasCorrectName()
+    {
+        await Assert.That(DekafMetrics.ConsumerBytesReceived.Name).IsEqualTo("dekaf.consumer.bytes.received");
+    }
+
+    [Test]
+    public async Task ConsumerErrors_HasCorrectName()
+    {
+        await Assert.That(DekafMetrics.ConsumerErrors.Name).IsEqualTo("dekaf.consumer.errors");
+    }
+
+    [Test]
+    public async Task ConsumerFetchLatency_HasCorrectName()
+    {
+        await Assert.That(DekafMetrics.ConsumerFetchLatency.Name).IsEqualTo("dekaf.consumer.fetch.latency");
+    }
+
+    [Test]
+    public async Task ConsumerRebalances_HasCorrectName()
+    {
+        await Assert.That(DekafMetrics.ConsumerRebalances.Name).IsEqualTo("dekaf.consumer.rebalances");
+    }
+
+    [Test]
+    public async Task ConnectionsActive_HasCorrectName()
+    {
+        await Assert.That(DekafMetrics.ConnectionsActive.Name).IsEqualTo("dekaf.connections.active");
+    }
+
+    [Test]
+    public async Task ConnectionsCreated_HasCorrectName()
+    {
+        await Assert.That(DekafMetrics.ConnectionsCreated.Name).IsEqualTo("dekaf.connections.created");
+    }
+
+    [Test]
+    public async Task ConnectionsClosed_HasCorrectName()
+    {
+        await Assert.That(DekafMetrics.ConnectionsClosed.Name).IsEqualTo("dekaf.connections.closed");
+    }
+}
+
+public sealed class DekafActivitySourceTests
+{
+    [Test]
+    public async Task SourceName_IsDekaf()
+    {
+        var sourceName = DekafActivitySource.SourceName;
+        await Assert.That(sourceName).IsEqualTo("Dekaf");
+    }
+
+    [Test]
+    public async Task Source_HasCorrectName()
+    {
+        await Assert.That(DekafActivitySource.Source.Name).IsEqualTo("Dekaf");
+    }
+
+    [Test]
+    public async Task StartProduce_WithListener_ReturnsActivityWithCorrectTags()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Dekaf",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var activity = DekafActivitySource.StartProduce("my-topic", partition: 3);
+
+        await Assert.That(activity).IsNotNull();
+        await Assert.That(activity!.OperationName).IsEqualTo("produce");
+        await Assert.That(activity.Kind).IsEqualTo(ActivityKind.Producer);
+        await Assert.That(activity.GetTagItem("messaging.system")).IsEqualTo("kafka");
+        await Assert.That(activity.GetTagItem("messaging.destination.name")).IsEqualTo("my-topic");
+        await Assert.That(activity.GetTagItem("messaging.operation")).IsEqualTo("publish");
+        await Assert.That(activity.GetTagItem("messaging.kafka.destination.partition")).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task StartProduce_WithoutPartition_DoesNotSetPartitionTag()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Dekaf",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var activity = DekafActivitySource.StartProduce("my-topic");
+
+        await Assert.That(activity).IsNotNull();
+        await Assert.That(activity!.GetTagItem("messaging.kafka.destination.partition")).IsNull();
+    }
+
+    [Test]
+    public async Task StartConsume_WithListener_ReturnsActivityWithCorrectTags()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Dekaf",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var activity = DekafActivitySource.StartConsume("my-topic", partition: 2, offset: 42);
+
+        await Assert.That(activity).IsNotNull();
+        await Assert.That(activity!.OperationName).IsEqualTo("consume");
+        await Assert.That(activity.Kind).IsEqualTo(ActivityKind.Consumer);
+        await Assert.That(activity.GetTagItem("messaging.system")).IsEqualTo("kafka");
+        await Assert.That(activity.GetTagItem("messaging.source.name")).IsEqualTo("my-topic");
+        await Assert.That(activity.GetTagItem("messaging.kafka.source.partition")).IsEqualTo(2);
+        await Assert.That(activity.GetTagItem("messaging.kafka.message.offset")).IsEqualTo(42L);
+        await Assert.That(activity.GetTagItem("messaging.operation")).IsEqualTo("receive");
+    }
+
+    [Test]
+    public async Task StartFetch_WithListener_ReturnsActivityWithCorrectTags()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Dekaf",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var activity = DekafActivitySource.StartFetch(brokerId: 5);
+
+        await Assert.That(activity).IsNotNull();
+        await Assert.That(activity!.OperationName).IsEqualTo("fetch");
+        await Assert.That(activity.Kind).IsEqualTo(ActivityKind.Client);
+        await Assert.That(activity.GetTagItem("messaging.system")).IsEqualTo("kafka");
+        await Assert.That(activity.GetTagItem("server.address")).IsEqualTo("5");
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerExtensionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerExtensionsTests.cs
@@ -1,0 +1,150 @@
+using Dekaf.Producer;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public sealed class ProducerExtensionsTests
+{
+    #region ProduceAsync with Headers
+
+    [Test]
+    public async Task ProduceAsync_WithHeaders_DelegatesToProducer()
+    {
+        var producer = Substitute.For<IKafkaProducer<string, string>>();
+        var expectedMetadata = new RecordMetadata
+        {
+            Topic = "my-topic",
+            Partition = 0,
+            Offset = 42,
+            Timestamp = DateTimeOffset.UtcNow
+        };
+        producer.ProduceAsync(Arg.Any<ProducerMessage<string, string>>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(expectedMetadata));
+
+        var headers = Headers.Create("h1", "v1");
+        var result = await producer.ProduceAsync("my-topic", "key", "value", headers);
+
+        await Assert.That(result.Offset).IsEqualTo(42);
+        await producer.Received(1).ProduceAsync(
+            Arg.Is<ProducerMessage<string, string>>(m =>
+                m.Topic == "my-topic" &&
+                m.Key == "key" &&
+                m.Value == "value" &&
+                m.Headers != null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ProduceAsync_WithHeaders_NullProducer_ThrowsArgumentNullException()
+    {
+        IKafkaProducer<string, string>? producer = null;
+        var headers = Headers.Create("h1", "v1");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await producer!.ProduceAsync("topic", "key", "value", headers));
+    }
+
+    [Test]
+    public async Task ProduceAsync_WithHeaders_NullTopic_ThrowsArgumentNullException()
+    {
+        var producer = Substitute.For<IKafkaProducer<string, string>>();
+        var headers = Headers.Create("h1", "v1");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await producer.ProduceAsync(null!, "key", "value", headers));
+    }
+
+    #endregion
+
+    #region ProduceAsync with Partition
+
+    [Test]
+    public async Task ProduceAsync_WithPartition_DelegatesToProducer()
+    {
+        var producer = Substitute.For<IKafkaProducer<string, string>>();
+        var expectedMetadata = new RecordMetadata
+        {
+            Topic = "my-topic",
+            Partition = 3,
+            Offset = 100,
+            Timestamp = DateTimeOffset.UtcNow
+        };
+        producer.ProduceAsync(Arg.Any<ProducerMessage<string, string>>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(expectedMetadata));
+
+        var result = await producer.ProduceAsync("my-topic", partition: 3, "key", "value");
+
+        await Assert.That(result.Partition).IsEqualTo(3);
+        await producer.Received(1).ProduceAsync(
+            Arg.Is<ProducerMessage<string, string>>(m =>
+                m.Topic == "my-topic" &&
+                m.Partition == 3 &&
+                m.Key == "key" &&
+                m.Value == "value"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ProduceAsync_WithPartition_NullProducer_ThrowsArgumentNullException()
+    {
+        IKafkaProducer<string, string>? producer = null;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await producer!.ProduceAsync("topic", partition: 0, "key", "value"));
+    }
+
+    [Test]
+    public async Task ProduceAsync_WithPartition_NullTopic_ThrowsArgumentNullException()
+    {
+        var producer = Substitute.For<IKafkaProducer<string, string>>();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await producer.ProduceAsync(null!, partition: 0, "key", "value"));
+    }
+
+    #endregion
+
+    #region Send with Headers
+
+    [Test]
+    public async Task Send_WithHeaders_DelegatesToProducer()
+    {
+        var producer = Substitute.For<IKafkaProducer<string, string>>();
+        var headers = Headers.Create("h1", "v1");
+
+        producer.Send("my-topic", "key", "value", headers);
+
+        producer.Received(1).Send(
+            Arg.Is<ProducerMessage<string, string>>(m =>
+                m.Topic == "my-topic" &&
+                m.Key == "key" &&
+                m.Value == "value" &&
+                m.Headers != null));
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Send_WithHeaders_NullProducer_ThrowsArgumentNullException()
+    {
+        IKafkaProducer<string, string>? producer = null;
+        var headers = Headers.Create("h1", "v1");
+
+        var act = () => producer!.Send("topic", "key", "value", headers);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Send_WithHeaders_NullTopic_ThrowsArgumentNullException()
+    {
+        var producer = Substitute.For<IKafkaProducer<string, string>>();
+        var headers = Headers.Create("h1", "v1");
+
+        var act = () => producer.Send(null!, "key", "value", headers);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/RequestResponseHeaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RequestResponseHeaderTests.cs
@@ -1,0 +1,147 @@
+using System.Buffers;
+using Dekaf.Protocol;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class RequestHeaderTests
+{
+    [Test]
+    public async Task WriteRead_V0_RoundTrip()
+    {
+        var original = new RequestHeader
+        {
+            ApiKey = ApiKey.Produce,
+            ApiVersion = 9,
+            CorrelationId = 42,
+            HeaderVersion = 0
+        };
+
+        var result = RoundTrip(original);
+
+        await Assert.That(result.ApiKey).IsEqualTo(ApiKey.Produce);
+        await Assert.That(result.ApiVersion).IsEqualTo((short)9);
+        await Assert.That(result.CorrelationId).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task WriteRead_V1_WithClientId_RoundTrip()
+    {
+        var original = new RequestHeader
+        {
+            ApiKey = ApiKey.Fetch,
+            ApiVersion = 12,
+            CorrelationId = 123,
+            ClientId = "dekaf-test",
+            HeaderVersion = 1
+        };
+
+        var result = RoundTrip(original);
+
+        await Assert.That(result.ApiKey).IsEqualTo(ApiKey.Fetch);
+        await Assert.That(result.ApiVersion).IsEqualTo((short)12);
+        await Assert.That(result.CorrelationId).IsEqualTo(123);
+        await Assert.That(result.ClientId).IsEqualTo("dekaf-test");
+    }
+
+    [Test]
+    public async Task WriteRead_V1_NullClientId_RoundTrip()
+    {
+        var original = new RequestHeader
+        {
+            ApiKey = ApiKey.Metadata,
+            ApiVersion = 3,
+            CorrelationId = 7,
+            ClientId = null,
+            HeaderVersion = 1
+        };
+
+        var result = RoundTrip(original);
+
+        await Assert.That(result.ClientId).IsNull();
+    }
+
+    [Test]
+    public async Task WriteRead_V2_WithTaggedFields_RoundTrip()
+    {
+        var original = new RequestHeader
+        {
+            ApiKey = ApiKey.ApiVersions,
+            ApiVersion = 3,
+            CorrelationId = 999,
+            ClientId = "dekaf-v2",
+            HeaderVersion = 2
+        };
+
+        var result = RoundTrip(original);
+
+        await Assert.That(result.ApiKey).IsEqualTo(ApiKey.ApiVersions);
+        await Assert.That(result.ApiVersion).IsEqualTo((short)3);
+        await Assert.That(result.CorrelationId).IsEqualTo(999);
+        await Assert.That(result.ClientId).IsEqualTo("dekaf-v2");
+    }
+
+    private static RequestHeader RoundTrip(RequestHeader original)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(new ReadOnlySequence<byte>(buffer.WrittenMemory));
+        return RequestHeader.Read(ref reader, original.HeaderVersion);
+    }
+}
+
+public sealed class ResponseHeaderTests
+{
+    [Test]
+    public async Task WriteRead_V0_RoundTrip()
+    {
+        var original = new ResponseHeader
+        {
+            CorrelationId = 42,
+            HeaderVersion = 0
+        };
+
+        var result = RoundTrip(original);
+
+        await Assert.That(result.CorrelationId).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task WriteRead_V1_WithTaggedFields_RoundTrip()
+    {
+        var original = new ResponseHeader
+        {
+            CorrelationId = 999,
+            HeaderVersion = 1
+        };
+
+        var result = RoundTrip(original);
+
+        await Assert.That(result.CorrelationId).IsEqualTo(999);
+    }
+
+    [Test]
+    public async Task WriteRead_V0_LargeCorrelationId_RoundTrip()
+    {
+        var original = new ResponseHeader
+        {
+            CorrelationId = int.MaxValue,
+            HeaderVersion = 0
+        };
+
+        var result = RoundTrip(original);
+
+        await Assert.That(result.CorrelationId).IsEqualTo(int.MaxValue);
+    }
+
+    private static ResponseHeader RoundTrip(ResponseHeader original)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(new ReadOnlySequence<byte>(buffer.WrittenMemory));
+        return ResponseHeader.Read(ref reader, original.HeaderVersion);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Security/CertificateLoadingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/CertificateLoadingTests.cs
@@ -8,6 +8,7 @@ namespace Dekaf.Tests.Unit.Security;
 /// Tests for certificate loading functionality.
 /// Tests PEM and PFX certificate loading from files.
 /// </summary>
+[NotInParallel("CertificateGeneration")]
 public class CertificateLoadingTests : IDisposable
 {
     private readonly string _tempDir;

--- a/tests/Dekaf.Tests.Unit/Security/CertificateValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/CertificateValidationTests.cs
@@ -9,6 +9,7 @@ namespace Dekaf.Tests.Unit.Security;
 /// These tests verify the certificate chain validation behavior by creating
 /// test certificates and validating them against custom trust stores.
 /// </summary>
+[NotInParallel("CertificateGeneration")]
 public class CertificateValidationTests
 {
     [Test]
@@ -79,12 +80,8 @@ public class CertificateValidationTests
     [Test]
     public async Task ChainStatus_DetectsExpiredCertificate()
     {
-        // Create an expired certificate using the fixed key
-        using var rsa = TestCertificateHelper.CreateRsaKey();
-        var request = new CertificateRequest("CN=Expired Cert", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-
-        // Certificate that expired yesterday
-        using var expiredCert = request.CreateSelfSigned(
+        // Create an expired certificate using the helper with custom dates
+        using var expiredCert = TestCertificateHelper.CreateCaCertificateWithCustomDates("CN=Expired Cert",
             DateTimeOffset.UtcNow.AddYears(-2),
             DateTimeOffset.UtcNow.AddDays(-1));
 

--- a/tests/Dekaf.Tests.Unit/Security/TlsConfigTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/TlsConfigTests.cs
@@ -4,6 +4,7 @@ using Dekaf.Security;
 
 namespace Dekaf.Tests.Unit.Security;
 
+[NotInParallel("CertificateGeneration")]
 public class TlsConfigTests
 {
     [Test]


### PR DESCRIPTION
## Summary

- **100+ new unit tests** covering 8 previously untested areas: ClusterMetadata, ConsumerExtensions, ProducerExtensions, RequestResponseHeader, KafkaFactory, builder edge cases, observability metrics/tracing, and KafkaConsumerService hosting lifecycle
- **Fix non-deterministic certificate test failures** caused by .NET 10's strict ASN.1 validation rejecting random serial numbers from `CreateSelfSigned()`, and thread-safety issues in the crypto stack under parallel execution
  - Replace all `CreateSelfSigned()` calls with `Create()` using deterministic subject-derived serial numbers
  - Add `[NotInParallel("CertificateGeneration")]` to all certificate test classes to prevent concurrent crypto operations

## Test plan

- [x] All 1660 unit tests pass (verified 5/5 consecutive full suite runs with 0 failures)
- [x] Certificate tests pass both in isolation and under full parallel suite load
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)