### PR TITLE
fix: make MultiPartition and LogCompaction integration tests more robust on slow CI

### DIFF
--- a/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
@@ -1,3 +1,4 @@
+using Dekaf.Errors;
 using Dekaf.Producer;
 
 namespace Dekaf.Tests.Integration;
@@ -56,6 +57,13 @@ public abstract class KafkaIntegrationTest(KafkaTestContainer kafkaTestContainer
                 // Timeout — retry. The cancellation only stops the caller's await;
                 // the message may still be delivered in the background.
                 await Task.Delay(500, cancellationToken);
+            }
+            catch (KafkaTimeoutException) when (attempt < maxAttempts - 1)
+            {
+                // BufferMemory backpressure timeout (max.block.ms). On slow CI runners
+                // with thread pool starvation, the send loop can't drain batches fast
+                // enough. Retry after a delay to let the send loop catch up.
+                await Task.Delay(1000, cancellationToken);
             }
             catch (ObjectDisposedException) when (attempt < maxAttempts - 1)
             {

--- a/tests/Dekaf.Tests.Integration/LogCompactionTests.cs
+++ b/tests/Dekaf.Tests.Integration/LogCompactionTests.cs
@@ -89,7 +89,9 @@ public sealed class LogCompactionTests(KafkaTestContainer kafka) : KafkaIntegrat
         await foreach (var msg in consumer.ConsumeAsync(cts.Token))
         {
             messages.Add(msg);
-            if (messages.Count >= 3) break; // warmup + 2 actual messages
+            // Count non-warmup messages, not total. ProduceWithRetryAsync may produce
+            // duplicate warmups on retry, so total count is unreliable.
+            if (messages.Count(m => m.Key != "warmup") >= 2) break;
         }
 
         var actual = messages.Where(m => m.Key != "warmup").ToList();

--- a/tests/Dekaf.Tests.Integration/MultiPartitionTests.cs
+++ b/tests/Dekaf.Tests.Integration/MultiPartitionTests.cs
@@ -227,7 +227,9 @@ public class MultiPartitionTests(KafkaTestContainer kafka) : KafkaIntegrationTes
         consumer.Subscribe(topic);
 
         var messages = new List<ConsumeResult<string, string>>();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        // Consumer group rebalance can take 30+ seconds on slow CI runners with
+        // thread pool starvation. Use a generous timeout to avoid flaky failures.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
         await foreach (var msg in consumer.ConsumeAsync(cts.Token))
         {


### PR DESCRIPTION
## Summary
Three fixes for intermittent CI failures on slow runners (4 CPUs, 16 parallel tests):

- **`ProduceWithRetryAsync` catches `KafkaTimeoutException`** — BufferMemory backpressure timeout (`max.block.ms`) was not retried. On slow CI with thread pool starvation, the send loop can't drain batches, causing `ReserveMemorySync` to timeout even for tiny messages.
- **`MultiPartition_ConsumerGroupSubscription` timeout 30s → 60s** — Consumer group rebalance can take 30+ seconds on slow CI runners.
- **`DuplicateKeys_ProduceSameKeyTwice` exit condition** — Used total message count (`messages.Count >= 3`) instead of non-warmup count. `ProduceWithRetryAsync` can produce duplicate warmups on retry, so total count is unreliable.

## Root Causes
| Test | Error | Root Cause |
|------|-------|------------|
| `MultiPartition_ConsumerGroupSubscription_GetsAllPartitions` | `KafkaTimeoutException: Failed to allocate buffer within max.block.ms` | Thread pool starvation → send loop stalled → buffer full |
| `MultiPartition_DifferentKeys_DistributeAcrossPartitions` | Same | Same |
| `DuplicateKeys_ProduceSameKeyTwice_BothMessagesConsumedFromBeginning` | `Expected count equal to 2` | Duplicate warmups from retry shifted message positions |

## Test plan
- [ ] `MultiPartition_ConsumerGroupSubscription_GetsAllPartitions` passes
- [ ] `MultiPartition_DifferentKeys_DistributeAcrossPartitions` passes
- [ ] `DuplicateKeys_ProduceSameKeyTwice_BothMessagesConsumedFromBeginning` passes
- [ ] All other Messaging integration tests still pass