### PR TITLE
perf(producer): reduce idempotent producer GC pressure from sequence tracking

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -924,6 +924,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // (lock-free hash lookup only), avoiding AddOrUpdate's per-call bucket locking.
     // During leader migration, two BrokerSender threads may access the same partition
     // concurrently, so StrongBox.Value is mutated via Interlocked.Add for atomicity.
+    //
+    // Reset operations use Interlocked.Exchange(ref box.Value, 0) instead of TryRemove
+    // to avoid re-allocating ConcurrentDictionary internal Node objects (~48 bytes) and
+    // StrongBox instances (~24 bytes) per partition. Under epoch bump recovery, TryRemove
+    // followed by GetOrAdd caused these mid-lived objects to survive Gen0, get promoted
+    // to Gen2, then die — creating pathological Gen2 GC pressure in idempotent workloads.
     private readonly ConcurrentDictionary<TopicPartition, StrongBox<int>> _sequenceNumbers = new();
 
     /// <summary>
@@ -940,10 +946,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     /// <summary>
     /// Resets all sequence numbers. Called after InitTransactionsAsync when epoch changes.
+    /// Resets values in place rather than clearing the dictionary to avoid re-allocating
+    /// ConcurrentDictionary Node and StrongBox objects when sequences are next assigned.
     /// </summary>
     internal void ResetSequenceNumbers()
     {
-        _sequenceNumbers.Clear();
+        foreach (var kvp in _sequenceNumbers)
+            Interlocked.Exchange(ref kvp.Value.Value, 0);
     }
 
     /// <summary>
@@ -952,11 +961,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// that triggered OOSN/InvalidProducerEpoch need their sequences reset to 0.
     /// Unaffected partitions keep their current sequence counters; the broker carries
     /// forward per-partition sequence state across epoch bumps (KIP-360).
+    /// Resets in place via Interlocked.Exchange to avoid Node/StrongBox reallocation.
     /// </summary>
     internal void ResetSequencesForPartitions(IReadOnlyCollection<TopicPartition> partitions)
     {
         foreach (var tp in partitions)
-            _sequenceNumbers.TryRemove(tp, out _);
+        {
+            if (_sequenceNumbers.TryGetValue(tp, out var box))
+                Interlocked.Exchange(ref box.Value, 0);
+        }
     }
 
     // Buffer memory tracking for backpressure.

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -948,7 +948,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// Resets all sequence numbers. Called after InitTransactionsAsync when epoch changes.
     /// Resets values in place rather than clearing the dictionary to avoid re-allocating
     /// ConcurrentDictionary Node and StrongBox objects when sequences are next assigned.
+    /// O(n) over tracked partitions; acceptable for this recovery path since n is bounded
+    /// by the partition count the producer writes to.
     /// </summary>
+    /// <remarks>
+    /// The dictionary is intentionally append-only — entries are never removed, only zeroed.
+    /// This avoids Node/StrongBox churn that causes Gen2 GC pressure under high throughput.
+    /// </remarks>
     internal void ResetSequenceNumbers()
     {
         foreach (var kvp in _sequenceNumbers)


### PR DESCRIPTION
## Summary

- Replace `TryRemove`/`Clear` + `GetOrAdd` pattern with in-place `Interlocked.Exchange(ref box.Value, 0)` for sequence number resets in `RecordAccumulator`
- During epoch bump recovery, the previous pattern removed `ConcurrentDictionary` entries, forcing reallocation of internal `Node` objects (~48 bytes) and `StrongBox<int>` instances (~24 bytes) per partition on next access
- These mid-lived objects survived Gen0 during the network round-trip, got promoted to Gen2, then died -- contributing to the pathological Gen2 GC pressure observed in idempotent producer stress tests (658 GB allocated, 450 Gen2 collections vs 4.65 GB / 17 Gen2 for non-idempotent)

## What changed

`ResetSequenceNumbers()` and `ResetSequencesForPartitions()` in `RecordAccumulator.cs` now reset `StrongBox<int>.Value` to 0 in place rather than removing dictionary entries. This eliminates Node + StrongBox reallocation when sequences are next assigned, keeping the idempotent path allocation-free in steady state.

## Test plan

- [x] All 3435 unit tests pass (including 57 epoch bump recovery tests that directly exercise `ResetSequenceNumbers`, `ResetSequencesForPartitions`, and concurrent access)
- [ ] Run idempotent producer stress test to verify reduced Gen2 collections