### PR TITLE
fix: make integration tests robust against CI thread pool starvation

### DIFF
--- a/tests/Dekaf.Tests.Integration/ExactlyOnceSemanticsTests.cs
+++ b/tests/Dekaf.Tests.Integration/ExactlyOnceSemanticsTests.cs
@@ -28,7 +28,7 @@ public sealed class ExactlyOnceSemanticsTests(KafkaTestContainer kafka) : KafkaI
 
         for (var i = 0; i < messageCount; i++)
         {
-            await seedProducer.ProduceAsync(new ProducerMessage<string, string>
+            await ProduceWithRetryAsync(seedProducer, new ProducerMessage<string, string>
             {
                 Topic = inputTopic,
                 Key = $"atomic-key-{i}",
@@ -55,7 +55,7 @@ public sealed class ExactlyOnceSemanticsTests(KafkaTestContainer kafka) : KafkaI
         consumer.Subscribe(inputTopic);
 
         var processedCount = 0;
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
         await foreach (var msg in consumer.ConsumeAsync(cts.Token))
         {
@@ -89,7 +89,7 @@ public sealed class ExactlyOnceSemanticsTests(KafkaTestContainer kafka) : KafkaI
         outputConsumer.Subscribe(outputTopic);
 
         var outputMessages = new List<ConsumeResult<string, string>>();
-        using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
         await foreach (var msg in outputConsumer.ConsumeAsync(cts2.Token))
         {
@@ -106,7 +106,8 @@ public sealed class ExactlyOnceSemanticsTests(KafkaTestContainer kafka) : KafkaI
         }
 
         // Assert: Verify consumer offsets were committed atomically --
-        // a new consumer with the same group should have no messages left to consume
+        // a new consumer with the same group should have no messages left to consume.
+        // Use generous timeouts — consumer group rebalance can take 30+ seconds on slow CI.
         await using var resumeConsumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithGroupId(consumerGroupId)
@@ -116,8 +117,8 @@ public sealed class ExactlyOnceSemanticsTests(KafkaTestContainer kafka) : KafkaI
 
         resumeConsumer.Subscribe(inputTopic);
 
-        using var resumeCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var resumeResult = await resumeConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(5), resumeCts.Token);
+        using var resumeCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var resumeResult = await resumeConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), resumeCts.Token);
 
         // Should be null because all offsets were atomically committed with the transaction
         await Assert.That(resumeResult).IsNull();
@@ -463,7 +464,7 @@ public sealed class ExactlyOnceSemanticsTests(KafkaTestContainer kafka) : KafkaI
 
         for (var i = 0; i < messageCount; i++)
         {
-            await seedProducer.ProduceAsync(new ProducerMessage<string, string>
+            await ProduceWithRetryAsync(seedProducer, new ProducerMessage<string, string>
             {
                 Topic = inputTopic,
                 Key = $"input-{i}",
@@ -561,8 +562,8 @@ public sealed class ExactlyOnceSemanticsTests(KafkaTestContainer kafka) : KafkaI
 
         rereadConsumer.Subscribe(inputTopic);
 
-        using var rereadCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var rereadResult = await rereadConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(5), rereadCts.Token);
+        using var rereadCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var rereadResult = await rereadConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), rereadCts.Token);
 
         await Assert.That(rereadResult).IsNull();
     }

--- a/tests/Dekaf.Tests.Integration/MultiPartitionTests.cs
+++ b/tests/Dekaf.Tests.Integration/MultiPartitionTests.cs
@@ -235,9 +235,9 @@ public class MultiPartitionTests(KafkaTestContainer kafka) : KafkaIntegrationTes
 
         var messages = new List<ConsumeResult<string, string>>();
         var seenPartitions = new HashSet<int>();
-        // Consumer group rebalance can take 30+ seconds on slow CI runners with
+        // Consumer group rebalance can take 60+ seconds on slow CI runners with
         // thread pool starvation. Use a generous timeout to avoid flaky failures.
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(90));
 
         await foreach (var msg in consumer.ConsumeAsync(cts.Token))
         {
@@ -267,20 +267,33 @@ public class MultiPartitionTests(KafkaTestContainer kafka) : KafkaIntegrationTes
 
         await WarmUpAllPartitions(producer, topic, 2);
 
-        // Produce ordered messages to partition 0.
-        // IMPORTANT: Do NOT use ProduceWithRetryAsync here. Cancellation after append
-        // doesn't prevent delivery (by design), so a retry would produce a duplicate,
-        // shifting indices and causing a false ordering failure.
+        // Produce ordered messages to partition 0 with per-call timeout.
+        // Don't use ProduceWithRetryAsync — retries could produce duplicates that shift
+        // indices, causing a false ordering failure. Instead, use a per-call CancellationToken
+        // so a hung delivery fails fast (~30s) instead of blocking for 360s.
+        // Cancellation after append doesn't prevent delivery (by design), so all messages
+        // will still be delivered in the background.
         for (var i = 0; i < 10; i++)
         {
-            await producer.ProduceAsync(new ProducerMessage<string, string>
+            using var perCallCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            try
             {
-                Topic = topic,
-                Key = $"key-{i}",
-                Value = $"value-{i:D2}",
-                Partition = 0
-            });
+                await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Key = $"key-{i}",
+                    Value = $"value-{i:D2}",
+                    Partition = 0
+                }, perCallCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Timeout — message was likely appended and will be delivered in background.
+            }
         }
+
+        // Flush to ensure all appended messages are sent before consuming.
+        await producer.FlushAsync();
 
         // Act
         await using var consumer = await Kafka.CreateConsumer<string, string>()
@@ -292,7 +305,7 @@ public class MultiPartitionTests(KafkaTestContainer kafka) : KafkaIntegrationTes
         consumer.Assign(new TopicPartition(topic, 0));
 
         var messages = new List<ConsumeResult<string, string>>();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
         await foreach (var msg in consumer.ConsumeAsync(cts.Token))
         {
@@ -303,7 +316,7 @@ public class MultiPartitionTests(KafkaTestContainer kafka) : KafkaIntegrationTes
         // Assert - order should be preserved (filter out warmup)
         var actual = messages.Where(m => m.Key != "warmup").ToList();
         await Assert.That(actual).Count().IsGreaterThanOrEqualTo(10);
-        for (var i = 0; i < 10; i++)
+        for (var i = 0; i < actual.Count; i++)
         {
             await Assert.That(actual[i].Value).IsEqualTo($"value-{i:D2}");
         }


### PR DESCRIPTION
## Summary

Fixes flaky integration test failures caused by thread pool starvation on CI runners (4 processors, 16 parallel tests). These tests fail intermittently on both main and feature branches with timeout/cancellation errors.

### Root cause

CI runners have limited thread pool capacity. When many integration tests run in parallel, the .NET thread pool becomes saturated. This causes:
- BrokerSender send loops to stall (can't iterate to process responses)
- Consumer group rebalances to take 60+ seconds
- `ConsumeOneAsync` with 5s timeout to fail before rebalance completes

Batch trace analysis (`EDQCSGWX`) confirms batches are written to wire but responses are never processed because the send loop continuation can't be scheduled.

### Changes

- **`MultiPartition_OrderWithinPartition_IsPreserved`**: Add 30s per-call timeout to `ProduceAsync` (fails fast instead of hanging 360s for orphan sweep), add `FlushAsync` to ensure delivery, increase consumer timeout to 60s

- **`MultiPartition_ConsumerGroupSubscription_GetsAllPartitions`**: Increase consumer timeout from 60s to 90s for slow rebalance

- **`TransactionOffsetCommit_Atomicity`**: Replace raw `ProduceAsync` with `ProduceWithRetryAsync` for seed messages, increase consumer timeouts from 30s to 60s, increase resume verification from 5s to 15s

- **`ConsumeThenProduce_FullCycle`**: Same seed producer and timeout fixes

## Test plan

- [x] Integration tests build successfully
- [ ] CI passes (these are the tests that were failing)