### PR TITLE
perf: add BatchArrayReuseQueue to eliminate per-batch ArrayPool churn

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2867,7 +2867,7 @@ internal sealed class PartitionBatch
         // Arrays were transferred to ReadyBatch by Complete() and are now null.
         // Try to reclaim arrays from the reuse queue first (returned by ReadyBatch.Cleanup()),
         // avoiding 4 ArrayPool Rent operations per batch cycle.
-        if (arrayReuseQueue is not null && arrayReuseQueue.TryDequeue(out var reusable))
+        if (_arrayReuseQueue is not null && _arrayReuseQueue.TryDequeue(out var reusable))
         {
             _records = reusable.Records;
             _completionSources = reusable.CompletionSources;
@@ -3431,30 +3431,16 @@ internal sealed class BatchArrayReuseQueue
         _maxSize = maxSize;
     }
 
-    internal readonly struct ReusableArrays
-    {
-        public readonly Record[] Records;
-        public readonly PooledValueTaskSource<RecordMetadata>[] CompletionSources;
-        public readonly byte[][] PooledDataArrays;
-        public readonly Header[][] PooledHeaderArrays;
-
-        public ReusableArrays(
-            Record[] records,
-            PooledValueTaskSource<RecordMetadata>[] completionSources,
-            byte[][] pooledDataArrays,
-            Header[][] pooledHeaderArrays)
-        {
-            Records = records;
-            CompletionSources = completionSources;
-            PooledDataArrays = pooledDataArrays;
-            PooledHeaderArrays = pooledHeaderArrays;
-        }
-    }
+    internal readonly record struct ReusableArrays(
+        Record[] Records,
+        PooledValueTaskSource<RecordMetadata>[] CompletionSources,
+        byte[][] PooledDataArrays,
+        Header[][] PooledHeaderArrays);
 
     /// <summary>
-    /// Enqueues a set of reusable arrays. If the queue is full, falls back to ArrayPool return.
+    /// Enqueues arrays for reuse, or returns them to ArrayPool if the queue is full.
     /// </summary>
-    public void TryEnqueue(
+    public void EnqueueOrReturn(
         Record[] records,
         PooledValueTaskSource<RecordMetadata>[] completionSources,
         byte[][] pooledDataArrays,
@@ -3958,7 +3944,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
             // PooledValueTaskSource references, but these are never accessed because counters reset to 0
             // on reuse. PooledValueTaskSource instances auto-return to their pool via GetResult(),
             // so stale references don't prevent pool recycling. This matches ArrayPool behavior.
-            _arrayReuseQueue.TryEnqueue(_pooledRecordsArray, _completionSourcesArray, _pooledDataArrays, _pooledHeaderArrays);
+            _arrayReuseQueue.EnqueueOrReturn(_pooledRecordsArray, _completionSourcesArray, _pooledDataArrays, _pooledHeaderArrays);
         }
         else
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BatchArrayReuseQueueTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BatchArrayReuseQueueTests.cs
@@ -22,7 +22,7 @@ public class BatchArrayReuseQueueTests
         var queue = new BatchArrayReuseQueue(maxSize: 4);
         var arrays = CreateTestArrays();
 
-        queue.TryEnqueue(arrays.Records, arrays.CompletionSources, arrays.PooledDataArrays, arrays.PooledHeaderArrays);
+        queue.EnqueueOrReturn(arrays.Records, arrays.CompletionSources, arrays.PooledDataArrays, arrays.PooledHeaderArrays);
 
         var success = queue.TryDequeue(out var dequeued);
 
@@ -41,12 +41,12 @@ public class BatchArrayReuseQueueTests
         // Fill the queue to capacity
         var arrays1 = CreateTestArrays();
         var arrays2 = CreateTestArrays();
-        queue.TryEnqueue(arrays1.Records, arrays1.CompletionSources, arrays1.PooledDataArrays, arrays1.PooledHeaderArrays);
-        queue.TryEnqueue(arrays2.Records, arrays2.CompletionSources, arrays2.PooledDataArrays, arrays2.PooledHeaderArrays);
+        queue.EnqueueOrReturn(arrays1.Records, arrays1.CompletionSources, arrays1.PooledDataArrays, arrays1.PooledHeaderArrays);
+        queue.EnqueueOrReturn(arrays2.Records, arrays2.CompletionSources, arrays2.PooledDataArrays, arrays2.PooledHeaderArrays);
 
         // This one should be returned to ArrayPool (queue is full)
         var overflow = CreateTestArrays();
-        queue.TryEnqueue(overflow.Records, overflow.CompletionSources, overflow.PooledDataArrays, overflow.PooledHeaderArrays);
+        queue.EnqueueOrReturn(overflow.Records, overflow.CompletionSources, overflow.PooledDataArrays, overflow.PooledHeaderArrays);
 
         // Should only be able to dequeue the 2 that fit
         var success1 = queue.TryDequeue(out _);
@@ -88,7 +88,7 @@ public class BatchArrayReuseQueueTests
                 for (var j = 0; j < operationsPerThread; j++)
                 {
                     var arrays = CreateTestArrays();
-                    queue.TryEnqueue(arrays.Records, arrays.CompletionSources, arrays.PooledDataArrays, arrays.PooledHeaderArrays);
+                    queue.EnqueueOrReturn(arrays.Records, arrays.CompletionSources, arrays.PooledDataArrays, arrays.PooledHeaderArrays);
                     Interlocked.Increment(ref enqueueCount);
                 }
             });
@@ -132,7 +132,7 @@ public class BatchArrayReuseQueueTests
 
         // First cycle
         var arrays1 = CreateTestArrays();
-        queue.TryEnqueue(arrays1.Records, arrays1.CompletionSources, arrays1.PooledDataArrays, arrays1.PooledHeaderArrays);
+        queue.EnqueueOrReturn(arrays1.Records, arrays1.CompletionSources, arrays1.PooledDataArrays, arrays1.PooledHeaderArrays);
         var success1 = queue.TryDequeue(out var dequeued1);
 
         await Assert.That(success1).IsTrue();
@@ -140,7 +140,7 @@ public class BatchArrayReuseQueueTests
 
         // Second cycle - queue should accept new items after draining
         var arrays2 = CreateTestArrays();
-        queue.TryEnqueue(arrays2.Records, arrays2.CompletionSources, arrays2.PooledDataArrays, arrays2.PooledHeaderArrays);
+        queue.EnqueueOrReturn(arrays2.Records, arrays2.CompletionSources, arrays2.PooledDataArrays, arrays2.PooledHeaderArrays);
         var success2 = queue.TryDequeue(out var dequeued2);
 
         await Assert.That(success2).IsTrue();


### PR DESCRIPTION
## Summary
- Add `BatchArrayReuseQueue` (bounded `ConcurrentQueue`, max 256) to recycle the 4 container arrays between `ReadyBatch.Cleanup()` and `PartitionBatch.PrepareForPooling()`
- `ReadyBatch` pushes arrays to reuse queue instead of `ArrayPool` after batch send completes
- `PartitionBatch` dequeues from reuse queue first, falling back to `ArrayPool` on miss
- Queue overflow falls back gracefully to `ArrayPool.Return()`

## Motivation
Each `PartitionBatch` rents 4 arrays from `ArrayPool` on creation/reset and returns them on completion. At ~100 batches/sec, that's ~800 ArrayPool Rent/Return operations/sec, causing bucket contention. The reuse queue short-circuits this by passing arrays directly between the consumer (`ReadyBatch`) and producer (`PartitionBatch`) of these arrays.

## Test plan
- [ ] Unit tests pass
- [ ] Integration tests pass (requires Docker)
- [ ] Stress test shows reduced ArrayPool contention