### PR TITLE
fix(stress): restore Acks.Leader in non-idempotent producer stress test

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -41,6 +41,14 @@ jobs:
             client: confluent
             brokers: 1
             name: Confluent Producer (Idempotent)
+          - scenario: producer-acks-all
+            client: dekaf
+            brokers: 1
+            name: Dekaf Producer (Acks All)
+          - scenario: producer-acks-all
+            client: confluent
+            brokers: 1
+            name: Confluent Producer (Acks All)
           - scenario: consumer
             client: dekaf
             brokers: 1
@@ -59,6 +67,14 @@ jobs:
             client: confluent
             brokers: 3
             name: Confluent Producer (3 Brokers)
+          - scenario: producer-acks-all
+            client: dekaf
+            brokers: 3
+            name: Dekaf Producer Acks All (3 Brokers)
+          - scenario: producer-acks-all
+            client: confluent
+            brokers: 3
+            name: Confluent Producer Acks All (3 Brokers)
           - scenario: producer-idempotent
             client: dekaf
             brokers: 3

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -214,6 +214,8 @@ public static class Program
             new ConfluentProducerIdempotentStressTest(),
             new ProducerAsyncStressTest(),
             new ConfluentProducerAsyncStressTest(),
+            new ProducerAcksAllStressTest(),
+            new ConfluentProducerAcksAllStressTest(),
             new ProducerAsyncIdempotentStressTest(),
             new ConfluentProducerAsyncIdempotentStressTest(),
             new ConsumerStressTest(),

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
@@ -57,8 +57,7 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
 
         throughput.Start();
         var messageIndex = 0L;
-        var lastStatusTime = DateTime.UtcNow;
-        var lastStatusMessageCount = 0L;
+        var progress = new PeriodicProgressReporter(throughput);
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
         var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
@@ -77,20 +76,11 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
                 throughput.RecordMessage(options.MessageSizeBytes);
                 messageIndex++;
 
-                // Yield and report status periodically
+                // Yield periodically to avoid starving other tasks
                 if (messageIndex % 100_000 == 0)
                 {
                     await Task.Yield();
-                    var now = DateTime.UtcNow;
-                    if ((now - lastStatusTime).TotalSeconds >= 10)
-                    {
-                        var elapsedSinceLastStatus = (now - lastStatusTime).TotalSeconds;
-                        var messagesSinceLastStatus = messageIndex - lastStatusMessageCount;
-                        var instantaneousMsgSec = messagesSinceLastStatus / elapsedSinceLastStatus;
-                        Console.WriteLine($"  [{now:HH:mm:ss}] Progress: {messageIndex:N0} messages | instant: {instantaneousMsgSec:N0} msg/sec | avg: {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
-                        lastStatusTime = now;
-                        lastStatusMessageCount = messageIndex;
-                    }
+                    progress.RecordMessage();
                 }
             }
             catch (OperationCanceledException)

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
@@ -1,0 +1,197 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
+using ConfluentKafka = Confluent.Kafka;
+
+namespace Dekaf.StressTests.Scenarios;
+
+internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
+{
+    private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
+
+    public string Name => "producer-acks-all";
+    public string Client => "Confluent";
+
+    public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
+    {
+        var messageValue = new string('x', options.MessageSizeBytes);
+        var throughput = new ThroughputTracker();
+        var latency = new LatencyTracker();
+        var startedAt = DateTime.UtcNow;
+
+        var config = new ConfluentKafka.ProducerConfig
+        {
+            BootstrapServers = options.BootstrapServers,
+            ClientId = "stress-producer-acks-all-confluent",
+            Acks = ConfluentKafka.Acks.All,
+            LingerMs = options.LingerMs,
+            BatchSize = options.BatchSize,
+            CompressionType = options.Compression switch
+            {
+                "lz4" => ConfluentKafka.CompressionType.Lz4,
+                "snappy" => ConfluentKafka.CompressionType.Snappy,
+                "zstd" => ConfluentKafka.CompressionType.Zstd,
+                _ => ConfluentKafka.CompressionType.None
+            }
+        };
+
+        using var producer = new ConfluentKafka.ProducerBuilder<string, string>(config).Build();
+
+        Console.WriteLine($"  Warming up Confluent acks-all producer...");
+        for (var i = 0; i < 1000; i++)
+        {
+            producer.Produce(options.Topic, new ConfluentKafka.Message<string, string> { Key = "warmup", Value = "warmup" });
+        }
+        producer.Flush(TimeSpan.FromSeconds(30));
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var gcStats = new GcStats();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
+
+        Console.WriteLine($"  Running Confluent acks-all producer stress test for {options.DurationMinutes} minutes...");
+        Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
+        LogResourceUsage("Initial");
+
+        throughput.Start();
+        var messageIndex = 0L;
+        var lastStatusTime = DateTime.UtcNow;
+        var lastStatusMessageCount = 0L;
+
+        var samplerTask = RunSamplerAsync(throughput, cts.Token);
+        var resourceMonitorTask = RunResourceMonitorAsync(cts.Token);
+
+        while (!cts.Token.IsCancellationRequested)
+        {
+            try
+            {
+                var start = Stopwatch.GetTimestamp();
+                producer.Produce(options.Topic, new ConfluentKafka.Message<string, string>
+                {
+                    Key = GetKey(messageIndex),
+                    Value = messageValue
+                });
+                latency.RecordTicks(Stopwatch.GetTimestamp() - start);
+                throughput.RecordMessage(options.MessageSizeBytes);
+                messageIndex++;
+
+                // Yield and report status periodically
+                if (messageIndex % 100_000 == 0)
+                {
+                    await Task.Yield();
+                    var now = DateTime.UtcNow;
+                    if ((now - lastStatusTime).TotalSeconds >= 10)
+                    {
+                        var elapsedSinceLastStatus = (now - lastStatusTime).TotalSeconds;
+                        var messagesSinceLastStatus = messageIndex - lastStatusMessageCount;
+                        var instantaneousMsgSec = messagesSinceLastStatus / elapsedSinceLastStatus;
+                        Console.WriteLine($"  [{now:HH:mm:ss}] Progress: {messageIndex:N0} messages | instant: {instantaneousMsgSec:N0} msg/sec | avg: {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
+                        lastStatusTime = now;
+                        lastStatusMessageCount = messageIndex;
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch
+            {
+                throughput.RecordError();
+            }
+        }
+
+        producer.Flush(TimeSpan.FromSeconds(30));
+        throughput.Stop();
+        gcStats.Capture();
+
+        try { await samplerTask.ConfigureAwait(false); } catch { }
+        try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
+
+        var completedAt = DateTime.UtcNow;
+        Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
+        LogResourceUsage("Final");
+
+        return new StressTestResult
+        {
+            Scenario = Name,
+            Client = Client,
+            DurationMinutes = options.DurationMinutes,
+            BrokerCount = options.BrokerCount,
+            MessageSizeBytes = options.MessageSizeBytes,
+            StartedAtUtc = startedAt,
+            CompletedAtUtc = completedAt,
+            Throughput = throughput.GetSnapshot(),
+            Latency = latency.GetSnapshot(),
+            GcStats = gcStats.ToSnapshot()
+        };
+    }
+
+    private static async Task RunSamplerAsync(ThroughputTracker throughput, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
+                throughput.TakeSample();
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    private static string[] CreatePreAllocatedKeys(int count)
+    {
+        var keys = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            keys[i] = $"key-{i}";
+        }
+        return keys;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
+
+    private static async Task RunResourceMonitorAsync(CancellationToken cancellationToken)
+    {
+        var process = Process.GetCurrentProcess();
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(5000, cancellationToken).ConfigureAwait(false);
+                LogResourceUsage("Monitor", process);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    private static void LogResourceUsage(string label, Process? process = null)
+    {
+        process ??= Process.GetCurrentProcess();
+        process.Refresh();
+
+        var workingSet = process.WorkingSet64 / (1024.0 * 1024.0);
+        var privateMemory = process.PrivateMemorySize64 / (1024.0 * 1024.0);
+        var gcHeap = GC.GetTotalMemory(forceFullCollection: false) / (1024.0 * 1024.0);
+        var threadCount = process.Threads.Count;
+        var gen0 = GC.CollectionCount(0);
+        var gen1 = GC.CollectionCount(1);
+        var gen2 = GC.CollectionCount(2);
+
+        Console.WriteLine($"  [{DateTime.UtcNow:HH:mm:ss}] {label} Resources: " +
+            $"WorkingSet={workingSet:F1}MB, Private={privateMemory:F1}MB, GCHeap={gcHeap:F1}MB, " +
+            $"Threads={threadCount}, GC=[{gen0}/{gen1}/{gen2}]");
+    }
+}

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 using ConfluentKafka = Confluent.Kafka;
@@ -8,8 +7,6 @@ namespace Dekaf.StressTests.Scenarios;
 
 internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
 {
-    private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
-
     public string Name => "producer-acks-all";
     public string Client => "Confluent";
 
@@ -24,6 +21,7 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
         {
             BootstrapServers = options.BootstrapServers,
             ClientId = "stress-producer-acks-all-confluent",
+            // Must match ProducerAcksAllStressTest for an apples-to-apples comparison
             Acks = ConfluentKafka.Acks.All,
             LingerMs = options.LingerMs,
             BatchSize = options.BatchSize,
@@ -55,15 +53,15 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
 
         Console.WriteLine($"  Running Confluent acks-all producer stress test for {options.DurationMinutes} minutes...");
         Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
-        LogResourceUsage("Initial");
+        StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
         var messageIndex = 0L;
         var lastStatusTime = DateTime.UtcNow;
         var lastStatusMessageCount = 0L;
 
-        var samplerTask = RunSamplerAsync(throughput, cts.Token);
-        var resourceMonitorTask = RunResourceMonitorAsync(cts.Token);
+        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
+        var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
 
         while (!cts.Token.IsCancellationRequested)
         {
@@ -72,7 +70,7 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
                 var start = Stopwatch.GetTimestamp();
                 producer.Produce(options.Topic, new ConfluentKafka.Message<string, string>
                 {
-                    Key = GetKey(messageIndex),
+                    Key = StressTestHelpers.GetKey(messageIndex),
                     Value = messageValue
                 });
                 latency.RecordTicks(Stopwatch.GetTimestamp() - start);
@@ -114,7 +112,7 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
-        LogResourceUsage("Final");
+        StressTestHelpers.LogResourceUsage("Final");
 
         return new StressTestResult
         {
@@ -129,69 +127,5 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot()
         };
-    }
-
-    private static async Task RunSamplerAsync(ThroughputTracker throughput, CancellationToken cancellationToken)
-    {
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
-                throughput.TakeSample();
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-    }
-
-    private static string[] CreatePreAllocatedKeys(int count)
-    {
-        var keys = new string[count];
-        for (var i = 0; i < count; i++)
-        {
-            keys[i] = $"key-{i}";
-        }
-        return keys;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
-
-    private static async Task RunResourceMonitorAsync(CancellationToken cancellationToken)
-    {
-        var process = Process.GetCurrentProcess();
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(5000, cancellationToken).ConfigureAwait(false);
-                LogResourceUsage("Monitor", process);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-    }
-
-    private static void LogResourceUsage(string label, Process? process = null)
-    {
-        process ??= Process.GetCurrentProcess();
-        process.Refresh();
-
-        var workingSet = process.WorkingSet64 / (1024.0 * 1024.0);
-        var privateMemory = process.PrivateMemorySize64 / (1024.0 * 1024.0);
-        var gcHeap = GC.GetTotalMemory(forceFullCollection: false) / (1024.0 * 1024.0);
-        var threadCount = process.Threads.Count;
-        var gen0 = GC.CollectionCount(0);
-        var gen1 = GC.CollectionCount(1);
-        var gen2 = GC.CollectionCount(2);
-
-        Console.WriteLine($"  [{DateTime.UtcNow:HH:mm:ss}] {label} Resources: " +
-            $"WorkingSet={workingSet:F1}MB, Private={privateMemory:F1}MB, GCHeap={gcHeap:F1}MB, " +
-            $"Threads={threadCount}, GC=[{gen0}/{gen1}/{gen2}]");
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Dekaf.Compression.Lz4;
 using Dekaf.Compression.Snappy;
 using Dekaf.Compression.Zstd;
@@ -11,8 +10,6 @@ namespace Dekaf.StressTests.Scenarios;
 
 internal sealed class ProducerAcksAllStressTest : IStressTestScenario
 {
-    private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
-
     public string Name => "producer-acks-all";
     public string Client => "Dekaf";
 
@@ -27,6 +24,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-producer-acks-all-dekaf")
             .WithIdempotence(false)
+            // Must match ConfluentProducerAcksAllStressTest for an apples-to-apples comparison
             .WithAcks(Acks.All)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
@@ -74,7 +72,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             try
             {
                 var start = Stopwatch.GetTimestamp();
-                await producer.FireAsync(options.Topic, GetKey(messageIndex), messageValue);
+                await producer.FireAsync(options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue);
                 latency.RecordTicks(Stopwatch.GetTimestamp() - start);
                 throughput.RecordMessage(options.MessageSizeBytes);
                 messageIndex++;
@@ -141,17 +139,4 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             GcStats = gcStats.ToSnapshot()
         };
     }
-
-    private static string[] CreatePreAllocatedKeys(int count)
-    {
-        var keys = new string[count];
-        for (var i = 0; i < count; i++)
-        {
-            keys[i] = $"key-{i}";
-        }
-        return keys;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -1,0 +1,157 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Dekaf.Compression.Lz4;
+using Dekaf.Compression.Snappy;
+using Dekaf.Compression.Zstd;
+using Dekaf.Producer;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
+
+namespace Dekaf.StressTests.Scenarios;
+
+internal sealed class ProducerAcksAllStressTest : IStressTestScenario
+{
+    private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
+
+    public string Name => "producer-acks-all";
+    public string Client => "Dekaf";
+
+    public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
+    {
+        var messageValue = new string('x', options.MessageSizeBytes);
+        var throughput = new ThroughputTracker();
+        var latency = new LatencyTracker();
+        var startedAt = DateTime.UtcNow;
+
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(options.BootstrapServers)
+            .WithClientId("stress-producer-acks-all-dekaf")
+            .WithIdempotence(false)
+            .WithAcks(Acks.All)
+            .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
+            .WithBatchSize(options.BatchSize)
+            .WithSocketSendBufferBytes(options.BatchSize);
+
+        _ = options.Compression switch
+        {
+            "lz4" => builder.UseLz4Compression(),
+            "snappy" => builder.UseSnappyCompression(),
+            "zstd" => builder.UseZstdCompression(),
+            _ => builder
+        };
+
+        var producer = await builder.BuildAsync(cancellationToken);
+
+        Console.WriteLine($"  Warming up Dekaf acks-all producer...");
+        await producer.ProduceAsync(options.Topic, "warmup", "warmup", cancellationToken).ConfigureAwait(false);
+        for (var i = 0; i < 999; i++)
+        {
+            await producer.FireAsync(options.Topic, "warmup", "warmup");
+        }
+        await producer.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var gcStats = new GcStats();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
+
+        Console.WriteLine($"  Running Dekaf acks-all producer stress test for {options.DurationMinutes} minutes...");
+        Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
+        StressTestHelpers.LogResourceUsage("Initial");
+
+        throughput.Start();
+        var messageIndex = 0L;
+        var progress = new PeriodicProgressReporter(throughput);
+
+        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
+        var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
+
+        while (!cts.Token.IsCancellationRequested)
+        {
+            try
+            {
+                var start = Stopwatch.GetTimestamp();
+                await producer.FireAsync(options.Topic, GetKey(messageIndex), messageValue);
+                latency.RecordTicks(Stopwatch.GetTimestamp() - start);
+                throughput.RecordMessage(options.MessageSizeBytes);
+                messageIndex++;
+
+                // Yield periodically to avoid starving other tasks
+                if (messageIndex % 100_000 == 0)
+                {
+                    await Task.Yield();
+                    progress.RecordMessage();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch
+            {
+                throughput.RecordError();
+            }
+        }
+
+        Console.WriteLine($"  Flushing remaining messages...");
+        try
+        {
+            await producer.FlushAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            Console.WriteLine($"  Warning: Flush timed out after 30 seconds");
+        }
+
+        throughput.Stop();
+        gcStats.Capture();
+
+        try { await samplerTask.ConfigureAwait(false); } catch { }
+        try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
+
+        var completedAt = DateTime.UtcNow;
+        Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
+        StressTestHelpers.LogResourceUsage("Final");
+
+        Console.WriteLine($"  Disposing producer...");
+        try
+        {
+            await producer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None).ConfigureAwait(false);
+            Console.WriteLine($"  Producer disposed successfully");
+        }
+        catch (TimeoutException)
+        {
+            Console.WriteLine($"  Warning: Dispose timed out after 30 seconds");
+        }
+
+        return new StressTestResult
+        {
+            Scenario = Name,
+            Client = Client,
+            DurationMinutes = options.DurationMinutes,
+            BrokerCount = options.BrokerCount,
+            MessageSizeBytes = options.MessageSizeBytes,
+            StartedAtUtc = startedAt,
+            CompletedAtUtc = completedAt,
+            Throughput = throughput.GetSnapshot(),
+            Latency = latency.GetSnapshot(),
+            GcStats = gcStats.ToSnapshot()
+        };
+    }
+
+    private static string[] CreatePreAllocatedKeys(int count)
+    {
+        var keys = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            keys[i] = $"key-{i}";
+        }
+        return keys;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
+}

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -27,6 +27,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-producer-dekaf")
             .WithIdempotence(false)
+            // Must match ConfluentProducerStressTest for an apples-to-apples comparison
             .WithAcks(Acks.Leader)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -27,7 +27,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-producer-dekaf")
             .WithIdempotence(false)
-            .WithAcks(Acks.All)
+            .WithAcks(Acks.Leader)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
             .WithSocketSendBufferBytes(options.BatchSize);


### PR DESCRIPTION
## Summary

- **Revert Acks.All → Acks.Leader** in `ProducerStressTest.cs` to match `ConfluentProducerStressTest.cs`, fixing the apples-to-oranges throughput comparison introduced by PR #783
- **Add new `producer-acks-all` scenario** with matched Dekaf + Confluent tests (non-idempotent, Acks.All) for the GC comparison that PR #783 originally intended
- Root cause of #792: on a 3-broker cluster, `Acks.All` requires all ISR replicas to acknowledge each batch, adding ~40% latency vs `Acks.Leader` — this config mismatch (not a code regression) explains the throughput drop from 218K to 131K msg/s

All Dekaf/Confluent stress test pairs now use matching Acks settings:
| Scenario | Dekaf | Confluent |
|----------|-------|-----------|
| producer | Leader | Leader |
| **producer-acks-all** | **All** | **All** |
| producer-async | Leader | Leader |
| producer-idempotent | All | All |
| producer-async-idempotent | All | All |

Closes #792

## Test plan

- [ ] Run 3-broker stress test with `--scenario producer --client all` and verify Dekaf throughput returns to ~218K+ msg/s
- [ ] Run `--scenario producer-acks-all --client all` to compare Dekaf vs Confluent GC under Acks.All
- [ ] Verify no change to idempotent producer stress test results