### PR TITLE
fix: recover ConsumeAsync from record parsing errors

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -779,7 +779,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 {
                     var pending = _pendingFetches.Peek();
                     // Compiler requires definite assignment; always assigned inside try before yield.
-                    ConsumeResult<TKey, TValue> nextResult = default;
+                    ConsumeResult<TKey, TValue> nextResult = default!;
 
                     while (true)
                     {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
@@ -53,19 +53,22 @@ public sealed class ConsumeAsyncRecoveryTests
 
         // Set _initialized = true via reflection (normally set by InitializeAsync)
         var initializedField = typeof(KafkaConsumer<string, string>)
-            .GetField("_initialized", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            .GetField("_initialized", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_initialized field not found — was it renamed?");
         initializedField.SetValue(consumer, true);
 
         // Pre-populate _fetchPositions so EnsureAssignmentAsync skips network calls
-        var fetchPositions = (ConcurrentDictionary<TopicPartition, long>)typeof(KafkaConsumer<string, string>)
-            .GetField("_fetchPositions", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .GetValue(consumer)!;
+        var fetchPositionsField = typeof(KafkaConsumer<string, string>)
+            .GetField("_fetchPositions", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_fetchPositions field not found — was it renamed?");
+        var fetchPositions = (ConcurrentDictionary<TopicPartition, long>)fetchPositionsField.GetValue(consumer)!;
         fetchPositions[new TopicPartition(topic, partition)] = 0;
 
         // Inject PendingFetchData into _pendingFetches queue
-        var pendingFetches = (Queue<PendingFetchData>)typeof(KafkaConsumer<string, string>)
-            .GetField("_pendingFetches", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .GetValue(consumer)!;
+        var pendingFetchesField = typeof(KafkaConsumer<string, string>)
+            .GetField("_pendingFetches", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_pendingFetches field not found — was it renamed?");
+        var pendingFetches = (Queue<PendingFetchData>)pendingFetchesField.GetValue(consumer)!;
 
         foreach (var fetch in fetches)
             pendingFetches.Enqueue(fetch);


### PR DESCRIPTION
## Summary

- Wraps the record iteration loop in `ConsumeAsync` with a try-catch so that a corrupted `PendingFetchData` (e.g., `InsufficientDataException` from truncated data) is logged and discarded instead of permanently killing the async iterator
- The `yield return` must remain outside the try block due to CS1626, so each `ConsumeResult` is built inside the try block and yielded after it
- `OperationCanceledException` is re-thrown to preserve normal cancellation behavior
- Successfully consumed position updates (`_positions`) are preserved on error — only the faulted fetch is discarded

## Test plan

- [x] `dotnet build src/Dekaf` compiles cleanly
- [x] All 3175 unit tests pass
- [ ] Verify with integration tests that normal consumption is unaffected
- [ ] Verify that a corrupted fetch response logs at Error level and the consumer continues processing subsequent fetches