### PR TITLE
perf: replace exception-based timeout with WaitToReadAsync in ConsumeAsync

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -677,7 +677,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                             }
                             else
                             {
-                                // Channel completed normally — prefetch loop has stopped (e.g., shutdown)
+                                // Channel completed without error — prefetch loop has stopped.
+                                // Currently unreachable: TryComplete() is only called with a KafkaException,
+                                // never with null. This guard prevents a silent infinite loop if a future
+                                // code path adds graceful channel completion (e.g., during rebalance).
                                 break;
                             }
                         }


### PR DESCRIPTION
## Summary
- Replace `ReadAsync(timeoutCts.Token)` with `WaitToReadAsync` + `TryRead` in the consumer prefetch channel read path
- Eliminates per-timeout `OperationCanceledException` allocations that occur on every prefetch timeout cycle
- Removes `ChannelClosedException` catch since `WaitToReadAsync` propagates the underlying exception directly

## Motivation
Consumer profiling showed `SetException`/`ExceptionDispatchInfo.Throw` at 0.02-0.2% CPU from the exception-based timeout pattern. While small, this is an unnecessary allocation on every timeout cycle when the consumer is waiting for data.

## Test plan
- [x] Unit tests pass
- [x] Code reviewed via /simplify
- [ ] Integration tests with Docker