### PR TITLE
fix: handle negative allocation deltas in stress test reports

### DIFF
--- a/tools/Dekaf.StressTests/Metrics/GcStats.cs
+++ b/tools/Dekaf.StressTests/Metrics/GcStats.cs
@@ -88,10 +88,10 @@ internal sealed class GcSnapshot
         return AllocatedBytes switch
         {
             null => "N/A (measurement error)",
-            < 1024 => $"{AllocatedBytes} B",
-            < 1024 * 1024 => $"{AllocatedBytes / 1024.0:F2} KB",
-            < 1024 * 1024 * 1024 => $"{AllocatedBytes / (1024.0 * 1024):F2} MB",
-            _ => $"{AllocatedBytes / (1024.0 * 1024 * 1024):F2} GB"
+            < 1024 => $"{AllocatedBytes.Value} B",
+            < 1024 * 1024 => $"{AllocatedBytes.Value / 1024.0:F2} KB",
+            < 1024 * 1024 * 1024 => $"{AllocatedBytes.Value / (1024.0 * 1024):F2} MB",
+            _ => $"{AllocatedBytes.Value / (1024.0 * 1024 * 1024):F2} GB"
         };
     }
 }


### PR DESCRIPTION
## Summary

Fixes #691

- `GC.GetTotalAllocatedBytes(precise: true)` can return inconsistent values under heavy concurrent allocation in .NET 10, producing negative "Total Allocated" values in multi-broker stress test reports
- When the precise delta is negative, the code now falls back to `precise: false`; if that also fails, reports "N/A (measurement error)" instead of a raw negative number
- Diagnostic logging captures the raw before/after values to help investigate the root cause in the runtime

## Test plan

- [ ] `dotnet build tools/Dekaf.StressTests` compiles cleanly (verified)
- [ ] Run multi-broker stress test and confirm no negative values appear in the report
- [ ] When a negative delta is detected, verify the fallback warning is logged to console with before/after values