### PR TITLE
perf: trim pending response list capacity to prevent memory ratcheting

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1098,6 +1098,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
                 _totalPendingResponseCount -= pendingList.Count;
                 pendingList.Clear();
+                // No TrimExcess — lists are unreachable after disposal
             }
 
             FailCarryOverBatches(carryOver);
@@ -1583,6 +1584,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             // After clearing all entries due to timeout, trim the internal array to
             // prevent capacity from ratcheting up across repeated timeout/recovery cycles.
+            // The > 16 guard avoids trimming tiny lists: with MaxInFlightRequestsPerConnection
+            // defaulting to 5, normal-operation lists stay within 8-16 capacity.
             if (pendingList.Capacity > 16)
             {
                 pendingList.TrimExcess();
@@ -2490,6 +2493,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                 _totalPendingResponseCount -= pendingList.Count;
                 pendingList.Clear();
+                // No TrimExcess — lists are unreachable after disposal
             }
         }
 


### PR DESCRIPTION
## Summary

- `List<PendingResponse>` arrays in `BrokerSender._pendingResponsesByConnection` use `RemoveRange()` and `Clear()` to remove completed entries, but `List<T>` never shrinks its internal array capacity. Over millions of batch cycles, capacity ratchets up permanently, contributing to observed memory growth (449MB to 2.59GB in a 3-minute stress test).
- Added amortized `TrimExcess()` calls after `RemoveRange()` (when count < capacity/4) and after `Clear()` on timeout paths, with a `capacity > 16` guard to avoid trimming tiny lists.
- This is a per-batch-cycle cost at most (not per-message), consistent with zero-allocation hot path requirements.

## Test plan

- [x] All 20 BrokerSender unit tests pass
- [x] All 3095 unit tests pass
- [ ] Verify memory profile improvement in stress test (manual)