### PR TITLE
fix: clear stale fetch data on reassignment to prevent partition misrouting

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -621,6 +621,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         }
 
         // Clear stale fetched data (same rationale as Assign).
+        // NOTE: This runs after releasing _assignmentLock, so there is a small race window
+        // where the prefetch worker could write new valid items into _prefetchChannel between
+        // lock release and this call. Those items get discarded here. Correctness is maintained
+        // because the worker will re-fetch them on the next iteration, but there is a small
+        // one-time latency cost for the discarded prefetch.
         ClearFetchBuffer();
 
         InvalidateFetchRequestCache();


### PR DESCRIPTION
## Summary

- **Root cause**: `Assign()`, `Unassign()`, `Subscribe()`, and `Unsubscribe()` did not clear `_pendingFetches` or drain `_prefetchChannel` when changing partition assignments. Stale fetched data from old partitions was yielded by the next `ConsumeAsync` call as if it belonged to the new assignment.
- **Fix**: Add `ClearFetchBuffer()` calls to all assignment-changing methods, and extend `ClearFetchBuffer()` to also drain the prefetch channel.
- **Exposure**: The bug was latent but surfaced after PRs #702 (reduced pool sizes) and #704 (pipelining) changed batch timing and fetch response boundaries, causing stale data to remain in the prefetch pipeline across reassignments.

## Test plan

- [ ] Existing `IdempotentMultiConnection_PerPartitionOrdering_Preserved` test should pass (was previously failing with `Expected "p3-seq-0000" but received "p2-seq-0000"`)
- [ ] All other integration tests pass (no regressions from clearing fetch buffers on reassignment)
- [ ] Unit tests pass

Closes #707