### PR TITLE
perf(tests): scope Repeat(25) to concurrency tests only

### DIFF
--- a/tests/Dekaf.Tests.Unit/AssemblyInfo.cs
+++ b/tests/Dekaf.Tests.Unit/AssemblyInfo.cs
@@ -1,7 +1,1 @@
 
-
-// Run each test 25 times to help catch race conditions and deadlocks
-// Note: TUnit's Repeat attribute may need to be applied at class or method level
-// depending on TUnit version. Verify this compiles and tests run 25x.
-// If assembly-level doesn't work, apply [Repeat(25)] to individual test classes.
-[assembly: Repeat(25)]

--- a/tests/Dekaf.Tests.Unit/Concurrency/AdminConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Concurrency/AdminConcurrencyTests.cs
@@ -10,6 +10,7 @@ namespace Dekaf.Tests.Unit.Concurrency;
 /// swapping, concurrent metadata reads during updates, and connection pool
 /// access patterns used by AdminClient operations.
 /// </summary>
+[Repeat(25)]
 public class AdminConcurrencyTests
 {
     private static MetadataResponse CreateMetadataResponse(string clusterId, int topicCount, int partitionCount)

--- a/tests/Dekaf.Tests.Unit/Concurrency/BatchArenaConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Concurrency/BatchArenaConcurrencyTests.cs
@@ -7,6 +7,7 @@ namespace Dekaf.Tests.Unit.Concurrency;
 /// Concurrency tests for BatchArena verifying thread-safety of the CAS-based
 /// TryAllocate method and the pool's RentOrCreate/ReturnToPool operations.
 /// </summary>
+[Repeat(25)]
 public class BatchArenaConcurrencyTests
 {
     [Test]

--- a/tests/Dekaf.Tests.Unit/Concurrency/ConsumerConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Concurrency/ConsumerConcurrencyTests.cs
@@ -11,6 +11,7 @@ namespace Dekaf.Tests.Unit.Concurrency;
 /// concurrent operations on shared consumer state do not corrupt data or
 /// deadlock.
 /// </summary>
+[Repeat(25)]
 public class ConsumerConcurrencyTests
 {
     [Test]

--- a/tests/Dekaf.Tests.Unit/Concurrency/ProducerConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Concurrency/ProducerConcurrencyTests.cs
@@ -8,6 +8,7 @@ namespace Dekaf.Tests.Unit.Concurrency;
 /// PartitionInflightTracker. Tests real race conditions using multiple
 /// concurrent tasks hitting the same objects simultaneously.
 /// </summary>
+[Repeat(25)]
 public class ProducerConcurrencyTests
 {
     [Test]

--- a/tests/Dekaf.Tests.Unit/Concurrency/RecordAccumulatorConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Concurrency/RecordAccumulatorConcurrencyTests.cs
@@ -9,6 +9,7 @@ namespace Dekaf.Tests.Unit.Concurrency;
 /// AppendAsync, TryAppendSync, ReleaseMemory, FlushAsync, and batch rotation
 /// under contention from multiple concurrent producers.
 /// </summary>
+[Repeat(25)]
 public class RecordAccumulatorConcurrencyTests
 {
     private static ProducerOptions CreateTestOptions(


### PR DESCRIPTION
## Summary
- Removed `[assembly: Repeat(25)]` from `AssemblyInfo.cs`, which was running all ~2,080 unit tests 25 times (52,000 total executions)
- Added `[Repeat(25)]` to the 5 concurrency test classes that actually benefit from repetition for race condition detection
- Reduces total test executions from ~52,000 to ~4,580, cutting unit test time from 15-30 minutes to ~2-4 minutes

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release` succeeds
- [ ] Unit tests pass locally
- [ ] CI passes with reduced test count