### PR TITLE
perf: Increase default BufferMemory from 256MB to 1GB

### DIFF
--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -47,9 +47,9 @@ public sealed class ProducerOptions
     /// <summary>
     /// Total memory buffer size in bytes for pending messages.
     /// When the buffer is full, Send() and ProduceAsync() will block until space is available.
-    /// Default is 256MB, which handles bursty workloads without excessive memory usage.
+    /// Default is 1GB, matching librdkafka's default (queue.buffering.max.kbytes).
     /// </summary>
-    public ulong BufferMemory { get; init; } = 268435456;
+    public ulong BufferMemory { get; init; } = 1073741824;
 
     /// <summary>
     /// Compression type.

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
@@ -48,10 +48,10 @@ public class ProducerOptionsDefaultsTests
     }
 
     [Test]
-    public async Task BufferMemory_DefaultsTo_256MB()
+    public async Task BufferMemory_DefaultsTo_1GB()
     {
         var options = CreateOptions();
-        await Assert.That(options.BufferMemory).IsEqualTo(268435456UL);
+        await Assert.That(options.BufferMemory).IsEqualTo(1073741824UL);
     }
 
     [Test]

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -182,7 +182,7 @@ public static class Program
             }
 
             // Flush every batch to avoid overwhelming the buffer with backpressure
-            // Each batch is 10K messages × 1KB = 10MB, buffer is 32MB
+            // Each batch is 10K messages × 1KB = 10MB, buffer is 1GB
             await producer.FlushAsync(CancellationToken.None).ConfigureAwait(false);
 
             if (batch % 10 == 0)


### PR DESCRIPTION
## Summary

- Increases the default `BufferMemory` from 256MB to 1GB to match librdkafka's default (`queue.buffering.max.kbytes = 1048576`)
- Gives more headroom for bursty workloads and high-throughput producers

## Test plan

- [x] Unit tests pass (including updated default assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)