### PR TITLE
perf: add 12.5% arena overflow margin to reduce per-message ArrayPool fallback

### DIFF
--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -295,9 +295,9 @@ public sealed class ProducerOptions
     /// <summary>
     /// Capacity of the arena buffer for zero-copy serialization in bytes.
     /// Larger arenas reduce fallback allocations when messages are larger than expected.
-    /// Should be at least as large as BatchSize for optimal performance.
-    /// Default is 0, which uses BatchSize + 12.5% margin as the arena capacity.
-    /// The margin reduces per-message ArrayPool fallback when batches near capacity.
+    /// Default is 0, which uses BatchSize + 12.5% overflow margin as the arena capacity.
+    /// The margin provides headroom so that messages appended near the end of a batch
+    /// can still be serialized in the arena instead of falling back to ArrayPool.
     /// For workloads with very large messages (approaching BatchSize), consider setting
     /// this to BatchSize * 2 to reduce slow-path fallbacks.
     /// </summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2750,11 +2750,21 @@ internal sealed class PartitionBatch
     private RecordAccumulator? _accumulator;
 
     /// <summary>
+    /// Divisor for computing the arena overflow margin from BatchSize.
+    /// A divisor of 8 gives a 12.5% margin (BatchSize / 8) above BatchSize,
+    /// reducing per-message ArrayPool fallback when batches near capacity.
+    /// </summary>
+    private const int ArenaOverflowMarginDivisor = 8;
+
+    /// <summary>
     /// Returns the effective arena capacity: explicit ArenaCapacity if set,
     /// otherwise BatchSize + 12.5% margin to reduce per-message ArrayPool fallback.
+    /// Uses long arithmetic to avoid integer overflow when BatchSize is large.
     /// </summary>
     private static int GetEffectiveArenaCapacity(ProducerOptions options) =>
-        options.ArenaCapacity > 0 ? options.ArenaCapacity : options.BatchSize + options.BatchSize / 8;
+        options.ArenaCapacity > 0
+            ? options.ArenaCapacity
+            : (int)Math.Min((long)options.BatchSize + options.BatchSize / ArenaOverflowMarginDivisor, int.MaxValue);
 
     public PartitionBatch(TopicPartition topicPartition, ProducerOptions options)
     {


### PR DESCRIPTION
## Summary
- Size `BatchArena` capacity to `BatchSize + 12.5%` instead of exactly `BatchSize`
- Extract duplicated arena capacity calculation into `GetEffectiveArenaCapacity()` helper
- Explicit `ArenaCapacity` option still takes precedence when set

## Motivation
When the arena buffer matches `BatchSize` exactly, the last ~10-20% of messages in each batch fall back to per-message `ArrayPool<byte>.Shared.Rent()` calls (key + value arrays). With 1KB messages and 100 batches/sec, this generates ~10,000-20,000 per-message ArrayPool operations/sec. A 12.5% margin reduces this fallback significantly with minimal memory overhead (~128KB per 1MB batch).

## Test plan
- [ ] Unit tests pass (3050 tests confirmed passing)
- [ ] Integration tests pass (requires Docker)
- [ ] Stress test shows reduced per-message ArrayPool fallback