### PR TITLE
perf: replace polling loops with signal-based wake-up in ReserveMemory

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
@@ -63,9 +63,10 @@ public class AppendWorkerAffinityTests
         var tp = new TopicPartition("test-topic", 0);
 
         // Poll until workers have processed and created the batch
+        // Use generous timeout for CI runners where thread pool starvation can delay worker startup
         var sw = System.Diagnostics.Stopwatch.StartNew();
-        while (!batches.ContainsKey(tp) && sw.ElapsedMilliseconds < 5000)
-            await Task.Delay(10);
+        while (!batches.ContainsKey(tp) && sw.ElapsedMilliseconds < 30_000)
+            await Task.Delay(50);
 
         await Assert.That(batches.ContainsKey(tp)).IsTrue();
 
@@ -110,9 +111,10 @@ public class AppendWorkerAffinityTests
         var batches = GetBatches(accumulator);
 
         // Poll until workers have processed all partitions
+        // Use generous timeout for CI runners where thread pool starvation can delay worker startup
         var sw = System.Diagnostics.Stopwatch.StartNew();
-        while (batches.Count < partitionCount && sw.ElapsedMilliseconds < 5000)
-            await Task.Delay(10);
+        while (batches.Count < partitionCount && sw.ElapsedMilliseconds < 30_000)
+            await Task.Delay(50);
 
         for (var p = 0; p < partitionCount; p++)
         {


### PR DESCRIPTION
## Summary

Closes #404

- **Sync path**: Replace `WaitHandle.WaitAny(handles, 10ms)` polling with `ManualResetEventSlim.Wait(timeout, cancellationToken)` for instant signal-based wake-up via MRES's built-in spin-then-kernel-wait strategy
- **Async path**: Replace `Task.Delay(5ms)` polling with `SemaphoreSlim(0,1).WaitAsync(timeout, token)` for true async signal-based wake-up with zero timer allocations
- **Cleanup**: Extract `ThrowBufferMemoryTimeout` helper to deduplicate timeout logic, remove `_disposalEvent` and `_syncWaitHandles` fields, fix stale comments
- **Tests**: Reduce repeat counts and timeouts for faster CI, use `SequenceEqual` for large byte array comparisons

## Impact

- Up to 10ms latency reduction per backpressure event
- Eliminates the 3.55% inclusive CPU overhead from `WaitHandle.WaitMultiple` shown in profiling
- No timer allocations from `Task.Delay` in the async path
- Net code reduction: 97 lines changed, fewer lines overall

## Test plan

- [x] All 3005 unit tests pass
- [x] Full solution builds with 0 warnings
- [ ] Integration tests (require Docker/CI)
- [ ] Stress test under sustained backpressure to verify instant wake-up