### PR TITLE
test: improve robustness of flaky tests on slow CI runners

### DIFF
--- a/tests/Dekaf.Tests.Integration/MultiPartitionTests.cs
+++ b/tests/Dekaf.Tests.Integration/MultiPartitionTests.cs
@@ -298,7 +298,7 @@ public class MultiPartitionTests(KafkaTestContainer kafka) : KafkaIntegrationTes
         // timed out (cancellation only stops the caller's await, not delivery).
         // Use a generous timeout — on slow CI runners with thread pool starvation, the
         // send loop may take 30+ seconds to drain batches for a newly-created topic.
-        using var flushCts = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+        using var flushCts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
         await producer.FlushAsync(flushCts.Token);
 
         // Act

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScalingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScalingTests.cs
@@ -193,8 +193,9 @@ public class AdaptiveScalingTests
     public async Task CancelledWaiterNode_IsSkippedByWakeNextSyncWaiter(CancellationToken cancellationToken)
     {
         var recordSize = await MeasureRecordSizeAsync();
-        // Use 5s maxBlockMs so even slow CI runners complete the timeout
-        var accumulator = CreateAccumulator(bufferMemory: (ulong)recordSize, maxBlockMs: 5_000);
+        // Use 2s maxBlockMs — shorter timeout reduces test duration on slow CI runners
+        // where thread pool starvation delays Task.Run scheduling significantly
+        var accumulator = CreateAccumulator(bufferMemory: (ulong)recordSize, maxBlockMs: 2_000);
 
         try
         {


### PR DESCRIPTION
## Summary

- **MultiPartition_OrderWithinPartition_IsPreserved**: Increase flush timeout from 90s to 3m. On underpowered CI runners, Kafka container response times can exceed 90s for batch completion.
- **CancelledWaiterNode_IsSkippedByWakeNextSyncWaiter**: Reduce `maxBlockMs` from 5s to 2s. The test needs waiter 1 to time out before waiter 2 can be tested — a shorter timeout means less total test time, reducing the window for thread pool starvation to cause a TUnit-level timeout.

## Test plan
- [x] Unit tests pass locally
- [ ] CI passes on this PR