### PR TITLE
refactor(consumer): remove dead state from PendingFetchData

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -169,8 +169,6 @@ internal sealed class PendingFetchData : IDisposable
     /// </summary>
     internal long CurrentBaseOffset { get; private set; }
     internal long CurrentBaseTimestamp { get; private set; }
-    internal RecordBatchAttributes CurrentBatchAttributes { get; private set; }
-
     /// <summary>
     /// Cached timestamp type for the current batch.
     /// Computed once per batch transition instead of per-message.
@@ -231,7 +229,6 @@ internal sealed class PendingFetchData : IDisposable
         CurrentBaseOffset = batch.BaseOffset;
         CurrentBaseTimestamp = batch.BaseTimestamp;
         var attrs = batch.Attributes;
-        CurrentBatchAttributes = attrs;
         CurrentTimestampType = (attrs & RecordBatchAttributes.TimestampTypeLogAppendTime) != 0
             ? TimestampType.LogAppendTime
             : TimestampType.CreateTime;
@@ -368,7 +365,6 @@ internal sealed class PendingFetchData : IDisposable
         _currentRecordsCount = 0;
         CurrentBaseOffset = 0;
         CurrentBaseTimestamp = 0;
-        CurrentBatchAttributes = RecordBatchAttributes.None;
         CurrentTimestampType = default;
         LastYieldedOffset = -1;
         TotalBytesConsumed = 0;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -210,7 +210,7 @@ internal sealed class PendingFetchData : IDisposable
     }
 
     /// <summary>
-    /// Caches batch-level state (Records list, BaseOffset, BaseTimestamp, Attributes)
+    /// Caches batch-level state (Records array, BaseOffset, BaseTimestamp, TimestampType)
     /// so per-message access avoids repeated property indirection through RecordBatch.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary

- Remove `CurrentBatchAttributes` property — only written, never read after #784 replaced its sole consumer with `CurrentTimestampType`
- Remove `_currentRecords` fallback field — unreachable after `CurrentRecord` uses `_currentRecordsArray` directly
- Simplify `CurrentRecord` getter — replace unreachable null-check branch with `Debug.Assert`, eliminating one branch per message in the hot path

## Test plan

- [ ] Unit tests pass (no behavioral change — only dead code removal)
- [ ] Build succeeds with 0 warnings