### PR TITLE
fix: address unresolved review comments from PR #412

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -126,10 +126,12 @@ public sealed class AdminClient : IAdminClient
         List<string> topicNames,
         CancellationToken cancellationToken)
     {
-        const int maxRetries = 5;
-        const int retryDelayMs = 500;
+        // Leader election is an async cluster operation that can take multiple metadata
+        // refresh cycles, especially with multi-partition topics. Use more retries than
+        // WithRetryAsync (which handles transient RPC errors) to give the cluster time.
+        const int leaderWaitRetries = 5;
 
-        for (var attempt = 0; attempt < maxRetries; attempt++)
+        for (var attempt = 0; attempt < leaderWaitRetries; attempt++)
         {
             await _metadataManager.RefreshMetadataAsync(topicNames, cancellationToken).ConfigureAwait(false);
 
@@ -162,11 +164,11 @@ public sealed class AdminClient : IAdminClient
             if (allReady)
                 return;
 
-            await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(RetryDelayMs, cancellationToken).ConfigureAwait(false);
         }
 
         throw new KafkaException(Protocol.ErrorCode.LeaderNotAvailable,
-            $"Topic(s) {string.Join(", ", topicNames)} did not have all partition leaders elected after {maxRetries * retryDelayMs}ms");
+            $"Topic(s) {string.Join(", ", topicNames)} did not have all partition leaders elected after {leaderWaitRetries * RetryDelayMs}ms");
     }
 
     public async ValueTask DeleteTopicsAsync(

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -7,6 +7,7 @@ using Dekaf.Security;
 using Dekaf.Security.Sasl;
 using Dekaf.Protocol.Messages;
 using Dekaf.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace Dekaf;
 
@@ -598,9 +599,15 @@ public sealed class ProducerBuilder<TKey, TValue>
         // Java Kafka client enforces acks=all when enable.idempotence=true.
         // With acks=leader, the leader acknowledges before ISR replication completes,
         // which can cause OutOfOrderSequenceNumber on leader failover and makes the
-        // idempotent guarantee weaker. Override silently to match Java client behavior.
+        // idempotent guarantee weaker. Override to match Java client behavior.
         if (_enableIdempotence && _acks != Acks.All)
+        {
+            _loggerFactory?.CreateLogger<KafkaProducer<TKey, TValue>>()
+                .LogWarning("Idempotence is enabled but acks was set to {Acks}. " +
+                            "Overriding to Acks.All as required by the Kafka protocol for idempotent producers.",
+                            _acks);
             _acks = Acks.All;
+        }
 
         var keySerializer = _keySerializer ?? GetDefaultSerializer<TKey>();
         var valueSerializer = _valueSerializer ?? GetDefaultSerializer<TValue>();

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -236,12 +236,13 @@ public sealed partial class MetadataManager : IAsyncDisposable
     }
 
     /// <summary>
-    /// Returns all TopicPartitions currently led by the given broker node.
+    /// Populates <paramref name="result"/> with all TopicPartitions currently led by the given broker node.
+    /// The caller owns the list and should clear/reuse it across iterations to avoid per-call allocations.
     /// Used by the sender loop's drain algorithm for per-broker batch selection.
     /// </summary>
-    internal IReadOnlyList<TopicPartition>? GetPartitionsForNode(int nodeId)
+    internal void GetPartitionsForNode(int nodeId, List<TopicPartition> result)
     {
-        var result = new List<TopicPartition>();
+        result.Clear();
         foreach (var topic in _metadata.GetTopics())
         {
             foreach (var partition in topic.Partitions)
@@ -250,7 +251,6 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     result.Add(new TopicPartition(topic.Name, partition.PartitionIndex));
             }
         }
-        return result.Count > 0 ? result : null;
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -124,26 +124,22 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     [StructLayout(LayoutKind.Auto)]
-    private struct SendLoopEvent
+    private readonly struct SendLoopEvent
     {
-        public SendLoopEventType Type;
-        public ReadyBatch? Batch;
+        public readonly SendLoopEventType Type;
+        public readonly ReadyBatch? Batch;
 
-        public static SendLoopEvent NewBatch(ReadyBatch batch) => new()
+        private SendLoopEvent(SendLoopEventType type, ReadyBatch? batch = null)
         {
-            Type = SendLoopEventType.NewBatch,
-            Batch = batch
-        };
+            Type = type;
+            Batch = batch;
+        }
 
-        public static SendLoopEvent ResponseReady() => new()
-        {
-            Type = SendLoopEventType.ResponseReady
-        };
+        public static SendLoopEvent NewBatch(ReadyBatch batch) => new(SendLoopEventType.NewBatch, batch);
 
-        public static SendLoopEvent Unmute() => new()
-        {
-            Type = SendLoopEventType.Unmute
-        };
+        public static SendLoopEvent ResponseReady() => new(SendLoopEventType.ResponseReady);
+
+        public static SendLoopEvent Unmute() => new(SendLoopEventType.Unmute);
     }
 
     /// <summary>
@@ -400,11 +396,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     private void FailEnqueuedBatch(ReadyBatch batch)
     {
-#if DEBUG
-        batch.DebugLastTransition = (int)BatchTransition.FailEnqueuedBatch;
-        batch.DebugLastBrokerId = _brokerId;
-        Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} FailEnqueuedBatch broker={_brokerId}");
-#endif
         if (batch.IsRetry)
         {
             batch.IsRetry = false;
@@ -476,7 +467,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             _bumpEpoch((short)staleEpoch, _partitionsNeedingSequenceReset);
                         }
 
-                        _partitionsNeedingSequenceReset.Clear();
                         Interlocked.CompareExchange(ref _epochBumpRequestedForEpoch, -1, staleEpoch);
                     }
                     catch (OperationCanceledException)
@@ -486,6 +476,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     catch (Exception ex)
                     {
                         LogEpochBumpFailed(ex, staleEpoch);
+                    }
+                    finally
+                    {
+                        _partitionsNeedingSequenceReset.Clear();
                     }
                 }
 
@@ -854,11 +848,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     batch.IsRetry = false;
                     batch.RetryNotBefore = 0;
                     UnmutePartition(batch.TopicPartition);
-#if DEBUG
-                    batch.DebugLastTransition = (int)BatchTransition.Rerouted;
-                    batch.DebugLastBrokerId = _brokerId;
-                    Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} Rerouted from broker={_brokerId} to broker={leader.NodeId}");
-#endif
                     _rerouteBatch(batch);
                     return;
                 }
@@ -882,11 +871,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             batch.AppendDiag('C');
             coalescedBatches[coalescedCount] = batch;
             coalescedCount++;
-#if DEBUG
-            batch.DebugLastTransition = (int)BatchTransition.Coalesced;
-            batch.DebugLastBrokerId = _brokerId;
-            Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} Coalesced (retry) broker={_brokerId}");
-#endif
             return;
         }
 
@@ -910,11 +894,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         batch.AppendDiag('C');
         coalescedBatches[coalescedCount] = batch;
         coalescedCount++;
-#if DEBUG
-        batch.DebugLastTransition = (int)BatchTransition.Coalesced;
-        batch.DebugLastBrokerId = _brokerId;
-        Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} Coalesced (normal) broker={_brokerId}");
-#endif
     }
 
     /// <summary>
@@ -1042,10 +1021,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var batch = batches[j];
             if (batch is null)
                 continue;
-#if DEBUG
-            batch.DebugLastTransition = (int)BatchTransition.ProcessingResponse;
-            Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} ProcessingResponse broker={_brokerId}");
-#endif
             try
             {
                 batch.AppendDiag('R');
@@ -1096,10 +1071,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     try
                     {
                         batch.Fail(failureException);
-#if DEBUG
-                        batch.DebugLastTransition = (int)BatchTransition.FailCalled;
-                        Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} FailCalled (non-retriable) broker={_brokerId} error={partitionResponse.ErrorCode}");
-#endif
                     }
                     catch (Exception failEx) { LogBatchCleanupStepFailed(failEx, _brokerId); }
                     try
@@ -1133,10 +1104,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 try { CompleteInflightEntry(batch); }
                 catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
                 batch.CompleteSend(partitionResponse.BaseOffset, timestamp);
-#if DEBUG
-                batch.DebugLastTransition = (int)BatchTransition.CompleteSendCalled;
-                Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} CompleteSendCalled broker={_brokerId} offset={partitionResponse.BaseOffset}");
-#endif
                 try
                 {
                     _onAcknowledgement?.Invoke(batch.TopicPartition,
@@ -1389,11 +1356,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         batch.IsRetry = true;
         batch.AppendDiag('H'); // HandleRetriableBatch → carry-over
         carryOver.AddAfterRetries(batch);
-#if DEBUG
-        batch.DebugLastTransition = (int)BatchTransition.AddedToCarryOver;
-        batch.DebugLastBrokerId = _brokerId;
-        Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} AddedToCarryOver broker={_brokerId}");
-#endif
     }
 
     /// <summary>
@@ -1467,10 +1429,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         batch.TopicPartition,
                         batch.RecordBatch.BaseSequence,
                         batch.CompletionSourcesCount);
-#if DEBUG
-                    batch.DebugLastTransition = (int)BatchTransition.InflightRegistered;
-                    Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} InflightRegistered broker={_brokerId}");
-#endif
                 }
             }
 
@@ -1517,10 +1475,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         batch.CompletionSourcesCount);
                     CompleteInflightEntry(batch);
                     batch.CompleteSend(-1, fireAndForgetTimestamp);
-#if DEBUG
-                    batch.DebugLastTransition = (int)BatchTransition.CompleteSendCalled;
-                    Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} CompleteSendCalled (fire-and-forget) broker={_brokerId}");
-#endif
                     try { _onAcknowledgement?.Invoke(batch.TopicPartition, -1, fireAndForgetTimestamp, batch.CompletionSourcesCount, null); }
                     catch (Exception ackEx) { LogBatchCleanupStepFailed(ackEx, _brokerId); }
                 }
@@ -1556,10 +1510,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 {
                     _accumulator.ReleaseMemory(batches[i].DataSize);
                     batches[i].MemoryReleased = true;
-#if DEBUG
-                    batches[i].DebugLastTransition = (int)BatchTransition.MemoryReleased;
-                    Debug.WriteLine($"[BatchTrack] {batches[i].TopicPartition} MemoryReleased broker={_brokerId}");
-#endif
                 }
             }
 
@@ -1580,13 +1530,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 CancellationToken.None,
                 TaskContinuationOptions.ExecuteSynchronously,
                 TaskScheduler.Default);
-#if DEBUG
-            for (var i = 0; i < count; i++)
-            {
-                batches[i].DebugLastTransition = (int)BatchTransition.AddedToPendingResponses;
-                Debug.WriteLine($"[BatchTrack] {batches[i].TopicPartition} AddedToPendingResponses broker={_brokerId}");
-            }
-#endif
 
             // Mute partitions at send time when limited to 1 in-flight request.
             // This ensures at most one batch per partition in-flight across all requests.
@@ -1655,11 +1598,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         batch.RetryNotBefore = Stopwatch.GetTimestamp() +
                             _options.RetryBackoffTicks;
                         _sendFailedRetries.Add(batch);
-#if DEBUG
-                        batch.DebugLastTransition = (int)BatchTransition.AddedToSendFailedRetries;
-                        batch.DebugLastBrokerId = _brokerId;
-                        Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} AddedToSendFailedRetries broker={_brokerId}");
-#endif
                         _statisticsCollector.RecordRetry();
                     }
                 }
@@ -1863,11 +1801,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private void FailAndCleanupBatch(ReadyBatch batch, Exception ex)
     {
         batch.AppendDiag('F');
-#if DEBUG
-        batch.DebugLastTransition = (int)BatchTransition.FailCalled;
-        batch.DebugLastBrokerId = _brokerId;
-        Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} FailAndCleanupBatch broker={_brokerId} ex={ex.GetType().Name}");
-#endif
         // Every operation is wrapped in try/catch to guarantee we reach CleanupBatch.
         // If CompleteInflightEntry throws, batch.Fail must still run to resolve completion sources.
         // If batch.Fail throws, CleanupBatch must still run to release memory and return the batch.
@@ -1892,10 +1825,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void CleanupBatch(ReadyBatch batch)
     {
-#if DEBUG
-        batch.DebugLastTransition = (int)BatchTransition.CleanupBatchCalled;
-        Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} CleanupBatch broker={_brokerId}");
-#endif
         // Release buffer memory at batch completion (matching Java's RecordAccumulator.deallocate()).
         // This is the primary release path: memory is held throughout the entire pipeline
         // (append → drain → send → response) to provide accurate end-to-end backpressure.

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2166,9 +2166,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                             for (var i = 0; i < batchList.Count; i++)
                             {
                                 batchList[i].CompleteDelivery();
-#if DEBUG
-                                batchList[i].DebugLastTransition = (int)BatchTransition.CompleteDelivery;
-#endif
                             }
 
                             try
@@ -2180,10 +2177,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                                 for (var i = 0; i < batchList.Count; i++)
                                 {
                                     batchList[i].AppendDiag('Q');
-#if DEBUG
-                                    batchList[i].DebugLastTransition = (int)BatchTransition.EnqueuedToBrokerSender;
-                                    batchList[i].DebugLastBrokerId = brokerId;
-#endif
                                     await brokerSender.EnqueueAsync(batchList[i], cancellationToken)
                                         .ConfigureAwait(false);
                                 }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -579,6 +579,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly Dictionary<int, int> _drainIndex = new();
 
     /// <summary>
+    /// Reusable list for <see cref="MetadataManager.GetPartitionsForNode"/> to avoid per-call allocations
+    /// in the drain loop. Single-threaded: only accessed by the sender loop.
+    /// </summary>
+    private readonly List<TopicPartition> _reusablePartitionList = new();
+
+    /// <summary>
     /// Signaled when new data is available for the sender loop to drain.
     /// Set by seal paths and reenqueue. Sender loop resets after wake.
     /// </summary>
@@ -890,9 +896,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int maxRequestSize,
         List<ReadyBatch> ready)
     {
-        var partitions = metadataManager.GetPartitionsForNode(nodeId);
-        if (partitions is null || partitions.Count == 0)
+        metadataManager.GetPartitionsForNode(nodeId, _reusablePartitionList);
+        if (_reusablePartitionList.Count == 0)
             return;
+
+        var partitions = _reusablePartitionList;
 
         if (!_drainIndex.TryGetValue(nodeId, out var startIndex))
             startIndex = 0;
@@ -1814,10 +1822,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Interlocked.Increment(ref _inFlightBatchCount);
         _inFlightBatches.TryAdd(batch, 0);
         batch.AppendDiag('E');
-#if DEBUG
-        batch.DebugLastTransition = (int)BatchTransition.EntersPipeline;
-        Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} EntersPipeline inFlight={Volatile.Read(ref _inFlightBatchCount)}");
-#endif
     }
 
     /// <summary>
@@ -1828,10 +1832,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// <returns>true if the batch was successfully removed from tracking; false if it was already removed by another thread.</returns>
     internal bool OnBatchExitsPipeline(ReadyBatch batch)
     {
-#if DEBUG
-        batch.DebugLastTransition = (int)BatchTransition.ExitsPipeline;
-        Debug.WriteLine($"[BatchTrack] {batch.TopicPartition} ExitsPipeline (was transition={(BatchTransition)batch.DebugLastTransition} broker={batch.DebugLastBrokerId})");
-#endif
         // TryRemove acts as a natural atomic guard: only the first thread to remove the batch
         // proceeds with the decrement. This prevents double-decrement from concurrent cleanup
         // paths (e.g., DisposeAsync racing with SendLoopAsync's finally block).
@@ -2918,34 +2918,6 @@ internal sealed class ReadyBatchPool
 /// Returns pooled arrays to ArrayPool when complete.
 /// PooledValueTaskSource instances auto-return to their pool when GetResult() is called.
 /// </summary>
-#if DEBUG
-/// <summary>
-/// Tracks the last known location of a ReadyBatch in the BrokerSender pipeline.
-/// Survives process kills — inspectable via hangdump's dumpobj command.
-/// </summary>
-internal enum BatchTransition : int
-{
-    None = 0,
-    EntersPipeline = 1,
-    CompleteDelivery = 2,
-    EnqueuedToBrokerSender = 3,
-    Coalesced = 4,
-    InflightRegistered = 5,
-    MemoryReleased = 6,
-    AddedToPendingResponses = 7,
-    ProcessingResponse = 8,
-    CompleteSendCalled = 9,
-    FailCalled = 10,
-    CleanupBatchCalled = 11,
-    ExitsPipeline = 12,
-    ReturnedToPool = 13,
-    AddedToSendFailedRetries = 14,
-    AddedToCarryOver = 15,
-    Rerouted = 16,
-    FailEnqueuedBatch = 17,
-}
-#endif
-
 internal sealed class ReadyBatch : IValueTaskSource<bool>
 {
     private TopicPartition _topicPartition;
@@ -2997,20 +2969,6 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     // In-flight tracker entry for coordinated retry with multiple in-flight batches per partition.
     // Set by KafkaProducer when registering with PartitionInflightTracker, cleared in Reset().
     internal InflightEntry? InflightEntry { get; set; }
-
-#if DEBUG
-    /// <summary>
-    /// Last transition this batch went through in the pipeline. Inspectable in hangdumps
-    /// via dumpobj to trace where a batch was "lost" when it fails to exit the pipeline.
-    /// </summary>
-    internal volatile int DebugLastTransition;
-
-    /// <summary>
-    /// Broker ID of the BrokerSender that last handled this batch. Helps correlate
-    /// batch state with specific BrokerSender instances in hangdump analysis.
-    /// </summary>
-    internal volatile int DebugLastBrokerId;
-#endif
 
     /// <summary>
     /// Lightweight lifecycle trace for diagnosing orphaned batches in Release builds.
@@ -3190,10 +3148,6 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         IsRetry = false;
         RetryNotBefore = 0;
         _diagTraceLen = 0;
-#if DEBUG
-        DebugLastTransition = (int)BatchTransition.ReturnedToPool;
-        DebugLastBrokerId = -1;
-#endif
 
         // NOTE: _cleanedUp, _completed, and _sendCompleted are NOT reset here. They stay
         // at 1 (armed) while the batch is in the pool, so that stale references from a

--- a/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
@@ -40,31 +40,34 @@ public abstract class KafkaIntegrationTest(KafkaTestContainer kafkaTestContainer
         IKafkaProducer<TKey, TValue> producer,
         ProducerMessage<TKey, TValue> message,
         int maxAttempts = 3,
-        int timeoutSeconds = 15)
+        int timeoutSeconds = 15,
+        CancellationToken cancellationToken = default)
     {
         for (var attempt = 0; attempt < maxAttempts; attempt++)
         {
             try
             {
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
                 return await producer.ProduceAsync(message, cts.Token);
             }
-            catch (OperationCanceledException) when (attempt < maxAttempts - 1)
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && attempt < maxAttempts - 1)
             {
                 // Timeout — retry. The cancellation only stops the caller's await;
                 // the message may still be delivered in the background.
-                await Task.Delay(500);
+                await Task.Delay(500, cancellationToken);
             }
             catch (ObjectDisposedException) when (attempt < maxAttempts - 1)
             {
                 // BrokerSender disposed during an in-flight produce (EDQCSGX pattern).
                 // The producer may recover with a new connection on the next attempt.
-                await Task.Delay(500);
+                await Task.Delay(500, cancellationToken);
             }
         }
 
         // Final attempt without retry catch
-        using var finalCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+        using var finalCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        finalCts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
         return await producer.ProduceAsync(message, finalCts.Token);
     }
 }


### PR DESCRIPTION
## Summary

PR #412 (unified event channel refactor) was accidentally auto-merged with several unresolved review comments from Claude. This PR addresses all outstanding feedback.

- **`_partitionsNeedingSequenceReset.Clear()` moved to `finally` block** — prevents unbounded set growth if `_bumpEpoch` throws (e.g. epoch overflow). The `Clear()` was previously skipped on exception, causing the set to accumulate indefinitely on subsequent iterations.
- **Log warning on silent acks override** — when idempotence is enabled and acks != All, the builder now logs a warning before overriding to `Acks.All`, matching Java client behavior of surfacing the override.
- **`SendLoopEvent` made `readonly struct`** — the struct is value-copied into the channel and never mutated after construction. `readonly` prevents accidental defensive copies and is more semantically correct.
- **`WaitForTopicLeadersAsync` retry constants consolidated** — now uses the shared `RetryDelayMs` constant for the delay, with a local `leaderWaitRetries = 5` constant (separate from `WithRetryAsync`'s `MaxRetries = 3` since leader election is an async cluster operation requiring more patience).
- **Remove `#if DEBUG` `BatchTransition` instrumentation** — `BatchTransition` enum, `DebugLastTransition`/`DebugLastBrokerId` fields, and all associated `Debug.WriteLine` calls removed. These were investigation-only artifacts that activate in Debug CI builds, adding output noise and build overhead. The Release-build `AppendDiag` trace (single-char codes) remains for production diagnostics.
- **`ProduceWithRetryAsync` respects caller cancellation** — added `CancellationToken` parameter, uses `CreateLinkedTokenSource` so both timeout and caller cancellation are honored, and passes token to `Task.Delay` calls to avoid hanging on test cancellation.
- **`GetPartitionsForNode` avoids per-call allocation** — changed from returning a new `List<TopicPartition>` to accepting a caller-supplied list that is cleared and repopulated. `RecordAccumulator` reuses a single `_reusablePartitionList` field across drain iterations.

## Test plan

- [x] All 3027 unit tests pass
- [ ] CI integration tests pass
- [ ] Verify no build warnings