### PR TITLE
feat: add global interceptor registration via DI

### DIFF
--- a/docs/docs/compression.md
+++ b/docs/docs/compression.md
@@ -39,10 +39,10 @@ Gzip is built into .NET, no additional package needed.
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .UseLz4Compression()    // or UseZstdCompression(), UseSnappyCompression(), UseGzipCompression()
-    .Build();
+    .BuildAsync();
 ```
 
 ### Using Enum
@@ -124,12 +124,12 @@ Compression works best with batching. Configure linger time to allow batches to 
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .UseLz4Compression()
     .WithLingerMs(5)        // Wait up to 5ms to fill batches
     .WithBatchSize(65536)   // 64KB batches
-    .Build();
+    .BuildAsync();
 ```
 
 ## Consumer Decompression
@@ -140,10 +140,10 @@ Consumers automatically detect and decompress messages. No configuration needed:
 using Dekaf;
 
 // Consumer handles decompression automatically
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
-    .Build();
+    .BuildAsync();
 
 await foreach (var msg in consumer.ConsumeAsync(ct))
 {
@@ -188,11 +188,11 @@ Typical performance characteristics:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .ForHighThroughput()     // Sets batching parameters
     .UseLz4Compression()     // Add compression
-    .Build();
+    .BuildAsync();
 
 // Send many messages
 for (int i = 0; i < 1_000_000; i++)

--- a/docs/docs/configuration/presets.md
+++ b/docs/docs/configuration/presets.md
@@ -15,10 +15,10 @@ Optimized for sending many messages with maximum efficiency:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .ForHighThroughput()
-    .Build();
+    .BuildAsync();
 ```
 
 **Settings applied:**
@@ -38,10 +38,10 @@ Optimized for minimal delay between sending and delivery:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .ForLowLatency()
-    .Build();
+    .BuildAsync();
 ```
 
 **Settings applied:**
@@ -60,10 +60,10 @@ Optimized for maximum durability and exactly-once semantics:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .ForReliability()
-    .Build();
+    .BuildAsync();
 ```
 
 **Settings applied:**
@@ -83,11 +83,11 @@ Optimized for processing many messages efficiently:
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .ForHighThroughput()
-    .Build();
+    .BuildAsync();
 ```
 
 **Settings applied:**
@@ -106,11 +106,11 @@ Optimized for processing messages as quickly as possible:
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .ForLowLatency()
-    .Build();
+    .BuildAsync();
 ```
 
 **Settings applied:**
@@ -129,12 +129,12 @@ Presets are just starting points. Override any setting by calling the appropriat
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .ForHighThroughput()
     .WithAcks(Acks.All)        // Override: want reliability too
     .WithLingerMs(10)          // Override: even more batching
-    .Build();
+    .BuildAsync();
 ```
 
 The order matters - later calls override earlier ones:
@@ -143,11 +143,11 @@ The order matters - later calls override earlier ones:
 using Dekaf;
 
 // Final acks will be Leader (from ForLowLatency)
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .ForReliability()      // Sets Acks.All
     .ForLowLatency()       // Overrides to Acks.Leader
-    .Build();
+    .BuildAsync();
 ```
 
 ## Combining Presets with Security
@@ -157,12 +157,12 @@ Presets work alongside security configuration:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9093")
     .UseTls()
     .WithSaslScramSha512("username", "password")
     .ForReliability()  // Performance preset
-    .Build();
+    .BuildAsync();
 ```
 
 ## Custom Presets
@@ -194,10 +194,10 @@ public static class DekafPresets
 }
 
 // Usage
-var producer = Kafka.CreateProducer<string, Order>()
+var producer = await Kafka.CreateProducer<string, Order>()
     .WithBootstrapServers("localhost:9092")
     .ForOrderProcessing()
-    .Build();
+    .BuildAsync();
 ```
 
 ## Choosing a Preset
@@ -220,14 +220,14 @@ If none of the presets match your needs, configure settings individually:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithAcks(Acks.All)
     .WithLingerMs(2)
     .WithBatchSize(32768)
     .EnableIdempotence()
     .UseZstdCompression()
-    .Build();
+    .BuildAsync();
 ```
 
 See [Producer Options](./producer-options) and [Consumer Options](./consumer-options) for all available settings.

--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -13,10 +13,10 @@ Use the fluent builder API:
 ```csharp
 using Dekaf;
 
-await using var consumer = Kafka.CreateConsumer<string, string>()
+await using var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-consumer-group")
-    .Build();
+    .BuildAsync();
 ```
 
 The type parameters `<TKey, TValue>` define the expected key and value types.
@@ -35,11 +35,11 @@ consumer.Subscribe("my-topic");
 consumer.Subscribe("topic1", "topic2", "topic3");
 
 // Using the builder
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .SubscribeTo("my-topic")  // Subscribe during build
-    .Build();
+    .BuildAsync();
 ```
 
 ## Consuming Messages
@@ -100,11 +100,11 @@ When a consumer starts with no committed offset, `AutoOffsetReset` determines wh
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .WithAutoOffsetReset(AutoOffsetReset.Earliest)  // Start from beginning
-    .Build();
+    .BuildAsync();
 ```
 
 | Value | Behavior |
@@ -150,11 +150,11 @@ Always dispose the consumer properly:
 ```csharp
 using Dekaf;
 
-await using var consumer = Kafka.CreateConsumer<string, string>()
+await using var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .SubscribeTo("my-topic")
-    .Build();
+    .BuildAsync();
 
 using var cts = new CancellationTokenSource();
 
@@ -229,12 +229,12 @@ public class OrderConsumer : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await using var consumer = Kafka.CreateConsumer<string, Order>()
+        await using var consumer = await Kafka.CreateConsumer<string, Order>()
             .WithBootstrapServers("localhost:9092")
             .WithGroupId("order-processor")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
             .SubscribeTo("orders")
-            .Build();
+            .BuildAsync();
 
         _logger.LogInformation("Order consumer started");
 

--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -36,18 +36,18 @@ Each consumer instance needs the same group ID:
 using Dekaf;
 
 // Instance 1
-var consumer1 = Kafka.CreateConsumer<string, string>()
+var consumer1 = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("order-processors")  // Same group ID
     .SubscribeTo("orders")
-    .Build();
+    .BuildAsync();
 
 // Instance 2 (different machine/process)
-var consumer2 = Kafka.CreateConsumer<string, string>()
+var consumer2 = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("order-processors")  // Same group ID
     .SubscribeTo("orders")
-    .Build();
+    .BuildAsync();
 ```
 
 ## Rebalancing
@@ -93,11 +93,11 @@ public class MyRebalanceListener : IRebalanceListener
     }
 }
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .WithRebalanceListener(new MyRebalanceListener())
-    .Build();
+    .BuildAsync();
 ```
 
 ### Cooperative Rebalancing
@@ -108,17 +108,17 @@ Dekaf uses cooperative (incremental) rebalancing by default, which minimizes dis
 using Dekaf;
 
 // Default: CooperativeSticky assignor
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
-    .Build();
+    .BuildAsync();
 
 // Or explicitly set the assignor
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .WithPartitionAssignmentStrategy(PartitionAssignmentStrategy.CooperativeSticky)
-    .Build();
+    .BuildAsync();
 ```
 
 With cooperative rebalancing:
@@ -133,11 +133,11 @@ For faster rebalances with planned restarts, use static membership:
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .WithGroupInstanceId("instance-1")  // Must be unique within the group
-    .Build();
+    .BuildAsync();
 ```
 
 Benefits:
@@ -154,12 +154,12 @@ Each instance in the group must have a unique `GroupInstanceId`. Using the same 
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .WithSessionTimeout(TimeSpan.FromSeconds(45))    // Max time before considered dead
     .WithHeartbeatInterval(TimeSpan.FromSeconds(3)) // How often to send heartbeats
-    .Build();
+    .BuildAsync();
 ```
 
 Guidelines:
@@ -214,16 +214,16 @@ Different groups consume the same topic independently:
 using Dekaf;
 
 // Analytics group - processes all messages
-var analyticsConsumer = Kafka.CreateConsumer<string, string>()
+var analyticsConsumer = await Kafka.CreateConsumer<string, string>()
     .WithGroupId("analytics")
     .SubscribeTo("orders")
-    .Build();
+    .BuildAsync();
 
 // Notification group - also processes all messages
-var notificationConsumer = Kafka.CreateConsumer<string, string>()
+var notificationConsumer = await Kafka.CreateConsumer<string, string>()
     .WithGroupId("notifications")
     .SubscribeTo("orders")
-    .Build();
+    .BuildAsync();
 ```
 
 Each group:
@@ -242,14 +242,14 @@ public class OrderProcessor
 
     public async Task RunAsync(string instanceId, CancellationToken ct)
     {
-        await using var consumer = Kafka.CreateConsumer<string, Order>()
+        await using var consumer = await Kafka.CreateConsumer<string, Order>()
             .WithBootstrapServers("localhost:9092")
             .WithGroupId("order-processors")
             .WithGroupInstanceId(instanceId)  // Static membership
             .WithRebalanceListener(new LoggingRebalanceListener(_logger))
             .WithOffsetCommitMode(OffsetCommitMode.Manual)
             .SubscribeTo("orders")
-            .Build();
+            .BuildAsync();
 
         _logger.LogInformation(
             "Consumer {InstanceId} started, member ID: {MemberId}",

--- a/docs/docs/consumer/manual-assignment.md
+++ b/docs/docs/consumer/manual-assignment.md
@@ -22,10 +22,10 @@ Use `Assign` instead of `Subscribe`:
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     // No group ID needed for manual assignment
-    .Build();
+    .BuildAsync();
 
 // Assign specific partitions
 consumer.Assign(
@@ -71,9 +71,9 @@ With manual assignment, you're responsible for tracking offsets:
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 
 // Load saved offsets from your storage
 var savedOffsets = await LoadOffsetsFromDatabaseAsync();
@@ -153,10 +153,10 @@ public class PartitionReader
         Func<ConsumeResult<string, string>, Task> processor,
         CancellationToken ct)
     {
-        await using var consumer = Kafka.CreateConsumer<string, string>()
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(bootstrapServers)
             .WithAutoOffsetReset(AutoOffsetReset.None)
-            .Build();
+            .BuildAsync();
 
         consumer.Assign(new TopicPartitionOffset(topic, partition, startOffset));
 
@@ -198,9 +198,9 @@ public class MultiPartitionWorker
 
     public MultiPartitionWorker(string bootstrapServers)
     {
-        _consumer = Kafka.CreateConsumer<string, string>()
+        _consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(bootstrapServers)
-            .Build();
+            .BuildAsync();
     }
 
     public async Task StartAsync(string topic, int[] partitions, CancellationToken ct)

--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -30,11 +30,11 @@ Offsets are automatically committed in the background:
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .WithOffsetCommitMode(OffsetCommitMode.Auto)
-    .Build();
+    .BuildAsync();
 
 await foreach (var msg in consumer.ConsumeAsync(ct))
 {
@@ -57,11 +57,11 @@ You control when offsets are committed by calling `CommitAsync()`:
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .WithOffsetCommitMode(OffsetCommitMode.Manual)
-    .Build();
+    .BuildAsync();
 
 await foreach (var msg in consumer.ConsumeAsync(ct))
 {

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -34,9 +34,9 @@ Dekaf's entry point is available through the `Dekaf` namespace:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 ```
 
 The `using Dekaf;` directive gives you access to:
@@ -76,9 +76,9 @@ Let's send a message to Kafka:
 using Dekaf;
 
 // Create a producer
-await using var producer = Kafka.CreateProducer<string, string>()
+await using var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 
 // Send a message and wait for acknowledgment
 var metadata = await producer.ProduceAsync("my-topic", "greeting", "Hello, Kafka!");
@@ -92,7 +92,7 @@ That's it! Let's break down what's happening:
 
 2. **`WithBootstrapServers()`** - Tells the producer where to find your Kafka cluster. It will discover other brokers automatically.
 
-3. **`Build()`** - Creates the producer instance. The producer is `IAsyncDisposable`, so use `await using` to ensure proper cleanup.
+3. **`BuildAsync()`** - Creates the producer instance. The producer is `IAsyncDisposable`, so use `await using` to ensure proper cleanup.
 
 4. **`ProduceAsync()`** - Sends the message and waits for the broker to acknowledge it.
 
@@ -104,11 +104,11 @@ Now let's consume messages:
 using Dekaf;
 
 // Create a consumer
-await using var consumer = Kafka.CreateConsumer<string, string>()
+await using var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-first-consumer")
     .SubscribeTo("my-topic")
-    .Build();
+    .BuildAsync();
 
 // Consume messages
 Console.WriteLine("Waiting for messages... (Ctrl+C to exit)");
@@ -146,12 +146,12 @@ const string topic = "getting-started";
 var cts = new CancellationTokenSource();
 var consumerTask = Task.Run(async () =>
 {
-    await using var consumer = Kafka.CreateConsumer<string, string>()
+    await using var consumer = await Kafka.CreateConsumer<string, string>()
         .WithBootstrapServers(bootstrapServers)
         .WithGroupId("getting-started-group")
         .WithAutoOffsetReset(AutoOffsetReset.Earliest)
         .SubscribeTo(topic)
-        .Build();
+        .BuildAsync();
 
     await foreach (var msg in consumer.ConsumeAsync(cts.Token))
     {
@@ -163,9 +163,9 @@ var consumerTask = Task.Run(async () =>
 await Task.Delay(2000);
 
 // Produce some messages
-await using var producer = Kafka.CreateProducer<string, string>()
+await using var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers(bootstrapServers)
-    .Build();
+    .BuildAsync();
 
 for (int i = 1; i <= 5; i++)
 {

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -62,19 +62,19 @@ When you need to push as many messages as possible:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .ForHighThroughput()  // Preset configuration
-    .Build();
+    .BuildAsync();
 
 // Or manual configuration
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithAcks(Acks.Leader)           // Don't wait for all replicas
     .WithLingerMs(5)                  // Batch for 5ms
     .WithBatchSize(65536)             // 64KB batches
     .WithCompression(CompressionType.Lz4)  // Fast compression
-    .Build();
+    .BuildAsync();
 ```
 
 #### Low Latency
@@ -84,18 +84,18 @@ When every millisecond counts:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .ForLowLatency()  // Preset configuration
-    .Build();
+    .BuildAsync();
 
 // Or manual configuration
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithAcks(Acks.Leader)
     .WithLingerMs(0)      // Send immediately
     .WithBatchSize(16384) // Smaller batches
-    .Build();
+    .BuildAsync();
 ```
 
 #### Maximum Reliability
@@ -105,17 +105,17 @@ When you absolutely cannot lose a message:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .ForReliability()  // Preset configuration
-    .Build();
+    .BuildAsync();
 
 // Or manual configuration
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithAcks(Acks.All)
     .WithIdempotence(true)
-    .Build();
+    .BuildAsync();
 ```
 
 ### Consumer Tuning
@@ -125,12 +125,12 @@ var producer = Kafka.CreateProducer<string, string>()
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .ForHighThroughput()
     .SubscribeTo("events")
-    .Build();
+    .BuildAsync();
 
 // Process in batches
 await foreach (var batch in consumer.ConsumeAsync(cts.Token).Batch(100))
@@ -145,12 +145,12 @@ await foreach (var batch in consumer.ConsumeAsync(cts.Token).Batch(100))
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
     .ForLowLatency()
     .SubscribeTo("events")
-    .Build();
+    .BuildAsync();
 ```
 
 ## Compression Trade-offs
@@ -176,10 +176,10 @@ Compression can dramatically reduce network usage, but it costs CPU. Here's how 
 using Dekaf;
 
 // LZ4 for balanced performance
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithCompression(CompressionType.Lz4)
-    .Build();
+    .BuildAsync();
 ```
 
 ## What to Expect
@@ -214,7 +214,7 @@ Hook into Dekaf's metrics to see what's happening:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithMetrics(metrics =>
     {
@@ -223,7 +223,7 @@ var producer = Kafka.CreateProducer<string, string>()
             // Record metrics
         };
     })
-    .Build();
+    .BuildAsync();
 ```
 
 ### Logging
@@ -233,10 +233,10 @@ Enable debug logging for performance troubleshooting:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithLoggerFactory(loggerFactory)
-    .Build();
+    .BuildAsync();
 ```
 
 ## Common Mistakes to Avoid
@@ -262,9 +262,9 @@ public class MessageService
 // Bad - creating per request
 public async Task SendAsync(string message)
 {
-    await using var producer = Kafka.CreateProducer<string, string>()
+    await using var producer = await Kafka.CreateProducer<string, string>()
         .WithBootstrapServers("localhost:9092")
-        .Build();
+        .BuildAsync();
     // ...
 }
 ```
@@ -343,9 +343,9 @@ public class MyBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        _producer = Kafka.CreateProducer<string, string>()
+        _producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers("localhost:9092")
-            .Build();
+            .BuildAsync();
     }
 
     [Benchmark]

--- a/docs/docs/producer/basics.md
+++ b/docs/docs/producer/basics.md
@@ -13,9 +13,9 @@ Use the fluent builder API to create a producer:
 ```csharp
 using Dekaf;
 
-await using var producer = Kafka.CreateProducer<string, string>()
+await using var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 ```
 
 The type parameters `<TKey, TValue>` define the types for message keys and values. Dekaf includes built-in serializers for common types.
@@ -76,10 +76,10 @@ The `Acks` setting controls when the broker considers a message "delivered":
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithAcks(Acks.All)  // Wait for all in-sync replicas
-    .Build();
+    .BuildAsync();
 ```
 
 | Acks Value | Behavior | Trade-off |
@@ -99,11 +99,11 @@ Dekaf automatically batches messages for efficiency. You can tune the batching b
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithLingerMs(5)       // Wait up to 5ms to collect more messages
     .WithBatchSize(65536)  // Maximum batch size in bytes
-    .Build();
+    .BuildAsync();
 ```
 
 - **`LingerMs`** - How long to wait before sending a batch that isn't full. Higher values = better batching but more latency.
@@ -116,10 +116,10 @@ Enable compression to reduce network usage:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .UseLz4Compression()  // Fast and good compression
-    .Build();
+    .BuildAsync();
 ```
 
 Available compression methods:
@@ -142,10 +142,10 @@ Enable idempotence to prevent duplicate messages during retries:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .EnableIdempotence()
-    .Build();
+    .BuildAsync();
 ```
 
 With idempotence enabled:

--- a/docs/docs/producer/fire-and-forget.md
+++ b/docs/docs/producer/fire-and-forget.md
@@ -185,13 +185,13 @@ For maximum throughput with fire-and-forget, tune the batching settings:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .ForHighThroughput()  // Preset with good defaults
     .WithLingerMs(10)     // Allow more time for batching
     .WithBatchSize(131072) // Larger batches (128KB)
     .UseLz4Compression()  // Compress batches
-    .Build();
+    .BuildAsync();
 ```
 
 This configuration:

--- a/docs/docs/producer/partitioning.md
+++ b/docs/docs/producer/partitioning.md
@@ -80,10 +80,10 @@ Dekaf supports different partitioning strategies:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithPartitioner(PartitionerType.Sticky)  // Change partitioner
-    .Build();
+    .BuildAsync();
 ```
 
 | Partitioner | Behavior |
@@ -99,11 +99,11 @@ The sticky partitioner improves batching efficiency for null-key messages:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithPartitioner(PartitionerType.Sticky)
     .WithLingerMs(5)
-    .Build();
+    .BuildAsync();
 
 // These will likely batch together in one partition
 producer.Send("events", null, "event1");

--- a/docs/docs/producer/topic-producer.md
+++ b/docs/docs/producer/topic-producer.md
@@ -28,11 +28,11 @@ Use the builder for more configuration options:
 ```csharp
 using Dekaf;
 
-await using var producer = Kafka.CreateProducer<string, string>()
+await using var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithAcks(Acks.All)
     .EnableIdempotence()
-    .BuildForTopic("orders");
+    .BuildForTopicAsync("orders");
 
 await producer.ProduceAsync("order-123", orderJson);
 ```
@@ -44,10 +44,10 @@ Create topic producers from a shared base producer. This is useful when you have
 ```csharp
 using Dekaf;
 
-await using var baseProducer = Kafka.CreateProducer<string, string>()
+await using var baseProducer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithAcks(Acks.All)
-    .Build();
+    .BuildAsync();
 
 // Create topic-specific wrappers (they share the base producer's resources)
 var ordersProducer = baseProducer.ForTopic("orders");

--- a/docs/docs/producer/transactions.md
+++ b/docs/docs/producer/transactions.md
@@ -21,10 +21,10 @@ Create a producer with a transactional ID:
 ```csharp
 using Dekaf;
 
-await using var producer = Kafka.CreateProducer<string, string>()
+await using var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithTransactionalId("my-service-instance-1")  // Must be unique per instance
-    .Build();
+    .BuildAsync();
 
 // Initialize transactions (required before first transaction)
 await producer.InitTransactionsAsync();
@@ -65,18 +65,18 @@ The most common use case for transactions is exactly-once stream processing:
 ```csharp
 using Dekaf;
 
-await using var consumer = Kafka.CreateConsumer<string, string>()
+await using var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("processor-group")
     .WithOffsetCommitMode(OffsetCommitMode.Manual)  // We'll commit via transaction
     .WithIsolationLevel(IsolationLevel.ReadCommitted)  // Only read committed messages
     .SubscribeTo("input-topic")
-    .Build();
+    .BuildAsync();
 
-await using var producer = Kafka.CreateProducer<string, string>()
+await using var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithTransactionalId($"processor-{Environment.MachineName}")
-    .Build();
+    .BuildAsync();
 
 await producer.InitTransactionsAsync();
 
@@ -134,11 +134,11 @@ Transactions have a timeout to prevent hanging transactions:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithTransactionalId("my-service")
     .WithTransactionTimeout(TimeSpan.FromMinutes(2))  // Default is 1 minute
-    .Build();
+    .BuildAsync();
 ```
 
 If a transaction isn't committed or aborted within the timeout, Kafka will abort it automatically.

--- a/docs/docs/security/oauth.md
+++ b/docs/docs/security/oauth.md
@@ -19,11 +19,11 @@ var oauthConfig = new OAuthBearerConfig
     Scope = "kafka"
 };
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9092")
     .UseTls()
     .WithOAuthBearer(oauthConfig)
-    .Build();
+    .BuildAsync();
 ```
 
 ## Custom Token Provider
@@ -33,7 +33,7 @@ For more control, implement a custom token provider:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9092")
     .UseTls()
     .WithOAuthBearer(async ct =>
@@ -46,7 +46,7 @@ var producer = Kafka.CreateProducer<string, string>()
             Principal = token.Subject
         };
     })
-    .Build();
+    .BuildAsync();
 ```
 
 ## Azure AD Example
@@ -56,7 +56,7 @@ using Dekaf;
 
 var credential = new DefaultAzureCredential();
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9092")
     .UseTls()
     .WithOAuthBearer(async ct =>
@@ -72,7 +72,7 @@ var producer = Kafka.CreateProducer<string, string>()
             ExpiresAt = token.ExpiresOn
         };
     })
-    .Build();
+    .BuildAsync();
 ```
 
 ## AWS MSK IAM
@@ -82,7 +82,7 @@ For AWS MSK with IAM authentication:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("broker.msk.us-east-1.amazonaws.com:9098")
     .UseTls()
     .WithOAuthBearer(async ct =>
@@ -95,7 +95,7 @@ var producer = Kafka.CreateProducer<string, string>()
             ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
         };
     })
-    .Build();
+    .BuildAsync();
 ```
 
 ## Token Refresh
@@ -131,13 +131,13 @@ public class OAuthKafkaClientFactory
         _config = config;
     }
 
-    public IKafkaProducer<string, string> CreateProducer()
+    public async Task<IKafkaProducer<string, string>> CreateProducer()
     {
-        return Kafka.CreateProducer<string, string>()
+        return await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(_config["Kafka:BootstrapServers"])
             .UseTls()
             .WithOAuthBearer(GetTokenAsync)
-            .Build();
+            .BuildAsync();
     }
 
     private async ValueTask<OAuthBearerToken> GetTokenAsync(CancellationToken ct)

--- a/docs/docs/security/sasl.md
+++ b/docs/docs/security/sasl.md
@@ -13,11 +13,11 @@ Simple username/password authentication:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9092")
     .UseTls()  // Always use TLS with PLAIN to encrypt credentials
     .WithSaslPlain("username", "password")
-    .Build();
+    .BuildAsync();
 ```
 
 :::warning
@@ -33,11 +33,11 @@ Challenge-response authentication that doesn't send passwords:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9092")
     .UseTls()
     .WithSaslScramSha256("username", "password")
-    .Build();
+    .BuildAsync();
 ```
 
 ### SCRAM-SHA-512 (Recommended)
@@ -45,11 +45,11 @@ var producer = Kafka.CreateProducer<string, string>()
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9092")
     .UseTls()
     .WithSaslScramSha512("username", "password")
-    .Build();
+    .BuildAsync();
 ```
 
 ## SASL/GSSAPI (Kerberos)
@@ -66,10 +66,10 @@ var gssapiConfig = new GssapiConfig
     Principal = "client@EXAMPLE.COM"
 };
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9092")
     .WithGssapi(gssapiConfig)
-    .Build();
+    .BuildAsync();
 ```
 
 ## Consumer Configuration
@@ -79,13 +79,13 @@ Same methods work for consumers:
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, string>()
+var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("kafka.example.com:9092")
     .WithGroupId("my-group")
     .UseTls()
     .WithSaslScramSha512("username", "password")
     .SubscribeTo("my-topic")
-    .Build();
+    .BuildAsync();
 ```
 
 ## Confluent Cloud Example
@@ -96,11 +96,11 @@ using Dekaf;
 var apiKey = Environment.GetEnvironmentVariable("CONFLUENT_API_KEY");
 var apiSecret = Environment.GetEnvironmentVariable("CONFLUENT_API_SECRET");
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("pkc-xxxxx.us-east-1.aws.confluent.cloud:9092")
     .UseTls()
     .WithSaslPlain(apiKey, apiSecret)
-    .Build();
+    .BuildAsync();
 ```
 
 ## Securing Credentials
@@ -130,9 +130,9 @@ public class SecureKafkaClient
 {
     private readonly IConfiguration _config;
 
-    public IKafkaProducer<string, string> CreateProducer()
+    public async Task<IKafkaProducer<string, string>> CreateProducer()
     {
-        return Kafka.CreateProducer<string, string>()
+        return await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(_config["Kafka:BootstrapServers"])
             .UseTls()
             .WithSaslScramSha512(
@@ -140,7 +140,7 @@ public class SecureKafkaClient
                 _config["Kafka:Password"]
             )
             .ForReliability()
-            .Build();
+            .BuildAsync();
     }
 }
 ```

--- a/docs/docs/security/tls.md
+++ b/docs/docs/security/tls.md
@@ -13,10 +13,10 @@ Enable TLS for encrypted connections:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9093")
     .UseTls()
-    .Build();
+    .BuildAsync();
 ```
 
 This uses system CA certificates to validate the broker's certificate.
@@ -33,10 +33,10 @@ var tlsConfig = new TlsConfig
     CaCertificatePath = "/path/to/ca.crt"
 };
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9093")
     .UseTls(tlsConfig)
-    .Build();
+    .BuildAsync();
 ```
 
 ## Mutual TLS (mTLS)
@@ -47,7 +47,7 @@ For client certificate authentication:
 using Dekaf;
 
 // Using file paths
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9093")
     .UseMutualTls(
         caCertPath: "/path/to/ca.crt",
@@ -55,16 +55,16 @@ var producer = Kafka.CreateProducer<string, string>()
         clientKeyPath: "/path/to/client.key",
         keyPassword: "optional-password"
     )
-    .Build();
+    .BuildAsync();
 
 // Using X509Certificate2
 var clientCert = new X509Certificate2("client.pfx", "password");
 var caCert = new X509Certificate2("ca.crt");
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9093")
     .UseMutualTls(clientCert, caCert)
-    .Build();
+    .BuildAsync();
 ```
 
 ## TLS Configuration Options
@@ -89,10 +89,10 @@ var tlsConfig = new TlsConfig
     EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13
 };
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9093")
     .UseTls(tlsConfig)
-    .Build();
+    .BuildAsync();
 ```
 
 ## Common Configurations
@@ -102,11 +102,11 @@ var producer = Kafka.CreateProducer<string, string>()
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("broker1.msk.us-east-1.amazonaws.com:9098")
     .UseTls()
     .WithSaslOAuthBearer(new AwsMskTokenProvider())
-    .Build();
+    .BuildAsync();
 ```
 
 ### Confluent Cloud
@@ -114,11 +114,11 @@ var producer = Kafka.CreateProducer<string, string>()
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("pkc-xxxxx.us-east-1.aws.confluent.cloud:9092")
     .UseTls()
     .WithSaslPlain(apiKey, apiSecret)
-    .Build();
+    .BuildAsync();
 ```
 
 ## Troubleshooting

--- a/docs/docs/serialization/built-in.md
+++ b/docs/docs/serialization/built-in.md
@@ -26,14 +26,14 @@ When you create a producer or consumer without specifying serializers, Dekaf aut
 using Dekaf;
 
 // Automatically uses Serializers.String for both key and value
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 
 // Automatically uses Serializers.String for key, Serializers.Int64 for value
-var producer = Kafka.CreateProducer<string, long>()
+var producer = await Kafka.CreateProducer<string, long>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 ```
 
 ## String Serializer
@@ -43,9 +43,9 @@ Encodes strings as UTF-8:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 
 await producer.ProduceAsync("topic", "key", "Hello, World!");
 ```
@@ -59,9 +59,9 @@ Passes bytes through unchanged:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, byte[]>()
+var producer = await Kafka.CreateProducer<string, byte[]>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 
 await producer.ProduceAsync("topic", "key", new byte[] { 1, 2, 3, 4 });
 ```
@@ -73,9 +73,9 @@ Zero-copy byte handling:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, ReadOnlyMemory<byte>>()
+var producer = await Kafka.CreateProducer<string, ReadOnlyMemory<byte>>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 
 ReadOnlyMemory<byte> data = GetData();
 await producer.ProduceAsync("topic", "key", data);
@@ -89,16 +89,16 @@ Big-endian encoding (network byte order):
 using Dekaf;
 
 // 32-bit integer
-var producer32 = Kafka.CreateProducer<int, string>()
+var producer32 = await Kafka.CreateProducer<int, string>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 
 await producer32.ProduceAsync("topic", 12345, "value");
 
 // 64-bit integer
-var producer64 = Kafka.CreateProducer<long, string>()
+var producer64 = await Kafka.CreateProducer<long, string>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 
 await producer64.ProduceAsync("topic", 123456789L, "value");
 ```
@@ -110,9 +110,9 @@ await producer64.ProduceAsync("topic", 123456789L, "value");
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<Guid, string>()
+var producer = await Kafka.CreateProducer<Guid, string>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 
 await producer.ProduceAsync("topic", Guid.NewGuid(), "value");
 ```
@@ -124,9 +124,9 @@ For topics where you don't need keys:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<Ignore, string>()
+var producer = await Kafka.CreateProducer<Ignore, string>()
     .WithBootstrapServers("localhost:9092")
-    .Build();
+    .BuildAsync();
 
 // Key is always null
 await producer.ProduceAsync("topic", Ignore.Value, "value");
@@ -139,11 +139,11 @@ You can also use the built-in serializers explicitly:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<string, string>()
+var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithKeySerializer(Serializers.String)
     .WithValueSerializer(Serializers.String)
-    .Build();
+    .BuildAsync();
 ```
 
 ## Unsupported Types
@@ -153,10 +153,10 @@ If you use a type without a built-in serializer:
 ```csharp
 using Dekaf;
 
-// This throws InvalidOperationException at Build()
-var producer = Kafka.CreateProducer<string, MyCustomType>()
+// This throws InvalidOperationException at BuildAsync()
+var producer = await Kafka.CreateProducer<string, MyCustomType>()
     .WithBootstrapServers("localhost:9092")
-    .Build();  // Error: No default serializer for type MyCustomType
+    .BuildAsync();  // Error: No default serializer for type MyCustomType
 ```
 
 For custom types, see [JSON Serialization](./json) or [Custom Serializers](./custom).

--- a/docs/docs/serialization/custom.md
+++ b/docs/docs/serialization/custom.md
@@ -43,10 +43,10 @@ public class OrderSerializer : ISerializer<Order>, IDeserializer<Order>
 }
 
 // Usage
-var producer = Kafka.CreateProducer<string, Order>()
+var producer = await Kafka.CreateProducer<string, Order>()
     .WithBootstrapServers("localhost:9092")
     .WithValueSerializer(new OrderSerializer())
-    .Build();
+    .BuildAsync();
 ```
 
 ## Zero-Allocation Serializer
@@ -115,10 +115,10 @@ public class MessagePackSerializer<T> : ISerializer<T>, IDeserializer<T>
 }
 
 // Usage
-var producer = Kafka.CreateProducer<string, Order>()
+var producer = await Kafka.CreateProducer<string, Order>()
     .WithBootstrapServers("localhost:9092")
     .WithValueSerializer(new MessagePackSerializer<Order>())
-    .Build();
+    .BuildAsync();
 ```
 
 ## Null Handling
@@ -178,11 +178,11 @@ public class OrderCodec : ISerializer<Order>, IDeserializer<Order>
 // Use same instance for both
 var codec = new OrderCodec();
 
-var producer = Kafka.CreateProducer<string, Order>()
+var producer = await Kafka.CreateProducer<string, Order>()
     .WithValueSerializer(codec)
-    .Build();
+    .BuildAsync();
 
-var consumer = Kafka.CreateConsumer<string, Order>()
+var consumer = await Kafka.CreateConsumer<string, Order>()
     .WithValueDeserializer(codec)
-    .Build();
+    .BuildAsync();
 ```

--- a/docs/docs/serialization/json.md
+++ b/docs/docs/serialization/json.md
@@ -19,10 +19,10 @@ dotnet add package Dekaf.Serialization.Json
 ```csharp
 using Dekaf.Serialization.Json;
 
-var producer = Kafka.CreateProducer<string, Order>()
+var producer = await Kafka.CreateProducer<string, Order>()
     .WithBootstrapServers("localhost:9092")
     .WithValueSerializer(new JsonSerializer<Order>())
-    .Build();
+    .BuildAsync();
 
 var order = new Order
 {
@@ -40,12 +40,12 @@ await producer.ProduceAsync("orders", order.Id, order);
 ```csharp
 using Dekaf.Serialization.Json;
 
-var consumer = Kafka.CreateConsumer<string, Order>()
+var consumer = await Kafka.CreateConsumer<string, Order>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("order-processors")
     .WithValueDeserializer(new JsonDeserializer<Order>())
     .SubscribeTo("orders")
-    .Build();
+    .BuildAsync();
 
 await foreach (var message in consumer.ConsumeAsync(ct))
 {
@@ -68,10 +68,10 @@ var options = new JsonSerializerOptions
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
 };
 
-var producer = Kafka.CreateProducer<string, Order>()
+var producer = await Kafka.CreateProducer<string, Order>()
     .WithBootstrapServers("localhost:9092")
     .WithValueSerializer(new JsonSerializer<Order>(options))
-    .Build();
+    .BuildAsync();
 ```
 
 ## Both Key and Value
@@ -81,11 +81,11 @@ Serialize both key and value as JSON:
 ```csharp
 using Dekaf;
 
-var producer = Kafka.CreateProducer<OrderKey, OrderEvent>()
+var producer = await Kafka.CreateProducer<OrderKey, OrderEvent>()
     .WithBootstrapServers("localhost:9092")
     .WithKeySerializer(new JsonSerializer<OrderKey>())
     .WithValueSerializer(new JsonSerializer<OrderEvent>())
-    .Build();
+    .BuildAsync();
 
 await producer.ProduceAsync("order-events",
     new OrderKey { TenantId = "acme", OrderId = "123" },
@@ -169,10 +169,10 @@ var jsonOptions = new JsonSerializerOptions
     PropertyNamingPolicy = JsonNamingPolicy.CamelCase
 };
 
-await using var producer = Kafka.CreateProducer<string, Order>()
+await using var producer = await Kafka.CreateProducer<string, Order>()
     .WithBootstrapServers("localhost:9092")
     .WithValueSerializer(new JsonSerializer<Order>(jsonOptions))
-    .Build();
+    .BuildAsync();
 
 var order = new Order(
     Id: "order-123",
@@ -189,12 +189,12 @@ var order = new Order(
 await producer.ProduceAsync("orders", order.Id, order);
 
 // Consumer
-await using var consumer = Kafka.CreateConsumer<string, Order>()
+await using var consumer = await Kafka.CreateConsumer<string, Order>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("order-processors")
     .WithValueDeserializer(new JsonDeserializer<Order>(jsonOptions))
     .SubscribeTo("orders")
-    .Build();
+    .BuildAsync();
 
 await foreach (var msg in consumer.ConsumeAsync(ct))
 {

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -31,10 +31,10 @@ var schemaRegistry = new CachedSchemaRegistryClient(
     new SchemaRegistryConfig { Url = "http://localhost:8081" }
 );
 
-var producer = Kafka.CreateProducer<string, Order>()
+var producer = await Kafka.CreateProducer<string, Order>()
     .WithBootstrapServers("localhost:9092")
     .WithValueSerializer(new AvroSerializer<Order>(schemaRegistry))
-    .Build();
+    .BuildAsync();
 
 await producer.ProduceAsync("orders", order.Id, order);
 ```
@@ -70,10 +70,10 @@ var schemaRegistry = new CachedSchemaRegistryClient(
     new SchemaRegistryConfig { Url = "http://localhost:8081" }
 );
 
-var producer = Kafka.CreateProducer<string, OrderProto>()
+var producer = await Kafka.CreateProducer<string, OrderProto>()
     .WithBootstrapServers("localhost:9092")
     .WithValueSerializer(new ProtobufSerializer<OrderProto>(schemaRegistry))
-    .Build();
+    .BuildAsync();
 ```
 
 ## Schema Registry Configuration
@@ -100,12 +100,12 @@ var schemaRegistry = new CachedSchemaRegistryClient(config);
 ```csharp
 using Dekaf;
 
-var consumer = Kafka.CreateConsumer<string, Order>()
+var consumer = await Kafka.CreateConsumer<string, Order>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("order-processors")
     .WithValueDeserializer(new AvroDeserializer<Order>(schemaRegistry))
     .SubscribeTo("orders")
-    .Build();
+    .BuildAsync();
 
 await foreach (var msg in consumer.ConsumeAsync(ct))
 {

--- a/tests/Dekaf.Tests.Unit/Extensions/GlobalInterceptorOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/GlobalInterceptorOrderingTests.cs
@@ -1,0 +1,371 @@
+using Dekaf.Consumer;
+using Dekaf.Extensions.DependencyInjection;
+using Dekaf.Producer;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dekaf.Tests.Unit.Extensions;
+
+public sealed class GlobalInterceptorOrderingTests
+{
+    #region Producer Interceptor Ordering Tests
+
+    [Test]
+    public async Task GlobalProducerInterceptors_ExecuteBeforePerInstance()
+    {
+        var callOrder = new List<string>();
+
+        var services = new ServiceCollection();
+        services.AddDekaf(builder =>
+        {
+            builder.AddGlobalProducerInterceptor(typeof(OrderTrackingProducerInterceptor<,>));
+            builder.AddProducer<string, string>(p =>
+            {
+                p.WithBootstrapServers("localhost:9092");
+                p.AddInterceptor(new NamedProducerInterceptor("per-instance", callOrder));
+            });
+        });
+
+        // Register the call order list and the name for the global interceptor in DI
+        services.AddSingleton(callOrder);
+        services.AddSingleton(new InterceptorName("global"));
+
+        var sp = services.BuildServiceProvider();
+        var producer = sp.GetRequiredService<IKafkaProducer<string, string>>();
+
+        // Get the interceptors from the producer via reflection to invoke them directly
+        var interceptors = GetProducerInterceptors<string, string>(producer);
+
+        await Assert.That(interceptors).IsNotNull();
+        await Assert.That(interceptors!).Count().IsEqualTo(2);
+
+        // Simulate interceptor invocation (same order as the producer pipeline)
+        var message = new ProducerMessage<string, string> { Topic = "test", Key = "key", Value = "value" };
+        foreach (var interceptor in interceptors)
+        {
+            message = interceptor.OnSend(message);
+        }
+
+        await Assert.That(callOrder).Count().IsEqualTo(2);
+        await Assert.That(callOrder[0]).IsEqualTo("global");
+        await Assert.That(callOrder[1]).IsEqualTo("per-instance");
+    }
+
+    [Test]
+    public async Task MultipleGlobalProducerInterceptors_ExecuteInRegistrationOrder()
+    {
+        var callOrder = new List<string>();
+
+        var services = new ServiceCollection();
+        services.AddDekaf(builder =>
+        {
+            builder.AddGlobalProducerInterceptor(typeof(OrderTrackingProducerInterceptor<,>));
+            builder.AddGlobalProducerInterceptor(typeof(SecondOrderTrackingProducerInterceptor<,>));
+            builder.AddProducer<string, string>(p =>
+            {
+                p.WithBootstrapServers("localhost:9092");
+            });
+        });
+
+        services.AddSingleton(callOrder);
+        services.AddSingleton(new InterceptorName("global-1"));
+        services.AddSingleton(new SecondInterceptorName("global-2"));
+
+        var sp = services.BuildServiceProvider();
+        var producer = sp.GetRequiredService<IKafkaProducer<string, string>>();
+
+        var interceptors = GetProducerInterceptors<string, string>(producer);
+
+        await Assert.That(interceptors).IsNotNull();
+        await Assert.That(interceptors!).Count().IsEqualTo(2);
+
+        var message = new ProducerMessage<string, string> { Topic = "test", Key = "key", Value = "value" };
+        foreach (var interceptor in interceptors)
+        {
+            message = interceptor.OnSend(message);
+        }
+
+        await Assert.That(callOrder).Count().IsEqualTo(2);
+        await Assert.That(callOrder[0]).IsEqualTo("global-1");
+        await Assert.That(callOrder[1]).IsEqualTo("global-2");
+    }
+
+    [Test]
+    public async Task PerInstanceProducerInterceptors_ExecuteInRegistrationOrderAfterGlobals()
+    {
+        var callOrder = new List<string>();
+
+        var services = new ServiceCollection();
+        services.AddDekaf(builder =>
+        {
+            builder.AddGlobalProducerInterceptor(typeof(OrderTrackingProducerInterceptor<,>));
+            builder.AddProducer<string, string>(p =>
+            {
+                p.WithBootstrapServers("localhost:9092");
+                p.AddInterceptor(new NamedProducerInterceptor("per-instance-1", callOrder));
+                p.AddInterceptor(new NamedProducerInterceptor("per-instance-2", callOrder));
+            });
+        });
+
+        services.AddSingleton(callOrder);
+        services.AddSingleton(new InterceptorName("global"));
+
+        var sp = services.BuildServiceProvider();
+        var producer = sp.GetRequiredService<IKafkaProducer<string, string>>();
+
+        var interceptors = GetProducerInterceptors<string, string>(producer);
+
+        await Assert.That(interceptors).IsNotNull();
+        await Assert.That(interceptors!).Count().IsEqualTo(3);
+
+        var message = new ProducerMessage<string, string> { Topic = "test", Key = "key", Value = "value" };
+        foreach (var interceptor in interceptors)
+        {
+            message = interceptor.OnSend(message);
+        }
+
+        await Assert.That(callOrder).Count().IsEqualTo(3);
+        await Assert.That(callOrder[0]).IsEqualTo("global");
+        await Assert.That(callOrder[1]).IsEqualTo("per-instance-1");
+        await Assert.That(callOrder[2]).IsEqualTo("per-instance-2");
+    }
+
+    [Test]
+    public async Task NoGlobalInterceptors_ProducerHasNoInterceptors()
+    {
+        var services = new ServiceCollection();
+        services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>(p =>
+            {
+                p.WithBootstrapServers("localhost:9092");
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var producer = sp.GetRequiredService<IKafkaProducer<string, string>>();
+
+        var interceptors = GetProducerInterceptors<string, string>(producer);
+        await Assert.That(interceptors).IsNull();
+    }
+
+    #endregion
+
+    #region Consumer Interceptor Ordering Tests
+
+    [Test]
+    public async Task GlobalConsumerInterceptors_ExecuteBeforePerInstance()
+    {
+        var callOrder = new List<string>();
+
+        var services = new ServiceCollection();
+        services.AddDekaf(builder =>
+        {
+            builder.AddGlobalConsumerInterceptor(typeof(OrderTrackingConsumerInterceptor<,>));
+            builder.AddConsumer<string, string>(c =>
+            {
+                c.WithBootstrapServers("localhost:9092")
+                    .WithGroupId("test-group");
+                c.AddInterceptor(new NamedConsumerInterceptor("per-instance", callOrder));
+            });
+        });
+
+        services.AddSingleton(callOrder);
+        services.AddSingleton(new InterceptorName("global"));
+
+        var sp = services.BuildServiceProvider();
+        var consumer = sp.GetRequiredService<IKafkaConsumer<string, string>>();
+
+        var interceptors = GetConsumerInterceptors<string, string>(consumer);
+
+        await Assert.That(interceptors).IsNotNull();
+        await Assert.That(interceptors!).Count().IsEqualTo(2);
+
+        // Simulate interceptor invocation
+        var result = default(ConsumeResult<string, string>);
+        foreach (var interceptor in interceptors)
+        {
+            result = interceptor.OnConsume(result);
+        }
+
+        await Assert.That(callOrder).Count().IsEqualTo(2);
+        await Assert.That(callOrder[0]).IsEqualTo("global");
+        await Assert.That(callOrder[1]).IsEqualTo("per-instance");
+    }
+
+    [Test]
+    public async Task MultipleGlobalConsumerInterceptors_ExecuteInRegistrationOrder()
+    {
+        var callOrder = new List<string>();
+
+        var services = new ServiceCollection();
+        services.AddDekaf(builder =>
+        {
+            builder.AddGlobalConsumerInterceptor(typeof(OrderTrackingConsumerInterceptor<,>));
+            builder.AddGlobalConsumerInterceptor(typeof(SecondOrderTrackingConsumerInterceptor<,>));
+            builder.AddConsumer<string, string>(c =>
+            {
+                c.WithBootstrapServers("localhost:9092")
+                    .WithGroupId("test-group");
+            });
+        });
+
+        services.AddSingleton(callOrder);
+        services.AddSingleton(new InterceptorName("global-1"));
+        services.AddSingleton(new SecondInterceptorName("global-2"));
+
+        var sp = services.BuildServiceProvider();
+        var consumer = sp.GetRequiredService<IKafkaConsumer<string, string>>();
+
+        var interceptors = GetConsumerInterceptors<string, string>(consumer);
+
+        await Assert.That(interceptors).IsNotNull();
+        await Assert.That(interceptors!).Count().IsEqualTo(2);
+
+        var result = default(ConsumeResult<string, string>);
+        foreach (var interceptor in interceptors)
+        {
+            result = interceptor.OnConsume(result);
+        }
+
+        await Assert.That(callOrder).Count().IsEqualTo(2);
+        await Assert.That(callOrder[0]).IsEqualTo("global-1");
+        await Assert.That(callOrder[1]).IsEqualTo("global-2");
+    }
+
+    #endregion
+
+    #region Reflection Helpers
+
+    private static IProducerInterceptor<TKey, TValue>[]? GetProducerInterceptors<TKey, TValue>(
+        IKafkaProducer<TKey, TValue> producer)
+    {
+        var field = producer.GetType().GetField("_interceptors",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        return field?.GetValue(producer) as IProducerInterceptor<TKey, TValue>[];
+    }
+
+    private static IConsumerInterceptor<TKey, TValue>[]? GetConsumerInterceptors<TKey, TValue>(
+        IKafkaConsumer<TKey, TValue> consumer)
+    {
+        var field = consumer.GetType().GetField("_interceptors",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        return field?.GetValue(consumer) as IConsumerInterceptor<TKey, TValue>[];
+    }
+
+    #endregion
+
+    #region DI-Injectable Interceptor Implementations
+
+    // Wrapper types to differentiate multiple interceptor names in DI
+    public sealed record InterceptorName(string Name);
+    public sealed record SecondInterceptorName(string Name);
+
+    // Open generic producer interceptor that can be resolved via ActivatorUtilities
+    public sealed class OrderTrackingProducerInterceptor<TKey, TValue> : IProducerInterceptor<TKey, TValue>
+    {
+        private readonly string _name;
+        private readonly List<string> _callOrder;
+
+        public OrderTrackingProducerInterceptor(List<string> callOrder, InterceptorName name)
+        {
+            _callOrder = callOrder;
+            _name = name.Name;
+        }
+
+        public ProducerMessage<TKey, TValue> OnSend(ProducerMessage<TKey, TValue> message)
+        {
+            _callOrder.Add(_name);
+            return message;
+        }
+
+        public void OnAcknowledgement(RecordMetadata metadata, Exception? exception) { }
+    }
+
+    public sealed class SecondOrderTrackingProducerInterceptor<TKey, TValue> : IProducerInterceptor<TKey, TValue>
+    {
+        private readonly string _name;
+        private readonly List<string> _callOrder;
+
+        public SecondOrderTrackingProducerInterceptor(List<string> callOrder, SecondInterceptorName name)
+        {
+            _callOrder = callOrder;
+            _name = name.Name;
+        }
+
+        public ProducerMessage<TKey, TValue> OnSend(ProducerMessage<TKey, TValue> message)
+        {
+            _callOrder.Add(_name);
+            return message;
+        }
+
+        public void OnAcknowledgement(RecordMetadata metadata, Exception? exception) { }
+    }
+
+    // Open generic consumer interceptor
+    public sealed class OrderTrackingConsumerInterceptor<TKey, TValue> : IConsumerInterceptor<TKey, TValue>
+    {
+        private readonly string _name;
+        private readonly List<string> _callOrder;
+
+        public OrderTrackingConsumerInterceptor(List<string> callOrder, InterceptorName name)
+        {
+            _callOrder = callOrder;
+            _name = name.Name;
+        }
+
+        public ConsumeResult<TKey, TValue> OnConsume(ConsumeResult<TKey, TValue> result)
+        {
+            _callOrder.Add(_name);
+            return result;
+        }
+
+        public void OnCommit(IReadOnlyList<TopicPartitionOffset> offsets) { }
+    }
+
+    public sealed class SecondOrderTrackingConsumerInterceptor<TKey, TValue> : IConsumerInterceptor<TKey, TValue>
+    {
+        private readonly string _name;
+        private readonly List<string> _callOrder;
+
+        public SecondOrderTrackingConsumerInterceptor(List<string> callOrder, SecondInterceptorName name)
+        {
+            _callOrder = callOrder;
+            _name = name.Name;
+        }
+
+        public ConsumeResult<TKey, TValue> OnConsume(ConsumeResult<TKey, TValue> result)
+        {
+            _callOrder.Add(_name);
+            return result;
+        }
+
+        public void OnCommit(IReadOnlyList<TopicPartitionOffset> offsets) { }
+    }
+
+    // Non-generic interceptor used from per-instance registration
+    private sealed class NamedProducerInterceptor(string name, List<string> callOrder)
+        : IProducerInterceptor<string, string>
+    {
+        public ProducerMessage<string, string> OnSend(ProducerMessage<string, string> message)
+        {
+            callOrder.Add(name);
+            return message;
+        }
+
+        public void OnAcknowledgement(RecordMetadata metadata, Exception? exception) { }
+    }
+
+    private sealed class NamedConsumerInterceptor(string name, List<string> callOrder)
+        : IConsumerInterceptor<string, string>
+    {
+        public ConsumeResult<string, string> OnConsume(ConsumeResult<string, string> result)
+        {
+            callOrder.Add(name);
+            return result;
+        }
+
+        public void OnCommit(IReadOnlyList<TopicPartitionOffset> offsets) { }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Add `AddGlobalProducerInterceptor` / `AddGlobalConsumerInterceptor` to `DekafBuilder` for registering cross-cutting interceptors (tracing, metrics, audit logging) that apply to all producers/consumers automatically
- Add `AddInterceptor` to `ProducerServiceBuilder` / `ConsumerServiceBuilder` for per-instance interceptors via DI
- Global interceptors execute before per-instance interceptors, in registration order, constructed via `ActivatorUtilities` for DI constructor injection support
- Update all docs to use `BuildAsync()` instead of `Build()` and correct DI examples to use the actual `AddDekaf` API

Closes #310

## Test plan

- [x] Unit tests for `DekafBuilder` chaining, null checks, and compose scenarios (DependencyInjectionTests)
- [x] Unit tests for interceptor execution ordering: globals before per-instance, registration order preserved (GlobalInterceptorOrderingTests)
- [x] Full unit test suite passes (52,676 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)