### PR TITLE
perf: replace Monitor lock with SpinLock in PartitionInflightTracker

### DIFF
--- a/src/Dekaf/Producer/PartitionInflightTracker.cs
+++ b/src/Dekaf/Producer/PartitionInflightTracker.cs
@@ -198,8 +198,8 @@ internal sealed class PartitionInflightTracker
             state.Lock.Enter(ref lockTaken);
 
             // Guard against double-return when FailAll and Complete race.
-            // TryRemoveFromList is atomic (Interlocked.Exchange), so exactly one
-            // caller wins even if FailAll cleared InList before we acquired the lock.
+            // Both Complete and FailAll acquire the same SpinLock, so TryRemoveFromList
+            // is already serialised: exactly one caller will see InList == true.
             if (!entry.TryRemoveFromList())
             {
                 return;


### PR DESCRIPTION
## Summary

- Replace `object Lock` + `lock()` (Monitor) with `SpinLock` in `PartitionState`, eliminating the 5.2% exclusive CPU time spent in `Monitor.Wait` under high-throughput multi-partition workloads
- Replace `bool InList` with atomic `int _inList` using `Interlocked.Exchange` (`TryRemoveFromList`), providing a lock-free guard against double-return when `FailAll` and `Complete` race
- Use `enableThreadOwnerTracking: false` to skip `Thread.CurrentThread` overhead on every Enter/Exit
- Use `useMemoryBarrier: false` on Exit since the critical sections only perform pointer manipulation (no dependent memory ordering required outside the lock)

## Why SpinLock over Monitor

The critical sections in `PartitionInflightTracker` are ~5-10 instructions (linked-list pointer manipulation + counter update). For sections this short:

- **Monitor** pays ~100ns overhead per acquire/release (kernel transition, object header manipulation, potential thread blocking)
- **SpinLock** pays ~10-20ns (CAS loop in user space, no kernel transition, no heap allocation for the lock object)

Under contention from multiple partitions completing responses concurrently (the profiled scenario), Monitor's blocking behavior causes threads to enter kernel wait states, which is where the 5.2% CPU in `Monitor.Wait` came from.

## Test plan

- [x] All 19 `PartitionInflightTrackerTests` pass (concurrent Register/Complete, FailAll racing with Complete, WaitForPredecessor, etc.)
- [x] All 323 Producer-related unit tests pass
- [x] All 3095 unit tests pass