### PR TITLE
fix: use precise mode for GC.GetTotalAllocatedBytes in stress tests

### DIFF
--- a/tools/Dekaf.Profiling/Program.cs
+++ b/tools/Dekaf.Profiling/Program.cs
@@ -581,7 +581,7 @@ public static class Program
             _gen0Before = GC.CollectionCount(0);
             _gen1Before = GC.CollectionCount(1);
             _gen2Before = GC.CollectionCount(2);
-            _allocatedBefore = GC.GetTotalAllocatedBytes(precise: false);
+            _allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
             Gen0 = Gen1 = Gen2 = 0;
             AllocatedBytes = 0;
         }
@@ -591,7 +591,7 @@ public static class Program
             Gen0 = GC.CollectionCount(0) - _gen0Before;
             Gen1 = GC.CollectionCount(1) - _gen1Before;
             Gen2 = GC.CollectionCount(2) - _gen2Before;
-            AllocatedBytes = GC.GetTotalAllocatedBytes(precise: false) - _allocatedBefore;
+            AllocatedBytes = GC.GetTotalAllocatedBytes(precise: true) - _allocatedBefore;
         }
     }
 

--- a/tools/Dekaf.StressTests/Metrics/GcStats.cs
+++ b/tools/Dekaf.StressTests/Metrics/GcStats.cs
@@ -21,7 +21,7 @@ internal struct GcStats
         _gen0Before = GC.CollectionCount(0);
         _gen1Before = GC.CollectionCount(1);
         _gen2Before = GC.CollectionCount(2);
-        _allocatedBefore = GC.GetTotalAllocatedBytes(precise: false);
+        _allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
         Gen0 = Gen1 = Gen2 = 0;
         AllocatedBytes = 0;
     }
@@ -31,7 +31,7 @@ internal struct GcStats
         Gen0 = GC.CollectionCount(0) - _gen0Before;
         Gen1 = GC.CollectionCount(1) - _gen1Before;
         Gen2 = GC.CollectionCount(2) - _gen2Before;
-        AllocatedBytes = GC.GetTotalAllocatedBytes(precise: false) - _allocatedBefore;
+        AllocatedBytes = GC.GetTotalAllocatedBytes(precise: true) - _allocatedBefore;
     }
 
     public GcSnapshot ToSnapshot() => new()


### PR DESCRIPTION
## Summary

- Fixes stress test `Total Allocated` reporting 0 B in fire-and-forget producer scenarios despite GC collections proving allocations occurred
- Changed `GC.GetTotalAllocatedBytes(precise: false)` to `precise: true` in both `GcStats` (stress tests) and the profiling tool's equivalent struct
- `precise: false` reads thread-local allocation counters without synchronization, returning stale values when allocations happen on background threads whose counters haven't been flushed to the global total

Closes #676

## Test plan

- [x] Solution builds successfully
- [x] Unit tests pass (3276/3277; 1 pre-existing timeout in BrokerSenderMuteOrderingTests)
- [ ] Run stress tests with fire-and-forget producer scenario and verify `Total Allocated` reports non-zero values