### PR TITLE
fix: use separate NetworkStream for reads to prevent PipeReader.ReadAsync blocking

### DIFF
--- a/src/Dekaf/Networking/DuplexPipe.cs
+++ b/src/Dekaf/Networking/DuplexPipe.cs
@@ -3,17 +3,16 @@ using System.IO.Pipelines;
 namespace Dekaf.Networking;
 
 /// <summary>
-/// Decouples reading from a <see cref="Stream"/> by pumping data into an internal <see cref="Pipe"/>,
-/// while writing goes directly to the stream via <see cref="PipeWriter.Create(Stream, StreamPipeWriterOptions?)"/>.
+/// Decouples reading from a <see cref="Stream"/> by pumping data into an internal <see cref="Pipe"/>.
 /// This avoids a known .NET issue where concurrent <c>StreamPipeReader</c> + <c>StreamPipeWriter</c>
 /// on the same stream causes <c>PipeReader.ReadAsync</c> to block indefinitely.
-/// Only the read path needs the pump — the write path was never affected by the bug.
+/// Used only for TLS connections where separate stream instances are not possible.
+/// Writing is handled directly by <see cref="KafkaConnection"/> via <c>PipeWriter.Create(stream)</c>.
 /// </summary>
 internal sealed class DuplexPipe : IAsyncDisposable
 {
     private readonly Stream _stream;
     private readonly Pipe _inputPipe;
-    private readonly PipeWriter _writer;
     private readonly Task _readPumpTask;
     private readonly int _readBufferSize;
     private int _disposed;
@@ -24,21 +23,10 @@ internal sealed class DuplexPipe : IAsyncDisposable
     /// </summary>
     public PipeReader Input => _inputPipe.Reader;
 
-    /// <summary>
-    /// The application-facing writer. Writes go directly to the stream via
-    /// <see cref="PipeWriter.Create(Stream, StreamPipeWriterOptions?)"/> — no pump needed.
-    /// </summary>
-    public PipeWriter Output => _writer;
-
-    public DuplexPipe(
-        Stream stream,
-        PipeOptions inputPipeOptions,
-        StreamPipeWriterOptions writerOptions,
-        int readBufferSize = 65536)
+    public DuplexPipe(Stream stream, PipeOptions inputPipeOptions, int readBufferSize = 65536)
     {
         _stream = stream;
         _inputPipe = new Pipe(inputPipeOptions);
-        _writer = PipeWriter.Create(stream, writerOptions);
         _readBufferSize = readBufferSize;
 
         // Start pump task inline — it yields at its first await
@@ -80,18 +68,6 @@ internal sealed class DuplexPipe : IAsyncDisposable
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
-
-        // Complete the direct writer so no more data can be sent.
-        // StreamPipeWriter.CompleteAsync may throw if it tries to flush pending data
-        // to an already-broken stream — catch and continue with disposal.
-        try
-        {
-            await _writer.CompleteAsync().ConfigureAwait(false);
-        }
-        catch
-        {
-            // Stream already broken (e.g. peer disconnected) — safe to ignore
-        }
 
         // Dispose the stream to abort any pending _stream.ReadAsync in the read pump.
         // The read pump's finally block then calls _inputPipe.Writer.CompleteAsync.

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -272,9 +272,8 @@ public sealed partial class KafkaConnection : IKafkaConnection
                 resumeWriterThreshold: resumeThreshold,
                 useSynchronizationContext: false);
 
-            var writerOptions = new StreamPipeWriterOptions(leaveOpen: true);
             var readBufferSize = _options.ReceiveBufferSize > 0 ? _options.ReceiveBufferSize : 65536;
-            _duplexPipe = new DuplexPipe(_stream, inputPipeOptions, writerOptions, readBufferSize);
+            _duplexPipe = new DuplexPipe(_stream, inputPipeOptions, readBufferSize);
             _reader = _duplexPipe.Input;
         }
 
@@ -1542,7 +1541,9 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
         _receiveCts?.Dispose();
 
-        if (_reader is not null)
+        // For the plain TCP path, complete reader/writer explicitly.
+        // For TLS, DuplexPipe owns the reader and stream — skip reader completion here.
+        if (_reader is not null && _duplexPipe is null)
             await _reader.CompleteAsync().ConfigureAwait(false);
 
         if (_writer is not null)
@@ -1551,7 +1552,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         if (_duplexPipe is not null)
             await _duplexPipe.DisposeAsync().ConfigureAwait(false);
         else
-            _stream?.Dispose(); // Only dispose here if DuplexPipe didn't own it
+            _stream?.Dispose();
 
         _readStream?.Dispose();
         _socket?.Dispose();

--- a/tests/Dekaf.Tests.Unit/Networking/DuplexPipeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/DuplexPipeTests.cs
@@ -9,7 +9,6 @@ namespace Dekaf.Tests.Unit.Networking;
 public sealed class DuplexPipeTests
 {
     private static PipeOptions DefaultPipeOptions => new(useSynchronizationContext: false);
-    private static StreamPipeWriterOptions DefaultWriterOptions => new();
 
     /// <summary>
     /// Creates a pair of connected streams using TCP loopback for testing.
@@ -36,7 +35,7 @@ public sealed class DuplexPipeTests
     {
         var (clientStream, serverStream) = await CreateConnectedStreamsAsync();
 
-        await using var pipe = new DuplexPipe(clientStream, DefaultPipeOptions, DefaultWriterOptions);
+        await using var pipe = new DuplexPipe(clientStream, DefaultPipeOptions);
 
         var expected = "hello from broker"u8.ToArray();
         await serverStream.WriteAsync(expected);
@@ -52,39 +51,11 @@ public sealed class DuplexPipeTests
     }
 
     [Test]
-    public async Task DataWrittenToOutput_AppearsInStream()
-    {
-        var (clientStream, serverStream) = await CreateConnectedStreamsAsync();
-
-        await using var pipe = new DuplexPipe(clientStream, DefaultPipeOptions, DefaultWriterOptions);
-
-        var expected = "hello from client"u8.ToArray();
-        var memory = pipe.Output.GetMemory(expected.Length);
-        expected.CopyTo(memory);
-        pipe.Output.Advance(expected.Length);
-        await pipe.Output.FlushAsync();
-
-        var buffer = new byte[expected.Length];
-        var totalRead = 0;
-        while (totalRead < expected.Length)
-        {
-            var bytesRead = await serverStream.ReadAsync(buffer.AsMemory(totalRead));
-            if (bytesRead == 0)
-                break;
-            totalRead += bytesRead;
-        }
-
-        await Assert.That(buffer).IsEquivalentTo(expected);
-
-        await serverStream.DisposeAsync();
-    }
-
-    [Test]
     public async Task StreamEof_SetsIsCompletedOnInput()
     {
         var (clientStream, serverStream) = await CreateConnectedStreamsAsync();
 
-        await using var pipe = new DuplexPipe(clientStream, DefaultPipeOptions, DefaultWriterOptions);
+        await using var pipe = new DuplexPipe(clientStream, DefaultPipeOptions);
 
         // Close the server side to signal EOF
         await serverStream.DisposeAsync();
@@ -105,7 +76,7 @@ public sealed class DuplexPipeTests
         await serverStream.DisposeAsync();
         await clientStream.DisposeAsync();
 
-        await using var pipe = new DuplexPipe(clientStream, DefaultPipeOptions, DefaultWriterOptions);
+        await using var pipe = new DuplexPipe(clientStream, DefaultPipeOptions);
 
         await Assert.That(async () =>
         {
@@ -119,7 +90,7 @@ public sealed class DuplexPipeTests
     {
         var (clientStream, serverStream) = await CreateConnectedStreamsAsync();
 
-        await using var pipe = new DuplexPipe(clientStream, DefaultPipeOptions, DefaultWriterOptions);
+        await using var pipe = new DuplexPipe(clientStream, DefaultPipeOptions);
 
         // Successfully exchange data first
         var data = "hello"u8.ToArray();
@@ -140,66 +111,11 @@ public sealed class DuplexPipeTests
     }
 
     [Test]
-    public async Task StreamErrorDuringActiveWrite_PropagatesFromOutput()
+    public async Task DisposeAsync_StopsPumpAndDisposesStream()
     {
         var (clientStream, serverStream) = await CreateConnectedStreamsAsync();
 
-        await using var pipe = new DuplexPipe(clientStream, DefaultPipeOptions, DefaultWriterOptions);
-
-        // Successfully write data first
-        var data = "hello"u8.ToArray();
-        var memory = pipe.Output.GetMemory(data.Length);
-        data.CopyTo(memory);
-        pipe.Output.Advance(data.Length);
-        await pipe.Output.FlushAsync();
-
-        // Verify server received it
-        var buffer = new byte[data.Length];
-        var bytesRead = await serverStream.ReadAsync(buffer);
-        await Assert.That(bytesRead).IsEqualTo(data.Length);
-
-        // Now kill the server mid-operation — simulates broker crash
-        await serverStream.DisposeAsync();
-
-        // Write data until the write pump detects the broken stream. The error surfaces
-        // either as FlushAsync returning IsCompleted or throwing IOException. We write
-        // in a loop because the OS TCP send buffer may absorb several writes before the
-        // broken connection is detected. Use a timeout to avoid hanging if the buffer
-        // is unexpectedly large on some CI hosts.
-        var errorDetected = false;
-        var largeData = new byte[65536];
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        while (!errorDetected && !cts.IsCancellationRequested)
-        {
-            try
-            {
-                memory = pipe.Output.GetMemory(largeData.Length);
-                largeData.CopyTo(memory);
-                pipe.Output.Advance(largeData.Length);
-
-                var flushResult = await pipe.Output.FlushAsync(cts.Token);
-                if (flushResult.IsCompleted)
-                    errorDetected = true;
-            }
-            catch (IOException)
-            {
-                errorDetected = true;
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-
-        await Assert.That(errorDetected).IsTrue();
-    }
-
-    [Test]
-    public async Task DisposeAsync_StopsPumpsAndDisposesStream()
-    {
-        var (clientStream, serverStream) = await CreateConnectedStreamsAsync();
-
-        var pipe = new DuplexPipe(clientStream, DefaultPipeOptions, DefaultWriterOptions);
+        var pipe = new DuplexPipe(clientStream, DefaultPipeOptions);
 
         await pipe.DisposeAsync();
 
@@ -217,53 +133,11 @@ public sealed class DuplexPipeTests
     {
         var (clientStream, serverStream) = await CreateConnectedStreamsAsync();
 
-        var pipe = new DuplexPipe(clientStream, DefaultPipeOptions, DefaultWriterOptions);
+        var pipe = new DuplexPipe(clientStream, DefaultPipeOptions);
 
         await pipe.DisposeAsync();
 
         await Assert.That(async () => await pipe.DisposeAsync()).ThrowsNothing();
-
-        await serverStream.DisposeAsync();
-    }
-
-    [Test]
-    public async Task BidirectionalCommunication_WorksSimultaneously()
-    {
-        var (clientStream, serverStream) = await CreateConnectedStreamsAsync();
-
-        await using var pipe = new DuplexPipe(clientStream, DefaultPipeOptions, DefaultWriterOptions);
-
-        var requestData = "request"u8.ToArray();
-        var responseData = "response"u8.ToArray();
-
-        // Server sends response
-        await serverStream.WriteAsync(responseData);
-        await serverStream.FlushAsync();
-
-        // Client sends request via DuplexPipe
-        var outMemory = pipe.Output.GetMemory(requestData.Length);
-        requestData.CopyTo(outMemory);
-        pipe.Output.Advance(requestData.Length);
-        await pipe.Output.FlushAsync();
-
-        // Verify client received response
-        var readResult = await pipe.Input.ReadAsync();
-        var receivedResponse = BuffersExtensions.ToArray(readResult.Buffer);
-        await Assert.That(receivedResponse).IsEquivalentTo(responseData);
-        pipe.Input.AdvanceTo(readResult.Buffer.End);
-
-        // Verify server received request
-        var serverBuffer = new byte[requestData.Length];
-        var totalRead = 0;
-        while (totalRead < requestData.Length)
-        {
-            var bytesRead = await serverStream.ReadAsync(serverBuffer.AsMemory(totalRead));
-            if (bytesRead == 0)
-                break;
-            totalRead += bytesRead;
-        }
-
-        await Assert.That(serverBuffer).IsEquivalentTo(requestData);
 
         await serverStream.DisposeAsync();
     }


### PR DESCRIPTION
## Summary

- **Fixes `PipeReader.ReadAsync` blocking indefinitely** on `KafkaConnection` when fetching metadata for new topics — a known .NET issue with concurrent `StreamPipeReader` + `StreamPipeWriter` on the same stream instance
- **Zero performance overhead** for plain TCP connections — uses separate `NetworkStream` instances on the same socket instead of a pump layer
- **Falls back to `DuplexPipe` read pump** for TLS (`SslStream`) where separate stream instances aren't possible
- **Fixes flaky `AppendWorkerAffinityTests`** — polls for actual batches, not just deque count

## Approach

The original bug is caused by `PipeReader.Create(stream)` and `PipeWriter.Create(stream)` sharing the same stream instance. Rather than adding a pump layer (which adds latency per response — we measured 3-4x slower integration tests), we give them separate `NetworkStream` instances:

```csharp
// Plain TCP: separate streams, zero overhead
_readStream = new NetworkStream(_socket, ownsSocket: false);
_reader = PipeReader.Create(_readStream, readerOptions);
_writer = PipeWriter.Create(_stream, writerOptions);

// TLS: read pump fallback (SslStream can't be split)
_duplexPipe = new DuplexPipe(_stream, inputPipeOptions, readBufferSize);
_reader = _duplexPipe.Input;
```

`Socket` natively supports concurrent `ReceiveAsync` + `SendAsync`, so two `NetworkStream` objects on the same socket are fully independent.

## Test plan

- [x] Unit tests: 3034/3034 passed
- [ ] Integration tests (requires Docker)
- [ ] Verify original bug reproduction: first `Send()` to new topic completes in <1s