### PR TITLE
perf: use SpinWait.NextSpinWillYield to reduce semaphore overhead

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1730,6 +1730,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             {
                 throw new ObjectDisposedException(nameof(RecordAccumulator));
             }
+
+            // Intentionally not resetting spinWait here. After the first blocking wait,
+            // the spin budget is exhausted so subsequent iterations go straight to the
+            // semaphore wait — this is correct because repeated contention means the
+            // semaphore is the right backpressure mechanism, not CPU-burning spins.
         }
 
         // Chain-wake: if space still remains after this reservation, signal the next sync waiter.


### PR DESCRIPTION
## Summary

- Replace hardcoded spin count of 10 with `SpinWait.NextSpinWillYield` in `ReserveMemorySync`, letting the runtime adapt spin duration to the hardware (more spins on multi-core, fewer on single-core)
- Reduces `SemaphoreSlim.WaitUntilCountOrTimeout` overhead (6.06% exclusive CPU in profiling) by allowing productive spins to complete before falling through to the expensive semaphore wait
- No change to `ReserveMemoryAsync` -- it doesn't have a spin loop (goes straight to async semaphore wait)

## Test plan

- [x] `dotnet build src/Dekaf` succeeds
- [x] All 3046 unit tests pass
- [ ] CI passes (integration tests, benchmarks)

Closes #479