### PR TITLE
perf: bulk-enqueue batches per broker to improve multi-broker coalescing

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -578,20 +578,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     /// <summary>
-    /// Enqueues a batch for sending to this broker.
-    /// TryWrite on the unbounded event channel always succeeds unless the channel is completed
-    /// (send loop exited). BufferMemory provides the backpressure — the channel does not need bounding.
-    /// </summary>
-    public ValueTask EnqueueAsync(ReadyBatch batch, CancellationToken cancellationToken)
-    {
-        if (_eventChannel.Writer.TryWrite(SendLoopEvent.NewBatch(batch)))
-            return ValueTask.CompletedTask;
-
-        FailEnqueuedBatch(batch);
-        return ValueTask.CompletedTask;
-    }
-
-    /// <summary>
     /// Bulk enqueue for the sender loop: writes all batches to the event channel before the
     /// send loop can wake and read them, ensuring all batches are available for coalescing
     /// into a single ProduceRequest. This reduces per-request overhead in multi-broker setups
@@ -609,7 +595,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         {
             if (!writer.TryWrite(SendLoopEvent.NewBatch(batches[i])))
             {
-                // Channel completed (disposal) — fail remaining batches
+                // Channel completed (disposal) — fail remaining batches.
+                // The caller's outer catch may also call FailAndCleanupBatch on these batches,
+                // but batch.Fail() is idempotent (guarded by Interlocked.Exchange on _sendCompleted)
+                // and TrySetMemoryReleased() is likewise atomic, so double-fail is safe.
                 for (var j = i; j < batches.Count; j++)
                     FailEnqueuedBatch(batches[j]);
                 return;

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1766,17 +1766,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                                 var brokerSender = GetOrCreateBrokerSender(brokerId);
                                 brokerSender.EnqueueBulk(batchList);
                             }
-                            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                            {
-                                // Fail remaining batches
-                                for (var i = 0; i < batchList.Count; i++)
-                                    FailAndCleanupBatch(batchList[i],
-                                        new OperationCanceledException(cancellationToken));
-                                throw;
-                            }
                             catch (Exception ex)
                             {
-                                // Fail all batches in this batch list
+                                // Fail all batches in this batch list.
+                                // Note: if EnqueueBulk hit a completed channel, it already failed
+                                // remaining batches via FailEnqueuedBatch — but batch.Fail() is
+                                // idempotent (guarded by Interlocked.Exchange), so double-fail is safe.
                                 for (var i = 0; i < batchList.Count; i++)
                                     FailAndCleanupBatch(batchList[i], ex);
                             }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -223,7 +223,7 @@ public sealed class BrokerSenderMuteOrderingTests
         {
             // Enqueue batch A (p0)
             var batchA = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batchA, CancellationToken.None);
+            sender.Enqueue(batchA);
 
             // Wait for send 1
             await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
@@ -240,7 +240,7 @@ public sealed class BrokerSenderMuteOrderingTests
 
             // Now enqueue batch B (p0) — retry already in flight, p0 is muted by _muteOnSend
             var batchB = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batchB, CancellationToken.None);
+            sender.Enqueue(batchB);
 
             // Complete retry → FinalizeCoalescedRetries unmutes p0
             tcs2.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 100));
@@ -321,8 +321,8 @@ public sealed class BrokerSenderMuteOrderingTests
             // Enqueue batch A (p0) and batch B (p1) — they'll coalesce
             var batchA = CreateTestBatch(vtPool, "test-topic", 0);
             var batchB = CreateTestBatch(vtPool, "test-topic", 1);
-            await sender.EnqueueAsync(batchA, CancellationToken.None);
-            await sender.EnqueueAsync(batchB, CancellationToken.None);
+            sender.Enqueue(batchA);
+            sender.Enqueue(batchB);
 
             // Wait for send 1 (coalesced A+B)
             await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
@@ -334,7 +334,7 @@ public sealed class BrokerSenderMuteOrderingTests
 
             // Enqueue batch C (p1) — should NOT be blocked (p1 is not muted)
             var batchC = CreateTestBatch(vtPool, "test-topic", 1);
-            await sender.EnqueueAsync(batchC, CancellationToken.None);
+            sender.Enqueue(batchC);
 
             // Wait for send 2 (batch A retry + batch C coalesced — both partitions)
             await sendSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
@@ -414,9 +414,9 @@ public sealed class BrokerSenderMuteOrderingTests
             var batchA = CreateTestBatch(vtPool, "test-topic", 0);
             var batchB = CreateTestBatch(vtPool, "test-topic", 1);
             var batchC = CreateTestBatch(vtPool, "test-topic", 2);
-            await sender.EnqueueAsync(batchA, CancellationToken.None);
-            await sender.EnqueueAsync(batchB, CancellationToken.None);
-            await sender.EnqueueAsync(batchC, CancellationToken.None);
+            sender.Enqueue(batchA);
+            sender.Enqueue(batchB);
+            sender.Enqueue(batchC);
 
             await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
@@ -499,7 +499,7 @@ public sealed class BrokerSenderMuteOrderingTests
         try
         {
             var batchA = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batchA, CancellationToken.None);
+            sender.Enqueue(batchA);
             await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
             // Connection fault → HandleRetriableBatch with NetworkException → mutes p0
@@ -507,7 +507,7 @@ public sealed class BrokerSenderMuteOrderingTests
 
             // Enqueue B (p0) — should be blocked
             var batchB = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batchB, CancellationToken.None);
+            sender.Enqueue(batchB);
 
             // Retry of A
             await sendSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
@@ -584,7 +584,7 @@ public sealed class BrokerSenderMuteOrderingTests
         try
         {
             var batchA = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batchA, CancellationToken.None);
+            sender.Enqueue(batchA);
             await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
             // First error
@@ -592,7 +592,7 @@ public sealed class BrokerSenderMuteOrderingTests
 
             // Enqueue B while A is retrying
             var batchB = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batchB, CancellationToken.None);
+            sender.Enqueue(batchB);
 
             // Retry 1 → error again
             await sendSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
@@ -673,8 +673,8 @@ public sealed class BrokerSenderMuteOrderingTests
         {
             var batchA = CreateTestBatch(vtPool, "test-topic", 0);
             var batchB = CreateTestBatch(vtPool, "test-topic", 1);
-            await sender.EnqueueAsync(batchA, CancellationToken.None);
-            await sender.EnqueueAsync(batchB, CancellationToken.None);
+            sender.Enqueue(batchA);
+            sender.Enqueue(batchB);
 
             await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
@@ -685,7 +685,7 @@ public sealed class BrokerSenderMuteOrderingTests
 
             // Enqueue C (p1) — p1 is NOT muted, should proceed
             var batchC = CreateTestBatch(vtPool, "test-topic", 1);
-            await sender.EnqueueAsync(batchC, CancellationToken.None);
+            sender.Enqueue(batchC);
 
             // Send 2: A retry (p0) + C (p1) coalesced
             await sendSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
@@ -776,8 +776,8 @@ public sealed class BrokerSenderMuteOrderingTests
             // Phase 1: enqueue A(p0) and B(p1) — coalesced into send 1
             var batchA = CreateTestBatch(vtPool, "test-topic", 0);
             var batchB = CreateTestBatch(vtPool, "test-topic", 1);
-            await sender.EnqueueAsync(batchA, CancellationToken.None);
-            await sender.EnqueueAsync(batchB, CancellationToken.None);
+            sender.Enqueue(batchA);
+            sender.Enqueue(batchB);
 
             await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
@@ -785,8 +785,8 @@ public sealed class BrokerSenderMuteOrderingTests
             // (maxInFlight=1, so the send loop is waiting for the response)
             var batchC = CreateTestBatch(vtPool, "test-topic", 0);
             var batchD = CreateTestBatch(vtPool, "test-topic", 1);
-            await sender.EnqueueAsync(batchC, CancellationToken.None);
-            await sender.EnqueueAsync(batchD, CancellationToken.None);
+            sender.Enqueue(batchC);
+            sender.Enqueue(batchD);
 
             // Complete send 1: p0 fails, p1 succeeds
             // This triggers the muted partition filter on already-coalesced batches

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -174,7 +174,7 @@ public sealed class BrokerSenderSendLoopTests
         try
         {
             var batch = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batch, CancellationToken.None);
+            sender.Enqueue(batch);
 
             // Wait for the send loop to actually send the request
             await requestSent.Task.WaitAsync(cancellationToken);
@@ -239,8 +239,8 @@ public sealed class BrokerSenderSendLoopTests
             var batch1 = CreateTestBatch(vtPool, "test-topic", 0);
             var batch2 = CreateTestBatch(vtPool, "test-topic", 1);
 
-            await sender.EnqueueAsync(batch1, CancellationToken.None);
-            await sender.EnqueueAsync(batch2, CancellationToken.None);
+            sender.Enqueue(batch1);
+            sender.Enqueue(batch2);
 
             // Wait for the send loop to send the coalesced request
             await requestSent.Task.WaitAsync(cancellationToken);
@@ -328,7 +328,7 @@ public sealed class BrokerSenderSendLoopTests
         {
             // Enqueue first batch — send loop sends it immediately
             var batch1 = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batch1, CancellationToken.None);
+            sender.Enqueue(batch1);
 
             // Wait for first request to be sent (deterministic, no Task.Delay)
             await sendSignals[0].Task.WaitAsync(cancellationToken);
@@ -336,7 +336,7 @@ public sealed class BrokerSenderSendLoopTests
 
             // Enqueue second batch while first is still in-flight
             var batch2 = CreateTestBatch(vtPool, "test-topic", 1);
-            await sender.EnqueueAsync(batch2, CancellationToken.None);
+            sender.Enqueue(batch2);
 
             // Second request should NOT have been sent yet (in-flight limit).
             // Give a brief moment for the send loop to process, then verify.
@@ -400,7 +400,7 @@ public sealed class BrokerSenderSendLoopTests
         try
         {
             var batch = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batch, CancellationToken.None);
+            sender.Enqueue(batch);
 
             // Wait for first send (deterministic)
             await sendSignals[0].Task.WaitAsync(cancellationToken);
@@ -479,7 +479,7 @@ public sealed class BrokerSenderSendLoopTests
             for (var i = 0; i < batchCount; i++)
             {
                 var batch = CreateTestBatch(vtPool, "test-topic", i);
-                await sender.EnqueueAsync(batch, CancellationToken.None);
+                sender.Enqueue(batch);
             }
 
             // Wait for at least one send to occur (deterministic)
@@ -555,7 +555,7 @@ public sealed class BrokerSenderSendLoopTests
         try
         {
             var batch = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batch, CancellationToken.None);
+            sender.Enqueue(batch);
 
             // Fire-and-forget should complete quickly without waiting for a response
             var offset = await acknowledged.Task.WaitAsync(cancellationToken);
@@ -624,7 +624,7 @@ public sealed class BrokerSenderSendLoopTests
         {
             // Enqueue batch A (partition 0) — send loop sends it immediately
             var batchA = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batchA, CancellationToken.None);
+            sender.Enqueue(batchA);
 
             // Wait for batch A to be sent (fills in-flight slot)
             await sendSignals[0].Task.WaitAsync(cancellationToken);
@@ -636,7 +636,7 @@ public sealed class BrokerSenderSendLoopTests
             // (ProcessCompletedResponses handles it inline), or wake up from the
             // fault if already waiting. Both paths exercise the carry-over fix.
             var batchB = CreateTestBatch(vtPool, "test-topic", 1);
-            await sender.EnqueueAsync(batchB, CancellationToken.None);
+            sender.Enqueue(batchB);
             tcs1.SetException(new IOException("Connection reset"));
 
             // Wait for batch B to be sent (slot freed by processing faulted response)
@@ -706,7 +706,7 @@ public sealed class BrokerSenderSendLoopTests
         try
         {
             var batch = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batch, CancellationToken.None);
+            sender.Enqueue(batch);
 
             // The response is already complete, so acknowledgement should happen very quickly
             var result = await acknowledged.Task.WaitAsync(cancellationToken);
@@ -772,7 +772,7 @@ public sealed class BrokerSenderSendLoopTests
         {
             // Send first batch — response will hang
             var batch1 = CreateTestBatch(vtPool, "test-topic", 0);
-            await sender.EnqueueAsync(batch1, CancellationToken.None);
+            sender.Enqueue(batch1);
             await sendSignals[0].Task.WaitAsync(cancellationToken);
 
             // Wait for HandleTimedOutRequests to process batch1 (request timeout 1s +
@@ -783,7 +783,7 @@ public sealed class BrokerSenderSendLoopTests
             // Send second batch on different partition — should not hang
             // (HandleTimedOutRequests cleared _pendingResponses, freeing the capacity slot)
             var batch2 = CreateTestBatch(vtPool, "test-topic", 1);
-            await sender.EnqueueAsync(batch2, CancellationToken.None);
+            sender.Enqueue(batch2);
 
             // Second batch should be sent (send loop freed the capacity slot)
             await sendSignals[1].Task.WaitAsync(cancellationToken);


### PR DESCRIPTION
## Summary

- Replace per-batch async `EnqueueAsync` with synchronous `EnqueueBulk` that writes all batches for a broker in a tight loop without yielding, ensuring all batches are visible in the channel before the send loop wakes
- Increase MicroLinger thresholds (batch threshold 2→3, max spins 10→20) to give the sender loop more time to accumulate batches in multi-broker setups
- Combine two separate loops (CompleteDelivery + AppendDiag) into one

**Expected impact**: Better batch coalescing in multi-broker setups reduces per-request overhead, targeting the ~19% throughput gap vs Confluent in 3-broker fire-and-forget scenarios.

Fixes #662

## Test plan

- [ ] Unit tests pass (`dotnet build tests/Dekaf.Tests.Unit --configuration Release && ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit`)
- [ ] Integration tests pass with Docker
- [ ] Run 3-broker stress test and compare throughput vs baseline (~162K msg/s)
- [ ] Verify single-broker throughput is not regressed (~402K msg/s)