### PR TITLE
fix: connection pool race conditions in group creation and replacement

### DIFF
--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -617,12 +617,13 @@ public sealed partial class ConnectionPool : IConnectionPool
         {
             for (var i = 0; i < _connectionsPerBroker; i++)
             {
-                if (_connectionReplacementLocks.TryRemove((brokerId, i), out var replacementLock))
-                    replacementLock.Dispose();
+                // Intentionally not disposed: a concurrent ReplaceConnectionInGroupAsync
+                // may be holding or waiting on it. Will be disposed during DisposeAsync.
+                _connectionReplacementLocks.TryRemove((brokerId, i), out _);
             }
 
-            if (_groupCreationLocks.TryRemove(brokerId, out var groupLock))
-                groupLock.Dispose();
+            // Same reasoning: a concurrent CreateConnectionGroupAsync may hold a reference.
+            _groupCreationLocks.TryRemove(brokerId, out _);
 
             foreach (var conn in group)
             {

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolConcurrencyTests.cs
@@ -80,7 +80,7 @@ public sealed class ConnectionPoolConcurrencyTests
         const int concurrentCallers = 10;
         const int deadIndex = 1;
         var replacementCount = 0;
-        var initialCreationDone = false;
+        var initialCreationDone = 0;
 
         var pool = new ConnectionPool(
             clientId: "test",
@@ -88,7 +88,7 @@ public sealed class ConnectionPoolConcurrencyTests
             connectionsPerBroker: connectionsPerBroker,
             connectionFactory: (brokerId, host, port, index, ct) =>
             {
-                if (initialCreationDone)
+                if (Volatile.Read(ref initialCreationDone) != 0)
                 {
                     // After initial group creation, count replacements
                     Interlocked.Increment(ref replacementCount);
@@ -108,7 +108,7 @@ public sealed class ConnectionPoolConcurrencyTests
 
             // Create the initial connection group
             await pool.GetConnectionAsync(1);
-            initialCreationDone = true;
+            Volatile.Write(ref initialCreationDone, 1);
 
             // Now mark connection at deadIndex as disconnected.
             // GetConnectionByIndexAsync will try to replace it.
@@ -151,7 +151,7 @@ public sealed class ConnectionPoolConcurrencyTests
         var replacementCreated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var proceedWithReplacement = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         IKafkaConnection? orphanedConnection = null;
-        var initialCreationDone = false;
+        var initialCreationDone = 0;
 
         var pool = new ConnectionPool(
             clientId: "test",
@@ -167,7 +167,7 @@ public sealed class ConnectionPoolConcurrencyTests
 
                 // Only delay during the replacement phase (after initial group creation),
                 // and only for the last index which will be shrunk away
-                if (initialCreationDone && index == connectionsPerBroker - 1)
+                if (Volatile.Read(ref initialCreationDone) != 0 && index == connectionsPerBroker - 1)
                 {
                     return new ValueTask<IKafkaConnection>(CreateDelayedConnection(conn));
                 }
@@ -191,7 +191,7 @@ public sealed class ConnectionPoolConcurrencyTests
 
             // Create the initial connection group (2 connections)
             await pool.GetConnectionAsync(1);
-            initialCreationDone = true;
+            Volatile.Write(ref initialCreationDone, 1);
 
             // Mark the last connection (index 1) as dead to trigger replacement
             var lastConn = await pool.GetConnectionByIndexAsync(1, connectionsPerBroker - 1);


### PR DESCRIPTION
## Summary

- **H4**: Added per-broker `SemaphoreSlim` to deduplicate concurrent connection group creation. Without this, multiple callers racing to create the same group would each create a full set of TCP connections, leaking all but one set.
- **H5**: Replaced `Lazy<ValueTask>` pattern with `SemaphoreSlim` for connection replacement. The `Lazy<ValueTask>` captured the first caller's `CancellationToken`, which could be disposed in that caller's `finally` block, causing `ObjectDisposedException` in subsequent callers reusing the cached task.
- **M12**: Protected the array write in `ReplaceConnectionInGroupAsync` with `_scaleLock` to prevent a race with concurrent `ShrinkConnectionGroupAsync`, which may swap the array reference between the bounds check and the write.
- Properly dispose `SemaphoreSlim` instances during connection removal and pool disposal.
- Simplified timeout handling with `using` declarations and `catch (OperationCanceledException) when` filters.

## Test plan

- [ ] Existing unit tests pass (`Dekaf.Tests.Unit`)
- [ ] Integration tests pass with Docker (`Dekaf.Tests.Integration`)
- [ ] Stress tests with concurrent producers/consumers do not leak connections
- [ ] Verify no `ObjectDisposedException` under concurrent connection replacement