### PR TITLE
fix: address pre-existing CI test flakiness

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -3610,9 +3610,12 @@ internal ref struct PooledBufferWriter : IBufferWriter<byte>
         // Copy existing data
         _buffer.AsSpan(0, _written).CopyTo(newBuffer);
 
-        // Return old buffer
-        ArrayPool<byte>.Shared.Return(_buffer, clearArray: true);
+        // Return old buffer - use clearArray: false since data has already been copied
+        // and clearing could cause a race condition with ArrayPool returning the
+        // just-cleared buffer to a concurrent caller
+        var oldBuffer = _buffer;
         _buffer = newBuffer;
+        ArrayPool<byte>.Shared.Return(oldBuffer, clearArray: false);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes four pre-existing test bugs on `main` that cause CI failures across multiple PRs:

- **PooledBufferWriter.Grow() ArrayPool race condition**: Under `[assembly: Repeat(25)]` (26 parallel test instances sharing `ArrayPool<byte>.Shared`), `clearArray: true` on `Return()` could zero out a buffer that was simultaneously rented by another test instance. Fixed by using `clearArray: false` (the old buffer contents are irrelevant after copy) and assigning `_buffer = newBuffer` before returning the old buffer.

- **FanOutPatternTests CI hangs**: Reduced timeout from 120s to 60s and linked all internal `CancellationTokenSource` instances with the test's `CancellationToken` via `CancellationTokenSource.CreateLinkedTokenSource()`. This ensures `[Timeout]` properly propagates cancellation into `ConsumeAsync` calls rather than just killing the test externally.

- **EventPipelineTests missing timeout**: Added `[Timeout(120_000)]` to the class and `CancellationToken cancellationToken` parameters to all test methods. The `Pipeline_FilterAndRoute_MessagesRoutedByContent` test was hanging for 19+ minutes in CI because it had no timeout and internal 30-second `CancellationTokenSource` timeouts were not being respected.

- **StaticMembershipTests empty assignment**: Replaced `ConsumeOneAsync` with a `ConsumeAsync` loop (consuming up to 4 messages) in `StaticMember_RetainsPartitionAssignment_AfterRestart`. The `Assignment` property may not be populated after consuming just one message; consuming multiple messages (matching the first consumer's pattern) ensures the assignment is stable before asserting equivalence.

## Test plan

- [x] `dotnet build` succeeds for `src/Dekaf`, `tests/Dekaf.Tests.Unit`, and `tests/Dekaf.Tests.Integration`
- [x] PooledBufferWriter unit tests pass all 624 runs (24 tests x 26 repeats) with zero failures
- [ ] CI integration tests pass (FanOutPatternTests, EventPipelineTests, StaticMembershipTests)