### PR TITLE
fix: handle truncated records gracefully in LazyRecordList

### DIFF
--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -855,7 +855,7 @@ internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
                 // Note: The pre-allocated List capacity may now exceed _count — this
                 // over-allocation is intentional and harmless (one batch lifetime).
                 Trace.WriteLine($"Dekaf: Truncated fetch response — {_parsedRecords.Count} of {_count} records parsed successfully.");
-                Volatile.Write(ref _count, _parsedRecords.Count);
+                _count = _parsedRecords.Count;
                 break;
             }
         }

--- a/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
@@ -125,20 +125,10 @@ public class LazyRecordListTests
         var record0 = lazyList[0];
         await Assert.That(record0.Key.ToArray()).IsEquivalentTo("k"u8.ToArray());
 
-        // Accessing record 1 triggers truncation detection — Count gets reduced
-        // The indexer checks index >= _count after EnsureParsedUpTo updates _count,
-        // so accessing index 1 when count becomes 1 should throw ArgumentOutOfRangeException
-        // via the GetEnumerator path, but through direct indexer it depends on order of checks.
-        // After EnsureParsedUpTo runs, _count becomes 1, and the loop in GetEnumerator stops.
-        // Let's verify via Count after triggering parse:
-        try
-        {
-            _ = lazyList[1];
-        }
-        catch (ArgumentOutOfRangeException)
-        {
-            // Expected: after parsing fails, count is reduced to 1, making index 1 out of range
-        }
+        // Accessing record 1 triggers truncation detection — Count gets reduced.
+        // The indexer re-checks index >= _count after EnsureParsedUpTo reduces _count,
+        // so it should throw ArgumentOutOfRangeException.
+        await Assert.That(() => lazyList[1]).ThrowsExactly<ArgumentOutOfRangeException>();
 
         await Assert.That(lazyList.Count).IsEqualTo(1);
     }


### PR DESCRIPTION
## Summary

- **Consumer resilience fix**: `LazyRecordList.EnsureParsedUpTo` now catches `InsufficientDataException` from `Record.Read()` when parsing truncated fetch response data, instead of letting it propagate and crash the consumer.
- When truncation is detected, the record count is capped to what was successfully parsed, so subsequent accesses return fewer records rather than throwing.
- This mirrors the existing partial batch handling pattern already used in `FetchResponse.cs`.

## Details

When Kafka returns a truncated fetch response (e.g., due to `max.partition.fetch.bytes` limits), the last record batch may contain incomplete record data. The lazy parsing in `LazyRecordList` would attempt to read this partial data via `Record.Read()`, which throws `InsufficientDataException`. Without a catch, this exception propagated all the way up to `ConsumeAsync`, killing the consumer.

The fix wraps the `Record.Read()` call in a try-catch. On `InsufficientDataException`, `_count` is set to `_parsedRecords.Count` (requiring removal of the `readonly` modifier) to prevent further parsing attempts, and the loop breaks. This is a per-batch cost (not per-message) and only triggers on the exceptional truncation path.

## Test plan

- [x] All 3175 unit tests pass
- [ ] Integration tests with truncated fetch responses (requires Docker)