### PR TITLE
fix: increase ProduceWithRetryAsync timeout from 15s to 30s

### DIFF
--- a/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
@@ -40,7 +40,7 @@ public abstract class KafkaIntegrationTest(KafkaTestContainer kafkaTestContainer
         IKafkaProducer<TKey, TValue> producer,
         ProducerMessage<TKey, TValue> message,
         int maxAttempts = 3,
-        int timeoutSeconds = 15,
+        int timeoutSeconds = 30,
         CancellationToken cancellationToken = default)
     {
         for (var attempt = 0; attempt < maxAttempts; attempt++)


### PR DESCRIPTION
## Summary

On slow CI runners, a single produce during warmup can take >15s when the broker is still initializing topic partitions. This causes flaky failures like `MultiPartition_ProduceAndConsumeWithKeys_PartitioningIsConsistent` timing out with `OperationCanceledException`.

Increases the default per-attempt timeout in the shared `ProduceWithRetryAsync` helper from 15s to 30s.

## Test plan

- [ ] CI integration tests pass without the `MultiPartition` flake