### PR TITLE
perf: serialize requests outside write lock to reduce contention

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -619,7 +619,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
     /// The ArrayPool rent/return is per-batch (amortized over ~1000 messages), so the overhead
     /// is negligible compared to the lock contention savings.
     /// </remarks>
-    private (byte[] Array, int Length) PreSerializeRequest<TRequest, TResponse>(
+    private (byte[] Buffer, int Length) PreSerializeRequest<TRequest, TResponse>(
         TRequest request,
         int correlationId,
         short apiVersion,


### PR DESCRIPTION
## Summary

- Move CPU-bound request serialization (header + body encoding) outside the `SemaphoreSlim` write lock in `KafkaConnection`
- The lock now only covers the fast memcpy into the PipeWriter and the async flush
- Addresses a 38% throughput reduction observed with 3+ broker connections due to lock contention on serialization

## Background

A previous attempt (PR #545, reverted in 7821cee) moved serialization outside the lock but was rolled back due to concerns about the extra buffer copy and `ArrayPool` rent/return overhead.

This implementation addresses those concerns:
- Uses the existing thread-local buffer for zero-allocation serialization (no change)
- Copies to a pooled array only to safely cross the `await` boundary (the thread-local buffer cannot survive an `await` since another task could resume on the same thread)
- The `ArrayPool` rent/return is per-batch (~1000 messages), so the overhead is negligible compared to the lock contention savings
- Preserves atomic PipeWriter write (single `GetMemory`/`Advance`) to prevent partial frame corruption

## Test plan

- [ ] Unit tests pass
- [ ] Integration tests pass (producer ordering, multi-partition, fire-and-forget)
- [ ] Stress tests confirm throughput improvement with multiple broker connections