### PR TITLE
perf: remove AggressiveInlining from SetResult/SetException in PooledValueTaskSource

### DIFF
--- a/src/Dekaf/Producer/PooledValueTaskSource.cs
+++ b/src/Dekaf/Producer/PooledValueTaskSource.cs
@@ -56,7 +56,6 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
     /// Completes the operation with a successful result.
     /// </summary>
     /// <param name="result">The result value.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SetResult(T result)
     {
         if (Interlocked.CompareExchange(ref _hasCompleted, 1, 0) != 0)
@@ -87,7 +86,6 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
     /// Completes the operation with an exception.
     /// </summary>
     /// <param name="exception">The exception.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SetException(Exception exception)
     {
         if (Interlocked.CompareExchange(ref _hasCompleted, 1, 0) != 0)


### PR DESCRIPTION
## Summary

- Removes `[MethodImpl(MethodImplOptions.AggressiveInlining)]` from `SetResult` and `SetException` in `PooledValueTaskSource<T>`
- These methods now contain `Interlocked.CompareExchange` (added in #609), which has memory barrier semantics — forcing inlining overrides the JIT's cost model and can cause unnecessary register pressure at all call sites
- The `Try*` variants (`TrySetResult`, `TrySetException`, `TrySetCanceled`) never had `AggressiveInlining` despite the same pattern — this aligns `SetResult`/`SetException` with that convention
- `ObserveForFireAndForget` retains `AggressiveInlining` as it contains no synchronization primitives

Closes #618

## Test plan

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] (Optional) Run producer benchmarks before/after to confirm no regression