### PR TITLE
Add DI convenience extensions for JSON serializer registration

### DIFF
--- a/benchmark-results/Client/BenchmarkRun-20260227-192533.log
+++ b/benchmark-results/Client/BenchmarkRun-20260227-192533.log
@@ -1,0 +1,2487 @@
+// Validating benchmarks:
+// ***** BenchmarkRunner: Start   *****
+// ***** Found 40 benchmark(s) in total *****
+// ***** Building 1 exe(s) in Parallel: Start   *****
+// start dotnet  restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true /p:IntermediateOutputPath="/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/obj/Release/net10.0/" /p:OutDir="/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0/" /p:OutputPath="/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0/" in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8
+// command took 2.12 sec and exited with 0
+// start dotnet  build -c Release --no-restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true /p:IntermediateOutputPath="/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/obj/Release/net10.0/" /p:OutDir="/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0/" /p:OutputPath="/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0/" --output "/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0/" in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8
+// command took 31.75 sec and exited with 0
+// ***** Done, took 00:00:33 (33.97 sec)   *****
+// Found 16 benchmarks:
+//   ConsumerBenchmarks.Confluent_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+//   ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+//   ConsumerBenchmarks.Confluent_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+//   ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+//   ConsumerBenchmarks.Confluent_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+//   ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+//   ConsumerBenchmarks.Confluent_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+//   ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+//   ConsumerBenchmarks.Confluent_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+//   ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+//   ConsumerBenchmarks.Confluent_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+//   ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+//   ConsumerBenchmarks.Confluent_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+//   ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+//   ConsumerBenchmarks.Confluent_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+//   ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+
+// **************************
+// Benchmark: ConsumerBenchmarks.Confluent_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Confluent_ConsumeAll(MessageCount: 100, MessageSize: 100)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 0 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-HJWRRW(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 296725.00 ns, 296.7250 us/op
+WorkloadJitting  1: 1 op, 6161787135.00 ns, 6.1618 s/op
+
+OverheadWarmup   1: 1 op, 631.00 ns, 631.0000 ns/op
+OverheadWarmup   2: 1 op, 541.00 ns, 541.0000 ns/op
+OverheadWarmup   3: 1 op, 531.00 ns, 531.0000 ns/op
+OverheadWarmup   4: 1 op, 582.00 ns, 582.0000 ns/op
+OverheadWarmup   5: 1 op, 521.00 ns, 521.0000 ns/op
+OverheadWarmup   6: 1 op, 451.00 ns, 451.0000 ns/op
+OverheadWarmup   7: 1 op, 471.00 ns, 471.0000 ns/op
+OverheadWarmup   8: 1 op, 430.00 ns, 430.0000 ns/op
+
+OverheadActual   1: 1 op, 451.00 ns, 451.0000 ns/op
+OverheadActual   2: 1 op, 441.00 ns, 441.0000 ns/op
+OverheadActual   3: 1 op, 732.00 ns, 732.0000 ns/op
+OverheadActual   4: 1 op, 461.00 ns, 461.0000 ns/op
+OverheadActual   5: 1 op, 461.00 ns, 461.0000 ns/op
+OverheadActual   6: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual   7: 1 op, 420.00 ns, 420.0000 ns/op
+OverheadActual   8: 1 op, 411.00 ns, 411.0000 ns/op
+OverheadActual   9: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual  10: 1 op, 451.00 ns, 451.0000 ns/op
+OverheadActual  11: 1 op, 1172.00 ns, 1.1720 us/op
+OverheadActual  12: 1 op, 491.00 ns, 491.0000 ns/op
+OverheadActual  13: 1 op, 471.00 ns, 471.0000 ns/op
+OverheadActual  14: 1 op, 461.00 ns, 461.0000 ns/op
+OverheadActual  15: 1 op, 471.00 ns, 471.0000 ns/op
+OverheadActual  16: 1 op, 471.00 ns, 471.0000 ns/op
+OverheadActual  17: 1 op, 481.00 ns, 481.0000 ns/op
+OverheadActual  18: 1 op, 471.00 ns, 471.0000 ns/op
+OverheadActual  19: 1 op, 461.00 ns, 461.0000 ns/op
+OverheadActual  20: 1 op, 391.00 ns, 391.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 3173408709.00 ns, 3.1734 s/op
+WorkloadWarmup   2: 1 op, 3172947924.00 ns, 3.1729 s/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 3170657867.00 ns, 3.1707 s/op
+WorkloadActual   2: 1 op, 3172308462.00 ns, 3.1723 s/op
+WorkloadActual   3: 1 op, 3170337952.00 ns, 3.1703 s/op
+WorkloadActual   4: 1 op, 3168452267.00 ns, 3.1685 s/op
+WorkloadActual   5: 1 op, 3170950477.00 ns, 3.1710 s/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 3170657406.00 ns, 3.1707 s/op
+WorkloadResult   2: 1 op, 3170337491.00 ns, 3.1703 s/op
+WorkloadResult   3: 1 op, 3168451806.00 ns, 3.1685 s/op
+WorkloadResult   4: 1 op, 3170950016.00 ns, 3.1710 s/op
+// GC:  0 0 0 76880 1
+// Threading:  0 0 1
+
+Using external Kafka - skipping container cleanup
+// AfterAll
+// Benchmark Process 4759 has exited with code 0.
+
+Mean = 3.170 s, StdErr = 0.001 s (0.02%), N = 4, StdDev = 0.001 s
+Min = 3.168 s, Q1 = 3.170 s, Median = 3.170 s, Q3 = 3.171 s, Max = 3.171 s
+IQR = 0.001 s, LowerFence = 3.169 s, UpperFence = 3.172 s
+ConfidenceInterval = [3.163 s; 3.177 s] (CI 99.9%), Margin = 0.007 s (0.23% of Mean)
+Skewness = -0.64, Kurtosis = 1.24, MValue = 2
+
+// ** Remained 39 (97.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:48 (0h 22m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll(MessageCount: 100, MessageSize: 100)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 1 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-RQNVKF(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 356808.00 ns, 356.8080 us/op
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before consuming messages.
+   at Dekaf.Consumer.KafkaConsumer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1663
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+MoveNext() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 647
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 163
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 163
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 170
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult[T](Task`1 task)
+   at BenchmarkDotNet.Autogenerated.Runnable_1.<.ctor>b__3_3() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 372
+   at BenchmarkDotNet.Autogenerated.Runnable_1.WorkloadActionUnroll(Int64 invokeCount) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 448
+   at BenchmarkDotNet.Engines.Engine.Measure(Action`1 action, Int64 invokeCount)
+   at BenchmarkDotNet.Engines.Engine.RunIteration(IterationData data)
+   at BenchmarkDotNet.Engines.EngineFactory.Jit(Engine engine, Int32 jitIndex, Int32 invokeCount, Int32 unrollFactor)
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_1.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 351
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 4901 has exited with code 255.
+
+// ** Remained 38 (95.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:37 (0h 10m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Confluent_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Confluent_ConsumeAll(MessageCount: 100, MessageSize: 1000)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 2 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-FYGSKH(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 322654.00 ns, 322.6540 us/op
+WorkloadJitting  1: 1 op, 3182583032.00 ns, 3.1826 s/op
+
+OverheadWarmup   1: 1 op, 601.00 ns, 601.0000 ns/op
+OverheadWarmup   2: 1 op, 401.00 ns, 401.0000 ns/op
+OverheadWarmup   3: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadWarmup   4: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadWarmup   5: 1 op, 431.00 ns, 431.0000 ns/op
+OverheadWarmup   6: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadWarmup   7: 1 op, 411.00 ns, 411.0000 ns/op
+OverheadWarmup   8: 1 op, 401.00 ns, 401.0000 ns/op
+
+OverheadActual   1: 1 op, 451.00 ns, 451.0000 ns/op
+OverheadActual   2: 1 op, 410.00 ns, 410.0000 ns/op
+OverheadActual   3: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual   4: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual   5: 1 op, 570.00 ns, 570.0000 ns/op
+OverheadActual   6: 1 op, 360.00 ns, 360.0000 ns/op
+OverheadActual   7: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual   8: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   9: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual  10: 1 op, 451.00 ns, 451.0000 ns/op
+OverheadActual  11: 1 op, 571.00 ns, 571.0000 ns/op
+OverheadActual  12: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual  13: 1 op, 471.00 ns, 471.0000 ns/op
+OverheadActual  14: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual  15: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  16: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  17: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  18: 1 op, 360.00 ns, 360.0000 ns/op
+OverheadActual  19: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual  20: 1 op, 330.00 ns, 330.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 3169040855.00 ns, 3.1690 s/op
+WorkloadWarmup   2: 1 op, 3169716483.00 ns, 3.1697 s/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 3171288473.00 ns, 3.1713 s/op
+WorkloadActual   2: 1 op, 3167278683.00 ns, 3.1673 s/op
+WorkloadActual   3: 1 op, 3168545431.00 ns, 3.1685 s/op
+WorkloadActual   4: 1 op, 3166609287.00 ns, 3.1666 s/op
+WorkloadActual   5: 1 op, 3166851482.00 ns, 3.1669 s/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 3167278322.50 ns, 3.1673 s/op
+WorkloadResult   2: 1 op, 3168545070.50 ns, 3.1685 s/op
+WorkloadResult   3: 1 op, 3166608926.50 ns, 3.1666 s/op
+WorkloadResult   4: 1 op, 3166851121.50 ns, 3.1669 s/op
+// GC:  0 0 0 256880 1
+// Threading:  0 0 1
+
+Using external Kafka - skipping container cleanup
+// AfterAll
+// Benchmark Process 4932 has exited with code 0.
+
+Mean = 3.167 s, StdErr = 0.000 s (0.01%), N = 4, StdDev = 0.001 s
+Min = 3.167 s, Q1 = 3.167 s, Median = 3.167 s, Q3 = 3.168 s, Max = 3.169 s
+IQR = 0.001 s, LowerFence = 3.166 s, UpperFence = 3.169 s
+ConfidenceInterval = [3.162 s; 3.173 s] (CI 99.9%), Margin = 0.006 s (0.18% of Mean)
+Skewness = 0.54, Kurtosis = 1.16, MValue = 2
+
+// ** Remained 37 (92.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:40 (0h 13m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll(MessageCount: 100, MessageSize: 1000)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 3 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-UFNTFZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 321903.00 ns, 321.9030 us/op
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before consuming messages.
+   at Dekaf.Consumer.KafkaConsumer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1663
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+MoveNext() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 647
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 163
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 163
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 170
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult[T](Task`1 task)
+   at BenchmarkDotNet.Autogenerated.Runnable_3.<.ctor>b__3_3() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 714
+   at BenchmarkDotNet.Autogenerated.Runnable_3.WorkloadActionUnroll(Int64 invokeCount) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 790
+   at BenchmarkDotNet.Engines.Engine.Measure(Action`1 action, Int64 invokeCount)
+   at BenchmarkDotNet.Engines.Engine.RunIteration(IterationData data)
+   at BenchmarkDotNet.Engines.EngineFactory.Jit(Engine engine, Int32 jitIndex, Int32 invokeCount, Int32 unrollFactor)
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_3.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 693
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 5064 has exited with code 255.
+
+// ** Remained 36 (90.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:37 (0h 9m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Confluent_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Confluent_ConsumeAll(MessageCount: 1000, MessageSize: 100)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 4 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-YSLHTH(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 317414.00 ns, 317.4140 us/op
+WorkloadJitting  1: 1 op, 3182609849.00 ns, 3.1826 s/op
+
+OverheadWarmup   1: 1 op, 501.00 ns, 501.0000 ns/op
+OverheadWarmup   2: 1 op, 480.00 ns, 480.0000 ns/op
+OverheadWarmup   3: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadWarmup   4: 1 op, 360.00 ns, 360.0000 ns/op
+OverheadWarmup   5: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadWarmup   6: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadWarmup   7: 1 op, 380.00 ns, 380.0000 ns/op
+OverheadWarmup   8: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadWarmup   9: 1 op, 420.00 ns, 420.0000 ns/op
+
+OverheadActual   1: 1 op, 360.00 ns, 360.0000 ns/op
+OverheadActual   2: 1 op, 411.00 ns, 411.0000 ns/op
+OverheadActual   3: 1 op, 451.00 ns, 451.0000 ns/op
+OverheadActual   4: 1 op, 441.00 ns, 441.0000 ns/op
+OverheadActual   5: 1 op, 411.00 ns, 411.0000 ns/op
+OverheadActual   6: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual   7: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual   8: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual   9: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual  10: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  11: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  12: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  13: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual  14: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  15: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual  16: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual  17: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  18: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual  19: 1 op, 581.00 ns, 581.0000 ns/op
+OverheadActual  20: 1 op, 3286.00 ns, 3.2860 us/op
+
+WorkloadWarmup   1: 1 op, 3167662412.00 ns, 3.1677 s/op
+WorkloadWarmup   2: 1 op, 3170251798.00 ns, 3.1703 s/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 3169793915.00 ns, 3.1698 s/op
+WorkloadActual   2: 1 op, 3168902543.00 ns, 3.1689 s/op
+WorkloadActual   3: 1 op, 3166199472.00 ns, 3.1662 s/op
+WorkloadActual   4: 1 op, 3166719846.00 ns, 3.1667 s/op
+WorkloadActual   5: 1 op, 3167115614.00 ns, 3.1671 s/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 3169793569.50 ns, 3.1698 s/op
+WorkloadResult   2: 1 op, 3168902197.50 ns, 3.1689 s/op
+WorkloadResult   3: 1 op, 3166199126.50 ns, 3.1662 s/op
+WorkloadResult   4: 1 op, 3166719500.50 ns, 3.1667 s/op
+WorkloadResult   5: 1 op, 3167115268.50 ns, 3.1671 s/op
+// GC:  0 0 0 616880 1
+// Threading:  0 0 1
+
+Using external Kafka - skipping container cleanup
+// AfterAll
+// Benchmark Process 5096 has exited with code 0.
+
+Mean = 3.168 s, StdErr = 0.001 s (0.02%), N = 5, StdDev = 0.002 s
+Min = 3.166 s, Q1 = 3.167 s, Median = 3.167 s, Q3 = 3.169 s, Max = 3.170 s
+IQR = 0.002 s, LowerFence = 3.163 s, UpperFence = 3.172 s
+ConfidenceInterval = [3.162 s; 3.174 s] (CI 99.9%), Margin = 0.006 s (0.19% of Mean)
+Skewness = 0.28, Kurtosis = 0.96, MValue = 2
+
+// ** Remained 35 (87.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:39 (0h 11m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll(MessageCount: 1000, MessageSize: 100)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 5 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-XNPWDC(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 346618.00 ns, 346.6180 us/op
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before consuming messages.
+   at Dekaf.Consumer.KafkaConsumer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1663
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+MoveNext() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 647
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 163
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 163
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 170
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult[T](Task`1 task)
+   at BenchmarkDotNet.Autogenerated.Runnable_5.<.ctor>b__3_3() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 1056
+   at BenchmarkDotNet.Autogenerated.Runnable_5.WorkloadActionUnroll(Int64 invokeCount) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 1132
+   at BenchmarkDotNet.Engines.Engine.Measure(Action`1 action, Int64 invokeCount)
+   at BenchmarkDotNet.Engines.Engine.RunIteration(IterationData data)
+   at BenchmarkDotNet.Engines.EngineFactory.Jit(Engine engine, Int32 jitIndex, Int32 invokeCount, Int32 unrollFactor)
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_5.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 1035
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 5228 has exited with code 255.
+
+// ** Remained 34 (85.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:36 (0h 9m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Confluent_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Confluent_ConsumeAll(MessageCount: 1000, MessageSize: 1000)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 6 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-LXCTLR(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 361767.00 ns, 361.7670 us/op
+WorkloadJitting  1: 1 op, 3182328987.00 ns, 3.1823 s/op
+
+OverheadWarmup   1: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadWarmup   2: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadWarmup   3: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadWarmup   4: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadWarmup   5: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadWarmup   6: 1 op, 341.00 ns, 341.0000 ns/op
+
+OverheadActual   1: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual   2: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual   3: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   4: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   5: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   6: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   7: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   8: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   9: 1 op, 390.00 ns, 390.0000 ns/op
+OverheadActual  10: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual  11: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual  12: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual  13: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  14: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual  15: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  16: 1 op, 370.00 ns, 370.0000 ns/op
+OverheadActual  17: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  18: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual  19: 1 op, 430.00 ns, 430.0000 ns/op
+OverheadActual  20: 1 op, 371.00 ns, 371.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 3169494915.00 ns, 3.1695 s/op
+WorkloadWarmup   2: 1 op, 3168230413.00 ns, 3.1682 s/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 3167900931.00 ns, 3.1679 s/op
+WorkloadActual   2: 1 op, 3169207976.00 ns, 3.1692 s/op
+WorkloadActual   3: 1 op, 3166466891.00 ns, 3.1665 s/op
+WorkloadActual   4: 1 op, 3166260125.00 ns, 3.1663 s/op
+WorkloadActual   5: 1 op, 3168055246.00 ns, 3.1681 s/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 3167900590.00 ns, 3.1679 s/op
+WorkloadResult   2: 1 op, 3169207635.00 ns, 3.1692 s/op
+WorkloadResult   3: 1 op, 3166466550.00 ns, 3.1665 s/op
+WorkloadResult   4: 1 op, 3166259784.00 ns, 3.1663 s/op
+WorkloadResult   5: 1 op, 3168054905.00 ns, 3.1681 s/op
+// GC:  0 0 0 2424896 1
+// Threading:  0 0 1
+
+Using external Kafka - skipping container cleanup
+// AfterAll
+// Benchmark Process 5258 has exited with code 0.
+
+Mean = 3.168 s, StdErr = 0.001 s (0.02%), N = 5, StdDev = 0.001 s
+Min = 3.166 s, Q1 = 3.166 s, Median = 3.168 s, Q3 = 3.168 s, Max = 3.169 s
+IQR = 0.002 s, LowerFence = 3.164 s, UpperFence = 3.170 s
+ConfidenceInterval = [3.163 s; 3.172 s] (CI 99.9%), Margin = 0.005 s (0.15% of Mean)
+Skewness = 0.09, Kurtosis = 1.05, MValue = 2
+
+// ** Remained 33 (82.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:38 (0h 10m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll(MessageCount: 1000, MessageSize: 1000)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 7 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-TWJQMM(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 372016.00 ns, 372.0160 us/op
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before consuming messages.
+   at Dekaf.Consumer.KafkaConsumer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1663
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+MoveNext() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 647
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 163
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 163
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_ConsumeAll() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 170
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult[T](Task`1 task)
+   at BenchmarkDotNet.Autogenerated.Runnable_7.<.ctor>b__3_3() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 1398
+   at BenchmarkDotNet.Autogenerated.Runnable_7.WorkloadActionUnroll(Int64 invokeCount) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 1474
+   at BenchmarkDotNet.Engines.Engine.Measure(Action`1 action, Int64 invokeCount)
+   at BenchmarkDotNet.Engines.Engine.RunIteration(IterationData data)
+   at BenchmarkDotNet.Engines.EngineFactory.Jit(Engine engine, Int32 jitIndex, Int32 invokeCount, Int32 unrollFactor)
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_7.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 1377
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 5389 has exited with code 255.
+
+// ** Remained 32 (80.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:36 (0h 8m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Confluent_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Confluent_PollSingle(MessageCount: 100, MessageSize: 100)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 8 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-PGVIAI(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 373829.00 ns, 373.8290 us/op
+WorkloadJitting  1: 1 op, 3139196363.00 ns, 3.1392 s/op
+
+OverheadWarmup   1: 1 op, 671.00 ns, 671.0000 ns/op
+OverheadWarmup   2: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadWarmup   3: 1 op, 511.00 ns, 511.0000 ns/op
+OverheadWarmup   4: 1 op, 511.00 ns, 511.0000 ns/op
+OverheadWarmup   5: 1 op, 531.00 ns, 531.0000 ns/op
+OverheadWarmup   6: 1 op, 331.00 ns, 331.0000 ns/op
+
+OverheadActual   1: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual   2: 1 op, 471.00 ns, 471.0000 ns/op
+OverheadActual   3: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual   4: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual   5: 1 op, 360.00 ns, 360.0000 ns/op
+OverheadActual   6: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual   7: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   8: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   9: 1 op, 441.00 ns, 441.0000 ns/op
+OverheadActual  10: 1 op, 370.00 ns, 370.0000 ns/op
+OverheadActual  11: 1 op, 411.00 ns, 411.0000 ns/op
+OverheadActual  12: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual  13: 1 op, 411.00 ns, 411.0000 ns/op
+OverheadActual  14: 1 op, 421.00 ns, 421.0000 ns/op
+OverheadActual  15: 1 op, 380.00 ns, 380.0000 ns/op
+OverheadActual  16: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadActual  17: 1 op, 370.00 ns, 370.0000 ns/op
+OverheadActual  18: 1 op, 390.00 ns, 390.0000 ns/op
+OverheadActual  19: 1 op, 431.00 ns, 431.0000 ns/op
+OverheadActual  20: 1 op, 401.00 ns, 401.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 3160922078.00 ns, 3.1609 s/op
+WorkloadWarmup   2: 1 op, 3163558207.00 ns, 3.1636 s/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 3162347430.00 ns, 3.1623 s/op
+WorkloadActual   2: 1 op, 3162075550.00 ns, 3.1621 s/op
+WorkloadActual   3: 1 op, 3163543200.00 ns, 3.1635 s/op
+WorkloadActual   4: 1 op, 3162455601.00 ns, 3.1625 s/op
+WorkloadActual   5: 1 op, 3160753854.00 ns, 3.1608 s/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 3162347049.50 ns, 3.1623 s/op
+WorkloadResult   2: 1 op, 3162075169.50 ns, 3.1621 s/op
+WorkloadResult   3: 1 op, 3162455220.50 ns, 3.1625 s/op
+WorkloadResult   4: 1 op, 3160753473.50 ns, 3.1608 s/op
+// GC:  0 0 0 3200 1
+// Threading:  0 0 1
+
+Using external Kafka - skipping container cleanup
+// AfterAll
+// Benchmark Process 5421 has exited with code 0.
+
+Mean = 3.162 s, StdErr = 0.000 s (0.01%), N = 4, StdDev = 0.001 s
+Min = 3.161 s, Q1 = 3.162 s, Median = 3.162 s, Q3 = 3.162 s, Max = 3.162 s
+IQR = 0.001 s, LowerFence = 3.161 s, UpperFence = 3.163 s
+ConfidenceInterval = [3.157 s; 3.167 s] (CI 99.9%), Margin = 0.005 s (0.16% of Mean)
+Skewness = -0.66, Kurtosis = 1.25, MValue = 2
+
+// ** Remained 31 (77.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:37 (0h 9m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_PollSingle(MessageCount: 100, MessageSize: 100)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 9 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-FOEHLE(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 330639.00 ns, 330.6390 us/op
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before consuming messages.
+   at Dekaf.Consumer.KafkaConsumer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1663
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+MoveNext() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 647
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeOneAsync(TimeSpan timeout, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1229
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeOneAsync(TimeSpan timeout, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1229
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_PollSingle() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 186
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult[T](Task`1 task)
+   at BenchmarkDotNet.Autogenerated.Runnable_9.<.ctor>b__3_2() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 1740
+   at BenchmarkDotNet.Autogenerated.Runnable_9.WorkloadActionUnroll(Int64 invokeCount) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 1819
+   at BenchmarkDotNet.Engines.Engine.Measure(Action`1 action, Int64 invokeCount)
+   at BenchmarkDotNet.Engines.Engine.RunIteration(IterationData data)
+   at BenchmarkDotNet.Engines.EngineFactory.Jit(Engine engine, Int32 jitIndex, Int32 invokeCount, Int32 unrollFactor)
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_9.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 1719
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 5583 has exited with code 255.
+
+// ** Remained 30 (75.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:36 (0h 8m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Confluent_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Confluent_PollSingle(MessageCount: 100, MessageSize: 1000)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 10 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-LOYPPU(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 369983.00 ns, 369.9830 us/op
+WorkloadJitting  1: 1 op, 3148101617.00 ns, 3.1481 s/op
+
+OverheadWarmup   1: 1 op, 621.00 ns, 621.0000 ns/op
+OverheadWarmup   2: 1 op, 481.00 ns, 481.0000 ns/op
+OverheadWarmup   3: 1 op, 572.00 ns, 572.0000 ns/op
+OverheadWarmup   4: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadWarmup   5: 1 op, 421.00 ns, 421.0000 ns/op
+OverheadWarmup   6: 1 op, 431.00 ns, 431.0000 ns/op
+OverheadWarmup   7: 1 op, 371.00 ns, 371.0000 ns/op
+
+OverheadActual   1: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual   2: 1 op, 1262.00 ns, 1.2620 us/op
+OverheadActual   3: 1 op, 702.00 ns, 702.0000 ns/op
+OverheadActual   4: 1 op, 671.00 ns, 671.0000 ns/op
+OverheadActual   5: 1 op, 651.00 ns, 651.0000 ns/op
+OverheadActual   6: 1 op, 621.00 ns, 621.0000 ns/op
+OverheadActual   7: 1 op, 581.00 ns, 581.0000 ns/op
+OverheadActual   8: 1 op, 752.00 ns, 752.0000 ns/op
+OverheadActual   9: 1 op, 521.00 ns, 521.0000 ns/op
+OverheadActual  10: 1 op, 551.00 ns, 551.0000 ns/op
+OverheadActual  11: 1 op, 591.00 ns, 591.0000 ns/op
+OverheadActual  12: 1 op, 501.00 ns, 501.0000 ns/op
+OverheadActual  13: 1 op, 451.00 ns, 451.0000 ns/op
+OverheadActual  14: 1 op, 441.00 ns, 441.0000 ns/op
+OverheadActual  15: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  16: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual  17: 1 op, 410.00 ns, 410.0000 ns/op
+OverheadActual  18: 1 op, 390.00 ns, 390.0000 ns/op
+OverheadActual  19: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual  20: 1 op, 371.00 ns, 371.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 3160081333.00 ns, 3.1601 s/op
+WorkloadWarmup   2: 1 op, 3160387247.00 ns, 3.1604 s/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 3162755856.00 ns, 3.1628 s/op
+WorkloadActual   2: 1 op, 3160476823.00 ns, 3.1605 s/op
+WorkloadActual   3: 1 op, 3160332026.00 ns, 3.1603 s/op
+WorkloadActual   4: 1 op, 3161440400.00 ns, 3.1614 s/op
+WorkloadActual   5: 1 op, 3160299564.00 ns, 3.1603 s/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 3162755345.00 ns, 3.1628 s/op
+WorkloadResult   2: 1 op, 3160476312.00 ns, 3.1605 s/op
+WorkloadResult   3: 1 op, 3160331515.00 ns, 3.1603 s/op
+WorkloadResult   4: 1 op, 3161439889.00 ns, 3.1614 s/op
+WorkloadResult   5: 1 op, 3160299053.00 ns, 3.1603 s/op
+// GC:  0 0 0 5288 1
+// Threading:  0 0 1
+
+Using external Kafka - skipping container cleanup
+// AfterAll
+// Benchmark Process 5617 has exited with code 0.
+
+Mean = 3.161 s, StdErr = 0.000 s (0.01%), N = 5, StdDev = 0.001 s
+Min = 3.160 s, Q1 = 3.160 s, Median = 3.160 s, Q3 = 3.161 s, Max = 3.163 s
+IQR = 0.001 s, LowerFence = 3.159 s, UpperFence = 3.163 s
+ConfidenceInterval = [3.157 s; 3.165 s] (CI 99.9%), Margin = 0.004 s (0.13% of Mean)
+Skewness = 0.66, Kurtosis = 1.44, MValue = 2
+
+// ** Remained 29 (72.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:37 (0h 8m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_PollSingle(MessageCount: 100, MessageSize: 1000)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 11 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-HNKSDN(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 326340.00 ns, 326.3400 us/op
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before consuming messages.
+   at Dekaf.Consumer.KafkaConsumer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1663
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+MoveNext() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 647
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeOneAsync(TimeSpan timeout, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1229
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeOneAsync(TimeSpan timeout, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1229
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_PollSingle() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 186
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult[T](Task`1 task)
+   at BenchmarkDotNet.Autogenerated.Runnable_11.<.ctor>b__3_2() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 2093
+   at BenchmarkDotNet.Autogenerated.Runnable_11.WorkloadActionUnroll(Int64 invokeCount) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 2172
+   at BenchmarkDotNet.Engines.Engine.Measure(Action`1 action, Int64 invokeCount)
+   at BenchmarkDotNet.Engines.Engine.RunIteration(IterationData data)
+   at BenchmarkDotNet.Engines.EngineFactory.Jit(Engine engine, Int32 jitIndex, Int32 invokeCount, Int32 unrollFactor)
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_11.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 2072
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 5751 has exited with code 255.
+
+// ** Remained 28 (70.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:36 (0h 7m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Confluent_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Confluent_PollSingle(MessageCount: 1000, MessageSize: 100)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 12 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-WOFNLD(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 340808.00 ns, 340.8080 us/op
+WorkloadJitting  1: 1 op, 3150413859.00 ns, 3.1504 s/op
+
+OverheadWarmup   1: 1 op, 752.00 ns, 752.0000 ns/op
+OverheadWarmup   2: 1 op, 1092.00 ns, 1.0920 us/op
+OverheadWarmup   3: 1 op, 541.00 ns, 541.0000 ns/op
+OverheadWarmup   4: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadWarmup   5: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadWarmup   6: 1 op, 371.00 ns, 371.0000 ns/op
+
+OverheadActual   1: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadActual   2: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual   3: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual   4: 1 op, 491.00 ns, 491.0000 ns/op
+OverheadActual   5: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual   6: 1 op, 370.00 ns, 370.0000 ns/op
+OverheadActual   7: 1 op, 431.00 ns, 431.0000 ns/op
+OverheadActual   8: 1 op, 400.00 ns, 400.0000 ns/op
+OverheadActual   9: 1 op, 401.00 ns, 401.0000 ns/op
+OverheadActual  10: 1 op, 370.00 ns, 370.0000 ns/op
+OverheadActual  11: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual  12: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual  13: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual  14: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual  15: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual  16: 1 op, 571.00 ns, 571.0000 ns/op
+OverheadActual  17: 1 op, 381.00 ns, 381.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 3163232905.00 ns, 3.1632 s/op
+WorkloadWarmup   2: 1 op, 3166867856.00 ns, 3.1669 s/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 3161800148.00 ns, 3.1618 s/op
+WorkloadActual   2: 1 op, 3161723878.00 ns, 3.1617 s/op
+WorkloadActual   3: 1 op, 3161481762.00 ns, 3.1615 s/op
+WorkloadActual   4: 1 op, 3162175698.00 ns, 3.1622 s/op
+WorkloadActual   5: 1 op, 3160767073.00 ns, 3.1608 s/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 3161799767.00 ns, 3.1618 s/op
+WorkloadResult   2: 1 op, 3161723497.00 ns, 3.1617 s/op
+WorkloadResult   3: 1 op, 3161481381.00 ns, 3.1615 s/op
+WorkloadResult   4: 1 op, 3162175317.00 ns, 3.1622 s/op
+WorkloadResult   5: 1 op, 3160766692.00 ns, 3.1608 s/op
+// GC:  0 0 0 3488 1
+// Threading:  0 0 1
+
+Using external Kafka - skipping container cleanup
+// AfterAll
+// Benchmark Process 5787 has exited with code 0.
+
+Mean = 3.162 s, StdErr = 0.000 s (0.01%), N = 5, StdDev = 0.001 s
+Min = 3.161 s, Q1 = 3.161 s, Median = 3.162 s, Q3 = 3.162 s, Max = 3.162 s
+IQR = 0.000 s, LowerFence = 3.161 s, UpperFence = 3.162 s
+ConfidenceInterval = [3.160 s; 3.164 s] (CI 99.9%), Margin = 0.002 s (0.06% of Mean)
+Skewness = -0.48, Kurtosis = 1.55, MValue = 2
+
+// ** Remained 27 (67.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:37 (0h 7m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_PollSingle(MessageCount: 1000, MessageSize: 100)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 13 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-IMBZPL(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 321581.00 ns, 321.5810 us/op
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before consuming messages.
+   at Dekaf.Consumer.KafkaConsumer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1663
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+MoveNext() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 647
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeOneAsync(TimeSpan timeout, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1229
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeOneAsync(TimeSpan timeout, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1229
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_PollSingle() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 186
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult[T](Task`1 task)
+   at BenchmarkDotNet.Autogenerated.Runnable_13.<.ctor>b__3_2() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 2446
+   at BenchmarkDotNet.Autogenerated.Runnable_13.WorkloadActionUnroll(Int64 invokeCount) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 2525
+   at BenchmarkDotNet.Engines.Engine.Measure(Action`1 action, Int64 invokeCount)
+   at BenchmarkDotNet.Engines.Engine.RunIteration(IterationData data)
+   at BenchmarkDotNet.Engines.EngineFactory.Jit(Engine engine, Int32 jitIndex, Int32 invokeCount, Int32 unrollFactor)
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_13.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 2425
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 5918 has exited with code 255.
+
+// ** Remained 26 (65.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:36 (0h 6m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Confluent_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 132 133 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Confluent_PollSingle(MessageCount: 1000, MessageSize: 1000)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 14 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-HSZHJP(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 372397.00 ns, 372.3970 us/op
+WorkloadJitting  1: 1 op, 3150235339.00 ns, 3.1502 s/op
+
+OverheadWarmup   1: 1 op, 742.00 ns, 742.0000 ns/op
+OverheadWarmup   2: 1 op, 611.00 ns, 611.0000 ns/op
+OverheadWarmup   3: 1 op, 561.00 ns, 561.0000 ns/op
+OverheadWarmup   4: 1 op, 582.00 ns, 582.0000 ns/op
+OverheadWarmup   5: 1 op, 370.00 ns, 370.0000 ns/op
+OverheadWarmup   6: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadWarmup   7: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadWarmup   8: 1 op, 351.00 ns, 351.0000 ns/op
+
+OverheadActual   1: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadActual   2: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadActual   3: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadActual   4: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual   5: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual   6: 1 op, 401.00 ns, 401.0000 ns/op
+OverheadActual   7: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual   8: 1 op, 370.00 ns, 370.0000 ns/op
+OverheadActual   9: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual  10: 1 op, 380.00 ns, 380.0000 ns/op
+OverheadActual  11: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  12: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  13: 1 op, 21750.00 ns, 21.7500 us/op
+OverheadActual  14: 1 op, 380.00 ns, 380.0000 ns/op
+OverheadActual  15: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  16: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  17: 1 op, 360.00 ns, 360.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 3162663378.00 ns, 3.1627 s/op
+WorkloadWarmup   2: 1 op, 3163053736.00 ns, 3.1631 s/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 3160919377.00 ns, 3.1609 s/op
+WorkloadActual   2: 1 op, 3161137115.00 ns, 3.1611 s/op
+WorkloadActual   3: 1 op, 3160673026.00 ns, 3.1607 s/op
+WorkloadActual   4: 1 op, 3158856104.00 ns, 3.1589 s/op
+WorkloadActual   5: 1 op, 3159335010.00 ns, 3.1593 s/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 3160918997.00 ns, 3.1609 s/op
+WorkloadResult   2: 1 op, 3161136735.00 ns, 3.1611 s/op
+WorkloadResult   3: 1 op, 3160672646.00 ns, 3.1607 s/op
+WorkloadResult   4: 1 op, 3158855724.00 ns, 3.1589 s/op
+WorkloadResult   5: 1 op, 3159334630.00 ns, 3.1593 s/op
+// GC:  0 0 0 5016 1
+// Threading:  0 0 1
+
+Using external Kafka - skipping container cleanup
+// AfterAll
+// Benchmark Process 5953 has exited with code 0.
+
+Mean = 3.160 s, StdErr = 0.000 s (0.01%), N = 5, StdDev = 0.001 s
+Min = 3.159 s, Q1 = 3.159 s, Median = 3.161 s, Q3 = 3.161 s, Max = 3.161 s
+IQR = 0.002 s, LowerFence = 3.157 s, UpperFence = 3.163 s
+ConfidenceInterval = [3.156 s; 3.164 s] (CI 99.9%), Margin = 0.004 s (0.12% of Mean)
+Skewness = -0.3, Kurtosis = 0.88, MValue = 2
+
+// ** Remained 25 (62.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:37 (0h 7m from now) **
+// **************************
+// Benchmark: ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 125 134 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_PollSingle(MessageCount: 1000, MessageSize: 1000)" --job "InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2" --benchmarkId 15 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-AHLXZJ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+OverheadJitting  1: 1 op, 325850.00 ns, 325.8500 us/op
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before consuming messages.
+   at Dekaf.Consumer.KafkaConsumer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1663
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+MoveNext() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 647
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeOneAsync(TimeSpan timeout, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1229
+   at Dekaf.Consumer.KafkaConsumer`2.ConsumeOneAsync(TimeSpan timeout, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Consumer/KafkaConsumer.cs:line 1229
+   at Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks.Dekaf_PollSingle() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs:line 186
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult[T](Task`1 task)
+   at BenchmarkDotNet.Autogenerated.Runnable_15.<.ctor>b__3_2() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 2799
+   at BenchmarkDotNet.Autogenerated.Runnable_15.WorkloadActionUnroll(Int64 invokeCount) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 2878
+   at BenchmarkDotNet.Engines.Engine.Measure(Action`1 action, Int64 invokeCount)
+   at BenchmarkDotNet.Engines.Engine.RunIteration(IterationData data)
+   at BenchmarkDotNet.Engines.EngineFactory.Jit(Engine engine, Int32 jitIndex, Int32 invokeCount, Int32 unrollFactor)
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_15.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 2778
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6087 has exited with code 255.
+
+// ** Remained 24 (60.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:36 (0h 6m from now) **
+// ***** BenchmarkRunner: Finish  *****
+
+// * Export *
+  BenchmarkResults/Client/results/Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks-report.csv
+  BenchmarkResults/Client/results/Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks-report-github.md
+  BenchmarkResults/Client/results/Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks-report.html
+  BenchmarkResults/Client/results/Dekaf.Benchmarks.Benchmarks.Client.ConsumerBenchmarks-report-full-compressed.json
+
+// * Detailed results *
+ConsumerBenchmarks.Confluent_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 3.170 s, StdErr = 0.001 s (0.02%), N = 4, StdDev = 0.001 s
+Min = 3.168 s, Q1 = 3.170 s, Median = 3.170 s, Q3 = 3.171 s, Max = 3.171 s
+IQR = 0.001 s, LowerFence = 3.169 s, UpperFence = 3.172 s
+ConfidenceInterval = [3.163 s; 3.177 s] (CI 99.9%), Margin = 0.007 s (0.23% of Mean)
+Skewness = -0.64, Kurtosis = 1.24, MValue = 2
+-------------------- Histogram --------------------
+[3.168 s ; 3.172 s) | @@@@
+---------------------------------------------------
+
+ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ConsumerBenchmarks.Confluent_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 3.167 s, StdErr = 0.000 s (0.01%), N = 4, StdDev = 0.001 s
+Min = 3.167 s, Q1 = 3.167 s, Median = 3.167 s, Q3 = 3.168 s, Max = 3.169 s
+IQR = 0.001 s, LowerFence = 3.166 s, UpperFence = 3.169 s
+ConfidenceInterval = [3.162 s; 3.173 s] (CI 99.9%), Margin = 0.006 s (0.18% of Mean)
+Skewness = 0.54, Kurtosis = 1.16, MValue = 2
+-------------------- Histogram --------------------
+[3.166 s ; 3.169 s) | @@@@
+---------------------------------------------------
+
+ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ConsumerBenchmarks.Confluent_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 3.168 s, StdErr = 0.001 s (0.02%), N = 5, StdDev = 0.002 s
+Min = 3.166 s, Q1 = 3.167 s, Median = 3.167 s, Q3 = 3.169 s, Max = 3.170 s
+IQR = 0.002 s, LowerFence = 3.163 s, UpperFence = 3.172 s
+ConfidenceInterval = [3.162 s; 3.174 s] (CI 99.9%), Margin = 0.006 s (0.19% of Mean)
+Skewness = 0.28, Kurtosis = 0.96, MValue = 2
+-------------------- Histogram --------------------
+[3.165 s ; 3.171 s) | @@@@@
+---------------------------------------------------
+
+ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ConsumerBenchmarks.Confluent_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 3.168 s, StdErr = 0.001 s (0.02%), N = 5, StdDev = 0.001 s
+Min = 3.166 s, Q1 = 3.166 s, Median = 3.168 s, Q3 = 3.168 s, Max = 3.169 s
+IQR = 0.002 s, LowerFence = 3.164 s, UpperFence = 3.170 s
+ConfidenceInterval = [3.163 s; 3.172 s] (CI 99.9%), Margin = 0.005 s (0.15% of Mean)
+Skewness = 0.09, Kurtosis = 1.05, MValue = 2
+-------------------- Histogram --------------------
+[3.165 s ; 3.170 s) | @@@@@
+---------------------------------------------------
+
+ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ConsumerBenchmarks.Confluent_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 3.162 s, StdErr = 0.000 s (0.01%), N = 4, StdDev = 0.001 s
+Min = 3.161 s, Q1 = 3.162 s, Median = 3.162 s, Q3 = 3.162 s, Max = 3.162 s
+IQR = 0.001 s, LowerFence = 3.161 s, UpperFence = 3.163 s
+ConfidenceInterval = [3.157 s; 3.167 s] (CI 99.9%), Margin = 0.005 s (0.16% of Mean)
+Skewness = -0.66, Kurtosis = 1.25, MValue = 2
+-------------------- Histogram --------------------
+[3.160 s ; 3.163 s) | @@@@
+---------------------------------------------------
+
+ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ConsumerBenchmarks.Confluent_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 3.161 s, StdErr = 0.000 s (0.01%), N = 5, StdDev = 0.001 s
+Min = 3.160 s, Q1 = 3.160 s, Median = 3.160 s, Q3 = 3.161 s, Max = 3.163 s
+IQR = 0.001 s, LowerFence = 3.159 s, UpperFence = 3.163 s
+ConfidenceInterval = [3.157 s; 3.165 s] (CI 99.9%), Margin = 0.004 s (0.13% of Mean)
+Skewness = 0.66, Kurtosis = 1.44, MValue = 2
+-------------------- Histogram --------------------
+[3.159 s ; 3.164 s) | @@@@@
+---------------------------------------------------
+
+ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ConsumerBenchmarks.Confluent_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 3.162 s, StdErr = 0.000 s (0.01%), N = 5, StdDev = 0.001 s
+Min = 3.161 s, Q1 = 3.161 s, Median = 3.162 s, Q3 = 3.162 s, Max = 3.162 s
+IQR = 0.000 s, LowerFence = 3.161 s, UpperFence = 3.162 s
+ConfidenceInterval = [3.160 s; 3.164 s] (CI 99.9%), Margin = 0.002 s (0.06% of Mean)
+Skewness = -0.48, Kurtosis = 1.55, MValue = 2
+-------------------- Histogram --------------------
+[3.160 s ; 3.163 s) | @@@@@
+---------------------------------------------------
+
+ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ConsumerBenchmarks.Confluent_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 3.160 s, StdErr = 0.000 s (0.01%), N = 5, StdDev = 0.001 s
+Min = 3.159 s, Q1 = 3.159 s, Median = 3.161 s, Q3 = 3.161 s, Max = 3.161 s
+IQR = 0.002 s, LowerFence = 3.157 s, UpperFence = 3.163 s
+ConfidenceInterval = [3.156 s; 3.164 s] (CI 99.9%), Margin = 0.004 s (0.12% of Mean)
+Skewness = -0.3, Kurtosis = 0.88, MValue = 2
+-------------------- Histogram --------------------
+[3.158 s ; 3.162 s) | @@@@@
+---------------------------------------------------
+
+ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+// * Summary *
+
+BenchmarkDotNet v0.14.0, Ubuntu 24.04.3 LTS (Noble Numbat)
+AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+.NET SDK 10.0.102
+  [Host]     : .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+  Job-VTGNCZ : .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+
+InvocationCount=1  IterationCount=5  RunStrategy=Throughput  
+UnrollFactor=1  WarmupCount=2  
+
+| Method               | Categories | MessageCount | MessageSize | Mean    | Error    | StdDev   | Ratio | RatioSD | Allocated | Alloc Ratio |
+|--------------------- |----------- |------------- |------------ |--------:|---------:|---------:|------:|--------:|----------:|------------:|
+| Confluent_ConsumeAll | ConsumeAll | 100          | 100         | 3.170 s | 0.0073 s | 0.0011 s |  1.00 |    0.00 |   76880 B |        1.00 |
+| Dekaf_ConsumeAll     | ConsumeAll | 100          | 100         |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| Confluent_ConsumeAll | ConsumeAll | 100          | 1000        | 3.167 s | 0.0056 s | 0.0009 s |  1.00 |    0.00 |  256880 B |        1.00 |
+| Dekaf_ConsumeAll     | ConsumeAll | 100          | 1000        |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| Confluent_ConsumeAll | ConsumeAll | 1000         | 100         | 3.168 s | 0.0059 s | 0.0015 s |  1.00 |    0.00 |  616880 B |        1.00 |
+| Dekaf_ConsumeAll     | ConsumeAll | 1000         | 100         |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| Confluent_ConsumeAll | ConsumeAll | 1000         | 1000        | 3.168 s | 0.0047 s | 0.0012 s |  1.00 |    0.00 | 2424896 B |        1.00 |
+| Dekaf_ConsumeAll     | ConsumeAll | 1000         | 1000        |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| Confluent_PollSingle | PollSingle | 100          | 100         | 3.162 s | 0.0051 s | 0.0008 s |  1.00 |    0.00 |         - |          NA |
+| Dekaf_PollSingle     | PollSingle | 100          | 100         |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| Confluent_PollSingle | PollSingle | 100          | 1000        | 3.161 s | 0.0041 s | 0.0011 s |  1.00 |    0.00 |         - |          NA |
+| Dekaf_PollSingle     | PollSingle | 100          | 1000        |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| Confluent_PollSingle | PollSingle | 1000         | 100         | 3.162 s | 0.0020 s | 0.0005 s |  1.00 |    0.00 |         - |          NA |
+| Dekaf_PollSingle     | PollSingle | 1000         | 100         |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| Confluent_PollSingle | PollSingle | 1000         | 1000        | 3.160 s | 0.0039 s | 0.0010 s |  1.00 |    0.00 |         - |          NA |
+| Dekaf_PollSingle     | PollSingle | 1000         | 1000        |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+
+Benchmarks with issues:
+  ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+  ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+  ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+  ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+  ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+  ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+  ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+  ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+
+// * Warnings *
+BaselineCustomAnalyzer
+  Summary -> A question mark '?' symbol indicates that it was not possible to compute the (Ratio, RatioSD, Alloc Ratio) column(s) because the baseline value is too close to zero.
+
+// * Hints *
+Outliers
+  ConsumerBenchmarks.Confluent_ConsumeAll: InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2 -> 1 outlier  was  removed, 2 outliers were detected (3.17 s, 3.17 s)
+  ConsumerBenchmarks.Confluent_ConsumeAll: InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2 -> 1 outlier  was  removed (3.17 s)
+  ConsumerBenchmarks.Confluent_PollSingle: InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2 -> 1 outlier  was  removed, 2 outliers were detected (3.16 s, 3.16 s)
+  ConsumerBenchmarks.Confluent_PollSingle: InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2 -> 1 outlier  was  detected (3.16 s)
+
+// * Legends *
+  Categories   : All categories of the corresponded method, class, and assembly
+  MessageCount : Value of the 'MessageCount' parameter
+  MessageSize  : Value of the 'MessageSize' parameter
+  Mean         : Arithmetic mean of all measurements
+  Error        : Half of 99.9% confidence interval
+  StdDev       : Standard deviation of all measurements
+  Ratio        : Mean of the ratio distribution ([Current]/[Baseline])
+  RatioSD      : Standard deviation of the ratio distribution ([Current]/[Baseline])
+  Allocated    : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
+  Alloc Ratio  : Allocated memory ratio distribution ([Current]/[Baseline])
+  1 s          : 1 Second (1 sec)
+
+// * Diagnostic Output - MemoryDiagnoser *
+
+
+// ***** BenchmarkRunner: End *****
+Run time: 00:04:15 (255.44 sec), executed benchmarks: 16
+
+// Found 24 benchmarks:
+//   ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+//   ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+//   ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+//   ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+//   ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+//   ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+//   ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+//   ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+//   ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+//   ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+//   ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+//   ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+//   ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+//   ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+//   ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+//   ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+//   ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+//   ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+//   ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+//   ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+//   ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+//   ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+//   ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+//   ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+
+// **************************
+// Benchmark: ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Confluent_ProduceBatch(MessageSize: 100, BatchSize: 100)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 16 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-XLSHKW(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_16.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 2974
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_16.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 2958
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6129 has exited with code 255.
+
+// ** Remained 23 (57.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:36 (0h 5m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Dekaf_ProduceBatch(MessageSize: 100, BatchSize: 100)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 17 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-LCVKAD(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_17.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 3168
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_17.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 3152
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6160 has exited with code 255.
+
+// ** Remained 22 (55.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:35 (0h 5m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Confluent_ProduceBatch(MessageSize: 100, BatchSize: 1000)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 18 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-IAWTHF(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_18.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 3362
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_18.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 3346
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6191 has exited with code 255.
+
+// ** Remained 21 (52.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:35 (0h 4m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Dekaf_ProduceBatch(MessageSize: 100, BatchSize: 1000)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 19 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-RNNOWW(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_19.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 3556
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_19.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 3540
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6222 has exited with code 255.
+
+// ** Remained 20 (50.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:34 (0h 4m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Confluent_ProduceBatch(MessageSize: 1000, BatchSize: 100)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 20 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-OEAWIS(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_20.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 3750
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_20.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 3734
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6253 has exited with code 255.
+
+// ** Remained 19 (47.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:34 (0h 3m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Dekaf_ProduceBatch(MessageSize: 1000, BatchSize: 100)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 21 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-VSSXIL(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_21.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 3944
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_21.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 3928
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6284 has exited with code 255.
+
+// ** Remained 18 (45.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:33 (0h 3m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Confluent_ProduceBatch(MessageSize: 1000, BatchSize: 1000)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 22 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-BENQCO(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_22.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 4138
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_22.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 4122
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6315 has exited with code 255.
+
+// ** Remained 17 (42.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:33 (0h 3m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Dekaf_ProduceBatch(MessageSize: 1000, BatchSize: 1000)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 23 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-AWQUQI(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_23.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 4332
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_23.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 4316
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6346 has exited with code 255.
+
+// ** Remained 16 (40.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:33 (0h 2m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Confluent_FireAndForget(MessageSize: 100, BatchSize: 100)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 24 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-MRMUEK(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_24.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 4526
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_24.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 4510
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6377 has exited with code 255.
+
+// ** Remained 15 (37.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:33 (0h 2m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Dekaf_FireAndForget(MessageSize: 100, BatchSize: 100)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 25 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-MMALGJ(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_25.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 4720
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_25.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 4704
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6408 has exited with code 255.
+
+// ** Remained 14 (35.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:32 (0h 2m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Confluent_FireAndForget(MessageSize: 100, BatchSize: 1000)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 26 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-VWAMAF(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_26.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 4914
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_26.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 4898
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6439 has exited with code 255.
+
+// ** Remained 13 (32.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:32 (0h 2m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Dekaf_FireAndForget(MessageSize: 100, BatchSize: 1000)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 27 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-WZEXKO(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_27.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 5108
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_27.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 5092
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6470 has exited with code 255.
+
+// ** Remained 12 (30.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:32 (0h 1m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Confluent_FireAndForget(MessageSize: 1000, BatchSize: 100)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 28 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-RHGVCD(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_28.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 5302
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_28.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 5286
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6503 has exited with code 255.
+
+// ** Remained 11 (27.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:32 (0h 1m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Dekaf_FireAndForget(MessageSize: 1000, BatchSize: 100)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 29 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-YSNINV(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_29.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 5496
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_29.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 5480
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6534 has exited with code 255.
+
+// ** Remained 10 (25.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:31 (0h 1m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 139 140 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Confluent_FireAndForget(MessageSize: 1000, BatchSize: 1000)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 30 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-MMQKLJ(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_30.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 5690
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_30.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 5674
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6566 has exited with code 255.
+
+// ** Remained 9 (22.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:31 (0h 1m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 137 138 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Dekaf_FireAndForget(MessageSize: 1000, BatchSize: 1000)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 31 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-VNCFTN(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_31.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 5884
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_31.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 5868
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6597 has exited with code 255.
+
+// ** Remained 8 (20.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:31 (0h 1m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 137 138 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Confluent_ProduceSingle(MessageSize: 100, BatchSize: 100)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 32 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-CVWSSJ(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_32.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 6078
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_32.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 6062
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6628 has exited with code 255.
+
+// ** Remained 7 (17.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:31 (0h 0m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 137 138 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Dekaf_ProduceSingle(MessageSize: 100, BatchSize: 100)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 33 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-WITGOZ(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_33.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 6277
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_33.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 6261
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6659 has exited with code 255.
+
+// ** Remained 6 (15.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:31 (0h 0m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 137 138 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Confluent_ProduceSingle(MessageSize: 100, BatchSize: 1000)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 34 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-AGOMXC(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_34.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 6487
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_34.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 6471
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6691 has exited with code 255.
+
+// ** Remained 5 (12.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:31 (0h 0m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 137 138 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Dekaf_ProduceSingle(MessageSize: 100, BatchSize: 1000)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 35 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-TCKSRM(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_35.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 6686
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_35.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 6670
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6722 has exited with code 255.
+
+// ** Remained 4 (10.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:31 (0h 0m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 137 138 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Confluent_ProduceSingle(MessageSize: 1000, BatchSize: 100)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 36 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-XPWLOJ(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_36.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 6896
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_36.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 6880
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6753 has exited with code 255.
+
+// ** Remained 3 (7.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:30 (0h 0m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 137 138 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Dekaf_ProduceSingle(MessageSize: 1000, BatchSize: 100)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 37 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-LKJOHU(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_37.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 7095
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_37.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 7079
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6784 has exited with code 255.
+
+// ** Remained 2 (5.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:30 (0h 0m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 137 138 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Confluent_ProduceSingle(MessageSize: 1000, BatchSize: 1000)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 38 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-COIWNX(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_38.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 7305
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_38.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 7289
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6815 has exited with code 255.
+
+// ** Remained 1 (2.5 %) benchmark(s) to run. Estimated finish 2026-02-27 19:30 (0h 0m from now) **
+// **************************
+// Benchmark: ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cc112001-ee62-4d99-8d21-2000067bf0b8.dll --anonymousPipes 137 138 --benchmarkName "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Dekaf_ProduceSingle(MessageSize: 1000, BatchSize: 1000)" --job "IterationCount=10, RunStrategy=Throughput, WarmupCount=3" --benchmarkId 39 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-AHWDOK(IterationCount=10, RunStrategy=Throughput, WarmupCount=3)
+
+Using external Kafka at localhost:9092
+Waiting for Kafka to be ready...
+Kafka is ready with 1 broker(s)
+
+System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.InvalidOperationException: Call InitializeAsync() or use BuildAsync() before producing messages.
+   at Dekaf.Producer.KafkaProducer`2.ThrowNotInitialized() in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 2713
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsyncCore(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 319
+   at Dekaf.Producer.KafkaProducer`2.ProduceAsync(ProducerMessage`2 message, CancellationToken cancellationToken) in /home/runner/work/Dekaf/Dekaf/src/Dekaf/Producer/KafkaProducer.cs:line 309
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.WarmupAsync() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 66
+   at Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks.Setup() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs:line 59
+   at BenchmarkDotNet.Helpers.AwaitHelper.GetResult(Task task)
+   at BenchmarkDotNet.Autogenerated.Runnable_39.<.ctor>b__3_0() in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 7504
+   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
+   at BenchmarkDotNet.Autogenerated.Runnable_39.Run(IHost host, String benchmarkName) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 7488
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   --- End of inner exception stack trace ---
+   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
+   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cc112001-ee62-4d99-8d21-2000067bf0b8/cc112001-ee62-4d99-8d21-2000067bf0b8.notcs:line 57
+// AfterAll
+No Workload Results were obtained from the run.
+// Benchmark Process 6846 has exited with code 255.
+
+// ** Remained 0 (0.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:30 (0h 0m from now) **
+// ***** BenchmarkRunner: Finish  *****
+
+// * Export *
+  BenchmarkResults/Client/results/Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks-report.csv
+  BenchmarkResults/Client/results/Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks-report-github.md
+  BenchmarkResults/Client/results/Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks-report.html
+  BenchmarkResults/Client/results/Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks-report-full-compressed.json
+
+// * Detailed results *
+ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+There are not any results runs
+
+// * Summary *
+
+BenchmarkDotNet v0.14.0, Ubuntu 24.04.3 LTS (Noble Numbat)
+AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+.NET SDK 10.0.102
+  [Host]     : .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+  Job-VDSHUR : .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+
+IterationCount=10  RunStrategy=Throughput  WarmupCount=3  
+
+| Method                  | Categories    | MessageSize | BatchSize | Mean | Error | Ratio | RatioSD | Alloc Ratio |
+|------------------------ |-------------- |------------ |---------- |-----:|------:|------:|--------:|------------:|
+| Confluent_ProduceBatch  | BatchProduce  | 100         | 100       |   NA |    NA |     ? |       ? |           ? |
+| Dekaf_ProduceBatch      | BatchProduce  | 100         | 100       |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| Confluent_ProduceBatch  | BatchProduce  | 100         | 1000      |   NA |    NA |     ? |       ? |           ? |
+| Dekaf_ProduceBatch      | BatchProduce  | 100         | 1000      |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| Confluent_ProduceBatch  | BatchProduce  | 1000        | 100       |   NA |    NA |     ? |       ? |           ? |
+| Dekaf_ProduceBatch      | BatchProduce  | 1000        | 100       |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| Confluent_ProduceBatch  | BatchProduce  | 1000        | 1000      |   NA |    NA |     ? |       ? |           ? |
+| Dekaf_ProduceBatch      | BatchProduce  | 1000        | 1000      |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| Confluent_FireAndForget | FireAndForget | 100         | 100       |   NA |    NA |     ? |       ? |           ? |
+| Dekaf_FireAndForget     | FireAndForget | 100         | 100       |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| Confluent_FireAndForget | FireAndForget | 100         | 1000      |   NA |    NA |     ? |       ? |           ? |
+| Dekaf_FireAndForget     | FireAndForget | 100         | 1000      |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| Confluent_FireAndForget | FireAndForget | 1000        | 100       |   NA |    NA |     ? |       ? |           ? |
+| Dekaf_FireAndForget     | FireAndForget | 1000        | 100       |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| Confluent_FireAndForget | FireAndForget | 1000        | 1000      |   NA |    NA |     ? |       ? |           ? |
+| Dekaf_FireAndForget     | FireAndForget | 1000        | 1000      |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| Confluent_ProduceSingle | SingleProduce | 100         | 100       |   NA |    NA |     ? |       ? |           ? |
+| Dekaf_ProduceSingle     | SingleProduce | 100         | 100       |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| Confluent_ProduceSingle | SingleProduce | 100         | 1000      |   NA |    NA |     ? |       ? |           ? |
+| Dekaf_ProduceSingle     | SingleProduce | 100         | 1000      |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| Confluent_ProduceSingle | SingleProduce | 1000        | 100       |   NA |    NA |     ? |       ? |           ? |
+| Dekaf_ProduceSingle     | SingleProduce | 1000        | 100       |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| Confluent_ProduceSingle | SingleProduce | 1000        | 1000      |   NA |    NA |     ? |       ? |           ? |
+| Dekaf_ProduceSingle     | SingleProduce | 1000        | 1000      |   NA |    NA |     ? |       ? |           ? |
+
+Benchmarks with issues:
+  ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+  ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+  ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+  ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+  ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+  ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+  ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+  ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+  ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+  ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+  ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+  ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+  ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+  ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+  ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+  ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+  ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+  ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+  ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+  ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+  ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+  ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+  ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+  ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+
+// * Warnings *
+BaselineCustomAnalyzer
+  Summary -> A question mark '?' symbol indicates that it was not possible to compute the (Ratio, RatioSD, Alloc Ratio) column(s) because the baseline value is too close to zero.
+
+// * Legends *
+  Categories  : All categories of the corresponded method, class, and assembly
+  MessageSize : Value of the 'MessageSize' parameter
+  BatchSize   : Value of the 'BatchSize' parameter
+  Mean        : Arithmetic mean of all measurements
+  Error       : Half of 99.9% confidence interval
+  Ratio       : Mean of the ratio distribution ([Current]/[Baseline])
+  RatioSD     : Standard deviation of the ratio distribution ([Current]/[Baseline])
+  Alloc Ratio : Allocated memory ratio distribution ([Current]/[Baseline])
+  1 ns        : 1 Nanosecond (0.000000001 sec)
+
+// * Diagnostic Output - MemoryDiagnoser *
+
+
+// ***** BenchmarkRunner: End *****
+Run time: 00:00:14 (14.48 sec), executed benchmarks: 24
+
+Global total time: 00:05:04 (304.1 sec), executed benchmarks: 40
+// * Artifacts cleanup *
+Artifacts cleanup is finished

--- a/benchmark-results/Unit/BenchmarkRun-20260227-192519.log
+++ b/benchmark-results/Unit/BenchmarkRun-20260227-192519.log
@@ -1,0 +1,6681 @@
+// Validating benchmarks:
+// ***** BenchmarkRunner: Start   *****
+// ***** Found 50 benchmark(s) in total *****
+// ***** Building 1 exe(s) in Parallel: Start   *****
+// start dotnet  restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true /p:IntermediateOutputPath="/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/obj/Release/net10.0/" /p:OutDir="/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0/" /p:OutputPath="/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0/" in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b
+// command took 1.58 sec and exited with 0
+// start dotnet  build -c Release --no-restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true /p:IntermediateOutputPath="/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/obj/Release/net10.0/" /p:OutDir="/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0/" /p:OutputPath="/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0/" --output "/home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0/" in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b
+// command took 29.9 sec and exited with 0
+// ***** Done, took 00:00:31 (31.59 sec)   *****
+// Found 4 benchmarks:
+//   CompressionBenchmarks.'Snappy Compress 1KB': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   CompressionBenchmarks.'Snappy Compress 1MB': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   CompressionBenchmarks.'Snappy Decompress 1KB': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   CompressionBenchmarks.'Snappy Decompress 1MB': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+// **************************
+// Benchmark: CompressionBenchmarks.'Snappy Compress 1KB': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 123 130 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionBenchmarks.Snappy_Compress_1KB --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 0 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-XGMAXA(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 237532.00 ns, 237.5320 us/op
+WorkloadJitting  1: 1 op, 199270.00 ns, 199.2700 us/op
+
+OverheadWarmup   1: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   2: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   3: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   4: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadWarmup   5: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   6: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   7: 1 op, 291.00 ns, 291.0000 ns/op
+
+OverheadActual   1: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   2: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   3: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual   4: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual   5: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual   6: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual   7: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   8: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   9: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  10: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  11: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  12: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  13: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  14: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  15: 1 op, 281.00 ns, 281.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 11712.00 ns, 11.7120 us/op
+WorkloadWarmup   2: 1 op, 11852.00 ns, 11.8520 us/op
+WorkloadWarmup   3: 1 op, 11562.00 ns, 11.5620 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 11812.00 ns, 11.8120 us/op
+WorkloadActual   2: 1 op, 15038.00 ns, 15.0380 us/op
+WorkloadActual   3: 1 op, 14897.00 ns, 14.8970 us/op
+WorkloadActual   4: 1 op, 15259.00 ns, 15.2590 us/op
+WorkloadActual   5: 1 op, 14617.00 ns, 14.6170 us/op
+WorkloadActual   6: 1 op, 15078.00 ns, 15.0780 us/op
+WorkloadActual   7: 1 op, 14767.00 ns, 14.7670 us/op
+WorkloadActual   8: 1 op, 14557.00 ns, 14.5570 us/op
+WorkloadActual   9: 1 op, 14327.00 ns, 14.3270 us/op
+WorkloadActual  10: 1 op, 14597.00 ns, 14.5970 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 11532.00 ns, 11.5320 us/op
+WorkloadResult   2: 1 op, 14758.00 ns, 14.7580 us/op
+WorkloadResult   3: 1 op, 14617.00 ns, 14.6170 us/op
+WorkloadResult   4: 1 op, 14979.00 ns, 14.9790 us/op
+WorkloadResult   5: 1 op, 14337.00 ns, 14.3370 us/op
+WorkloadResult   6: 1 op, 14798.00 ns, 14.7980 us/op
+WorkloadResult   7: 1 op, 14487.00 ns, 14.4870 us/op
+WorkloadResult   8: 1 op, 14277.00 ns, 14.2770 us/op
+WorkloadResult   9: 1 op, 14047.00 ns, 14.0470 us/op
+WorkloadResult  10: 1 op, 14317.00 ns, 14.3170 us/op
+// GC:  0 0 0 1120 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3334 has exited with code 0.
+
+Mean = 14.215 μs, StdErr = 0.311 μs (2.19%), N = 10, StdDev = 0.984 μs
+Min = 11.532 μs, Q1 = 14.287 μs, Median = 14.412 μs, Q3 = 14.723 μs, Max = 14.979 μs
+IQR = 0.436 μs, LowerFence = 13.633 μs, UpperFence = 15.376 μs
+ConfidenceInterval = [12.728 μs; 15.702 μs] (CI 99.9%), Margin = 1.487 μs (10.46% of Mean)
+Skewness = -1.94, Kurtosis = 5.59, MValue = 2
+
+// ** Remained 49 (98.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionBenchmarks.'Snappy Compress 1MB': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 123 130 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionBenchmarks.Snappy_Compress_1MB --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 1 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-CZQILM(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 239675.00 ns, 239.6750 us/op
+WorkloadJitting  1: 1 op, 780020.00 ns, 780.0200 us/op
+
+OverheadWarmup   1: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   2: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadWarmup   3: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   4: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   5: 1 op, 320.00 ns, 320.0000 ns/op
+
+OverheadActual   1: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   2: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual   3: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual   4: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual   5: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual   6: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual   7: 1 op, 380.00 ns, 380.0000 ns/op
+OverheadActual   8: 1 op, 400.00 ns, 400.0000 ns/op
+OverheadActual   9: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  10: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual  11: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual  12: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadActual  13: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  14: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual  15: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  16: 1 op, 550.00 ns, 550.0000 ns/op
+OverheadActual  17: 1 op, 652.00 ns, 652.0000 ns/op
+OverheadActual  18: 1 op, 701.00 ns, 701.0000 ns/op
+OverheadActual  19: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  20: 1 op, 350.00 ns, 350.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 576340.00 ns, 576.3400 us/op
+WorkloadWarmup   2: 1 op, 559199.00 ns, 559.1990 us/op
+WorkloadWarmup   3: 1 op, 566052.00 ns, 566.0520 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 572694.00 ns, 572.6940 us/op
+WorkloadActual   2: 1 op, 565801.00 ns, 565.8010 us/op
+WorkloadActual   3: 1 op, 534172.00 ns, 534.1720 us/op
+WorkloadActual   4: 1 op, 521069.00 ns, 521.0690 us/op
+WorkloadActual   5: 1 op, 546586.00 ns, 546.5860 us/op
+WorkloadActual   6: 1 op, 550212.00 ns, 550.2120 us/op
+WorkloadActual   7: 1 op, 525787.00 ns, 525.7870 us/op
+WorkloadActual   8: 1 op, 525386.00 ns, 525.3860 us/op
+WorkloadActual   9: 1 op, 558849.00 ns, 558.8490 us/op
+WorkloadActual  10: 1 op, 560601.00 ns, 560.6010 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 572344.00 ns, 572.3440 us/op
+WorkloadResult   2: 1 op, 565451.00 ns, 565.4510 us/op
+WorkloadResult   3: 1 op, 533822.00 ns, 533.8220 us/op
+WorkloadResult   4: 1 op, 520719.00 ns, 520.7190 us/op
+WorkloadResult   5: 1 op, 546236.00 ns, 546.2360 us/op
+WorkloadResult   6: 1 op, 549862.00 ns, 549.8620 us/op
+WorkloadResult   7: 1 op, 525437.00 ns, 525.4370 us/op
+WorkloadResult   8: 1 op, 525036.00 ns, 525.0360 us/op
+WorkloadResult   9: 1 op, 558499.00 ns, 558.4990 us/op
+WorkloadResult  10: 1 op, 560251.00 ns, 560.2510 us/op
+// GC:  0 0 0 1840 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3345 has exited with code 0.
+
+Mean = 545.766 μs, StdErr = 5.865 μs (1.07%), N = 10, StdDev = 18.547 μs
+Min = 520.719 μs, Q1 = 527.533 μs, Median = 548.049 μs, Q3 = 559.813 μs, Max = 572.344 μs
+IQR = 32.280 μs, LowerFence = 479.114 μs, UpperFence = 608.233 μs
+ConfidenceInterval = [517.726 μs; 573.806 μs] (CI 99.9%), Margin = 28.040 μs (5.14% of Mean)
+Skewness = -0.05, Kurtosis = 1.26, MValue = 2
+
+// ** Remained 48 (96.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionBenchmarks.'Snappy Decompress 1KB': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 123 130 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionBenchmarks.Snappy_Decompress_1KB --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 2 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-ADSDRL(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 242210.00 ns, 242.2100 us/op
+WorkloadJitting  1: 1 op, 9348763.00 ns, 9.3488 ms/op
+
+OverheadWarmup   1: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadWarmup   2: 1 op, 661.00 ns, 661.0000 ns/op
+OverheadWarmup   3: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadWarmup   4: 1 op, 611.00 ns, 611.0000 ns/op
+OverheadWarmup   5: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadWarmup   6: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadWarmup   7: 1 op, 652.00 ns, 652.0000 ns/op
+OverheadWarmup   8: 1 op, 351.00 ns, 351.0000 ns/op
+
+OverheadActual   1: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   2: 1 op, 380.00 ns, 380.0000 ns/op
+OverheadActual   3: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   4: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   5: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadActual   6: 1 op, 360.00 ns, 360.0000 ns/op
+OverheadActual   7: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   8: 1 op, 631.00 ns, 631.0000 ns/op
+OverheadActual   9: 1 op, 681.00 ns, 681.0000 ns/op
+OverheadActual  10: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual  11: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual  12: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  13: 1 op, 621.00 ns, 621.0000 ns/op
+OverheadActual  14: 1 op, 691.00 ns, 691.0000 ns/op
+OverheadActual  15: 1 op, 652.00 ns, 652.0000 ns/op
+OverheadActual  16: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual  17: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  18: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  19: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  20: 1 op, 310.00 ns, 310.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 45594.00 ns, 45.5940 us/op
+WorkloadWarmup   2: 1 op, 9988.00 ns, 9.9880 us/op
+WorkloadWarmup   3: 1 op, 10018.00 ns, 10.0180 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 10509.00 ns, 10.5090 us/op
+WorkloadActual   2: 1 op, 9978.00 ns, 9.9780 us/op
+WorkloadActual   3: 1 op, 9999.00 ns, 9.9990 us/op
+WorkloadActual   4: 1 op, 10339.00 ns, 10.3390 us/op
+WorkloadActual   5: 1 op, 10229.00 ns, 10.2290 us/op
+WorkloadActual   6: 1 op, 10219.00 ns, 10.2190 us/op
+WorkloadActual   7: 1 op, 10198.00 ns, 10.1980 us/op
+WorkloadActual   8: 1 op, 9948.00 ns, 9.9480 us/op
+WorkloadActual   9: 1 op, 9618.00 ns, 9.6180 us/op
+WorkloadActual  10: 1 op, 10049.00 ns, 10.0490 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 10158.00 ns, 10.1580 us/op
+WorkloadResult   2: 1 op, 9627.00 ns, 9.6270 us/op
+WorkloadResult   3: 1 op, 9648.00 ns, 9.6480 us/op
+WorkloadResult   4: 1 op, 9988.00 ns, 9.9880 us/op
+WorkloadResult   5: 1 op, 9878.00 ns, 9.8780 us/op
+WorkloadResult   6: 1 op, 9868.00 ns, 9.8680 us/op
+WorkloadResult   7: 1 op, 9847.00 ns, 9.8470 us/op
+WorkloadResult   8: 1 op, 9597.00 ns, 9.5970 us/op
+WorkloadResult   9: 1 op, 9267.00 ns, 9.2670 us/op
+WorkloadResult  10: 1 op, 9698.00 ns, 9.6980 us/op
+// GC:  0 0 0 1152 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3353 has exited with code 0.
+
+Mean = 9.758 μs, StdErr = 0.078 μs (0.80%), N = 10, StdDev = 0.247 μs
+Min = 9.267 μs, Q1 = 9.632 μs, Median = 9.773 μs, Q3 = 9.876 μs, Max = 10.158 μs
+IQR = 0.243 μs, LowerFence = 9.267 μs, UpperFence = 10.240 μs
+ConfidenceInterval = [9.385 μs; 10.130 μs] (CI 99.9%), Margin = 0.373 μs (3.82% of Mean)
+Skewness = -0.31, Kurtosis = 2.38, MValue = 2
+
+// ** Remained 47 (94.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionBenchmarks.'Snappy Decompress 1MB': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 123 130 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionBenchmarks.Snappy_Decompress_1MB --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 3 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-DMEQGA(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 238664.00 ns, 238.6640 us/op
+WorkloadJitting  1: 1 op, 15054155.00 ns, 15.0542 ms/op
+
+OverheadWarmup   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   2: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadWarmup   3: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   4: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadWarmup   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   6: 1 op, 291.00 ns, 291.0000 ns/op
+
+OverheadActual   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   2: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   3: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   4: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   5: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   6: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   7: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   8: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   9: 1 op, 401.00 ns, 401.0000 ns/op
+OverheadActual  10: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  11: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  12: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual  13: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  14: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  15: 1 op, 290.00 ns, 290.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 1861208.00 ns, 1.8612 ms/op
+WorkloadWarmup   2: 1 op, 1718333.00 ns, 1.7183 ms/op
+WorkloadWarmup   3: 1 op, 1726348.00 ns, 1.7263 ms/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 1687876.00 ns, 1.6879 ms/op
+WorkloadActual   2: 1 op, 1645278.00 ns, 1.6453 ms/op
+WorkloadActual   3: 1 op, 1626532.00 ns, 1.6265 ms/op
+WorkloadActual   4: 1 op, 1642202.00 ns, 1.6422 ms/op
+WorkloadActual   5: 1 op, 1616484.00 ns, 1.6165 ms/op
+WorkloadActual   6: 1 op, 1576399.00 ns, 1.5764 ms/op
+WorkloadActual   7: 1 op, 1582581.00 ns, 1.5826 ms/op
+WorkloadActual   8: 1 op, 1592929.00 ns, 1.5929 ms/op
+WorkloadActual   9: 1 op, 1588703.00 ns, 1.5887 ms/op
+WorkloadActual  10: 1 op, 1600594.00 ns, 1.6006 ms/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 1687576.00 ns, 1.6876 ms/op
+WorkloadResult   2: 1 op, 1644978.00 ns, 1.6450 ms/op
+WorkloadResult   3: 1 op, 1626232.00 ns, 1.6262 ms/op
+WorkloadResult   4: 1 op, 1641902.00 ns, 1.6419 ms/op
+WorkloadResult   5: 1 op, 1616184.00 ns, 1.6162 ms/op
+WorkloadResult   6: 1 op, 1576099.00 ns, 1.5761 ms/op
+WorkloadResult   7: 1 op, 1582281.00 ns, 1.5823 ms/op
+WorkloadResult   8: 1 op, 1592629.00 ns, 1.5926 ms/op
+WorkloadResult   9: 1 op, 1588403.00 ns, 1.5884 ms/op
+WorkloadResult  10: 1 op, 1600294.00 ns, 1.6003 ms/op
+// GC:  0 0 0 2352 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3360 has exited with code 0.
+
+Mean = 1.616 ms, StdErr = 0.011 ms (0.68%), N = 10, StdDev = 0.035 ms
+Min = 1.576 ms, Q1 = 1.589 ms, Median = 1.608 ms, Q3 = 1.638 ms, Max = 1.688 ms
+IQR = 0.049 ms, LowerFence = 1.517 ms, UpperFence = 1.711 ms
+ConfidenceInterval = [1.563 ms; 1.669 ms] (CI 99.9%), Margin = 0.053 ms (3.27% of Mean)
+Skewness = 0.66, Kurtosis = 2.17, MValue = 2
+
+// ** Remained 46 (92.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// ***** BenchmarkRunner: Finish  *****
+
+// * Export *
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.CompressionBenchmarks-report.csv
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.CompressionBenchmarks-report-github.md
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.CompressionBenchmarks-report.html
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.CompressionBenchmarks-report-full-compressed.json
+
+// * Detailed results *
+CompressionBenchmarks.'Snappy Compress 1KB': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 14.215 μs, StdErr = 0.311 μs (2.19%), N = 10, StdDev = 0.984 μs
+Min = 11.532 μs, Q1 = 14.287 μs, Median = 14.412 μs, Q3 = 14.723 μs, Max = 14.979 μs
+IQR = 0.436 μs, LowerFence = 13.633 μs, UpperFence = 15.376 μs
+ConfidenceInterval = [12.728 μs; 15.702 μs] (CI 99.9%), Margin = 1.487 μs (10.46% of Mean)
+Skewness = -1.94, Kurtosis = 5.59, MValue = 2
+-------------------- Histogram --------------------
+[10.933 μs ; 12.131 μs) | @
+[12.131 μs ; 13.330 μs) | 
+[13.330 μs ; 13.914 μs) | 
+[13.914 μs ; 15.112 μs) | @@@@@@@@@
+---------------------------------------------------
+
+CompressionBenchmarks.'Snappy Compress 1MB': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 545.766 μs, StdErr = 5.865 μs (1.07%), N = 10, StdDev = 18.547 μs
+Min = 520.719 μs, Q1 = 527.533 μs, Median = 548.049 μs, Q3 = 559.813 μs, Max = 572.344 μs
+IQR = 32.280 μs, LowerFence = 479.114 μs, UpperFence = 608.233 μs
+ConfidenceInterval = [517.726 μs; 573.806 μs] (CI 99.9%), Margin = 28.040 μs (5.14% of Mean)
+Skewness = -0.05, Kurtosis = 1.26, MValue = 2
+-------------------- Histogram --------------------
+[515.972 μs ; 544.545 μs) | @@@@
+[544.545 μs ; 567.142 μs) | @@@@@
+[567.142 μs ; 583.643 μs) | @
+---------------------------------------------------
+
+CompressionBenchmarks.'Snappy Decompress 1KB': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 9.758 μs, StdErr = 0.078 μs (0.80%), N = 10, StdDev = 0.247 μs
+Min = 9.267 μs, Q1 = 9.632 μs, Median = 9.773 μs, Q3 = 9.876 μs, Max = 10.158 μs
+IQR = 0.243 μs, LowerFence = 9.267 μs, UpperFence = 10.240 μs
+ConfidenceInterval = [9.385 μs; 10.130 μs] (CI 99.9%), Margin = 0.373 μs (3.82% of Mean)
+Skewness = -0.31, Kurtosis = 2.38, MValue = 2
+-------------------- Histogram --------------------
+[9.117 μs ;  9.417 μs) | @
+[9.417 μs ;  9.888 μs) | @@@@@@@
+[9.888 μs ; 10.223 μs) | @@
+---------------------------------------------------
+
+CompressionBenchmarks.'Snappy Decompress 1MB': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 1.616 ms, StdErr = 0.011 ms (0.68%), N = 10, StdDev = 0.035 ms
+Min = 1.576 ms, Q1 = 1.589 ms, Median = 1.608 ms, Q3 = 1.638 ms, Max = 1.688 ms
+IQR = 0.049 ms, LowerFence = 1.517 ms, UpperFence = 1.711 ms
+ConfidenceInterval = [1.563 ms; 1.669 ms] (CI 99.9%), Margin = 0.053 ms (3.27% of Mean)
+Skewness = 0.66, Kurtosis = 2.17, MValue = 2
+-------------------- Histogram --------------------
+[1.575 ms ; 1.617 ms) | @@@@@@
+[1.617 ms ; 1.666 ms) | @@@
+[1.666 ms ; 1.709 ms) | @
+---------------------------------------------------
+
+// * Summary *
+
+BenchmarkDotNet v0.14.0, Ubuntu 24.04.3 LTS (Noble Numbat)
+AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+.NET SDK 10.0.102
+  [Host]     : .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+  Job-JHGESK : .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+
+InvocationCount=1  IterationCount=10  UnrollFactor=1  
+WarmupCount=3  
+
+| Method                  | Mean         | Error      | StdDev     | Allocated |
+|------------------------ |-------------:|-----------:|-----------:|----------:|
+| 'Snappy Compress 1KB'   |    14.215 μs |  1.4873 μs |  0.9837 μs |         - |
+| 'Snappy Compress 1MB'   |   545.766 μs | 28.0401 μs | 18.5468 μs |         - |
+| 'Snappy Decompress 1KB' |     9.758 μs |  0.3728 μs |  0.2466 μs |         - |
+| 'Snappy Decompress 1MB' | 1,615.658 μs | 52.9051 μs | 34.9934 μs |         - |
+
+// * Warnings *
+MinIterationTime
+  CompressionBenchmarks.'Snappy Compress 1KB': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3   -> The minimum observed iteration time is 11.812μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionBenchmarks.'Snappy Compress 1MB': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3   -> The minimum observed iteration time is 521.069μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionBenchmarks.'Snappy Decompress 1KB': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3 -> The minimum observed iteration time is 9.618μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionBenchmarks.'Snappy Decompress 1MB': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3 -> The minimum observed iteration time is 1.576ms which is very small. It's recommended to increase it to at least 100ms using more operations.
+
+// * Hints *
+Outliers
+  CompressionBenchmarks.'Snappy Compress 1KB': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3   -> 1 outlier  was  detected (11.81 μs)
+  CompressionBenchmarks.'Snappy Decompress 1KB': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3 -> 1 outlier  was  detected (9.62 μs)
+
+// * Legends *
+  Mean      : Arithmetic mean of all measurements
+  Error     : Half of 99.9% confidence interval
+  StdDev    : Standard deviation of all measurements
+  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
+  1 μs      : 1 Microsecond (0.000001 sec)
+
+// * Diagnostic Output - MemoryDiagnoser *
+
+
+// ***** BenchmarkRunner: End *****
+Run time: 00:00:00 (0.9 sec), executed benchmarks: 4
+
+// Found 30 benchmarks:
+//   CompressionCodecComparisonBenchmarks.'Gzip Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Snappy Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'LZ4 Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Zstd Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Brotli Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Gzip Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Snappy Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'LZ4 Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Zstd Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Brotli Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Gzip Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Snappy Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'LZ4 Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Zstd Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Brotli Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Gzip Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Snappy Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'LZ4 Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Zstd Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Brotli Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Gzip Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Snappy Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'LZ4 Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Zstd Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Brotli Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Gzip Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Snappy Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'LZ4 Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Zstd Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+//   CompressionCodecComparisonBenchmarks.'Brotli Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Gzip Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Gzip_Compress_1KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 4 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-PUNBQS(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 279029.00 ns, 279.0290 us/op
+WorkloadJitting  1: 1 op, 210882.00 ns, 210.8820 us/op
+
+OverheadWarmup   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   2: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   3: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   4: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   5: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   6: 1 op, 280.00 ns, 280.0000 ns/op
+
+OverheadActual   1: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   2: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   3: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   4: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   6: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual   7: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   8: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   9: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  10: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  11: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  12: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  13: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual  14: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  15: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  16: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  17: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  18: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  19: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  20: 1 op, 261.00 ns, 261.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 21760.00 ns, 21.7600 us/op
+WorkloadWarmup   2: 1 op, 20408.00 ns, 20.4080 us/op
+WorkloadWarmup   3: 1 op, 18705.00 ns, 18.7050 us/op
+WorkloadWarmup   4: 1 op, 18073.00 ns, 18.0730 us/op
+WorkloadWarmup   5: 1 op, 18956.00 ns, 18.9560 us/op
+WorkloadWarmup   6: 1 op, 18014.00 ns, 18.0140 us/op
+WorkloadWarmup   7: 1 op, 18805.00 ns, 18.8050 us/op
+WorkloadWarmup   8: 1 op, 19276.00 ns, 19.2760 us/op
+WorkloadWarmup   9: 1 op, 19155.00 ns, 19.1550 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 18744.00 ns, 18.7440 us/op
+WorkloadActual   2: 1 op, 19196.00 ns, 19.1960 us/op
+WorkloadActual   3: 1 op, 18775.00 ns, 18.7750 us/op
+WorkloadActual   4: 1 op, 18464.00 ns, 18.4640 us/op
+WorkloadActual   5: 1 op, 18193.00 ns, 18.1930 us/op
+WorkloadActual   6: 1 op, 19746.00 ns, 19.7460 us/op
+WorkloadActual   7: 1 op, 19086.00 ns, 19.0860 us/op
+WorkloadActual   8: 1 op, 18855.00 ns, 18.8550 us/op
+WorkloadActual   9: 1 op, 18725.00 ns, 18.7250 us/op
+WorkloadActual  10: 1 op, 18073.00 ns, 18.0730 us/op
+WorkloadActual  11: 1 op, 19857.00 ns, 19.8570 us/op
+WorkloadActual  12: 1 op, 18795.00 ns, 18.7950 us/op
+WorkloadActual  13: 1 op, 18474.00 ns, 18.4740 us/op
+WorkloadActual  14: 1 op, 18735.00 ns, 18.7350 us/op
+WorkloadActual  15: 1 op, 19807.00 ns, 19.8070 us/op
+WorkloadActual  16: 1 op, 19596.00 ns, 19.5960 us/op
+WorkloadActual  17: 1 op, 18945.00 ns, 18.9450 us/op
+WorkloadActual  18: 1 op, 19807.00 ns, 19.8070 us/op
+WorkloadActual  19: 1 op, 18995.00 ns, 18.9950 us/op
+WorkloadActual  20: 1 op, 19536.00 ns, 19.5360 us/op
+WorkloadActual  21: 1 op, 18685.00 ns, 18.6850 us/op
+WorkloadActual  22: 1 op, 20057.00 ns, 20.0570 us/op
+WorkloadActual  23: 1 op, 19086.00 ns, 19.0860 us/op
+WorkloadActual  24: 1 op, 18034.00 ns, 18.0340 us/op
+WorkloadActual  25: 1 op, 19096.00 ns, 19.0960 us/op
+WorkloadActual  26: 1 op, 18525.00 ns, 18.5250 us/op
+WorkloadActual  27: 1 op, 20117.00 ns, 20.1170 us/op
+WorkloadActual  28: 1 op, 18615.00 ns, 18.6150 us/op
+WorkloadActual  29: 1 op, 18575.00 ns, 18.5750 us/op
+WorkloadActual  30: 1 op, 18224.00 ns, 18.2240 us/op
+WorkloadActual  31: 1 op, 18856.00 ns, 18.8560 us/op
+WorkloadActual  32: 1 op, 18965.00 ns, 18.9650 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 18438.50 ns, 18.4385 us/op
+WorkloadResult   2: 1 op, 18890.50 ns, 18.8905 us/op
+WorkloadResult   3: 1 op, 18469.50 ns, 18.4695 us/op
+WorkloadResult   4: 1 op, 18158.50 ns, 18.1585 us/op
+WorkloadResult   5: 1 op, 17887.50 ns, 17.8875 us/op
+WorkloadResult   6: 1 op, 19440.50 ns, 19.4405 us/op
+WorkloadResult   7: 1 op, 18780.50 ns, 18.7805 us/op
+WorkloadResult   8: 1 op, 18549.50 ns, 18.5495 us/op
+WorkloadResult   9: 1 op, 18419.50 ns, 18.4195 us/op
+WorkloadResult  10: 1 op, 17767.50 ns, 17.7675 us/op
+WorkloadResult  11: 1 op, 19551.50 ns, 19.5515 us/op
+WorkloadResult  12: 1 op, 18489.50 ns, 18.4895 us/op
+WorkloadResult  13: 1 op, 18168.50 ns, 18.1685 us/op
+WorkloadResult  14: 1 op, 18429.50 ns, 18.4295 us/op
+WorkloadResult  15: 1 op, 19501.50 ns, 19.5015 us/op
+WorkloadResult  16: 1 op, 19290.50 ns, 19.2905 us/op
+WorkloadResult  17: 1 op, 18639.50 ns, 18.6395 us/op
+WorkloadResult  18: 1 op, 19501.50 ns, 19.5015 us/op
+WorkloadResult  19: 1 op, 18689.50 ns, 18.6895 us/op
+WorkloadResult  20: 1 op, 19230.50 ns, 19.2305 us/op
+WorkloadResult  21: 1 op, 18379.50 ns, 18.3795 us/op
+WorkloadResult  22: 1 op, 19751.50 ns, 19.7515 us/op
+WorkloadResult  23: 1 op, 18780.50 ns, 18.7805 us/op
+WorkloadResult  24: 1 op, 17728.50 ns, 17.7285 us/op
+WorkloadResult  25: 1 op, 18790.50 ns, 18.7905 us/op
+WorkloadResult  26: 1 op, 18219.50 ns, 18.2195 us/op
+WorkloadResult  27: 1 op, 19811.50 ns, 19.8115 us/op
+WorkloadResult  28: 1 op, 18309.50 ns, 18.3095 us/op
+WorkloadResult  29: 1 op, 18269.50 ns, 18.2695 us/op
+WorkloadResult  30: 1 op, 17918.50 ns, 17.9185 us/op
+WorkloadResult  31: 1 op, 18550.50 ns, 18.5505 us/op
+WorkloadResult  32: 1 op, 18659.50 ns, 18.6595 us/op
+// GC:  0 0 0 1336 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3372 has exited with code 0.
+
+Mean = 18.671 μs, StdErr = 0.102 μs (0.54%), N = 32, StdDev = 0.575 μs
+Min = 17.729 μs, Q1 = 18.299 μs, Median = 18.550 μs, Q3 = 18.976 μs, Max = 19.811 μs
+IQR = 0.676 μs, LowerFence = 17.285 μs, UpperFence = 19.989 μs
+ConfidenceInterval = [18.301 μs; 19.040 μs] (CI 99.9%), Margin = 0.369 μs (1.98% of Mean)
+Skewness = 0.4, Kurtosis = 2.17, MValue = 2
+
+// ** Remained 45 (90.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Snappy Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Snappy_Compress_1KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 5 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-TCZXLB(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 256937.00 ns, 256.9370 us/op
+WorkloadJitting  1: 1 op, 206844.00 ns, 206.8440 us/op
+
+OverheadWarmup   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   2: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadWarmup   3: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   4: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   5: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   6: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   7: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   8: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   9: 1 op, 301.00 ns, 301.0000 ns/op
+
+OverheadActual   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   3: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   4: 1 op, 681.00 ns, 681.0000 ns/op
+OverheadActual   5: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual   6: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   7: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual   8: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual   9: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  10: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual  11: 1 op, 671.00 ns, 671.0000 ns/op
+OverheadActual  12: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual  13: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual  14: 1 op, 691.00 ns, 691.0000 ns/op
+OverheadActual  15: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual  16: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  17: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  18: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  19: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  20: 1 op, 321.00 ns, 321.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 14567.00 ns, 14.5670 us/op
+WorkloadWarmup   2: 1 op, 11291.00 ns, 11.2910 us/op
+WorkloadWarmup   3: 1 op, 11311.00 ns, 11.3110 us/op
+WorkloadWarmup   4: 1 op, 12463.00 ns, 12.4630 us/op
+WorkloadWarmup   5: 1 op, 11171.00 ns, 11.1710 us/op
+WorkloadWarmup   6: 1 op, 11221.00 ns, 11.2210 us/op
+WorkloadWarmup   7: 1 op, 11241.00 ns, 11.2410 us/op
+WorkloadWarmup   8: 1 op, 11321.00 ns, 11.3210 us/op
+WorkloadWarmup   9: 1 op, 11021.00 ns, 11.0210 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 11561.00 ns, 11.5610 us/op
+WorkloadActual   2: 1 op, 11290.00 ns, 11.2900 us/op
+WorkloadActual   3: 1 op, 13405.00 ns, 13.4050 us/op
+WorkloadActual   4: 1 op, 31709.00 ns, 31.7090 us/op
+WorkloadActual   5: 1 op, 13094.00 ns, 13.0940 us/op
+WorkloadActual   6: 1 op, 14516.00 ns, 14.5160 us/op
+WorkloadActual   7: 1 op, 11531.00 ns, 11.5310 us/op
+WorkloadActual   8: 1 op, 11441.00 ns, 11.4410 us/op
+WorkloadActual   9: 1 op, 11551.00 ns, 11.5510 us/op
+WorkloadActual  10: 1 op, 11431.00 ns, 11.4310 us/op
+WorkloadActual  11: 1 op, 11181.00 ns, 11.1810 us/op
+WorkloadActual  12: 1 op, 11491.00 ns, 11.4910 us/op
+WorkloadActual  13: 1 op, 11502.00 ns, 11.5020 us/op
+WorkloadActual  14: 1 op, 11472.00 ns, 11.4720 us/op
+WorkloadActual  15: 1 op, 11471.00 ns, 11.4710 us/op
+WorkloadActual  16: 1 op, 11261.00 ns, 11.2610 us/op
+WorkloadActual  17: 1 op, 11141.00 ns, 11.1410 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 11230.50 ns, 11.2305 us/op
+WorkloadResult   2: 1 op, 10959.50 ns, 10.9595 us/op
+WorkloadResult   3: 1 op, 11200.50 ns, 11.2005 us/op
+WorkloadResult   4: 1 op, 11110.50 ns, 11.1105 us/op
+WorkloadResult   5: 1 op, 11220.50 ns, 11.2205 us/op
+WorkloadResult   6: 1 op, 11100.50 ns, 11.1005 us/op
+WorkloadResult   7: 1 op, 10850.50 ns, 10.8505 us/op
+WorkloadResult   8: 1 op, 11160.50 ns, 11.1605 us/op
+WorkloadResult   9: 1 op, 11171.50 ns, 11.1715 us/op
+WorkloadResult  10: 1 op, 11141.50 ns, 11.1415 us/op
+WorkloadResult  11: 1 op, 11140.50 ns, 11.1405 us/op
+WorkloadResult  12: 1 op, 10930.50 ns, 10.9305 us/op
+WorkloadResult  13: 1 op, 10810.50 ns, 10.8105 us/op
+// GC:  0 0 0 1120 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3379 has exited with code 0.
+
+Mean = 11.079 μs, StdErr = 0.039 μs (0.36%), N = 13, StdDev = 0.142 μs
+Min = 10.810 μs, Q1 = 10.960 μs, Median = 11.140 μs, Q3 = 11.171 μs, Max = 11.230 μs
+IQR = 0.212 μs, LowerFence = 10.642 μs, UpperFence = 11.489 μs
+ConfidenceInterval = [10.909 μs; 11.249 μs] (CI 99.9%), Margin = 0.170 μs (1.54% of Mean)
+Skewness = -0.7, Kurtosis = 1.86, MValue = 2
+
+// ** Remained 44 (88.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'LZ4 Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Lz4_Compress_1KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 6 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-THZWZR(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 256596.00 ns, 256.5960 us/op
+WorkloadJitting  1: 1 op, 225238.00 ns, 225.2380 us/op
+
+OverheadWarmup   1: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadWarmup   2: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadWarmup   3: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   4: 1 op, 571.00 ns, 571.0000 ns/op
+OverheadWarmup   5: 1 op, 651.00 ns, 651.0000 ns/op
+OverheadWarmup   6: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadWarmup   7: 1 op, 611.00 ns, 611.0000 ns/op
+OverheadWarmup   8: 1 op, 602.00 ns, 602.0000 ns/op
+
+OverheadActual   1: 1 op, 701.00 ns, 701.0000 ns/op
+OverheadActual   2: 1 op, 601.00 ns, 601.0000 ns/op
+OverheadActual   3: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   4: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual   5: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   6: 1 op, 621.00 ns, 621.0000 ns/op
+OverheadActual   7: 1 op, 571.00 ns, 571.0000 ns/op
+OverheadActual   8: 1 op, 592.00 ns, 592.0000 ns/op
+OverheadActual   9: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  10: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  11: 1 op, 602.00 ns, 602.0000 ns/op
+OverheadActual  12: 1 op, 601.00 ns, 601.0000 ns/op
+OverheadActual  13: 1 op, 602.00 ns, 602.0000 ns/op
+OverheadActual  14: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  15: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual  16: 1 op, 701.00 ns, 701.0000 ns/op
+OverheadActual  17: 1 op, 671.00 ns, 671.0000 ns/op
+OverheadActual  18: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  19: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual  20: 1 op, 291.00 ns, 291.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 27130.00 ns, 27.1300 us/op
+WorkloadWarmup   2: 1 op, 26389.00 ns, 26.3890 us/op
+WorkloadWarmup   3: 1 op, 26218.00 ns, 26.2180 us/op
+WorkloadWarmup   4: 1 op, 26299.00 ns, 26.2990 us/op
+WorkloadWarmup   5: 1 op, 25678.00 ns, 25.6780 us/op
+WorkloadWarmup   6: 1 op, 25357.00 ns, 25.3570 us/op
+WorkloadWarmup   7: 1 op, 25868.00 ns, 25.8680 us/op
+WorkloadWarmup   8: 1 op, 26319.00 ns, 26.3190 us/op
+WorkloadWarmup   9: 1 op, 26219.00 ns, 26.2190 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 27091.00 ns, 27.0910 us/op
+WorkloadActual   2: 1 op, 26479.00 ns, 26.4790 us/op
+WorkloadActual   3: 1 op, 25427.00 ns, 25.4270 us/op
+WorkloadActual   4: 1 op, 25508.00 ns, 25.5080 us/op
+WorkloadActual   5: 1 op, 25467.00 ns, 25.4670 us/op
+WorkloadActual   6: 1 op, 44803.00 ns, 44.8030 us/op
+WorkloadActual   7: 1 op, 25778.00 ns, 25.7780 us/op
+WorkloadActual   8: 1 op, 25878.00 ns, 25.8780 us/op
+WorkloadActual   9: 1 op, 25848.00 ns, 25.8480 us/op
+WorkloadActual  10: 1 op, 25728.00 ns, 25.7280 us/op
+WorkloadActual  11: 1 op, 26288.00 ns, 26.2880 us/op
+WorkloadActual  12: 1 op, 26008.00 ns, 26.0080 us/op
+WorkloadActual  13: 1 op, 26298.00 ns, 26.2980 us/op
+WorkloadActual  14: 1 op, 44373.00 ns, 44.3730 us/op
+WorkloadActual  15: 1 op, 26268.00 ns, 26.2680 us/op
+WorkloadActual  16: 1 op, 26499.00 ns, 26.4990 us/op
+WorkloadActual  17: 1 op, 26890.00 ns, 26.8900 us/op
+WorkloadActual  18: 1 op, 26559.00 ns, 26.5590 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 26630.00 ns, 26.6300 us/op
+WorkloadResult   2: 1 op, 26018.00 ns, 26.0180 us/op
+WorkloadResult   3: 1 op, 24966.00 ns, 24.9660 us/op
+WorkloadResult   4: 1 op, 25047.00 ns, 25.0470 us/op
+WorkloadResult   5: 1 op, 25006.00 ns, 25.0060 us/op
+WorkloadResult   6: 1 op, 25317.00 ns, 25.3170 us/op
+WorkloadResult   7: 1 op, 25417.00 ns, 25.4170 us/op
+WorkloadResult   8: 1 op, 25387.00 ns, 25.3870 us/op
+WorkloadResult   9: 1 op, 25267.00 ns, 25.2670 us/op
+WorkloadResult  10: 1 op, 25827.00 ns, 25.8270 us/op
+WorkloadResult  11: 1 op, 25547.00 ns, 25.5470 us/op
+WorkloadResult  12: 1 op, 25837.00 ns, 25.8370 us/op
+WorkloadResult  13: 1 op, 25807.00 ns, 25.8070 us/op
+WorkloadResult  14: 1 op, 26038.00 ns, 26.0380 us/op
+WorkloadResult  15: 1 op, 26429.00 ns, 26.4290 us/op
+WorkloadResult  16: 1 op, 26098.00 ns, 26.0980 us/op
+// GC:  0 0 0 1560 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3386 has exited with code 0.
+
+Mean = 25.665 μs, StdErr = 0.125 μs (0.49%), N = 16, StdDev = 0.502 μs
+Min = 24.966 μs, Q1 = 25.305 μs, Median = 25.677 μs, Q3 = 26.023 μs, Max = 26.630 μs
+IQR = 0.719 μs, LowerFence = 24.227 μs, UpperFence = 27.101 μs
+ConfidenceInterval = [25.154 μs; 26.176 μs] (CI 99.9%), Margin = 0.511 μs (1.99% of Mean)
+Skewness = 0.26, Kurtosis = 1.87, MValue = 2
+
+// ** Remained 43 (86.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Zstd Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Zstd_Compress_1KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 7 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-ARVANS(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 296231.00 ns, 296.2310 us/op
+WorkloadJitting  1: 1 op, 304987.00 ns, 304.9870 us/op
+
+OverheadWarmup   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   2: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadWarmup   3: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadWarmup   4: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   5: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   6: 1 op, 291.00 ns, 291.0000 ns/op
+
+OverheadActual   1: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   2: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   3: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   4: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   6: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual   7: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   8: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   9: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual  10: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual  11: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  12: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual  13: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  14: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  15: 1 op, 280.00 ns, 280.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 126034.00 ns, 126.0340 us/op
+WorkloadWarmup   2: 1 op, 102139.00 ns, 102.1390 us/op
+WorkloadWarmup   3: 1 op, 101568.00 ns, 101.5680 us/op
+WorkloadWarmup   4: 1 op, 100697.00 ns, 100.6970 us/op
+WorkloadWarmup   5: 1 op, 100977.00 ns, 100.9770 us/op
+WorkloadWarmup   6: 1 op, 117639.00 ns, 117.6390 us/op
+WorkloadWarmup   7: 1 op, 100767.00 ns, 100.7670 us/op
+WorkloadWarmup   8: 1 op, 99916.00 ns, 99.9160 us/op
+WorkloadWarmup   9: 1 op, 99986.00 ns, 99.9860 us/op
+WorkloadWarmup  10: 1 op, 118430.00 ns, 118.4300 us/op
+WorkloadWarmup  11: 1 op, 115475.00 ns, 115.4750 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 101940.00 ns, 101.9400 us/op
+WorkloadActual   2: 1 op, 144007.00 ns, 144.0070 us/op
+WorkloadActual   3: 1 op, 123469.00 ns, 123.4690 us/op
+WorkloadActual   4: 1 op, 134550.00 ns, 134.5500 us/op
+WorkloadActual   5: 1 op, 125353.00 ns, 125.3530 us/op
+WorkloadActual   6: 1 op, 125964.00 ns, 125.9640 us/op
+WorkloadActual   7: 1 op, 127978.00 ns, 127.9780 us/op
+WorkloadActual   8: 1 op, 124642.00 ns, 124.6420 us/op
+WorkloadActual   9: 1 op, 133298.00 ns, 133.2980 us/op
+WorkloadActual  10: 1 op, 125833.00 ns, 125.8330 us/op
+WorkloadActual  11: 1 op, 126765.00 ns, 126.7650 us/op
+WorkloadActual  12: 1 op, 124320.00 ns, 124.3200 us/op
+WorkloadActual  13: 1 op, 145630.00 ns, 145.6300 us/op
+WorkloadActual  14: 1 op, 126024.00 ns, 126.0240 us/op
+WorkloadActual  15: 1 op, 124952.00 ns, 124.9520 us/op
+WorkloadActual  16: 1 op, 124742.00 ns, 124.7420 us/op
+WorkloadActual  17: 1 op, 125093.00 ns, 125.0930 us/op
+WorkloadActual  18: 1 op, 125102.00 ns, 125.1020 us/op
+WorkloadActual  19: 1 op, 125533.00 ns, 125.5330 us/op
+WorkloadActual  20: 1 op, 124692.00 ns, 124.6920 us/op
+WorkloadActual  21: 1 op, 125142.00 ns, 125.1420 us/op
+WorkloadActual  22: 1 op, 124242.00 ns, 124.2420 us/op
+WorkloadActual  23: 1 op, 132797.00 ns, 132.7970 us/op
+WorkloadActual  24: 1 op, 136704.00 ns, 136.7040 us/op
+WorkloadActual  25: 1 op, 132205.00 ns, 132.2050 us/op
+WorkloadActual  26: 1 op, 152373.00 ns, 152.3730 us/op
+WorkloadActual  27: 1 op, 132997.00 ns, 132.9970 us/op
+WorkloadActual  28: 1 op, 133198.00 ns, 133.1980 us/op
+WorkloadActual  29: 1 op, 136263.00 ns, 136.2630 us/op
+WorkloadActual  30: 1 op, 135252.00 ns, 135.2520 us/op
+WorkloadActual  31: 1 op, 136353.00 ns, 136.3530 us/op
+WorkloadActual  32: 1 op, 136313.00 ns, 136.3130 us/op
+WorkloadActual  33: 1 op, 136123.00 ns, 136.1230 us/op
+WorkloadActual  34: 1 op, 135993.00 ns, 135.9930 us/op
+WorkloadActual  35: 1 op, 139680.00 ns, 139.6800 us/op
+WorkloadActual  36: 1 op, 137405.00 ns, 137.4050 us/op
+WorkloadActual  37: 1 op, 136674.00 ns, 136.6740 us/op
+WorkloadActual  38: 1 op, 138287.00 ns, 138.2870 us/op
+WorkloadActual  39: 1 op, 156491.00 ns, 156.4910 us/op
+WorkloadActual  40: 1 op, 137687.00 ns, 137.6870 us/op
+WorkloadActual  41: 1 op, 137896.00 ns, 137.8960 us/op
+WorkloadActual  42: 1 op, 136804.00 ns, 136.8040 us/op
+WorkloadActual  43: 1 op, 138438.00 ns, 138.4380 us/op
+WorkloadActual  44: 1 op, 136754.00 ns, 136.7540 us/op
+WorkloadActual  45: 1 op, 159146.00 ns, 159.1460 us/op
+WorkloadActual  46: 1 op, 141393.00 ns, 141.3930 us/op
+WorkloadActual  47: 1 op, 140011.00 ns, 140.0110 us/op
+WorkloadActual  48: 1 op, 141162.00 ns, 141.1620 us/op
+WorkloadActual  49: 1 op, 141823.00 ns, 141.8230 us/op
+WorkloadActual  50: 1 op, 142285.00 ns, 142.2850 us/op
+WorkloadActual  51: 1 op, 170768.00 ns, 170.7680 us/op
+WorkloadActual  52: 1 op, 147785.00 ns, 147.7850 us/op
+WorkloadActual  53: 1 op, 147785.00 ns, 147.7850 us/op
+WorkloadActual  54: 1 op, 147535.00 ns, 147.5350 us/op
+WorkloadActual  55: 1 op, 150349.00 ns, 150.3490 us/op
+WorkloadActual  56: 1 op, 150209.00 ns, 150.2090 us/op
+WorkloadActual  57: 1 op, 148446.00 ns, 148.4460 us/op
+WorkloadActual  58: 1 op, 150520.00 ns, 150.5200 us/op
+WorkloadActual  59: 1 op, 149047.00 ns, 149.0470 us/op
+WorkloadActual  60: 1 op, 149588.00 ns, 149.5880 us/op
+WorkloadActual  61: 1 op, 170797.00 ns, 170.7970 us/op
+WorkloadActual  62: 1 op, 148957.00 ns, 148.9570 us/op
+WorkloadActual  63: 1 op, 148255.00 ns, 148.2550 us/op
+WorkloadActual  64: 1 op, 146492.00 ns, 146.4920 us/op
+WorkloadActual  65: 1 op, 147534.00 ns, 147.5340 us/op
+WorkloadActual  66: 1 op, 170126.00 ns, 170.1260 us/op
+WorkloadActual  67: 1 op, 147955.00 ns, 147.9550 us/op
+WorkloadActual  68: 1 op, 146813.00 ns, 146.8130 us/op
+WorkloadActual  69: 1 op, 157052.00 ns, 157.0520 us/op
+WorkloadActual  70: 1 op, 148135.00 ns, 148.1350 us/op
+WorkloadActual  71: 1 op, 168694.00 ns, 168.6940 us/op
+WorkloadActual  72: 1 op, 148085.00 ns, 148.0850 us/op
+WorkloadActual  73: 1 op, 148646.00 ns, 148.6460 us/op
+WorkloadActual  74: 1 op, 149017.00 ns, 149.0170 us/op
+WorkloadActual  75: 1 op, 163544.00 ns, 163.5440 us/op
+WorkloadActual  76: 1 op, 170878.00 ns, 170.8780 us/op
+WorkloadActual  77: 1 op, 150921.00 ns, 150.9210 us/op
+WorkloadActual  78: 1 op, 152774.00 ns, 152.7740 us/op
+WorkloadActual  79: 1 op, 150069.00 ns, 150.0690 us/op
+WorkloadActual  80: 1 op, 150269.00 ns, 150.2690 us/op
+WorkloadActual  81: 1 op, 149338.00 ns, 149.3380 us/op
+WorkloadActual  82: 1 op, 150290.00 ns, 150.2900 us/op
+WorkloadActual  83: 1 op, 150179.00 ns, 150.1790 us/op
+WorkloadActual  84: 1 op, 149578.00 ns, 149.5780 us/op
+WorkloadActual  85: 1 op, 168443.00 ns, 168.4430 us/op
+WorkloadActual  86: 1 op, 150730.00 ns, 150.7300 us/op
+WorkloadActual  87: 1 op, 150169.00 ns, 150.1690 us/op
+WorkloadActual  88: 1 op, 151812.00 ns, 151.8120 us/op
+WorkloadActual  89: 1 op, 172360.00 ns, 172.3600 us/op
+WorkloadActual  90: 1 op, 151352.00 ns, 151.3520 us/op
+WorkloadActual  91: 1 op, 148847.00 ns, 148.8470 us/op
+WorkloadActual  92: 1 op, 149037.00 ns, 149.0370 us/op
+WorkloadActual  93: 1 op, 148476.00 ns, 148.4760 us/op
+WorkloadActual  94: 1 op, 150249.00 ns, 150.2490 us/op
+WorkloadActual  95: 1 op, 149377.00 ns, 149.3770 us/op
+WorkloadActual  96: 1 op, 149418.00 ns, 149.4180 us/op
+WorkloadActual  97: 1 op, 149778.00 ns, 149.7780 us/op
+WorkloadActual  98: 1 op, 148125.00 ns, 148.1250 us/op
+WorkloadActual  99: 1 op, 121475.00 ns, 121.4750 us/op
+WorkloadActual  100: 1 op, 118080.00 ns, 118.0800 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 101650.00 ns, 101.6500 us/op
+WorkloadResult   2: 1 op, 143717.00 ns, 143.7170 us/op
+WorkloadResult   3: 1 op, 123179.00 ns, 123.1790 us/op
+WorkloadResult   4: 1 op, 134260.00 ns, 134.2600 us/op
+WorkloadResult   5: 1 op, 125063.00 ns, 125.0630 us/op
+WorkloadResult   6: 1 op, 125674.00 ns, 125.6740 us/op
+WorkloadResult   7: 1 op, 127688.00 ns, 127.6880 us/op
+WorkloadResult   8: 1 op, 124352.00 ns, 124.3520 us/op
+WorkloadResult   9: 1 op, 133008.00 ns, 133.0080 us/op
+WorkloadResult  10: 1 op, 125543.00 ns, 125.5430 us/op
+WorkloadResult  11: 1 op, 126475.00 ns, 126.4750 us/op
+WorkloadResult  12: 1 op, 124030.00 ns, 124.0300 us/op
+WorkloadResult  13: 1 op, 145340.00 ns, 145.3400 us/op
+WorkloadResult  14: 1 op, 125734.00 ns, 125.7340 us/op
+WorkloadResult  15: 1 op, 124662.00 ns, 124.6620 us/op
+WorkloadResult  16: 1 op, 124452.00 ns, 124.4520 us/op
+WorkloadResult  17: 1 op, 124803.00 ns, 124.8030 us/op
+WorkloadResult  18: 1 op, 124812.00 ns, 124.8120 us/op
+WorkloadResult  19: 1 op, 125243.00 ns, 125.2430 us/op
+WorkloadResult  20: 1 op, 124402.00 ns, 124.4020 us/op
+WorkloadResult  21: 1 op, 124852.00 ns, 124.8520 us/op
+WorkloadResult  22: 1 op, 123952.00 ns, 123.9520 us/op
+WorkloadResult  23: 1 op, 132507.00 ns, 132.5070 us/op
+WorkloadResult  24: 1 op, 136414.00 ns, 136.4140 us/op
+WorkloadResult  25: 1 op, 131915.00 ns, 131.9150 us/op
+WorkloadResult  26: 1 op, 152083.00 ns, 152.0830 us/op
+WorkloadResult  27: 1 op, 132707.00 ns, 132.7070 us/op
+WorkloadResult  28: 1 op, 132908.00 ns, 132.9080 us/op
+WorkloadResult  29: 1 op, 135973.00 ns, 135.9730 us/op
+WorkloadResult  30: 1 op, 134962.00 ns, 134.9620 us/op
+WorkloadResult  31: 1 op, 136063.00 ns, 136.0630 us/op
+WorkloadResult  32: 1 op, 136023.00 ns, 136.0230 us/op
+WorkloadResult  33: 1 op, 135833.00 ns, 135.8330 us/op
+WorkloadResult  34: 1 op, 135703.00 ns, 135.7030 us/op
+WorkloadResult  35: 1 op, 139390.00 ns, 139.3900 us/op
+WorkloadResult  36: 1 op, 137115.00 ns, 137.1150 us/op
+WorkloadResult  37: 1 op, 136384.00 ns, 136.3840 us/op
+WorkloadResult  38: 1 op, 137997.00 ns, 137.9970 us/op
+WorkloadResult  39: 1 op, 156201.00 ns, 156.2010 us/op
+WorkloadResult  40: 1 op, 137397.00 ns, 137.3970 us/op
+WorkloadResult  41: 1 op, 137606.00 ns, 137.6060 us/op
+WorkloadResult  42: 1 op, 136514.00 ns, 136.5140 us/op
+WorkloadResult  43: 1 op, 138148.00 ns, 138.1480 us/op
+WorkloadResult  44: 1 op, 136464.00 ns, 136.4640 us/op
+WorkloadResult  45: 1 op, 158856.00 ns, 158.8560 us/op
+WorkloadResult  46: 1 op, 141103.00 ns, 141.1030 us/op
+WorkloadResult  47: 1 op, 139721.00 ns, 139.7210 us/op
+WorkloadResult  48: 1 op, 140872.00 ns, 140.8720 us/op
+WorkloadResult  49: 1 op, 141533.00 ns, 141.5330 us/op
+WorkloadResult  50: 1 op, 141995.00 ns, 141.9950 us/op
+WorkloadResult  51: 1 op, 170478.00 ns, 170.4780 us/op
+WorkloadResult  52: 1 op, 147495.00 ns, 147.4950 us/op
+WorkloadResult  53: 1 op, 147495.00 ns, 147.4950 us/op
+WorkloadResult  54: 1 op, 147245.00 ns, 147.2450 us/op
+WorkloadResult  55: 1 op, 150059.00 ns, 150.0590 us/op
+WorkloadResult  56: 1 op, 149919.00 ns, 149.9190 us/op
+WorkloadResult  57: 1 op, 148156.00 ns, 148.1560 us/op
+WorkloadResult  58: 1 op, 150230.00 ns, 150.2300 us/op
+WorkloadResult  59: 1 op, 148757.00 ns, 148.7570 us/op
+WorkloadResult  60: 1 op, 149298.00 ns, 149.2980 us/op
+WorkloadResult  61: 1 op, 170507.00 ns, 170.5070 us/op
+WorkloadResult  62: 1 op, 148667.00 ns, 148.6670 us/op
+WorkloadResult  63: 1 op, 147965.00 ns, 147.9650 us/op
+WorkloadResult  64: 1 op, 146202.00 ns, 146.2020 us/op
+WorkloadResult  65: 1 op, 147244.00 ns, 147.2440 us/op
+WorkloadResult  66: 1 op, 169836.00 ns, 169.8360 us/op
+WorkloadResult  67: 1 op, 147665.00 ns, 147.6650 us/op
+WorkloadResult  68: 1 op, 146523.00 ns, 146.5230 us/op
+WorkloadResult  69: 1 op, 156762.00 ns, 156.7620 us/op
+WorkloadResult  70: 1 op, 147845.00 ns, 147.8450 us/op
+WorkloadResult  71: 1 op, 168404.00 ns, 168.4040 us/op
+WorkloadResult  72: 1 op, 147795.00 ns, 147.7950 us/op
+WorkloadResult  73: 1 op, 148356.00 ns, 148.3560 us/op
+WorkloadResult  74: 1 op, 148727.00 ns, 148.7270 us/op
+WorkloadResult  75: 1 op, 163254.00 ns, 163.2540 us/op
+WorkloadResult  76: 1 op, 170588.00 ns, 170.5880 us/op
+WorkloadResult  77: 1 op, 150631.00 ns, 150.6310 us/op
+WorkloadResult  78: 1 op, 152484.00 ns, 152.4840 us/op
+WorkloadResult  79: 1 op, 149779.00 ns, 149.7790 us/op
+WorkloadResult  80: 1 op, 149979.00 ns, 149.9790 us/op
+WorkloadResult  81: 1 op, 149048.00 ns, 149.0480 us/op
+WorkloadResult  82: 1 op, 150000.00 ns, 150.0000 us/op
+WorkloadResult  83: 1 op, 149889.00 ns, 149.8890 us/op
+WorkloadResult  84: 1 op, 149288.00 ns, 149.2880 us/op
+WorkloadResult  85: 1 op, 168153.00 ns, 168.1530 us/op
+WorkloadResult  86: 1 op, 150440.00 ns, 150.4400 us/op
+WorkloadResult  87: 1 op, 149879.00 ns, 149.8790 us/op
+WorkloadResult  88: 1 op, 151522.00 ns, 151.5220 us/op
+WorkloadResult  89: 1 op, 172070.00 ns, 172.0700 us/op
+WorkloadResult  90: 1 op, 151062.00 ns, 151.0620 us/op
+WorkloadResult  91: 1 op, 148557.00 ns, 148.5570 us/op
+WorkloadResult  92: 1 op, 148747.00 ns, 148.7470 us/op
+WorkloadResult  93: 1 op, 148186.00 ns, 148.1860 us/op
+WorkloadResult  94: 1 op, 149959.00 ns, 149.9590 us/op
+WorkloadResult  95: 1 op, 149087.00 ns, 149.0870 us/op
+WorkloadResult  96: 1 op, 149128.00 ns, 149.1280 us/op
+WorkloadResult  97: 1 op, 149488.00 ns, 149.4880 us/op
+WorkloadResult  98: 1 op, 147835.00 ns, 147.8350 us/op
+WorkloadResult  99: 1 op, 121185.00 ns, 121.1850 us/op
+WorkloadResult  100: 1 op, 117790.00 ns, 117.7900 us/op
+// GC:  0 0 0 1136 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3393 has exited with code 0.
+
+Mean = 142.329 μs, StdErr = 1.321 μs (0.93%), N = 100, StdDev = 13.214 μs
+Min = 101.650 μs, Q1 = 133.947 μs, Median = 146.363 μs, Q3 = 149.804 μs, Max = 172.070 μs
+IQR = 15.857 μs, LowerFence = 110.162 μs, UpperFence = 173.589 μs
+ConfidenceInterval = [137.848 μs; 146.811 μs] (CI 99.9%), Margin = 4.482 μs (3.15% of Mean)
+Skewness = -0.03, Kurtosis = 3.13, MValue = 3.9
+
+// ** Remained 42 (84.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Brotli Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Brotli_Compress_1KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 8 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-QMQSAU(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 253862.00 ns, 253.8620 us/op
+WorkloadJitting  1: 1 op, 214679.00 ns, 214.6790 us/op
+
+OverheadWarmup   1: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   2: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   3: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadWarmup   4: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   5: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   6: 1 op, 280.00 ns, 280.0000 ns/op
+
+OverheadActual   1: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   2: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   3: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   4: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   5: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   6: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   7: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   8: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   9: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  10: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  11: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  12: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  13: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  14: 1 op, 661.00 ns, 661.0000 ns/op
+OverheadActual  15: 1 op, 321.00 ns, 321.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 28574.00 ns, 28.5740 us/op
+WorkloadWarmup   2: 1 op, 26469.00 ns, 26.4690 us/op
+WorkloadWarmup   3: 1 op, 26309.00 ns, 26.3090 us/op
+WorkloadWarmup   4: 1 op, 25668.00 ns, 25.6680 us/op
+WorkloadWarmup   5: 1 op, 25257.00 ns, 25.2570 us/op
+WorkloadWarmup   6: 1 op, 25588.00 ns, 25.5880 us/op
+WorkloadWarmup   7: 1 op, 25638.00 ns, 25.6380 us/op
+WorkloadWarmup   8: 1 op, 25918.00 ns, 25.9180 us/op
+WorkloadWarmup   9: 1 op, 25598.00 ns, 25.5980 us/op
+WorkloadWarmup  10: 1 op, 25768.00 ns, 25.7680 us/op
+WorkloadWarmup  11: 1 op, 25607.00 ns, 25.6070 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 27091.00 ns, 27.0910 us/op
+WorkloadActual   2: 1 op, 25969.00 ns, 25.9690 us/op
+WorkloadActual   3: 1 op, 26269.00 ns, 26.2690 us/op
+WorkloadActual   4: 1 op, 26018.00 ns, 26.0180 us/op
+WorkloadActual   5: 1 op, 25126.00 ns, 25.1260 us/op
+WorkloadActual   6: 1 op, 25578.00 ns, 25.5780 us/op
+WorkloadActual   7: 1 op, 25548.00 ns, 25.5480 us/op
+WorkloadActual   8: 1 op, 25848.00 ns, 25.8480 us/op
+WorkloadActual   9: 1 op, 25818.00 ns, 25.8180 us/op
+WorkloadActual  10: 1 op, 26229.00 ns, 26.2290 us/op
+WorkloadActual  11: 1 op, 25697.00 ns, 25.6970 us/op
+WorkloadActual  12: 1 op, 25046.00 ns, 25.0460 us/op
+WorkloadActual  13: 1 op, 25337.00 ns, 25.3370 us/op
+WorkloadActual  14: 1 op, 25828.00 ns, 25.8280 us/op
+WorkloadActual  15: 1 op, 25327.00 ns, 25.3270 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 25669.00 ns, 25.6690 us/op
+WorkloadResult   2: 1 op, 25969.00 ns, 25.9690 us/op
+WorkloadResult   3: 1 op, 25718.00 ns, 25.7180 us/op
+WorkloadResult   4: 1 op, 24826.00 ns, 24.8260 us/op
+WorkloadResult   5: 1 op, 25278.00 ns, 25.2780 us/op
+WorkloadResult   6: 1 op, 25248.00 ns, 25.2480 us/op
+WorkloadResult   7: 1 op, 25548.00 ns, 25.5480 us/op
+WorkloadResult   8: 1 op, 25518.00 ns, 25.5180 us/op
+WorkloadResult   9: 1 op, 25929.00 ns, 25.9290 us/op
+WorkloadResult  10: 1 op, 25397.00 ns, 25.3970 us/op
+WorkloadResult  11: 1 op, 24746.00 ns, 24.7460 us/op
+WorkloadResult  12: 1 op, 25037.00 ns, 25.0370 us/op
+WorkloadResult  13: 1 op, 25528.00 ns, 25.5280 us/op
+WorkloadResult  14: 1 op, 25027.00 ns, 25.0270 us/op
+// GC:  0 0 0 1448 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3400 has exited with code 0.
+
+Mean = 25.388 μs, StdErr = 0.102 μs (0.40%), N = 14, StdDev = 0.382 μs
+Min = 24.746 μs, Q1 = 25.090 μs, Median = 25.457 μs, Q3 = 25.639 μs, Max = 25.969 μs
+IQR = 0.549 μs, LowerFence = 24.266 μs, UpperFence = 26.462 μs
+ConfidenceInterval = [24.958 μs; 25.819 μs] (CI 99.9%), Margin = 0.431 μs (1.70% of Mean)
+Skewness = -0.15, Kurtosis = 1.76, MValue = 2
+
+// ** Remained 41 (82.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Gzip Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Gzip_Compress_1MB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 9 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-AOOVDG(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 293826.00 ns, 293.8260 us/op
+WorkloadJitting  1: 1 op, 466356.00 ns, 466.3560 us/op
+
+OverheadWarmup   1: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   3: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   4: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadWarmup   5: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   6: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadWarmup   7: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadWarmup   8: 1 op, 261.00 ns, 261.0000 ns/op
+
+OverheadActual   1: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   2: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   3: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   4: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   5: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   6: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   7: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   8: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadActual   9: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  10: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  11: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  12: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  13: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  14: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  15: 1 op, 250.00 ns, 250.0000 ns/op
+OverheadActual  16: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  17: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  18: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  19: 1 op, 290.00 ns, 290.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 279991.00 ns, 279.9910 us/op
+WorkloadWarmup   2: 1 op, 290851.00 ns, 290.8510 us/op
+WorkloadWarmup   3: 1 op, 277365.00 ns, 277.3650 us/op
+WorkloadWarmup   4: 1 op, 292984.00 ns, 292.9840 us/op
+WorkloadWarmup   5: 1 op, 277235.00 ns, 277.2350 us/op
+WorkloadWarmup   6: 1 op, 290250.00 ns, 290.2500 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 261376.00 ns, 261.3760 us/op
+WorkloadActual   2: 1 op, 260254.00 ns, 260.2540 us/op
+WorkloadActual   3: 1 op, 259593.00 ns, 259.5930 us/op
+WorkloadActual   4: 1 op, 287555.00 ns, 287.5550 us/op
+WorkloadActual   5: 1 op, 304817.00 ns, 304.8170 us/op
+WorkloadActual   6: 1 op, 287975.00 ns, 287.9750 us/op
+WorkloadActual   7: 1 op, 278287.00 ns, 278.2870 us/op
+WorkloadActual   8: 1 op, 294938.00 ns, 294.9380 us/op
+WorkloadActual   9: 1 op, 286031.00 ns, 286.0310 us/op
+WorkloadActual  10: 1 op, 287725.00 ns, 287.7250 us/op
+WorkloadActual  11: 1 op, 290380.00 ns, 290.3800 us/op
+WorkloadActual  12: 1 op, 294707.00 ns, 294.7070 us/op
+WorkloadActual  13: 1 op, 294367.00 ns, 294.3670 us/op
+WorkloadActual  14: 1 op, 270794.00 ns, 270.7940 us/op
+WorkloadActual  15: 1 op, 270482.00 ns, 270.4820 us/op
+WorkloadActual  16: 1 op, 270283.00 ns, 270.2830 us/op
+WorkloadActual  17: 1 op, 270763.00 ns, 270.7630 us/op
+WorkloadActual  18: 1 op, 271184.00 ns, 271.1840 us/op
+WorkloadActual  19: 1 op, 271425.00 ns, 271.4250 us/op
+WorkloadActual  20: 1 op, 274310.00 ns, 274.3100 us/op
+WorkloadActual  21: 1 op, 274230.00 ns, 274.2300 us/op
+WorkloadActual  22: 1 op, 273838.00 ns, 273.8380 us/op
+WorkloadActual  23: 1 op, 273909.00 ns, 273.9090 us/op
+WorkloadActual  24: 1 op, 274079.00 ns, 274.0790 us/op
+WorkloadActual  25: 1 op, 273959.00 ns, 273.9590 us/op
+WorkloadActual  26: 1 op, 296000.00 ns, 296.0000 us/op
+WorkloadActual  27: 1 op, 296581.00 ns, 296.5810 us/op
+WorkloadActual  28: 1 op, 295349.00 ns, 295.3490 us/op
+WorkloadActual  29: 1 op, 299297.00 ns, 299.2970 us/op
+WorkloadActual  30: 1 op, 295789.00 ns, 295.7890 us/op
+WorkloadActual  31: 1 op, 295449.00 ns, 295.4490 us/op
+WorkloadActual  32: 1 op, 296702.00 ns, 296.7020 us/op
+WorkloadActual  33: 1 op, 302633.00 ns, 302.6330 us/op
+WorkloadActual  34: 1 op, 296240.00 ns, 296.2400 us/op
+WorkloadActual  35: 1 op, 290600.00 ns, 290.6000 us/op
+WorkloadActual  36: 1 op, 275753.00 ns, 275.7530 us/op
+WorkloadActual  37: 1 op, 274350.00 ns, 274.3500 us/op
+WorkloadActual  38: 1 op, 273257.00 ns, 273.2570 us/op
+WorkloadActual  39: 1 op, 274019.00 ns, 274.0190 us/op
+WorkloadActual  40: 1 op, 275803.00 ns, 275.8030 us/op
+WorkloadActual  41: 1 op, 273779.00 ns, 273.7790 us/op
+WorkloadActual  42: 1 op, 273698.00 ns, 273.6980 us/op
+WorkloadActual  43: 1 op, 274039.00 ns, 274.0390 us/op
+WorkloadActual  44: 1 op, 259081.00 ns, 259.0810 us/op
+WorkloadActual  45: 1 op, 260725.00 ns, 260.7250 us/op
+WorkloadActual  46: 1 op, 260163.00 ns, 260.1630 us/op
+WorkloadActual  47: 1 op, 259753.00 ns, 259.7530 us/op
+WorkloadActual  48: 1 op, 260865.00 ns, 260.8650 us/op
+WorkloadActual  49: 1 op, 259251.00 ns, 259.2510 us/op
+WorkloadActual  50: 1 op, 259212.00 ns, 259.2120 us/op
+WorkloadActual  51: 1 op, 259662.00 ns, 259.6620 us/op
+WorkloadActual  52: 1 op, 259081.00 ns, 259.0810 us/op
+WorkloadActual  53: 1 op, 259903.00 ns, 259.9030 us/op
+WorkloadActual  54: 1 op, 259533.00 ns, 259.5330 us/op
+WorkloadActual  55: 1 op, 259572.00 ns, 259.5720 us/op
+WorkloadActual  56: 1 op, 258771.00 ns, 258.7710 us/op
+WorkloadActual  57: 1 op, 259823.00 ns, 259.8230 us/op
+WorkloadActual  58: 1 op, 260153.00 ns, 260.1530 us/op
+WorkloadActual  59: 1 op, 260124.00 ns, 260.1240 us/op
+WorkloadActual  60: 1 op, 259563.00 ns, 259.5630 us/op
+WorkloadActual  61: 1 op, 260144.00 ns, 260.1440 us/op
+WorkloadActual  62: 1 op, 259713.00 ns, 259.7130 us/op
+WorkloadActual  63: 1 op, 259402.00 ns, 259.4020 us/op
+WorkloadActual  64: 1 op, 260013.00 ns, 260.0130 us/op
+WorkloadActual  65: 1 op, 259723.00 ns, 259.7230 us/op
+WorkloadActual  66: 1 op, 259993.00 ns, 259.9930 us/op
+WorkloadActual  67: 1 op, 259272.00 ns, 259.2720 us/op
+WorkloadActual  68: 1 op, 259583.00 ns, 259.5830 us/op
+WorkloadActual  69: 1 op, 260304.00 ns, 260.3040 us/op
+WorkloadActual  70: 1 op, 259842.00 ns, 259.8420 us/op
+WorkloadActual  71: 1 op, 259883.00 ns, 259.8830 us/op
+WorkloadActual  72: 1 op, 260003.00 ns, 260.0030 us/op
+WorkloadActual  73: 1 op, 259753.00 ns, 259.7530 us/op
+WorkloadActual  74: 1 op, 259703.00 ns, 259.7030 us/op
+WorkloadActual  75: 1 op, 259582.00 ns, 259.5820 us/op
+WorkloadActual  76: 1 op, 259683.00 ns, 259.6830 us/op
+WorkloadActual  77: 1 op, 259613.00 ns, 259.6130 us/op
+WorkloadActual  78: 1 op, 259652.00 ns, 259.6520 us/op
+WorkloadActual  79: 1 op, 259783.00 ns, 259.7830 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 261086.00 ns, 261.0860 us/op
+WorkloadResult   2: 1 op, 259964.00 ns, 259.9640 us/op
+WorkloadResult   3: 1 op, 259303.00 ns, 259.3030 us/op
+WorkloadResult   4: 1 op, 287265.00 ns, 287.2650 us/op
+WorkloadResult   5: 1 op, 287685.00 ns, 287.6850 us/op
+WorkloadResult   6: 1 op, 277997.00 ns, 277.9970 us/op
+WorkloadResult   7: 1 op, 294648.00 ns, 294.6480 us/op
+WorkloadResult   8: 1 op, 285741.00 ns, 285.7410 us/op
+WorkloadResult   9: 1 op, 287435.00 ns, 287.4350 us/op
+WorkloadResult  10: 1 op, 290090.00 ns, 290.0900 us/op
+WorkloadResult  11: 1 op, 294417.00 ns, 294.4170 us/op
+WorkloadResult  12: 1 op, 294077.00 ns, 294.0770 us/op
+WorkloadResult  13: 1 op, 270504.00 ns, 270.5040 us/op
+WorkloadResult  14: 1 op, 270192.00 ns, 270.1920 us/op
+WorkloadResult  15: 1 op, 269993.00 ns, 269.9930 us/op
+WorkloadResult  16: 1 op, 270473.00 ns, 270.4730 us/op
+WorkloadResult  17: 1 op, 270894.00 ns, 270.8940 us/op
+WorkloadResult  18: 1 op, 271135.00 ns, 271.1350 us/op
+WorkloadResult  19: 1 op, 274020.00 ns, 274.0200 us/op
+WorkloadResult  20: 1 op, 273940.00 ns, 273.9400 us/op
+WorkloadResult  21: 1 op, 273548.00 ns, 273.5480 us/op
+WorkloadResult  22: 1 op, 273619.00 ns, 273.6190 us/op
+WorkloadResult  23: 1 op, 273789.00 ns, 273.7890 us/op
+WorkloadResult  24: 1 op, 273669.00 ns, 273.6690 us/op
+WorkloadResult  25: 1 op, 295710.00 ns, 295.7100 us/op
+WorkloadResult  26: 1 op, 296291.00 ns, 296.2910 us/op
+WorkloadResult  27: 1 op, 295059.00 ns, 295.0590 us/op
+WorkloadResult  28: 1 op, 299007.00 ns, 299.0070 us/op
+WorkloadResult  29: 1 op, 295499.00 ns, 295.4990 us/op
+WorkloadResult  30: 1 op, 295159.00 ns, 295.1590 us/op
+WorkloadResult  31: 1 op, 296412.00 ns, 296.4120 us/op
+WorkloadResult  32: 1 op, 302343.00 ns, 302.3430 us/op
+WorkloadResult  33: 1 op, 295950.00 ns, 295.9500 us/op
+WorkloadResult  34: 1 op, 290310.00 ns, 290.3100 us/op
+WorkloadResult  35: 1 op, 275463.00 ns, 275.4630 us/op
+WorkloadResult  36: 1 op, 274060.00 ns, 274.0600 us/op
+WorkloadResult  37: 1 op, 272967.00 ns, 272.9670 us/op
+WorkloadResult  38: 1 op, 273729.00 ns, 273.7290 us/op
+WorkloadResult  39: 1 op, 275513.00 ns, 275.5130 us/op
+WorkloadResult  40: 1 op, 273489.00 ns, 273.4890 us/op
+WorkloadResult  41: 1 op, 273408.00 ns, 273.4080 us/op
+WorkloadResult  42: 1 op, 273749.00 ns, 273.7490 us/op
+WorkloadResult  43: 1 op, 258791.00 ns, 258.7910 us/op
+WorkloadResult  44: 1 op, 260435.00 ns, 260.4350 us/op
+WorkloadResult  45: 1 op, 259873.00 ns, 259.8730 us/op
+WorkloadResult  46: 1 op, 259463.00 ns, 259.4630 us/op
+WorkloadResult  47: 1 op, 260575.00 ns, 260.5750 us/op
+WorkloadResult  48: 1 op, 258961.00 ns, 258.9610 us/op
+WorkloadResult  49: 1 op, 258922.00 ns, 258.9220 us/op
+WorkloadResult  50: 1 op, 259372.00 ns, 259.3720 us/op
+WorkloadResult  51: 1 op, 258791.00 ns, 258.7910 us/op
+WorkloadResult  52: 1 op, 259613.00 ns, 259.6130 us/op
+WorkloadResult  53: 1 op, 259243.00 ns, 259.2430 us/op
+WorkloadResult  54: 1 op, 259282.00 ns, 259.2820 us/op
+WorkloadResult  55: 1 op, 258481.00 ns, 258.4810 us/op
+WorkloadResult  56: 1 op, 259533.00 ns, 259.5330 us/op
+WorkloadResult  57: 1 op, 259863.00 ns, 259.8630 us/op
+WorkloadResult  58: 1 op, 259834.00 ns, 259.8340 us/op
+WorkloadResult  59: 1 op, 259273.00 ns, 259.2730 us/op
+WorkloadResult  60: 1 op, 259854.00 ns, 259.8540 us/op
+WorkloadResult  61: 1 op, 259423.00 ns, 259.4230 us/op
+WorkloadResult  62: 1 op, 259112.00 ns, 259.1120 us/op
+WorkloadResult  63: 1 op, 259723.00 ns, 259.7230 us/op
+WorkloadResult  64: 1 op, 259433.00 ns, 259.4330 us/op
+WorkloadResult  65: 1 op, 259703.00 ns, 259.7030 us/op
+WorkloadResult  66: 1 op, 258982.00 ns, 258.9820 us/op
+WorkloadResult  67: 1 op, 259293.00 ns, 259.2930 us/op
+WorkloadResult  68: 1 op, 260014.00 ns, 260.0140 us/op
+WorkloadResult  69: 1 op, 259552.00 ns, 259.5520 us/op
+WorkloadResult  70: 1 op, 259593.00 ns, 259.5930 us/op
+WorkloadResult  71: 1 op, 259713.00 ns, 259.7130 us/op
+WorkloadResult  72: 1 op, 259463.00 ns, 259.4630 us/op
+WorkloadResult  73: 1 op, 259413.00 ns, 259.4130 us/op
+WorkloadResult  74: 1 op, 259292.00 ns, 259.2920 us/op
+WorkloadResult  75: 1 op, 259393.00 ns, 259.3930 us/op
+WorkloadResult  76: 1 op, 259323.00 ns, 259.3230 us/op
+WorkloadResult  77: 1 op, 259362.00 ns, 259.3620 us/op
+WorkloadResult  78: 1 op, 259493.00 ns, 259.4930 us/op
+// GC:  0 0 0 1336 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3407 has exited with code 0.
+
+Mean = 271.026 μs, StdErr = 1.569 μs (0.58%), N = 78, StdDev = 13.861 μs
+Min = 258.481 μs, Q1 = 259.440 μs, Median = 265.539 μs, Q3 = 275.500 μs, Max = 302.343 μs
+IQR = 16.060 μs, LowerFence = 235.351 μs, UpperFence = 299.591 μs
+ConfidenceInterval = [265.656 μs; 276.396 μs] (CI 99.9%), Margin = 5.370 μs (1.98% of Mean)
+Skewness = 0.81, Kurtosis = 2.19, MValue = 3.54
+
+// ** Remained 40 (80.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Snappy Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Snappy_Compress_1MB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 10 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-CGMPHI(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 258621.00 ns, 258.6210 us/op
+WorkloadJitting  1: 1 op, 839050.00 ns, 839.0500 us/op
+
+OverheadWarmup   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   2: 1 op, 671.00 ns, 671.0000 ns/op
+OverheadWarmup   3: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadWarmup   4: 1 op, 370.00 ns, 370.0000 ns/op
+OverheadWarmup   5: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadWarmup   6: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadWarmup   7: 1 op, 360.00 ns, 360.0000 ns/op
+OverheadWarmup   8: 1 op, 691.00 ns, 691.0000 ns/op
+OverheadWarmup   9: 1 op, 701.00 ns, 701.0000 ns/op
+OverheadWarmup  10: 1 op, 310.00 ns, 310.0000 ns/op
+
+OverheadActual   1: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadActual   2: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual   3: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual   4: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   6: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   7: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   8: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   9: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  10: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  11: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  12: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  13: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual  14: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  15: 1 op, 310.00 ns, 310.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 534965.00 ns, 534.9650 us/op
+WorkloadWarmup   2: 1 op, 541396.00 ns, 541.3960 us/op
+WorkloadWarmup   3: 1 op, 520217.00 ns, 520.2170 us/op
+WorkloadWarmup   4: 1 op, 502504.00 ns, 502.5040 us/op
+WorkloadWarmup   5: 1 op, 502724.00 ns, 502.7240 us/op
+WorkloadWarmup   6: 1 op, 523984.00 ns, 523.9840 us/op
+WorkloadWarmup   7: 1 op, 516800.00 ns, 516.8000 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 511571.00 ns, 511.5710 us/op
+WorkloadActual   2: 1 op, 515167.00 ns, 515.1670 us/op
+WorkloadActual   3: 1 op, 491674.00 ns, 491.6740 us/op
+WorkloadActual   4: 1 op, 839970.00 ns, 839.9700 us/op
+WorkloadActual   5: 1 op, 827057.00 ns, 827.0570 us/op
+WorkloadActual   6: 1 op, 864677.00 ns, 864.6770 us/op
+WorkloadActual   7: 1 op, 886939.00 ns, 886.9390 us/op
+WorkloadActual   8: 1 op, 487436.00 ns, 487.4360 us/op
+WorkloadActual   9: 1 op, 485031.00 ns, 485.0310 us/op
+WorkloadActual  10: 1 op, 507984.00 ns, 507.9840 us/op
+WorkloadActual  11: 1 op, 514125.00 ns, 514.1250 us/op
+WorkloadActual  12: 1 op, 511430.00 ns, 511.4300 us/op
+WorkloadActual  13: 1 op, 483708.00 ns, 483.7080 us/op
+WorkloadActual  14: 1 op, 481955.00 ns, 481.9550 us/op
+WorkloadActual  15: 1 op, 512993.00 ns, 512.9930 us/op
+WorkloadActual  16: 1 op, 511931.00 ns, 511.9310 us/op
+WorkloadActual  17: 1 op, 482787.00 ns, 482.7870 us/op
+WorkloadActual  18: 1 op, 517111.00 ns, 517.1110 us/op
+WorkloadActual  19: 1 op, 499629.00 ns, 499.6290 us/op
+WorkloadActual  20: 1 op, 482126.00 ns, 482.1260 us/op
+WorkloadActual  21: 1 op, 482838.00 ns, 482.8380 us/op
+WorkloadActual  22: 1 op, 498236.00 ns, 498.2360 us/op
+WorkloadActual  23: 1 op, 497614.00 ns, 497.6140 us/op
+WorkloadActual  24: 1 op, 480754.00 ns, 480.7540 us/op
+WorkloadActual  25: 1 op, 479411.00 ns, 479.4110 us/op
+WorkloadActual  26: 1 op, 482647.00 ns, 482.6470 us/op
+WorkloadActual  27: 1 op, 493968.00 ns, 493.9680 us/op
+WorkloadActual  28: 1 op, 509346.00 ns, 509.3460 us/op
+WorkloadActual  29: 1 op, 478529.00 ns, 478.5290 us/op
+WorkloadActual  30: 1 op, 478610.00 ns, 478.6100 us/op
+WorkloadActual  31: 1 op, 510479.00 ns, 510.4790 us/op
+WorkloadActual  32: 1 op, 494408.00 ns, 494.4080 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 511270.00 ns, 511.2700 us/op
+WorkloadResult   2: 1 op, 514866.00 ns, 514.8660 us/op
+WorkloadResult   3: 1 op, 491373.00 ns, 491.3730 us/op
+WorkloadResult   4: 1 op, 487135.00 ns, 487.1350 us/op
+WorkloadResult   5: 1 op, 484730.00 ns, 484.7300 us/op
+WorkloadResult   6: 1 op, 507683.00 ns, 507.6830 us/op
+WorkloadResult   7: 1 op, 513824.00 ns, 513.8240 us/op
+WorkloadResult   8: 1 op, 511129.00 ns, 511.1290 us/op
+WorkloadResult   9: 1 op, 483407.00 ns, 483.4070 us/op
+WorkloadResult  10: 1 op, 481654.00 ns, 481.6540 us/op
+WorkloadResult  11: 1 op, 512692.00 ns, 512.6920 us/op
+WorkloadResult  12: 1 op, 511630.00 ns, 511.6300 us/op
+WorkloadResult  13: 1 op, 482486.00 ns, 482.4860 us/op
+WorkloadResult  14: 1 op, 516810.00 ns, 516.8100 us/op
+WorkloadResult  15: 1 op, 499328.00 ns, 499.3280 us/op
+WorkloadResult  16: 1 op, 481825.00 ns, 481.8250 us/op
+WorkloadResult  17: 1 op, 482537.00 ns, 482.5370 us/op
+WorkloadResult  18: 1 op, 497935.00 ns, 497.9350 us/op
+WorkloadResult  19: 1 op, 497313.00 ns, 497.3130 us/op
+WorkloadResult  20: 1 op, 480453.00 ns, 480.4530 us/op
+WorkloadResult  21: 1 op, 479110.00 ns, 479.1100 us/op
+WorkloadResult  22: 1 op, 482346.00 ns, 482.3460 us/op
+WorkloadResult  23: 1 op, 493667.00 ns, 493.6670 us/op
+WorkloadResult  24: 1 op, 509045.00 ns, 509.0450 us/op
+WorkloadResult  25: 1 op, 478228.00 ns, 478.2280 us/op
+WorkloadResult  26: 1 op, 478309.00 ns, 478.3090 us/op
+WorkloadResult  27: 1 op, 510178.00 ns, 510.1780 us/op
+WorkloadResult  28: 1 op, 494107.00 ns, 494.1070 us/op
+// GC:  0 0 0 1840 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3414 has exited with code 0.
+
+Mean = 495.538 μs, StdErr = 2.602 μs (0.53%), N = 28, StdDev = 13.767 μs
+Min = 478.228 μs, Q1 = 482.451 μs, Median = 493.887 μs, Q3 = 510.416 μs, Max = 516.810 μs
+IQR = 27.965 μs, LowerFence = 440.504 μs, UpperFence = 552.363 μs
+ConfidenceInterval = [485.939 μs; 505.138 μs] (CI 99.9%), Margin = 9.599 μs (1.94% of Mean)
+Skewness = 0.18, Kurtosis = 1.33, MValue = 2.67
+
+// ** Remained 39 (78.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'LZ4 Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Lz4_Compress_1MB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 11 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-LTZYRV(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 259252.00 ns, 259.2520 us/op
+WorkloadJitting  1: 1 op, 637034.00 ns, 637.0340 us/op
+
+OverheadWarmup   1: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   2: 1 op, 682.00 ns, 682.0000 ns/op
+OverheadWarmup   3: 1 op, 701.00 ns, 701.0000 ns/op
+OverheadWarmup   4: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadWarmup   5: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadWarmup   6: 1 op, 291.00 ns, 291.0000 ns/op
+
+OverheadActual   1: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   3: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   4: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   5: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   6: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   7: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   8: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   9: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  10: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  11: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  12: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  13: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  14: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  15: 1 op, 310.00 ns, 310.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 447732.00 ns, 447.7320 us/op
+WorkloadWarmup   2: 1 op, 407758.00 ns, 407.7580 us/op
+WorkloadWarmup   3: 1 op, 394052.00 ns, 394.0520 us/op
+WorkloadWarmup   4: 1 op, 393882.00 ns, 393.8820 us/op
+WorkloadWarmup   5: 1 op, 414730.00 ns, 414.7300 us/op
+WorkloadWarmup   6: 1 op, 428305.00 ns, 428.3050 us/op
+WorkloadWarmup   7: 1 op, 449456.00 ns, 449.4560 us/op
+WorkloadWarmup   8: 1 op, 443565.00 ns, 443.5650 us/op
+WorkloadWarmup   9: 1 op, 415752.00 ns, 415.7520 us/op
+WorkloadWarmup  10: 1 op, 415753.00 ns, 415.7530 us/op
+WorkloadWarmup  11: 1 op, 428687.00 ns, 428.6870 us/op
+WorkloadWarmup  12: 1 op, 447472.00 ns, 447.4720 us/op
+WorkloadWarmup  13: 1 op, 432193.00 ns, 432.1930 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 404752.00 ns, 404.7520 us/op
+WorkloadActual   2: 1 op, 395846.00 ns, 395.8460 us/op
+WorkloadActual   3: 1 op, 396958.00 ns, 396.9580 us/op
+WorkloadActual   4: 1 op, 410914.00 ns, 410.9140 us/op
+WorkloadActual   5: 1 op, 446099.00 ns, 446.0990 us/op
+WorkloadActual   6: 1 op, 424730.00 ns, 424.7300 us/op
+WorkloadActual   7: 1 op, 467278.00 ns, 467.2780 us/op
+WorkloadActual   8: 1 op, 395374.00 ns, 395.3740 us/op
+WorkloadActual   9: 1 op, 396106.00 ns, 396.1060 us/op
+WorkloadActual  10: 1 op, 675586.00 ns, 675.5860 us/op
+WorkloadActual  11: 1 op, 419600.00 ns, 419.6000 us/op
+WorkloadActual  12: 1 op, 417115.00 ns, 417.1150 us/op
+WorkloadActual  13: 1 op, 389584.00 ns, 389.5840 us/op
+WorkloadActual  14: 1 op, 391197.00 ns, 391.1970 us/op
+WorkloadActual  15: 1 op, 388943.00 ns, 388.9430 us/op
+WorkloadActual  16: 1 op, 386939.00 ns, 386.9390 us/op
+WorkloadActual  17: 1 op, 385316.00 ns, 385.3160 us/op
+WorkloadActual  18: 1 op, 404953.00 ns, 404.9530 us/op
+WorkloadActual  19: 1 op, 402478.00 ns, 402.4780 us/op
+WorkloadActual  20: 1 op, 385537.00 ns, 385.5370 us/op
+WorkloadActual  21: 1 op, 383642.00 ns, 383.6420 us/op
+WorkloadActual  22: 1 op, 382582.00 ns, 382.5820 us/op
+WorkloadActual  23: 1 op, 385036.00 ns, 385.0360 us/op
+WorkloadActual  24: 1 op, 385737.00 ns, 385.7370 us/op
+WorkloadActual  25: 1 op, 460476.00 ns, 460.4760 us/op
+WorkloadActual  26: 1 op, 401146.00 ns, 401.1460 us/op
+WorkloadActual  27: 1 op, 384885.00 ns, 384.8850 us/op
+WorkloadActual  28: 1 op, 384675.00 ns, 384.6750 us/op
+WorkloadActual  29: 1 op, 384445.00 ns, 384.4450 us/op
+WorkloadActual  30: 1 op, 384745.00 ns, 384.7450 us/op
+WorkloadActual  31: 1 op, 384024.00 ns, 384.0240 us/op
+WorkloadActual  32: 1 op, 400986.00 ns, 400.9860 us/op
+WorkloadActual  33: 1 op, 402468.00 ns, 402.4680 us/op
+WorkloadActual  34: 1 op, 415432.00 ns, 415.4320 us/op
+WorkloadActual  35: 1 op, 381599.00 ns, 381.5990 us/op
+WorkloadActual  36: 1 op, 382902.00 ns, 382.9020 us/op
+WorkloadActual  37: 1 op, 383993.00 ns, 383.9930 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 404471.00 ns, 404.4710 us/op
+WorkloadResult   2: 1 op, 395565.00 ns, 395.5650 us/op
+WorkloadResult   3: 1 op, 396677.00 ns, 396.6770 us/op
+WorkloadResult   4: 1 op, 410633.00 ns, 410.6330 us/op
+WorkloadResult   5: 1 op, 424449.00 ns, 424.4490 us/op
+WorkloadResult   6: 1 op, 395093.00 ns, 395.0930 us/op
+WorkloadResult   7: 1 op, 395825.00 ns, 395.8250 us/op
+WorkloadResult   8: 1 op, 419319.00 ns, 419.3190 us/op
+WorkloadResult   9: 1 op, 416834.00 ns, 416.8340 us/op
+WorkloadResult  10: 1 op, 389303.00 ns, 389.3030 us/op
+WorkloadResult  11: 1 op, 390916.00 ns, 390.9160 us/op
+WorkloadResult  12: 1 op, 388662.00 ns, 388.6620 us/op
+WorkloadResult  13: 1 op, 386658.00 ns, 386.6580 us/op
+WorkloadResult  14: 1 op, 385035.00 ns, 385.0350 us/op
+WorkloadResult  15: 1 op, 404672.00 ns, 404.6720 us/op
+WorkloadResult  16: 1 op, 402197.00 ns, 402.1970 us/op
+WorkloadResult  17: 1 op, 385256.00 ns, 385.2560 us/op
+WorkloadResult  18: 1 op, 383361.00 ns, 383.3610 us/op
+WorkloadResult  19: 1 op, 382301.00 ns, 382.3010 us/op
+WorkloadResult  20: 1 op, 384755.00 ns, 384.7550 us/op
+WorkloadResult  21: 1 op, 385456.00 ns, 385.4560 us/op
+WorkloadResult  22: 1 op, 400865.00 ns, 400.8650 us/op
+WorkloadResult  23: 1 op, 384604.00 ns, 384.6040 us/op
+WorkloadResult  24: 1 op, 384394.00 ns, 384.3940 us/op
+WorkloadResult  25: 1 op, 384164.00 ns, 384.1640 us/op
+WorkloadResult  26: 1 op, 384464.00 ns, 384.4640 us/op
+WorkloadResult  27: 1 op, 383743.00 ns, 383.7430 us/op
+WorkloadResult  28: 1 op, 400705.00 ns, 400.7050 us/op
+WorkloadResult  29: 1 op, 402187.00 ns, 402.1870 us/op
+WorkloadResult  30: 1 op, 415151.00 ns, 415.1510 us/op
+WorkloadResult  31: 1 op, 381318.00 ns, 381.3180 us/op
+WorkloadResult  32: 1 op, 382621.00 ns, 382.6210 us/op
+WorkloadResult  33: 1 op, 383712.00 ns, 383.7120 us/op
+// GC:  0 0 0 1560 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3421 has exited with code 0.
+
+Mean = 394.405 μs, StdErr = 2.137 μs (0.54%), N = 33, StdDev = 12.274 μs
+Min = 381.318 μs, Q1 = 384.464 μs, Median = 389.303 μs, Q3 = 402.187 μs, Max = 424.449 μs
+IQR = 17.723 μs, LowerFence = 357.880 μs, UpperFence = 428.772 μs
+ConfidenceInterval = [386.666 μs; 402.144 μs] (CI 99.9%), Margin = 7.739 μs (1.96% of Mean)
+Skewness = 0.87, Kurtosis = 2.57, MValue = 2
+
+// ** Remained 38 (76.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Zstd Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Zstd_Compress_1MB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 12 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-ZLCPQI(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 257689.00 ns, 257.6890 us/op
+WorkloadJitting  1: 1 op, 2036594.00 ns, 2.0366 ms/op
+
+OverheadWarmup   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   2: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadWarmup   3: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   4: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   5: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadWarmup   6: 1 op, 311.00 ns, 311.0000 ns/op
+
+OverheadActual   1: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   2: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual   3: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   4: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   6: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   7: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   8: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   9: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  10: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  11: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual  12: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  13: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  14: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  15: 1 op, 341.00 ns, 341.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 1746556.00 ns, 1.7466 ms/op
+WorkloadWarmup   2: 1 op, 1695431.00 ns, 1.6954 ms/op
+WorkloadWarmup   3: 1 op, 1689089.00 ns, 1.6891 ms/op
+WorkloadWarmup   4: 1 op, 1683148.00 ns, 1.6831 ms/op
+WorkloadWarmup   5: 1 op, 1663251.00 ns, 1.6633 ms/op
+WorkloadWarmup   6: 1 op, 1677938.00 ns, 1.6779 ms/op
+WorkloadWarmup   7: 1 op, 1694369.00 ns, 1.6944 ms/op
+WorkloadWarmup   8: 1 op, 1690581.00 ns, 1.6906 ms/op
+WorkloadWarmup   9: 1 op, 1691603.00 ns, 1.6916 ms/op
+WorkloadWarmup  10: 1 op, 1668781.00 ns, 1.6688 ms/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 1718353.00 ns, 1.7184 ms/op
+WorkloadActual   2: 1 op, 1725857.00 ns, 1.7259 ms/op
+WorkloadActual   3: 1 op, 1732970.00 ns, 1.7330 ms/op
+WorkloadActual   4: 1 op, 1716690.00 ns, 1.7167 ms/op
+WorkloadActual   5: 1 op, 1706451.00 ns, 1.7065 ms/op
+WorkloadActual   6: 1 op, 1686855.00 ns, 1.6869 ms/op
+WorkloadActual   7: 1 op, 1704448.00 ns, 1.7044 ms/op
+WorkloadActual   8: 1 op, 1661648.00 ns, 1.6616 ms/op
+WorkloadActual   9: 1 op, 1694389.00 ns, 1.6944 ms/op
+WorkloadActual  10: 1 op, 1685522.00 ns, 1.6855 ms/op
+WorkloadActual  11: 1 op, 1691153.00 ns, 1.6912 ms/op
+WorkloadActual  12: 1 op, 1685592.00 ns, 1.6856 ms/op
+WorkloadActual  13: 1 op, 1658662.00 ns, 1.6587 ms/op
+WorkloadActual  14: 1 op, 1677497.00 ns, 1.6775 ms/op
+WorkloadActual  15: 1 op, 1668150.00 ns, 1.6682 ms/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 1718063.00 ns, 1.7181 ms/op
+WorkloadResult   2: 1 op, 1725567.00 ns, 1.7256 ms/op
+WorkloadResult   3: 1 op, 1732680.00 ns, 1.7327 ms/op
+WorkloadResult   4: 1 op, 1716400.00 ns, 1.7164 ms/op
+WorkloadResult   5: 1 op, 1706161.00 ns, 1.7062 ms/op
+WorkloadResult   6: 1 op, 1686565.00 ns, 1.6866 ms/op
+WorkloadResult   7: 1 op, 1704158.00 ns, 1.7042 ms/op
+WorkloadResult   8: 1 op, 1661358.00 ns, 1.6614 ms/op
+WorkloadResult   9: 1 op, 1694099.00 ns, 1.6941 ms/op
+WorkloadResult  10: 1 op, 1685232.00 ns, 1.6852 ms/op
+WorkloadResult  11: 1 op, 1690863.00 ns, 1.6909 ms/op
+WorkloadResult  12: 1 op, 1685302.00 ns, 1.6853 ms/op
+WorkloadResult  13: 1 op, 1658372.00 ns, 1.6584 ms/op
+WorkloadResult  14: 1 op, 1677207.00 ns, 1.6772 ms/op
+WorkloadResult  15: 1 op, 1667860.00 ns, 1.6679 ms/op
+// GC:  0 0 0 1136 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3428 has exited with code 0.
+
+Mean = 1.694 ms, StdErr = 0.006 ms (0.35%), N = 15, StdDev = 0.023 ms
+Min = 1.658 ms, Q1 = 1.681 ms, Median = 1.691 ms, Q3 = 1.711 ms, Max = 1.733 ms
+IQR = 0.030 ms, LowerFence = 1.636 ms, UpperFence = 1.756 ms
+ConfidenceInterval = [1.670 ms; 1.718 ms] (CI 99.9%), Margin = 0.024 ms (1.45% of Mean)
+Skewness = 0.07, Kurtosis = 1.74, MValue = 2
+
+// ** Remained 37 (74.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Brotli Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Brotli_Compress_1MB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 13 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-OSMNOJ(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 260363.00 ns, 260.3630 us/op
+WorkloadJitting  1: 1 op, 321918.00 ns, 321.9180 us/op
+
+OverheadWarmup   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   2: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   3: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadWarmup   4: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   5: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   6: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   7: 1 op, 270.00 ns, 270.0000 ns/op
+
+OverheadActual   1: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   3: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   4: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   5: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual   6: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   7: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual   8: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   9: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual  10: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  11: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  12: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadActual  13: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  14: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  15: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  16: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  17: 1 op, 281.00 ns, 281.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 120694.00 ns, 120.6940 us/op
+WorkloadWarmup   2: 1 op, 109183.00 ns, 109.1830 us/op
+WorkloadWarmup   3: 1 op, 122147.00 ns, 122.1470 us/op
+WorkloadWarmup   4: 1 op, 107680.00 ns, 107.6800 us/op
+WorkloadWarmup   5: 1 op, 105977.00 ns, 105.9770 us/op
+WorkloadWarmup   6: 1 op, 121185.00 ns, 121.1850 us/op
+WorkloadWarmup   7: 1 op, 102049.00 ns, 102.0490 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 108572.00 ns, 108.5720 us/op
+WorkloadActual   2: 1 op, 118550.00 ns, 118.5500 us/op
+WorkloadActual   3: 1 op, 103873.00 ns, 103.8730 us/op
+WorkloadActual   4: 1 op, 185465.00 ns, 185.4650 us/op
+WorkloadActual   5: 1 op, 184793.00 ns, 184.7930 us/op
+WorkloadActual   6: 1 op, 214339.00 ns, 214.3390 us/op
+WorkloadActual   7: 1 op, 193990.00 ns, 193.9900 us/op
+WorkloadActual   8: 1 op, 191596.00 ns, 191.5960 us/op
+WorkloadActual   9: 1 op, 182879.00 ns, 182.8790 us/op
+WorkloadActual  10: 1 op, 185975.00 ns, 185.9750 us/op
+WorkloadActual  11: 1 op, 177930.00 ns, 177.9300 us/op
+WorkloadActual  12: 1 op, 199591.00 ns, 199.5910 us/op
+WorkloadActual  13: 1 op, 193740.00 ns, 193.7400 us/op
+WorkloadActual  14: 1 op, 183982.00 ns, 183.9820 us/op
+WorkloadActual  15: 1 op, 188150.00 ns, 188.1500 us/op
+WorkloadActual  16: 1 op, 192898.00 ns, 192.8980 us/op
+WorkloadActual  17: 1 op, 216111.00 ns, 216.1110 us/op
+WorkloadActual  18: 1 op, 178963.00 ns, 178.9630 us/op
+WorkloadActual  19: 1 op, 183822.00 ns, 183.8220 us/op
+WorkloadActual  20: 1 op, 172461.00 ns, 172.4610 us/op
+WorkloadActual  21: 1 op, 190514.00 ns, 190.5140 us/op
+WorkloadActual  22: 1 op, 190154.00 ns, 190.1540 us/op
+WorkloadActual  23: 1 op, 107229.00 ns, 107.2290 us/op
+WorkloadActual  24: 1 op, 106638.00 ns, 106.6380 us/op
+WorkloadActual  25: 1 op, 119693.00 ns, 119.6930 us/op
+WorkloadActual  26: 1 op, 130793.00 ns, 130.7930 us/op
+WorkloadActual  27: 1 op, 123850.00 ns, 123.8500 us/op
+WorkloadActual  28: 1 op, 120384.00 ns, 120.3840 us/op
+WorkloadActual  29: 1 op, 148416.00 ns, 148.4160 us/op
+WorkloadActual  30: 1 op, 127336.00 ns, 127.3360 us/op
+WorkloadActual  31: 1 op, 129280.00 ns, 129.2800 us/op
+WorkloadActual  32: 1 op, 128399.00 ns, 128.3990 us/op
+WorkloadActual  33: 1 op, 121176.00 ns, 121.1760 us/op
+WorkloadActual  34: 1 op, 106318.00 ns, 106.3180 us/op
+WorkloadActual  35: 1 op, 105787.00 ns, 105.7870 us/op
+WorkloadActual  36: 1 op, 104394.00 ns, 104.3940 us/op
+WorkloadActual  37: 1 op, 127647.00 ns, 127.6470 us/op
+WorkloadActual  38: 1 op, 104174.00 ns, 104.1740 us/op
+WorkloadActual  39: 1 op, 106809.00 ns, 106.8090 us/op
+WorkloadActual  40: 1 op, 104655.00 ns, 104.6550 us/op
+WorkloadActual  41: 1 op, 104744.00 ns, 104.7440 us/op
+WorkloadActual  42: 1 op, 104695.00 ns, 104.6950 us/op
+WorkloadActual  43: 1 op, 126645.00 ns, 126.6450 us/op
+WorkloadActual  44: 1 op, 103032.00 ns, 103.0320 us/op
+WorkloadActual  45: 1 op, 102842.00 ns, 102.8420 us/op
+WorkloadActual  46: 1 op, 102681.00 ns, 102.6810 us/op
+WorkloadActual  47: 1 op, 102971.00 ns, 102.9710 us/op
+WorkloadActual  48: 1 op, 103833.00 ns, 103.8330 us/op
+WorkloadActual  49: 1 op, 122759.00 ns, 122.7590 us/op
+WorkloadActual  50: 1 op, 118651.00 ns, 118.6510 us/op
+WorkloadActual  51: 1 op, 104684.00 ns, 104.6840 us/op
+WorkloadActual  52: 1 op, 103111.00 ns, 103.1110 us/op
+WorkloadActual  53: 1 op, 103292.00 ns, 103.2920 us/op
+WorkloadActual  54: 1 op, 105096.00 ns, 105.0960 us/op
+WorkloadActual  55: 1 op, 102992.00 ns, 102.9920 us/op
+WorkloadActual  56: 1 op, 133989.00 ns, 133.9890 us/op
+WorkloadActual  57: 1 op, 104384.00 ns, 104.3840 us/op
+WorkloadActual  58: 1 op, 105416.00 ns, 105.4160 us/op
+WorkloadActual  59: 1 op, 102210.00 ns, 102.2100 us/op
+WorkloadActual  60: 1 op, 104154.00 ns, 104.1540 us/op
+WorkloadActual  61: 1 op, 104074.00 ns, 104.0740 us/op
+WorkloadActual  62: 1 op, 118941.00 ns, 118.9410 us/op
+WorkloadActual  63: 1 op, 120384.00 ns, 120.3840 us/op
+WorkloadActual  64: 1 op, 103332.00 ns, 103.3320 us/op
+WorkloadActual  65: 1 op, 103572.00 ns, 103.5720 us/op
+WorkloadActual  66: 1 op, 104995.00 ns, 104.9950 us/op
+WorkloadActual  67: 1 op, 103823.00 ns, 103.8230 us/op
+WorkloadActual  68: 1 op, 104995.00 ns, 104.9950 us/op
+WorkloadActual  69: 1 op, 104394.00 ns, 104.3940 us/op
+WorkloadActual  70: 1 op, 131785.00 ns, 131.7850 us/op
+WorkloadActual  71: 1 op, 102912.00 ns, 102.9120 us/op
+WorkloadActual  72: 1 op, 104254.00 ns, 104.2540 us/op
+WorkloadActual  73: 1 op, 102831.00 ns, 102.8310 us/op
+WorkloadActual  74: 1 op, 103412.00 ns, 103.4120 us/op
+WorkloadActual  75: 1 op, 104404.00 ns, 104.4040 us/op
+WorkloadActual  76: 1 op, 102210.00 ns, 102.2100 us/op
+WorkloadActual  77: 1 op, 129350.00 ns, 129.3500 us/op
+WorkloadActual  78: 1 op, 128820.00 ns, 128.8200 us/op
+WorkloadActual  79: 1 op, 115034.00 ns, 115.0340 us/op
+WorkloadActual  80: 1 op, 105066.00 ns, 105.0660 us/op
+WorkloadActual  81: 1 op, 104163.00 ns, 104.1630 us/op
+WorkloadActual  82: 1 op, 105236.00 ns, 105.2360 us/op
+WorkloadActual  83: 1 op, 105146.00 ns, 105.1460 us/op
+WorkloadActual  84: 1 op, 102740.00 ns, 102.7400 us/op
+WorkloadActual  85: 1 op, 105326.00 ns, 105.3260 us/op
+WorkloadActual  86: 1 op, 128579.00 ns, 128.5790 us/op
+WorkloadActual  87: 1 op, 103994.00 ns, 103.9940 us/op
+WorkloadActual  88: 1 op, 104194.00 ns, 104.1940 us/op
+WorkloadActual  89: 1 op, 103341.00 ns, 103.3410 us/op
+WorkloadActual  90: 1 op, 101799.00 ns, 101.7990 us/op
+WorkloadActual  91: 1 op, 104845.00 ns, 104.8450 us/op
+WorkloadActual  92: 1 op, 104294.00 ns, 104.2940 us/op
+WorkloadActual  93: 1 op, 104764.00 ns, 104.7640 us/op
+WorkloadActual  94: 1 op, 105456.00 ns, 105.4560 us/op
+WorkloadActual  95: 1 op, 103032.00 ns, 103.0320 us/op
+WorkloadActual  96: 1 op, 104845.00 ns, 104.8450 us/op
+WorkloadActual  97: 1 op, 105145.00 ns, 105.1450 us/op
+WorkloadActual  98: 1 op, 104785.00 ns, 104.7850 us/op
+WorkloadActual  99: 1 op, 104684.00 ns, 104.6840 us/op
+WorkloadActual  100: 1 op, 104404.00 ns, 104.4040 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 108291.00 ns, 108.2910 us/op
+WorkloadResult   2: 1 op, 118269.00 ns, 118.2690 us/op
+WorkloadResult   3: 1 op, 103592.00 ns, 103.5920 us/op
+WorkloadResult   4: 1 op, 106948.00 ns, 106.9480 us/op
+WorkloadResult   5: 1 op, 106357.00 ns, 106.3570 us/op
+WorkloadResult   6: 1 op, 119412.00 ns, 119.4120 us/op
+WorkloadResult   7: 1 op, 130512.00 ns, 130.5120 us/op
+WorkloadResult   8: 1 op, 123569.00 ns, 123.5690 us/op
+WorkloadResult   9: 1 op, 120103.00 ns, 120.1030 us/op
+WorkloadResult  10: 1 op, 148135.00 ns, 148.1350 us/op
+WorkloadResult  11: 1 op, 127055.00 ns, 127.0550 us/op
+WorkloadResult  12: 1 op, 128999.00 ns, 128.9990 us/op
+WorkloadResult  13: 1 op, 128118.00 ns, 128.1180 us/op
+WorkloadResult  14: 1 op, 120895.00 ns, 120.8950 us/op
+WorkloadResult  15: 1 op, 106037.00 ns, 106.0370 us/op
+WorkloadResult  16: 1 op, 105506.00 ns, 105.5060 us/op
+WorkloadResult  17: 1 op, 104113.00 ns, 104.1130 us/op
+WorkloadResult  18: 1 op, 127366.00 ns, 127.3660 us/op
+WorkloadResult  19: 1 op, 103893.00 ns, 103.8930 us/op
+WorkloadResult  20: 1 op, 106528.00 ns, 106.5280 us/op
+WorkloadResult  21: 1 op, 104374.00 ns, 104.3740 us/op
+WorkloadResult  22: 1 op, 104463.00 ns, 104.4630 us/op
+WorkloadResult  23: 1 op, 104414.00 ns, 104.4140 us/op
+WorkloadResult  24: 1 op, 126364.00 ns, 126.3640 us/op
+WorkloadResult  25: 1 op, 102751.00 ns, 102.7510 us/op
+WorkloadResult  26: 1 op, 102561.00 ns, 102.5610 us/op
+WorkloadResult  27: 1 op, 102400.00 ns, 102.4000 us/op
+WorkloadResult  28: 1 op, 102690.00 ns, 102.6900 us/op
+WorkloadResult  29: 1 op, 103552.00 ns, 103.5520 us/op
+WorkloadResult  30: 1 op, 122478.00 ns, 122.4780 us/op
+WorkloadResult  31: 1 op, 118370.00 ns, 118.3700 us/op
+WorkloadResult  32: 1 op, 104403.00 ns, 104.4030 us/op
+WorkloadResult  33: 1 op, 102830.00 ns, 102.8300 us/op
+WorkloadResult  34: 1 op, 103011.00 ns, 103.0110 us/op
+WorkloadResult  35: 1 op, 104815.00 ns, 104.8150 us/op
+WorkloadResult  36: 1 op, 102711.00 ns, 102.7110 us/op
+WorkloadResult  37: 1 op, 133708.00 ns, 133.7080 us/op
+WorkloadResult  38: 1 op, 104103.00 ns, 104.1030 us/op
+WorkloadResult  39: 1 op, 105135.00 ns, 105.1350 us/op
+WorkloadResult  40: 1 op, 101929.00 ns, 101.9290 us/op
+WorkloadResult  41: 1 op, 103873.00 ns, 103.8730 us/op
+WorkloadResult  42: 1 op, 103793.00 ns, 103.7930 us/op
+WorkloadResult  43: 1 op, 118660.00 ns, 118.6600 us/op
+WorkloadResult  44: 1 op, 120103.00 ns, 120.1030 us/op
+WorkloadResult  45: 1 op, 103051.00 ns, 103.0510 us/op
+WorkloadResult  46: 1 op, 103291.00 ns, 103.2910 us/op
+WorkloadResult  47: 1 op, 104714.00 ns, 104.7140 us/op
+WorkloadResult  48: 1 op, 103542.00 ns, 103.5420 us/op
+WorkloadResult  49: 1 op, 104714.00 ns, 104.7140 us/op
+WorkloadResult  50: 1 op, 104113.00 ns, 104.1130 us/op
+WorkloadResult  51: 1 op, 131504.00 ns, 131.5040 us/op
+WorkloadResult  52: 1 op, 102631.00 ns, 102.6310 us/op
+WorkloadResult  53: 1 op, 103973.00 ns, 103.9730 us/op
+WorkloadResult  54: 1 op, 102550.00 ns, 102.5500 us/op
+WorkloadResult  55: 1 op, 103131.00 ns, 103.1310 us/op
+WorkloadResult  56: 1 op, 104123.00 ns, 104.1230 us/op
+WorkloadResult  57: 1 op, 101929.00 ns, 101.9290 us/op
+WorkloadResult  58: 1 op, 129069.00 ns, 129.0690 us/op
+WorkloadResult  59: 1 op, 128539.00 ns, 128.5390 us/op
+WorkloadResult  60: 1 op, 114753.00 ns, 114.7530 us/op
+WorkloadResult  61: 1 op, 104785.00 ns, 104.7850 us/op
+WorkloadResult  62: 1 op, 103882.00 ns, 103.8820 us/op
+WorkloadResult  63: 1 op, 104955.00 ns, 104.9550 us/op
+WorkloadResult  64: 1 op, 104865.00 ns, 104.8650 us/op
+WorkloadResult  65: 1 op, 102459.00 ns, 102.4590 us/op
+WorkloadResult  66: 1 op, 105045.00 ns, 105.0450 us/op
+WorkloadResult  67: 1 op, 128298.00 ns, 128.2980 us/op
+WorkloadResult  68: 1 op, 103713.00 ns, 103.7130 us/op
+WorkloadResult  69: 1 op, 103913.00 ns, 103.9130 us/op
+WorkloadResult  70: 1 op, 103060.00 ns, 103.0600 us/op
+WorkloadResult  71: 1 op, 101518.00 ns, 101.5180 us/op
+WorkloadResult  72: 1 op, 104564.00 ns, 104.5640 us/op
+WorkloadResult  73: 1 op, 104013.00 ns, 104.0130 us/op
+WorkloadResult  74: 1 op, 104483.00 ns, 104.4830 us/op
+WorkloadResult  75: 1 op, 105175.00 ns, 105.1750 us/op
+WorkloadResult  76: 1 op, 102751.00 ns, 102.7510 us/op
+WorkloadResult  77: 1 op, 104564.00 ns, 104.5640 us/op
+WorkloadResult  78: 1 op, 104864.00 ns, 104.8640 us/op
+WorkloadResult  79: 1 op, 104504.00 ns, 104.5040 us/op
+WorkloadResult  80: 1 op, 104403.00 ns, 104.4030 us/op
+WorkloadResult  81: 1 op, 104123.00 ns, 104.1230 us/op
+// GC:  0 0 0 440 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3435 has exited with code 0.
+
+Mean = 109.911 μs, StdErr = 1.156 μs (1.05%), N = 81, StdDev = 10.408 μs
+Min = 101.518 μs, Q1 = 103.592 μs, Median = 104.504 μs, Q3 = 118.269 μs, Max = 148.135 μs
+IQR = 14.677 μs, LowerFence = 81.576 μs, UpperFence = 140.285 μs
+ConfidenceInterval = [105.960 μs; 113.861 μs] (CI 99.9%), Margin = 3.951 μs (3.59% of Mean)
+Skewness = 1.46, Kurtosis = 4.13, MValue = 2.54
+
+// ** Remained 36 (72.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Gzip Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Gzip_Compress_64KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 14 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-DQONBX(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 263419.00 ns, 263.4190 us/op
+WorkloadJitting  1: 1 op, 233885.00 ns, 233.8850 us/op
+
+OverheadWarmup   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   2: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   3: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   4: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   5: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   6: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   7: 1 op, 270.00 ns, 270.0000 ns/op
+
+OverheadActual   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   2: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   3: 1 op, 390.00 ns, 390.0000 ns/op
+OverheadActual   4: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   5: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual   6: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   7: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual   8: 1 op, 752.00 ns, 752.0000 ns/op
+OverheadActual   9: 1 op, 661.00 ns, 661.0000 ns/op
+OverheadActual  10: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  11: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  12: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  13: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual  14: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  15: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  16: 1 op, 671.00 ns, 671.0000 ns/op
+OverheadActual  17: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  18: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  19: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  20: 1 op, 281.00 ns, 281.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 35967.00 ns, 35.9670 us/op
+WorkloadWarmup   2: 1 op, 29865.00 ns, 29.8650 us/op
+WorkloadWarmup   3: 1 op, 28994.00 ns, 28.9940 us/op
+WorkloadWarmup   4: 1 op, 28473.00 ns, 28.4730 us/op
+WorkloadWarmup   5: 1 op, 28432.00 ns, 28.4320 us/op
+WorkloadWarmup   6: 1 op, 51937.00 ns, 51.9370 us/op
+WorkloadWarmup   7: 1 op, 28604.00 ns, 28.6040 us/op
+WorkloadWarmup   8: 1 op, 28343.00 ns, 28.3430 us/op
+WorkloadWarmup   9: 1 op, 29074.00 ns, 29.0740 us/op
+WorkloadWarmup  10: 1 op, 28283.00 ns, 28.2830 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 30216.00 ns, 30.2160 us/op
+WorkloadActual   2: 1 op, 28723.00 ns, 28.7230 us/op
+WorkloadActual   3: 1 op, 28443.00 ns, 28.4430 us/op
+WorkloadActual   4: 1 op, 28994.00 ns, 28.9940 us/op
+WorkloadActual   5: 1 op, 28383.00 ns, 28.3830 us/op
+WorkloadActual   6: 1 op, 28483.00 ns, 28.4830 us/op
+WorkloadActual   7: 1 op, 28393.00 ns, 28.3930 us/op
+WorkloadActual   8: 1 op, 28343.00 ns, 28.3430 us/op
+WorkloadActual   9: 1 op, 28443.00 ns, 28.4430 us/op
+WorkloadActual  10: 1 op, 28573.00 ns, 28.5730 us/op
+WorkloadActual  11: 1 op, 28843.00 ns, 28.8430 us/op
+WorkloadActual  12: 1 op, 28382.00 ns, 28.3820 us/op
+WorkloadActual  13: 1 op, 28653.00 ns, 28.6530 us/op
+WorkloadActual  14: 1 op, 29505.00 ns, 29.5050 us/op
+WorkloadActual  15: 1 op, 28553.00 ns, 28.5530 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 28422.00 ns, 28.4220 us/op
+WorkloadResult   2: 1 op, 28142.00 ns, 28.1420 us/op
+WorkloadResult   3: 1 op, 28693.00 ns, 28.6930 us/op
+WorkloadResult   4: 1 op, 28082.00 ns, 28.0820 us/op
+WorkloadResult   5: 1 op, 28182.00 ns, 28.1820 us/op
+WorkloadResult   6: 1 op, 28092.00 ns, 28.0920 us/op
+WorkloadResult   7: 1 op, 28042.00 ns, 28.0420 us/op
+WorkloadResult   8: 1 op, 28142.00 ns, 28.1420 us/op
+WorkloadResult   9: 1 op, 28272.00 ns, 28.2720 us/op
+WorkloadResult  10: 1 op, 28542.00 ns, 28.5420 us/op
+WorkloadResult  11: 1 op, 28081.00 ns, 28.0810 us/op
+WorkloadResult  12: 1 op, 28352.00 ns, 28.3520 us/op
+WorkloadResult  13: 1 op, 28252.00 ns, 28.2520 us/op
+// GC:  0 0 0 1336 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3442 has exited with code 0.
+
+Mean = 28.254 μs, StdErr = 0.055 μs (0.20%), N = 13, StdDev = 0.199 μs
+Min = 28.042 μs, Q1 = 28.092 μs, Median = 28.182 μs, Q3 = 28.352 μs, Max = 28.693 μs
+IQR = 0.260 μs, LowerFence = 27.702 μs, UpperFence = 28.742 μs
+ConfidenceInterval = [28.015 μs; 28.492 μs] (CI 99.9%), Margin = 0.238 μs (0.84% of Mean)
+Skewness = 0.86, Kurtosis = 2.45, MValue = 2
+
+// ** Remained 35 (70.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Snappy Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Snappy_Compress_64KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 15 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-NKSEAL(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 289278.00 ns, 289.2780 us/op
+WorkloadJitting  1: 1 op, 251728.00 ns, 251.7280 us/op
+
+OverheadWarmup   1: 1 op, 682.00 ns, 682.0000 ns/op
+OverheadWarmup   2: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadWarmup   3: 1 op, 360.00 ns, 360.0000 ns/op
+OverheadWarmup   4: 1 op, 671.00 ns, 671.0000 ns/op
+OverheadWarmup   5: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadWarmup   6: 1 op, 651.00 ns, 651.0000 ns/op
+OverheadWarmup   7: 1 op, 612.00 ns, 612.0000 ns/op
+
+OverheadActual   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   2: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   3: 1 op, 631.00 ns, 631.0000 ns/op
+OverheadActual   4: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   5: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   6: 1 op, 631.00 ns, 631.0000 ns/op
+OverheadActual   7: 1 op, 630.00 ns, 630.0000 ns/op
+OverheadActual   8: 1 op, 732.00 ns, 732.0000 ns/op
+OverheadActual   9: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  10: 1 op, 621.00 ns, 621.0000 ns/op
+OverheadActual  11: 1 op, 691.00 ns, 691.0000 ns/op
+OverheadActual  12: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  13: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  14: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  15: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  16: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  17: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  18: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  19: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  20: 1 op, 291.00 ns, 291.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 48319.00 ns, 48.3190 us/op
+WorkloadWarmup   2: 1 op, 46466.00 ns, 46.4660 us/op
+WorkloadWarmup   3: 1 op, 46306.00 ns, 46.3060 us/op
+WorkloadWarmup   4: 1 op, 46526.00 ns, 46.5260 us/op
+WorkloadWarmup   5: 1 op, 46165.00 ns, 46.1650 us/op
+WorkloadWarmup   6: 1 op, 46256.00 ns, 46.2560 us/op
+WorkloadWarmup   7: 1 op, 44843.00 ns, 44.8430 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 47739.00 ns, 47.7390 us/op
+WorkloadActual   2: 1 op, 44924.00 ns, 44.9240 us/op
+WorkloadActual   3: 1 op, 44693.00 ns, 44.6930 us/op
+WorkloadActual   4: 1 op, 44653.00 ns, 44.6530 us/op
+WorkloadActual   5: 1 op, 44552.00 ns, 44.5520 us/op
+WorkloadActual   6: 1 op, 44533.00 ns, 44.5330 us/op
+WorkloadActual   7: 1 op, 44122.00 ns, 44.1220 us/op
+WorkloadActual   8: 1 op, 43000.00 ns, 43.0000 us/op
+WorkloadActual   9: 1 op, 42258.00 ns, 42.2580 us/op
+WorkloadActual  10: 1 op, 42168.00 ns, 42.1680 us/op
+WorkloadActual  11: 1 op, 42419.00 ns, 42.4190 us/op
+WorkloadActual  12: 1 op, 42229.00 ns, 42.2290 us/op
+WorkloadActual  13: 1 op, 42179.00 ns, 42.1790 us/op
+WorkloadActual  14: 1 op, 42709.00 ns, 42.7090 us/op
+WorkloadActual  15: 1 op, 42609.00 ns, 42.6090 us/op
+WorkloadActual  16: 1 op, 42540.00 ns, 42.5400 us/op
+WorkloadActual  17: 1 op, 42549.00 ns, 42.5490 us/op
+WorkloadActual  18: 1 op, 42479.00 ns, 42.4790 us/op
+WorkloadActual  19: 1 op, 42239.00 ns, 42.2390 us/op
+WorkloadActual  20: 1 op, 42098.00 ns, 42.0980 us/op
+WorkloadActual  21: 1 op, 42189.00 ns, 42.1890 us/op
+WorkloadActual  22: 1 op, 42238.00 ns, 42.2380 us/op
+WorkloadActual  23: 1 op, 42469.00 ns, 42.4690 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 44628.50 ns, 44.6285 us/op
+WorkloadResult   2: 1 op, 44397.50 ns, 44.3975 us/op
+WorkloadResult   3: 1 op, 44357.50 ns, 44.3575 us/op
+WorkloadResult   4: 1 op, 44256.50 ns, 44.2565 us/op
+WorkloadResult   5: 1 op, 44237.50 ns, 44.2375 us/op
+WorkloadResult   6: 1 op, 43826.50 ns, 43.8265 us/op
+WorkloadResult   7: 1 op, 42704.50 ns, 42.7045 us/op
+WorkloadResult   8: 1 op, 41962.50 ns, 41.9625 us/op
+WorkloadResult   9: 1 op, 41872.50 ns, 41.8725 us/op
+WorkloadResult  10: 1 op, 42123.50 ns, 42.1235 us/op
+WorkloadResult  11: 1 op, 41933.50 ns, 41.9335 us/op
+WorkloadResult  12: 1 op, 41883.50 ns, 41.8835 us/op
+WorkloadResult  13: 1 op, 42413.50 ns, 42.4135 us/op
+WorkloadResult  14: 1 op, 42313.50 ns, 42.3135 us/op
+WorkloadResult  15: 1 op, 42244.50 ns, 42.2445 us/op
+WorkloadResult  16: 1 op, 42253.50 ns, 42.2535 us/op
+WorkloadResult  17: 1 op, 42183.50 ns, 42.1835 us/op
+WorkloadResult  18: 1 op, 41943.50 ns, 41.9435 us/op
+WorkloadResult  19: 1 op, 41802.50 ns, 41.8025 us/op
+WorkloadResult  20: 1 op, 41893.50 ns, 41.8935 us/op
+WorkloadResult  21: 1 op, 41942.50 ns, 41.9425 us/op
+WorkloadResult  22: 1 op, 42173.50 ns, 42.1735 us/op
+// GC:  0 0 0 1120 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3449 has exited with code 0.
+
+Mean = 42.698 μs, StdErr = 0.218 μs (0.51%), N = 22, StdDev = 1.024 μs
+Min = 41.803 μs, Q1 = 41.943 μs, Median = 42.214 μs, Q3 = 43.546 μs, Max = 44.629 μs
+IQR = 1.603 μs, LowerFence = 39.538 μs, UpperFence = 45.951 μs
+ConfidenceInterval = [41.864 μs; 43.531 μs] (CI 99.9%), Margin = 0.833 μs (1.95% of Mean)
+Skewness = 0.88, Kurtosis = 1.93, MValue = 2.75
+
+// ** Remained 34 (68.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'LZ4 Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Lz4_Compress_64KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 16 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-MBJIVB(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 255114.00 ns, 255.1140 us/op
+WorkloadJitting  1: 1 op, 245987.00 ns, 245.9870 us/op
+
+OverheadWarmup   1: 1 op, 621.00 ns, 621.0000 ns/op
+OverheadWarmup   2: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   3: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   4: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   6: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   7: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   8: 1 op, 260.00 ns, 260.0000 ns/op
+
+OverheadActual   1: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   3: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   4: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   5: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   6: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   7: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   8: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   9: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  10: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  11: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual  12: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  13: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  14: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  15: 1 op, 270.00 ns, 270.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 45305.00 ns, 45.3050 us/op
+WorkloadWarmup   2: 1 op, 43140.00 ns, 43.1400 us/op
+WorkloadWarmup   3: 1 op, 43080.00 ns, 43.0800 us/op
+WorkloadWarmup   4: 1 op, 42700.00 ns, 42.7000 us/op
+WorkloadWarmup   5: 1 op, 43010.00 ns, 43.0100 us/op
+WorkloadWarmup   6: 1 op, 42750.00 ns, 42.7500 us/op
+WorkloadWarmup   7: 1 op, 41998.00 ns, 41.9980 us/op
+WorkloadWarmup   8: 1 op, 40556.00 ns, 40.5560 us/op
+WorkloadWarmup   9: 1 op, 41166.00 ns, 41.1660 us/op
+WorkloadWarmup  10: 1 op, 40385.00 ns, 40.3850 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 42048.00 ns, 42.0480 us/op
+WorkloadActual   2: 1 op, 40746.00 ns, 40.7460 us/op
+WorkloadActual   3: 1 op, 41136.00 ns, 41.1360 us/op
+WorkloadActual   4: 1 op, 40666.00 ns, 40.6660 us/op
+WorkloadActual   5: 1 op, 40485.00 ns, 40.4850 us/op
+WorkloadActual   6: 1 op, 41447.00 ns, 41.4470 us/op
+WorkloadActual   7: 1 op, 41267.00 ns, 41.2670 us/op
+WorkloadActual   8: 1 op, 40445.00 ns, 40.4450 us/op
+WorkloadActual   9: 1 op, 40916.00 ns, 40.9160 us/op
+WorkloadActual  10: 1 op, 41097.00 ns, 41.0970 us/op
+WorkloadActual  11: 1 op, 40586.00 ns, 40.5860 us/op
+WorkloadActual  12: 1 op, 40886.00 ns, 40.8860 us/op
+WorkloadActual  13: 1 op, 40947.00 ns, 40.9470 us/op
+WorkloadActual  14: 1 op, 40956.00 ns, 40.9560 us/op
+WorkloadActual  15: 1 op, 41227.00 ns, 41.2270 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 40456.00 ns, 40.4560 us/op
+WorkloadResult   2: 1 op, 40846.00 ns, 40.8460 us/op
+WorkloadResult   3: 1 op, 40376.00 ns, 40.3760 us/op
+WorkloadResult   4: 1 op, 40195.00 ns, 40.1950 us/op
+WorkloadResult   5: 1 op, 41157.00 ns, 41.1570 us/op
+WorkloadResult   6: 1 op, 40977.00 ns, 40.9770 us/op
+WorkloadResult   7: 1 op, 40155.00 ns, 40.1550 us/op
+WorkloadResult   8: 1 op, 40626.00 ns, 40.6260 us/op
+WorkloadResult   9: 1 op, 40807.00 ns, 40.8070 us/op
+WorkloadResult  10: 1 op, 40296.00 ns, 40.2960 us/op
+WorkloadResult  11: 1 op, 40596.00 ns, 40.5960 us/op
+WorkloadResult  12: 1 op, 40657.00 ns, 40.6570 us/op
+WorkloadResult  13: 1 op, 40666.00 ns, 40.6660 us/op
+WorkloadResult  14: 1 op, 40937.00 ns, 40.9370 us/op
+// GC:  0 0 0 1560 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3456 has exited with code 0.
+
+Mean = 40.625 μs, StdErr = 0.081 μs (0.20%), N = 14, StdDev = 0.303 μs
+Min = 40.155 μs, Q1 = 40.396 μs, Median = 40.642 μs, Q3 = 40.836 μs, Max = 41.157 μs
+IQR = 0.440 μs, LowerFence = 39.736 μs, UpperFence = 41.497 μs
+ConfidenceInterval = [40.283 μs; 40.967 μs] (CI 99.9%), Margin = 0.342 μs (0.84% of Mean)
+Skewness = 0.01, Kurtosis = 1.76, MValue = 2
+
+// ** Remained 33 (66.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Zstd Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Zstd_Compress_64KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 17 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-TGBYYT(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 284088.00 ns, 284.0880 us/op
+WorkloadJitting  1: 1 op, 331366.00 ns, 331.3660 us/op
+
+OverheadWarmup   1: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   2: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   3: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   4: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   5: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   6: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   7: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   8: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   9: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup  10: 1 op, 281.00 ns, 281.0000 ns/op
+
+OverheadActual   1: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   2: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   3: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   4: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   5: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   6: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   7: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   8: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   9: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  10: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadActual  11: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  12: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  13: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  14: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  15: 1 op, 301.00 ns, 301.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 124952.00 ns, 124.9520 us/op
+WorkloadWarmup   2: 1 op, 120755.00 ns, 120.7550 us/op
+WorkloadWarmup   3: 1 op, 118480.00 ns, 118.4800 us/op
+WorkloadWarmup   4: 1 op, 118400.00 ns, 118.4000 us/op
+WorkloadWarmup   5: 1 op, 117508.00 ns, 117.5080 us/op
+WorkloadWarmup   6: 1 op, 118280.00 ns, 118.2800 us/op
+WorkloadWarmup   7: 1 op, 118270.00 ns, 118.2700 us/op
+WorkloadWarmup   8: 1 op, 117990.00 ns, 117.9900 us/op
+WorkloadWarmup   9: 1 op, 117979.00 ns, 117.9790 us/op
+WorkloadWarmup  10: 1 op, 117910.00 ns, 117.9100 us/op
+WorkloadWarmup  11: 1 op, 118290.00 ns, 118.2900 us/op
+WorkloadWarmup  12: 1 op, 144008.00 ns, 144.0080 us/op
+WorkloadWarmup  13: 1 op, 118591.00 ns, 118.5910 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 162692.00 ns, 162.6920 us/op
+WorkloadActual   2: 1 op, 163794.00 ns, 163.7940 us/op
+WorkloadActual   3: 1 op, 161681.00 ns, 161.6810 us/op
+WorkloadActual   4: 1 op, 164176.00 ns, 164.1760 us/op
+WorkloadActual   5: 1 op, 184572.00 ns, 184.5720 us/op
+WorkloadActual   6: 1 op, 187107.00 ns, 187.1070 us/op
+WorkloadActual   7: 1 op, 162472.00 ns, 162.4720 us/op
+WorkloadActual   8: 1 op, 166890.00 ns, 166.8900 us/op
+WorkloadActual   9: 1 op, 162131.00 ns, 162.1310 us/op
+WorkloadActual  10: 1 op, 162632.00 ns, 162.6320 us/op
+WorkloadActual  11: 1 op, 161801.00 ns, 161.8010 us/op
+WorkloadActual  12: 1 op, 160248.00 ns, 160.2480 us/op
+WorkloadActual  13: 1 op, 191315.00 ns, 191.3150 us/op
+WorkloadActual  14: 1 op, 180836.00 ns, 180.8360 us/op
+WorkloadActual  15: 1 op, 158925.00 ns, 158.9250 us/op
+WorkloadActual  16: 1 op, 160729.00 ns, 160.7290 us/op
+WorkloadActual  17: 1 op, 162572.00 ns, 162.5720 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 162401.00 ns, 162.4010 us/op
+WorkloadResult   2: 1 op, 163503.00 ns, 163.5030 us/op
+WorkloadResult   3: 1 op, 161390.00 ns, 161.3900 us/op
+WorkloadResult   4: 1 op, 163885.00 ns, 163.8850 us/op
+WorkloadResult   5: 1 op, 162181.00 ns, 162.1810 us/op
+WorkloadResult   6: 1 op, 166599.00 ns, 166.5990 us/op
+WorkloadResult   7: 1 op, 161840.00 ns, 161.8400 us/op
+WorkloadResult   8: 1 op, 162341.00 ns, 162.3410 us/op
+WorkloadResult   9: 1 op, 161510.00 ns, 161.5100 us/op
+WorkloadResult  10: 1 op, 159957.00 ns, 159.9570 us/op
+WorkloadResult  11: 1 op, 158634.00 ns, 158.6340 us/op
+WorkloadResult  12: 1 op, 160438.00 ns, 160.4380 us/op
+WorkloadResult  13: 1 op, 162281.00 ns, 162.2810 us/op
+// GC:  0 0 0 1136 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3463 has exited with code 0.
+
+Mean = 162.074 μs, StdErr = 0.542 μs (0.33%), N = 13, StdDev = 1.955 μs
+Min = 158.634 μs, Q1 = 161.390 μs, Median = 162.181 μs, Q3 = 162.401 μs, Max = 166.599 μs
+IQR = 1.011 μs, LowerFence = 159.874 μs, UpperFence = 163.917 μs
+ConfidenceInterval = [159.733 μs; 164.415 μs] (CI 99.9%), Margin = 2.341 μs (1.44% of Mean)
+Skewness = 0.48, Kurtosis = 3.17, MValue = 2
+
+// ** Remained 32 (64.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Brotli Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Brotli_Compress_64KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 18 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-VPBVUH(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 262257.00 ns, 262.2570 us/op
+WorkloadJitting  1: 1 op, 229717.00 ns, 229.7170 us/op
+
+OverheadWarmup   1: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   2: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   3: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   4: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   5: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   6: 1 op, 301.00 ns, 301.0000 ns/op
+
+OverheadActual   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   2: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   3: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   4: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   5: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   6: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   7: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   8: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   9: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  10: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  11: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  12: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  13: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  14: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  15: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  16: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  17: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  18: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  19: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  20: 1 op, 301.00 ns, 301.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 35496.00 ns, 35.4960 us/op
+WorkloadWarmup   2: 1 op, 30577.00 ns, 30.5770 us/op
+WorkloadWarmup   3: 1 op, 29405.00 ns, 29.4050 us/op
+WorkloadWarmup   4: 1 op, 29295.00 ns, 29.2950 us/op
+WorkloadWarmup   5: 1 op, 29445.00 ns, 29.4450 us/op
+WorkloadWarmup   6: 1 op, 60934.00 ns, 60.9340 us/op
+WorkloadWarmup   7: 1 op, 29345.00 ns, 29.3450 us/op
+WorkloadWarmup   8: 1 op, 28974.00 ns, 28.9740 us/op
+WorkloadWarmup   9: 1 op, 29214.00 ns, 29.2140 us/op
+WorkloadWarmup  10: 1 op, 29024.00 ns, 29.0240 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 31098.00 ns, 31.0980 us/op
+WorkloadActual   2: 1 op, 29555.00 ns, 29.5550 us/op
+WorkloadActual   3: 1 op, 29254.00 ns, 29.2540 us/op
+WorkloadActual   4: 1 op, 29815.00 ns, 29.8150 us/op
+WorkloadActual   5: 1 op, 28914.00 ns, 28.9140 us/op
+WorkloadActual   6: 1 op, 29054.00 ns, 29.0540 us/op
+WorkloadActual   7: 1 op, 29054.00 ns, 29.0540 us/op
+WorkloadActual   8: 1 op, 28924.00 ns, 28.9240 us/op
+WorkloadActual   9: 1 op, 28954.00 ns, 28.9540 us/op
+WorkloadActual  10: 1 op, 28924.00 ns, 28.9240 us/op
+WorkloadActual  11: 1 op, 29184.00 ns, 29.1840 us/op
+WorkloadActual  12: 1 op, 28753.00 ns, 28.7530 us/op
+WorkloadActual  13: 1 op, 29094.00 ns, 29.0940 us/op
+WorkloadActual  14: 1 op, 28803.00 ns, 28.8030 us/op
+WorkloadActual  15: 1 op, 28944.00 ns, 28.9440 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 29249.00 ns, 29.2490 us/op
+WorkloadResult   2: 1 op, 28948.00 ns, 28.9480 us/op
+WorkloadResult   3: 1 op, 28608.00 ns, 28.6080 us/op
+WorkloadResult   4: 1 op, 28748.00 ns, 28.7480 us/op
+WorkloadResult   5: 1 op, 28748.00 ns, 28.7480 us/op
+WorkloadResult   6: 1 op, 28618.00 ns, 28.6180 us/op
+WorkloadResult   7: 1 op, 28648.00 ns, 28.6480 us/op
+WorkloadResult   8: 1 op, 28618.00 ns, 28.6180 us/op
+WorkloadResult   9: 1 op, 28878.00 ns, 28.8780 us/op
+WorkloadResult  10: 1 op, 28447.00 ns, 28.4470 us/op
+WorkloadResult  11: 1 op, 28788.00 ns, 28.7880 us/op
+WorkloadResult  12: 1 op, 28497.00 ns, 28.4970 us/op
+WorkloadResult  13: 1 op, 28638.00 ns, 28.6380 us/op
+// GC:  0 0 0 1448 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3470 has exited with code 0.
+
+Mean = 28.726 μs, StdErr = 0.058 μs (0.20%), N = 13, StdDev = 0.211 μs
+Min = 28.447 μs, Q1 = 28.618 μs, Median = 28.648 μs, Q3 = 28.788 μs, Max = 29.249 μs
+IQR = 0.170 μs, LowerFence = 28.363 μs, UpperFence = 29.043 μs
+ConfidenceInterval = [28.473 μs; 28.978 μs] (CI 99.9%), Margin = 0.252 μs (0.88% of Mean)
+Skewness = 0.98, Kurtosis = 3.42, MValue = 2
+
+// ** Remained 31 (62.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Gzip Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Gzip_Decompress_1KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 19 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-UUOWGD(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 257498.00 ns, 257.4980 us/op
+WorkloadJitting  1: 1 op, 975373.00 ns, 975.3730 us/op
+
+OverheadWarmup   1: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadWarmup   2: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   3: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   4: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   6: 1 op, 671.00 ns, 671.0000 ns/op
+OverheadWarmup   7: 1 op, 661.00 ns, 661.0000 ns/op
+
+OverheadActual   1: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual   2: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   3: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual   4: 1 op, 691.00 ns, 691.0000 ns/op
+OverheadActual   5: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   6: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   7: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   8: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   9: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual  10: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  11: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  12: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  13: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  14: 1 op, 672.00 ns, 672.0000 ns/op
+OverheadActual  15: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  16: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  17: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual  18: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  19: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  20: 1 op, 290.00 ns, 290.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 68778.00 ns, 68.7780 us/op
+WorkloadWarmup   2: 1 op, 14036.00 ns, 14.0360 us/op
+WorkloadWarmup   3: 1 op, 13746.00 ns, 13.7460 us/op
+WorkloadWarmup   4: 1 op, 13715.00 ns, 13.7150 us/op
+WorkloadWarmup   5: 1 op, 13515.00 ns, 13.5150 us/op
+WorkloadWarmup   6: 1 op, 13715.00 ns, 13.7150 us/op
+WorkloadWarmup   7: 1 op, 13496.00 ns, 13.4960 us/op
+WorkloadWarmup   8: 1 op, 13435.00 ns, 13.4350 us/op
+WorkloadWarmup   9: 1 op, 13445.00 ns, 13.4450 us/op
+WorkloadWarmup  10: 1 op, 13535.00 ns, 13.5350 us/op
+WorkloadWarmup  11: 1 op, 13355.00 ns, 13.3550 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 14226.00 ns, 14.2260 us/op
+WorkloadActual   2: 1 op, 13645.00 ns, 13.6450 us/op
+WorkloadActual   3: 1 op, 13515.00 ns, 13.5150 us/op
+WorkloadActual   4: 1 op, 13415.00 ns, 13.4150 us/op
+WorkloadActual   5: 1 op, 13646.00 ns, 13.6460 us/op
+WorkloadActual   6: 1 op, 13596.00 ns, 13.5960 us/op
+WorkloadActual   7: 1 op, 13896.00 ns, 13.8960 us/op
+WorkloadActual   8: 1 op, 13676.00 ns, 13.6760 us/op
+WorkloadActual   9: 1 op, 13715.00 ns, 13.7150 us/op
+WorkloadActual  10: 1 op, 13546.00 ns, 13.5460 us/op
+WorkloadActual  11: 1 op, 13776.00 ns, 13.7760 us/op
+WorkloadActual  12: 1 op, 13445.00 ns, 13.4450 us/op
+WorkloadActual  13: 1 op, 13665.00 ns, 13.6650 us/op
+WorkloadActual  14: 1 op, 13445.00 ns, 13.4450 us/op
+WorkloadActual  15: 1 op, 13385.00 ns, 13.3850 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 13345.00 ns, 13.3450 us/op
+WorkloadResult   2: 1 op, 13215.00 ns, 13.2150 us/op
+WorkloadResult   3: 1 op, 13115.00 ns, 13.1150 us/op
+WorkloadResult   4: 1 op, 13346.00 ns, 13.3460 us/op
+WorkloadResult   5: 1 op, 13296.00 ns, 13.2960 us/op
+WorkloadResult   6: 1 op, 13596.00 ns, 13.5960 us/op
+WorkloadResult   7: 1 op, 13376.00 ns, 13.3760 us/op
+WorkloadResult   8: 1 op, 13415.00 ns, 13.4150 us/op
+WorkloadResult   9: 1 op, 13246.00 ns, 13.2460 us/op
+WorkloadResult  10: 1 op, 13476.00 ns, 13.4760 us/op
+WorkloadResult  11: 1 op, 13145.00 ns, 13.1450 us/op
+WorkloadResult  12: 1 op, 13365.00 ns, 13.3650 us/op
+WorkloadResult  13: 1 op, 13145.00 ns, 13.1450 us/op
+WorkloadResult  14: 1 op, 13085.00 ns, 13.0850 us/op
+// GC:  0 0 0 1384 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3477 has exited with code 0.
+
+Mean = 13.298 μs, StdErr = 0.040 μs (0.30%), N = 14, StdDev = 0.148 μs
+Min = 13.085 μs, Q1 = 13.162 μs, Median = 13.320 μs, Q3 = 13.373 μs, Max = 13.596 μs
+IQR = 0.211 μs, LowerFence = 12.846 μs, UpperFence = 13.689 μs
+ConfidenceInterval = [13.131 μs; 13.464 μs] (CI 99.9%), Margin = 0.167 μs (1.26% of Mean)
+Skewness = 0.25, Kurtosis = 2.01, MValue = 2
+
+// ** Remained 30 (60.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Snappy Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Snappy_Decompress_1KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 20 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-KMECBK(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 270263.00 ns, 270.2630 us/op
+WorkloadJitting  1: 1 op, 8375165.00 ns, 8.3752 ms/op
+
+OverheadWarmup   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   2: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadWarmup   3: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadWarmup   4: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   5: 1 op, 280.00 ns, 280.0000 ns/op
+
+OverheadActual   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   3: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   4: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   5: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadActual   6: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   7: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   8: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   9: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  10: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  11: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  12: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  13: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  14: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  15: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual  16: 1 op, 280.00 ns, 280.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 13204.00 ns, 13.2040 us/op
+WorkloadWarmup   2: 1 op, 8235.00 ns, 8.2350 us/op
+WorkloadWarmup   3: 1 op, 8075.00 ns, 8.0750 us/op
+WorkloadWarmup   4: 1 op, 8185.00 ns, 8.1850 us/op
+WorkloadWarmup   5: 1 op, 7975.00 ns, 7.9750 us/op
+WorkloadWarmup   6: 1 op, 7965.00 ns, 7.9650 us/op
+WorkloadWarmup   7: 1 op, 8126.00 ns, 8.1260 us/op
+WorkloadWarmup   8: 1 op, 7975.00 ns, 7.9750 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 8545.00 ns, 8.5450 us/op
+WorkloadActual   2: 1 op, 8135.00 ns, 8.1350 us/op
+WorkloadActual   3: 1 op, 8225.00 ns, 8.2250 us/op
+WorkloadActual   4: 1 op, 31779.00 ns, 31.7790 us/op
+WorkloadActual   5: 1 op, 8236.00 ns, 8.2360 us/op
+WorkloadActual   6: 1 op, 8065.00 ns, 8.0650 us/op
+WorkloadActual   7: 1 op, 8065.00 ns, 8.0650 us/op
+WorkloadActual   8: 1 op, 8025.00 ns, 8.0250 us/op
+WorkloadActual   9: 1 op, 8055.00 ns, 8.0550 us/op
+WorkloadActual  10: 1 op, 7965.00 ns, 7.9650 us/op
+WorkloadActual  11: 1 op, 7955.00 ns, 7.9550 us/op
+WorkloadActual  12: 1 op, 7924.00 ns, 7.9240 us/op
+WorkloadActual  13: 1 op, 8105.00 ns, 8.1050 us/op
+WorkloadActual  14: 1 op, 8075.00 ns, 8.0750 us/op
+WorkloadActual  15: 1 op, 7954.00 ns, 7.9540 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 7849.50 ns, 7.8495 us/op
+WorkloadResult   2: 1 op, 7939.50 ns, 7.9395 us/op
+WorkloadResult   3: 1 op, 7950.50 ns, 7.9505 us/op
+WorkloadResult   4: 1 op, 7779.50 ns, 7.7795 us/op
+WorkloadResult   5: 1 op, 7779.50 ns, 7.7795 us/op
+WorkloadResult   6: 1 op, 7739.50 ns, 7.7395 us/op
+WorkloadResult   7: 1 op, 7769.50 ns, 7.7695 us/op
+WorkloadResult   8: 1 op, 7679.50 ns, 7.6795 us/op
+WorkloadResult   9: 1 op, 7669.50 ns, 7.6695 us/op
+WorkloadResult  10: 1 op, 7638.50 ns, 7.6385 us/op
+WorkloadResult  11: 1 op, 7819.50 ns, 7.8195 us/op
+WorkloadResult  12: 1 op, 7789.50 ns, 7.7895 us/op
+WorkloadResult  13: 1 op, 7668.50 ns, 7.6685 us/op
+// GC:  0 0 0 1152 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3484 has exited with code 0.
+
+Mean = 7.775 μs, StdErr = 0.027 μs (0.35%), N = 13, StdDev = 0.099 μs
+Min = 7.638 μs, Q1 = 7.679 μs, Median = 7.779 μs, Q3 = 7.819 μs, Max = 7.950 μs
+IQR = 0.140 μs, LowerFence = 7.470 μs, UpperFence = 8.030 μs
+ConfidenceInterval = [7.656 μs; 7.893 μs] (CI 99.9%), Margin = 0.118 μs (1.52% of Mean)
+Skewness = 0.37, Kurtosis = 1.94, MValue = 2
+
+// ** Remained 29 (58.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'LZ4 Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Lz4_Decompress_1KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 21 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-AHCREP(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 260374.00 ns, 260.3740 us/op
+WorkloadJitting  1: 1 op, 5407201.00 ns, 5.4072 ms/op
+
+OverheadWarmup   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   2: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   3: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   4: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   5: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   6: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   7: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   8: 1 op, 310.00 ns, 310.0000 ns/op
+
+OverheadActual   1: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   2: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   3: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   4: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   5: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   6: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   7: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   8: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   9: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  10: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadActual  11: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  12: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  13: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  14: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  15: 1 op, 300.00 ns, 300.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 68738.00 ns, 68.7380 us/op
+WorkloadWarmup   2: 1 op, 13966.00 ns, 13.9660 us/op
+WorkloadWarmup   3: 1 op, 13846.00 ns, 13.8460 us/op
+WorkloadWarmup   4: 1 op, 13645.00 ns, 13.6450 us/op
+WorkloadWarmup   5: 1 op, 13395.00 ns, 13.3950 us/op
+WorkloadWarmup   6: 1 op, 13375.00 ns, 13.3750 us/op
+WorkloadWarmup   7: 1 op, 13345.00 ns, 13.3450 us/op
+WorkloadWarmup   8: 1 op, 13434.00 ns, 13.4340 us/op
+WorkloadWarmup   9: 1 op, 13365.00 ns, 13.3650 us/op
+WorkloadWarmup  10: 1 op, 13425.00 ns, 13.4250 us/op
+WorkloadWarmup  11: 1 op, 13415.00 ns, 13.4150 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 13966.00 ns, 13.9660 us/op
+WorkloadActual   2: 1 op, 13786.00 ns, 13.7860 us/op
+WorkloadActual   3: 1 op, 13385.00 ns, 13.3850 us/op
+WorkloadActual   4: 1 op, 13626.00 ns, 13.6260 us/op
+WorkloadActual   5: 1 op, 13565.00 ns, 13.5650 us/op
+WorkloadActual   6: 1 op, 13625.00 ns, 13.6250 us/op
+WorkloadActual   7: 1 op, 13445.00 ns, 13.4450 us/op
+WorkloadActual   8: 1 op, 13374.00 ns, 13.3740 us/op
+WorkloadActual   9: 1 op, 13566.00 ns, 13.5660 us/op
+WorkloadActual  10: 1 op, 13355.00 ns, 13.3550 us/op
+WorkloadActual  11: 1 op, 13595.00 ns, 13.5950 us/op
+WorkloadActual  12: 1 op, 13365.00 ns, 13.3650 us/op
+WorkloadActual  13: 1 op, 13755.00 ns, 13.7550 us/op
+WorkloadActual  14: 1 op, 13365.00 ns, 13.3650 us/op
+WorkloadActual  15: 1 op, 13294.00 ns, 13.2940 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 13676.00 ns, 13.6760 us/op
+WorkloadResult   2: 1 op, 13496.00 ns, 13.4960 us/op
+WorkloadResult   3: 1 op, 13095.00 ns, 13.0950 us/op
+WorkloadResult   4: 1 op, 13336.00 ns, 13.3360 us/op
+WorkloadResult   5: 1 op, 13275.00 ns, 13.2750 us/op
+WorkloadResult   6: 1 op, 13335.00 ns, 13.3350 us/op
+WorkloadResult   7: 1 op, 13155.00 ns, 13.1550 us/op
+WorkloadResult   8: 1 op, 13084.00 ns, 13.0840 us/op
+WorkloadResult   9: 1 op, 13276.00 ns, 13.2760 us/op
+WorkloadResult  10: 1 op, 13065.00 ns, 13.0650 us/op
+WorkloadResult  11: 1 op, 13305.00 ns, 13.3050 us/op
+WorkloadResult  12: 1 op, 13075.00 ns, 13.0750 us/op
+WorkloadResult  13: 1 op, 13465.00 ns, 13.4650 us/op
+WorkloadResult  14: 1 op, 13075.00 ns, 13.0750 us/op
+WorkloadResult  15: 1 op, 13004.00 ns, 13.0040 us/op
+// GC:  0 0 0 1584 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3491 has exited with code 0.
+
+Mean = 13.248 μs, StdErr = 0.050 μs (0.38%), N = 15, StdDev = 0.193 μs
+Min = 13.004 μs, Q1 = 13.079 μs, Median = 13.275 μs, Q3 = 13.335 μs, Max = 13.676 μs
+IQR = 0.256 μs, LowerFence = 12.695 μs, UpperFence = 13.720 μs
+ConfidenceInterval = [13.041 μs; 13.455 μs] (CI 99.9%), Margin = 0.207 μs (1.56% of Mean)
+Skewness = 0.61, Kurtosis = 2.27, MValue = 2
+
+// ** Remained 28 (56.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Zstd Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Zstd_Decompress_1KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 22 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-XSKRZE(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 257479.00 ns, 257.4790 us/op
+WorkloadJitting  1: 1 op, 13077397.00 ns, 13.0774 ms/op
+
+OverheadWarmup   1: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadWarmup   2: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   3: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadWarmup   4: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadWarmup   5: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   6: 1 op, 260.00 ns, 260.0000 ns/op
+
+OverheadActual   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   2: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   3: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   4: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   5: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   6: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   7: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   8: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   9: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  10: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  11: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual  12: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  13: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  14: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual  15: 1 op, 300.00 ns, 300.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 29425.00 ns, 29.4250 us/op
+WorkloadWarmup   2: 1 op, 23875.00 ns, 23.8750 us/op
+WorkloadWarmup   3: 1 op, 23223.00 ns, 23.2230 us/op
+WorkloadWarmup   4: 1 op, 23424.00 ns, 23.4240 us/op
+WorkloadWarmup   5: 1 op, 23253.00 ns, 23.2530 us/op
+WorkloadWarmup   6: 1 op, 23213.00 ns, 23.2130 us/op
+WorkloadWarmup   7: 1 op, 23443.00 ns, 23.4430 us/op
+WorkloadWarmup   8: 1 op, 23203.00 ns, 23.2030 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 23503.00 ns, 23.5030 us/op
+WorkloadActual   2: 1 op, 23383.00 ns, 23.3830 us/op
+WorkloadActual   3: 1 op, 23253.00 ns, 23.2530 us/op
+WorkloadActual   4: 1 op, 23153.00 ns, 23.1530 us/op
+WorkloadActual   5: 1 op, 23123.00 ns, 23.1230 us/op
+WorkloadActual   6: 1 op, 23103.00 ns, 23.1030 us/op
+WorkloadActual   7: 1 op, 22952.00 ns, 22.9520 us/op
+WorkloadActual   8: 1 op, 22762.00 ns, 22.7620 us/op
+WorkloadActual   9: 1 op, 23043.00 ns, 23.0430 us/op
+WorkloadActual  10: 1 op, 22712.00 ns, 22.7120 us/op
+WorkloadActual  11: 1 op, 23063.00 ns, 23.0630 us/op
+WorkloadActual  12: 1 op, 22793.00 ns, 22.7930 us/op
+WorkloadActual  13: 1 op, 23043.00 ns, 23.0430 us/op
+WorkloadActual  14: 1 op, 22872.00 ns, 22.8720 us/op
+WorkloadActual  15: 1 op, 22823.00 ns, 22.8230 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 23203.00 ns, 23.2030 us/op
+WorkloadResult   2: 1 op, 23083.00 ns, 23.0830 us/op
+WorkloadResult   3: 1 op, 22953.00 ns, 22.9530 us/op
+WorkloadResult   4: 1 op, 22853.00 ns, 22.8530 us/op
+WorkloadResult   5: 1 op, 22823.00 ns, 22.8230 us/op
+WorkloadResult   6: 1 op, 22803.00 ns, 22.8030 us/op
+WorkloadResult   7: 1 op, 22652.00 ns, 22.6520 us/op
+WorkloadResult   8: 1 op, 22462.00 ns, 22.4620 us/op
+WorkloadResult   9: 1 op, 22743.00 ns, 22.7430 us/op
+WorkloadResult  10: 1 op, 22412.00 ns, 22.4120 us/op
+WorkloadResult  11: 1 op, 22763.00 ns, 22.7630 us/op
+WorkloadResult  12: 1 op, 22493.00 ns, 22.4930 us/op
+WorkloadResult  13: 1 op, 22743.00 ns, 22.7430 us/op
+WorkloadResult  14: 1 op, 22572.00 ns, 22.5720 us/op
+WorkloadResult  15: 1 op, 22523.00 ns, 22.5230 us/op
+// GC:  0 0 0 1128 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3498 has exited with code 0.
+
+Mean = 22.739 μs, StdErr = 0.059 μs (0.26%), N = 15, StdDev = 0.228 μs
+Min = 22.412 μs, Q1 = 22.547 μs, Median = 22.743 μs, Q3 = 22.838 μs, Max = 23.203 μs
+IQR = 0.290 μs, LowerFence = 22.112 μs, UpperFence = 23.274 μs
+ConfidenceInterval = [22.495 μs; 22.983 μs] (CI 99.9%), Margin = 0.244 μs (1.07% of Mean)
+Skewness = 0.37, Kurtosis = 2.12, MValue = 2
+
+// ** Remained 27 (54.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Brotli Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Brotli_Decompress_1KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 23 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-DNIUUU(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 260344.00 ns, 260.3440 us/op
+WorkloadJitting  1: 1 op, 943404.00 ns, 943.4040 us/op
+
+OverheadWarmup   1: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   2: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   3: 1 op, 691.00 ns, 691.0000 ns/op
+OverheadWarmup   4: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadWarmup   5: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadWarmup   6: 1 op, 291.00 ns, 291.0000 ns/op
+
+OverheadActual   1: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   2: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   3: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   4: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   5: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   6: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   7: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   8: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   9: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  10: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual  11: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  12: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  13: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  14: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  15: 1 op, 270.00 ns, 270.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 26359.00 ns, 26.3590 us/op
+WorkloadWarmup   2: 1 op, 20217.00 ns, 20.2170 us/op
+WorkloadWarmup   3: 1 op, 47658.00 ns, 47.6580 us/op
+WorkloadWarmup   4: 1 op, 19436.00 ns, 19.4360 us/op
+WorkloadWarmup   5: 1 op, 19406.00 ns, 19.4060 us/op
+WorkloadWarmup   6: 1 op, 19427.00 ns, 19.4270 us/op
+WorkloadWarmup   7: 1 op, 19096.00 ns, 19.0960 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 26159.00 ns, 26.1590 us/op
+WorkloadActual   2: 1 op, 19847.00 ns, 19.8470 us/op
+WorkloadActual   3: 1 op, 19677.00 ns, 19.6770 us/op
+WorkloadActual   4: 1 op, 18995.00 ns, 18.9950 us/op
+WorkloadActual   5: 1 op, 18745.00 ns, 18.7450 us/op
+WorkloadActual   6: 1 op, 18695.00 ns, 18.6950 us/op
+WorkloadActual   7: 1 op, 18896.00 ns, 18.8960 us/op
+WorkloadActual   8: 1 op, 18625.00 ns, 18.6250 us/op
+WorkloadActual   9: 1 op, 19006.00 ns, 19.0060 us/op
+WorkloadActual  10: 1 op, 18966.00 ns, 18.9660 us/op
+WorkloadActual  11: 1 op, 18564.00 ns, 18.5640 us/op
+WorkloadActual  12: 1 op, 18715.00 ns, 18.7150 us/op
+WorkloadActual  13: 1 op, 18715.00 ns, 18.7150 us/op
+WorkloadActual  14: 1 op, 18444.00 ns, 18.4440 us/op
+WorkloadActual  15: 1 op, 18945.00 ns, 18.9450 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 18705.00 ns, 18.7050 us/op
+WorkloadResult   2: 1 op, 18455.00 ns, 18.4550 us/op
+WorkloadResult   3: 1 op, 18405.00 ns, 18.4050 us/op
+WorkloadResult   4: 1 op, 18606.00 ns, 18.6060 us/op
+WorkloadResult   5: 1 op, 18335.00 ns, 18.3350 us/op
+WorkloadResult   6: 1 op, 18716.00 ns, 18.7160 us/op
+WorkloadResult   7: 1 op, 18676.00 ns, 18.6760 us/op
+WorkloadResult   8: 1 op, 18274.00 ns, 18.2740 us/op
+WorkloadResult   9: 1 op, 18425.00 ns, 18.4250 us/op
+WorkloadResult  10: 1 op, 18425.00 ns, 18.4250 us/op
+WorkloadResult  11: 1 op, 18154.00 ns, 18.1540 us/op
+WorkloadResult  12: 1 op, 18655.00 ns, 18.6550 us/op
+// GC:  0 0 0 1480 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3505 has exited with code 0.
+
+Mean = 18.486 μs, StdErr = 0.053 μs (0.29%), N = 12, StdDev = 0.184 μs
+Min = 18.154 μs, Q1 = 18.387 μs, Median = 18.440 μs, Q3 = 18.660 μs, Max = 18.716 μs
+IQR = 0.273 μs, LowerFence = 17.978 μs, UpperFence = 19.069 μs
+ConfidenceInterval = [18.250 μs; 18.722 μs] (CI 99.9%), Margin = 0.236 μs (1.28% of Mean)
+Skewness = -0.19, Kurtosis = 1.61, MValue = 2
+
+// ** Remained 26 (52.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Gzip Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Gzip_Decompress_1MB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 24 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-IBKFKA(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 261747.00 ns, 261.7470 us/op
+WorkloadJitting  1: 1 op, 1738602.00 ns, 1.7386 ms/op
+
+OverheadWarmup   1: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadWarmup   2: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadWarmup   3: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   4: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   5: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadWarmup   6: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   7: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   8: 1 op, 280.00 ns, 280.0000 ns/op
+
+OverheadActual   1: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   2: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   3: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   4: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   5: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   6: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   7: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   8: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   9: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  10: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  11: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  12: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  13: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  14: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  15: 1 op, 311.00 ns, 311.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 231230.00 ns, 231.2300 us/op
+WorkloadWarmup   2: 1 op, 225770.00 ns, 225.7700 us/op
+WorkloadWarmup   3: 1 op, 214518.00 ns, 214.5180 us/op
+WorkloadWarmup   4: 1 op, 222193.00 ns, 222.1930 us/op
+WorkloadWarmup   5: 1 op, 211523.00 ns, 211.5230 us/op
+WorkloadWarmup   6: 1 op, 220179.00 ns, 220.1790 us/op
+WorkloadWarmup   7: 1 op, 210722.00 ns, 210.7220 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 220840.00 ns, 220.8400 us/op
+WorkloadActual   2: 1 op, 210501.00 ns, 210.5010 us/op
+WorkloadActual   3: 1 op, 218466.00 ns, 218.4660 us/op
+WorkloadActual   4: 1 op, 209299.00 ns, 209.2990 us/op
+WorkloadActual   5: 1 op, 217945.00 ns, 217.9450 us/op
+WorkloadActual   6: 1 op, 210090.00 ns, 210.0900 us/op
+WorkloadActual   7: 1 op, 218717.00 ns, 218.7170 us/op
+WorkloadActual   8: 1 op, 209550.00 ns, 209.5500 us/op
+WorkloadActual   9: 1 op, 218386.00 ns, 218.3860 us/op
+WorkloadActual  10: 1 op, 210221.00 ns, 210.2210 us/op
+WorkloadActual  11: 1 op, 244324.00 ns, 244.3240 us/op
+WorkloadActual  12: 1 op, 224938.00 ns, 224.9380 us/op
+WorkloadActual  13: 1 op, 233634.00 ns, 233.6340 us/op
+WorkloadActual  14: 1 op, 208648.00 ns, 208.6480 us/op
+WorkloadActual  15: 1 op, 217574.00 ns, 217.5740 us/op
+WorkloadActual  16: 1 op, 209489.00 ns, 209.4890 us/op
+WorkloadActual  17: 1 op, 217624.00 ns, 217.6240 us/op
+WorkloadActual  18: 1 op, 210631.00 ns, 210.6310 us/op
+WorkloadActual  19: 1 op, 218717.00 ns, 218.7170 us/op
+WorkloadActual  20: 1 op, 210280.00 ns, 210.2800 us/op
+WorkloadActual  21: 1 op, 218125.00 ns, 218.1250 us/op
+WorkloadActual  22: 1 op, 209900.00 ns, 209.9000 us/op
+WorkloadActual  23: 1 op, 218337.00 ns, 218.3370 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 220529.00 ns, 220.5290 us/op
+WorkloadResult   2: 1 op, 210190.00 ns, 210.1900 us/op
+WorkloadResult   3: 1 op, 218155.00 ns, 218.1550 us/op
+WorkloadResult   4: 1 op, 208988.00 ns, 208.9880 us/op
+WorkloadResult   5: 1 op, 217634.00 ns, 217.6340 us/op
+WorkloadResult   6: 1 op, 209779.00 ns, 209.7790 us/op
+WorkloadResult   7: 1 op, 218406.00 ns, 218.4060 us/op
+WorkloadResult   8: 1 op, 209239.00 ns, 209.2390 us/op
+WorkloadResult   9: 1 op, 218075.00 ns, 218.0750 us/op
+WorkloadResult  10: 1 op, 209910.00 ns, 209.9100 us/op
+WorkloadResult  11: 1 op, 224627.00 ns, 224.6270 us/op
+WorkloadResult  12: 1 op, 208337.00 ns, 208.3370 us/op
+WorkloadResult  13: 1 op, 217263.00 ns, 217.2630 us/op
+WorkloadResult  14: 1 op, 209178.00 ns, 209.1780 us/op
+WorkloadResult  15: 1 op, 217313.00 ns, 217.3130 us/op
+WorkloadResult  16: 1 op, 210320.00 ns, 210.3200 us/op
+WorkloadResult  17: 1 op, 218406.00 ns, 218.4060 us/op
+WorkloadResult  18: 1 op, 209969.00 ns, 209.9690 us/op
+WorkloadResult  19: 1 op, 217814.00 ns, 217.8140 us/op
+WorkloadResult  20: 1 op, 209589.00 ns, 209.5890 us/op
+WorkloadResult  21: 1 op, 218026.00 ns, 218.0260 us/op
+// GC:  0 0 0 1384 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3512 has exited with code 0.
+
+Mean = 214.369 μs, StdErr = 1.083 μs (0.51%), N = 21, StdDev = 4.962 μs
+Min = 208.337 μs, Q1 = 209.779 μs, Median = 217.263 μs, Q3 = 218.075 μs, Max = 224.627 μs
+IQR = 8.296 μs, LowerFence = 197.335 μs, UpperFence = 230.519 μs
+ConfidenceInterval = [210.201 μs; 218.537 μs] (CI 99.9%), Margin = 4.168 μs (1.94% of Mean)
+Skewness = 0.22, Kurtosis = 1.56, MValue = 4
+
+// ** Remained 25 (50.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Snappy Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Snappy_Decompress_1MB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 25 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-SPJUBD(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 254664.00 ns, 254.6640 us/op
+WorkloadJitting  1: 1 op, 13706096.00 ns, 13.7061 ms/op
+
+OverheadWarmup   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   2: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadWarmup   3: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   4: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   5: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadWarmup   6: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   7: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   8: 1 op, 260.00 ns, 260.0000 ns/op
+
+OverheadActual   1: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   2: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   3: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   4: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   5: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   6: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   7: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   8: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual   9: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  10: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  11: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  12: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  13: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  14: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  15: 1 op, 300.00 ns, 300.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 1815906.00 ns, 1.8159 ms/op
+WorkloadWarmup   2: 1 op, 1684641.00 ns, 1.6846 ms/op
+WorkloadWarmup   3: 1 op, 1673140.00 ns, 1.6731 ms/op
+WorkloadWarmup   4: 1 op, 1605624.00 ns, 1.6056 ms/op
+WorkloadWarmup   5: 1 op, 1597870.00 ns, 1.5979 ms/op
+WorkloadWarmup   6: 1 op, 1611415.00 ns, 1.6114 ms/op
+WorkloadWarmup   7: 1 op, 1608911.00 ns, 1.6089 ms/op
+WorkloadWarmup   8: 1 op, 1575629.00 ns, 1.5756 ms/op
+WorkloadWarmup   9: 1 op, 1577802.00 ns, 1.5778 ms/op
+WorkloadWarmup  10: 1 op, 1577743.00 ns, 1.5777 ms/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 1589374.00 ns, 1.5894 ms/op
+WorkloadActual   2: 1 op, 1600415.00 ns, 1.6004 ms/op
+WorkloadActual   3: 1 op, 1586288.00 ns, 1.5863 ms/op
+WorkloadActual   4: 1 op, 1666858.00 ns, 1.6669 ms/op
+WorkloadActual   5: 1 op, 1635129.00 ns, 1.6351 ms/op
+WorkloadActual   6: 1 op, 1586459.00 ns, 1.5865 ms/op
+WorkloadActual   7: 1 op, 1605695.00 ns, 1.6057 ms/op
+WorkloadActual   8: 1 op, 1582862.00 ns, 1.5829 ms/op
+WorkloadActual   9: 1 op, 1571932.00 ns, 1.5719 ms/op
+WorkloadActual  10: 1 op, 1588393.00 ns, 1.5884 ms/op
+WorkloadActual  11: 1 op, 1586479.00 ns, 1.5865 ms/op
+WorkloadActual  12: 1 op, 1573504.00 ns, 1.5735 ms/op
+WorkloadActual  13: 1 op, 1573284.00 ns, 1.5733 ms/op
+WorkloadActual  14: 1 op, 1585467.00 ns, 1.5855 ms/op
+WorkloadActual  15: 1 op, 1569257.00 ns, 1.5693 ms/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 1589094.00 ns, 1.5891 ms/op
+WorkloadResult   2: 1 op, 1600135.00 ns, 1.6001 ms/op
+WorkloadResult   3: 1 op, 1586008.00 ns, 1.5860 ms/op
+WorkloadResult   4: 1 op, 1586179.00 ns, 1.5862 ms/op
+WorkloadResult   5: 1 op, 1605415.00 ns, 1.6054 ms/op
+WorkloadResult   6: 1 op, 1582582.00 ns, 1.5826 ms/op
+WorkloadResult   7: 1 op, 1571652.00 ns, 1.5717 ms/op
+WorkloadResult   8: 1 op, 1588113.00 ns, 1.5881 ms/op
+WorkloadResult   9: 1 op, 1586199.00 ns, 1.5862 ms/op
+WorkloadResult  10: 1 op, 1573224.00 ns, 1.5732 ms/op
+WorkloadResult  11: 1 op, 1573004.00 ns, 1.5730 ms/op
+WorkloadResult  12: 1 op, 1585187.00 ns, 1.5852 ms/op
+WorkloadResult  13: 1 op, 1568977.00 ns, 1.5690 ms/op
+// GC:  0 0 0 2352 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3519 has exited with code 0.
+
+Mean = 1.584 ms, StdErr = 0.003 ms (0.19%), N = 13, StdDev = 0.011 ms
+Min = 1.569 ms, Q1 = 1.573 ms, Median = 1.586 ms, Q3 = 1.588 ms, Max = 1.605 ms
+IQR = 0.015 ms, LowerFence = 1.551 ms, UpperFence = 1.610 ms
+ConfidenceInterval = [1.571 ms; 1.597 ms] (CI 99.9%), Margin = 0.013 ms (0.81% of Mean)
+Skewness = 0.32, Kurtosis = 2.14, MValue = 2
+
+// ** Remained 24 (48.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'LZ4 Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Lz4_Decompress_1MB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 26 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-UHRPDN(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 254052.00 ns, 254.0520 us/op
+WorkloadJitting  1: 1 op, 6673144.00 ns, 6.6731 ms/op
+
+OverheadWarmup   1: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   2: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadWarmup   3: 1 op, 692.00 ns, 692.0000 ns/op
+OverheadWarmup   4: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadWarmup   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   6: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   7: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   8: 1 op, 290.00 ns, 290.0000 ns/op
+
+OverheadActual   1: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   2: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   3: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   4: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   5: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   6: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   7: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   8: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   9: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  10: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  11: 1 op, 240.00 ns, 240.0000 ns/op
+OverheadActual  12: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  13: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  14: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  15: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual  16: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  17: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual  18: 1 op, 291.00 ns, 291.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 534363.00 ns, 534.3630 us/op
+WorkloadWarmup   2: 1 op, 580559.00 ns, 580.5590 us/op
+WorkloadWarmup   3: 1 op, 594034.00 ns, 594.0340 us/op
+WorkloadWarmup   4: 1 op, 557086.00 ns, 557.0860 us/op
+WorkloadWarmup   5: 1 op, 539583.00 ns, 539.5830 us/op
+WorkloadWarmup   6: 1 op, 555192.00 ns, 555.1920 us/op
+WorkloadWarmup   7: 1 op, 548429.00 ns, 548.4290 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 517932.00 ns, 517.9320 us/op
+WorkloadActual   2: 1 op, 533392.00 ns, 533.3920 us/op
+WorkloadActual   3: 1 op, 534944.00 ns, 534.9440 us/op
+WorkloadActual   4: 1 op, 516320.00 ns, 516.3200 us/op
+WorkloadActual   5: 1 op, 515598.00 ns, 515.5980 us/op
+WorkloadActual   6: 1 op, 531678.00 ns, 531.6780 us/op
+WorkloadActual   7: 1 op, 530146.00 ns, 530.1460 us/op
+WorkloadActual   8: 1 op, 519526.00 ns, 519.5260 us/op
+WorkloadActual   9: 1 op, 505840.00 ns, 505.8400 us/op
+WorkloadActual  10: 1 op, 506952.00 ns, 506.9520 us/op
+WorkloadActual  11: 1 op, 525186.00 ns, 525.1860 us/op
+WorkloadActual  12: 1 op, 521609.00 ns, 521.6090 us/op
+WorkloadActual  13: 1 op, 505439.00 ns, 505.4390 us/op
+WorkloadActual  14: 1 op, 506722.00 ns, 506.7220 us/op
+WorkloadActual  15: 1 op, 524084.00 ns, 524.0840 us/op
+WorkloadActual  16: 1 op, 522572.00 ns, 522.5720 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 517651.00 ns, 517.6510 us/op
+WorkloadResult   2: 1 op, 533111.00 ns, 533.1110 us/op
+WorkloadResult   3: 1 op, 534663.00 ns, 534.6630 us/op
+WorkloadResult   4: 1 op, 516039.00 ns, 516.0390 us/op
+WorkloadResult   5: 1 op, 515317.00 ns, 515.3170 us/op
+WorkloadResult   6: 1 op, 531397.00 ns, 531.3970 us/op
+WorkloadResult   7: 1 op, 529865.00 ns, 529.8650 us/op
+WorkloadResult   8: 1 op, 519245.00 ns, 519.2450 us/op
+WorkloadResult   9: 1 op, 505559.00 ns, 505.5590 us/op
+WorkloadResult  10: 1 op, 506671.00 ns, 506.6710 us/op
+WorkloadResult  11: 1 op, 524905.00 ns, 524.9050 us/op
+WorkloadResult  12: 1 op, 521328.00 ns, 521.3280 us/op
+WorkloadResult  13: 1 op, 505158.00 ns, 505.1580 us/op
+WorkloadResult  14: 1 op, 506441.00 ns, 506.4410 us/op
+WorkloadResult  15: 1 op, 523803.00 ns, 523.8030 us/op
+WorkloadResult  16: 1 op, 522291.00 ns, 522.2910 us/op
+// GC:  0 0 0 1584 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3526 has exited with code 0.
+
+Mean = 519.590 μs, StdErr = 2.492 μs (0.48%), N = 16, StdDev = 9.970 μs
+Min = 505.158 μs, Q1 = 513.155 μs, Median = 520.287 μs, Q3 = 526.145 μs, Max = 534.663 μs
+IQR = 12.989 μs, LowerFence = 493.671 μs, UpperFence = 545.629 μs
+ConfidenceInterval = [509.439 μs; 529.742 μs] (CI 99.9%), Margin = 10.151 μs (1.95% of Mean)
+Skewness = -0.09, Kurtosis = 1.63, MValue = 2
+
+// ** Remained 23 (46.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Zstd Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Zstd_Decompress_1MB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 27 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-NDWICC(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 255054.00 ns, 255.0540 us/op
+WorkloadJitting  1: 1 op, 14160861.00 ns, 14.1609 ms/op
+
+OverheadWarmup   1: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   3: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   4: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   5: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadWarmup   6: 1 op, 291.00 ns, 291.0000 ns/op
+
+OverheadActual   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   3: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   4: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   5: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   6: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   7: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   8: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   9: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  10: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  11: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  12: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  13: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  14: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  15: 1 op, 271.00 ns, 271.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 371771.00 ns, 371.7710 us/op
+WorkloadWarmup   2: 1 op, 371120.00 ns, 371.1200 us/op
+WorkloadWarmup   3: 1 op, 338639.00 ns, 338.6390 us/op
+WorkloadWarmup   4: 1 op, 339931.00 ns, 339.9310 us/op
+WorkloadWarmup   5: 1 op, 333120.00 ns, 333.1200 us/op
+WorkloadWarmup   6: 1 op, 332678.00 ns, 332.6780 us/op
+WorkloadWarmup   7: 1 op, 322039.00 ns, 322.0390 us/op
+WorkloadWarmup   8: 1 op, 318813.00 ns, 318.8130 us/op
+WorkloadWarmup   9: 1 op, 311490.00 ns, 311.4900 us/op
+WorkloadWarmup  10: 1 op, 314575.00 ns, 314.5750 us/op
+WorkloadWarmup  11: 1 op, 312010.00 ns, 312.0100 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 298294.00 ns, 298.2940 us/op
+WorkloadActual   2: 1 op, 298765.00 ns, 298.7650 us/op
+WorkloadActual   3: 1 op, 298274.00 ns, 298.2740 us/op
+WorkloadActual   4: 1 op, 293325.00 ns, 293.3250 us/op
+WorkloadActual   5: 1 op, 288566.00 ns, 288.5660 us/op
+WorkloadActual   6: 1 op, 287865.00 ns, 287.8650 us/op
+WorkloadActual   7: 1 op, 288476.00 ns, 288.4760 us/op
+WorkloadActual   8: 1 op, 289338.00 ns, 289.3380 us/op
+WorkloadActual   9: 1 op, 289308.00 ns, 289.3080 us/op
+WorkloadActual  10: 1 op, 289578.00 ns, 289.5780 us/op
+WorkloadActual  11: 1 op, 290730.00 ns, 290.7300 us/op
+WorkloadActual  12: 1 op, 288346.00 ns, 288.3460 us/op
+WorkloadActual  13: 1 op, 288115.00 ns, 288.1150 us/op
+WorkloadActual  14: 1 op, 288536.00 ns, 288.5360 us/op
+WorkloadActual  15: 1 op, 288757.00 ns, 288.7570 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 293034.00 ns, 293.0340 us/op
+WorkloadResult   2: 1 op, 288275.00 ns, 288.2750 us/op
+WorkloadResult   3: 1 op, 287574.00 ns, 287.5740 us/op
+WorkloadResult   4: 1 op, 288185.00 ns, 288.1850 us/op
+WorkloadResult   5: 1 op, 289047.00 ns, 289.0470 us/op
+WorkloadResult   6: 1 op, 289017.00 ns, 289.0170 us/op
+WorkloadResult   7: 1 op, 289287.00 ns, 289.2870 us/op
+WorkloadResult   8: 1 op, 290439.00 ns, 290.4390 us/op
+WorkloadResult   9: 1 op, 288055.00 ns, 288.0550 us/op
+WorkloadResult  10: 1 op, 287824.00 ns, 287.8240 us/op
+WorkloadResult  11: 1 op, 288245.00 ns, 288.2450 us/op
+WorkloadResult  12: 1 op, 288466.00 ns, 288.4660 us/op
+// GC:  0 0 0 1128 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3533 has exited with code 0.
+
+Mean = 288.954 μs, StdErr = 0.433 μs (0.15%), N = 12, StdDev = 1.500 μs
+Min = 287.574 μs, Q1 = 288.152 μs, Median = 288.370 μs, Q3 = 289.107 μs, Max = 293.034 μs
+IQR = 0.955 μs, LowerFence = 286.721 μs, UpperFence = 290.539 μs
+ConfidenceInterval = [287.032 μs; 290.876 μs] (CI 99.9%), Margin = 1.922 μs (0.67% of Mean)
+Skewness = 1.61, Kurtosis = 4.75, MValue = 2
+
+// ** Remained 22 (44.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Brotli Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Brotli_Decompress_1MB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 28 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-LNJCSK(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 288446.00 ns, 288.4460 us/op
+WorkloadJitting  1: 1 op, 2265571.00 ns, 2.2656 ms/op
+
+OverheadWarmup   1: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   2: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   3: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadWarmup   4: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadWarmup   5: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadWarmup   6: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   7: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadWarmup   8: 1 op, 281.00 ns, 281.0000 ns/op
+
+OverheadActual   1: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual   2: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   3: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   4: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   5: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   6: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual   7: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   8: 1 op, 661.00 ns, 661.0000 ns/op
+OverheadActual   9: 1 op, 681.00 ns, 681.0000 ns/op
+OverheadActual  10: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadActual  11: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  12: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  13: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  14: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  15: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  16: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  17: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  18: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadActual  19: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  20: 1 op, 271.00 ns, 271.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 722623.00 ns, 722.6230 us/op
+WorkloadWarmup   2: 1 op, 718827.00 ns, 718.8270 us/op
+WorkloadWarmup   3: 1 op, 724687.00 ns, 724.6870 us/op
+WorkloadWarmup   4: 1 op, 712725.00 ns, 712.7250 us/op
+WorkloadWarmup   5: 1 op, 675145.00 ns, 675.1450 us/op
+WorkloadWarmup   6: 1 op, 704459.00 ns, 704.4590 us/op
+WorkloadWarmup   7: 1 op, 673843.00 ns, 673.8430 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 736349.00 ns, 736.3490 us/op
+WorkloadActual   2: 1 op, 708607.00 ns, 708.6070 us/op
+WorkloadActual   3: 1 op, 708317.00 ns, 708.3170 us/op
+WorkloadActual   4: 1 op, 724537.00 ns, 724.5370 us/op
+WorkloadActual   5: 1 op, 698418.00 ns, 698.4180 us/op
+WorkloadActual   6: 1 op, 679422.00 ns, 679.4220 us/op
+WorkloadActual   7: 1 op, 696915.00 ns, 696.9150 us/op
+WorkloadActual   8: 1 op, 687468.00 ns, 687.4680 us/op
+WorkloadActual   9: 1 op, 699189.00 ns, 699.1890 us/op
+WorkloadActual  10: 1 op, 706594.00 ns, 706.5940 us/op
+WorkloadActual  11: 1 op, 714649.00 ns, 714.6490 us/op
+WorkloadActual  12: 1 op, 706994.00 ns, 706.9940 us/op
+WorkloadActual  13: 1 op, 672581.00 ns, 672.5810 us/op
+WorkloadActual  14: 1 op, 704550.00 ns, 704.5500 us/op
+WorkloadActual  15: 1 op, 688780.00 ns, 688.7800 us/op
+WorkloadActual  16: 1 op, 728273.00 ns, 728.2730 us/op
+WorkloadActual  17: 1 op, 707815.00 ns, 707.8150 us/op
+WorkloadActual  18: 1 op, 725058.00 ns, 725.0580 us/op
+WorkloadActual  19: 1 op, 715860.00 ns, 715.8600 us/op
+WorkloadActual  20: 1 op, 680485.00 ns, 680.4850 us/op
+WorkloadActual  21: 1 op, 700542.00 ns, 700.5420 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 736058.50 ns, 736.0585 us/op
+WorkloadResult   2: 1 op, 708316.50 ns, 708.3165 us/op
+WorkloadResult   3: 1 op, 708026.50 ns, 708.0265 us/op
+WorkloadResult   4: 1 op, 724246.50 ns, 724.2465 us/op
+WorkloadResult   5: 1 op, 698127.50 ns, 698.1275 us/op
+WorkloadResult   6: 1 op, 679131.50 ns, 679.1315 us/op
+WorkloadResult   7: 1 op, 696624.50 ns, 696.6245 us/op
+WorkloadResult   8: 1 op, 687177.50 ns, 687.1775 us/op
+WorkloadResult   9: 1 op, 698898.50 ns, 698.8985 us/op
+WorkloadResult  10: 1 op, 706303.50 ns, 706.3035 us/op
+WorkloadResult  11: 1 op, 714358.50 ns, 714.3585 us/op
+WorkloadResult  12: 1 op, 706703.50 ns, 706.7035 us/op
+WorkloadResult  13: 1 op, 672290.50 ns, 672.2905 us/op
+WorkloadResult  14: 1 op, 704259.50 ns, 704.2595 us/op
+WorkloadResult  15: 1 op, 688489.50 ns, 688.4895 us/op
+WorkloadResult  16: 1 op, 727982.50 ns, 727.9825 us/op
+WorkloadResult  17: 1 op, 707524.50 ns, 707.5245 us/op
+WorkloadResult  18: 1 op, 724767.50 ns, 724.7675 us/op
+WorkloadResult  19: 1 op, 715569.50 ns, 715.5695 us/op
+WorkloadResult  20: 1 op, 680194.50 ns, 680.1945 us/op
+WorkloadResult  21: 1 op, 700251.50 ns, 700.2515 us/op
+// GC:  0 0 0 1480 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3540 has exited with code 0.
+
+Mean = 704.062 μs, StdErr = 3.648 μs (0.52%), N = 21, StdDev = 16.716 μs
+Min = 672.290 μs, Q1 = 696.625 μs, Median = 706.303 μs, Q3 = 714.359 μs, Max = 736.058 μs
+IQR = 17.734 μs, LowerFence = 670.024 μs, UpperFence = 740.960 μs
+ConfidenceInterval = [690.020 μs; 718.104 μs] (CI 99.9%), Margin = 14.042 μs (1.99% of Mean)
+Skewness = -0.04, Kurtosis = 2.21, MValue = 2
+
+// ** Remained 21 (42.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Gzip Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Gzip_Decompress_64KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 29 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-IHAOXV(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 262147.00 ns, 262.1470 us/op
+WorkloadJitting  1: 1 op, 1035124.00 ns, 1.0351 ms/op
+
+OverheadWarmup   1: 1 op, 681.00 ns, 681.0000 ns/op
+OverheadWarmup   2: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadWarmup   3: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadWarmup   4: 1 op, 251.00 ns, 251.0000 ns/op
+OverheadWarmup   5: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadWarmup   6: 1 op, 260.00 ns, 260.0000 ns/op
+
+OverheadActual   1: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   2: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   3: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   4: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   5: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   6: 1 op, 250.00 ns, 250.0000 ns/op
+OverheadActual   7: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual   8: 1 op, 230.00 ns, 230.0000 ns/op
+OverheadActual   9: 1 op, 250.00 ns, 250.0000 ns/op
+OverheadActual  10: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  11: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  12: 1 op, 250.00 ns, 250.0000 ns/op
+OverheadActual  13: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual  14: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  15: 1 op, 241.00 ns, 241.0000 ns/op
+OverheadActual  16: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  17: 1 op, 251.00 ns, 251.0000 ns/op
+OverheadActual  18: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual  19: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  20: 1 op, 250.00 ns, 250.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 58178.00 ns, 58.1780 us/op
+WorkloadWarmup   2: 1 op, 27020.00 ns, 27.0200 us/op
+WorkloadWarmup   3: 1 op, 27161.00 ns, 27.1610 us/op
+WorkloadWarmup   4: 1 op, 26489.00 ns, 26.4890 us/op
+WorkloadWarmup   5: 1 op, 26900.00 ns, 26.9000 us/op
+WorkloadWarmup   6: 1 op, 26750.00 ns, 26.7500 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 39173.00 ns, 39.1730 us/op
+WorkloadActual   2: 1 op, 57516.00 ns, 57.5160 us/op
+WorkloadActual   3: 1 op, 36869.00 ns, 36.8690 us/op
+WorkloadActual   4: 1 op, 36908.00 ns, 36.9080 us/op
+WorkloadActual   5: 1 op, 36989.00 ns, 36.9890 us/op
+WorkloadActual   6: 1 op, 35786.00 ns, 35.7860 us/op
+WorkloadActual   7: 1 op, 36969.00 ns, 36.9690 us/op
+WorkloadActual   8: 1 op, 36738.00 ns, 36.7380 us/op
+WorkloadActual   9: 1 op, 37609.00 ns, 37.6090 us/op
+WorkloadActual  10: 1 op, 36107.00 ns, 36.1070 us/op
+WorkloadActual  11: 1 op, 36618.00 ns, 36.6180 us/op
+WorkloadActual  12: 1 op, 26309.00 ns, 26.3090 us/op
+WorkloadActual  13: 1 op, 26440.00 ns, 26.4400 us/op
+WorkloadActual  14: 1 op, 26039.00 ns, 26.0390 us/op
+WorkloadActual  15: 1 op, 26269.00 ns, 26.2690 us/op
+WorkloadActual  16: 1 op, 25989.00 ns, 25.9890 us/op
+WorkloadActual  17: 1 op, 43621.00 ns, 43.6210 us/op
+WorkloadActual  18: 1 op, 26259.00 ns, 26.2590 us/op
+WorkloadActual  19: 1 op, 26460.00 ns, 26.4600 us/op
+WorkloadActual  20: 1 op, 26159.00 ns, 26.1590 us/op
+WorkloadActual  21: 1 op, 26670.00 ns, 26.6700 us/op
+WorkloadActual  22: 1 op, 25989.00 ns, 25.9890 us/op
+WorkloadActual  23: 1 op, 26649.00 ns, 26.6490 us/op
+WorkloadActual  24: 1 op, 26059.00 ns, 26.0590 us/op
+WorkloadActual  25: 1 op, 26409.00 ns, 26.4090 us/op
+WorkloadActual  26: 1 op, 26409.00 ns, 26.4090 us/op
+WorkloadActual  27: 1 op, 26740.00 ns, 26.7400 us/op
+WorkloadActual  28: 1 op, 26400.00 ns, 26.4000 us/op
+WorkloadActual  29: 1 op, 26760.00 ns, 26.7600 us/op
+WorkloadActual  30: 1 op, 26429.00 ns, 26.4290 us/op
+WorkloadActual  31: 1 op, 26780.00 ns, 26.7800 us/op
+WorkloadActual  32: 1 op, 26489.00 ns, 26.4890 us/op
+WorkloadActual  33: 1 op, 26700.00 ns, 26.7000 us/op
+WorkloadActual  34: 1 op, 26329.00 ns, 26.3290 us/op
+WorkloadActual  35: 1 op, 26890.00 ns, 26.8900 us/op
+WorkloadActual  36: 1 op, 26299.00 ns, 26.2990 us/op
+WorkloadActual  37: 1 op, 26790.00 ns, 26.7900 us/op
+WorkloadActual  38: 1 op, 26449.00 ns, 26.4490 us/op
+WorkloadActual  39: 1 op, 26679.00 ns, 26.6790 us/op
+WorkloadActual  40: 1 op, 26209.00 ns, 26.2090 us/op
+WorkloadActual  41: 1 op, 26549.00 ns, 26.5490 us/op
+WorkloadActual  42: 1 op, 26259.00 ns, 26.2590 us/op
+WorkloadActual  43: 1 op, 26589.00 ns, 26.5890 us/op
+WorkloadActual  44: 1 op, 26349.00 ns, 26.3490 us/op
+WorkloadActual  45: 1 op, 26429.00 ns, 26.4290 us/op
+WorkloadActual  46: 1 op, 26429.00 ns, 26.4290 us/op
+WorkloadActual  47: 1 op, 26659.00 ns, 26.6590 us/op
+WorkloadActual  48: 1 op, 26289.00 ns, 26.2890 us/op
+WorkloadActual  49: 1 op, 26429.00 ns, 26.4290 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 26038.50 ns, 26.0385 us/op
+WorkloadResult   2: 1 op, 26169.50 ns, 26.1695 us/op
+WorkloadResult   3: 1 op, 25768.50 ns, 25.7685 us/op
+WorkloadResult   4: 1 op, 25998.50 ns, 25.9985 us/op
+WorkloadResult   5: 1 op, 25718.50 ns, 25.7185 us/op
+WorkloadResult   6: 1 op, 25988.50 ns, 25.9885 us/op
+WorkloadResult   7: 1 op, 26189.50 ns, 26.1895 us/op
+WorkloadResult   8: 1 op, 25888.50 ns, 25.8885 us/op
+WorkloadResult   9: 1 op, 26399.50 ns, 26.3995 us/op
+WorkloadResult  10: 1 op, 25718.50 ns, 25.7185 us/op
+WorkloadResult  11: 1 op, 26378.50 ns, 26.3785 us/op
+WorkloadResult  12: 1 op, 25788.50 ns, 25.7885 us/op
+WorkloadResult  13: 1 op, 26138.50 ns, 26.1385 us/op
+WorkloadResult  14: 1 op, 26138.50 ns, 26.1385 us/op
+WorkloadResult  15: 1 op, 26469.50 ns, 26.4695 us/op
+WorkloadResult  16: 1 op, 26129.50 ns, 26.1295 us/op
+WorkloadResult  17: 1 op, 26489.50 ns, 26.4895 us/op
+WorkloadResult  18: 1 op, 26158.50 ns, 26.1585 us/op
+WorkloadResult  19: 1 op, 26509.50 ns, 26.5095 us/op
+WorkloadResult  20: 1 op, 26218.50 ns, 26.2185 us/op
+WorkloadResult  21: 1 op, 26429.50 ns, 26.4295 us/op
+WorkloadResult  22: 1 op, 26058.50 ns, 26.0585 us/op
+WorkloadResult  23: 1 op, 26619.50 ns, 26.6195 us/op
+WorkloadResult  24: 1 op, 26028.50 ns, 26.0285 us/op
+WorkloadResult  25: 1 op, 26519.50 ns, 26.5195 us/op
+WorkloadResult  26: 1 op, 26178.50 ns, 26.1785 us/op
+WorkloadResult  27: 1 op, 26408.50 ns, 26.4085 us/op
+WorkloadResult  28: 1 op, 25938.50 ns, 25.9385 us/op
+WorkloadResult  29: 1 op, 26278.50 ns, 26.2785 us/op
+WorkloadResult  30: 1 op, 25988.50 ns, 25.9885 us/op
+WorkloadResult  31: 1 op, 26318.50 ns, 26.3185 us/op
+WorkloadResult  32: 1 op, 26078.50 ns, 26.0785 us/op
+WorkloadResult  33: 1 op, 26158.50 ns, 26.1585 us/op
+WorkloadResult  34: 1 op, 26158.50 ns, 26.1585 us/op
+WorkloadResult  35: 1 op, 26388.50 ns, 26.3885 us/op
+WorkloadResult  36: 1 op, 26018.50 ns, 26.0185 us/op
+WorkloadResult  37: 1 op, 26158.50 ns, 26.1585 us/op
+// GC:  0 0 0 1384 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3547 has exited with code 0.
+
+Mean = 26.163 μs, StdErr = 0.038 μs (0.15%), N = 37, StdDev = 0.233 μs
+Min = 25.718 μs, Q1 = 26.018 μs, Median = 26.159 μs, Q3 = 26.378 μs, Max = 26.619 μs
+IQR = 0.360 μs, LowerFence = 25.479 μs, UpperFence = 26.919 μs
+ConfidenceInterval = [26.025 μs; 26.300 μs] (CI 99.9%), Margin = 0.137 μs (0.53% of Mean)
+Skewness = -0.05, Kurtosis = 2.23, MValue = 2
+
+// ** Remained 20 (40.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Snappy Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Snappy_Decompress_64KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 30 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-LMDPXK(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 257098.00 ns, 257.0980 us/op
+WorkloadJitting  1: 1 op, 8371701.00 ns, 8.3717 ms/op
+
+OverheadWarmup   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   2: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadWarmup   3: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   4: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   5: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadWarmup   6: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   7: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadWarmup   8: 1 op, 641.00 ns, 641.0000 ns/op
+
+OverheadActual   1: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   2: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   3: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   4: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   6: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   7: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   8: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual   9: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  10: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  11: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  12: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadActual  13: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  14: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  15: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  16: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  17: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadActual  18: 1 op, 531.00 ns, 531.0000 ns/op
+OverheadActual  19: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  20: 1 op, 291.00 ns, 291.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 98192.00 ns, 98.1920 us/op
+WorkloadWarmup   2: 1 op, 93705.00 ns, 93.7050 us/op
+WorkloadWarmup   3: 1 op, 93614.00 ns, 93.6140 us/op
+WorkloadWarmup   4: 1 op, 117098.00 ns, 117.0980 us/op
+WorkloadWarmup   5: 1 op, 93443.00 ns, 93.4430 us/op
+WorkloadWarmup   6: 1 op, 93463.00 ns, 93.4630 us/op
+WorkloadWarmup   7: 1 op, 93695.00 ns, 93.6950 us/op
+WorkloadWarmup   8: 1 op, 135172.00 ns, 135.1720 us/op
+WorkloadWarmup   9: 1 op, 3608287.00 ns, 3.6083 ms/op
+WorkloadWarmup  10: 1 op, 134309.00 ns, 134.3090 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 157121.00 ns, 157.1210 us/op
+WorkloadActual   2: 1 op, 144138.00 ns, 144.1380 us/op
+WorkloadActual   3: 1 op, 143998.00 ns, 143.9980 us/op
+WorkloadActual   4: 1 op, 143767.00 ns, 143.7670 us/op
+WorkloadActual   5: 1 op, 143407.00 ns, 143.4070 us/op
+WorkloadActual   6: 1 op, 156952.00 ns, 156.9520 us/op
+WorkloadActual   7: 1 op, 130934.00 ns, 130.9340 us/op
+WorkloadActual   8: 1 op, 130102.00 ns, 130.1020 us/op
+WorkloadActual   9: 1 op, 129871.00 ns, 129.8710 us/op
+WorkloadActual  10: 1 op, 134130.00 ns, 134.1300 us/op
+WorkloadActual  11: 1 op, 133188.00 ns, 133.1880 us/op
+WorkloadActual  12: 1 op, 135582.00 ns, 135.5820 us/op
+WorkloadActual  13: 1 op, 146973.00 ns, 146.9730 us/op
+WorkloadActual  14: 1 op, 205061.00 ns, 205.0610 us/op
+WorkloadActual  15: 1 op, 149568.00 ns, 149.5680 us/op
+WorkloadActual  16: 1 op, 120925.00 ns, 120.9250 us/op
+WorkloadActual  17: 1 op, 120264.00 ns, 120.2640 us/op
+WorkloadActual  18: 1 op, 120273.00 ns, 120.2730 us/op
+WorkloadActual  19: 1 op, 120814.00 ns, 120.8140 us/op
+WorkloadActual  20: 1 op, 120774.00 ns, 120.7740 us/op
+WorkloadActual  21: 1 op, 120655.00 ns, 120.6550 us/op
+WorkloadActual  22: 1 op, 117989.00 ns, 117.9890 us/op
+WorkloadActual  23: 1 op, 112429.00 ns, 112.4290 us/op
+WorkloadActual  24: 1 op, 112539.00 ns, 112.5390 us/op
+WorkloadActual  25: 1 op, 112499.00 ns, 112.4990 us/op
+WorkloadActual  26: 1 op, 112178.00 ns, 112.1780 us/op
+WorkloadActual  27: 1 op, 113802.00 ns, 113.8020 us/op
+WorkloadActual  28: 1 op, 111747.00 ns, 111.7470 us/op
+WorkloadActual  29: 1 op, 112018.00 ns, 112.0180 us/op
+WorkloadActual  30: 1 op, 112249.00 ns, 112.2490 us/op
+WorkloadActual  31: 1 op, 112058.00 ns, 112.0580 us/op
+WorkloadActual  32: 1 op, 112970.00 ns, 112.9700 us/op
+WorkloadActual  33: 1 op, 112529.00 ns, 112.5290 us/op
+WorkloadActual  34: 1 op, 112309.00 ns, 112.3090 us/op
+WorkloadActual  35: 1 op, 112109.00 ns, 112.1090 us/op
+WorkloadActual  36: 1 op, 112069.00 ns, 112.0690 us/op
+WorkloadActual  37: 1 op, 112479.00 ns, 112.4790 us/op
+WorkloadActual  38: 1 op, 112258.00 ns, 112.2580 us/op
+WorkloadActual  39: 1 op, 135341.00 ns, 135.3410 us/op
+WorkloadActual  40: 1 op, 111708.00 ns, 111.7080 us/op
+WorkloadActual  41: 1 op, 112179.00 ns, 112.1790 us/op
+WorkloadActual  42: 1 op, 111347.00 ns, 111.3470 us/op
+WorkloadActual  43: 1 op, 112098.00 ns, 112.0980 us/op
+WorkloadActual  44: 1 op, 112809.00 ns, 112.8090 us/op
+WorkloadActual  45: 1 op, 141162.00 ns, 141.1620 us/op
+WorkloadActual  46: 1 op, 112619.00 ns, 112.6190 us/op
+WorkloadActual  47: 1 op, 112108.00 ns, 112.1080 us/op
+WorkloadActual  48: 1 op, 112279.00 ns, 112.2790 us/op
+WorkloadActual  49: 1 op, 112498.00 ns, 112.4980 us/op
+WorkloadActual  50: 1 op, 112008.00 ns, 112.0080 us/op
+WorkloadActual  51: 1 op, 112008.00 ns, 112.0080 us/op
+WorkloadActual  52: 1 op, 112509.00 ns, 112.5090 us/op
+WorkloadActual  53: 1 op, 112389.00 ns, 112.3890 us/op
+WorkloadActual  54: 1 op, 111958.00 ns, 111.9580 us/op
+WorkloadActual  55: 1 op, 111398.00 ns, 111.3980 us/op
+WorkloadActual  56: 1 op, 107941.00 ns, 107.9410 us/op
+WorkloadActual  57: 1 op, 108611.00 ns, 108.6110 us/op
+WorkloadActual  58: 1 op, 115204.00 ns, 115.2040 us/op
+WorkloadActual  59: 1 op, 107860.00 ns, 107.8600 us/op
+WorkloadActual  60: 1 op, 111828.00 ns, 111.8280 us/op
+WorkloadActual  61: 1 op, 108661.00 ns, 108.6610 us/op
+WorkloadActual  62: 1 op, 108351.00 ns, 108.3510 us/op
+WorkloadActual  63: 1 op, 108441.00 ns, 108.4410 us/op
+WorkloadActual  64: 1 op, 107990.00 ns, 107.9900 us/op
+WorkloadActual  65: 1 op, 122939.00 ns, 122.9390 us/op
+WorkloadActual  66: 1 op, 108011.00 ns, 108.0110 us/op
+WorkloadActual  67: 1 op, 108372.00 ns, 108.3720 us/op
+WorkloadActual  68: 1 op, 108361.00 ns, 108.3610 us/op
+WorkloadActual  69: 1 op, 108071.00 ns, 108.0710 us/op
+WorkloadActual  70: 1 op, 108642.00 ns, 108.6420 us/op
+WorkloadActual  71: 1 op, 107640.00 ns, 107.6400 us/op
+WorkloadActual  72: 1 op, 135772.00 ns, 135.7720 us/op
+WorkloadActual  73: 1 op, 107690.00 ns, 107.6900 us/op
+WorkloadActual  74: 1 op, 108632.00 ns, 108.6320 us/op
+WorkloadActual  75: 1 op, 108301.00 ns, 108.3010 us/op
+WorkloadActual  76: 1 op, 108031.00 ns, 108.0310 us/op
+WorkloadActual  77: 1 op, 107610.00 ns, 107.6100 us/op
+WorkloadActual  78: 1 op, 108572.00 ns, 108.5720 us/op
+WorkloadActual  79: 1 op, 126716.00 ns, 126.7160 us/op
+WorkloadActual  80: 1 op, 107940.00 ns, 107.9400 us/op
+WorkloadActual  81: 1 op, 108001.00 ns, 108.0010 us/op
+WorkloadActual  82: 1 op, 107990.00 ns, 107.9900 us/op
+WorkloadActual  83: 1 op, 107971.00 ns, 107.9710 us/op
+WorkloadActual  84: 1 op, 108081.00 ns, 108.0810 us/op
+WorkloadActual  85: 1 op, 108341.00 ns, 108.3410 us/op
+WorkloadActual  86: 1 op, 133929.00 ns, 133.9290 us/op
+WorkloadActual  87: 1 op, 107941.00 ns, 107.9410 us/op
+WorkloadActual  88: 1 op, 108151.00 ns, 108.1510 us/op
+WorkloadActual  89: 1 op, 108322.00 ns, 108.3220 us/op
+WorkloadActual  90: 1 op, 108121.00 ns, 108.1210 us/op
+WorkloadActual  91: 1 op, 108782.00 ns, 108.7820 us/op
+WorkloadActual  92: 1 op, 108151.00 ns, 108.1510 us/op
+WorkloadActual  93: 1 op, 107660.00 ns, 107.6600 us/op
+WorkloadActual  94: 1 op, 137415.00 ns, 137.4150 us/op
+WorkloadActual  95: 1 op, 107621.00 ns, 107.6210 us/op
+WorkloadActual  96: 1 op, 108682.00 ns, 108.6820 us/op
+WorkloadActual  97: 1 op, 108632.00 ns, 108.6320 us/op
+WorkloadActual  98: 1 op, 107900.00 ns, 107.9000 us/op
+WorkloadActual  99: 1 op, 107971.00 ns, 107.9710 us/op
+WorkloadActual  100: 1 op, 107710.00 ns, 107.7100 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 130633.00 ns, 130.6330 us/op
+WorkloadResult   2: 1 op, 129801.00 ns, 129.8010 us/op
+WorkloadResult   3: 1 op, 129570.00 ns, 129.5700 us/op
+WorkloadResult   4: 1 op, 133829.00 ns, 133.8290 us/op
+WorkloadResult   5: 1 op, 132887.00 ns, 132.8870 us/op
+WorkloadResult   6: 1 op, 135281.00 ns, 135.2810 us/op
+WorkloadResult   7: 1 op, 120624.00 ns, 120.6240 us/op
+WorkloadResult   8: 1 op, 119963.00 ns, 119.9630 us/op
+WorkloadResult   9: 1 op, 119972.00 ns, 119.9720 us/op
+WorkloadResult  10: 1 op, 120513.00 ns, 120.5130 us/op
+WorkloadResult  11: 1 op, 120473.00 ns, 120.4730 us/op
+WorkloadResult  12: 1 op, 120354.00 ns, 120.3540 us/op
+WorkloadResult  13: 1 op, 117688.00 ns, 117.6880 us/op
+WorkloadResult  14: 1 op, 112128.00 ns, 112.1280 us/op
+WorkloadResult  15: 1 op, 112238.00 ns, 112.2380 us/op
+WorkloadResult  16: 1 op, 112198.00 ns, 112.1980 us/op
+WorkloadResult  17: 1 op, 111877.00 ns, 111.8770 us/op
+WorkloadResult  18: 1 op, 113501.00 ns, 113.5010 us/op
+WorkloadResult  19: 1 op, 111446.00 ns, 111.4460 us/op
+WorkloadResult  20: 1 op, 111717.00 ns, 111.7170 us/op
+WorkloadResult  21: 1 op, 111948.00 ns, 111.9480 us/op
+WorkloadResult  22: 1 op, 111757.00 ns, 111.7570 us/op
+WorkloadResult  23: 1 op, 112669.00 ns, 112.6690 us/op
+WorkloadResult  24: 1 op, 112228.00 ns, 112.2280 us/op
+WorkloadResult  25: 1 op, 112008.00 ns, 112.0080 us/op
+WorkloadResult  26: 1 op, 111808.00 ns, 111.8080 us/op
+WorkloadResult  27: 1 op, 111768.00 ns, 111.7680 us/op
+WorkloadResult  28: 1 op, 112178.00 ns, 112.1780 us/op
+WorkloadResult  29: 1 op, 111957.00 ns, 111.9570 us/op
+WorkloadResult  30: 1 op, 135040.00 ns, 135.0400 us/op
+WorkloadResult  31: 1 op, 111407.00 ns, 111.4070 us/op
+WorkloadResult  32: 1 op, 111878.00 ns, 111.8780 us/op
+WorkloadResult  33: 1 op, 111046.00 ns, 111.0460 us/op
+WorkloadResult  34: 1 op, 111797.00 ns, 111.7970 us/op
+WorkloadResult  35: 1 op, 112508.00 ns, 112.5080 us/op
+WorkloadResult  36: 1 op, 112318.00 ns, 112.3180 us/op
+WorkloadResult  37: 1 op, 111807.00 ns, 111.8070 us/op
+WorkloadResult  38: 1 op, 111978.00 ns, 111.9780 us/op
+WorkloadResult  39: 1 op, 112197.00 ns, 112.1970 us/op
+WorkloadResult  40: 1 op, 111707.00 ns, 111.7070 us/op
+WorkloadResult  41: 1 op, 111707.00 ns, 111.7070 us/op
+WorkloadResult  42: 1 op, 112208.00 ns, 112.2080 us/op
+WorkloadResult  43: 1 op, 112088.00 ns, 112.0880 us/op
+WorkloadResult  44: 1 op, 111657.00 ns, 111.6570 us/op
+WorkloadResult  45: 1 op, 111097.00 ns, 111.0970 us/op
+WorkloadResult  46: 1 op, 107640.00 ns, 107.6400 us/op
+WorkloadResult  47: 1 op, 108310.00 ns, 108.3100 us/op
+WorkloadResult  48: 1 op, 114903.00 ns, 114.9030 us/op
+WorkloadResult  49: 1 op, 107559.00 ns, 107.5590 us/op
+WorkloadResult  50: 1 op, 111527.00 ns, 111.5270 us/op
+WorkloadResult  51: 1 op, 108360.00 ns, 108.3600 us/op
+WorkloadResult  52: 1 op, 108050.00 ns, 108.0500 us/op
+WorkloadResult  53: 1 op, 108140.00 ns, 108.1400 us/op
+WorkloadResult  54: 1 op, 107689.00 ns, 107.6890 us/op
+WorkloadResult  55: 1 op, 122638.00 ns, 122.6380 us/op
+WorkloadResult  56: 1 op, 107710.00 ns, 107.7100 us/op
+WorkloadResult  57: 1 op, 108071.00 ns, 108.0710 us/op
+WorkloadResult  58: 1 op, 108060.00 ns, 108.0600 us/op
+WorkloadResult  59: 1 op, 107770.00 ns, 107.7700 us/op
+WorkloadResult  60: 1 op, 108341.00 ns, 108.3410 us/op
+WorkloadResult  61: 1 op, 107339.00 ns, 107.3390 us/op
+WorkloadResult  62: 1 op, 135471.00 ns, 135.4710 us/op
+WorkloadResult  63: 1 op, 107389.00 ns, 107.3890 us/op
+WorkloadResult  64: 1 op, 108331.00 ns, 108.3310 us/op
+WorkloadResult  65: 1 op, 108000.00 ns, 108.0000 us/op
+WorkloadResult  66: 1 op, 107730.00 ns, 107.7300 us/op
+WorkloadResult  67: 1 op, 107309.00 ns, 107.3090 us/op
+WorkloadResult  68: 1 op, 108271.00 ns, 108.2710 us/op
+WorkloadResult  69: 1 op, 126415.00 ns, 126.4150 us/op
+WorkloadResult  70: 1 op, 107639.00 ns, 107.6390 us/op
+WorkloadResult  71: 1 op, 107700.00 ns, 107.7000 us/op
+WorkloadResult  72: 1 op, 107689.00 ns, 107.6890 us/op
+WorkloadResult  73: 1 op, 107670.00 ns, 107.6700 us/op
+WorkloadResult  74: 1 op, 107780.00 ns, 107.7800 us/op
+WorkloadResult  75: 1 op, 108040.00 ns, 108.0400 us/op
+WorkloadResult  76: 1 op, 133628.00 ns, 133.6280 us/op
+WorkloadResult  77: 1 op, 107640.00 ns, 107.6400 us/op
+WorkloadResult  78: 1 op, 107850.00 ns, 107.8500 us/op
+WorkloadResult  79: 1 op, 108021.00 ns, 108.0210 us/op
+WorkloadResult  80: 1 op, 107820.00 ns, 107.8200 us/op
+WorkloadResult  81: 1 op, 108481.00 ns, 108.4810 us/op
+WorkloadResult  82: 1 op, 107850.00 ns, 107.8500 us/op
+WorkloadResult  83: 1 op, 107359.00 ns, 107.3590 us/op
+WorkloadResult  84: 1 op, 137114.00 ns, 137.1140 us/op
+WorkloadResult  85: 1 op, 107320.00 ns, 107.3200 us/op
+WorkloadResult  86: 1 op, 108381.00 ns, 108.3810 us/op
+WorkloadResult  87: 1 op, 108331.00 ns, 108.3310 us/op
+WorkloadResult  88: 1 op, 107599.00 ns, 107.5990 us/op
+WorkloadResult  89: 1 op, 107670.00 ns, 107.6700 us/op
+WorkloadResult  90: 1 op, 107409.00 ns, 107.4090 us/op
+// GC:  0 0 0 1152 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3554 has exited with code 0.
+
+Mean = 113.527 μs, StdErr = 0.854 μs (0.75%), N = 90, StdDev = 8.101 μs
+Min = 107.309 μs, Q1 = 107.888 μs, Median = 111.707 μs, Q3 = 112.460 μs, Max = 137.114 μs
+IQR = 4.573 μs, LowerFence = 101.028 μs, UpperFence = 119.320 μs
+ConfidenceInterval = [110.621 μs; 116.433 μs] (CI 99.9%), Margin = 2.906 μs (2.56% of Mean)
+Skewness = 1.65, Kurtosis = 4.55, MValue = 2
+
+// ** Remained 19 (38.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'LZ4 Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Lz4_Decompress_64KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 31 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-YJYOQJ(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 295349.00 ns, 295.3490 us/op
+WorkloadJitting  1: 1 op, 5474866.00 ns, 5.4749 ms/op
+
+OverheadWarmup   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   3: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   4: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   5: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   6: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   7: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   8: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   9: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup  10: 1 op, 281.00 ns, 281.0000 ns/op
+
+OverheadActual   1: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   2: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   3: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   4: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   5: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual   6: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual   7: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   8: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   9: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  10: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  11: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual  12: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  13: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  14: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  15: 1 op, 290.00 ns, 290.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 210561.00 ns, 210.5610 us/op
+WorkloadWarmup   2: 1 op, 51025.00 ns, 51.0250 us/op
+WorkloadWarmup   3: 1 op, 68698.00 ns, 68.6980 us/op
+WorkloadWarmup   4: 1 op, 50574.00 ns, 50.5740 us/op
+WorkloadWarmup   5: 1 op, 49431.00 ns, 49.4310 us/op
+WorkloadWarmup   6: 1 op, 50354.00 ns, 50.3540 us/op
+WorkloadWarmup   7: 1 op, 49853.00 ns, 49.8530 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 66433.00 ns, 66.4330 us/op
+WorkloadActual   2: 1 op, 51516.00 ns, 51.5160 us/op
+WorkloadActual   3: 1 op, 47608.00 ns, 47.6080 us/op
+WorkloadActual   4: 1 op, 47038.00 ns, 47.0380 us/op
+WorkloadActual   5: 1 op, 47388.00 ns, 47.3880 us/op
+WorkloadActual   6: 1 op, 47078.00 ns, 47.0780 us/op
+WorkloadActual   7: 1 op, 47288.00 ns, 47.2880 us/op
+WorkloadActual   8: 1 op, 47609.00 ns, 47.6090 us/op
+WorkloadActual   9: 1 op, 70651.00 ns, 70.6510 us/op
+WorkloadActual  10: 1 op, 47668.00 ns, 47.6680 us/op
+WorkloadActual  11: 1 op, 47047.00 ns, 47.0470 us/op
+WorkloadActual  12: 1 op, 47258.00 ns, 47.2580 us/op
+WorkloadActual  13: 1 op, 47168.00 ns, 47.1680 us/op
+WorkloadActual  14: 1 op, 46927.00 ns, 46.9270 us/op
+WorkloadActual  15: 1 op, 47098.00 ns, 47.0980 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 47318.00 ns, 47.3180 us/op
+WorkloadResult   2: 1 op, 46748.00 ns, 46.7480 us/op
+WorkloadResult   3: 1 op, 47098.00 ns, 47.0980 us/op
+WorkloadResult   4: 1 op, 46788.00 ns, 46.7880 us/op
+WorkloadResult   5: 1 op, 46998.00 ns, 46.9980 us/op
+WorkloadResult   6: 1 op, 47319.00 ns, 47.3190 us/op
+WorkloadResult   7: 1 op, 47378.00 ns, 47.3780 us/op
+WorkloadResult   8: 1 op, 46757.00 ns, 46.7570 us/op
+WorkloadResult   9: 1 op, 46968.00 ns, 46.9680 us/op
+WorkloadResult  10: 1 op, 46878.00 ns, 46.8780 us/op
+WorkloadResult  11: 1 op, 46637.00 ns, 46.6370 us/op
+WorkloadResult  12: 1 op, 46808.00 ns, 46.8080 us/op
+// GC:  0 0 0 1584 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3561 has exited with code 0.
+
+Mean = 46.975 μs, StdErr = 0.073 μs (0.15%), N = 12, StdDev = 0.252 μs
+Min = 46.637 μs, Q1 = 46.780 μs, Median = 46.923 μs, Q3 = 47.153 μs, Max = 47.378 μs
+IQR = 0.373 μs, LowerFence = 46.221 μs, UpperFence = 47.712 μs
+ConfidenceInterval = [46.652 μs; 47.298 μs] (CI 99.9%), Margin = 0.323 μs (0.69% of Mean)
+Skewness = 0.4, Kurtosis = 1.54, MValue = 2
+
+// ** Remained 18 (36.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Zstd Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Zstd_Decompress_64KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 32 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-MMWNSE(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 255636.00 ns, 255.6360 us/op
+WorkloadJitting  1: 1 op, 13226164.00 ns, 13.2262 ms/op
+
+OverheadWarmup   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   2: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   3: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   4: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   5: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   6: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   7: 1 op, 291.00 ns, 291.0000 ns/op
+
+OverheadActual   1: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   2: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   3: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   4: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   5: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual   6: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   7: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   8: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   9: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  10: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  11: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  12: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  13: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  14: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  15: 1 op, 280.00 ns, 280.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 50704.00 ns, 50.7040 us/op
+WorkloadWarmup   2: 1 op, 45736.00 ns, 45.7360 us/op
+WorkloadWarmup   3: 1 op, 45605.00 ns, 45.6050 us/op
+WorkloadWarmup   4: 1 op, 329222.00 ns, 329.2220 us/op
+WorkloadWarmup   5: 1 op, 70551.00 ns, 70.5510 us/op
+WorkloadWarmup   6: 1 op, 65491.00 ns, 65.4910 us/op
+WorkloadWarmup   7: 1 op, 65542.00 ns, 65.5420 us/op
+WorkloadWarmup   8: 1 op, 65762.00 ns, 65.7620 us/op
+WorkloadWarmup   9: 1 op, 65311.00 ns, 65.3110 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 83064.00 ns, 83.0640 us/op
+WorkloadActual   2: 1 op, 59992.00 ns, 59.9920 us/op
+WorkloadActual   3: 1 op, 57166.00 ns, 57.1660 us/op
+WorkloadActual   4: 1 op, 57026.00 ns, 57.0260 us/op
+WorkloadActual   5: 1 op, 83425.00 ns, 83.4250 us/op
+WorkloadActual   6: 1 op, 56495.00 ns, 56.4950 us/op
+WorkloadActual   7: 1 op, 55954.00 ns, 55.9540 us/op
+WorkloadActual   8: 1 op, 56976.00 ns, 56.9760 us/op
+WorkloadActual   9: 1 op, 56214.00 ns, 56.2140 us/op
+WorkloadActual  10: 1 op, 56465.00 ns, 56.4650 us/op
+WorkloadActual  11: 1 op, 56395.00 ns, 56.3950 us/op
+WorkloadActual  12: 1 op, 56375.00 ns, 56.3750 us/op
+WorkloadActual  13: 1 op, 55843.00 ns, 55.8430 us/op
+WorkloadActual  14: 1 op, 55934.00 ns, 55.9340 us/op
+WorkloadActual  15: 1 op, 55944.00 ns, 55.9440 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 56876.00 ns, 56.8760 us/op
+WorkloadResult   2: 1 op, 56736.00 ns, 56.7360 us/op
+WorkloadResult   3: 1 op, 56205.00 ns, 56.2050 us/op
+WorkloadResult   4: 1 op, 55664.00 ns, 55.6640 us/op
+WorkloadResult   5: 1 op, 56686.00 ns, 56.6860 us/op
+WorkloadResult   6: 1 op, 55924.00 ns, 55.9240 us/op
+WorkloadResult   7: 1 op, 56175.00 ns, 56.1750 us/op
+WorkloadResult   8: 1 op, 56105.00 ns, 56.1050 us/op
+WorkloadResult   9: 1 op, 56085.00 ns, 56.0850 us/op
+WorkloadResult  10: 1 op, 55553.00 ns, 55.5530 us/op
+WorkloadResult  11: 1 op, 55644.00 ns, 55.6440 us/op
+WorkloadResult  12: 1 op, 55654.00 ns, 55.6540 us/op
+// GC:  0 0 0 1128 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3568 has exited with code 0.
+
+Mean = 56.109 μs, StdErr = 0.132 μs (0.23%), N = 12, StdDev = 0.457 μs
+Min = 55.553 μs, Q1 = 55.661 μs, Median = 56.095 μs, Q3 = 56.325 μs, Max = 56.876 μs
+IQR = 0.664 μs, LowerFence = 54.666 μs, UpperFence = 57.321 μs
+ConfidenceInterval = [55.524 μs; 56.694 μs] (CI 99.9%), Margin = 0.585 μs (1.04% of Mean)
+Skewness = 0.38, Kurtosis = 1.61, MValue = 2
+
+// ** Remained 17 (34.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: CompressionCodecComparisonBenchmarks.'Brotli Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 135 136 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks.Brotli_Decompress_64KB --job "InvocationCount=1, UnrollFactor=1" --benchmarkId 33 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-YPGYAW(InvocationCount=1, UnrollFactor=1)
+
+OverheadJitting  1: 1 op, 255966.00 ns, 255.9660 us/op
+WorkloadJitting  1: 1 op, 1032930.00 ns, 1.0329 ms/op
+
+OverheadWarmup   1: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   2: 1 op, 652.00 ns, 652.0000 ns/op
+OverheadWarmup   3: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   4: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   5: 1 op, 260.00 ns, 260.0000 ns/op
+
+OverheadActual   1: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   2: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual   3: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual   4: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual   5: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual   6: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadActual   7: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual   8: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual   9: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  10: 1 op, 240.00 ns, 240.0000 ns/op
+OverheadActual  11: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  12: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  13: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  14: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  15: 1 op, 281.00 ns, 281.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 80850.00 ns, 80.8500 us/op
+WorkloadWarmup   2: 1 op, 74339.00 ns, 74.3390 us/op
+WorkloadWarmup   3: 1 op, 74178.00 ns, 74.1780 us/op
+WorkloadWarmup   4: 1 op, 73848.00 ns, 73.8480 us/op
+WorkloadWarmup   5: 1 op, 73867.00 ns, 73.8670 us/op
+WorkloadWarmup   6: 1 op, 73617.00 ns, 73.6170 us/op
+WorkloadWarmup   7: 1 op, 73918.00 ns, 73.9180 us/op
+WorkloadWarmup   8: 1 op, 73807.00 ns, 73.8070 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 74909.00 ns, 74.9090 us/op
+WorkloadActual   2: 1 op, 90458.00 ns, 90.4580 us/op
+WorkloadActual   3: 1 op, 88905.00 ns, 88.9050 us/op
+WorkloadActual   4: 1 op, 89326.00 ns, 89.3260 us/op
+WorkloadActual   5: 1 op, 91821.00 ns, 91.8210 us/op
+WorkloadActual   6: 1 op, 88955.00 ns, 88.9550 us/op
+WorkloadActual   7: 1 op, 89707.00 ns, 89.7070 us/op
+WorkloadActual   8: 1 op, 84277.00 ns, 84.2770 us/op
+WorkloadActual   9: 1 op, 84367.00 ns, 84.3670 us/op
+WorkloadActual  10: 1 op, 107841.00 ns, 107.8410 us/op
+WorkloadActual  11: 1 op, 88414.00 ns, 88.4140 us/op
+WorkloadActual  12: 1 op, 89125.00 ns, 89.1250 us/op
+WorkloadActual  13: 1 op, 88845.00 ns, 88.8450 us/op
+WorkloadActual  14: 1 op, 92081.00 ns, 92.0810 us/op
+WorkloadActual  15: 1 op, 88875.00 ns, 88.8750 us/op
+WorkloadActual  16: 1 op, 89015.00 ns, 89.0150 us/op
+WorkloadActual  17: 1 op, 103151.00 ns, 103.1510 us/op
+WorkloadActual  18: 1 op, 95077.00 ns, 95.0770 us/op
+WorkloadActual  19: 1 op, 95828.00 ns, 95.8280 us/op
+WorkloadActual  20: 1 op, 95217.00 ns, 95.2170 us/op
+WorkloadActual  21: 1 op, 116858.00 ns, 116.8580 us/op
+WorkloadActual  22: 1 op, 94867.00 ns, 94.8670 us/op
+WorkloadActual  23: 1 op, 94044.00 ns, 94.0440 us/op
+WorkloadActual  24: 1 op, 97722.00 ns, 97.7220 us/op
+WorkloadActual  25: 1 op, 96760.00 ns, 96.7600 us/op
+WorkloadActual  26: 1 op, 94305.00 ns, 94.3050 us/op
+WorkloadActual  27: 1 op, 94866.00 ns, 94.8660 us/op
+WorkloadActual  28: 1 op, 100236.00 ns, 100.2360 us/op
+WorkloadActual  29: 1 op, 94786.00 ns, 94.7860 us/op
+WorkloadActual  30: 1 op, 94375.00 ns, 94.3750 us/op
+WorkloadActual  31: 1 op, 95037.00 ns, 95.0370 us/op
+WorkloadActual  32: 1 op, 128219.00 ns, 128.2190 us/op
+WorkloadActual  33: 1 op, 93924.00 ns, 93.9240 us/op
+WorkloadActual  34: 1 op, 97080.00 ns, 97.0800 us/op
+WorkloadActual  35: 1 op, 94546.00 ns, 94.5460 us/op
+WorkloadActual  36: 1 op, 91200.00 ns, 91.2000 us/op
+WorkloadActual  37: 1 op, 96390.00 ns, 96.3900 us/op
+WorkloadActual  38: 1 op, 101388.00 ns, 101.3880 us/op
+WorkloadActual  39: 1 op, 99294.00 ns, 99.2940 us/op
+WorkloadActual  40: 1 op, 94536.00 ns, 94.5360 us/op
+WorkloadActual  41: 1 op, 73837.00 ns, 73.8370 us/op
+WorkloadActual  42: 1 op, 73637.00 ns, 73.6370 us/op
+WorkloadActual  43: 1 op, 73877.00 ns, 73.8770 us/op
+WorkloadActual  44: 1 op, 73777.00 ns, 73.7770 us/op
+WorkloadActual  45: 1 op, 77084.00 ns, 77.0840 us/op
+WorkloadActual  46: 1 op, 74117.00 ns, 74.1170 us/op
+WorkloadActual  47: 1 op, 73747.00 ns, 73.7470 us/op
+WorkloadActual  48: 1 op, 100627.00 ns, 100.6270 us/op
+WorkloadActual  49: 1 op, 97040.00 ns, 97.0400 us/op
+WorkloadActual  50: 1 op, 110686.00 ns, 110.6860 us/op
+WorkloadActual  51: 1 op, 98022.00 ns, 98.0220 us/op
+WorkloadActual  52: 1 op, 95948.00 ns, 95.9480 us/op
+WorkloadActual  53: 1 op, 97511.00 ns, 97.5110 us/op
+WorkloadActual  54: 1 op, 98664.00 ns, 98.6640 us/op
+WorkloadActual  55: 1 op, 95788.00 ns, 95.7880 us/op
+WorkloadActual  56: 1 op, 95248.00 ns, 95.2480 us/op
+WorkloadActual  57: 1 op, 98113.00 ns, 98.1130 us/op
+WorkloadActual  58: 1 op, 75260.00 ns, 75.2600 us/op
+WorkloadActual  59: 1 op, 72995.00 ns, 72.9950 us/op
+WorkloadActual  60: 1 op, 73026.00 ns, 73.0260 us/op
+WorkloadActual  61: 1 op, 73065.00 ns, 73.0650 us/op
+WorkloadActual  62: 1 op, 72996.00 ns, 72.9960 us/op
+WorkloadActual  63: 1 op, 100387.00 ns, 100.3870 us/op
+WorkloadActual  64: 1 op, 72816.00 ns, 72.8160 us/op
+WorkloadActual  65: 1 op, 76442.00 ns, 76.4420 us/op
+WorkloadActual  66: 1 op, 73377.00 ns, 73.3770 us/op
+WorkloadActual  67: 1 op, 73276.00 ns, 73.2760 us/op
+WorkloadActual  68: 1 op, 115325.00 ns, 115.3250 us/op
+WorkloadActual  69: 1 op, 73256.00 ns, 73.2560 us/op
+WorkloadActual  70: 1 op, 73026.00 ns, 73.0260 us/op
+WorkloadActual  71: 1 op, 76382.00 ns, 76.3820 us/op
+WorkloadActual  72: 1 op, 73036.00 ns, 73.0360 us/op
+WorkloadActual  73: 1 op, 73978.00 ns, 73.9780 us/op
+WorkloadActual  74: 1 op, 73015.00 ns, 73.0150 us/op
+WorkloadActual  75: 1 op, 73006.00 ns, 73.0060 us/op
+WorkloadActual  76: 1 op, 72745.00 ns, 72.7450 us/op
+WorkloadActual  77: 1 op, 73136.00 ns, 73.1360 us/op
+WorkloadActual  78: 1 op, 73467.00 ns, 73.4670 us/op
+WorkloadActual  79: 1 op, 76322.00 ns, 76.3220 us/op
+WorkloadActual  80: 1 op, 73647.00 ns, 73.6470 us/op
+WorkloadActual  81: 1 op, 73717.00 ns, 73.7170 us/op
+WorkloadActual  82: 1 op, 73737.00 ns, 73.7370 us/op
+WorkloadActual  83: 1 op, 73827.00 ns, 73.8270 us/op
+WorkloadActual  84: 1 op, 105356.00 ns, 105.3560 us/op
+WorkloadActual  85: 1 op, 100656.00 ns, 100.6560 us/op
+WorkloadActual  86: 1 op, 94515.00 ns, 94.5150 us/op
+WorkloadActual  87: 1 op, 93895.00 ns, 93.8950 us/op
+WorkloadActual  88: 1 op, 96770.00 ns, 96.7700 us/op
+WorkloadActual  89: 1 op, 94065.00 ns, 94.0650 us/op
+WorkloadActual  90: 1 op, 94786.00 ns, 94.7860 us/op
+WorkloadActual  91: 1 op, 95577.00 ns, 95.5770 us/op
+WorkloadActual  92: 1 op, 104194.00 ns, 104.1940 us/op
+WorkloadActual  93: 1 op, 116637.00 ns, 116.6370 us/op
+WorkloadActual  94: 1 op, 94275.00 ns, 94.2750 us/op
+WorkloadActual  95: 1 op, 94726.00 ns, 94.7260 us/op
+WorkloadActual  96: 1 op, 99765.00 ns, 99.7650 us/op
+WorkloadActual  97: 1 op, 94696.00 ns, 94.6960 us/op
+WorkloadActual  98: 1 op, 94545.00 ns, 94.5450 us/op
+WorkloadActual  99: 1 op, 97771.00 ns, 97.7710 us/op
+WorkloadActual  100: 1 op, 92462.00 ns, 92.4620 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 74638.00 ns, 74.6380 us/op
+WorkloadResult   2: 1 op, 90187.00 ns, 90.1870 us/op
+WorkloadResult   3: 1 op, 88634.00 ns, 88.6340 us/op
+WorkloadResult   4: 1 op, 89055.00 ns, 89.0550 us/op
+WorkloadResult   5: 1 op, 91550.00 ns, 91.5500 us/op
+WorkloadResult   6: 1 op, 88684.00 ns, 88.6840 us/op
+WorkloadResult   7: 1 op, 89436.00 ns, 89.4360 us/op
+WorkloadResult   8: 1 op, 84006.00 ns, 84.0060 us/op
+WorkloadResult   9: 1 op, 84096.00 ns, 84.0960 us/op
+WorkloadResult  10: 1 op, 107570.00 ns, 107.5700 us/op
+WorkloadResult  11: 1 op, 88143.00 ns, 88.1430 us/op
+WorkloadResult  12: 1 op, 88854.00 ns, 88.8540 us/op
+WorkloadResult  13: 1 op, 88574.00 ns, 88.5740 us/op
+WorkloadResult  14: 1 op, 91810.00 ns, 91.8100 us/op
+WorkloadResult  15: 1 op, 88604.00 ns, 88.6040 us/op
+WorkloadResult  16: 1 op, 88744.00 ns, 88.7440 us/op
+WorkloadResult  17: 1 op, 102880.00 ns, 102.8800 us/op
+WorkloadResult  18: 1 op, 94806.00 ns, 94.8060 us/op
+WorkloadResult  19: 1 op, 95557.00 ns, 95.5570 us/op
+WorkloadResult  20: 1 op, 94946.00 ns, 94.9460 us/op
+WorkloadResult  21: 1 op, 116587.00 ns, 116.5870 us/op
+WorkloadResult  22: 1 op, 94596.00 ns, 94.5960 us/op
+WorkloadResult  23: 1 op, 93773.00 ns, 93.7730 us/op
+WorkloadResult  24: 1 op, 97451.00 ns, 97.4510 us/op
+WorkloadResult  25: 1 op, 96489.00 ns, 96.4890 us/op
+WorkloadResult  26: 1 op, 94034.00 ns, 94.0340 us/op
+WorkloadResult  27: 1 op, 94595.00 ns, 94.5950 us/op
+WorkloadResult  28: 1 op, 99965.00 ns, 99.9650 us/op
+WorkloadResult  29: 1 op, 94515.00 ns, 94.5150 us/op
+WorkloadResult  30: 1 op, 94104.00 ns, 94.1040 us/op
+WorkloadResult  31: 1 op, 94766.00 ns, 94.7660 us/op
+WorkloadResult  32: 1 op, 127948.00 ns, 127.9480 us/op
+WorkloadResult  33: 1 op, 93653.00 ns, 93.6530 us/op
+WorkloadResult  34: 1 op, 96809.00 ns, 96.8090 us/op
+WorkloadResult  35: 1 op, 94275.00 ns, 94.2750 us/op
+WorkloadResult  36: 1 op, 90929.00 ns, 90.9290 us/op
+WorkloadResult  37: 1 op, 96119.00 ns, 96.1190 us/op
+WorkloadResult  38: 1 op, 101117.00 ns, 101.1170 us/op
+WorkloadResult  39: 1 op, 99023.00 ns, 99.0230 us/op
+WorkloadResult  40: 1 op, 94265.00 ns, 94.2650 us/op
+WorkloadResult  41: 1 op, 73566.00 ns, 73.5660 us/op
+WorkloadResult  42: 1 op, 73366.00 ns, 73.3660 us/op
+WorkloadResult  43: 1 op, 73606.00 ns, 73.6060 us/op
+WorkloadResult  44: 1 op, 73506.00 ns, 73.5060 us/op
+WorkloadResult  45: 1 op, 76813.00 ns, 76.8130 us/op
+WorkloadResult  46: 1 op, 73846.00 ns, 73.8460 us/op
+WorkloadResult  47: 1 op, 73476.00 ns, 73.4760 us/op
+WorkloadResult  48: 1 op, 100356.00 ns, 100.3560 us/op
+WorkloadResult  49: 1 op, 96769.00 ns, 96.7690 us/op
+WorkloadResult  50: 1 op, 110415.00 ns, 110.4150 us/op
+WorkloadResult  51: 1 op, 97751.00 ns, 97.7510 us/op
+WorkloadResult  52: 1 op, 95677.00 ns, 95.6770 us/op
+WorkloadResult  53: 1 op, 97240.00 ns, 97.2400 us/op
+WorkloadResult  54: 1 op, 98393.00 ns, 98.3930 us/op
+WorkloadResult  55: 1 op, 95517.00 ns, 95.5170 us/op
+WorkloadResult  56: 1 op, 94977.00 ns, 94.9770 us/op
+WorkloadResult  57: 1 op, 97842.00 ns, 97.8420 us/op
+WorkloadResult  58: 1 op, 74989.00 ns, 74.9890 us/op
+WorkloadResult  59: 1 op, 72724.00 ns, 72.7240 us/op
+WorkloadResult  60: 1 op, 72755.00 ns, 72.7550 us/op
+WorkloadResult  61: 1 op, 72794.00 ns, 72.7940 us/op
+WorkloadResult  62: 1 op, 72725.00 ns, 72.7250 us/op
+WorkloadResult  63: 1 op, 100116.00 ns, 100.1160 us/op
+WorkloadResult  64: 1 op, 72545.00 ns, 72.5450 us/op
+WorkloadResult  65: 1 op, 76171.00 ns, 76.1710 us/op
+WorkloadResult  66: 1 op, 73106.00 ns, 73.1060 us/op
+WorkloadResult  67: 1 op, 73005.00 ns, 73.0050 us/op
+WorkloadResult  68: 1 op, 115054.00 ns, 115.0540 us/op
+WorkloadResult  69: 1 op, 72985.00 ns, 72.9850 us/op
+WorkloadResult  70: 1 op, 72755.00 ns, 72.7550 us/op
+WorkloadResult  71: 1 op, 76111.00 ns, 76.1110 us/op
+WorkloadResult  72: 1 op, 72765.00 ns, 72.7650 us/op
+WorkloadResult  73: 1 op, 73707.00 ns, 73.7070 us/op
+WorkloadResult  74: 1 op, 72744.00 ns, 72.7440 us/op
+WorkloadResult  75: 1 op, 72735.00 ns, 72.7350 us/op
+WorkloadResult  76: 1 op, 72474.00 ns, 72.4740 us/op
+WorkloadResult  77: 1 op, 72865.00 ns, 72.8650 us/op
+WorkloadResult  78: 1 op, 73196.00 ns, 73.1960 us/op
+WorkloadResult  79: 1 op, 76051.00 ns, 76.0510 us/op
+WorkloadResult  80: 1 op, 73376.00 ns, 73.3760 us/op
+WorkloadResult  81: 1 op, 73446.00 ns, 73.4460 us/op
+WorkloadResult  82: 1 op, 73466.00 ns, 73.4660 us/op
+WorkloadResult  83: 1 op, 73556.00 ns, 73.5560 us/op
+WorkloadResult  84: 1 op, 105085.00 ns, 105.0850 us/op
+WorkloadResult  85: 1 op, 100385.00 ns, 100.3850 us/op
+WorkloadResult  86: 1 op, 94244.00 ns, 94.2440 us/op
+WorkloadResult  87: 1 op, 93624.00 ns, 93.6240 us/op
+WorkloadResult  88: 1 op, 96499.00 ns, 96.4990 us/op
+WorkloadResult  89: 1 op, 93794.00 ns, 93.7940 us/op
+WorkloadResult  90: 1 op, 94515.00 ns, 94.5150 us/op
+WorkloadResult  91: 1 op, 95306.00 ns, 95.3060 us/op
+WorkloadResult  92: 1 op, 103923.00 ns, 103.9230 us/op
+WorkloadResult  93: 1 op, 116366.00 ns, 116.3660 us/op
+WorkloadResult  94: 1 op, 94004.00 ns, 94.0040 us/op
+WorkloadResult  95: 1 op, 94455.00 ns, 94.4550 us/op
+WorkloadResult  96: 1 op, 99494.00 ns, 99.4940 us/op
+WorkloadResult  97: 1 op, 94425.00 ns, 94.4250 us/op
+WorkloadResult  98: 1 op, 94274.00 ns, 94.2740 us/op
+WorkloadResult  99: 1 op, 97500.00 ns, 97.5000 us/op
+WorkloadResult  100: 1 op, 92191.00 ns, 92.1910 us/op
+// GC:  0 0 0 1480 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3575 has exited with code 0.
+
+Mean = 89.172 μs, StdErr = 1.241 μs (1.39%), N = 100, StdDev = 12.406 μs
+Min = 72.474 μs, Q1 = 73.811 μs, Median = 93.713 μs, Q3 = 96.492 μs, Max = 127.948 μs
+IQR = 22.680 μs, LowerFence = 39.791 μs, UpperFence = 130.512 μs
+ConfidenceInterval = [84.965 μs; 93.380 μs] (CI 99.9%), Margin = 4.208 μs (4.72% of Mean)
+Skewness = 0.2, Kurtosis = 2.7, MValue = 3.57
+
+// ** Remained 16 (32.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// ***** BenchmarkRunner: Finish  *****
+
+// * Export *
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks-report.csv
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks-report-github.md
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks-report.html
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.CompressionCodecComparisonBenchmarks-report-full-compressed.json
+
+// * Detailed results *
+CompressionCodecComparisonBenchmarks.'Gzip Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 18.671 μs, StdErr = 0.102 μs (0.54%), N = 32, StdDev = 0.575 μs
+Min = 17.729 μs, Q1 = 18.299 μs, Median = 18.550 μs, Q3 = 18.976 μs, Max = 19.811 μs
+IQR = 0.676 μs, LowerFence = 17.285 μs, UpperFence = 19.989 μs
+ConfidenceInterval = [18.301 μs; 19.040 μs] (CI 99.9%), Margin = 0.369 μs (1.98% of Mean)
+Skewness = 0.4, Kurtosis = 2.17, MValue = 2
+-------------------- Histogram --------------------
+[17.491 μs ; 17.861 μs) | @@
+[17.861 μs ; 18.347 μs) | @@@@@@@
+[18.347 μs ; 18.823 μs) | @@@@@@@@@@@@@@
+[18.823 μs ; 19.629 μs) | @@@@@@@
+[19.629 μs ; 20.049 μs) | @@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Snappy Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 11.079 μs, StdErr = 0.039 μs (0.36%), N = 13, StdDev = 0.142 μs
+Min = 10.810 μs, Q1 = 10.960 μs, Median = 11.140 μs, Q3 = 11.171 μs, Max = 11.230 μs
+IQR = 0.212 μs, LowerFence = 10.642 μs, UpperFence = 11.489 μs
+ConfidenceInterval = [10.909 μs; 11.249 μs] (CI 99.9%), Margin = 0.170 μs (1.54% of Mean)
+Skewness = -0.7, Kurtosis = 1.86, MValue = 2
+-------------------- Histogram --------------------
+[10.776 μs ; 11.277 μs) | @@@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'LZ4 Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 25.665 μs, StdErr = 0.125 μs (0.49%), N = 16, StdDev = 0.502 μs
+Min = 24.966 μs, Q1 = 25.305 μs, Median = 25.677 μs, Q3 = 26.023 μs, Max = 26.630 μs
+IQR = 0.719 μs, LowerFence = 24.227 μs, UpperFence = 27.101 μs
+ConfidenceInterval = [25.154 μs; 26.176 μs] (CI 99.9%), Margin = 0.511 μs (1.99% of Mean)
+Skewness = 0.26, Kurtosis = 1.87, MValue = 2
+-------------------- Histogram --------------------
+[24.930 μs ; 25.453 μs) | @@@@@@@
+[25.453 μs ; 26.214 μs) | @@@@@@@
+[26.214 μs ; 26.795 μs) | @@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Zstd Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 142.329 μs, StdErr = 1.321 μs (0.93%), N = 100, StdDev = 13.214 μs
+Min = 101.650 μs, Q1 = 133.947 μs, Median = 146.363 μs, Q3 = 149.804 μs, Max = 172.070 μs
+IQR = 15.857 μs, LowerFence = 110.162 μs, UpperFence = 173.589 μs
+ConfidenceInterval = [137.848 μs; 146.811 μs] (CI 99.9%), Margin = 4.482 μs (3.15% of Mean)
+Skewness = -0.03, Kurtosis = 3.13, MValue = 3.9
+-------------------- Histogram --------------------
+[ 97.913 μs ; 105.387 μs) | @
+[105.387 μs ; 114.053 μs) | 
+[114.053 μs ; 120.700 μs) | @
+[120.700 μs ; 128.173 μs) | @@@@@@@@@@@@@@@@@@
+[128.173 μs ; 132.377 μs) | @
+[132.377 μs ; 139.851 μs) | @@@@@@@@@@@@@@@@@@@@@@
+[139.851 μs ; 145.175 μs) | @@@@@
+[145.175 μs ; 152.649 μs) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+[152.649 μs ; 155.991 μs) | 
+[155.991 μs ; 163.464 μs) | @@@@
+[163.464 μs ; 173.848 μs) | @@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Brotli Compress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 25.388 μs, StdErr = 0.102 μs (0.40%), N = 14, StdDev = 0.382 μs
+Min = 24.746 μs, Q1 = 25.090 μs, Median = 25.457 μs, Q3 = 25.639 μs, Max = 25.969 μs
+IQR = 0.549 μs, LowerFence = 24.266 μs, UpperFence = 26.462 μs
+ConfidenceInterval = [24.958 μs; 25.819 μs] (CI 99.9%), Margin = 0.431 μs (1.70% of Mean)
+Skewness = -0.15, Kurtosis = 1.76, MValue = 2
+-------------------- Histogram --------------------
+[24.643 μs ; 25.144 μs) | @@@@
+[25.144 μs ; 26.077 μs) | @@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Gzip Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 271.026 μs, StdErr = 1.569 μs (0.58%), N = 78, StdDev = 13.861 μs
+Min = 258.481 μs, Q1 = 259.440 μs, Median = 265.539 μs, Q3 = 275.500 μs, Max = 302.343 μs
+IQR = 16.060 μs, LowerFence = 235.351 μs, UpperFence = 299.591 μs
+ConfidenceInterval = [265.656 μs; 276.396 μs] (CI 99.9%), Margin = 5.370 μs (1.98% of Mean)
+Skewness = 0.81, Kurtosis = 2.19, MValue = 3.54
+-------------------- Histogram --------------------
+[255.526 μs ; 264.041 μs) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+[264.041 μs ; 269.737 μs) | 
+[269.737 μs ; 278.253 μs) | @@@@@@@@@@@@@@@@@@@@@
+[278.253 μs ; 288.993 μs) | @@@@
+[288.993 μs ; 297.509 μs) | @@@@@@@@@@@@
+[297.509 μs ; 306.601 μs) | @@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Snappy Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 495.538 μs, StdErr = 2.602 μs (0.53%), N = 28, StdDev = 13.767 μs
+Min = 478.228 μs, Q1 = 482.451 μs, Median = 493.887 μs, Q3 = 510.416 μs, Max = 516.810 μs
+IQR = 27.965 μs, LowerFence = 440.504 μs, UpperFence = 552.363 μs
+ConfidenceInterval = [485.939 μs; 505.138 μs] (CI 99.9%), Margin = 9.599 μs (1.94% of Mean)
+Skewness = 0.18, Kurtosis = 1.33, MValue = 2.67
+-------------------- Histogram --------------------
+[476.731 μs ; 488.632 μs) | @@@@@@@@@@@@
+[488.632 μs ; 501.301 μs) | @@@@@@
+[501.301 μs ; 518.197 μs) | @@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'LZ4 Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 394.405 μs, StdErr = 2.137 μs (0.54%), N = 33, StdDev = 12.274 μs
+Min = 381.318 μs, Q1 = 384.464 μs, Median = 389.303 μs, Q3 = 402.187 μs, Max = 424.449 μs
+IQR = 17.723 μs, LowerFence = 357.880 μs, UpperFence = 428.772 μs
+ConfidenceInterval = [386.666 μs; 402.144 μs] (CI 99.9%), Margin = 7.739 μs (1.96% of Mean)
+Skewness = 0.87, Kurtosis = 2.57, MValue = 2
+-------------------- Histogram --------------------
+[381.094 μs ; 391.140 μs) | @@@@@@@@@@@@@@@@@@
+[391.140 μs ; 404.905 μs) | @@@@@@@@@@
+[404.905 μs ; 419.999 μs) | @@@@
+[419.999 μs ; 429.472 μs) | @
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Zstd Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 1.694 ms, StdErr = 0.006 ms (0.35%), N = 15, StdDev = 0.023 ms
+Min = 1.658 ms, Q1 = 1.681 ms, Median = 1.691 ms, Q3 = 1.711 ms, Max = 1.733 ms
+IQR = 0.030 ms, LowerFence = 1.636 ms, UpperFence = 1.756 ms
+ConfidenceInterval = [1.670 ms; 1.718 ms] (CI 99.9%), Margin = 0.024 ms (1.45% of Mean)
+Skewness = 0.07, Kurtosis = 1.74, MValue = 2
+-------------------- Histogram --------------------
+[1.646 ms ; 1.745 ms) | @@@@@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Brotli Compress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 109.911 μs, StdErr = 1.156 μs (1.05%), N = 81, StdDev = 10.408 μs
+Min = 101.518 μs, Q1 = 103.592 μs, Median = 104.504 μs, Q3 = 118.269 μs, Max = 148.135 μs
+IQR = 14.677 μs, LowerFence = 81.576 μs, UpperFence = 140.285 μs
+ConfidenceInterval = [105.960 μs; 113.861 μs] (CI 99.9%), Margin = 3.951 μs (3.59% of Mean)
+Skewness = 1.46, Kurtosis = 4.13, MValue = 2.54
+-------------------- Histogram --------------------
+[101.076 μs ; 107.390 μs) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+[107.390 μs ; 111.448 μs) | @
+[111.448 μs ; 117.762 μs) | @
+[117.762 μs ; 124.076 μs) | @@@@@@@@@
+[124.076 μs ; 132.091 μs) | @@@@@@@@@@
+[132.091 μs ; 136.865 μs) | @
+[136.865 μs ; 144.978 μs) | 
+[144.978 μs ; 151.292 μs) | @
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Gzip Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 28.254 μs, StdErr = 0.055 μs (0.20%), N = 13, StdDev = 0.199 μs
+Min = 28.042 μs, Q1 = 28.092 μs, Median = 28.182 μs, Q3 = 28.352 μs, Max = 28.693 μs
+IQR = 0.260 μs, LowerFence = 27.702 μs, UpperFence = 28.742 μs
+ConfidenceInterval = [28.015 μs; 28.492 μs] (CI 99.9%), Margin = 0.238 μs (0.84% of Mean)
+Skewness = 0.86, Kurtosis = 2.45, MValue = 2
+-------------------- Histogram --------------------
+[27.931 μs ; 28.804 μs) | @@@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Snappy Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 42.698 μs, StdErr = 0.218 μs (0.51%), N = 22, StdDev = 1.024 μs
+Min = 41.803 μs, Q1 = 41.943 μs, Median = 42.214 μs, Q3 = 43.546 μs, Max = 44.629 μs
+IQR = 1.603 μs, LowerFence = 39.538 μs, UpperFence = 45.951 μs
+ConfidenceInterval = [41.864 μs; 43.531 μs] (CI 99.9%), Margin = 0.833 μs (1.95% of Mean)
+Skewness = 0.88, Kurtosis = 1.93, MValue = 2.75
+-------------------- Histogram --------------------
+[41.774 μs ; 42.733 μs) | @@@@@@@@@@@@@@@@
+[42.733 μs ; 43.748 μs) | 
+[43.748 μs ; 44.707 μs) | @@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'LZ4 Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 40.625 μs, StdErr = 0.081 μs (0.20%), N = 14, StdDev = 0.303 μs
+Min = 40.155 μs, Q1 = 40.396 μs, Median = 40.642 μs, Q3 = 40.836 μs, Max = 41.157 μs
+IQR = 0.440 μs, LowerFence = 39.736 μs, UpperFence = 41.497 μs
+ConfidenceInterval = [40.283 μs; 40.967 μs] (CI 99.9%), Margin = 0.342 μs (0.84% of Mean)
+Skewness = 0.01, Kurtosis = 1.76, MValue = 2
+-------------------- Histogram --------------------
+[39.990 μs ; 41.322 μs) | @@@@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Zstd Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 162.074 μs, StdErr = 0.542 μs (0.33%), N = 13, StdDev = 1.955 μs
+Min = 158.634 μs, Q1 = 161.390 μs, Median = 162.181 μs, Q3 = 162.401 μs, Max = 166.599 μs
+IQR = 1.011 μs, LowerFence = 159.874 μs, UpperFence = 163.917 μs
+ConfidenceInterval = [159.733 μs; 164.415 μs] (CI 99.9%), Margin = 2.341 μs (1.44% of Mean)
+Skewness = 0.48, Kurtosis = 3.17, MValue = 2
+-------------------- Histogram --------------------
+[157.543 μs ; 163.034 μs) | @@@@@@@@@@
+[163.034 μs ; 167.690 μs) | @@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Brotli Compress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 28.726 μs, StdErr = 0.058 μs (0.20%), N = 13, StdDev = 0.211 μs
+Min = 28.447 μs, Q1 = 28.618 μs, Median = 28.648 μs, Q3 = 28.788 μs, Max = 29.249 μs
+IQR = 0.170 μs, LowerFence = 28.363 μs, UpperFence = 29.043 μs
+ConfidenceInterval = [28.473 μs; 28.978 μs] (CI 99.9%), Margin = 0.252 μs (0.88% of Mean)
+Skewness = 0.98, Kurtosis = 3.42, MValue = 2
+-------------------- Histogram --------------------
+[28.411 μs ; 29.367 μs) | @@@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Gzip Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 13.298 μs, StdErr = 0.040 μs (0.30%), N = 14, StdDev = 0.148 μs
+Min = 13.085 μs, Q1 = 13.162 μs, Median = 13.320 μs, Q3 = 13.373 μs, Max = 13.596 μs
+IQR = 0.211 μs, LowerFence = 12.846 μs, UpperFence = 13.689 μs
+ConfidenceInterval = [13.131 μs; 13.464 μs] (CI 99.9%), Margin = 0.167 μs (1.26% of Mean)
+Skewness = 0.25, Kurtosis = 2.01, MValue = 2
+-------------------- Histogram --------------------
+[13.004 μs ; 13.677 μs) | @@@@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Snappy Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 7.775 μs, StdErr = 0.027 μs (0.35%), N = 13, StdDev = 0.099 μs
+Min = 7.638 μs, Q1 = 7.679 μs, Median = 7.779 μs, Q3 = 7.819 μs, Max = 7.950 μs
+IQR = 0.140 μs, LowerFence = 7.470 μs, UpperFence = 8.030 μs
+ConfidenceInterval = [7.656 μs; 7.893 μs] (CI 99.9%), Margin = 0.118 μs (1.52% of Mean)
+Skewness = 0.37, Kurtosis = 1.94, MValue = 2
+-------------------- Histogram --------------------
+[7.583 μs ; 8.006 μs) | @@@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'LZ4 Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 13.248 μs, StdErr = 0.050 μs (0.38%), N = 15, StdDev = 0.193 μs
+Min = 13.004 μs, Q1 = 13.079 μs, Median = 13.275 μs, Q3 = 13.335 μs, Max = 13.676 μs
+IQR = 0.256 μs, LowerFence = 12.695 μs, UpperFence = 13.720 μs
+ConfidenceInterval = [13.041 μs; 13.455 μs] (CI 99.9%), Margin = 0.207 μs (1.56% of Mean)
+Skewness = 0.61, Kurtosis = 2.27, MValue = 2
+-------------------- Histogram --------------------
+[12.949 μs ; 13.236 μs) | @@@@@@@
+[13.236 μs ; 13.779 μs) | @@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Zstd Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 22.739 μs, StdErr = 0.059 μs (0.26%), N = 15, StdDev = 0.228 μs
+Min = 22.412 μs, Q1 = 22.547 μs, Median = 22.743 μs, Q3 = 22.838 μs, Max = 23.203 μs
+IQR = 0.290 μs, LowerFence = 22.112 μs, UpperFence = 23.274 μs
+ConfidenceInterval = [22.495 μs; 22.983 μs] (CI 99.9%), Margin = 0.244 μs (1.07% of Mean)
+Skewness = 0.37, Kurtosis = 2.12, MValue = 2
+-------------------- Histogram --------------------
+[22.290 μs ; 23.325 μs) | @@@@@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Brotli Decompress 1KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 18.486 μs, StdErr = 0.053 μs (0.29%), N = 12, StdDev = 0.184 μs
+Min = 18.154 μs, Q1 = 18.387 μs, Median = 18.440 μs, Q3 = 18.660 μs, Max = 18.716 μs
+IQR = 0.273 μs, LowerFence = 17.978 μs, UpperFence = 19.069 μs
+ConfidenceInterval = [18.250 μs; 18.722 μs] (CI 99.9%), Margin = 0.236 μs (1.28% of Mean)
+Skewness = -0.19, Kurtosis = 1.61, MValue = 2
+-------------------- Histogram --------------------
+[18.048 μs ; 18.822 μs) | @@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Gzip Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 214.369 μs, StdErr = 1.083 μs (0.51%), N = 21, StdDev = 4.962 μs
+Min = 208.337 μs, Q1 = 209.779 μs, Median = 217.263 μs, Q3 = 218.075 μs, Max = 224.627 μs
+IQR = 8.296 μs, LowerFence = 197.335 μs, UpperFence = 230.519 μs
+ConfidenceInterval = [210.201 μs; 218.537 μs] (CI 99.9%), Margin = 4.168 μs (1.94% of Mean)
+Skewness = 0.22, Kurtosis = 1.56, MValue = 4
+-------------------- Histogram --------------------
+[206.968 μs ; 211.689 μs) | @@@@@@@@@@
+[211.689 μs ; 216.536 μs) | 
+[216.536 μs ; 222.267 μs) | @@@@@@@@@@
+[222.267 μs ; 226.987 μs) | @
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Snappy Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 1.584 ms, StdErr = 0.003 ms (0.19%), N = 13, StdDev = 0.011 ms
+Min = 1.569 ms, Q1 = 1.573 ms, Median = 1.586 ms, Q3 = 1.588 ms, Max = 1.605 ms
+IQR = 0.015 ms, LowerFence = 1.551 ms, UpperFence = 1.610 ms
+ConfidenceInterval = [1.571 ms; 1.597 ms] (CI 99.9%), Margin = 0.013 ms (0.81% of Mean)
+Skewness = 0.32, Kurtosis = 2.14, MValue = 2
+-------------------- Histogram --------------------
+[1.563 ms ; 1.611 ms) | @@@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'LZ4 Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 519.590 μs, StdErr = 2.492 μs (0.48%), N = 16, StdDev = 9.970 μs
+Min = 505.158 μs, Q1 = 513.155 μs, Median = 520.287 μs, Q3 = 526.145 μs, Max = 534.663 μs
+IQR = 12.989 μs, LowerFence = 493.671 μs, UpperFence = 545.629 μs
+ConfidenceInterval = [509.439 μs; 529.742 μs] (CI 99.9%), Margin = 10.151 μs (1.95% of Mean)
+Skewness = -0.09, Kurtosis = 1.63, MValue = 2
+-------------------- Histogram --------------------
+[499.965 μs ; 511.108 μs) | @@@@
+[511.108 μs ; 525.312 μs) | @@@@@@@@
+[525.312 μs ; 537.587 μs) | @@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Zstd Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 288.954 μs, StdErr = 0.433 μs (0.15%), N = 12, StdDev = 1.500 μs
+Min = 287.574 μs, Q1 = 288.152 μs, Median = 288.370 μs, Q3 = 289.107 μs, Max = 293.034 μs
+IQR = 0.955 μs, LowerFence = 286.721 μs, UpperFence = 290.539 μs
+ConfidenceInterval = [287.032 μs; 290.876 μs] (CI 99.9%), Margin = 1.922 μs (0.67% of Mean)
+Skewness = 1.61, Kurtosis = 4.75, MValue = 2
+-------------------- Histogram --------------------
+[286.714 μs ; 293.894 μs) | @@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Brotli Decompress 1MB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 704.062 μs, StdErr = 3.648 μs (0.52%), N = 21, StdDev = 16.716 μs
+Min = 672.290 μs, Q1 = 696.625 μs, Median = 706.303 μs, Q3 = 714.359 μs, Max = 736.058 μs
+IQR = 17.734 μs, LowerFence = 670.024 μs, UpperFence = 740.960 μs
+ConfidenceInterval = [690.020 μs; 718.104 μs] (CI 99.9%), Margin = 14.042 μs (1.99% of Mean)
+Skewness = -0.04, Kurtosis = 2.21, MValue = 2
+-------------------- Histogram --------------------
+[664.338 μs ; 694.518 μs) | @@@@@
+[694.518 μs ; 710.423 μs) | @@@@@@@@@@
+[710.423 μs ; 729.123 μs) | @@@@@
+[729.123 μs ; 744.011 μs) | @
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Gzip Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 26.163 μs, StdErr = 0.038 μs (0.15%), N = 37, StdDev = 0.233 μs
+Min = 25.718 μs, Q1 = 26.018 μs, Median = 26.159 μs, Q3 = 26.378 μs, Max = 26.619 μs
+IQR = 0.360 μs, LowerFence = 25.479 μs, UpperFence = 26.919 μs
+ConfidenceInterval = [26.025 μs; 26.300 μs] (CI 99.9%), Margin = 0.137 μs (0.53% of Mean)
+Skewness = -0.05, Kurtosis = 2.23, MValue = 2
+-------------------- Histogram --------------------
+[25.627 μs ; 26.711 μs) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Snappy Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 113.527 μs, StdErr = 0.854 μs (0.75%), N = 90, StdDev = 8.101 μs
+Min = 107.309 μs, Q1 = 107.888 μs, Median = 111.707 μs, Q3 = 112.460 μs, Max = 137.114 μs
+IQR = 4.573 μs, LowerFence = 101.028 μs, UpperFence = 119.320 μs
+ConfidenceInterval = [110.621 μs; 116.433 μs] (CI 99.9%), Margin = 2.906 μs (2.56% of Mean)
+Skewness = 1.65, Kurtosis = 4.55, MValue = 2
+-------------------- Histogram --------------------
+[104.937 μs ; 107.526 μs) | @@@@@@
+[107.526 μs ; 112.271 μs) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+[112.271 μs ; 115.983 μs) | @@@@@
+[115.983 μs ; 118.928 μs) | @
+[118.928 μs ; 123.673 μs) | @@@@@@@
+[123.673 μs ; 126.152 μs) | 
+[126.152 μs ; 132.628 μs) | @@@@
+[132.628 μs ; 137.373 μs) | @@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'LZ4 Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 46.975 μs, StdErr = 0.073 μs (0.15%), N = 12, StdDev = 0.252 μs
+Min = 46.637 μs, Q1 = 46.780 μs, Median = 46.923 μs, Q3 = 47.153 μs, Max = 47.378 μs
+IQR = 0.373 μs, LowerFence = 46.221 μs, UpperFence = 47.712 μs
+ConfidenceInterval = [46.652 μs; 47.298 μs] (CI 99.9%), Margin = 0.323 μs (0.69% of Mean)
+Skewness = 0.4, Kurtosis = 1.54, MValue = 2
+-------------------- Histogram --------------------
+[46.492 μs ; 47.523 μs) | @@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Zstd Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 56.109 μs, StdErr = 0.132 μs (0.23%), N = 12, StdDev = 0.457 μs
+Min = 55.553 μs, Q1 = 55.661 μs, Median = 56.095 μs, Q3 = 56.325 μs, Max = 56.876 μs
+IQR = 0.664 μs, LowerFence = 54.666 μs, UpperFence = 57.321 μs
+ConfidenceInterval = [55.524 μs; 56.694 μs] (CI 99.9%), Margin = 0.585 μs (1.04% of Mean)
+Skewness = 0.38, Kurtosis = 1.61, MValue = 2
+-------------------- Histogram --------------------
+[55.291 μs ; 57.138 μs) | @@@@@@@@@@@@
+---------------------------------------------------
+
+CompressionCodecComparisonBenchmarks.'Brotli Decompress 64KB': Job-PWUCSU(InvocationCount=1, UnrollFactor=1)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 89.172 μs, StdErr = 1.241 μs (1.39%), N = 100, StdDev = 12.406 μs
+Min = 72.474 μs, Q1 = 73.811 μs, Median = 93.713 μs, Q3 = 96.492 μs, Max = 127.948 μs
+IQR = 22.680 μs, LowerFence = 39.791 μs, UpperFence = 130.512 μs
+ConfidenceInterval = [84.965 μs; 93.380 μs] (CI 99.9%), Margin = 4.208 μs (4.72% of Mean)
+Skewness = 0.2, Kurtosis = 2.7, MValue = 3.57
+-------------------- Histogram --------------------
+[ 71.135 μs ;  78.152 μs) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+[ 78.152 μs ;  80.543 μs) | 
+[ 80.543 μs ;  86.659 μs) | @@
+[ 86.659 μs ;  93.496 μs) | @@@@@@@@@@@@@@
+[ 93.496 μs ; 100.513 μs) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+[100.513 μs ; 107.852 μs) | @@@@@
+[107.852 μs ; 117.009 μs) | @@@@
+[117.009 μs ; 124.440 μs) | 
+[124.440 μs ; 131.456 μs) | @
+---------------------------------------------------
+
+// * Summary *
+
+BenchmarkDotNet v0.14.0, Ubuntu 24.04.3 LTS (Noble Numbat)
+AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+.NET SDK 10.0.102
+  [Host]     : .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+  Job-PWUCSU : .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+
+InvocationCount=1  UnrollFactor=1  
+
+| Method                   | Mean         | Error      | StdDev     | Median       | Allocated |
+|------------------------- |-------------:|-----------:|-----------:|-------------:|----------:|
+| 'Gzip Compress 1KB'      |    18.671 μs |  0.3695 μs |  0.5753 μs |    18.550 μs |         - |
+| 'Snappy Compress 1KB'    |    11.079 μs |  0.1703 μs |  0.1422 μs |    11.140 μs |         - |
+| 'LZ4 Compress 1KB'       |    25.665 μs |  0.5111 μs |  0.5019 μs |    25.677 μs |         - |
+| 'Zstd Compress 1KB'      |   142.329 μs |  4.4817 μs | 13.2145 μs |   146.363 μs |         - |
+| 'Brotli Compress 1KB'    |    25.388 μs |  0.4305 μs |  0.3816 μs |    25.457 μs |         - |
+| 'Gzip Compress 1MB'      |   271.026 μs |  5.3697 μs | 13.8609 μs |   265.539 μs |         - |
+| 'Snappy Compress 1MB'    |   495.538 μs |  9.5993 μs | 13.7671 μs |   493.887 μs |         - |
+| 'LZ4 Compress 1MB'       |   394.405 μs |  7.7387 μs | 12.2743 μs |   389.303 μs |         - |
+| 'Zstd Compress 1MB'      | 1,693.992 μs | 24.4824 μs | 22.9009 μs | 1,690.863 μs |         - |
+| 'Brotli Compress 1MB'    |   109.911 μs |  3.9509 μs | 10.4082 μs |   104.504 μs |         - |
+| 'Gzip Compress 64KB'     |    28.254 μs |  0.2382 μs |  0.1989 μs |    28.182 μs |         - |
+| 'Snappy Compress 64KB'   |    42.698 μs |  0.8335 μs |  1.0236 μs |    42.214 μs |         - |
+| 'LZ4 Compress 64KB'      |    40.625 μs |  0.3419 μs |  0.3031 μs |    40.642 μs |         - |
+| 'Zstd Compress 64KB'     |   162.074 μs |  2.3411 μs |  1.9550 μs |   162.181 μs |         - |
+| 'Brotli Compress 64KB'   |    28.726 μs |  0.2522 μs |  0.2106 μs |    28.648 μs |         - |
+| 'Gzip Decompress 1KB'    |    13.298 μs |  0.1669 μs |  0.1479 μs |    13.320 μs |         - |
+| 'Snappy Decompress 1KB'  |     7.775 μs |  0.1183 μs |  0.0988 μs |     7.779 μs |         - |
+| 'LZ4 Decompress 1KB'     |    13.248 μs |  0.2068 μs |  0.1934 μs |    13.275 μs |         - |
+| 'Zstd Decompress 1KB'    |    22.739 μs |  0.2442 μs |  0.2284 μs |    22.743 μs |         - |
+| 'Brotli Decompress 1KB'  |    18.486 μs |  0.2358 μs |  0.1841 μs |    18.440 μs |         - |
+| 'Gzip Decompress 1MB'    |   214.369 μs |  4.1681 μs |  4.9619 μs |   217.263 μs |         - |
+| 'Snappy Decompress 1MB'  | 1,584.290 μs | 12.9023 μs | 10.7740 μs | 1,586.008 μs |         - |
+| 'LZ4 Decompress 1MB'     |   519.590 μs | 10.1513 μs |  9.9700 μs |   520.287 μs |         - |
+| 'Zstd Decompress 1MB'    |   288.954 μs |  1.9216 μs |  1.5002 μs |   288.370 μs |         - |
+| 'Brotli Decompress 1MB'  |   704.062 μs | 14.0418 μs | 16.7157 μs |   706.303 μs |         - |
+| 'Gzip Decompress 64KB'   |    26.163 μs |  0.1375 μs |  0.2334 μs |    26.159 μs |         - |
+| 'Snappy Decompress 64KB' |   113.527 μs |  2.9059 μs |  8.1006 μs |   111.707 μs |         - |
+| 'LZ4 Decompress 64KB'    |    46.975 μs |  0.3230 μs |  0.2522 μs |    46.923 μs |         - |
+| 'Zstd Decompress 64KB'   |    56.109 μs |  0.5848 μs |  0.4566 μs |    56.095 μs |         - |
+| 'Brotli Decompress 64KB' |    89.172 μs |  4.2075 μs | 12.4059 μs |    93.713 μs |         - |
+
+// * Warnings *
+MultimodalDistribution
+  CompressionCodecComparisonBenchmarks.'Zstd Compress 1KB': InvocationCount=1, UnrollFactor=1      -> It seems that the distribution is bimodal (mValue = 3.9)
+  CompressionCodecComparisonBenchmarks.'Gzip Compress 1MB': InvocationCount=1, UnrollFactor=1      -> It seems that the distribution is bimodal (mValue = 3.54)
+  CompressionCodecComparisonBenchmarks.'Gzip Decompress 1MB': InvocationCount=1, UnrollFactor=1    -> It seems that the distribution is bimodal (mValue = 4)
+  CompressionCodecComparisonBenchmarks.'Brotli Decompress 64KB': InvocationCount=1, UnrollFactor=1 -> It seems that the distribution is bimodal (mValue = 3.57)
+MinIterationTime
+  CompressionCodecComparisonBenchmarks.'Gzip Compress 1KB': InvocationCount=1, UnrollFactor=1      -> The minimum observed iteration time is 18.034μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Snappy Compress 1KB': InvocationCount=1, UnrollFactor=1    -> The minimum observed iteration time is 11.141μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'LZ4 Compress 1KB': InvocationCount=1, UnrollFactor=1       -> The minimum observed iteration time is 25.427μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Zstd Compress 1KB': InvocationCount=1, UnrollFactor=1      -> The minimum observed iteration time is 101.94μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Brotli Compress 1KB': InvocationCount=1, UnrollFactor=1    -> The minimum observed iteration time is 25.046μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Gzip Compress 1MB': InvocationCount=1, UnrollFactor=1      -> The minimum observed iteration time is 258.771μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Snappy Compress 1MB': InvocationCount=1, UnrollFactor=1    -> The minimum observed iteration time is 478.529μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'LZ4 Compress 1MB': InvocationCount=1, UnrollFactor=1       -> The minimum observed iteration time is 381.599μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Zstd Compress 1MB': InvocationCount=1, UnrollFactor=1      -> The minimum observed iteration time is 1.659ms which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Brotli Compress 1MB': InvocationCount=1, UnrollFactor=1    -> The minimum observed iteration time is 101.799μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Gzip Compress 64KB': InvocationCount=1, UnrollFactor=1     -> The minimum observed iteration time is 28.343μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Snappy Compress 64KB': InvocationCount=1, UnrollFactor=1   -> The minimum observed iteration time is 42.098μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'LZ4 Compress 64KB': InvocationCount=1, UnrollFactor=1      -> The minimum observed iteration time is 40.445μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Zstd Compress 64KB': InvocationCount=1, UnrollFactor=1     -> The minimum observed iteration time is 158.925μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Brotli Compress 64KB': InvocationCount=1, UnrollFactor=1   -> The minimum observed iteration time is 28.753μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Gzip Decompress 1KB': InvocationCount=1, UnrollFactor=1    -> The minimum observed iteration time is 13.385μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Snappy Decompress 1KB': InvocationCount=1, UnrollFactor=1  -> The minimum observed iteration time is 7.924μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'LZ4 Decompress 1KB': InvocationCount=1, UnrollFactor=1     -> The minimum observed iteration time is 13.294μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Zstd Decompress 1KB': InvocationCount=1, UnrollFactor=1    -> The minimum observed iteration time is 22.712μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Brotli Decompress 1KB': InvocationCount=1, UnrollFactor=1  -> The minimum observed iteration time is 18.444μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Gzip Decompress 1MB': InvocationCount=1, UnrollFactor=1    -> The minimum observed iteration time is 208.648μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Snappy Decompress 1MB': InvocationCount=1, UnrollFactor=1  -> The minimum observed iteration time is 1.569ms which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'LZ4 Decompress 1MB': InvocationCount=1, UnrollFactor=1     -> The minimum observed iteration time is 505.439μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Zstd Decompress 1MB': InvocationCount=1, UnrollFactor=1    -> The minimum observed iteration time is 287.865μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Brotli Decompress 1MB': InvocationCount=1, UnrollFactor=1  -> The minimum observed iteration time is 672.581μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Gzip Decompress 64KB': InvocationCount=1, UnrollFactor=1   -> The minimum observed iteration time is 25.989μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Snappy Decompress 64KB': InvocationCount=1, UnrollFactor=1 -> The minimum observed iteration time is 107.61μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'LZ4 Decompress 64KB': InvocationCount=1, UnrollFactor=1    -> The minimum observed iteration time is 46.927μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Zstd Decompress 64KB': InvocationCount=1, UnrollFactor=1   -> The minimum observed iteration time is 55.843μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  CompressionCodecComparisonBenchmarks.'Brotli Decompress 64KB': InvocationCount=1, UnrollFactor=1 -> The minimum observed iteration time is 72.745μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+
+// * Hints *
+Outliers
+  CompressionCodecComparisonBenchmarks.'Snappy Compress 1KB': InvocationCount=1, UnrollFactor=1    -> 4 outliers were removed, 6 outliers were detected (11.14 μs, 11.18 μs, 13.09 μs..31.71 μs)
+  CompressionCodecComparisonBenchmarks.'LZ4 Compress 1KB': InvocationCount=1, UnrollFactor=1       -> 2 outliers were removed (44.37 μs, 44.80 μs)
+  CompressionCodecComparisonBenchmarks.'Zstd Compress 1KB': InvocationCount=1, UnrollFactor=1      -> 1 outlier  was  detected (101.94 μs)
+  CompressionCodecComparisonBenchmarks.'Brotli Compress 1KB': InvocationCount=1, UnrollFactor=1    -> 1 outlier  was  removed (27.09 μs)
+  CompressionCodecComparisonBenchmarks.'Gzip Compress 1MB': InvocationCount=1, UnrollFactor=1      -> 1 outlier  was  removed (304.82 μs)
+  CompressionCodecComparisonBenchmarks.'Snappy Compress 1MB': InvocationCount=1, UnrollFactor=1    -> 4 outliers were removed (827.06 μs..886.94 μs)
+  CompressionCodecComparisonBenchmarks.'LZ4 Compress 1MB': InvocationCount=1, UnrollFactor=1       -> 4 outliers were removed (446.10 μs..675.59 μs)
+  CompressionCodecComparisonBenchmarks.'Brotli Compress 1MB': InvocationCount=1, UnrollFactor=1    -> 19 outliers were removed (172.46 μs..216.11 μs)
+  CompressionCodecComparisonBenchmarks.'Gzip Compress 64KB': InvocationCount=1, UnrollFactor=1     -> 2 outliers were removed (29.50 μs, 30.22 μs)
+  CompressionCodecComparisonBenchmarks.'Snappy Compress 64KB': InvocationCount=1, UnrollFactor=1   -> 1 outlier  was  removed (47.74 μs)
+  CompressionCodecComparisonBenchmarks.'LZ4 Compress 64KB': InvocationCount=1, UnrollFactor=1      -> 1 outlier  was  removed (42.05 μs)
+  CompressionCodecComparisonBenchmarks.'Zstd Compress 64KB': InvocationCount=1, UnrollFactor=1     -> 4 outliers were removed (180.84 μs..191.31 μs)
+  CompressionCodecComparisonBenchmarks.'Brotli Compress 64KB': InvocationCount=1, UnrollFactor=1   -> 2 outliers were removed (29.82 μs, 31.10 μs)
+  CompressionCodecComparisonBenchmarks.'Gzip Decompress 1KB': InvocationCount=1, UnrollFactor=1    -> 1 outlier  was  removed (14.23 μs)
+  CompressionCodecComparisonBenchmarks.'Snappy Decompress 1KB': InvocationCount=1, UnrollFactor=1  -> 2 outliers were removed (8.54 μs, 31.78 μs)
+  CompressionCodecComparisonBenchmarks.'Brotli Decompress 1KB': InvocationCount=1, UnrollFactor=1  -> 3 outliers were removed (19.68 μs..26.16 μs)
+  CompressionCodecComparisonBenchmarks.'Gzip Decompress 1MB': InvocationCount=1, UnrollFactor=1    -> 2 outliers were removed (233.63 μs, 244.32 μs)
+  CompressionCodecComparisonBenchmarks.'Snappy Decompress 1MB': InvocationCount=1, UnrollFactor=1  -> 2 outliers were removed (1.64 ms, 1.67 ms)
+  CompressionCodecComparisonBenchmarks.'Zstd Decompress 1MB': InvocationCount=1, UnrollFactor=1    -> 3 outliers were removed (298.27 μs..298.76 μs)
+  CompressionCodecComparisonBenchmarks.'Gzip Decompress 64KB': InvocationCount=1, UnrollFactor=1   -> 12 outliers were removed (35.79 μs..57.52 μs)
+  CompressionCodecComparisonBenchmarks.'Snappy Decompress 64KB': InvocationCount=1, UnrollFactor=1 -> 10 outliers were removed (141.16 μs..205.06 μs)
+  CompressionCodecComparisonBenchmarks.'LZ4 Decompress 64KB': InvocationCount=1, UnrollFactor=1    -> 3 outliers were removed (51.52 μs..70.65 μs)
+  CompressionCodecComparisonBenchmarks.'Zstd Decompress 64KB': InvocationCount=1, UnrollFactor=1   -> 3 outliers were removed (59.99 μs..83.42 μs)
+
+// * Legends *
+  Mean      : Arithmetic mean of all measurements
+  Error     : Half of 99.9% confidence interval
+  StdDev    : Standard deviation of all measurements
+  Median    : Value separating the higher half of all measurements (50th percentile)
+  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
+  1 μs      : 1 Microsecond (0.000001 sec)
+
+// * Diagnostic Output - MemoryDiagnoser *
+
+
+// ***** BenchmarkRunner: End *****
+Run time: 00:00:08 (8.14 sec), executed benchmarks: 30
+
+// Found 8 benchmarks:
+//   ProtocolBenchmarks.'Write 1000 Int32s': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   ProtocolBenchmarks.'Write 100 Strings (100 chars)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   ProtocolBenchmarks.'Write 100 CompactStrings': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   ProtocolBenchmarks.'Write 1000 VarInts': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   ProtocolBenchmarks.'Read 1000 Int32s': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   ProtocolBenchmarks.'Read 1000 VarInts': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   ProtocolBenchmarks.'Write RecordBatch (10 records)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   ProtocolBenchmarks.'Read RecordBatch (10 records)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+// **************************
+// Benchmark: ProtocolBenchmarks.'Write 1000 Int32s': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.ProtocolBenchmarks.WriteInt32_Thousand --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 34 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-CIWAOC(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 233624.00 ns, 233.6240 us/op
+WorkloadJitting  1: 1 op, 261636.00 ns, 261.6360 us/op
+
+OverheadWarmup   1: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadWarmup   2: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   3: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   4: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   5: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   6: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   7: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadWarmup   8: 1 op, 321.00 ns, 321.0000 ns/op
+
+OverheadActual   1: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   2: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   3: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   4: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   5: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   6: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   7: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   8: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   9: 1 op, 230.00 ns, 230.0000 ns/op
+OverheadActual  10: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  11: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual  12: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  13: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  14: 1 op, 250.00 ns, 250.0000 ns/op
+OverheadActual  15: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  16: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  17: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  18: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  19: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  20: 1 op, 321.00 ns, 321.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 15258.00 ns, 15.2580 us/op
+WorkloadWarmup   2: 1 op, 15118.00 ns, 15.1180 us/op
+WorkloadWarmup   3: 1 op, 15128.00 ns, 15.1280 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 26248.00 ns, 26.2480 us/op
+WorkloadActual   2: 1 op, 29074.00 ns, 29.0740 us/op
+WorkloadActual   3: 1 op, 26859.00 ns, 26.8590 us/op
+WorkloadActual   4: 1 op, 25097.00 ns, 25.0970 us/op
+WorkloadActual   5: 1 op, 55844.00 ns, 55.8440 us/op
+WorkloadActual   6: 1 op, 534634.00 ns, 534.6340 us/op
+WorkloadActual   7: 1 op, 39022.00 ns, 39.0220 us/op
+WorkloadActual   8: 1 op, 38832.00 ns, 38.8320 us/op
+WorkloadActual   9: 1 op, 38802.00 ns, 38.8020 us/op
+WorkloadActual  10: 1 op, 39754.00 ns, 39.7540 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 25938.00 ns, 25.9380 us/op
+WorkloadResult   2: 1 op, 28764.00 ns, 28.7640 us/op
+WorkloadResult   3: 1 op, 26549.00 ns, 26.5490 us/op
+WorkloadResult   4: 1 op, 24787.00 ns, 24.7870 us/op
+WorkloadResult   5: 1 op, 55534.00 ns, 55.5340 us/op
+WorkloadResult   6: 1 op, 38712.00 ns, 38.7120 us/op
+WorkloadResult   7: 1 op, 38522.00 ns, 38.5220 us/op
+WorkloadResult   8: 1 op, 38492.00 ns, 38.4920 us/op
+WorkloadResult   9: 1 op, 39444.00 ns, 39.4440 us/op
+// GC:  0 0 0 448 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3583 has exited with code 0.
+
+Mean = 35.194 μs, StdErr = 3.283 μs (9.33%), N = 9, StdDev = 9.850 μs
+Min = 24.787 μs, Q1 = 26.549 μs, Median = 38.492 μs, Q3 = 38.712 μs, Max = 55.534 μs
+IQR = 12.163 μs, LowerFence = 8.305 μs, UpperFence = 56.956 μs
+ConfidenceInterval = [18.641 μs; 51.746 μs] (CI 99.9%), Margin = 16.552 μs (47.03% of Mean)
+Skewness = 0.67, Kurtosis = 2.34, MValue = 2.4
+
+// ** Remained 15 (30.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: ProtocolBenchmarks.'Write 100 Strings (100 chars)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.ProtocolBenchmarks.WriteString_Hundred --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 35 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-RQHFNX(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 229126.00 ns, 229.1260 us/op
+WorkloadJitting  1: 1 op, 556534.00 ns, 556.5340 us/op
+
+OverheadWarmup   1: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadWarmup   2: 1 op, 681.00 ns, 681.0000 ns/op
+OverheadWarmup   3: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadWarmup   4: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadWarmup   5: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadWarmup   6: 1 op, 360.00 ns, 360.0000 ns/op
+
+OverheadActual   1: 1 op, 761.00 ns, 761.0000 ns/op
+OverheadActual   2: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   3: 1 op, 691.00 ns, 691.0000 ns/op
+OverheadActual   4: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual   5: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadActual   6: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadActual   7: 1 op, 631.00 ns, 631.0000 ns/op
+OverheadActual   8: 1 op, 701.00 ns, 701.0000 ns/op
+OverheadActual   9: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual  10: 1 op, 702.00 ns, 702.0000 ns/op
+OverheadActual  11: 1 op, 621.00 ns, 621.0000 ns/op
+OverheadActual  12: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  13: 1 op, 612.00 ns, 612.0000 ns/op
+OverheadActual  14: 1 op, 611.00 ns, 611.0000 ns/op
+OverheadActual  15: 1 op, 581.00 ns, 581.0000 ns/op
+OverheadActual  16: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual  17: 1 op, 622.00 ns, 622.0000 ns/op
+OverheadActual  18: 1 op, 360.00 ns, 360.0000 ns/op
+OverheadActual  19: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual  20: 1 op, 311.00 ns, 311.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 14998.00 ns, 14.9980 us/op
+WorkloadWarmup   2: 1 op, 13956.00 ns, 13.9560 us/op
+WorkloadWarmup   3: 1 op, 13665.00 ns, 13.6650 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 13736.00 ns, 13.7360 us/op
+WorkloadActual   2: 1 op, 13755.00 ns, 13.7550 us/op
+WorkloadActual   3: 1 op, 13575.00 ns, 13.5750 us/op
+WorkloadActual   4: 1 op, 13414.00 ns, 13.4140 us/op
+WorkloadActual   5: 1 op, 14226.00 ns, 14.2260 us/op
+WorkloadActual   6: 1 op, 13495.00 ns, 13.4950 us/op
+WorkloadActual   7: 1 op, 13856.00 ns, 13.8560 us/op
+WorkloadActual   8: 1 op, 13625.00 ns, 13.6250 us/op
+WorkloadActual   9: 1 op, 13856.00 ns, 13.8560 us/op
+WorkloadActual  10: 1 op, 13785.00 ns, 13.7850 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 13140.00 ns, 13.1400 us/op
+WorkloadResult   2: 1 op, 13159.00 ns, 13.1590 us/op
+WorkloadResult   3: 1 op, 12979.00 ns, 12.9790 us/op
+WorkloadResult   4: 1 op, 12818.00 ns, 12.8180 us/op
+WorkloadResult   5: 1 op, 12899.00 ns, 12.8990 us/op
+WorkloadResult   6: 1 op, 13260.00 ns, 13.2600 us/op
+WorkloadResult   7: 1 op, 13029.00 ns, 13.0290 us/op
+WorkloadResult   8: 1 op, 13260.00 ns, 13.2600 us/op
+WorkloadResult   9: 1 op, 13189.00 ns, 13.1890 us/op
+// GC:  0 0 0 736 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3590 has exited with code 0.
+
+Mean = 13.081 μs, StdErr = 0.053 μs (0.40%), N = 9, StdDev = 0.158 μs
+Min = 12.818 μs, Q1 = 12.979 μs, Median = 13.140 μs, Q3 = 13.189 μs, Max = 13.260 μs
+IQR = 0.210 μs, LowerFence = 12.664 μs, UpperFence = 13.504 μs
+ConfidenceInterval = [12.815 μs; 13.348 μs] (CI 99.9%), Margin = 0.266 μs (2.03% of Mean)
+Skewness = -0.34, Kurtosis = 1.46, MValue = 2
+
+// ** Remained 14 (28.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: ProtocolBenchmarks.'Write 100 CompactStrings': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.ProtocolBenchmarks.WriteCompactString_Hundred --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 36 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-ADZXRO(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 254664.00 ns, 254.6640 us/op
+WorkloadJitting  1: 1 op, 510238.00 ns, 510.2380 us/op
+
+OverheadWarmup   1: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   2: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   3: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadWarmup   4: 1 op, 591.00 ns, 591.0000 ns/op
+OverheadWarmup   5: 1 op, 631.00 ns, 631.0000 ns/op
+OverheadWarmup   6: 1 op, 591.00 ns, 591.0000 ns/op
+OverheadWarmup   7: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   8: 1 op, 390.00 ns, 390.0000 ns/op
+OverheadWarmup   9: 1 op, 331.00 ns, 331.0000 ns/op
+
+OverheadActual   1: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   2: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual   3: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   4: 1 op, 360.00 ns, 360.0000 ns/op
+OverheadActual   5: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   6: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   7: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual   8: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   9: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  10: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  11: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  12: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  13: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  14: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  15: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  16: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  17: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  18: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  19: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual  20: 1 op, 320.00 ns, 320.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 11211.00 ns, 11.2110 us/op
+WorkloadWarmup   2: 1 op, 10870.00 ns, 10.8700 us/op
+WorkloadWarmup   3: 1 op, 11031.00 ns, 11.0310 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 11401.00 ns, 11.4010 us/op
+WorkloadActual   2: 1 op, 11020.00 ns, 11.0200 us/op
+WorkloadActual   3: 1 op, 11060.00 ns, 11.0600 us/op
+WorkloadActual   4: 1 op, 11151.00 ns, 11.1510 us/op
+WorkloadActual   5: 1 op, 11121.00 ns, 11.1210 us/op
+WorkloadActual   6: 1 op, 31579.00 ns, 31.5790 us/op
+WorkloadActual   7: 1 op, 11150.00 ns, 11.1500 us/op
+WorkloadActual   8: 1 op, 11031.00 ns, 11.0310 us/op
+WorkloadActual   9: 1 op, 11170.00 ns, 11.1700 us/op
+WorkloadActual  10: 1 op, 11331.00 ns, 11.3310 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 11091.00 ns, 11.0910 us/op
+WorkloadResult   2: 1 op, 10710.00 ns, 10.7100 us/op
+WorkloadResult   3: 1 op, 10750.00 ns, 10.7500 us/op
+WorkloadResult   4: 1 op, 10841.00 ns, 10.8410 us/op
+WorkloadResult   5: 1 op, 10811.00 ns, 10.8110 us/op
+WorkloadResult   6: 1 op, 10840.00 ns, 10.8400 us/op
+WorkloadResult   7: 1 op, 10721.00 ns, 10.7210 us/op
+WorkloadResult   8: 1 op, 10860.00 ns, 10.8600 us/op
+WorkloadResult   9: 1 op, 11021.00 ns, 11.0210 us/op
+// GC:  0 0 0 736 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3597 has exited with code 0.
+
+Mean = 10.849 μs, StdErr = 0.043 μs (0.40%), N = 9, StdDev = 0.130 μs
+Min = 10.710 μs, Q1 = 10.750 μs, Median = 10.840 μs, Q3 = 10.860 μs, Max = 11.091 μs
+IQR = 0.110 μs, LowerFence = 10.585 μs, UpperFence = 11.025 μs
+ConfidenceInterval = [10.631 μs; 11.068 μs] (CI 99.9%), Margin = 0.219 μs (2.01% of Mean)
+Skewness = 0.67, Kurtosis = 1.95, MValue = 2
+
+// ** Remained 13 (26.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: ProtocolBenchmarks.'Write 1000 VarInts': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.ProtocolBenchmarks.WriteVarInt_Thousand --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 37 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-OFEXQU(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 245937.00 ns, 245.9370 us/op
+WorkloadJitting  1: 1 op, 241629.00 ns, 241.6290 us/op
+
+OverheadWarmup   1: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   2: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   3: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadWarmup   4: 1 op, 631.00 ns, 631.0000 ns/op
+OverheadWarmup   5: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadWarmup   6: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   7: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadWarmup   8: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   9: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup  10: 1 op, 290.00 ns, 290.0000 ns/op
+
+OverheadActual   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   2: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   3: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual   4: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   5: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   6: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   7: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   8: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   9: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  10: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  11: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  12: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  13: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  14: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  15: 1 op, 651.00 ns, 651.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 35356.00 ns, 35.3560 us/op
+WorkloadWarmup   2: 1 op, 26950.00 ns, 26.9500 us/op
+WorkloadWarmup   3: 1 op, 26940.00 ns, 26.9400 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 27370.00 ns, 27.3700 us/op
+WorkloadActual   2: 1 op, 27090.00 ns, 27.0900 us/op
+WorkloadActual   3: 1 op, 27330.00 ns, 27.3300 us/op
+WorkloadActual   4: 1 op, 26970.00 ns, 26.9700 us/op
+WorkloadActual   5: 1 op, 37199.00 ns, 37.1990 us/op
+WorkloadActual   6: 1 op, 397659.00 ns, 397.6590 us/op
+WorkloadActual   7: 1 op, 41887.00 ns, 41.8870 us/op
+WorkloadActual   8: 1 op, 42208.00 ns, 42.2080 us/op
+WorkloadActual   9: 1 op, 41086.00 ns, 41.0860 us/op
+WorkloadActual  10: 1 op, 41457.00 ns, 41.4570 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 27070.00 ns, 27.0700 us/op
+WorkloadResult   2: 1 op, 26790.00 ns, 26.7900 us/op
+WorkloadResult   3: 1 op, 27030.00 ns, 27.0300 us/op
+WorkloadResult   4: 1 op, 26670.00 ns, 26.6700 us/op
+WorkloadResult   5: 1 op, 36899.00 ns, 36.8990 us/op
+WorkloadResult   6: 1 op, 41587.00 ns, 41.5870 us/op
+WorkloadResult   7: 1 op, 41908.00 ns, 41.9080 us/op
+WorkloadResult   8: 1 op, 40786.00 ns, 40.7860 us/op
+WorkloadResult   9: 1 op, 41157.00 ns, 41.1570 us/op
+// GC:  0 0 0 736 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3604 has exited with code 0.
+
+Mean = 34.433 μs, StdErr = 2.434 μs (7.07%), N = 9, StdDev = 7.301 μs
+Min = 26.670 μs, Q1 = 27.030 μs, Median = 36.899 μs, Q3 = 41.157 μs, Max = 41.908 μs
+IQR = 14.127 μs, LowerFence = 5.840 μs, UpperFence = 62.347 μs
+ConfidenceInterval = [22.165 μs; 46.701 μs] (CI 99.9%), Margin = 12.268 μs (35.63% of Mean)
+Skewness = -0.1, Kurtosis = 0.88, MValue = 3.6
+
+// ** Remained 12 (24.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: ProtocolBenchmarks.'Read 1000 Int32s': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.ProtocolBenchmarks.ReadInt32_Thousand --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 38 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-CAMRKA(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 261436.00 ns, 261.4360 us/op
+WorkloadJitting  1: 1 op, 541707.00 ns, 541.7070 us/op
+
+OverheadWarmup   1: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadWarmup   2: 1 op, 671.00 ns, 671.0000 ns/op
+OverheadWarmup   3: 1 op, 240.00 ns, 240.0000 ns/op
+OverheadWarmup   4: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   5: 1 op, 300.00 ns, 300.0000 ns/op
+
+OverheadActual   1: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   2: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual   3: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   4: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   5: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   6: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   7: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   8: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   9: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  10: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual  11: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  12: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual  13: 1 op, 250.00 ns, 250.0000 ns/op
+OverheadActual  14: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  15: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  16: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  17: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  18: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  19: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  20: 1 op, 311.00 ns, 311.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 9507.00 ns, 9.5070 us/op
+WorkloadWarmup   2: 1 op, 9257.00 ns, 9.2570 us/op
+WorkloadWarmup   3: 1 op, 9308.00 ns, 9.3080 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 9417.00 ns, 9.4170 us/op
+WorkloadActual   2: 1 op, 9528.00 ns, 9.5280 us/op
+WorkloadActual   3: 1 op, 9247.00 ns, 9.2470 us/op
+WorkloadActual   4: 1 op, 9577.00 ns, 9.5770 us/op
+WorkloadActual   5: 1 op, 17172.00 ns, 17.1720 us/op
+WorkloadActual   6: 1 op, 499569.00 ns, 499.5690 us/op
+WorkloadActual   7: 1 op, 21330.00 ns, 21.3300 us/op
+WorkloadActual   8: 1 op, 21120.00 ns, 21.1200 us/op
+WorkloadActual   9: 1 op, 20959.00 ns, 20.9590 us/op
+WorkloadActual  10: 1 op, 21089.00 ns, 21.0890 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 9116.50 ns, 9.1165 us/op
+WorkloadResult   2: 1 op, 9227.50 ns, 9.2275 us/op
+WorkloadResult   3: 1 op, 8946.50 ns, 8.9465 us/op
+WorkloadResult   4: 1 op, 9276.50 ns, 9.2765 us/op
+WorkloadResult   5: 1 op, 16871.50 ns, 16.8715 us/op
+WorkloadResult   6: 1 op, 21029.50 ns, 21.0295 us/op
+WorkloadResult   7: 1 op, 20819.50 ns, 20.8195 us/op
+WorkloadResult   8: 1 op, 20658.50 ns, 20.6585 us/op
+WorkloadResult   9: 1 op, 20788.50 ns, 20.7885 us/op
+// GC:  0 0 0 736 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3611 has exited with code 0.
+
+Mean = 15.193 μs, StdErr = 1.959 μs (12.89%), N = 9, StdDev = 5.876 μs
+Min = 8.947 μs, Q1 = 9.227 μs, Median = 16.872 μs, Q3 = 20.788 μs, Max = 21.029 μs
+IQR = 11.561 μs, LowerFence = -8.114 μs, UpperFence = 38.130 μs
+ConfidenceInterval = [5.318 μs; 25.068 μs] (CI 99.9%), Margin = 9.875 μs (65.00% of Mean)
+Skewness = -0.09, Kurtosis = 0.88, MValue = 2
+
+// ** Remained 11 (22.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: ProtocolBenchmarks.'Read 1000 VarInts': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.ProtocolBenchmarks.ReadVarInt_Thousand --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 39 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-VZCIZY(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 264793.00 ns, 264.7930 us/op
+WorkloadJitting  1: 1 op, 650800.00 ns, 650.8000 us/op
+
+OverheadWarmup   1: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadWarmup   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   3: 1 op, 240.00 ns, 240.0000 ns/op
+OverheadWarmup   4: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadWarmup   5: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadWarmup   6: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   7: 1 op, 310.00 ns, 310.0000 ns/op
+
+OverheadActual   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   2: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   3: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual   4: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   5: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   6: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   7: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   8: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   9: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  10: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  11: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  12: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  13: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual  14: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual  15: 1 op, 320.00 ns, 320.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 19676.00 ns, 19.6760 us/op
+WorkloadWarmup   2: 1 op, 19576.00 ns, 19.5760 us/op
+WorkloadWarmup   3: 1 op, 19316.00 ns, 19.3160 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 19547.00 ns, 19.5470 us/op
+WorkloadActual   2: 1 op, 19706.00 ns, 19.7060 us/op
+WorkloadActual   3: 1 op, 19597.00 ns, 19.5970 us/op
+WorkloadActual   4: 1 op, 19386.00 ns, 19.3860 us/op
+WorkloadActual   5: 1 op, 26920.00 ns, 26.9200 us/op
+WorkloadActual   6: 1 op, 541818.00 ns, 541.8180 us/op
+WorkloadActual   7: 1 op, 30637.00 ns, 30.6370 us/op
+WorkloadActual   8: 1 op, 30647.00 ns, 30.6470 us/op
+WorkloadActual   9: 1 op, 30166.00 ns, 30.1660 us/op
+WorkloadActual  10: 1 op, 30327.00 ns, 30.3270 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 19227.00 ns, 19.2270 us/op
+WorkloadResult   2: 1 op, 19386.00 ns, 19.3860 us/op
+WorkloadResult   3: 1 op, 19277.00 ns, 19.2770 us/op
+WorkloadResult   4: 1 op, 19066.00 ns, 19.0660 us/op
+WorkloadResult   5: 1 op, 26600.00 ns, 26.6000 us/op
+WorkloadResult   6: 1 op, 30317.00 ns, 30.3170 us/op
+WorkloadResult   7: 1 op, 30327.00 ns, 30.3270 us/op
+WorkloadResult   8: 1 op, 29846.00 ns, 29.8460 us/op
+WorkloadResult   9: 1 op, 30007.00 ns, 30.0070 us/op
+// GC:  0 0 0 736 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3618 has exited with code 0.
+
+Mean = 24.895 μs, StdErr = 1.828 μs (7.34%), N = 9, StdDev = 5.483 μs
+Min = 19.066 μs, Q1 = 19.277 μs, Median = 26.600 μs, Q3 = 30.007 μs, Max = 30.327 μs
+IQR = 10.730 μs, LowerFence = 3.182 μs, UpperFence = 46.102 μs
+ConfidenceInterval = [15.682 μs; 34.108 μs] (CI 99.9%), Margin = 9.213 μs (37.01% of Mean)
+Skewness = -0.1, Kurtosis = 0.88, MValue = 3.6
+
+// ** Remained 10 (20.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: ProtocolBenchmarks.'Write RecordBatch (10 records)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.ProtocolBenchmarks.WriteRecordBatch --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 40 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-KBCTRG(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 228625.00 ns, 228.6250 us/op
+WorkloadJitting  1: 1 op, 442082.00 ns, 442.0820 us/op
+
+OverheadWarmup   1: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadWarmup   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   3: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadWarmup   4: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadWarmup   5: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   6: 1 op, 241.00 ns, 241.0000 ns/op
+OverheadWarmup   7: 1 op, 241.00 ns, 241.0000 ns/op
+
+OverheadActual   1: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   3: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   4: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   5: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual   6: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadActual   7: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual   8: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   9: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  10: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  11: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual  12: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  13: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  14: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual  15: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  16: 1 op, 271.00 ns, 271.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 17623.00 ns, 17.6230 us/op
+WorkloadWarmup   2: 1 op, 17512.00 ns, 17.5120 us/op
+WorkloadWarmup   3: 1 op, 17243.00 ns, 17.2430 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 17592.00 ns, 17.5920 us/op
+WorkloadActual   2: 1 op, 17102.00 ns, 17.1020 us/op
+WorkloadActual   3: 1 op, 17052.00 ns, 17.0520 us/op
+WorkloadActual   4: 1 op, 17001.00 ns, 17.0010 us/op
+WorkloadActual   5: 1 op, 17272.00 ns, 17.2720 us/op
+WorkloadActual   6: 1 op, 17002.00 ns, 17.0020 us/op
+WorkloadActual   7: 1 op, 16921.00 ns, 16.9210 us/op
+WorkloadActual   8: 1 op, 17192.00 ns, 17.1920 us/op
+WorkloadActual   9: 1 op, 17021.00 ns, 17.0210 us/op
+WorkloadActual  10: 1 op, 17162.00 ns, 17.1620 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 16831.00 ns, 16.8310 us/op
+WorkloadResult   2: 1 op, 16781.00 ns, 16.7810 us/op
+WorkloadResult   3: 1 op, 16730.00 ns, 16.7300 us/op
+WorkloadResult   4: 1 op, 17001.00 ns, 17.0010 us/op
+WorkloadResult   5: 1 op, 16731.00 ns, 16.7310 us/op
+WorkloadResult   6: 1 op, 16650.00 ns, 16.6500 us/op
+WorkloadResult   7: 1 op, 16921.00 ns, 16.9210 us/op
+WorkloadResult   8: 1 op, 16750.00 ns, 16.7500 us/op
+WorkloadResult   9: 1 op, 16891.00 ns, 16.8910 us/op
+// GC:  0 0 0 3024 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3625 has exited with code 0.
+
+Mean = 16.810 μs, StdErr = 0.037 μs (0.22%), N = 9, StdDev = 0.111 μs
+Min = 16.650 μs, Q1 = 16.731 μs, Median = 16.781 μs, Q3 = 16.891 μs, Max = 17.001 μs
+IQR = 0.160 μs, LowerFence = 16.491 μs, UpperFence = 17.131 μs
+ConfidenceInterval = [16.623 μs; 16.996 μs] (CI 99.9%), Margin = 0.186 μs (1.11% of Mean)
+Skewness = 0.3, Kurtosis = 1.67, MValue = 2
+
+// ** Remained 9 (18.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: ProtocolBenchmarks.'Read RecordBatch (10 records)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.ProtocolBenchmarks.ReadRecordBatch --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 41 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-FKDCCN(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 281794.00 ns, 281.7940 us/op
+WorkloadJitting  1: 1 op, 1728443.00 ns, 1.7284 ms/op
+
+OverheadWarmup   1: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   2: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadWarmup   3: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadWarmup   4: 1 op, 261.00 ns, 261.0000 ns/op
+OverheadWarmup   5: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadWarmup   6: 1 op, 261.00 ns, 261.0000 ns/op
+
+OverheadActual   1: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   2: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   3: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   4: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   5: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   6: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   7: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   8: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual   9: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  10: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  11: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  12: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  13: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual  14: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual  15: 1 op, 311.00 ns, 311.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 4859.00 ns, 4.8590 us/op
+WorkloadWarmup   2: 1 op, 4749.00 ns, 4.7490 us/op
+WorkloadWarmup   3: 1 op, 4849.00 ns, 4.8490 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 4829.00 ns, 4.8290 us/op
+WorkloadActual   2: 1 op, 4719.00 ns, 4.7190 us/op
+WorkloadActual   3: 1 op, 4678.00 ns, 4.6780 us/op
+WorkloadActual   4: 1 op, 4648.00 ns, 4.6480 us/op
+WorkloadActual   5: 1 op, 4699.00 ns, 4.6990 us/op
+WorkloadActual   6: 1 op, 4649.00 ns, 4.6490 us/op
+WorkloadActual   7: 1 op, 4819.00 ns, 4.8190 us/op
+WorkloadActual   8: 1 op, 4649.00 ns, 4.6490 us/op
+WorkloadActual   9: 1 op, 4698.00 ns, 4.6980 us/op
+WorkloadActual  10: 1 op, 4719.00 ns, 4.7190 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 4388.00 ns, 4.3880 us/op
+WorkloadResult   2: 1 op, 4347.00 ns, 4.3470 us/op
+WorkloadResult   3: 1 op, 4317.00 ns, 4.3170 us/op
+WorkloadResult   4: 1 op, 4368.00 ns, 4.3680 us/op
+WorkloadResult   5: 1 op, 4318.00 ns, 4.3180 us/op
+WorkloadResult   6: 1 op, 4318.00 ns, 4.3180 us/op
+WorkloadResult   7: 1 op, 4367.00 ns, 4.3670 us/op
+WorkloadResult   8: 1 op, 4388.00 ns, 4.3880 us/op
+// GC:  0 0 0 2960 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3632 has exited with code 0.
+
+Mean = 4.351 μs, StdErr = 0.011 μs (0.25%), N = 8, StdDev = 0.031 μs
+Min = 4.317 μs, Q1 = 4.318 μs, Median = 4.357 μs, Q3 = 4.373 μs, Max = 4.388 μs
+IQR = 0.055 μs, LowerFence = 4.236 μs, UpperFence = 4.455 μs
+ConfidenceInterval = [4.293 μs; 4.410 μs] (CI 99.9%), Margin = 0.059 μs (1.35% of Mean)
+Skewness = -0.04, Kurtosis = 1.06, MValue = 2
+
+// ** Remained 8 (16.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// ***** BenchmarkRunner: Finish  *****
+
+// * Export *
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.ProtocolBenchmarks-report.csv
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.ProtocolBenchmarks-report-github.md
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.ProtocolBenchmarks-report.html
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.ProtocolBenchmarks-report-full-compressed.json
+
+// * Detailed results *
+ProtocolBenchmarks.'Write 1000 Int32s': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 35.194 μs, StdErr = 3.283 μs (9.33%), N = 9, StdDev = 9.850 μs
+Min = 24.787 μs, Q1 = 26.549 μs, Median = 38.492 μs, Q3 = 38.712 μs, Max = 55.534 μs
+IQR = 12.163 μs, LowerFence = 8.305 μs, UpperFence = 56.956 μs
+ConfidenceInterval = [18.641 μs; 51.746 μs] (CI 99.9%), Margin = 16.552 μs (47.03% of Mean)
+Skewness = 0.67, Kurtosis = 2.34, MValue = 2.4
+-------------------- Histogram --------------------
+[18.572 μs ; 27.889 μs) | @@@
+[27.889 μs ; 40.319 μs) | @@@@@
+[40.319 μs ; 49.319 μs) | 
+[49.319 μs ; 61.749 μs) | @
+---------------------------------------------------
+
+ProtocolBenchmarks.'Write 100 Strings (100 chars)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 13.081 μs, StdErr = 0.053 μs (0.40%), N = 9, StdDev = 0.158 μs
+Min = 12.818 μs, Q1 = 12.979 μs, Median = 13.140 μs, Q3 = 13.189 μs, Max = 13.260 μs
+IQR = 0.210 μs, LowerFence = 12.664 μs, UpperFence = 13.504 μs
+ConfidenceInterval = [12.815 μs; 13.348 μs] (CI 99.9%), Margin = 0.266 μs (2.03% of Mean)
+Skewness = -0.34, Kurtosis = 1.46, MValue = 2
+-------------------- Histogram --------------------
+[12.718 μs ; 13.332 μs) | @@@@@@@@@
+---------------------------------------------------
+
+ProtocolBenchmarks.'Write 100 CompactStrings': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 10.849 μs, StdErr = 0.043 μs (0.40%), N = 9, StdDev = 0.130 μs
+Min = 10.710 μs, Q1 = 10.750 μs, Median = 10.840 μs, Q3 = 10.860 μs, Max = 11.091 μs
+IQR = 0.110 μs, LowerFence = 10.585 μs, UpperFence = 11.025 μs
+ConfidenceInterval = [10.631 μs; 11.068 μs] (CI 99.9%), Margin = 0.219 μs (2.01% of Mean)
+Skewness = 0.67, Kurtosis = 1.95, MValue = 2
+-------------------- Histogram --------------------
+[10.677 μs ; 10.945 μs) | @@@@@@@
+[10.945 μs ; 11.173 μs) | @@
+---------------------------------------------------
+
+ProtocolBenchmarks.'Write 1000 VarInts': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 34.433 μs, StdErr = 2.434 μs (7.07%), N = 9, StdDev = 7.301 μs
+Min = 26.670 μs, Q1 = 27.030 μs, Median = 36.899 μs, Q3 = 41.157 μs, Max = 41.908 μs
+IQR = 14.127 μs, LowerFence = 5.840 μs, UpperFence = 62.347 μs
+ConfidenceInterval = [22.165 μs; 46.701 μs] (CI 99.9%), Margin = 12.268 μs (35.63% of Mean)
+Skewness = -0.1, Kurtosis = 0.88, MValue = 3.6
+-------------------- Histogram --------------------
+[22.063 μs ; 31.477 μs) | @@@@
+[31.477 μs ; 34.797 μs) | 
+[34.797 μs ; 44.010 μs) | @@@@@
+---------------------------------------------------
+
+ProtocolBenchmarks.'Read 1000 Int32s': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 15.193 μs, StdErr = 1.959 μs (12.89%), N = 9, StdDev = 5.876 μs
+Min = 8.947 μs, Q1 = 9.227 μs, Median = 16.872 μs, Q3 = 20.788 μs, Max = 21.029 μs
+IQR = 11.561 μs, LowerFence = -8.114 μs, UpperFence = 38.130 μs
+ConfidenceInterval = [5.318 μs; 25.068 μs] (CI 99.9%), Margin = 9.875 μs (65.00% of Mean)
+Skewness = -0.09, Kurtosis = 0.88, MValue = 2
+-------------------- Histogram --------------------
+[ 5.239 μs ; 12.819 μs) | @@@@
+[12.819 μs ; 22.658 μs) | @@@@@
+---------------------------------------------------
+
+ProtocolBenchmarks.'Read 1000 VarInts': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 24.895 μs, StdErr = 1.828 μs (7.34%), N = 9, StdDev = 5.483 μs
+Min = 19.066 μs, Q1 = 19.277 μs, Median = 26.600 μs, Q3 = 30.007 μs, Max = 30.327 μs
+IQR = 10.730 μs, LowerFence = 3.182 μs, UpperFence = 46.102 μs
+ConfidenceInterval = [15.682 μs; 34.108 μs] (CI 99.9%), Margin = 9.213 μs (37.01% of Mean)
+Skewness = -0.1, Kurtosis = 0.88, MValue = 3.6
+-------------------- Histogram --------------------
+[15.607 μs ; 22.685 μs) | @@@@
+[22.685 μs ; 25.004 μs) | 
+[25.004 μs ; 31.923 μs) | @@@@@
+---------------------------------------------------
+
+ProtocolBenchmarks.'Write RecordBatch (10 records)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 16.810 μs, StdErr = 0.037 μs (0.22%), N = 9, StdDev = 0.111 μs
+Min = 16.650 μs, Q1 = 16.731 μs, Median = 16.781 μs, Q3 = 16.891 μs, Max = 17.001 μs
+IQR = 0.160 μs, LowerFence = 16.491 μs, UpperFence = 17.131 μs
+ConfidenceInterval = [16.623 μs; 16.996 μs] (CI 99.9%), Margin = 0.186 μs (1.11% of Mean)
+Skewness = 0.3, Kurtosis = 1.67, MValue = 2
+-------------------- Histogram --------------------
+[16.613 μs ; 17.071 μs) | @@@@@@@@@
+---------------------------------------------------
+
+ProtocolBenchmarks.'Read RecordBatch (10 records)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 4.351 μs, StdErr = 0.011 μs (0.25%), N = 8, StdDev = 0.031 μs
+Min = 4.317 μs, Q1 = 4.318 μs, Median = 4.357 μs, Q3 = 4.373 μs, Max = 4.388 μs
+IQR = 0.055 μs, LowerFence = 4.236 μs, UpperFence = 4.455 μs
+ConfidenceInterval = [4.293 μs; 4.410 μs] (CI 99.9%), Margin = 0.059 μs (1.35% of Mean)
+Skewness = -0.04, Kurtosis = 1.06, MValue = 2
+-------------------- Histogram --------------------
+[4.297 μs ; 4.408 μs) | @@@@@@@@
+---------------------------------------------------
+
+// * Summary *
+
+BenchmarkDotNet v0.14.0, Ubuntu 24.04.3 LTS (Noble Numbat)
+AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+.NET SDK 10.0.102
+  [Host]     : .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+  Job-JHGESK : .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+
+InvocationCount=1  IterationCount=10  UnrollFactor=1  
+WarmupCount=3  
+
+| Method                           | Mean      | Error      | StdDev    | Allocated |
+|--------------------------------- |----------:|-----------:|----------:|----------:|
+| 'Write 1000 Int32s'              | 35.194 μs | 16.5521 μs | 9.8499 μs |         - |
+| 'Write 100 Strings (100 chars)'  | 13.081 μs |  0.2662 μs | 0.1584 μs |         - |
+| 'Write 100 CompactStrings'       | 10.849 μs |  0.2186 μs | 0.1301 μs |         - |
+| 'Write 1000 VarInts'             | 34.433 μs | 12.2684 μs | 7.3007 μs |         - |
+| 'Read 1000 Int32s'               | 15.193 μs |  9.8749 μs | 5.8764 μs |         - |
+| 'Read 1000 VarInts'              | 24.895 μs |  9.2132 μs | 5.4826 μs |         - |
+| 'Write RecordBatch (10 records)' | 16.810 μs |  0.1864 μs | 0.1110 μs |         - |
+| 'Read RecordBatch (10 records)'  |  4.351 μs |  0.0589 μs | 0.0308 μs |         - |
+
+// * Warnings *
+MinIterationTime
+  ProtocolBenchmarks.'Write 1000 Int32s': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3              -> The minimum observed iteration time is 25.097μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  ProtocolBenchmarks.'Write 100 Strings (100 chars)': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3  -> The minimum observed iteration time is 13.414μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  ProtocolBenchmarks.'Write 100 CompactStrings': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3       -> The minimum observed iteration time is 11.02μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  ProtocolBenchmarks.'Write 1000 VarInts': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3             -> The minimum observed iteration time is 26.97μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  ProtocolBenchmarks.'Read 1000 Int32s': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3               -> The minimum observed iteration time is 9.247μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  ProtocolBenchmarks.'Read 1000 VarInts': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3              -> The minimum observed iteration time is 19.386μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  ProtocolBenchmarks.'Write RecordBatch (10 records)': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3 -> The minimum observed iteration time is 16.921μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  ProtocolBenchmarks.'Read RecordBatch (10 records)': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3  -> The minimum observed iteration time is 4.648μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+
+// * Hints *
+Outliers
+  ProtocolBenchmarks.'Write 1000 Int32s': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3              -> 1 outlier  was  removed (534.63 μs)
+  ProtocolBenchmarks.'Write 100 Strings (100 chars)': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3  -> 1 outlier  was  removed (14.23 μs)
+  ProtocolBenchmarks.'Write 100 CompactStrings': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3       -> 1 outlier  was  removed (31.58 μs)
+  ProtocolBenchmarks.'Write 1000 VarInts': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3             -> 1 outlier  was  removed (397.66 μs)
+  ProtocolBenchmarks.'Read 1000 Int32s': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3               -> 1 outlier  was  removed (499.57 μs)
+  ProtocolBenchmarks.'Read 1000 VarInts': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3              -> 1 outlier  was  removed (541.82 μs)
+  ProtocolBenchmarks.'Write RecordBatch (10 records)': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3 -> 1 outlier  was  removed (17.59 μs)
+  ProtocolBenchmarks.'Read RecordBatch (10 records)': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3  -> 2 outliers were removed (4.82 μs, 4.83 μs)
+
+// * Legends *
+  Mean      : Arithmetic mean of all measurements
+  Error     : Half of 99.9% confidence interval
+  StdDev    : Standard deviation of all measurements
+  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
+  1 μs      : 1 Microsecond (0.000001 sec)
+
+// * Diagnostic Output - MemoryDiagnoser *
+
+
+// ***** BenchmarkRunner: End *****
+Run time: 00:00:01 (1.43 sec), executed benchmarks: 8
+
+// Found 8 benchmarks:
+//   SerializerBenchmarks.'Serialize String (10 chars)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   SerializerBenchmarks.'Serialize String (100 chars)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   SerializerBenchmarks.'Serialize String (1000 chars)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   SerializerBenchmarks.'Deserialize String': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   SerializerBenchmarks.'Serialize Int32': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   SerializerBenchmarks.'Serialize 100 Messages (key+value)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   SerializerBenchmarks.'ArrayBufferWriter + Copy': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+//   SerializerBenchmarks.'PooledBufferWriter Direct': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+// **************************
+// Benchmark: SerializerBenchmarks.'Serialize String (10 chars)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.SerializerBenchmarks.SerializeString_Small --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 42 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-FATMLQ(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 305659.00 ns, 305.6590 us/op
+WorkloadJitting  1: 1 op, 1260203.00 ns, 1.2602 ms/op
+
+OverheadWarmup   1: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadWarmup   2: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   3: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   4: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   6: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadWarmup   7: 1 op, 311.00 ns, 311.0000 ns/op
+
+OverheadActual   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   2: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual   3: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   4: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   6: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   7: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   8: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   9: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  10: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  11: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  12: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  13: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  14: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  15: 1 op, 300.00 ns, 300.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 14436.00 ns, 14.4360 us/op
+WorkloadWarmup   2: 1 op, 1593.00 ns, 1.5930 us/op
+WorkloadWarmup   3: 1 op, 1643.00 ns, 1.6430 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 1754.00 ns, 1.7540 us/op
+WorkloadActual   2: 1 op, 1563.00 ns, 1.5630 us/op
+WorkloadActual   3: 1 op, 1563.00 ns, 1.5630 us/op
+WorkloadActual   4: 1 op, 1533.00 ns, 1.5330 us/op
+WorkloadActual   5: 1 op, 1543.00 ns, 1.5430 us/op
+WorkloadActual   6: 1 op, 1553.00 ns, 1.5530 us/op
+WorkloadActual   7: 1 op, 1533.00 ns, 1.5330 us/op
+WorkloadActual   8: 1 op, 1543.00 ns, 1.5430 us/op
+WorkloadActual   9: 1 op, 1562.00 ns, 1.5620 us/op
+WorkloadActual  10: 1 op, 1543.00 ns, 1.5430 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 1262.00 ns, 1.2620 us/op
+WorkloadResult   2: 1 op, 1262.00 ns, 1.2620 us/op
+WorkloadResult   3: 1 op, 1232.00 ns, 1.2320 us/op
+WorkloadResult   4: 1 op, 1242.00 ns, 1.2420 us/op
+WorkloadResult   5: 1 op, 1252.00 ns, 1.2520 us/op
+WorkloadResult   6: 1 op, 1232.00 ns, 1.2320 us/op
+WorkloadResult   7: 1 op, 1242.00 ns, 1.2420 us/op
+WorkloadResult   8: 1 op, 1261.00 ns, 1.2610 us/op
+WorkloadResult   9: 1 op, 1242.00 ns, 1.2420 us/op
+// GC:  0 0 0 736 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3639 has exited with code 0.
+
+Mean = 1.247 μs, StdErr = 0.004 μs (0.33%), N = 9, StdDev = 0.012 μs
+Min = 1.232 μs, Q1 = 1.242 μs, Median = 1.242 μs, Q3 = 1.261 μs, Max = 1.262 μs
+IQR = 0.019 μs, LowerFence = 1.214 μs, UpperFence = 1.290 μs
+ConfidenceInterval = [1.227 μs; 1.268 μs] (CI 99.9%), Margin = 0.021 μs (1.65% of Mean)
+Skewness = 0.05, Kurtosis = 1.2, MValue = 2
+
+// ** Remained 7 (14.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: SerializerBenchmarks.'Serialize String (100 chars)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.SerializerBenchmarks.SerializeString_Medium --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 43 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-RRSAFF(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 242841.00 ns, 242.8410 us/op
+WorkloadJitting  1: 1 op, 1245845.00 ns, 1.2458 ms/op
+
+OverheadWarmup   1: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadWarmup   2: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadWarmup   3: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadWarmup   4: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadWarmup   5: 1 op, 381.00 ns, 381.0000 ns/op
+
+OverheadActual   1: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual   2: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual   3: 1 op, 381.00 ns, 381.0000 ns/op
+OverheadActual   4: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   5: 1 op, 370.00 ns, 370.0000 ns/op
+OverheadActual   6: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   7: 1 op, 621.00 ns, 621.0000 ns/op
+OverheadActual   8: 1 op, 662.00 ns, 662.0000 ns/op
+OverheadActual   9: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  10: 1 op, 721.00 ns, 721.0000 ns/op
+OverheadActual  11: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual  12: 1 op, 621.00 ns, 621.0000 ns/op
+OverheadActual  13: 1 op, 631.00 ns, 631.0000 ns/op
+OverheadActual  14: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual  15: 1 op, 601.00 ns, 601.0000 ns/op
+OverheadActual  16: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadActual  17: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  18: 1 op, 602.00 ns, 602.0000 ns/op
+OverheadActual  19: 1 op, 701.00 ns, 701.0000 ns/op
+OverheadActual  20: 1 op, 641.00 ns, 641.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 18705.00 ns, 18.7050 us/op
+WorkloadWarmup   2: 1 op, 2254.00 ns, 2.2540 us/op
+WorkloadWarmup   3: 1 op, 2244.00 ns, 2.2440 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 2014.00 ns, 2.0140 us/op
+WorkloadActual   2: 1 op, 2244.00 ns, 2.2440 us/op
+WorkloadActual   3: 1 op, 2124.00 ns, 2.1240 us/op
+WorkloadActual   4: 1 op, 2204.00 ns, 2.2040 us/op
+WorkloadActual   5: 1 op, 1933.00 ns, 1.9330 us/op
+WorkloadActual   6: 1 op, 1994.00 ns, 1.9940 us/op
+WorkloadActual   7: 1 op, 2074.00 ns, 2.0740 us/op
+WorkloadActual   8: 1 op, 2034.00 ns, 2.0340 us/op
+WorkloadActual   9: 1 op, 2194.00 ns, 2.1940 us/op
+WorkloadActual  10: 1 op, 2054.00 ns, 2.0540 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 1628.00 ns, 1.6280 us/op
+WorkloadResult   2: 1 op, 1858.00 ns, 1.8580 us/op
+WorkloadResult   3: 1 op, 1738.00 ns, 1.7380 us/op
+WorkloadResult   4: 1 op, 1818.00 ns, 1.8180 us/op
+WorkloadResult   5: 1 op, 1547.00 ns, 1.5470 us/op
+WorkloadResult   6: 1 op, 1608.00 ns, 1.6080 us/op
+WorkloadResult   7: 1 op, 1688.00 ns, 1.6880 us/op
+WorkloadResult   8: 1 op, 1648.00 ns, 1.6480 us/op
+WorkloadResult   9: 1 op, 1808.00 ns, 1.8080 us/op
+WorkloadResult  10: 1 op, 1668.00 ns, 1.6680 us/op
+// GC:  0 0 0 736 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3646 has exited with code 0.
+
+Mean = 1.701 μs, StdErr = 0.032 μs (1.89%), N = 10, StdDev = 0.102 μs
+Min = 1.547 μs, Q1 = 1.633 μs, Median = 1.678 μs, Q3 = 1.790 μs, Max = 1.858 μs
+IQR = 0.158 μs, LowerFence = 1.397 μs, UpperFence = 2.027 μs
+ConfidenceInterval = [1.547 μs; 1.855 μs] (CI 99.9%), Margin = 0.154 μs (9.03% of Mean)
+Skewness = 0.17, Kurtosis = 1.5, MValue = 2
+
+// ** Remained 6 (12.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: SerializerBenchmarks.'Serialize String (1000 chars)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.SerializerBenchmarks.SerializeString_Large --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 44 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-ADYCAP(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 237712.00 ns, 237.7120 us/op
+WorkloadJitting  1: 1 op, 1254722.00 ns, 1.2547 ms/op
+
+OverheadWarmup   1: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadWarmup   2: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadWarmup   3: 1 op, 400.00 ns, 400.0000 ns/op
+OverheadWarmup   4: 1 op, 611.00 ns, 611.0000 ns/op
+OverheadWarmup   5: 1 op, 701.00 ns, 701.0000 ns/op
+OverheadWarmup   6: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadWarmup   7: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadWarmup   8: 1 op, 311.00 ns, 311.0000 ns/op
+
+OverheadActual   1: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual   2: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   3: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual   4: 1 op, 390.00 ns, 390.0000 ns/op
+OverheadActual   5: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual   6: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual   7: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   8: 1 op, 751.00 ns, 751.0000 ns/op
+OverheadActual   9: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  10: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual  11: 1 op, 681.00 ns, 681.0000 ns/op
+OverheadActual  12: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadActual  13: 1 op, 671.00 ns, 671.0000 ns/op
+OverheadActual  14: 1 op, 380.00 ns, 380.0000 ns/op
+OverheadActual  15: 1 op, 390.00 ns, 390.0000 ns/op
+OverheadActual  16: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual  17: 1 op, 652.00 ns, 652.0000 ns/op
+OverheadActual  18: 1 op, 361.00 ns, 361.0000 ns/op
+OverheadActual  19: 1 op, 641.00 ns, 641.0000 ns/op
+OverheadActual  20: 1 op, 381.00 ns, 381.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 18044.00 ns, 18.0440 us/op
+WorkloadWarmup   2: 1 op, 2194.00 ns, 2.1940 us/op
+WorkloadWarmup   3: 1 op, 2154.00 ns, 2.1540 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 2174.00 ns, 2.1740 us/op
+WorkloadActual   2: 1 op, 2495.00 ns, 2.4950 us/op
+WorkloadActual   3: 1 op, 2244.00 ns, 2.2440 us/op
+WorkloadActual   4: 1 op, 2213.00 ns, 2.2130 us/op
+WorkloadActual   5: 1 op, 2354.00 ns, 2.3540 us/op
+WorkloadActual   6: 1 op, 2244.00 ns, 2.2440 us/op
+WorkloadActual   7: 1 op, 2004.00 ns, 2.0040 us/op
+WorkloadActual   8: 1 op, 2084.00 ns, 2.0840 us/op
+WorkloadActual   9: 1 op, 2154.00 ns, 2.1540 us/op
+WorkloadActual  10: 1 op, 2214.00 ns, 2.2140 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 1803.00 ns, 1.8030 us/op
+WorkloadResult   2: 1 op, 1873.00 ns, 1.8730 us/op
+WorkloadResult   3: 1 op, 1842.00 ns, 1.8420 us/op
+WorkloadResult   4: 1 op, 1983.00 ns, 1.9830 us/op
+WorkloadResult   5: 1 op, 1873.00 ns, 1.8730 us/op
+WorkloadResult   6: 1 op, 1633.00 ns, 1.6330 us/op
+WorkloadResult   7: 1 op, 1713.00 ns, 1.7130 us/op
+WorkloadResult   8: 1 op, 1783.00 ns, 1.7830 us/op
+WorkloadResult   9: 1 op, 1843.00 ns, 1.8430 us/op
+// GC:  0 0 0 736 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3653 has exited with code 0.
+
+Mean = 1.816 μs, StdErr = 0.034 μs (1.85%), N = 9, StdDev = 0.101 μs
+Min = 1.633 μs, Q1 = 1.783 μs, Median = 1.842 μs, Q3 = 1.873 μs, Max = 1.983 μs
+IQR = 0.090 μs, LowerFence = 1.648 μs, UpperFence = 2.008 μs
+ConfidenceInterval = [1.647 μs; 1.985 μs] (CI 99.9%), Margin = 0.169 μs (9.32% of Mean)
+Skewness = -0.24, Kurtosis = 2.2, MValue = 2.33
+
+// ** Remained 5 (10.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: SerializerBenchmarks.'Deserialize String': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.SerializerBenchmarks.DeserializeString --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 45 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-WGOQHO(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 289288.00 ns, 289.2880 us/op
+WorkloadJitting  1: 1 op, 1473388.00 ns, 1.4734 ms/op
+
+OverheadWarmup   1: 1 op, 360.00 ns, 360.0000 ns/op
+OverheadWarmup   2: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   3: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   4: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   5: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadWarmup   6: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   7: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   8: 1 op, 311.00 ns, 311.0000 ns/op
+
+OverheadActual   1: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual   2: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   3: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   4: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   5: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual   6: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   7: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   8: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   9: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  10: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual  11: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  12: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual  13: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  14: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  15: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  16: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  17: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  18: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  19: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  20: 1 op, 330.00 ns, 330.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 36347.00 ns, 36.3470 us/op
+WorkloadWarmup   2: 1 op, 3155.00 ns, 3.1550 us/op
+WorkloadWarmup   3: 1 op, 3176.00 ns, 3.1760 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 3226.00 ns, 3.2260 us/op
+WorkloadActual   2: 1 op, 3166.00 ns, 3.1660 us/op
+WorkloadActual   3: 1 op, 3136.00 ns, 3.1360 us/op
+WorkloadActual   4: 1 op, 3116.00 ns, 3.1160 us/op
+WorkloadActual   5: 1 op, 3157.00 ns, 3.1570 us/op
+WorkloadActual   6: 1 op, 3136.00 ns, 3.1360 us/op
+WorkloadActual   7: 1 op, 3156.00 ns, 3.1560 us/op
+WorkloadActual   8: 1 op, 3066.00 ns, 3.0660 us/op
+WorkloadActual   9: 1 op, 3106.00 ns, 3.1060 us/op
+WorkloadActual  10: 1 op, 3126.00 ns, 3.1260 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 2850.50 ns, 2.8505 us/op
+WorkloadResult   2: 1 op, 2820.50 ns, 2.8205 us/op
+WorkloadResult   3: 1 op, 2800.50 ns, 2.8005 us/op
+WorkloadResult   4: 1 op, 2841.50 ns, 2.8415 us/op
+WorkloadResult   5: 1 op, 2820.50 ns, 2.8205 us/op
+WorkloadResult   6: 1 op, 2840.50 ns, 2.8405 us/op
+WorkloadResult   7: 1 op, 2750.50 ns, 2.7505 us/op
+WorkloadResult   8: 1 op, 2790.50 ns, 2.7905 us/op
+WorkloadResult   9: 1 op, 2810.50 ns, 2.8105 us/op
+// GC:  0 0 0 672 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3660 has exited with code 0.
+
+Mean = 2.814 μs, StdErr = 0.010 μs (0.37%), N = 9, StdDev = 0.031 μs
+Min = 2.751 μs, Q1 = 2.800 μs, Median = 2.821 μs, Q3 = 2.841 μs, Max = 2.850 μs
+IQR = 0.040 μs, LowerFence = 2.740 μs, UpperFence = 2.901 μs
+ConfidenceInterval = [2.762 μs; 2.866 μs] (CI 99.9%), Margin = 0.052 μs (1.85% of Mean)
+Skewness = -0.68, Kurtosis = 2.35, MValue = 2
+
+// ** Remained 4 (8.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: SerializerBenchmarks.'Serialize Int32': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.SerializerBenchmarks.SerializeInt32 --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 46 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-IUGYUI(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 239937.00 ns, 239.9370 us/op
+WorkloadJitting  1: 1 op, 1227542.00 ns, 1.2275 ms/op
+
+OverheadWarmup   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   2: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   3: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   4: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   5: 1 op, 501.00 ns, 501.0000 ns/op
+OverheadWarmup   6: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   7: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadWarmup   8: 1 op, 321.00 ns, 321.0000 ns/op
+
+OverheadActual   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   2: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   3: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   4: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   6: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual   7: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   8: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   9: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  10: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  11: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual  12: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  13: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual  14: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual  15: 1 op, 311.00 ns, 311.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 13686.00 ns, 13.6860 us/op
+WorkloadWarmup   2: 1 op, 1022.00 ns, 1.0220 us/op
+WorkloadWarmup   3: 1 op, 1002.00 ns, 1.0020 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 1082.00 ns, 1.0820 us/op
+WorkloadActual   2: 1 op, 992.00 ns, 992.0000 ns/op
+WorkloadActual   3: 1 op, 982.00 ns, 982.0000 ns/op
+WorkloadActual   4: 1 op, 972.00 ns, 972.0000 ns/op
+WorkloadActual   5: 1 op, 982.00 ns, 982.0000 ns/op
+WorkloadActual   6: 1 op, 962.00 ns, 962.0000 ns/op
+WorkloadActual   7: 1 op, 921.00 ns, 921.0000 ns/op
+WorkloadActual   8: 1 op, 972.00 ns, 972.0000 ns/op
+WorkloadActual   9: 1 op, 962.00 ns, 962.0000 ns/op
+WorkloadActual  10: 1 op, 942.00 ns, 942.0000 ns/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 672.00 ns, 672.0000 ns/op
+WorkloadResult   2: 1 op, 662.00 ns, 662.0000 ns/op
+WorkloadResult   3: 1 op, 652.00 ns, 652.0000 ns/op
+WorkloadResult   4: 1 op, 662.00 ns, 662.0000 ns/op
+WorkloadResult   5: 1 op, 642.00 ns, 642.0000 ns/op
+WorkloadResult   6: 1 op, 601.00 ns, 601.0000 ns/op
+WorkloadResult   7: 1 op, 652.00 ns, 652.0000 ns/op
+WorkloadResult   8: 1 op, 642.00 ns, 642.0000 ns/op
+WorkloadResult   9: 1 op, 622.00 ns, 622.0000 ns/op
+// GC:  0 0 0 736 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3667 has exited with code 0.
+
+Mean = 645.222 ns, StdErr = 7.348 ns (1.14%), N = 9, StdDev = 22.044 ns
+Min = 601.000 ns, Q1 = 642.000 ns, Median = 652.000 ns, Q3 = 662.000 ns, Max = 672.000 ns
+IQR = 20.000 ns, LowerFence = 612.000 ns, UpperFence = 692.000 ns
+ConfidenceInterval = [608.178 ns; 682.266 ns] (CI 99.9%), Margin = 37.044 ns (5.74% of Mean)
+Skewness = -0.72, Kurtosis = 2.25, MValue = 2
+
+// ** Remained 3 (6.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: SerializerBenchmarks.'Serialize 100 Messages (key+value)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.SerializerBenchmarks.SerializeBatch --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 47 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-RBDEJI(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 238974.00 ns, 238.9740 us/op
+WorkloadJitting  1: 1 op, 1841293.00 ns, 1.8413 ms/op
+
+OverheadWarmup   1: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadWarmup   2: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   3: 1 op, 701.00 ns, 701.0000 ns/op
+OverheadWarmup   4: 1 op, 351.00 ns, 351.0000 ns/op
+OverheadWarmup   5: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadWarmup   6: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   7: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   8: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadWarmup   9: 1 op, 280.00 ns, 280.0000 ns/op
+
+OverheadActual   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   2: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   3: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual   4: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual   5: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   6: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   7: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual   8: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   9: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  10: 1 op, 250.00 ns, 250.0000 ns/op
+OverheadActual  11: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  12: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  13: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  14: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual  15: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  16: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadActual  17: 1 op, 260.00 ns, 260.0000 ns/op
+OverheadActual  18: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  19: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadActual  20: 1 op, 320.00 ns, 320.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 34455.00 ns, 34.4550 us/op
+WorkloadWarmup   2: 1 op, 34294.00 ns, 34.2940 us/op
+WorkloadWarmup   3: 1 op, 34505.00 ns, 34.5050 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 34474.00 ns, 34.4740 us/op
+WorkloadActual   2: 1 op, 34634.00 ns, 34.6340 us/op
+WorkloadActual   3: 1 op, 33813.00 ns, 33.8130 us/op
+WorkloadActual   4: 1 op, 34494.00 ns, 34.4940 us/op
+WorkloadActual   5: 1 op, 34174.00 ns, 34.1740 us/op
+WorkloadActual   6: 1 op, 33803.00 ns, 33.8030 us/op
+WorkloadActual   7: 1 op, 34303.00 ns, 34.3030 us/op
+WorkloadActual   8: 1 op, 34284.00 ns, 34.2840 us/op
+WorkloadActual   9: 1 op, 34003.00 ns, 34.0030 us/op
+WorkloadActual  10: 1 op, 35085.00 ns, 35.0850 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 34188.50 ns, 34.1885 us/op
+WorkloadResult   2: 1 op, 34348.50 ns, 34.3485 us/op
+WorkloadResult   3: 1 op, 33527.50 ns, 33.5275 us/op
+WorkloadResult   4: 1 op, 34208.50 ns, 34.2085 us/op
+WorkloadResult   5: 1 op, 33888.50 ns, 33.8885 us/op
+WorkloadResult   6: 1 op, 33517.50 ns, 33.5175 us/op
+WorkloadResult   7: 1 op, 34017.50 ns, 34.0175 us/op
+WorkloadResult   8: 1 op, 33998.50 ns, 33.9985 us/op
+WorkloadResult   9: 1 op, 33717.50 ns, 33.7175 us/op
+WorkloadResult  10: 1 op, 34799.50 ns, 34.7995 us/op
+// GC:  0 0 0 4656 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3674 has exited with code 0.
+
+Mean = 34.021 μs, StdErr = 0.124 μs (0.36%), N = 10, StdDev = 0.392 μs
+Min = 33.517 μs, Q1 = 33.760 μs, Median = 34.008 μs, Q3 = 34.203 μs, Max = 34.800 μs
+IQR = 0.443 μs, LowerFence = 33.095 μs, UpperFence = 34.868 μs
+ConfidenceInterval = [33.428 μs; 34.614 μs] (CI 99.9%), Margin = 0.593 μs (1.74% of Mean)
+Skewness = 0.4, Kurtosis = 2.17, MValue = 2
+
+// ** Remained 2 (4.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: SerializerBenchmarks.'ArrayBufferWriter + Copy': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.SerializerBenchmarks.Serialize_ArrayBufferWriter --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 48 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-GCYZFY(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 301901.00 ns, 301.9010 us/op
+WorkloadJitting  1: 1 op, 1424868.00 ns, 1.4249 ms/op
+
+OverheadWarmup   1: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   2: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   3: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadWarmup   4: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   5: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadWarmup   6: 1 op, 250.00 ns, 250.0000 ns/op
+
+OverheadActual   1: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual   2: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   3: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadActual   4: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadActual   5: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   6: 1 op, 602.00 ns, 602.0000 ns/op
+OverheadActual   7: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual   8: 1 op, 731.00 ns, 731.0000 ns/op
+OverheadActual   9: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  10: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  11: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  12: 1 op, 270.00 ns, 270.0000 ns/op
+OverheadActual  13: 1 op, 301.00 ns, 301.0000 ns/op
+OverheadActual  14: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  15: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  16: 1 op, 681.00 ns, 681.0000 ns/op
+OverheadActual  17: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  18: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual  19: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadActual  20: 1 op, 290.00 ns, 290.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 22492.00 ns, 22.4920 us/op
+WorkloadWarmup   2: 1 op, 4258.00 ns, 4.2580 us/op
+WorkloadWarmup   3: 1 op, 4068.00 ns, 4.0680 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 4518.00 ns, 4.5180 us/op
+WorkloadActual   2: 1 op, 4268.00 ns, 4.2680 us/op
+WorkloadActual   3: 1 op, 4128.00 ns, 4.1280 us/op
+WorkloadActual   4: 1 op, 4198.00 ns, 4.1980 us/op
+WorkloadActual   5: 1 op, 4037.00 ns, 4.0370 us/op
+WorkloadActual   6: 1 op, 4098.00 ns, 4.0980 us/op
+WorkloadActual   7: 1 op, 4158.00 ns, 4.1580 us/op
+WorkloadActual   8: 1 op, 4147.00 ns, 4.1470 us/op
+WorkloadActual   9: 1 op, 4127.00 ns, 4.1270 us/op
+WorkloadActual  10: 1 op, 4077.00 ns, 4.0770 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 3962.00 ns, 3.9620 us/op
+WorkloadResult   2: 1 op, 3822.00 ns, 3.8220 us/op
+WorkloadResult   3: 1 op, 3892.00 ns, 3.8920 us/op
+WorkloadResult   4: 1 op, 3731.00 ns, 3.7310 us/op
+WorkloadResult   5: 1 op, 3792.00 ns, 3.7920 us/op
+WorkloadResult   6: 1 op, 3852.00 ns, 3.8520 us/op
+WorkloadResult   7: 1 op, 3841.00 ns, 3.8410 us/op
+WorkloadResult   8: 1 op, 3821.00 ns, 3.8210 us/op
+WorkloadResult   9: 1 op, 3771.00 ns, 3.7710 us/op
+// GC:  0 0 0 1200 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3681 has exited with code 0.
+
+Mean = 3.832 μs, StdErr = 0.023 μs (0.59%), N = 9, StdDev = 0.068 μs
+Min = 3.731 μs, Q1 = 3.792 μs, Median = 3.822 μs, Q3 = 3.852 μs, Max = 3.962 μs
+IQR = 0.060 μs, LowerFence = 3.702 μs, UpperFence = 3.942 μs
+ConfidenceInterval = [3.718 μs; 3.945 μs] (CI 99.9%), Margin = 0.114 μs (2.97% of Mean)
+Skewness = 0.41, Kurtosis = 2.22, MValue = 2
+
+// ** Remained 1 (2.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// **************************
+// Benchmark: SerializerBenchmarks.'PooledBufferWriter Direct': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet cf76599f-c67d-4c4c-8b2e-5576dfa62b9b.dll --anonymousPipes 133 134 --benchmarkName Dekaf.Benchmarks.Benchmarks.Unit.SerializerBenchmarks.Serialize_PooledBufferWriter --job "InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3" --benchmarkId 49 in /home/runner/work/Dekaf/Dekaf/tools/Dekaf.Benchmarks/bin/Release/net10.0/cf76599f-c67d-4c4c-8b2e-5576dfa62b9b/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.14.0
+// Runtime=.NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: Job-NHNJAD(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+
+OverheadJitting  1: 1 op, 276554.00 ns, 276.5540 us/op
+WorkloadJitting  1: 1 op, 1713034.00 ns, 1.7130 ms/op
+
+OverheadWarmup   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadWarmup   2: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadWarmup   3: 1 op, 271.00 ns, 271.0000 ns/op
+OverheadWarmup   4: 1 op, 280.00 ns, 280.0000 ns/op
+OverheadWarmup   5: 1 op, 300.00 ns, 300.0000 ns/op
+OverheadWarmup   6: 1 op, 290.00 ns, 290.0000 ns/op
+OverheadWarmup   7: 1 op, 281.00 ns, 281.0000 ns/op
+OverheadWarmup   8: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadWarmup   9: 1 op, 281.00 ns, 281.0000 ns/op
+
+OverheadActual   1: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   2: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual   3: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   4: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual   5: 1 op, 321.00 ns, 321.0000 ns/op
+OverheadActual   6: 1 op, 330.00 ns, 330.0000 ns/op
+OverheadActual   7: 1 op, 331.00 ns, 331.0000 ns/op
+OverheadActual   8: 1 op, 341.00 ns, 341.0000 ns/op
+OverheadActual   9: 1 op, 370.00 ns, 370.0000 ns/op
+OverheadActual  10: 1 op, 310.00 ns, 310.0000 ns/op
+OverheadActual  11: 1 op, 340.00 ns, 340.0000 ns/op
+OverheadActual  12: 1 op, 291.00 ns, 291.0000 ns/op
+OverheadActual  13: 1 op, 350.00 ns, 350.0000 ns/op
+OverheadActual  14: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  15: 1 op, 371.00 ns, 371.0000 ns/op
+OverheadActual  16: 1 op, 801.00 ns, 801.0000 ns/op
+OverheadActual  17: 1 op, 320.00 ns, 320.0000 ns/op
+OverheadActual  18: 1 op, 391.00 ns, 391.0000 ns/op
+OverheadActual  19: 1 op, 311.00 ns, 311.0000 ns/op
+OverheadActual  20: 1 op, 291.00 ns, 291.0000 ns/op
+
+WorkloadWarmup   1: 1 op, 3897.00 ns, 3.8970 us/op
+WorkloadWarmup   2: 1 op, 3807.00 ns, 3.8070 us/op
+WorkloadWarmup   3: 1 op, 3717.00 ns, 3.7170 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 1 op, 3787.00 ns, 3.7870 us/op
+WorkloadActual   2: 1 op, 3817.00 ns, 3.8170 us/op
+WorkloadActual   3: 1 op, 3737.00 ns, 3.7370 us/op
+WorkloadActual   4: 1 op, 3736.00 ns, 3.7360 us/op
+WorkloadActual   5: 1 op, 3777.00 ns, 3.7770 us/op
+WorkloadActual   6: 1 op, 3707.00 ns, 3.7070 us/op
+WorkloadActual   7: 1 op, 3677.00 ns, 3.6770 us/op
+WorkloadActual   8: 1 op, 3637.00 ns, 3.6370 us/op
+WorkloadActual   9: 1 op, 3707.00 ns, 3.7070 us/op
+WorkloadActual  10: 1 op, 3677.00 ns, 3.6770 us/op
+
+// AfterActualRun
+WorkloadResult   1: 1 op, 3466.00 ns, 3.4660 us/op
+WorkloadResult   2: 1 op, 3496.00 ns, 3.4960 us/op
+WorkloadResult   3: 1 op, 3416.00 ns, 3.4160 us/op
+WorkloadResult   4: 1 op, 3415.00 ns, 3.4150 us/op
+WorkloadResult   5: 1 op, 3456.00 ns, 3.4560 us/op
+WorkloadResult   6: 1 op, 3386.00 ns, 3.3860 us/op
+WorkloadResult   7: 1 op, 3356.00 ns, 3.3560 us/op
+WorkloadResult   8: 1 op, 3316.00 ns, 3.3160 us/op
+WorkloadResult   9: 1 op, 3386.00 ns, 3.3860 us/op
+WorkloadResult  10: 1 op, 3356.00 ns, 3.3560 us/op
+// GC:  0 0 0 1016 1
+// Threading:  0 0 1
+
+// AfterAll
+// Benchmark Process 3688 has exited with code 0.
+
+Mean = 3.405 μs, StdErr = 0.018 μs (0.52%), N = 10, StdDev = 0.056 μs
+Min = 3.316 μs, Q1 = 3.364 μs, Median = 3.401 μs, Q3 = 3.446 μs, Max = 3.496 μs
+IQR = 0.083 μs, LowerFence = 3.240 μs, UpperFence = 3.570 μs
+ConfidenceInterval = [3.320 μs; 3.490 μs] (CI 99.9%), Margin = 0.085 μs (2.49% of Mean)
+Skewness = 0.1, Kurtosis = 1.66, MValue = 2
+
+// ** Remained 0 (0.0 %) benchmark(s) to run. Estimated finish 2026-02-27 19:26 (0h 0m from now) **
+// ***** BenchmarkRunner: Finish  *****
+
+// * Export *
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.SerializerBenchmarks-report.csv
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.SerializerBenchmarks-report-github.md
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.SerializerBenchmarks-report.html
+  BenchmarkResults/Unit/results/Dekaf.Benchmarks.Benchmarks.Unit.SerializerBenchmarks-report-full-compressed.json
+
+// * Detailed results *
+SerializerBenchmarks.'Serialize String (10 chars)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 1.247 μs, StdErr = 0.004 μs (0.33%), N = 9, StdDev = 0.012 μs
+Min = 1.232 μs, Q1 = 1.242 μs, Median = 1.242 μs, Q3 = 1.261 μs, Max = 1.262 μs
+IQR = 0.019 μs, LowerFence = 1.214 μs, UpperFence = 1.290 μs
+ConfidenceInterval = [1.227 μs; 1.268 μs] (CI 99.9%), Margin = 0.021 μs (1.65% of Mean)
+Skewness = 0.05, Kurtosis = 1.2, MValue = 2
+-------------------- Histogram --------------------
+[1.224 μs ; 1.270 μs) | @@@@@@@@@
+---------------------------------------------------
+
+SerializerBenchmarks.'Serialize String (100 chars)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 1.701 μs, StdErr = 0.032 μs (1.89%), N = 10, StdDev = 0.102 μs
+Min = 1.547 μs, Q1 = 1.633 μs, Median = 1.678 μs, Q3 = 1.790 μs, Max = 1.858 μs
+IQR = 0.158 μs, LowerFence = 1.397 μs, UpperFence = 2.027 μs
+ConfidenceInterval = [1.547 μs; 1.855 μs] (CI 99.9%), Margin = 0.154 μs (9.03% of Mean)
+Skewness = 0.17, Kurtosis = 1.5, MValue = 2
+-------------------- Histogram --------------------
+[1.485 μs ; 1.586 μs) | @
+[1.586 μs ; 1.710 μs) | @@@@@
+[1.710 μs ; 1.860 μs) | @@@@
+---------------------------------------------------
+
+SerializerBenchmarks.'Serialize String (1000 chars)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 1.816 μs, StdErr = 0.034 μs (1.85%), N = 9, StdDev = 0.101 μs
+Min = 1.633 μs, Q1 = 1.783 μs, Median = 1.842 μs, Q3 = 1.873 μs, Max = 1.983 μs
+IQR = 0.090 μs, LowerFence = 1.648 μs, UpperFence = 2.008 μs
+ConfidenceInterval = [1.647 μs; 1.985 μs] (CI 99.9%), Margin = 0.169 μs (9.32% of Mean)
+Skewness = -0.24, Kurtosis = 2.2, MValue = 2.33
+-------------------- Histogram --------------------
+[1.609 μs ; 1.737 μs) | @@
+[1.737 μs ; 1.892 μs) | @@@@@@
+[1.892 μs ; 2.047 μs) | @
+---------------------------------------------------
+
+SerializerBenchmarks.'Deserialize String': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 2.814 μs, StdErr = 0.010 μs (0.37%), N = 9, StdDev = 0.031 μs
+Min = 2.751 μs, Q1 = 2.800 μs, Median = 2.821 μs, Q3 = 2.841 μs, Max = 2.850 μs
+IQR = 0.040 μs, LowerFence = 2.740 μs, UpperFence = 2.901 μs
+ConfidenceInterval = [2.762 μs; 2.866 μs] (CI 99.9%), Margin = 0.052 μs (1.85% of Mean)
+Skewness = -0.68, Kurtosis = 2.35, MValue = 2
+-------------------- Histogram --------------------
+[2.731 μs ; 2.870 μs) | @@@@@@@@@
+---------------------------------------------------
+
+SerializerBenchmarks.'Serialize Int32': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 645.222 ns, StdErr = 7.348 ns (1.14%), N = 9, StdDev = 22.044 ns
+Min = 601.000 ns, Q1 = 642.000 ns, Median = 652.000 ns, Q3 = 662.000 ns, Max = 672.000 ns
+IQR = 20.000 ns, LowerFence = 612.000 ns, UpperFence = 692.000 ns
+ConfidenceInterval = [608.178 ns; 682.266 ns] (CI 99.9%), Margin = 37.044 ns (5.74% of Mean)
+Skewness = -0.72, Kurtosis = 2.25, MValue = 2
+-------------------- Histogram --------------------
+[597.590 ns ; 625.409 ns) | @@
+[625.409 ns ; 638.090 ns) | 
+[638.090 ns ; 665.909 ns) | @@@@@@
+[665.909 ns ; 685.910 ns) | @
+---------------------------------------------------
+
+SerializerBenchmarks.'Serialize 100 Messages (key+value)': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 34.021 μs, StdErr = 0.124 μs (0.36%), N = 10, StdDev = 0.392 μs
+Min = 33.517 μs, Q1 = 33.760 μs, Median = 34.008 μs, Q3 = 34.203 μs, Max = 34.800 μs
+IQR = 0.443 μs, LowerFence = 33.095 μs, UpperFence = 34.868 μs
+ConfidenceInterval = [33.428 μs; 34.614 μs] (CI 99.9%), Margin = 0.593 μs (1.74% of Mean)
+Skewness = 0.4, Kurtosis = 2.17, MValue = 2
+-------------------- Histogram --------------------
+[33.279 μs ; 35.038 μs) | @@@@@@@@@@
+---------------------------------------------------
+
+SerializerBenchmarks.'ArrayBufferWriter + Copy': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 3.832 μs, StdErr = 0.023 μs (0.59%), N = 9, StdDev = 0.068 μs
+Min = 3.731 μs, Q1 = 3.792 μs, Median = 3.822 μs, Q3 = 3.852 μs, Max = 3.962 μs
+IQR = 0.060 μs, LowerFence = 3.702 μs, UpperFence = 3.942 μs
+ConfidenceInterval = [3.718 μs; 3.945 μs] (CI 99.9%), Margin = 0.114 μs (2.97% of Mean)
+Skewness = 0.41, Kurtosis = 2.22, MValue = 2
+-------------------- Histogram --------------------
+[3.688 μs ; 3.769 μs) | @
+[3.769 μs ; 3.854 μs) | @@@@@@
+[3.854 μs ; 3.970 μs) | @@
+---------------------------------------------------
+
+SerializerBenchmarks.'PooledBufferWriter Direct': Job-JHGESK(InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3)
+Runtime = .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 3.405 μs, StdErr = 0.018 μs (0.52%), N = 10, StdDev = 0.056 μs
+Min = 3.316 μs, Q1 = 3.364 μs, Median = 3.401 μs, Q3 = 3.446 μs, Max = 3.496 μs
+IQR = 0.083 μs, LowerFence = 3.240 μs, UpperFence = 3.570 μs
+ConfidenceInterval = [3.320 μs; 3.490 μs] (CI 99.9%), Margin = 0.085 μs (2.49% of Mean)
+Skewness = 0.1, Kurtosis = 1.66, MValue = 2
+-------------------- Histogram --------------------
+[3.282 μs ; 3.352 μs) | @
+[3.352 μs ; 3.511 μs) | @@@@@@@@@
+---------------------------------------------------
+
+// * Summary *
+
+BenchmarkDotNet v0.14.0, Ubuntu 24.04.3 LTS (Noble Numbat)
+AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+.NET SDK 10.0.102
+  [Host]     : .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+  Job-JHGESK : .NET 10.0.3 (10.0.326.7603), X64 RyuJIT AVX2
+
+InvocationCount=1  IterationCount=10  UnrollFactor=1  
+WarmupCount=3  
+
+| Method                               | Mean        | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
+|------------------------------------- |------------:|----------:|----------:|------:|--------:|----------:|------------:|
+| 'Serialize String (10 chars)'        |  1,247.4 ns |  20.53 ns |  12.22 ns |  0.33 |    0.01 |         - |          NA |
+| 'Serialize String (100 chars)'       |  1,700.9 ns | 153.62 ns | 101.61 ns |  0.44 |    0.03 |         - |          NA |
+| 'Serialize String (1000 chars)'      |  1,816.2 ns | 169.24 ns | 100.71 ns |  0.47 |    0.03 |         - |          NA |
+| 'Deserialize String'                 |  2,813.9 ns |  51.98 ns |  30.93 ns |  0.73 |    0.01 |         - |          NA |
+| 'Serialize Int32'                    |    645.2 ns |  37.04 ns |  22.04 ns |  0.17 |    0.01 |         - |          NA |
+| 'Serialize 100 Messages (key+value)' | 34,021.2 ns | 592.82 ns | 392.11 ns |  8.88 |    0.18 |         - |          NA |
+| 'ArrayBufferWriter + Copy'           |  3,831.6 ns | 113.85 ns |  67.75 ns |  1.00 |    0.02 |         - |          NA |
+| 'PooledBufferWriter Direct'          |  3,404.9 ns |  84.73 ns |  56.04 ns |  0.89 |    0.02 |         - |          NA |
+
+// * Warnings *
+MinIterationTime
+  SerializerBenchmarks.'Serialize String (10 chars)': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3        -> The minimum observed iteration time is 1.533μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  SerializerBenchmarks.'Serialize String (100 chars)': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3       -> The minimum observed iteration time is 1.933μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  SerializerBenchmarks.'Serialize String (1000 chars)': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3      -> The minimum observed iteration time is 2.004μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  SerializerBenchmarks.'Deserialize String': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3                 -> The minimum observed iteration time is 3.066μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  SerializerBenchmarks.'Serialize Int32': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3                    -> The minimum observed iteration time is 921ns which is very small. It's recommended to increase it to at least 100ms using more operations.
+  SerializerBenchmarks.'Serialize 100 Messages (key+value)': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3 -> The minimum observed iteration time is 33.803μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  SerializerBenchmarks.'ArrayBufferWriter + Copy': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3           -> The minimum observed iteration time is 4.037μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+  SerializerBenchmarks.'PooledBufferWriter Direct': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3          -> The minimum observed iteration time is 3.637μs which is very small. It's recommended to increase it to at least 100ms using more operations.
+
+// * Hints *
+Outliers
+  SerializerBenchmarks.'Serialize String (10 chars)': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3   -> 1 outlier  was  removed (1.75 μs)
+  SerializerBenchmarks.'Serialize String (1000 chars)': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3 -> 1 outlier  was  removed, 2 outliers were detected (2.00 μs, 2.50 μs)
+  SerializerBenchmarks.'Deserialize String': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3            -> 1 outlier  was  removed (3.23 μs)
+  SerializerBenchmarks.'Serialize Int32': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3               -> 1 outlier  was  removed, 2 outliers were detected (921.00 ns, 1.08 μs)
+  SerializerBenchmarks.'ArrayBufferWriter + Copy': InvocationCount=1, IterationCount=10, UnrollFactor=1, WarmupCount=3      -> 1 outlier  was  removed (4.52 μs)
+
+// * Legends *
+  Mean        : Arithmetic mean of all measurements
+  Error       : Half of 99.9% confidence interval
+  StdDev      : Standard deviation of all measurements
+  Ratio       : Mean of the ratio distribution ([Current]/[Baseline])
+  RatioSD     : Standard deviation of the ratio distribution ([Current]/[Baseline])
+  Allocated   : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
+  Alloc Ratio : Allocated memory ratio distribution ([Current]/[Baseline])
+  1 ns        : 1 Nanosecond (0.000000001 sec)
+
+// * Diagnostic Output - MemoryDiagnoser *
+
+
+// ***** BenchmarkRunner: End *****
+Run time: 00:00:01 (1.38 sec), executed benchmarks: 8
+
+Global total time: 00:00:43 (43.67 sec), executed benchmarks: 50
+// * Artifacts cleanup *
+Artifacts cleanup is finished

--- a/docs/docs/benchmarks.md
+++ b/docs/docs/benchmarks.md
@@ -6,7 +6,7 @@ sidebar_position: 13
 
 Live benchmark comparisons between Dekaf and Confluent.Kafka, automatically updated on every commit to main.
 
-**Last Updated:** 2026-02-08 11:19 UTC
+**Last Updated:** 2026-02-27 19:30 UTC
 
 :::info
 These benchmarks run on GitHub Actions (ubuntu-latest) using BenchmarkDotNet. 
@@ -17,78 +17,110 @@ These benchmarks run on GitHub Actions (ubuntu-latest) using BenchmarkDotNet.
 
 Comparing Dekaf vs Confluent.Kafka for message production across different scenarios.
 
-| Method                  | Categories    | MessageSize | BatchSize | Mean        | Error       | StdDev      | Median      | Ratio | RatioSD | Gen0     | Gen1    | Allocated  | Alloc Ratio |
-|------------------------ |-------------- |------------ |---------- |------------:|------------:|------------:|------------:|------:|--------:|---------:|--------:|-----------:|------------:|
-| **Confluent_ProduceBatch**  | **BatchProduce**  | **100**         | **100**       |  **5,916.1 μs** |    **52.39 μs** |    **34.66 μs** |  **5,914.4 μs** |  **1.00** |    **0.01** |        **-** |       **-** |  **106.55 KB** |        **1.00** |
-| Dekaf_ProduceBatch      | BatchProduce  | 100         | 100       |  1,249.1 μs |    37.62 μs |    22.39 μs |  1,244.8 μs |  0.21 |    0.00 |   1.9531 |       - |   37.77 KB |        0.35 |
-|                         |               |             |           |             |             |             |             |       |         |          |         |            |             |
-| **Confluent_ProduceBatch**  | **BatchProduce**  | **100**         | **1000**      |  **7,221.0 μs** |    **83.00 μs** |    **54.90 μs** |  **7,204.8 μs** |  **1.00** |    **0.01** |  **62.5000** | **46.8750** | **1062.83 KB** |        **1.00** |
-| Dekaf_ProduceBatch      | BatchProduce  | 100         | 1000      |  6,015.1 μs | 3,339.33 μs | 2,208.76 μs |  5,841.4 μs |  0.83 |    0.29 |  23.4375 |  7.8125 |  474.79 KB |        0.45 |
-|                         |               |             |           |             |             |             |             |       |         |          |         |            |             |
-| **Confluent_ProduceBatch**  | **BatchProduce**  | **1000**        | **100**       |  **6,655.9 μs** |    **13.62 μs** |     **9.01 μs** |  **6,656.3 μs** |  **1.00** |    **0.00** |   **7.8125** |       **-** |  **194.05 KB** |        **1.00** |
-| Dekaf_ProduceBatch      | BatchProduce  | 1000        | 100       |  1,750.2 μs |   869.79 μs |   575.31 μs |  1,371.2 μs |  0.26 |    0.08 |        - |       - |   45.51 KB |        0.23 |
-|                         |               |             |           |             |             |             |             |       |         |          |         |            |             |
-| **Confluent_ProduceBatch**  | **BatchProduce**  | **1000**        | **1000**      | **11,479.1 μs** |   **253.24 μs** |   **167.50 μs** | **11,458.4 μs** |  **1.00** |    **0.02** | **109.3750** | **62.5000** | **1937.84 KB** |        **1.00** |
-| Dekaf_ProduceBatch      | BatchProduce  | 1000        | 1000      | 23,559.6 μs | 6,086.81 μs | 3,622.16 μs | 23,066.1 μs |  2.05 |    0.30 |  62.5000 |       - | 1273.62 KB |        0.66 |
-|                         |               |             |           |             |             |             |             |       |         |          |         |            |             |
-| **Confluent_FireAndForget** | **FireAndForget** | **100**         | **100**       |    **134.1 μs** |     **2.34 μs** |     **1.55 μs** |    **134.3 μs** |  **1.00** |    **0.02** |   **2.4414** |       **-** |   **42.06 KB** |        **1.00** |
-| Dekaf_FireAndForget     | FireAndForget | 100         | 100       |    367.7 μs |   184.40 μs |   121.97 μs |    387.0 μs |  2.74 |    0.87 |   0.2441 |       - |    5.23 KB |        0.12 |
-|                         |               |             |           |             |             |             |             |       |         |          |         |            |             |
-| **Confluent_FireAndForget** | **FireAndForget** | **100**         | **1000**      |  **1,326.6 μs** |    **49.58 μs** |    **29.50 μs** |  **1,329.9 μs** |  **1.00** |    **0.03** |  **25.3906** |       **-** |   **421.8 KB** |        **1.00** |
-| Dekaf_FireAndForget     | FireAndForget | 100         | 1000      |  3,212.7 μs |   665.53 μs |   348.09 μs |  3,322.4 μs |  2.42 |    0.25 |   1.9531 |       - |   52.87 KB |        0.13 |
-|                         |               |             |           |             |             |             |             |       |         |          |         |            |             |
-| **Confluent_FireAndForget** | **FireAndForget** | **1000**        | **100**       |          **NA** |          **NA** |          **NA** |          **NA** |     **?** |       **?** |       **NA** |      **NA** |         **NA** |           **?** |
-| Dekaf_FireAndForget     | FireAndForget | 1000        | 100       |  2,989.0 μs |   519.61 μs |   343.69 μs |  2,939.7 μs |     ? |       ? |   0.4883 |       - |   15.67 KB |           ? |
-|                         |               |             |           |             |             |             |             |       |         |          |         |            |             |
-| **Confluent_FireAndForget** | **FireAndForget** | **1000**        | **1000**      |          **NA** |          **NA** |          **NA** |          **NA** |     **?** |       **?** |       **NA** |      **NA** |         **NA** |           **?** |
-| Dekaf_FireAndForget     | FireAndForget | 1000        | 1000      | 25,444.0 μs | 2,314.18 μs | 1,377.13 μs | 25,533.9 μs |     ? |       ? |   7.8125 |       - |  159.48 KB |           ? |
-|                         |               |             |           |             |             |             |             |       |         |          |         |            |             |
-| **Confluent_ProduceSingle** | **SingleProduce** | **100**         | **100**       |  **5,366.0 μs** |     **3.34 μs** |     **1.99 μs** |  **5,366.2 μs** |  **1.00** |    **0.00** |        **-** |       **-** |    **1.19 KB** |        **1.00** |
-| Dekaf_ProduceSingle     | SingleProduce | 100         | 100       |  1,334.8 μs |    24.68 μs |    16.33 μs |  1,335.9 μs |  0.25 |    0.00 |        - |       - |     1.6 KB |        1.34 |
-|                         |               |             |           |             |             |             |             |       |         |          |         |            |             |
-| **Confluent_ProduceSingle** | **SingleProduce** | **100**         | **1000**      |  **5,368.1 μs** |     **5.14 μs** |     **3.06 μs** |  **5,367.7 μs** |  **1.00** |    **0.00** |        **-** |       **-** |    **1.19 KB** |        **1.00** |
-| Dekaf_ProduceSingle     | SingleProduce | 100         | 1000      |  1,313.4 μs |    32.49 μs |    21.49 μs |  1,324.0 μs |  0.24 |    0.00 |        - |       - |     1.6 KB |        1.34 |
-|                         |               |             |           |             |             |             |             |       |         |          |         |            |             |
-| **Confluent_ProduceSingle** | **SingleProduce** | **1000**        | **100**       |  **5,365.4 μs** |     **1.93 μs** |     **1.01 μs** |  **5,365.3 μs** |  **1.00** |    **0.00** |        **-** |       **-** |    **2.06 KB** |        **1.00** |
-| Dekaf_ProduceSingle     | SingleProduce | 1000        | 100       |  1,242.0 μs |    29.98 μs |    19.83 μs |  1,248.2 μs |  0.23 |    0.00 |        - |       - |     1.6 KB |        0.77 |
-|                         |               |             |           |             |             |             |             |       |         |          |         |            |             |
-| **Confluent_ProduceSingle** | **SingleProduce** | **1000**        | **1000**      |  **5,367.1 μs** |     **3.91 μs** |     **2.59 μs** |  **5,368.1 μs** |  **1.00** |    **0.00** |        **-** |       **-** |    **2.06 KB** |        **1.00** |
-| Dekaf_ProduceSingle     | SingleProduce | 1000        | 1000      |  1,096.2 μs |     1.32 μs |     0.87 μs |  1,096.4 μs |  0.20 |    0.00 |        - |       - |     1.6 KB |        0.77 |
+| Method                  | Categories    | MessageSize | BatchSize | Mean | Error | Ratio | RatioSD | Alloc Ratio |
+|------------------------ |-------------- |------------ |---------- |-----:|------:|------:|--------:|------------:|
+| **Confluent_ProduceBatch**  | **BatchProduce**  | **100**         | **100**       |   **NA** |    **NA** |     **?** |       **?** |           **?** |
+| Dekaf_ProduceBatch      | BatchProduce  | 100         | 100       |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| **Confluent_ProduceBatch**  | **BatchProduce**  | **100**         | **1000**      |   **NA** |    **NA** |     **?** |       **?** |           **?** |
+| Dekaf_ProduceBatch      | BatchProduce  | 100         | 1000      |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| **Confluent_ProduceBatch**  | **BatchProduce**  | **1000**        | **100**       |   **NA** |    **NA** |     **?** |       **?** |           **?** |
+| Dekaf_ProduceBatch      | BatchProduce  | 1000        | 100       |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| **Confluent_ProduceBatch**  | **BatchProduce**  | **1000**        | **1000**      |   **NA** |    **NA** |     **?** |       **?** |           **?** |
+| Dekaf_ProduceBatch      | BatchProduce  | 1000        | 1000      |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| **Confluent_FireAndForget** | **FireAndForget** | **100**         | **100**       |   **NA** |    **NA** |     **?** |       **?** |           **?** |
+| Dekaf_FireAndForget     | FireAndForget | 100         | 100       |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| **Confluent_FireAndForget** | **FireAndForget** | **100**         | **1000**      |   **NA** |    **NA** |     **?** |       **?** |           **?** |
+| Dekaf_FireAndForget     | FireAndForget | 100         | 1000      |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| **Confluent_FireAndForget** | **FireAndForget** | **1000**        | **100**       |   **NA** |    **NA** |     **?** |       **?** |           **?** |
+| Dekaf_FireAndForget     | FireAndForget | 1000        | 100       |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| **Confluent_FireAndForget** | **FireAndForget** | **1000**        | **1000**      |   **NA** |    **NA** |     **?** |       **?** |           **?** |
+| Dekaf_FireAndForget     | FireAndForget | 1000        | 1000      |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| **Confluent_ProduceSingle** | **SingleProduce** | **100**         | **100**       |   **NA** |    **NA** |     **?** |       **?** |           **?** |
+| Dekaf_ProduceSingle     | SingleProduce | 100         | 100       |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| **Confluent_ProduceSingle** | **SingleProduce** | **100**         | **1000**      |   **NA** |    **NA** |     **?** |       **?** |           **?** |
+| Dekaf_ProduceSingle     | SingleProduce | 100         | 1000      |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| **Confluent_ProduceSingle** | **SingleProduce** | **1000**        | **100**       |   **NA** |    **NA** |     **?** |       **?** |           **?** |
+| Dekaf_ProduceSingle     | SingleProduce | 1000        | 100       |   NA |    NA |     ? |       ? |           ? |
+|                         |               |             |           |      |       |       |         |             |
+| **Confluent_ProduceSingle** | **SingleProduce** | **1000**        | **1000**      |   **NA** |    **NA** |     **?** |       **?** |           **?** |
+| Dekaf_ProduceSingle     | SingleProduce | 1000        | 1000      |   NA |    NA |     ? |       ? |           ? |
 
 Benchmarks with issues:
-  ProducerBenchmarks.Confluent_FireAndForget: Job-OHSMRJ(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
-  ProducerBenchmarks.Confluent_FireAndForget: Job-OHSMRJ(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+  ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+  ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+  ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+  ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+  ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+  ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+  ProducerBenchmarks.Confluent_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+  ProducerBenchmarks.Dekaf_ProduceBatch: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+  ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+  ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+  ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+  ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+  ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+  ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+  ProducerBenchmarks.Confluent_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+  ProducerBenchmarks.Dekaf_FireAndForget: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+  ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+  ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=100]
+  ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+  ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=100, BatchSize=1000]
+  ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+  ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=100]
+  ProducerBenchmarks.Confluent_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
+  ProducerBenchmarks.Dekaf_ProduceSingle: Job-VDSHUR(IterationCount=10, RunStrategy=Throughput, WarmupCount=3) [MessageSize=1000, BatchSize=1000]
 
 
 ## Consumer Benchmarks
 
 Comparing Dekaf vs Confluent.Kafka for message consumption.
 
-| Method               | Categories | MessageCount | MessageSize | Mean    | Error    | StdDev   | Ratio | Allocated | Alloc Ratio |
-|--------------------- |----------- |------------- |------------ |--------:|---------:|---------:|------:|----------:|------------:|
-| **Confluent_ConsumeAll** | **ConsumeAll** | **100**          | **100**         | **3.177 s** | **0.0039 s** | **0.0006 s** |  **1.00** |   **77008 B** |        **1.00** |
-| Dekaf_ConsumeAll     | ConsumeAll | 100          | 100         | 3.016 s | 0.0074 s | 0.0011 s |  0.95 |  121784 B |        1.58 |
-|                      |            |              |             |         |          |          |       |           |             |
-| **Confluent_ConsumeAll** | **ConsumeAll** | **100**          | **1000**        | **3.174 s** | **0.0027 s** | **0.0007 s** |  **1.00** |  **257008 B** |        **1.00** |
-| Dekaf_ConsumeAll     | ConsumeAll | 100          | 1000        | 3.015 s | 0.0031 s | 0.0005 s |  0.95 |  316584 B |        1.23 |
-|                      |            |              |             |         |          |          |       |           |             |
-| **Confluent_ConsumeAll** | **ConsumeAll** | **1000**         | **100**         | **3.175 s** | **0.0013 s** | **0.0003 s** |  **1.00** |  **617008 B** |        **1.00** |
-| Dekaf_ConsumeAll     | ConsumeAll | 1000         | 100         | 3.015 s | 0.0034 s | 0.0005 s |  0.95 |  370432 B |        0.60 |
-|                      |            |              |             |         |          |          |       |           |             |
-| **Confluent_ConsumeAll** | **ConsumeAll** | **1000**         | **1000**        | **3.174 s** | **0.0019 s** | **0.0005 s** |  **1.00** | **2424736 B** |        **1.00** |
-| Dekaf_ConsumeAll     | ConsumeAll | 1000         | 1000        | 3.015 s | 0.0045 s | 0.0007 s |  0.95 | 2185672 B |        0.90 |
-|                      |            |              |             |         |          |          |       |           |             |
-| **Confluent_PollSingle** | **PollSingle** | **100**          | **100**         | **3.164 s** | **0.0015 s** | **0.0004 s** |  **1.00** |         **-** |          **NA** |
-| Dekaf_PollSingle     | PollSingle | 100          | 100         | 3.013 s | 0.0044 s | 0.0011 s |  0.95 |   83792 B |          NA |
-|                      |            |              |             |         |          |          |       |           |             |
-| **Confluent_PollSingle** | **PollSingle** | **100**          | **1000**        | **3.164 s** | **0.0024 s** | **0.0006 s** |  **1.00** |         **-** |          **NA** |
-| Dekaf_PollSingle     | PollSingle | 100          | 1000        | 3.013 s | 0.0024 s | 0.0006 s |  0.95 |   85512 B |          NA |
-|                      |            |              |             |         |          |          |       |           |             |
-| **Confluent_PollSingle** | **PollSingle** | **1000**         | **100**         | **3.164 s** | **0.0031 s** | **0.0008 s** |  **1.00** |         **-** |          **NA** |
-| Dekaf_PollSingle     | PollSingle | 1000         | 100         | 3.012 s | 0.0022 s | 0.0006 s |  0.95 |   84440 B |          NA |
-|                      |            |              |             |         |          |          |       |           |             |
-| **Confluent_PollSingle** | **PollSingle** | **1000**         | **1000**        | **3.164 s** | **0.0016 s** | **0.0004 s** |  **1.00** |         **-** |          **NA** |
-| Dekaf_PollSingle     | PollSingle | 1000         | 1000        | 3.013 s | 0.0033 s | 0.0009 s |  0.95 |   89824 B |          NA |
+| Method               | Categories | MessageCount | MessageSize | Mean    | Error    | StdDev   | Ratio | RatioSD | Allocated | Alloc Ratio |
+|--------------------- |----------- |------------- |------------ |--------:|---------:|---------:|------:|--------:|----------:|------------:|
+| **Confluent_ConsumeAll** | **ConsumeAll** | **100**          | **100**         | **3.170 s** | **0.0073 s** | **0.0011 s** |  **1.00** |    **0.00** |   **76880 B** |        **1.00** |
+| Dekaf_ConsumeAll     | ConsumeAll | 100          | 100         |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| **Confluent_ConsumeAll** | **ConsumeAll** | **100**          | **1000**        | **3.167 s** | **0.0056 s** | **0.0009 s** |  **1.00** |    **0.00** |  **256880 B** |        **1.00** |
+| Dekaf_ConsumeAll     | ConsumeAll | 100          | 1000        |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| **Confluent_ConsumeAll** | **ConsumeAll** | **1000**         | **100**         | **3.168 s** | **0.0059 s** | **0.0015 s** |  **1.00** |    **0.00** |  **616880 B** |        **1.00** |
+| Dekaf_ConsumeAll     | ConsumeAll | 1000         | 100         |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| **Confluent_ConsumeAll** | **ConsumeAll** | **1000**         | **1000**        | **3.168 s** | **0.0047 s** | **0.0012 s** |  **1.00** |    **0.00** | **2424896 B** |        **1.00** |
+| Dekaf_ConsumeAll     | ConsumeAll | 1000         | 1000        |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| **Confluent_PollSingle** | **PollSingle** | **100**          | **100**         | **3.162 s** | **0.0051 s** | **0.0008 s** |  **1.00** |    **0.00** |         **-** |          **NA** |
+| Dekaf_PollSingle     | PollSingle | 100          | 100         |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| **Confluent_PollSingle** | **PollSingle** | **100**          | **1000**        | **3.161 s** | **0.0041 s** | **0.0011 s** |  **1.00** |    **0.00** |         **-** |          **NA** |
+| Dekaf_PollSingle     | PollSingle | 100          | 1000        |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| **Confluent_PollSingle** | **PollSingle** | **1000**         | **100**         | **3.162 s** | **0.0020 s** | **0.0005 s** |  **1.00** |    **0.00** |         **-** |          **NA** |
+| Dekaf_PollSingle     | PollSingle | 1000         | 100         |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+|                      |            |              |             |         |          |          |       |         |           |             |
+| **Confluent_PollSingle** | **PollSingle** | **1000**         | **1000**        | **3.160 s** | **0.0039 s** | **0.0010 s** |  **1.00** |    **0.00** |         **-** |          **NA** |
+| Dekaf_PollSingle     | PollSingle | 1000         | 1000        |      NA |       NA |       NA |     ? |       ? |        NA |           ? |
+
+Benchmarks with issues:
+  ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+  ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+  ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+  ConsumerBenchmarks.Dekaf_ConsumeAll: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
+  ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=100]
+  ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=100, MessageSize=1000]
+  ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=100]
+  ConsumerBenchmarks.Dekaf_PollSingle: Job-VTGNCZ(InvocationCount=1, IterationCount=5, RunStrategy=Throughput, UnrollFactor=1, WarmupCount=2) [MessageCount=1000, MessageSize=1000]
 
 
 ## Protocol Benchmarks
@@ -101,38 +133,38 @@ Zero-allocation wire protocol serialization/deserialization.
 
 | Method                           | Mean      | Error      | StdDev    | Allocated |
 |--------------------------------- |----------:|-----------:|----------:|----------:|
-| &#39;Write 1000 Int32s&#39;              | 27.075 μs |  8.6571 μs | 5.1517 μs |         - |
-| &#39;Write 100 Strings (100 chars)&#39;  | 10.445 μs |  0.4452 μs | 0.2649 μs |         - |
-| &#39;Write 100 CompactStrings&#39;       | 13.256 μs |  0.2769 μs | 0.1448 μs |         - |
-| &#39;Write 1000 VarInts&#39;             | 43.372 μs | 17.5646 μs | 9.1866 μs |         - |
-| &#39;Read 1000 Int32s&#39;               | 24.608 μs |  8.3445 μs | 4.9657 μs |         - |
-| &#39;Read 1000 VarInts&#39;              | 21.909 μs |  9.9775 μs | 5.9374 μs |         - |
-| &#39;Write RecordBatch (10 records)&#39; | 18.033 μs |  1.0433 μs | 0.6209 μs |         - |
-| &#39;Read RecordBatch (10 records)&#39;  |  4.175 μs |  0.7192 μs | 0.4757 μs |         - |
+| &#39;Write 1000 Int32s&#39;              | 35.194 μs | 16.5521 μs | 9.8499 μs |         - |
+| &#39;Write 100 Strings (100 chars)&#39;  | 13.081 μs |  0.2662 μs | 0.1584 μs |         - |
+| &#39;Write 100 CompactStrings&#39;       | 10.849 μs |  0.2186 μs | 0.1301 μs |         - |
+| &#39;Write 1000 VarInts&#39;             | 34.433 μs | 12.2684 μs | 7.3007 μs |         - |
+| &#39;Read 1000 Int32s&#39;               | 15.193 μs |  9.8749 μs | 5.8764 μs |         - |
+| &#39;Read 1000 VarInts&#39;              | 24.895 μs |  9.2132 μs | 5.4826 μs |         - |
+| &#39;Write RecordBatch (10 records)&#39; | 16.810 μs |  0.1864 μs | 0.1110 μs |         - |
+| &#39;Read RecordBatch (10 records)&#39;  |  4.351 μs |  0.0589 μs | 0.0308 μs |         - |
 
 
 ## Serializer Benchmarks
 
-| Method                               | Mean        | Error        | StdDev       | Ratio | RatioSD | Allocated | Alloc Ratio |
-|------------------------------------- |------------:|-------------:|-------------:|------:|--------:|----------:|------------:|
-| &#39;Serialize String (10 chars)&#39;        |  1,412.9 ns |    265.75 ns |    158.14 ns |  0.36 |    0.05 |         - |          NA |
-| &#39;Serialize String (100 chars)&#39;       |  1,516.5 ns |    257.14 ns |    153.02 ns |  0.38 |    0.05 |         - |          NA |
-| &#39;Serialize String (1000 chars)&#39;      |  1,509.7 ns |    410.09 ns |    244.04 ns |  0.38 |    0.07 |         - |          NA |
-| &#39;Deserialize String&#39;                 |  3,121.2 ns |    392.91 ns |    259.89 ns |  0.79 |    0.10 |         - |          NA |
-| &#39;Serialize Int32&#39;                    |    634.1 ns |     61.19 ns |     32.00 ns |  0.16 |    0.02 |         - |          NA |
-| &#39;Serialize 100 Messages (key+value)&#39; | 40,091.0 ns | 17,191.89 ns | 11,371.37 ns | 10.12 |    2.93 |         - |          NA |
-| &#39;ArrayBufferWriter + Copy&#39;           |  4,000.3 ns |    725.04 ns |    431.46 ns |  1.01 |    0.14 |         - |          NA |
-| &#39;PooledBufferWriter Direct&#39;          |  4,145.6 ns |    908.30 ns |    600.78 ns |  1.05 |    0.18 |         - |          NA |
+| Method                               | Mean        | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
+|------------------------------------- |------------:|----------:|----------:|------:|--------:|----------:|------------:|
+| &#39;Serialize String (10 chars)&#39;        |  1,247.4 ns |  20.53 ns |  12.22 ns |  0.33 |    0.01 |         - |          NA |
+| &#39;Serialize String (100 chars)&#39;       |  1,700.9 ns | 153.62 ns | 101.61 ns |  0.44 |    0.03 |         - |          NA |
+| &#39;Serialize String (1000 chars)&#39;      |  1,816.2 ns | 169.24 ns | 100.71 ns |  0.47 |    0.03 |         - |          NA |
+| &#39;Deserialize String&#39;                 |  2,813.9 ns |  51.98 ns |  30.93 ns |  0.73 |    0.01 |         - |          NA |
+| &#39;Serialize Int32&#39;                    |    645.2 ns |  37.04 ns |  22.04 ns |  0.17 |    0.01 |         - |          NA |
+| &#39;Serialize 100 Messages (key+value)&#39; | 34,021.2 ns | 592.82 ns | 392.11 ns |  8.88 |    0.18 |         - |          NA |
+| &#39;ArrayBufferWriter + Copy&#39;           |  3,831.6 ns | 113.85 ns |  67.75 ns |  1.00 |    0.02 |         - |          NA |
+| &#39;PooledBufferWriter Direct&#39;          |  3,404.9 ns |  84.73 ns |  56.04 ns |  0.89 |    0.02 |         - |          NA |
 
 
 ## Compression Benchmarks
 
 | Method                  | Mean         | Error      | StdDev     | Allocated |
 |------------------------ |-------------:|-----------:|-----------:|----------:|
-| &#39;Snappy Compress 1KB&#39;   |    10.274 μs |  0.6675 μs |  0.3972 μs |         - |
-| &#39;Snappy Compress 1MB&#39;   |   461.664 μs | 15.9367 μs | 10.5411 μs |         - |
-| &#39;Snappy Decompress 1KB&#39; |     8.216 μs |  0.7232 μs |  0.4784 μs |         - |
-| &#39;Snappy Decompress 1MB&#39; | 1,395.917 μs | 33.5210 μs | 22.1721 μs |         - |
+| &#39;Snappy Compress 1KB&#39;   |    14.215 μs |  1.4873 μs |  0.9837 μs |         - |
+| &#39;Snappy Compress 1MB&#39;   |   545.766 μs | 28.0401 μs | 18.5468 μs |         - |
+| &#39;Snappy Decompress 1KB&#39; |     9.758 μs |  0.3728 μs |  0.2466 μs |         - |
+| &#39;Snappy Decompress 1MB&#39; | 1,615.658 μs | 52.9051 μs | 34.9934 μs |         - |
 
 
 ---


### PR DESCRIPTION
## Summary

Closes #347

- Added `JsonSerializerServiceBuilderExtensions` in `Dekaf.Serialization.Json` with four extension methods for the DI service builders:
  - `UseJsonSerializer` on `ProducerServiceBuilder<TKey, TValue>`
  - `UseJsonKeySerializer` on `ProducerServiceBuilder<TKey, TValue>`
  - `UseJsonDeserializer` on `ConsumerServiceBuilder<TKey, TValue>`
  - `UseJsonKeyDeserializer` on `ConsumerServiceBuilder<TKey, TValue>`
- These mirror the existing `JsonSerializerExtensions` that target the core `ProducerBuilder`/`ConsumerBuilder`, enabling the same fluent JSON serialization configuration within `AddDekaf` DI builder blocks
- Added project reference from `Dekaf.Serialization.Json` to `Dekaf.Extensions.DependencyInjection`

### Usage example

```csharp
services.AddDekaf(builder =>
{
    builder.AddProducer<string, OrderEvent>(p => p
        .WithBootstrapServers("localhost:9092")
        .UseJsonSerializer());

    builder.AddConsumer<string, OrderEvent>(c => c
        .WithBootstrapServers("localhost:9092")
        .WithGroupId("order-processors")
        .UseJsonDeserializer());
});
```

## Test plan

- [x] Added 12 unit tests covering all four extension methods (chaining, custom options, DI integration, key+value chaining)
- [x] Full unit test suite passes (53,352 tests, 0 failures)
- [x] Build succeeds for all projects