### PR TITLE
perf: use permanent arena buffers to eliminate LOH fragmentation

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -333,6 +333,9 @@ internal readonly struct AppendWorkItem
 internal sealed class BatchArena
 {
     private static readonly ConcurrentQueue<BatchArena> s_pool = new();
+    // Memory tradeoff: at the default 1MB batch size, pooling up to 128 arenas holds
+    // up to ~128MB permanently on the LOH. This is acceptable for high-throughput
+    // workloads where these arenas are in active use and would be reallocated anyway.
     private const int MaxPoolSize = 128;
     private static int s_poolCount;
 
@@ -470,13 +473,14 @@ internal sealed class BatchArena
 
     /// <summary>
     /// Releases the arena's buffer reference.
-    /// Thread-safe: uses Interlocked.Exchange to prevent double-release.
+    /// Defensive nulling to prevent use-after-return — the arena is single-owner
+    /// at this point so a plain write is sufficient (no atomic exchange needed).
     /// The buffer is permanently allocated (not from ArrayPool), so it is simply
     /// released for GC collection.
     /// </summary>
     public void Return()
     {
-        Interlocked.Exchange(ref _buffer, null!);
+        _buffer = null!;
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace `ArrayPool<byte>.Shared.Rent/Return` in `BatchArena` with `GC.AllocateUninitializedArray<byte>` to eliminate LOH churn
- Arena buffers are now permanent — allocated once and reused across pool cycles instead of cycling through ArrayPool
- When arenas are returned to the pool, the buffer stays; only discarded arenas lose their buffer

## Motivation
Profiling showed 590 Gen0 / 79 Gen1 / 25 Gen2 GC collections in a 3-minute stress test with throughput degrading from 155K to 57K msg/sec. Each `BatchArena` rented a ~1MB array from `ArrayPool<byte>.Shared`, which goes to LOH (>85KB). With ~100 batches/sec, this caused LOH fragmentation and escalating Gen2 GC pressure.

## Test plan
- [ ] Unit tests pass (`dotnet build tests/Dekaf.Tests.Unit --configuration Release && ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit`)
- [ ] Integration tests pass (requires Docker)
- [ ] Stress test shows reduced Gen2 GC collections