### PR TITLE
perf: improve ForHighThroughput() consumer defaults

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1287,7 +1287,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <item><description>FetchMinBytes: 1KB (wait for more data)</description></item>
     /// <item><description>FetchMaxWaitMs: 200ms (matches default; higher values like 500ms cause stalls when the prefetch pipeline restarts after hitting memory limits)</description></item>
     /// <item><description>MaxPartitionFetchBytes: 4MB (larger fetch responses reduce round-trip overhead per byte)</description></item>
-    /// <item><description>FetchMaxBytes: 100MB (allow larger total fetch responses)</description></item>
+    /// <item><description>FetchMaxBytes: 100MB (allow larger total fetch responses; note that the response buffer pool
+    /// may retain up to 8 arrays of this size per consumer instance)</description></item>
     /// </list>
     /// <para>These settings can be overridden by calling other builder methods after this one.</para>
     /// </remarks>


### PR DESCRIPTION
## Summary
- Remove `FetchMaxWaitMs=500` which caused 500ms stalls every time the prefetch pipeline restarted after hitting memory limits. Revert to default 200ms.
- Add `MaxPartitionFetchBytes=4MB` (up from 1MB) to reduce round-trip overhead per byte fetched
- Add `FetchMaxBytes=100MB` (up from 50MB) to allow larger total fetch responses

## Context
Stress tests showed consumer throughput oscillating wildly between 34K and 468K msg/sec. The 500ms `FetchMaxWaitMs` was a major contributor — when the prefetch pipeline paused at the memory limit and then restarted, each new fetch request had to wait up to 500ms broker-side before getting data.

## Test plan
- [ ] Verify unit tests pass
- [ ] Run consumer stress test and compare throughput stability