### PR TITLE
fix: use PendingFetchData.Create() in EstimatePendingFetchBytesTests

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/EstimatePendingFetchBytesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/EstimatePendingFetchBytesTests.cs
@@ -9,7 +9,7 @@ public class EstimatePendingFetchBytesTests
     public async Task EmptyBatches_ReturnsPartitionOverheadOnly()
     {
         // Arrange - no batches, just partition-level overhead
-        using var pending = new PendingFetchData(
+        using var pending = PendingFetchData.Create(
             "test-topic",
             partitionIndex: 0,
             batches: Array.Empty<RecordBatch>());
@@ -34,7 +34,7 @@ public class EstimatePendingFetchBytesTests
             Records = []
         };
 
-        using var pending = new PendingFetchData(
+        using var pending = PendingFetchData.Create(
             "test-topic",
             partitionIndex: 0,
             batches: [batch]);
@@ -67,7 +67,7 @@ public class EstimatePendingFetchBytesTests
             Records = []
         };
 
-        using var pending = new PendingFetchData(
+        using var pending = PendingFetchData.Create(
             "test-topic",
             partitionIndex: 0,
             batches: [batch1, batch2]);
@@ -92,7 +92,7 @@ public class EstimatePendingFetchBytesTests
             Records = []
         };
 
-        using var pending = new PendingFetchData(
+        using var pending = PendingFetchData.Create(
             "test-topic",
             partitionIndex: 0,
             batches: [batch]);


### PR DESCRIPTION
## Summary

Fixes broken main build.

PR #666 added `EstimatePendingFetchBytesTests` using `new PendingFetchData(topic, partitionIndex, batches)`. PR #668 changed `PendingFetchData` to a pooled factory pattern with a private constructor and `Create()` static method. When both merged to main, the tests broke with `CS1729: 'PendingFetchData' does not contain a constructor that takes 3 arguments`.

**Fix:** Replace `new PendingFetchData(...)` with `PendingFetchData.Create(...)` in all 4 test methods.

## Test plan

- [x] All 4 EstimatePendingFetchBytesTests pass
- [x] Build succeeds with 0 errors