### PR TITLE
fix: fetch request cache data race between concurrent broker tasks

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2620,7 +2620,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             ));
         }
 
-        // Build result — caller owns these objects, no sharing
+        // Shared-reference invariant: BuildResultFromDict extracts FetchRequestPartition
+        // objects that are the same instances we store in _cachedTopicPartitions below.
+        // This is safe because cache hits (the concurrent path) always create fresh copies
+        // via BuildResultFromCache, so no other broker task will ever read or mutate these
+        // instances. The cache-miss caller's result is already serialized onto the wire
+        // before any concurrent cache-hit caller reads the cached templates to copy from.
         var result = BuildResultFromDict(topicPartitions);
 
         // Update cache (first writer wins to avoid overwriting fresher data)


### PR DESCRIPTION
## Summary

- **Fix data race** in `BuildFetchRequestTopics` where multiple broker fetch tasks running via `Task.WhenAll` shared the same `FetchRequestPartition` objects from the cache. One task could mutate `FetchOffset` via `UpdateCachedOffsets` while another task was serializing the request, causing partially-updated offsets to be sent to Kafka.
- **Each broker task now gets its own `FetchRequestPartition` copies** with snapshot offsets taken at call time. The cached dictionary structure (partition grouping by topic) is still reused — only the mutable partition objects are freshly allocated.
- **Removed `_cachedFetchRequestTopics` field** since the result list is no longer cached (each call builds a fresh one). Extracted `BuildResultFromCache` and `BuildResultFromDict` helper methods for clarity.

Allocation cost is per fetch cycle (per-batch), not per-message — acceptable per project guidelines.

## Test plan

- [x] `dotnet build src/Dekaf` succeeds with no warnings
- [x] All 3148 unit tests pass
- [ ] Integration tests with multi-broker setup to exercise concurrent fetch tasks