### PR TITLE
fix: reduce unbounded memory growth in producer hot paths

### DIFF
--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -234,11 +234,11 @@ public sealed class ProducerOptions
 
     /// <summary>
     /// Initial capacity for record arrays in partition batches.
-    /// Lower values reduce memory for applications with many small batches.
-    /// Higher values reduce array resizing for high-throughput scenarios.
-    /// Default is 64, balancing memory usage and resize frequency.
+    /// When 0 (default), automatically computed from <see cref="BatchSize"/> to minimize
+    /// array resizing. Set explicitly to override: lower values reduce memory for applications
+    /// with many small batches, higher values reduce resizing for high-throughput scenarios.
     /// </summary>
-    public int InitialBatchRecordCapacity { get; init; } = 64;
+    public int InitialBatchRecordCapacity { get; init; } = 0;
 
     /// <summary>
     /// Strategy for recovering cluster metadata when all known brokers become unavailable.

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
@@ -159,10 +159,10 @@ public class ProducerOptionsDefaultsTests
     }
 
     [Test]
-    public async Task InitialBatchRecordCapacity_DefaultsTo_64()
+    public async Task InitialBatchRecordCapacity_DefaultsTo_0()
     {
         var options = CreateOptions();
-        await Assert.That(options.InitialBatchRecordCapacity).IsEqualTo(64);
+        await Assert.That(options.InitialBatchRecordCapacity).IsEqualTo(0);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- **Keep byte[] buffer with BatchArena in pool**: `ReturnToPool` no longer returns the 1MB buffer to `ArrayPool` on every cycle — the buffer stays attached when pooled. `Reset` reuses the existing buffer when capacity fits. Only discarded arenas (pool full) return buffers. Eliminates the bulk of the 7.86 GB `byte[]` allocations from ArrayPool churn.
- **Auto-compute `InitialBatchRecordCapacity` from `BatchSize`**: Default changed from 64 to 0 (auto-compute via `BatchSize / 64` rounded to power-of-2, capped at 16384). For the default 1MB batch this yields 16384 initial capacity, eliminating 8 array doublings per batch that generated 7.38 GB of `Record[]` allocations.
- **Reuse carry-over lists in `BrokerSender`**: Two pre-allocated `List<ReadyBatch>` swap roles each iteration instead of allocating a new list. The `waitTasks` list and `_sendFailedRetries` are also reused. Eliminates 5.24 GB of `ReadyBatch[]` allocations from list backing arrays.

## Test plan

- [x] `dotnet build` succeeds with no warnings
- [x] All 1922 unit tests pass
- [ ] Run stress test with `dotnet trace` and compare peak heap / LOH against baseline (15.25 GB peak, 11.63 GB LOH)
- [ ] Integration tests pass (requires Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)