### PR TITLE
perf: enable pipelined sends in BrokerSender for multi-broker throughput

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1122,6 +1122,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                     if (canPipeline)
                     {
+                        // Note: if this wakes on a ResponseReady event, the freed in-flight slot
+                        // is only visible after ProcessCompletedResponses runs at the top of the
+                        // next iteration — not in this one.
                         if (!await eventReader.WaitToReadAsync(cancellationToken)
                             .ConfigureAwait(false))
                             break;

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -723,6 +723,91 @@ public sealed class BrokerSenderSendLoopTests
 
     [Test]
     [Timeout(120_000)]
+    public async Task SendLoop_PipeliningEnabled_SendsSecondBatchBeforeFirstResponse(CancellationToken cancellationToken)
+    {
+        // With maxInFlight=2, after sending batch A (in-flight=1), the canPipeline guard
+        // evaluates to true (sentThisIteration=true, carryOver empty, 1 < 2). The send loop
+        // waits on the event channel instead of WaitForAnyResponseAsync. When batch B arrives
+        // via a NewBatch event, the loop wakes and sends B immediately — before A's response
+        // arrives. This verifies the pipelining optimization introduced in PR #704.
+
+        var tcs1 = new TaskCompletionSource<ProduceResponse>();
+        var tcs2 = new TaskCompletionSource<ProduceResponse>();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
+        responseQueue.Enqueue(tcs1);
+        responseQueue.Enqueue(tcs2);
+
+        var sendCount = 0;
+        var sendSignals = new[] { new TaskCompletionSource(), new TaskCompletionSource() };
+
+        var (pool, _) = CreateMockConnection(responseQueue, onSend: () =>
+        {
+            var idx = Interlocked.Increment(ref sendCount) - 1;
+            if (idx < sendSignals.Length)
+                sendSignals[idx].TrySetResult();
+        });
+        var options = CreateOptions(maxInFlight: 2);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+
+        var ackOffsets = new List<long>();
+        var allAcknowledged = new TaskCompletionSource();
+
+        var sender = CreateSender(pool, options, accumulator, (_, offset, _, _, ex) =>
+        {
+            if (ex is null)
+            {
+                lock (ackOffsets)
+                {
+                    ackOffsets.Add(offset);
+                    if (ackOffsets.Count >= 2)
+                        allAcknowledged.TrySetResult();
+                }
+            }
+        });
+
+        try
+        {
+            // Send batch A (partition 0) — in-flight count becomes 1
+            var batchA = CreateTestBatch(vtPool, "test-topic", 0);
+            sender.Enqueue(batchA);
+            await sendSignals[0].Task.WaitAsync(cancellationToken);
+
+            // Batch A's response is still pending. canPipeline = true because:
+            // sentThisIteration=true, carryOver.Count=0, waitPendingCount(1) < _totalMaxInFlight(2).
+            // The send loop is now waiting on the event channel (not WaitForAnyResponseAsync).
+
+            // Enqueue batch B (partition 1) — this pushes a NewBatch event to the channel,
+            // waking the send loop. It should send B immediately without waiting for A's response.
+            var batchB = CreateTestBatch(vtPool, "test-topic", 1);
+            sender.Enqueue(batchB);
+
+            // Wait for batch B to be sent — this proves pipelining worked: B was sent
+            // while A's response was still pending.
+            await sendSignals[1].Task.WaitAsync(cancellationToken);
+
+            // Both requests are now in-flight. Verify A's response hasn't arrived yet.
+            await Assert.That(Volatile.Read(ref sendCount)).IsEqualTo(2);
+
+            // Complete both responses
+            tcs1.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 100));
+            tcs2.SetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 200));
+
+            await allAcknowledged.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(ackOffsets).Contains(100L);
+            await Assert.That(ackOffsets).Contains(200L);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
     public async Task SendLoop_HungResponseWithExpiredBatches_FreesCapacitySlot(CancellationToken cancellationToken)
     {
         // Regression test: when a response task never completes (hung connection),


### PR DESCRIPTION
## Summary

- Enable pipelined batch sending in `BrokerSender` when in-flight capacity is available, eliminating dead time between send and response in multi-broker setups
- When batches are sent successfully with no muted carry-over, use the event channel (which receives both `NewBatch` and `ResponseReady` events) instead of waiting solely for responses
- Guards prevent spin loops: only activates when progress was made, no muted partitions exist, and in-flight slots remain

Closes #698

## Context

In 3-broker stress tests, Dekaf achieves only 0.79x of Confluent.Kafka's throughput (155K vs 197K msg/s). With 6 partitions across 3 brokers, each broker receives only 2 partitions per linger cycle. The previous code always waited for a response before processing new batches, even when in-flight capacity was available. This created dead time where new batches sat in the channel while the BrokerSender waited for the previous response.

The idempotent 3-broker scenario already achieved parity (1.00x) because its different send path didn't have this bottleneck, confirming the issue was in the non-idempotent BrokerSender wait logic.

## Test plan

- [x] BrokerSender unit tests pass (20/20)
- [ ] Integration tests pass
- [ ] Run stress test with 3-broker producer to verify throughput improvement