### PR TITLE
test(stress): restore multi-connection (3conn) stress test variant

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -83,6 +83,28 @@ jobs:
             client: confluent
             brokers: 3
             name: Confluent Producer Idempotent (3 Brokers)
+          # Multi-connection variants: Dekaf-only with explicit 3 connections per broker.
+          # Tests whether explicit multi-connection config outperforms adaptive scaling.
+          - scenario: producer
+            client: dekaf
+            brokers: 1
+            connections_per_broker: 3
+            name: Dekaf Producer (3conn)
+          - scenario: producer
+            client: dekaf
+            brokers: 3
+            connections_per_broker: 3
+            name: Dekaf Producer (3conn, 3 Brokers)
+          - scenario: producer-idempotent
+            client: dekaf
+            brokers: 1
+            connections_per_broker: 3
+            name: Dekaf Producer Idempotent (3conn)
+          - scenario: producer-idempotent
+            client: dekaf
+            brokers: 3
+            connections_per_broker: 3
+            name: Dekaf Producer Idempotent (3conn, 3 Brokers)
 
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -146,12 +168,13 @@ jobs:
             --scenario ${{ matrix.scenario }} \
             --client ${{ matrix.client }} \
             --brokers ${{ matrix.brokers }} \
+            --connections-per-broker ${{ matrix.connections_per_broker || '1' }} \
             --output ./results
 
       - name: Upload Results
         uses: actions/upload-artifact@v7
         with:
-          name: results-${{ matrix.client }}-${{ matrix.scenario }}-${{ matrix.brokers }}brokers
+          name: results-${{ matrix.client }}-${{ matrix.scenario }}-${{ matrix.brokers }}brokers${{ matrix.connections_per_broker && format('-{0}conn', matrix.connections_per_broker) || '' }}
           path: tools/Dekaf.StressTests/results/
           retention-days: 90
 

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -112,11 +112,9 @@ public static class Program
             ConnectionsPerBroker = connectionsPerBroker
         };
 
-        // Baseline pass: single connection for fair comparison with Confluent.
-        // Skipped when running a multi-connection-only job (the baseline already
-        // exists from the dedicated single-connection CI matrix entry).
         if (options.ConnectionsPerBroker == 1)
         {
+            // Baseline pass: single connection for fair comparison with Confluent.
             foreach (var scenario in scenarios)
             {
                 Console.WriteLine();
@@ -130,11 +128,10 @@ public static class Program
                 GC.Collect();
             }
         }
-
-        // Multi-connection pass: run Dekaf-only producer scenarios with explicit
-        // ConnectionsPerBroker to measure parallel TCP connection throughput.
-        if (options.ConnectionsPerBroker > 1)
+        else
         {
+            // Multi-connection pass: Dekaf-only producer scenarios with explicit
+            // ConnectionsPerBroker to measure parallel TCP connection throughput.
             var multiConnScenarios = scenarios
                 .Where(s => s.Client == "Dekaf" && s.Name.StartsWith("producer", StringComparison.OrdinalIgnoreCase))
                 .ToList();
@@ -372,7 +369,7 @@ public static class Program
               --batch-size <bytes>    Producer batch size (default: 1048576)
               --compression <type>   Compression type: none, lz4, snappy, zstd (default: none)
               --brokers <count>      Number of Kafka brokers (default: 1, use 3 for multi-broker)
-              --connections-per-broker <n>  TCP connections per broker for multi-conn pass (default: 3, use 1 to skip)
+              --connections-per-broker <n>  TCP connections per broker (default: 1, pass 3 for multi-connection comparison)
               report --input <path>   Generate report from existing results
 
             Environment Variables:
@@ -399,6 +396,6 @@ public static class Program
         public int BatchSize { get; set; } = 1048576;
         public string Compression { get; set; } = "none";
         public int Brokers { get; set; } = 1;
-        public int ConnectionsPerBroker { get; set; } = 3;
+        public int ConnectionsPerBroker { get; set; } = 1;
     }
 }

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -76,7 +76,8 @@ public static class Program
         Console.WriteLine($"Client: {options.Client}");
         Console.WriteLine($"Compression: {options.Compression}");
         Console.WriteLine($"Brokers: {options.Brokers}");
-        Console.WriteLine("Adaptive connections: enabled (scales up automatically)");
+        if (options.ConnectionsPerBroker > 1)
+            Console.WriteLine($"Multi-connection: {options.ConnectionsPerBroker} connections per broker (Dekaf only)");
         Console.WriteLine(new string('-', 50));
 
         await using var kafka = await KafkaEnvironment.CreateAsync(options.Brokers).ConfigureAwait(false);
@@ -97,34 +98,60 @@ public static class Program
         var results = new List<StressTestResult>();
         var runStartedAt = DateTime.UtcNow;
 
-        foreach (var scenario in scenarios)
+        StressTestOptions BuildTestOptions(string scenarioName, int connectionsPerBroker) => new()
         {
-            Console.WriteLine();
-            Console.WriteLine($"=== Running: {scenario.Client} {scenario.Name} ===");
+            BootstrapServers = kafka.BootstrapServers,
+            Topic = scenarioName.StartsWith("producer", StringComparison.OrdinalIgnoreCase) ? producerTopic : consumerTopic,
+            DurationMinutes = options.DurationMinutes,
+            MessageSizeBytes = options.MessageSizeBytes,
+            Partitions = options.Partitions,
+            LingerMs = options.LingerMs,
+            BatchSize = options.BatchSize,
+            Compression = options.Compression,
+            BrokerCount = options.Brokers,
+            ConnectionsPerBroker = connectionsPerBroker
+        };
 
-            var testOptions = new StressTestOptions
+        // Baseline pass: single connection for fair comparison with Confluent.
+        // Skipped when running a multi-connection-only job (the baseline already
+        // exists from the dedicated single-connection CI matrix entry).
+        if (options.ConnectionsPerBroker == 1)
+        {
+            foreach (var scenario in scenarios)
             {
-                BootstrapServers = kafka.BootstrapServers,
-                Topic = scenario.Name.StartsWith("producer", StringComparison.OrdinalIgnoreCase) ? producerTopic : consumerTopic,
-                DurationMinutes = options.DurationMinutes,
-                MessageSizeBytes = options.MessageSizeBytes,
-                Partitions = options.Partitions,
-                LingerMs = options.LingerMs,
-                BatchSize = options.BatchSize,
-                Compression = options.Compression,
-                BrokerCount = options.Brokers
-            };
+                Console.WriteLine();
+                Console.WriteLine($"=== Running: {scenario.Client} {scenario.Name} ===");
 
-            var result = await scenario.RunAsync(testOptions, CancellationToken.None).ConfigureAwait(false);
-            results.Add(result);
+                var result = await scenario.RunAsync(BuildTestOptions(scenario.Name, connectionsPerBroker: 1), CancellationToken.None).ConfigureAwait(false);
+                results.Add(result);
 
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            }
         }
 
-        // Multi-connection pass removed: adaptive connection scaling now handles
-        // scaling up connections automatically based on buffer pressure.
+        // Multi-connection pass: run Dekaf-only producer scenarios with explicit
+        // ConnectionsPerBroker to measure parallel TCP connection throughput.
+        if (options.ConnectionsPerBroker > 1)
+        {
+            var multiConnScenarios = scenarios
+                .Where(s => s.Client == "Dekaf" && s.Name.StartsWith("producer", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            foreach (var scenario in multiConnScenarios)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"=== Running: {scenario.Client} {scenario.Name} ({options.ConnectionsPerBroker}conn) ===");
+
+                var result = await scenario.RunAsync(BuildTestOptions(scenario.Name, options.ConnectionsPerBroker), CancellationToken.None).ConfigureAwait(false);
+                result.Client = $"Dekaf ({options.ConnectionsPerBroker}conn)";
+                results.Add(result);
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            }
+        }
 
         var runCompletedAt = DateTime.UtcNow;
 
@@ -309,8 +336,11 @@ public static class Program
                     }
                     break;
                 case "--connections-per-broker":
-                    _ = int.Parse(args[++i]);
-                    Console.Error.WriteLine("WARNING: --connections-per-broker is deprecated. Adaptive connection scaling now handles this automatically.");
+                    options.ConnectionsPerBroker = int.Parse(args[++i]);
+                    if (options.ConnectionsPerBroker < 1)
+                    {
+                        throw new ArgumentException("--connections-per-broker must be at least 1");
+                    }
                     break;
                 case "--help":
                 case "-h":
@@ -342,6 +372,7 @@ public static class Program
               --batch-size <bytes>    Producer batch size (default: 1048576)
               --compression <type>   Compression type: none, lz4, snappy, zstd (default: none)
               --brokers <count>      Number of Kafka brokers (default: 1, use 3 for multi-broker)
+              --connections-per-broker <n>  TCP connections per broker for multi-conn pass (default: 3, use 1 to skip)
               report --input <path>   Generate report from existing results
 
             Environment Variables:
@@ -368,5 +399,6 @@ public static class Program
         public int BatchSize { get; set; } = 1048576;
         public string Compression { get; set; } = "none";
         public int Brokers { get; set; } = 1;
+        public int ConnectionsPerBroker { get; set; } = 3;
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -20,4 +20,5 @@ internal sealed class StressTestOptions
     public int BatchSize { get; init; } = 16384;
     public string Compression { get; init; } = "none";
     public int BrokerCount { get; init; } = 1;
+    public int ConnectionsPerBroker { get; init; } = 1;
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -28,6 +28,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             .WithAcks(Acks.All)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
             .WithSocketSendBufferBytes(options.BatchSize);
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
@@ -30,6 +30,7 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
             .WithAcks(Acks.All)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
             .WithSocketSendBufferBytes(options.BatchSize);
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
@@ -30,6 +30,7 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
             .WithAcks(Acks.Leader)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
             .WithSocketSendBufferBytes(options.BatchSize);
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -27,6 +27,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             .WithAcks(Acks.All)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
             .WithSocketSendBufferBytes(options.BatchSize);
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -31,6 +31,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
             .WithAcks(Acks.Leader)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
             .WithSocketSendBufferBytes(options.BatchSize);
 
         _ = options.Compression switch

--- a/tools/profile-stress-test.sh
+++ b/tools/profile-stress-test.sh
@@ -70,7 +70,7 @@ fi
 # Pass remaining args to stress test (defaults if none given)
 STRESS_ARGS=("$@")
 if [ ${#STRESS_ARGS[@]} -eq 0 ]; then
-    STRESS_ARGS=(--duration 5 --scenario producer --client dekaf --message-size 1000 --connections-per-broker 1)
+    STRESS_ARGS=(--duration 5 --scenario producer --client dekaf --message-size 1000)
 fi
 
 # --- Preflight checks ---

--- a/tools/profile-stress-test.sh
+++ b/tools/profile-stress-test.sh
@@ -70,7 +70,7 @@ fi
 # Pass remaining args to stress test (defaults if none given)
 STRESS_ARGS=("$@")
 if [ ${#STRESS_ARGS[@]} -eq 0 ]; then
-    STRESS_ARGS=(--duration 5 --scenario producer --client dekaf --message-size 1000)
+    STRESS_ARGS=(--duration 5 --scenario producer --client dekaf --message-size 1000 --connections-per-broker 1)
 fi
 
 # --- Preflight checks ---


### PR DESCRIPTION
## Summary

- Restores the `Dekaf (3conn)` stress test variant removed in `254262f` when adaptive connection scaling was enabled by default
- Stress results since removal show adaptive scaling is **not** achieving the same throughput as explicit 3-connection configuration (32% gap on 3-broker non-idempotent production)
- Adds 4 parallel CI matrix entries (producer + producer-idempotent × 1/3 brokers) with no increase in CI wall-clock time
- Skips the redundant baseline pass in 3conn jobs, saving ~1hr of CI compute per weekly run
- Extracts `BuildTestOptions` helper to eliminate duplicated `StressTestOptions` construction

## Test plan

- [ ] Verify stress test builds: `dotnet build tools/Dekaf.StressTests -c Release`
- [ ] Verify 3conn jobs appear in CI matrix and run in parallel with existing jobs
- [ ] Confirm 3conn results are tagged as `Dekaf (3conn)` in the merged report
- [ ] Confirm baseline-only jobs (`--connections-per-broker 1`) still work unchanged
- [ ] Compare 3conn throughput vs default adaptive scaling on next stress test run

Closes #793