### PR TITLE
test: fix concurrency test timeouts on low-CPU CI runners

### DIFF
--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolConcurrencyTests.cs
@@ -22,7 +22,7 @@ public sealed class ConnectionPoolConcurrencyTests
     public async Task CreateConnectionGroup_ConcurrentCallers_CreatesExactlyConnectionsPerBrokerConnections()
     {
         const int connectionsPerBroker = 3;
-        const int concurrentCallers = 10;
+        var concurrentCallers = Math.Max(2, Environment.ProcessorCount);
         var connectionCount = 0;
 
         // Factory that counts how many connections are created
@@ -77,7 +77,7 @@ public sealed class ConnectionPoolConcurrencyTests
     public async Task ReplaceConnectionInGroup_ConcurrentCallers_CreatesExactlyOneReplacement()
     {
         const int connectionsPerBroker = 3;
-        const int concurrentCallers = 10;
+        var concurrentCallers = Math.Max(2, Environment.ProcessorCount);
         const int deadIndex = 1;
         var replacementCount = 0;
         var initialCreationDone = 0;
@@ -235,7 +235,7 @@ public sealed class ConnectionPoolConcurrencyTests
     public async Task CreateConnectionGroup_ConcurrentCallers_AllReceiveConnectionsFromSameGroup()
     {
         const int connectionsPerBroker = 2;
-        const int concurrentCallers = 20;
+        var concurrentCallers = Math.Max(2, Environment.ProcessorCount);
         var createdConnections = new ConcurrentBag<IKafkaConnection>();
 
         var pool = new ConnectionPool(

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -192,7 +192,8 @@ public sealed class ConnectionPoolTests
         var pool = new ConnectionPool("test-client");
 
         // Launch many concurrent disposal calls to exercise the atomic guard
-        var tasks = new Task[10];
+        var threadCount = Math.Max(2, Environment.ProcessorCount);
+        var tasks = new Task[threadCount];
         using var barrier = new Barrier(tasks.Length);
 
         for (var i = 0; i < tasks.Length; i++)

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -124,7 +124,8 @@ public sealed class KafkaConnectionTests
         var connection = new KafkaConnection("localhost", 9092);
 
         // Launch many concurrent disposal calls to exercise the atomic guard
-        var tasks = new Task[10];
+        var threadCount = Math.Max(2, Environment.ProcessorCount);
+        var tasks = new Task[threadCount];
         using var barrier = new Barrier(tasks.Length);
 
         for (var i = 0; i < tasks.Length; i++)

--- a/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
@@ -216,13 +216,14 @@ public class PooledPendingRequestTests
         var request = pool.Rent();
         request.Initialize(responseHeaderVersion: 0, CancellationToken.None);
 
+        var threadCount = Math.Max(2, Environment.ProcessorCount);
         var successCount = 0;
-        var barrier = new Barrier(10);
+        var barrier = new Barrier(threadCount);
         var tasks = new List<Task>();
 
-        for (int i = 0; i < 10; i++)
+        for (int i = 0; i < threadCount; i++)
         {
-            var value = (byte)i;
+            var value = (byte)(i % 256);
             tasks.Add(Task.Run(() =>
             {
                 barrier.SignalAndWait();
@@ -249,14 +250,16 @@ public class PooledPendingRequestTests
         var request = pool.Rent();
         request.Initialize(responseHeaderVersion: 0, CancellationToken.None);
 
+        var halfThreads = Math.Max(1, Environment.ProcessorCount / 2);
+        var threadCount = halfThreads * 2; // Ensure even split
         var successCount = 0;
-        var barrier = new Barrier(4);
+        var barrier = new Barrier(threadCount);
         var tasks = new List<Task>();
 
-        // 2 threads try TryComplete
-        for (int i = 0; i < 2; i++)
+        // Half the threads try TryComplete
+        for (int i = 0; i < halfThreads; i++)
         {
-            var value = (byte)i;
+            var value = (byte)(i % 256);
             tasks.Add(Task.Run(() =>
             {
                 barrier.SignalAndWait();
@@ -267,8 +270,8 @@ public class PooledPendingRequestTests
             }));
         }
 
-        // 2 threads try TrySetException
-        for (int i = 0; i < 2; i++)
+        // Half the threads try TrySetException
+        for (int i = 0; i < halfThreads; i++)
         {
             tasks.Add(Task.Run(() =>
             {

--- a/tests/Dekaf.Tests.Unit/Producer/EpochBumpRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/EpochBumpRecoveryTests.cs
@@ -522,10 +522,11 @@ public sealed class EpochBumpRecoveryTests
         // Reset while concurrent threads are incrementing.
         // Use generous timeouts — CI runners with 16+ parallel tests suffer thread pool
         // starvation that can delay Task.Run/Task.Delay by 10-30x.
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var threadCount = Math.Max(2, Environment.ProcessorCount);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         var tasks = new List<Task>();
 
-        for (var i = 0; i < 4; i++)
+        for (var i = 0; i < threadCount; i++)
         {
             var partId = i;
             tasks.Add(Task.Run(() =>

--- a/tests/Dekaf.Tests.Unit/Producer/MaxBlockMsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/MaxBlockMsTests.cs
@@ -212,11 +212,14 @@ public sealed class MaxBlockMsTests
     [Test]
     public async Task RecordAccumulator_TimeoutMessage_ContainsMaxBlockMs()
     {
+        // Use a generous MaxBlockMs to give timer callbacks headroom on CI runners
+        // where thread pool starvation can delay async callbacks significantly.
+        var maxBlockMs = 5000;
         var options = new ProducerOptions
         {
             BootstrapServers = ["localhost:9092"],
             BufferMemory = 1,
-            MaxBlockMs = 2000
+            MaxBlockMs = maxBlockMs
         };
 
         await using var accumulator = new RecordAccumulator(options);
@@ -232,9 +235,9 @@ public sealed class MaxBlockMsTests
         catch (KafkaTimeoutException ex)
         {
             await Assert.That(ex.Message).Contains("max.block.ms");
-            await Assert.That(ex.Message).Contains("2000");
+            await Assert.That(ex.Message).Contains(maxBlockMs.ToString());
             await Assert.That(ex.TimeoutKind).IsEqualTo(TimeoutKind.MaxBlock);
-            await Assert.That(ex.Configured).IsEqualTo(TimeSpan.FromMilliseconds(2000));
+            await Assert.That(ex.Configured).IsEqualTo(TimeSpan.FromMilliseconds(maxBlockMs));
             await Assert.That(ex.Elapsed).IsGreaterThanOrEqualTo(TimeSpan.Zero);
             // Generous upper bound: on CI with 16 parallel tests on 4 cores, thread pool
             // starvation can delay async timer callbacks by 3-5 minutes. This only asserts

--- a/tests/Dekaf.Tests.Unit/Producer/MemoryReleasedAtomicityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/MemoryReleasedAtomicityTests.cs
@@ -62,11 +62,11 @@ public class MemoryReleasedAtomicityTests
         // This is the core regression test: multiple threads racing to release
         // the same batch must result in exactly one winner.
 
-        // Reduced from 10,000 iterations: on CI runners with 16+ parallel tests,
-        // spawning 16 threads × 10K iterations saturates the thread pool and
-        // causes 2-minute timeouts. 500 iterations is still sufficient to catch
-        // race conditions (Barrier synchronizes all threads per iteration).
-        const int threadCount = 16;
+        // Scale thread count to available processors to avoid thread pool starvation
+        // on CI runners with limited cores. Math.Max(2, ...) ensures at least 2 threads
+        // always compete. 500 iterations is sufficient to catch race conditions
+        // (Barrier synchronizes all threads per iteration).
+        var threadCount = Math.Max(2, Environment.ProcessorCount);
         const int iterations = 500;
         var failedIterations = 0;
 

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -315,11 +315,12 @@ public class PooledValueTaskSourceTests
         var pool = new ValueTaskSourcePool<int>();
         var source = pool.Rent();
 
+        var threadCount = Math.Max(2, Environment.ProcessorCount);
         var successCount = 0;
-        var barrier = new Barrier(10);
+        var barrier = new Barrier(threadCount);
         var tasks = new List<Task>();
 
-        for (int i = 0; i < 10; i++)
+        for (int i = 0; i < threadCount; i++)
         {
             var value = i;
             tasks.Add(Task.Run(() =>
@@ -340,7 +341,7 @@ public class PooledValueTaskSourceTests
         // The task should complete with a value
         var result = await source.Task.ConfigureAwait(false);
         await Assert.That(result).IsGreaterThanOrEqualTo(0);
-        await Assert.That(result).IsLessThan(10);
+        await Assert.That(result).IsLessThan(threadCount);
     }
 
     [Test]
@@ -594,9 +595,13 @@ public class PooledValueTaskSourceTests
         // Complete after observing - should trigger continuation
         source.SetResult(42);
 
-        // Give a tiny bit of time for the callback to execute
-        await Task.Yield();
-        await Task.Delay(1); // Small delay to ensure continuation runs
+        // Spin-wait with timeout for the continuation to execute,
+        // as Task.Delay(1) is too short under thread pool starvation on CI
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (pool.ApproximateCount == 0 && sw.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            await Task.Yield();
+        }
 
         // Source should have been returned to pool
         await Assert.That(pool.ApproximateCount).IsEqualTo(1);


### PR DESCRIPTION
## Summary

- Replace hard-coded thread counts (10, 16, 20) in 11 concurrency tests with `Math.Max(2, Environment.ProcessorCount)` to prevent thread pool starvation when `Barrier` synchronization exceeds available threads on 4-CPU CI runners
- Increase `MaxBlockMs` from 2000ms to 5000ms in timer-callback test to give more headroom under starvation
- Replace `Task.Delay(1)` with a spin-wait timeout loop in `ObserveForFireAndForget` test that was too short under starvation
- Increase spin-loop timeout from 5s to 15s in `ResetSequenceNumbers_ConcurrentAccess_ThreadSafe`

## Test plan

- [x] All 11 affected tests pass individually
- [x] Full unit test suite passes (3264 tests, 0 failures)
- [ ] CI pipeline passes on 4-CPU runners without timeouts