### PR TITLE
perf: reduce per-message overhead in consumer hot path

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1117,8 +1117,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         if (release)
         {
             Interlocked.Add(ref _prefetchedBytes, -bytes);
-            // Signal prefetch loop that memory is now available
-            _prefetchMemoryAvailable.Release();
+            // Signal prefetch loop that memory is now available (skip for empty responses to avoid spurious wakeups)
+            if (bytes > 0)
+                _prefetchMemoryAvailable.Release();
         }
         else
         {


### PR DESCRIPTION
## Summary

The Dekaf consumer was achieving ~210 msg/sec vs Confluent's ~98K msg/sec in stress tests, with 1,508 GB allocated and 1,418 Gen2 GCs in 15 minutes. This PR addresses the main per-message overheads in the consume loop and a polling bottleneck in the prefetch memory management.

**Changes:**

- **Replace 50ms Task.Delay polling with SemaphoreSlim signal** — When the prefetch loop hits the memory limit (`QueuedMaxMessagesKbytes`), it was sleeping 50ms per cycle. Now it waits on a `SemaphoreSlim` that gets signaled immediately when the consumer releases prefetched bytes. This eliminates up to 20 stalls/second that capped throughput.

- **Guard all Activity/tracing code with HasListeners()** — The consume loop was calling `ExtractTraceContext`, saving/restoring `Activity.Current`, and creating `ActivityLink` arrays on every message even when no diagnostic listener was attached. Now a single `HasListeners()` check (~2ns) skips all tracing work when unused. The tracing code is extracted into a `[NoInlining]` `StartConsumeActivity` method to keep the hot path JIT-friendly.

- **Cache TagList per topic** — Each message was creating a new `System.Diagnostics.TagList` struct and boxing the topic string. Now TagLists are cached per topic in a plain `Dictionary` (safe because `ConsumeAsync` is single-threaded).

- **Reuse pendingItems list across prefetch cycles** — `PrefetchFromBrokerAsync` was allocating a new `List<PendingFetchData>` on every fetch cycle via `pendingItems ??= []`. Now the list is stored as a field and reused with `Clear()`.

## Test plan

- [x] All 439 consumer unit tests pass
- [x] Full unit test suite passes (3094/3095 — 1 pre-existing flaky timing test in producer)
- [ ] Run stress test to measure throughput improvement: `dotnet run --project tools/Dekaf.StressTests -c Release -- --duration 5 --message-size 1000 --scenario consumer --client dekaf`