### PR TITLE
perf: reduce thread pool churn with LongRunning tasks and PeriodicTimer

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -424,7 +424,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             catch (SemaphoreFullException) { /* Already signaled — benign race */ }
         };
         _cts = new CancellationTokenSource();
-        _sendLoopTask = SendLoopAsync(_cts.Token);
+        _sendLoopTask = Task.Factory.StartNew(
+            () => SendLoopAsync(_cts.Token),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default).Unwrap();
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -217,8 +217,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // sources (awaited produces), but waits for full LingerMs for fire-and-forget batches.
         // This provides low latency for ProduceAsync while maintaining efficient batching for Send.
         _lingerTimer = new PeriodicTimer(TimeSpan.FromMilliseconds(1));
-        _senderTask = SenderLoopAsync(_senderCts.Token);
-        _lingerTask = LingerLoopAsync(_senderCts.Token);
+        _senderTask = Task.Factory.StartNew(
+            () => SenderLoopAsync(_senderCts.Token),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default).Unwrap();
+        _lingerTask = Task.Factory.StartNew(
+            () => LingerLoopAsync(_senderCts.Token),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default).Unwrap();
         _accumulator.StartAppendWorkers(_senderCts.Token);
 
         // Start statistics emitter if configured
@@ -2250,7 +2258,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 // Observe any disposal exceptions to prevent UnobservedTaskException
                 _ = t.Exception;
-            }, null, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+            }, null, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
             return replacement;
         }
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1119,9 +1119,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         for (var i = 0; i < _appendWorkerCount; i++)
         {
             var workerIndex = i;
-            _appendWorkerTasks[i] = Task.Run(
+            _appendWorkerTasks[i] = Task.Factory.StartNew(
                 () => ProcessAppendWorkerAsync(workerIndex, cancellationToken),
-                CancellationToken.None);
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default).Unwrap();
         }
     }
 

--- a/src/Dekaf/Statistics/StatisticsEmitter.cs
+++ b/src/Dekaf/Statistics/StatisticsEmitter.cs
@@ -2,13 +2,16 @@ namespace Dekaf.Statistics;
 
 /// <summary>
 /// Background timer that periodically emits statistics.
+/// Uses <see cref="PeriodicTimer"/> instead of <c>Task.Delay</c> to avoid
+/// timer allocations on each tick. The <c>PeriodicTimer.WaitForNextTickAsync</c>
+/// call is allocation-free after the timer is constructed.
 /// </summary>
 internal sealed class StatisticsEmitter<TStatistics> : IAsyncDisposable
 {
-    private readonly TimeSpan _interval;
     private readonly Func<TStatistics> _collectStatistics;
     private readonly Action<TStatistics> _handler;
     private readonly CancellationTokenSource _cts;
+    private readonly PeriodicTimer _timer;
     private readonly Task _emitTask;
     private volatile bool _disposed;
 
@@ -17,21 +20,19 @@ internal sealed class StatisticsEmitter<TStatistics> : IAsyncDisposable
         Func<TStatistics> collectStatistics,
         Action<TStatistics> handler)
     {
-        _interval = interval;
         _collectStatistics = collectStatistics;
         _handler = handler;
         _cts = new CancellationTokenSource();
+        _timer = new PeriodicTimer(interval);
         _emitTask = EmitLoopAsync(_cts.Token);
     }
 
     private async Task EmitLoopAsync(CancellationToken cancellationToken)
     {
-        while (!cancellationToken.IsCancellationRequested)
+        while (await _timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
         {
             try
             {
-                await Task.Delay(_interval, cancellationToken).ConfigureAwait(false);
-
                 var stats = _collectStatistics();
                 _handler(stats);
             }
@@ -54,6 +55,7 @@ internal sealed class StatisticsEmitter<TStatistics> : IAsyncDisposable
         _disposed = true;
 
         _cts.Cancel();
+        _timer.Dispose();
 
         try
         {


### PR DESCRIPTION
## Summary
- Use `TaskCreationOptions.LongRunning` for all permanent async loops (send loop, linger loop, append workers) so they get dedicated threads instead of borrowing from the thread pool
- Replace `Task.Delay` loop in `StatisticsEmitter` with `PeriodicTimer` to eliminate per-tick timer allocations
- Add `ExecuteSynchronously` to exception-observing `ContinueWith` to avoid unnecessary thread pool scheduling

## Problem
Profiling a 3-minute producer stress test showed **`RuntimeTypeHandle.GetRuntimeTypeFromHandleSlow` consuming 6.45% of CPU**, called from `ThreadPoolWorkQueueThreadLocals.Finalize()`. This indicates thread pool threads being created and destroyed rapidly — each finalized thread triggers expensive type handle resolution during GC.

Root cause: Long-running async loops (`SendLoopAsync`, `SenderLoopAsync`, `LingerLoopAsync`, append workers) were started as regular `Task.Run`/`async` calls, running on thread pool threads. This caused the pool to scale up during bursts, then threads retire and get finalized during GC.

## Changes
| File | Change |
|------|--------|
| `BrokerSender.cs` | `SendLoopAsync` → `LongRunning` dedicated thread |
| `KafkaProducer.cs` | `SenderLoopAsync` + `LingerLoopAsync` → `LongRunning` dedicated threads |
| `KafkaProducer.cs` | Exception-observing `ContinueWith` → `ExecuteSynchronously` |
| `RecordAccumulator.cs` | Append workers → `LongRunning` dedicated threads |
| `StatisticsEmitter.cs` | `Task.Delay` loop → `PeriodicTimer` (allocation-free ticks) |

## Test plan
- [ ] Unit tests pass
- [ ] Run producer stress test and verify reduced `RuntimeTypeHandle` CPU time
- [ ] Verify thread count is stable (no creation/destruction churn)