### PR TITLE
perf: skip MicroLinger when all partitions already coalesced

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -367,6 +367,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     // Tracks distinct partitions this broker has seen, used to skip MicroLinger when all
     // known partitions are already coalesced (e.g., single-partition topics).
+    // Conservative: a brand-new partition not yet in _knownPartitions may miss one
+    // coalescing opportunity on its first appearance — benign, picked up next iteration.
     // Single-threaded: only accessed by the send loop.
     private readonly HashSet<TopicPartition> _knownPartitions = [];
 


### PR DESCRIPTION
## Summary
- Track distinct partitions per BrokerSender via `_knownPartitions` HashSet
- Skip MicroLinger spin-wait when `coalescedPartitions.Count >= _knownPartitions.Count`
- Eliminates wasted SpinWait iterations for single-partition topics where MicroLinger can never succeed

## Context
Profiling showed MicroLinger fires on every send loop iteration for single-partition topics (coalescedCount=1 <= threshold=2), but every spin is wasted because any new batch from the channel is for the same partition and gets carried over. This adds unnecessary CPU overhead.

## Test plan
- [x] `dotnet build` succeeds
- [x] All 3052 unit tests pass
- [ ] Verify with stress test profiling that MicroLinger no longer fires for single-partition workloads