### PR TITLE
test: Handle OperationCanceledException in disposal flush test

### DIFF
--- a/tests/Dekaf.Tests.Integration/RealWorld/ErrorPropagationTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/ErrorPropagationTests.cs
@@ -226,10 +226,17 @@ public sealed class ErrorPropagationTests(KafkaTestContainer kafka) : KafkaInteg
         var consumed = new List<ConsumeResult<string, string>>();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        await foreach (var msg in consumer.ConsumeAsync(cts.Token))
+        try
         {
-            consumed.Add(msg);
-            if (consumed.Count >= 10) break;
+            await foreach (var msg in consumer.ConsumeAsync(cts.Token))
+            {
+                consumed.Add(msg);
+                if (consumed.Count >= 10) break;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Timeout reached - fall through to assertion
         }
 
         // Assert - all messages should have been flushed on disposal


### PR DESCRIPTION
## Summary
- The `ProducerDisposal_FlushesInFlightMessages` integration test was failing across all 8 open PRs on ubuntu-latest CI
- Root cause: the sender pipeline stall (fixed in #260) prevented messages from being flushed during producer disposal
- This PR adds a `try-catch` for `OperationCanceledException` around the consume loop so the assertion always runs with a clear message, rather than throwing an unhandled exception on timeout

## Test plan
- [ ] CI passes on this PR
- [ ] Re-run CI on the 8 affected PRs (#239, #240, #248, #251, #253, #254, #256, #258) — they should now pass since #260 (sender pipeline fix) is merged into main

🤖 Generated with [Claude Code](https://claude.com/claude-code)