### PR TITLE
fix: consumer memory owner use-after-free on out-of-order disposal

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
@@ -102,6 +103,7 @@ internal sealed class PendingFetchData : IDisposable
     /// </summary>
     public void SetMemoryOwner(IPooledMemory memoryOwner)
     {
+        Debug.Assert(_memoryOwner is null, "SetMemoryOwner called when a memory owner is already set. This indicates a bug — the previous owner would be silently overwritten and leaked.");
         _memoryOwner = memoryOwner;
     }
 

--- a/src/Dekaf/Protocol/RefCountedMemoryOwner.cs
+++ b/src/Dekaf/Protocol/RefCountedMemoryOwner.cs
@@ -26,9 +26,16 @@ internal sealed class RefCountedMemoryOwner : IPooledMemory
 
     public void Dispose()
     {
-        if (Interlocked.Decrement(ref _refCount) == 0)
+        var newCount = Interlocked.Decrement(ref _refCount);
+
+        if (newCount == 0)
         {
             _inner.Dispose();
+        }
+        else if (newCount < 0)
+        {
+            // Already fully disposed — increment back to prevent further underflow.
+            Interlocked.Increment(ref _refCount);
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Protocol/RefCountedMemoryOwnerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RefCountedMemoryOwnerTests.cs
@@ -1,0 +1,147 @@
+using Dekaf.Protocol;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public class RefCountedMemoryOwnerTests
+{
+    /// <summary>
+    /// Simple test implementation of IPooledMemory that tracks dispose calls.
+    /// </summary>
+    private sealed class TrackingPooledMemory : IPooledMemory
+    {
+        public int DisposeCount { get; private set; }
+        public ReadOnlyMemory<byte> Memory { get; } = new byte[] { 1, 2, 3 };
+
+        public void Dispose() => DisposeCount++;
+    }
+
+    [Test]
+    public async Task Dispose_WithInitialRefCountOne_DisposesInnerImmediately()
+    {
+        // Arrange
+        var inner = new TrackingPooledMemory();
+        var owner = new RefCountedMemoryOwner(inner, initialRefCount: 1);
+
+        // Act
+        owner.Dispose();
+
+        // Assert
+        await Assert.That(inner.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Dispose_WithRefCountTwo_DoesNotDisposeOnFirstDispose()
+    {
+        // Arrange
+        var inner = new TrackingPooledMemory();
+        var owner = new RefCountedMemoryOwner(inner, initialRefCount: 2);
+
+        // Act - first dispose decrements from 2 to 1
+        owner.Dispose();
+
+        // Assert - inner should NOT be disposed yet
+        await Assert.That(inner.DisposeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Dispose_WithRefCountTwo_DisposesOnSecondDispose()
+    {
+        // Arrange
+        var inner = new TrackingPooledMemory();
+        var owner = new RefCountedMemoryOwner(inner, initialRefCount: 2);
+
+        // Act - two disposes: 2 -> 1 -> 0
+        owner.Dispose();
+        owner.Dispose();
+
+        // Assert - inner disposed exactly once
+        await Assert.That(inner.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Dispose_WithRefCountThree_OnlyDisposesAfterLastRelease()
+    {
+        // Arrange
+        var inner = new TrackingPooledMemory();
+        var owner = new RefCountedMemoryOwner(inner, initialRefCount: 3);
+
+        // Act & Assert - first two disposes should not release
+        owner.Dispose();
+        await Assert.That(inner.DisposeCount).IsEqualTo(0);
+
+        owner.Dispose();
+        await Assert.That(inner.DisposeCount).IsEqualTo(0);
+
+        // Third dispose should release
+        owner.Dispose();
+        await Assert.That(inner.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Dispose_DoubleDisposeAfterFullyReleased_DoesNotDoubleFree()
+    {
+        // Arrange
+        var inner = new TrackingPooledMemory();
+        var owner = new RefCountedMemoryOwner(inner, initialRefCount: 1);
+
+        // Act - first dispose releases, second should be a no-op
+        owner.Dispose();
+        owner.Dispose();
+
+        // Assert - inner disposed exactly once, not twice
+        await Assert.That(inner.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Dispose_MultipleExtraDisposesAfterFullyReleased_DoesNotDoubleFree()
+    {
+        // Arrange
+        var inner = new TrackingPooledMemory();
+        var owner = new RefCountedMemoryOwner(inner, initialRefCount: 2);
+
+        // Fully release: 2 -> 1 -> 0
+        owner.Dispose();
+        owner.Dispose();
+        await Assert.That(inner.DisposeCount).IsEqualTo(1);
+
+        // Extra disposes should be no-ops
+        owner.Dispose();
+        owner.Dispose();
+        owner.Dispose();
+
+        await Assert.That(inner.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public void Constructor_RejectsInitialRefCountLessThanOne()
+    {
+        var inner = new TrackingPooledMemory();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            using var owner = new RefCountedMemoryOwner(inner, initialRefCount: 0);
+        });
+    }
+
+    [Test]
+    public void Constructor_RejectsNegativeInitialRefCount()
+    {
+        var inner = new TrackingPooledMemory();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            using var owner = new RefCountedMemoryOwner(inner, initialRefCount: -1);
+        });
+    }
+
+    [Test]
+    public async Task Memory_DelegatesInnerMemory()
+    {
+        // Arrange
+        var inner = new TrackingPooledMemory();
+        var owner = new RefCountedMemoryOwner(inner, initialRefCount: 1);
+
+        // Act & Assert
+        await Assert.That(owner.Memory.ToArray()).IsEquivalentTo(inner.Memory.ToArray());
+    }
+}


### PR DESCRIPTION
## Summary

- **Fixes a critical use-after-free bug** where `PendingFetchData` items from the same fetch response share a single pooled memory buffer, but the memory owner was attached only to the last item assuming FIFO disposal order
- During rebalance, `ClearFetchBufferForPartitions` can dispose items out of order, freeing the buffer while earlier items still reference it — causing use-after-free / corrupted reads
- **Fix:** Introduces `RefCountedMemoryOwner` that wraps `IPooledMemory` with `Interlocked` ref counting, so the underlying buffer is only returned to the pool when every sharing `PendingFetchData` item has been disposed

## Changes

- `src/Dekaf/Protocol/RefCountedMemoryOwner.cs` — New `IPooledMemory` wrapper with atomic reference counting
- `src/Dekaf/Consumer/KafkaConsumer.cs` — Replace last-item-only memory owner assignment with shared ref-counted owner via `AssignSharedMemoryOwner` helper

## Test plan

- [ ] Unit tests pass (`dotnet build tests/Dekaf.Tests.Unit --configuration Release`)
- [ ] Integration tests pass with Docker (rebalance scenarios exercise `ClearFetchBufferForPartitions`)
- [ ] Verify no regressions in stress tests under concurrent rebalance + consumption