### PR TITLE
fix: use BuildAsync() in benchmarks and create PR for docs updates

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -283,6 +283,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -433,14 +434,12 @@ jobs:
           print(f"Generated benchmarks.md with {len(output)} lines")
           EOF
 
-      - name: Commit and Push Benchmark Results
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/docs/benchmarks.md
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "docs: Update benchmark results"
-            git push
-          fi
+      - name: Create Pull Request for Benchmark Results
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "docs: Update benchmark results"
+          branch: docs/benchmark-results
+          title: "docs: Update benchmark results"
+          body: "Automated update of benchmark results documentation."
+          labels: documentation
+          delete-branch: true

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs
@@ -87,7 +87,9 @@ public class ConsumerBenchmarks
             .WithClientId("dekaf-poll-benchmark")
             .WithGroupId($"dekaf-poll-{Guid.NewGuid():N}")
             .WithAutoOffsetReset(DekafConsumer.AutoOffsetReset.Earliest)
-            .Build();
+            .BuildAsync()
+            .GetAwaiter()
+            .GetResult();
         _dekafPollConsumer.Subscribe(_topic);
     }
 
@@ -149,12 +151,13 @@ public class ConsumerBenchmarks
     {
         var count = 0;
 
-        await using var consumer = Kafka.CreateConsumer<string, string>()
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(_kafka.BootstrapServers)
             .WithClientId("dekaf-consumer-benchmark")
             .WithGroupId($"dekaf-benchmark-{Guid.NewGuid():N}")
             .WithAutoOffsetReset(DekafConsumer.AutoOffsetReset.Earliest)
-            .Build();
+            .BuildAsync()
+            .ConfigureAwait(false);
 
         consumer.Subscribe(_topic);
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs
@@ -37,13 +37,14 @@ public class ProducerBenchmarks
 
         _messageValue = new string('x', MessageSize);
 
-        _dekafProducer = Kafka.CreateProducer<string, string>()
+        _dekafProducer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(_kafka.BootstrapServers)
             .WithClientId("dekaf-benchmark")
             .WithAcks(DekafProducer.Acks.Leader)
             .WithLinger(TimeSpan.FromMilliseconds(5))
             .WithBatchSize(16384)
-            .Build();
+            .BuildAsync()
+            .ConfigureAwait(false);
 
         var confluentConfig = new Confluent.Kafka.ProducerConfig
         {


### PR DESCRIPTION
## Summary

- **Dekaf benchmarks showing NA**: All Dekaf producer and consumer benchmarks used `.Build()` (sync) which doesn't initialize the client, causing `InvalidOperationException`. Switched to `.BuildAsync()` in all three locations.
- **Docs publish job failing**: The `publish-to-docs` job pushed directly to `main`, which is blocked by branch protection rules (16 required status checks). Replaced with `peter-evans/create-pull-request@v7` to create a PR instead.

## Test plan

- [ ] Verify benchmarks project builds successfully (`dotnet build tools/Dekaf.Benchmarks --configuration Release`)
- [ ] Verify benchmark workflow runs without failures on next push to main
- [ ] Verify docs publish job creates a PR instead of pushing directly