### PR TITLE
perf: parallelize multi-connection TCP sends in BrokerSender

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -700,6 +700,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             newBucketCts[i] = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                         bucketTimeoutCts = newBucketCts;
 
+                        // No Array.Copy needed: ValueTask is a struct and entries are overwritten
+                        // before each use. pendingSendCount bounds iteration so stale entries
+                        // beyond the new connection count are never accessed.
                         parallelSends = new ValueTask[scaledToCount];
                     }
                 }
@@ -2213,14 +2216,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private static async ValueTask<int> AwaitParallelSendsAsync(ValueTask[] sends, int count)
     {
         Exception? firstException = null;
-        var completed = 0;
 
         for (var i = 0; i < count; i++)
         {
             try
             {
                 await sends[i].ConfigureAwait(false);
-                completed++;
             }
             catch (Exception ex) when (firstException is null)
             {
@@ -2237,7 +2238,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             ExceptionDispatchInfo.Capture(firstException).Throw();
         }
 
-        return completed;
+        // All sends succeeded — partial completion is not possible on the success path
+        // because any failure throws above.
+        return count;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- When multiple connections exist per broker, the send loop previously dispatched to each connection **sequentially** (`await` in a for-loop), meaning connection 1's TCP flush had to complete before connection 2's even started
- Fire all eligible connection sends concurrently via a pre-allocated `ValueTask[]` array and await them together through `AwaitParallelSendsAsync`, overlapping TCP `FlushAsync` waits across connections
- The helper method observes all `ValueTask`s even if one faults, rethrowing the first exception with preserved stack trace via `ExceptionDispatchInfo`

**Safety properties preserved:**
- Single-threaded send loop still owns all mutable state (carry-over, mute sets, epoch bumps)
- Sequence numbers assigned before dispatch (unchanged)
- Partition affinity ensures no cross-connection ordering dependency for idempotent producers
- Per-connection `_writeLock` serializes writes within each connection
- Single-connection path (`_connectionCount == 1`) is completely unchanged
- `parallelSends` array resized correctly during adaptive connection scaling

## Test plan

- [x] All 3059 unit tests pass
- [ ] Integration tests pass (CI)
- [ ] Stress test with `ConnectionsPerBroker > 1` to validate parallel dispatch under load