### PR TITLE
fix: consumer coordinator concurrency in heartbeat, rebalance, and leave group

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1119,35 +1119,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             return;
         LogCoordinatorDisposing();
 
-        CancellationTokenSource? cts;
-        Task? task;
+        await StopHeartbeatAsync().ConfigureAwait(false);
 
-        lock (_heartbeatGuard)
-        {
-            cts = _heartbeatCts;
-            task = _heartbeatTask;
-            _heartbeatCts = null;
-            _heartbeatTask = null;
-        }
-
-        if (cts is not null)
-        {
-            await cts.CancelAsync().ConfigureAwait(false);
-        }
-
-        if (task is not null)
-        {
-            try
-            {
-                await task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-            }
-            catch
-            {
-                // Ignore
-            }
-        }
-
-        cts?.Dispose();
         _lock.Dispose();
         _commitLock.Dispose();
         _fetchLock.Dispose();


### PR DESCRIPTION
## Summary

- **H4 (High)**: Rebalance listener now receives `IReadOnlyList<TopicPartition>` snapshots, preventing mutation of partition data after lock release. The lists were already independent copies created inside the lock, but the type now enforces immutability.
- **M2 (Medium)**: Made `_coordinatorId` field `volatile` so heartbeat loop writes (`MarkCoordinatorUnknown`) are visible across threads without holding `_lock`. The `_state` field was already volatile.
- **M3 (Medium)**: `StartHeartbeat` is now `StartHeartbeatAsync` — it cancels, awaits (with 5s timeout), and disposes the old CTS before creating a new heartbeat loop, preventing dual concurrent loops and CTS leaks.
- **M4 (Medium)**: `LeaveGroupAsync` now acquires `_lock` before resetting `_memberId`, `_generationId`, `_assignedPartitions`, and `_state`, preventing races with the heartbeat loop and `EnsureActiveGroupAsync`.

## Test plan

- [x] `dotnet build src/Dekaf` — zero warnings, zero errors
- [x] All 3148 unit tests pass
- [ ] Integration tests (require Docker)