### PR TITLE
perf(producer): drain inflight to unblock idempotent connection scale-up

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -753,6 +753,38 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 {
                     var scaledToCount = MaybeScaleConnections();
 
+                    // Deferred scale drain: idempotent producers defer scale operations until
+                    // inflight reaches 0, but under sustained load the send loop refills slots
+                    // immediately, permanently blocking the scale-up. Pause sending briefly
+                    // (~1-5ms, at most once per ScaleCooldownMs) to let inflight drain.
+                    if (scaledToCount == 0
+                        && (_deferredScaleUpCount > 0 || _deferredScaleDownConnection is not null))
+                    {
+                        var drainDeadline = Environment.TickCount64 + ScaleCooldownMs;
+                        var pending = Volatile.Read(ref _totalPendingResponseCount);
+
+                        while (pending > 0 && Environment.TickCount64 < drainDeadline)
+                        {
+                            ProcessCompletedResponses(carryOver, cancellationToken, responseLookup);
+                            pending = Volatile.Read(ref _totalPendingResponseCount);
+
+                            if (pending > 0)
+                            {
+                                HandleTimedOutRequests(carryOver, cancellationToken);
+                                pending = Volatile.Read(ref _totalPendingResponseCount);
+
+                                if (pending > 0)
+                                {
+                                    await WaitForAnyResponseAsync(cancellationToken).ConfigureAwait(false);
+                                    pending = Volatile.Read(ref _totalPendingResponseCount);
+                                }
+                            }
+                        }
+
+                        // Re-run: inflight should be 0 so the deferred operation will be applied.
+                        scaledToCount = MaybeScaleConnections();
+                    }
+
                     if (scaledToCount > 0)
                     {
                         var newScratches = new ProduceRequestScratch[scaledToCount];


### PR DESCRIPTION
## Summary

- **Root cause**: Idempotent producers defer connection scale-up until `_totalPendingResponseCount == 0` (to avoid `OutOfOrderSequenceNumber` from partition affinity remapping). Under sustained fire-and-forget load, the send loop immediately refills inflight slots after each response, so inflight **never reaches 0** — permanently blocking the deferred scale-up and keeping the producer stuck at 1 connection.
- **Impact**: With 1 connection, drain throughput can't keep up → buffer fills → every message enters the allocation-heavy cold path (`AppendFromSpansAsyncSlowPath`): ~1700 bytes/msg × 400K msg/sec = **668 GB allocations, 470 Gen2 collections** over 15 minutes.
- **Fix**: When a deferred scale operation is pending, temporarily pause sending and drain in-flight responses (~1-5ms, at most once per 5s cooldown), allowing `_totalPendingResponseCount` to reach 0 so the scale-up proceeds.

**Why only 1-broker idempotent is affected**:
- 3-broker idempotent: each broker gets its own connection (3x drain capacity) → no buffer pressure
- 1-broker non-idempotent: bypasses the `_isIdempotent` guard, scales connections freely

**Expected results**: <10 GB total allocation, single-digit Gen2 collections, no throughput regression.

Closes #791

## Test plan

- [ ] Run 1-broker idempotent stress test: verify allocations drop from ~668 GB to <10 GB
- [ ] Run 1-broker idempotent stress test: verify Gen2 collections drop from ~470 to single digits
- [ ] Run 1-broker idempotent stress test: verify throughput stays ~400K msg/sec (no regression)
- [ ] Run 1-broker non-idempotent stress test: verify no regression in allocations or throughput
- [ ] Run 3-broker idempotent stress test: verify no regression
- [ ] Run full unit test suite: all tests pass