### PR TITLE
perf: use SendPipelinedAsync for consumer fetch requests

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -964,7 +964,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
         var fetchStarted = System.Diagnostics.Stopwatch.GetTimestamp();
 
-        var response = await connection.SendAsync<FetchRequest, FetchResponse>(
+        var response = await connection.SendPipelinedAsync<FetchRequest, FetchResponse>(
             request,
             (short)apiVersion,
             cancellationToken).ConfigureAwait(false);
@@ -2181,7 +2181,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
         var fetchStarted = System.Diagnostics.Stopwatch.GetTimestamp();
 
-        var response = await connection.SendAsync<FetchRequest, FetchResponse>(
+        var response = await connection.SendPipelinedAsync<FetchRequest, FetchResponse>(
             request,
             (short)apiVersion,
             cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

- Switch consumer fetch requests from `SendAsync` to `SendPipelinedAsync` in both `PrefetchFromBrokerAsync` and `FetchFromBrokerAsync` code paths
- Reduces write lock hold time from ~200ms (full fetch wait) to ~0.1ms (serialization only)
- Improves throughput when consumer and producer share the same broker connection by eliminating write lock contention during fetch waits

## Details

`SendAsync` holds the connection's `SemaphoreSlim(1,1)` write lock for the entire request-response cycle, including the broker-side wait (`FetchMaxWaitMs`). `SendPipelinedAsync` releases the write lock immediately after the request is serialized and written to the pipe, allowing other operations (produce requests, metadata requests) to proceed while the fetch response is awaited.

Both fetch paths (prefetch pipeline and legacy single-fetch) are updated.

## Test plan

- [x] `dotnet build` compiles without errors
- [x] All 3122 unit tests pass
- [ ] Integration tests (require Docker)
- [ ] Stress tests to verify no regression under load