### PR TITLE
fix: overflow-safe bounds check in ReadStringContent

### DIFF
--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -587,7 +587,7 @@ public ref struct KafkaProtocolReader
 
         if (_isContiguous)
         {
-            if (_position + length > _span.Length)
+            if (length < 0 || _position > _span.Length - length)
                 ThrowInsufficientData();
             var result = Encoding.UTF8.GetString(_span.Slice(_position, length));
             _position += length;


### PR DESCRIPTION
## Summary

- Fix integer overflow vulnerability in `ReadStringContent` bounds check in `KafkaProtocolReader`, which was missed in the original overflow fix (efc1589)
- The old check `_position + length > _span.Length` can overflow when `_position + length` exceeds `Int32.MaxValue`, bypassing the bounds check entirely
- Replaced with the overflow-safe pattern `length < 0 || _position > _span.Length - length`, matching the fix already applied to `ReadBytesContent`, `ReadRawBytes`, `ReadMemorySlice`, and `Skip`

## Integer overflow scenario

When a malformed Kafka protocol message contains a large `length` value (e.g., close to `Int32.MaxValue`), adding it to `_position` wraps around to a negative number, which is always less than `_span.Length`. This silently passes the bounds check and leads to an out-of-bounds read via `_span.Slice(_position, length)`.

## Test plan

- [x] All 3175 unit tests pass
- [x] Verified the fix matches the pattern used by the other methods fixed in efc1589