### PR TITLE
feat: allow multiple in-flight batches per partition

### DIFF
--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -68,6 +68,9 @@ public sealed class ProducerOptions
 
     /// <summary>
     /// Maximum in-flight requests per connection.
+    /// For idempotent producers (the default), values greater than 1 allow multiple batches
+    /// per partition to be in-flight simultaneously, improving throughput. Ordering is
+    /// guaranteed by Kafka's idempotent sequence numbers. Default is 5.
     /// </summary>
     public int MaxInFlightRequestsPerConnection { get; init; } = 5;
 


### PR DESCRIPTION
## Summary
- Separates send-time muting (`_muteOnSend`, only when `MaxInFlight <= 1`) from retry muting (`_guaranteeMessageOrder`), allowing idempotent producers with `MaxInFlight > 1` (default 5) to have multiple batches per partition in-flight simultaneously
- Previously all idempotent producers were limited to 1 in-flight batch per partition, capping throughput at `1/RTT` (~200 batches/sec at 5ms RTT)
- Ordering remains guaranteed by Kafka's idempotent sequence numbers; retry muting still prevents reordering during error recovery

Closes #263

## Test plan
- [x] All 52,676 unit tests pass
- [x] All 21 MultiInflightProducerTests pass (now exercising true multi-inflight paths)
- [x] All 48 ProducerOrderingTests pass (validates ordering integrity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)