### PR TITLE
perf: eliminate per-iteration CancellationTokenRegistration in receive loop

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -777,11 +777,11 @@ public sealed partial class KafkaConnection : IKafkaConnection
                 {
                     // Apply RequestTimeout to each read operation.
                     // TryReset clears any pending CancelAfter timer from the previous iteration.
-                    // It can only return false if cancellationToken fired between iterations,
-                    // but the while-loop condition prevents us from reaching here in that case.
-                    // We still call CancelAfter so the token is armed for this read.
-                    _ = timeoutCts.TryReset();
-                    timeoutCts.CancelAfter(_options.RequestTimeout);
+                    // It returns false if the outer cancellationToken fired (via the registration),
+                    // in which case ReadAsync will throw immediately and the while-condition
+                    // will exit before the next iteration.
+                    if (timeoutCts.TryReset())
+                        timeoutCts.CancelAfter(_options.RequestTimeout);
 
                     // ReadResult state machine (System.IO.Pipelines):
                     //


### PR DESCRIPTION
## Summary

- Hoists the pooled `CancellationTokenSource` and `CancellationTokenRegistration` out of the receive loop's `while` body so they are allocated once per loop lifetime instead of once per iteration
- Each iteration now calls `TryReset()` + `CancelAfter()` to rearm the timeout, avoiding the registration/unregistration overhead on every read
- Follows the same optimization pattern already used in `BrokerSender` for `sendTimeoutCts`

This is a per-batch cost (not per-message), so the previous code was correct, but this eliminates unnecessary allocations in a long-running hot loop.

Closes #507

## Test plan

- [ ] Verify unit tests pass (`dotnet build tests/Dekaf.Tests.Unit --configuration Release && ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit`)
- [ ] Verify integration tests pass (requires Docker)
- [ ] Review that cancellation semantics are preserved: timeout fires correctly, disposal cancellation propagates promptly