### PR TITLE
fix: suppress spurious 'unknown correlation ID' warnings for cancelled requests

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -132,6 +132,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
     // Using globally unique correlation IDs prevents this issue.
     private static int s_globalCorrelationId;
     private readonly ConcurrentDictionary<int, PooledPendingRequest> _pendingRequests = new();
+    private readonly ConcurrentDictionary<int, byte> _cancelledCorrelationIds = new();
     private readonly PendingRequestPool _pendingRequestPool = new();
     private readonly CancellationTokenSourcePool _timeoutCtsPool = new();
     private readonly SemaphoreSlim _writeLock = new(1, 1);
@@ -530,6 +531,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
+        var responseReceived = false;
         try
         {
             LogWaitingForResponse(correlationId);
@@ -554,6 +556,8 @@ public sealed partial class KafkaConnection : IKafkaConnection
             {
                 pending.DisposeRegistration();
             }
+
+            responseReceived = true;
 
             LogResponseReceived(correlationId);
 
@@ -604,6 +608,15 @@ public sealed partial class KafkaConnection : IKafkaConnection
             if (_pendingRequests.TryRemove(correlationId, out var removed))
             {
                 _pendingRequestPool.Return(removed);
+
+                // Broker may still send a response for a timed-out/cancelled request.
+                // Record it so the receive loop discards silently instead of warning.
+                // If the receive loop already called TryComplete (and lost the CAS),
+                // this entry becomes a harmless no-op cleaned up by DisposeAsync.
+                if (!responseReceived)
+                {
+                    _cancelledCorrelationIds.TryAdd(correlationId, 0);
+                }
             }
         }
     }
@@ -872,6 +885,11 @@ public sealed partial class KafkaConnection : IKafkaConnection
                             // Request was already cancelled/failed - dispose the buffer
                             responseData.Dispose();
                         }
+                    }
+                    else if (_cancelledCorrelationIds.TryRemove(correlationId, out _))
+                    {
+                        LogLateResponseForCancelledRequest(correlationId);
+                        responseData.Dispose();
                     }
                     else
                     {
@@ -1793,6 +1811,8 @@ public sealed partial class KafkaConnection : IKafkaConnection
                 _pendingRequestPool.Return(orphaned);
             }
         }
+
+        _cancelledCorrelationIds.Clear();
     }
 
 
@@ -1839,6 +1859,9 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Received response for correlation ID {CorrelationId}, {Length} bytes")]
     private partial void LogReceivedResponse(int correlationId, int length);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Received late response for cancelled/timed-out correlation ID {CorrelationId}, discarding")]
+    private partial void LogLateResponseForCancelledRequest(int correlationId);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Received response for unknown correlation ID {CorrelationId}")]
     private partial void LogUnknownCorrelationId(int correlationId);


### PR DESCRIPTION
## Summary

- Track cancelled/timed-out correlation IDs so the receive loop can silently discard expected late responses instead of logging misleading "unknown correlation ID" warnings
- Preserves the Warning log for truly unexpected correlation IDs (protocol errors, data corruption)
- No changes to pool-return semantics, `PooledPendingRequest` ownership, or `FailAllPendingRequests` behavior

## Root Cause

When a request times out or is cancelled after being written to the broker, `AwaitAndParseResponseAsync`'s `finally` block removes the correlation ID from `_pendingRequests` before the broker's response arrives. The receive loop then can't find it → `LogUnknownCorrelationId` warning.

Under high parallelism (16 concurrent tests from #649), the single Kafka container gets overloaded, causing more timeouts and making this race much more frequent.

## How It Works

1. **New field**: `_cancelledCorrelationIds` (`ConcurrentDictionary<int, byte>`) tracks correlation IDs where the request was sent but the response was not received
2. **On timeout/cancellation**: after removing from `_pendingRequests` and returning to pool, the correlation ID is added to `_cancelledCorrelationIds`
3. **In receive loop**: checks `_cancelledCorrelationIds` before logging Warning — silently discards at Debug level if found
4. **Cleanup**: entries removed when the late response arrives; remaining entries GC'd on connection disposal

## Test plan

- [x] All 3233 unit tests pass
- [x] Zero build warnings
- [ ] Integration tests with high parallelism no longer produce "unknown correlation ID" warnings

Closes #651