### PR TITLE
perf: cache Stopwatch.GetTimestamp() in Ready()

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1042,6 +1042,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         MetadataManager metadataManager, HashSet<int> readyNodes)
     {
         var unknownLeadersExist = false;
+        var nowTimestamp = Stopwatch.GetTimestamp();
 
         // Snapshot the current queue length to avoid infinite loop: partitions that need
         // re-enqueue (backoff, unknown leader) are added back during the loop, but we only
@@ -1077,7 +1078,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             // Check retry backoff
             if (head.IsRetry && head.RetryNotBefore > 0)
             {
-                var backoffRemaining = head.RetryNotBefore - Stopwatch.GetTimestamp();
+                var backoffRemaining = head.RetryNotBefore - nowTimestamp;
                 if (backoffRemaining > 0)
                 {
                     var backoffMs = (int)(backoffRemaining * 1000 / Stopwatch.Frequency);


### PR DESCRIPTION
## Summary
- Cache `Stopwatch.GetTimestamp()` at the entry of `RecordAccumulator.Ready()` instead of calling it per retry-batch iteration
- Under high partition counts with many retry batches, this eliminates redundant system calls without affecting backoff precision
- Zero additional allocations; the cached value is a stack-local `long`

## Test plan
- [x] Solution builds with zero errors/warnings
- [x] All 258 RecordAccumulator unit tests pass
- [x] All 323 Producer unit tests pass