### PR TITLE
perf(producer): retain PipeWriter buffer across flushes to eliminate allocation churn

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -368,14 +368,13 @@ public sealed partial class KafkaConnection : IKafkaConnection
             _pipeMemoryPool = new PipeMemoryPool();
         }
 
-        // minimumBufferSize controls the buffer the writer retains between writes. Keep it
-        // modest (64 KB) — larger values cause each connection to permanently hold a large
-        // ArrayPool buffer, which accumulates across many connections (3 brokers * adaptive
-        // scaling). The writer allocates larger buffers on demand via GetMemory when needed.
-        _writer = PipeWriter.Create(_stream, new StreamPipeWriterOptions(
-            pool: _pipeMemoryPool,
-            minimumBufferSize: 65536,
-            leaveOpen: true));
+        // RetainedBufferPipeWriter keeps its internal buffer across FlushAsync calls, avoiding
+        // the per-flush rent/return cycle of StreamPipeWriter that causes hundreds of GB of
+        // allocation churn under high-throughput single-connection scenarios (idempotent producer).
+        // minimumBufferSize is kept modest (64 KB) — the writer allocates larger buffers on demand
+        // via GetMemory when needed, and retains the high-water-mark buffer for the connection's
+        // lifetime. See RetainedBufferPipeWriter for full rationale.
+        _writer = new RetainedBufferPipeWriter(_stream, _pipeMemoryPool, minimumBufferSize: 65536);
 
         // Use a read pump to decouple reads from PipeReader signaling.
         // PipeReader.Create(Stream).ReadAsync can block indefinitely when concurrent reads

--- a/src/Dekaf/Networking/RetainedBufferPipeWriter.cs
+++ b/src/Dekaf/Networking/RetainedBufferPipeWriter.cs
@@ -23,6 +23,10 @@ namespace Dekaf.Networking;
 /// <b>Usage pattern:</b> <c>KafkaConnection</c> always follows the sequence
 /// <c>GetMemory(length) → copy → Advance(length) → FlushAsync()</c> under a write lock,
 /// with at most one unflushed write at a time. This writer is optimized for that pattern.
+/// <para/>
+/// <b>Memory:</b> The buffer grows to fit the largest message seen on the connection (high-water
+/// mark) and is retained until the connection closes. This trades per-flush GC churn for
+/// connection-lifetime memory proportional to the largest message size.
 /// </summary>
 internal sealed class RetainedBufferPipeWriter : PipeWriter
 {
@@ -47,7 +51,7 @@ internal sealed class RetainedBufferPipeWriter : PipeWriter
 
     public override void Advance(int bytes)
     {
-        ObjectDisposedException.ThrowIf(_completed, this);
+        ThrowIfCompleted();
 
         ArgumentOutOfRangeException.ThrowIfNegative(bytes);
 
@@ -61,14 +65,14 @@ internal sealed class RetainedBufferPipeWriter : PipeWriter
 
     public override Memory<byte> GetMemory(int sizeHint = 0)
     {
-        ObjectDisposedException.ThrowIf(_completed, this);
+        ThrowIfCompleted();
         EnsureCapacity(sizeHint);
         return _currentBuffer!.Memory[_bytesWritten..];
     }
 
     public override Span<byte> GetSpan(int sizeHint = 0)
     {
-        ObjectDisposedException.ThrowIf(_completed, this);
+        ThrowIfCompleted();
         EnsureCapacity(sizeHint);
         return _currentBuffer!.Memory.Span[_bytesWritten..];
     }
@@ -84,6 +88,7 @@ internal sealed class RetainedBufferPipeWriter : PipeWriter
         {
             await _stream.WriteAsync(_currentBuffer!.Memory[.._bytesWritten], cancellationToken)
                 .ConfigureAwait(false);
+            await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
             _bytesWritten = 0;
             // Buffer is RETAINED — not returned to the pool.
         }
@@ -144,6 +149,14 @@ internal sealed class RetainedBufferPipeWriter : PipeWriter
         _currentBuffer?.Dispose();
         _currentBuffer = newBuffer;
         _currentBufferSize = newBufferSize;
+    }
+
+    private void ThrowIfCompleted()
+    {
+        if (_completed)
+        {
+            throw new InvalidOperationException("PipeWriter has been completed.");
+        }
     }
 
     private void ReturnBuffer()

--- a/src/Dekaf/Networking/RetainedBufferPipeWriter.cs
+++ b/src/Dekaf/Networking/RetainedBufferPipeWriter.cs
@@ -86,11 +86,12 @@ internal sealed class RetainedBufferPipeWriter : PipeWriter
 
         if (_bytesWritten > 0)
         {
-            await _stream.WriteAsync(_currentBuffer!.Memory[.._bytesWritten], cancellationToken)
+            var bytesToFlush = _bytesWritten;
+            _bytesWritten = 0; // Optimistic reset — connection is closed on failure anyway.
+            // Buffer is RETAINED — not returned to the pool.
+            await _stream.WriteAsync(_currentBuffer!.Memory[..bytesToFlush], cancellationToken)
                 .ConfigureAwait(false);
             await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
-            _bytesWritten = 0;
-            // Buffer is RETAINED — not returned to the pool.
         }
 
         return new FlushResult(isCanceled: false, isCompleted: false);

--- a/src/Dekaf/Networking/RetainedBufferPipeWriter.cs
+++ b/src/Dekaf/Networking/RetainedBufferPipeWriter.cs
@@ -1,0 +1,156 @@
+using System.Buffers;
+using System.IO.Pipelines;
+
+namespace Dekaf.Networking;
+
+/// <summary>
+/// A <see cref="PipeWriter"/> that retains its internal buffer across flushes, avoiding the
+/// per-flush rent/return cycle inherent in <see cref="PipeWriter"/>.<c>Create(Stream)</c>.
+/// <para/>
+/// <b>Problem:</b> <c>StreamPipeWriter</c> (created by <c>PipeWriter.Create(stream)</c>)
+/// returns ALL segments to the <see cref="MemoryPool{T}"/> on every <c>FlushAsync</c> call,
+/// then rents a fresh segment on the next <c>GetMemory</c>. Under high-throughput production
+/// (especially with a single connection), this creates hundreds of thousands of rent/return
+/// cycles per second. When the pool's <c>ConfigurableArrayPool</c> bucket capacity is exceeded,
+/// each miss allocates a new <c>byte[]</c> on the heap — causing hundreds of GB of allocation
+/// churn and severe Gen2 GC pressure.
+/// <para/>
+/// <b>Solution:</b> This writer holds a single contiguous buffer that grows on demand but is
+/// never returned to the pool until the writer is completed. On <c>FlushAsync</c>, the buffered
+/// data is written to the underlying <see cref="Stream"/> and the write position resets to zero,
+/// but the buffer itself is retained for the next write.
+/// <para/>
+/// <b>Usage pattern:</b> <c>KafkaConnection</c> always follows the sequence
+/// <c>GetMemory(length) → copy → Advance(length) → FlushAsync()</c> under a write lock,
+/// with at most one unflushed write at a time. This writer is optimized for that pattern.
+/// </summary>
+internal sealed class RetainedBufferPipeWriter : PipeWriter
+{
+    private readonly Stream _stream;
+    private readonly MemoryPool<byte> _pool;
+    private readonly int _minimumBufferSize;
+
+    private IMemoryOwner<byte>? _currentBuffer;
+    private int _currentBufferSize;
+    private int _bytesWritten;
+    private bool _completed;
+
+    public RetainedBufferPipeWriter(Stream stream, MemoryPool<byte> pool, int minimumBufferSize = 65536)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(pool);
+
+        _stream = stream;
+        _pool = pool;
+        _minimumBufferSize = minimumBufferSize;
+    }
+
+    public override void Advance(int bytes)
+    {
+        ObjectDisposedException.ThrowIf(_completed, this);
+
+        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+
+        if (_currentBuffer is null || _bytesWritten + bytes > _currentBufferSize)
+        {
+            throw new InvalidOperationException("Cannot advance past the end of the buffer.");
+        }
+
+        _bytesWritten += bytes;
+    }
+
+    public override Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        ObjectDisposedException.ThrowIf(_completed, this);
+        EnsureCapacity(sizeHint);
+        return _currentBuffer!.Memory[_bytesWritten..];
+    }
+
+    public override Span<byte> GetSpan(int sizeHint = 0)
+    {
+        ObjectDisposedException.ThrowIf(_completed, this);
+        EnsureCapacity(sizeHint);
+        return _currentBuffer!.Memory.Span[_bytesWritten..];
+    }
+
+    public override async ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
+    {
+        if (_completed)
+        {
+            return new FlushResult(isCanceled: false, isCompleted: true);
+        }
+
+        if (_bytesWritten > 0)
+        {
+            await _stream.WriteAsync(_currentBuffer!.Memory[.._bytesWritten], cancellationToken)
+                .ConfigureAwait(false);
+            _bytesWritten = 0;
+            // Buffer is RETAINED — not returned to the pool.
+        }
+
+        return new FlushResult(isCanceled: false, isCompleted: false);
+    }
+
+    public override void CancelPendingFlush()
+    {
+        // No-op: cancellation is handled by the CancellationToken passed to FlushAsync.
+        // StreamPipeWriter uses an internal flag for this, but KafkaConnection never calls
+        // CancelPendingFlush — it uses CancellationToken-based timeout instead.
+    }
+
+    public override void Complete(Exception? exception = null)
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        _completed = true;
+        ReturnBuffer();
+    }
+
+    public override ValueTask CompleteAsync(Exception? exception = null)
+    {
+        Complete(exception);
+        return default;
+    }
+
+    private void EnsureCapacity(int sizeHint)
+    {
+        if (sizeHint <= 0)
+        {
+            sizeHint = _minimumBufferSize;
+        }
+
+        int remainingCapacity = _currentBufferSize - _bytesWritten;
+
+        if (_currentBuffer is not null && remainingCapacity >= sizeHint)
+        {
+            return;
+        }
+
+        // Need a larger buffer. Since we always flush before the next write,
+        // _bytesWritten is typically 0 here, making the copy a no-op.
+        int requiredSize = _bytesWritten + sizeHint;
+        IMemoryOwner<byte> newBuffer = _pool.Rent(Math.Max(requiredSize, _minimumBufferSize));
+        int newBufferSize = newBuffer.Memory.Length;
+
+        if (_bytesWritten > 0)
+        {
+            // Preserve any unflushed data (defensive — shouldn't happen in normal use).
+            _currentBuffer!.Memory.Span[.._bytesWritten].CopyTo(newBuffer.Memory.Span);
+        }
+
+        _currentBuffer?.Dispose();
+        _currentBuffer = newBuffer;
+        _currentBufferSize = newBufferSize;
+    }
+
+    private void ReturnBuffer()
+    {
+        _currentBuffer?.Dispose();
+        _currentBuffer = null;
+        _currentBufferSize = 0;
+        _bytesWritten = 0;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Networking/RetainedBufferPipeWriterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/RetainedBufferPipeWriterTests.cs
@@ -1,0 +1,221 @@
+using System.Buffers;
+using Dekaf.Networking;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public class RetainedBufferPipeWriterTests
+{
+    private static RetainedBufferPipeWriter CreateWriter(MemoryStream? stream = null, int minimumBufferSize = 256)
+    {
+        return new RetainedBufferPipeWriter(
+            stream ?? new MemoryStream(),
+            MemoryPool<byte>.Shared,
+            minimumBufferSize);
+    }
+
+    [Test]
+    public async Task GetMemory_ReturnsWritableMemory()
+    {
+        var writer = CreateWriter();
+
+        var memory = writer.GetMemory(16);
+
+        await Assert.That(memory.Length).IsGreaterThanOrEqualTo(16);
+    }
+
+    [Test]
+    public async Task GetSpan_ReturnsWritableSpan()
+    {
+        var writer = CreateWriter();
+
+        var span = writer.GetSpan(16);
+
+        await Assert.That(span.Length).IsGreaterThanOrEqualTo(16);
+    }
+
+    [Test]
+    public async Task FlushAsync_WritesDataToStream()
+    {
+        var stream = new MemoryStream();
+        var writer = CreateWriter(stream);
+
+        var memory = writer.GetMemory(4);
+        memory.Span[0] = 0xDE;
+        memory.Span[1] = 0xAD;
+        memory.Span[2] = 0xBE;
+        memory.Span[3] = 0xEF;
+        writer.Advance(4);
+
+        await writer.FlushAsync();
+
+        await Assert.That(stream.ToArray()).IsEquivalentTo(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF });
+    }
+
+    [Test]
+    public async Task FlushAsync_ResetsPositionButRetainsBuffer()
+    {
+        var stream = new MemoryStream();
+        var writer = CreateWriter(stream, minimumBufferSize: 64);
+
+        // First write-flush cycle
+        var memory1 = writer.GetMemory(4);
+        memory1.Span[0] = 1;
+        memory1.Span[1] = 2;
+        writer.Advance(2);
+        await writer.FlushAsync();
+
+        // Second write-flush cycle — should reuse the same buffer (no rent/return)
+        var memory2 = writer.GetMemory(4);
+        memory2.Span[0] = 3;
+        memory2.Span[1] = 4;
+        writer.Advance(2);
+        await writer.FlushAsync();
+
+        await Assert.That(stream.ToArray()).IsEquivalentTo(new byte[] { 1, 2, 3, 4 });
+    }
+
+    [Test]
+    public async Task FlushAsync_WithNoData_DoesNotWriteToStream()
+    {
+        var stream = new MemoryStream();
+        var writer = CreateWriter(stream);
+
+        var result = await writer.FlushAsync();
+
+        await Assert.That(stream.Length).IsEqualTo(0);
+        await Assert.That(result.IsCompleted).IsFalse();
+    }
+
+    [Test]
+    public async Task FlushAsync_AfterComplete_ReturnsIsCompletedTrue()
+    {
+        var writer = CreateWriter();
+
+        writer.Complete();
+        var result = await writer.FlushAsync();
+
+        await Assert.That(result.IsCompleted).IsTrue();
+    }
+
+    [Test]
+    public async Task Advance_PastBufferEnd_ThrowsInvalidOperationException()
+    {
+        var writer = CreateWriter(minimumBufferSize: 64);
+        writer.GetMemory(64);
+
+        await Assert.That(() => writer.Advance(int.MaxValue)).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Advance_NegativeBytes_ThrowsArgumentOutOfRangeException()
+    {
+        var writer = CreateWriter();
+        writer.GetMemory(16);
+
+        await Assert.That(() => writer.Advance(-1)).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task Advance_WithoutGetMemory_ThrowsInvalidOperationException()
+    {
+        var writer = CreateWriter();
+
+        await Assert.That(() => writer.Advance(1)).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task GetMemory_AfterComplete_ThrowsInvalidOperationException()
+    {
+        var writer = CreateWriter();
+        writer.Complete();
+
+        await Assert.That(() => writer.GetMemory(16)).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task GetSpan_AfterComplete_ThrowsInvalidOperationException()
+    {
+        var writer = CreateWriter();
+        writer.Complete();
+
+        await Assert.That(() => writer.GetSpan(16)).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Advance_AfterComplete_ThrowsInvalidOperationException()
+    {
+        var writer = CreateWriter();
+        writer.GetMemory(16);
+        writer.Complete();
+
+        await Assert.That(() => writer.Advance(1)).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Complete_CalledTwice_DoesNotThrow()
+    {
+        var writer = CreateWriter();
+
+        writer.Complete();
+        writer.Complete();
+
+        // Should not throw — second call is a no-op.
+        // Verify writer is completed by checking FlushAsync returns isCompleted.
+        var result = await writer.FlushAsync();
+        await Assert.That(result.IsCompleted).IsTrue();
+    }
+
+    [Test]
+    public async Task CompleteAsync_CompletesWriter()
+    {
+        var writer = CreateWriter();
+
+        await writer.CompleteAsync();
+
+        await Assert.That(() => writer.GetMemory(16)).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task EnsureCapacity_PreservesUnflushedBytesWhenGrowing()
+    {
+        var stream = new MemoryStream();
+        // Use a very small minimum buffer to force a grow.
+        var writer = CreateWriter(stream, minimumBufferSize: 8);
+
+        // Write some data that fits in the initial buffer.
+        var memory = writer.GetMemory(4);
+        memory.Span[0] = 0xAA;
+        memory.Span[1] = 0xBB;
+        writer.Advance(2);
+
+        // Now request more memory than remains — forces a grow with unflushed data.
+        var grownMemory = writer.GetMemory(1024);
+        grownMemory.Span[0] = 0xCC;
+        grownMemory.Span[1] = 0xDD;
+        writer.Advance(2);
+
+        await writer.FlushAsync();
+
+        // All 4 bytes should appear: the 2 preserved from before the grow + 2 after.
+        await Assert.That(stream.ToArray()).IsEquivalentTo(new byte[] { 0xAA, 0xBB, 0xCC, 0xDD });
+    }
+
+    [Test]
+    public async Task FlushAsync_OptimisticReset_PreventsDoubleSend()
+    {
+        var stream = new MemoryStream();
+        var writer = CreateWriter(stream);
+
+        var memory = writer.GetMemory(2);
+        memory.Span[0] = 0x01;
+        memory.Span[1] = 0x02;
+        writer.Advance(2);
+
+        await writer.FlushAsync();
+
+        // A second flush without new data should not re-send.
+        await writer.FlushAsync();
+
+        await Assert.That(stream.ToArray()).IsEquivalentTo(new byte[] { 0x01, 0x02 });
+    }
+}

--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -209,8 +209,12 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
     {
         if (_container is not null)
         {
-            await ExecCreateTopicAsync(_container, "kafka-topics", "localhost:9092",
-                topic, partitions, replicationFactor).ConfigureAwait(false);
+            // Use the Dekaf admin client API instead of exec-ing kafka-topics inside the
+            // container. The cp-kafka broker advertises its external host port in metadata,
+            // which the CLI inside the container can't reach — causing a 60-second timeout.
+            // The admin client runs on the host and connects via the external bootstrap address.
+            await AdminCreateTopicAsync(BootstrapServers, topic, partitions, replicationFactor)
+                .ConfigureAwait(false);
             return;
         }
 


### PR DESCRIPTION
## Summary

- Replace `StreamPipeWriter` with `RetainedBufferPipeWriter` in `KafkaConnection` to eliminate the per-flush rent/return cycle that caused hundreds of GB of allocation churn under high-throughput single-connection scenarios (idempotent producer)
- Fix stress test topic creation for single-broker containers by using the Dekaf admin client API instead of exec-ing `kafka-topics` inside the container

## Problem

`StreamPipeWriter` (created by `PipeWriter.Create(stream)`) returns **ALL** segments to the `MemoryPool<byte>` on every `FlushAsync` call, then rents a fresh segment on the next `GetMemory`. Under high-throughput production with a single connection (idempotent producer stuck at 1 connection due to adaptive scaling deferral), this creates hundreds of thousands of rent/return cycles per second.

When the pool's `ConfigurableArrayPool` bucket capacity is exceeded (~16 arrays per bucket), each miss allocates a **new** `byte[]` on the heap. At ~131 KB per buffer and hundreds of thousands of cycles per second, this causes hundreds of GB of allocation churn and severe Gen2 GC pressure.

## Solution

`RetainedBufferPipeWriter` holds a single contiguous buffer that grows on demand but is **never returned to the pool** until the writer is completed (connection closed). On `FlushAsync`, the buffered data is written to the underlying stream and the write position resets to zero, but the buffer itself is retained for the next write.

This matches `KafkaConnection`'s usage pattern: `GetMemory(length) -> copy -> Advance(length) -> FlushAsync()` under a write lock, with at most one unflushed write at a time.

## Stress Test Results

2-minute, 1-broker, idempotent producer, fire-and-forget:

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Total Allocated | 669 GB | **13.45 GB** | **50x reduction** |
| Gen2 Collections | 470 | **21** | **22x reduction** |
| Throughput | ~83K msg/s | ~83K msg/s | No regression |
| Errors | 0 | 0 | Clean |

## Notes

- The remaining ~13 GB of allocations is baseline overhead that affects both idempotent and non-idempotent producers equally (previously measured at ~14 GB for non-idempotent). This is a separate concern from the PipeWriter issue.
- The idempotent producer is constrained to a single connection due to adaptive scaling being deferred when `_totalPendingResponseCount > 0` (always true under high throughput). Addressing this is a separate concern that requires careful handling of out-of-sequence errors during connection transitions.

Closes #791
