### PR TITLE
fix: make Send() synchronously wait for topic metadata on cache miss

### DIFF
--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -186,11 +186,16 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// concurrent GetOrAdd calls (ConcurrentDictionary may invoke the factory speculatively,
     /// but Lazy defers execution until .Value is accessed).
     /// </remarks>
-    internal TopicInfo? WaitForTopicMetadataSync(string topicName, int timeoutMs, CancellationToken disposalToken)
+    internal TopicInfo? WaitForTopicMetadataSync(string topicName, int timeoutMs)
     {
         if (TryGetCachedTopicMetadata(topicName, out var topic))
             return topic;
 
+        // Coalesce: all callers for the same topic share one fetch task.
+        // The inner task uses _disposalCts so it is cancelled promptly on disposal,
+        // regardless of the caller's timeout. This is intentional — the underlying
+        // network operation should continue running even if one waiter times out,
+        // so that other waiters (or retry callers) can benefit from the result.
         var sharedTask = _pendingTopicFetches.GetOrAdd(topicName,
             static (t, self) => new Lazy<Task<TopicInfo?>>(
                 () => self.GetTopicMetadataSlowAsync(t, self._disposalCts.Token).AsTask()),
@@ -198,11 +203,11 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
         try
         {
-            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(disposalToken);
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_disposalCts.Token);
             timeoutCts.CancelAfter(timeoutMs);
             return sharedTask.Value.WaitAsync(timeoutCts.Token).GetAwaiter().GetResult();
         }
-        catch (OperationCanceledException) when (disposalToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (_disposalCts.IsCancellationRequested)
         {
             throw new ObjectDisposedException(nameof(MetadataManager));
         }
@@ -224,13 +229,13 @@ public sealed partial class MetadataManager : IAsyncDisposable
             else if (sharedTask.IsValueCreated)
             {
                 // We timed out but the inner task is still running.
-                // Attach cleanup so a faulted/cancelled task doesn't linger forever
-                // and block future metadata fetches for this topic.
+                // Remove unconditionally on completion so callers always get a fresh
+                // fetch — a successful-but-late result would otherwise leave a stale
+                // entry permanently in the dictionary.
                 sharedTask.Value.ContinueWith(static (t, state) =>
                 {
                     var (dict, key) = ((ConcurrentDictionary<string, Lazy<Task<TopicInfo?>>>, string))state!;
-                    if (t.IsFaulted || t.IsCanceled)
-                        dict.TryRemove(key, out _);
+                    dict.TryRemove(key, out _);
                 }, (_pendingTopicFetches, topicName),
                 CancellationToken.None,
                 TaskContinuationOptions.ExecuteSynchronously,

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2451,7 +2451,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private void EnsureTopicMetadataSync(string topic)
     {
         var topicInfo = _metadataManager.WaitForTopicMetadataSync(
-            topic, _options.MaxBlockMs, _senderCts.Token);
+            topic, _options.MaxBlockMs);
 
         if (topicInfo is not null)
         {

--- a/tests/Dekaf.Tests.Integration/BufferMemoryStressTests.cs
+++ b/tests/Dekaf.Tests.Integration/BufferMemoryStressTests.cs
@@ -202,7 +202,8 @@ public class BufferMemoryStressTests(KafkaTestContainer kafka) : KafkaIntegratio
     /// </summary>
     [Test]
     [NotInParallel]
-    public async Task Send_TightLoopToNewTopic_DoesNotTimeout()
+    [Timeout(120_000)] // 2 minutes — bounded failure if FlushAsync hangs
+    public async Task Send_TightLoopToNewTopic_DoesNotTimeout(CancellationToken testTimeout)
     {
         // Arrange: create topic before producer so it exists in Kafka but not in producer cache
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
@@ -214,7 +215,7 @@ public class BufferMemoryStressTests(KafkaTestContainer kafka) : KafkaIntegratio
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithClientId("send-metadata-test")
             .WithAcks(Acks.Leader)
-            .BuildAsync();
+            .BuildAsync(testTimeout);
 
         var messageValue = new string('x', 1000); // 1 KB messages
 
@@ -228,24 +229,30 @@ public class BufferMemoryStressTests(KafkaTestContainer kafka) : KafkaIntegratio
             producer.Send(topic, $"key-{i % 100}", messageValue);
         }
 
-        await producer.FlushAsync(CancellationToken.None);
+        await producer.FlushAsync(testTimeout);
 
         // Assert: consume messages to verify they were all delivered
         await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithGroupId($"verify-{Guid.NewGuid():N}")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
-            .BuildAsync();
+            .BuildAsync(testTimeout);
 
         consumer.Subscribe(topic);
 
         var received = 0;
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        await foreach (var msg in consumer.ConsumeAsync(cts.Token))
+        try
         {
-            received++;
-            if (received >= messageCount)
-                break;
+            await foreach (var msg in consumer.ConsumeAsync(testTimeout))
+            {
+                received++;
+                if (received >= messageCount)
+                    break;
+            }
+        }
+        catch (OperationCanceledException) when (received < messageCount)
+        {
+            // Test timeout while consuming — will fail the assertion below
         }
 
         await Assert.That(received).IsEqualTo(messageCount);


### PR DESCRIPTION
## Summary

- **Root cause**: When `Send()` (fire-and-forget) encountered a topic not in the metadata cache, it launched a separate async Task **per message**. In a tight loop (e.g. consumer stress test pre-seeding 500K messages), this created hundreds of thousands of tasks — a thundering herd that exhausted `BufferMemory` (256MB) and threw `KafkaTimeoutException`.
- **Fix**: `Send()` now synchronously blocks on a **coalesced metadata fetch** (one per topic) using `Lazy<Task>` + `ConcurrentDictionary`, matching Java's `KafkaProducer.send()` → `waitOnMetadata()` pattern. All messages stay on the fast sync path with proper `ReserveMemorySync` backpressure.
- **Regression test**: Tight `Send()` loop to a new topic with 16MB buffer, 50K×1KB messages (50MB total), no intermediate flushes.

## Test plan

- [ ] Unit tests pass (3049/3049 verified locally)
- [ ] New regression test `Send_TightLoopToNewTopic_DoesNotTimeout` passes
- [ ] Existing integration tests pass
- [ ] Consumer stress test CI job no longer fails with `KafkaTimeoutException`