### PR TITLE
fix(consumer): incremental frame consumption eliminates pipeline stutter-step

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -167,6 +167,11 @@ public sealed partial class KafkaConnection : IKafkaConnection
     private readonly PendingRequestPool _pendingRequestPool;
     private readonly CancellationTokenSourcePool _timeoutCtsPool;
     private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    // Partial frame assembly state for incremental response consumption.
+    // Only accessed from ReceiveLoopAsync (single-threaded reader).
+    private PartialFrameContext _partialFrame;
+
     private Task? _receiveTask;
     private CancellationTokenSource? _receiveCts;
     private OAuthBearerTokenProvider? _ownedTokenProvider;
@@ -985,28 +990,39 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
                 LogReceivedBytes(buffer.Length, _host, _port);
 
-                while (TryReadResponse(ref buffer, out var correlationId, out var responseData))
+                // Phase 1: Continue assembling a partial frame if one is in progress.
+                // The partial frame consumes data from the pipe buffer as it copies,
+                // keeping the buffer below the pause threshold for large responses.
+                if (_partialFrame.IsActive)
                 {
-                    LogReceivedResponse(correlationId, responseData.Length);
+                    if (ContinuePartialFrame(ref buffer, ref _partialFrame))
+                    {
+                        // Frame complete — dispatch it
+                        var responseData = new PooledResponseBuffer(
+                            _partialFrame.Buffer!, _partialFrame.FrameSize,
+                            _partialFrame.IsPooled, pool: _responseBufferPool);
+                        DispatchResponse(_partialFrame.CorrelationId, responseData);
+                        _partialFrame = default;
+                    }
+                }
 
-                    if (_pendingRequests.TryGetValue(correlationId, out var pending))
+                // Phase 2: Process any complete responses available in the buffer.
+                // This is the fast path for small responses (e.g., producer acks)
+                // that fit entirely within the pipe buffer.
+                if (!_partialFrame.IsActive)
+                {
+                    while (TryReadResponse(ref buffer, out var correlationId, out var responseData))
                     {
-                        if (!pending.TryComplete(responseData))
-                        {
-                            // Request was already cancelled/failed - dispose the buffer
-                            responseData.Dispose();
-                        }
+                        DispatchResponse(correlationId, responseData);
                     }
-                    else if (_cancelledCorrelationIds.TryRemove(correlationId, out _))
+
+                    // Phase 3: If there's a frame header for a large response that doesn't
+                    // fit in the current buffer, start incremental assembly. This rents a
+                    // response buffer, copies what's available, and consumes it from the pipe
+                    // so subsequent reads can continue filling without hitting the pause threshold.
+                    if (!_partialFrame.IsActive && buffer.Length >= 8)
                     {
-                        LogLateResponseForCancelledRequest(correlationId);
-                        responseData.Dispose();
-                    }
-                    else
-                    {
-                        LogUnknownCorrelationId(correlationId);
-                        // No pending request - dispose the buffer
-                        responseData.Dispose();
+                        TryStartPartialFrame(ref buffer, ref _partialFrame, _responseBufferPool);
                     }
                 }
 
@@ -1048,6 +1064,29 @@ public sealed partial class KafkaConnection : IKafkaConnection
             LogReceiveLoopError(ex);
             Volatile.Write(ref _disposed, 1); // Prevent new requests from being queued on a dead connection
             FailAllPendingRequests(ex);
+        }
+    }
+
+    private void DispatchResponse(int correlationId, PooledResponseBuffer responseData)
+    {
+        LogReceivedResponse(correlationId, responseData.Length);
+
+        if (_pendingRequests.TryGetValue(correlationId, out var pending))
+        {
+            if (!pending.TryComplete(responseData))
+            {
+                responseData.Dispose();
+            }
+        }
+        else if (_cancelledCorrelationIds.TryRemove(correlationId, out _))
+        {
+            LogLateResponseForCancelledRequest(correlationId);
+            responseData.Dispose();
+        }
+        else
+        {
+            LogUnknownCorrelationId(correlationId);
+            responseData.Dispose();
         }
     }
 
@@ -1162,6 +1201,14 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
     private void FailAllPendingRequests(Exception ex)
     {
+        // Clean up any partial frame being assembled
+        if (_partialFrame.IsActive)
+        {
+            if (_partialFrame.IsPooled)
+                _responseBufferPool.Pool.Return(_partialFrame.Buffer!);
+            _partialFrame = default;
+        }
+
         // Do NOT remove from _pendingRequests here. The awaiter's finally block in
         // AwaitAndParseResponseAsync (or the catch in SendAsync/SendPipelinedAsync)
         // will TryRemove and return the request to the pool.

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -2194,7 +2194,13 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
         if (available > 0)
         {
-            buffer.Slice(0, available).CopyTo(context.Buffer.AsSpan(context.Offset));
+            var destination = context.Buffer.AsSpan(context.Offset, available);
+
+            if (buffer.IsSingleSegment)
+                buffer.FirstSpan.Slice(0, available).CopyTo(destination);
+            else
+                buffer.Slice(0, available).CopyTo(destination);
+
             context.Offset += available;
             buffer = buffer.Slice(available);
         }

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1016,11 +1016,9 @@ public sealed partial class KafkaConnection : IKafkaConnection
                         DispatchResponse(correlationId, responseData);
                     }
 
-                    // Phase 3: If there's a frame header for a large response that doesn't
-                    // fit in the current buffer, start incremental assembly. This rents a
-                    // response buffer, copies what's available, and consumes it from the pipe
-                    // so subsequent reads can continue filling without hitting the pause threshold.
-                    if (!_partialFrame.IsActive && buffer.Length >= 8)
+                    // Phase 3: Start incremental assembly for frames that don't fit
+                    // in the current buffer, keeping the pipe below the pause threshold.
+                    if (buffer.Length >= 8)
                     {
                         TryStartPartialFrame(ref buffer, ref _partialFrame, _responseBufferPool);
                     }
@@ -1204,8 +1202,9 @@ public sealed partial class KafkaConnection : IKafkaConnection
         // Clean up any partial frame being assembled
         if (_partialFrame.IsActive)
         {
-            if (_partialFrame.IsPooled)
-                _responseBufferPool.Pool.Return(_partialFrame.Buffer!);
+            new PooledResponseBuffer(
+                _partialFrame.Buffer!, _partialFrame.FrameSize,
+                _partialFrame.IsPooled, pool: _responseBufferPool).Dispose();
             _partialFrame = default;
         }
 
@@ -2159,19 +2158,10 @@ public sealed partial class KafkaConnection : IKafkaConnection
         buffer.Slice(4, 4).CopyTo(corrSpan);
         var correlationId = BinaryPrimitives.ReadInt32BigEndian(corrSpan);
 
-        // Rent response buffer
-        byte[] responseArray;
-        bool isPooled;
-        if (frameSize <= responseBufferPool.MaxArrayLength)
-        {
-            responseArray = responseBufferPool.Pool.Rent(frameSize);
-            isPooled = true;
-        }
-        else
-        {
-            responseArray = new byte[frameSize];
-            isPooled = false;
-        }
+        // Rent response buffer (same logic as RentResponseArray instance method)
+        var (responseArray, isPooled) = frameSize <= responseBufferPool.MaxArrayLength
+            ? (responseBufferPool.Pool.Rent(frameSize), true)
+            : (new byte[frameSize], false);
 
         // Copy all available payload (skip the 4-byte size header, it's not part of the response)
         var availablePayload = (int)(buffer.Length - 4);

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -2067,6 +2067,103 @@ public sealed partial class KafkaConnection : IKafkaConnection
     private partial void LogReceiveLoopShutdownRetryFailed(Exception ex, int brokerId);
 
     #endregion
+
+    /// <summary>
+    /// Tracks the state of a response frame being assembled incrementally
+    /// across multiple pipe read cycles. Used when the response is larger
+    /// than what's currently available in the pipe buffer.
+    /// </summary>
+    internal struct PartialFrameContext
+    {
+        public byte[]? Buffer;
+        public int FrameSize;
+        public int Offset;
+        public int CorrelationId;
+        public bool IsPooled;
+
+        public readonly bool IsActive => Buffer is not null;
+        public readonly int Remaining => FrameSize - Offset;
+    }
+
+    /// <summary>
+    /// Called when the pipe buffer has the 4-byte frame size header but not the full payload.
+    /// Rents a response buffer, copies all available data, and consumes it from the pipe.
+    /// Requires at least 8 bytes (4-byte size + 4-byte correlation ID).
+    /// </summary>
+    internal static bool TryStartPartialFrame(
+        ref ReadOnlySequence<byte> buffer,
+        ref PartialFrameContext context,
+        ResponseBufferPool responseBufferPool)
+    {
+        if (buffer.Length < 8) // Need size header + correlation ID
+            return false;
+
+        // Read frame size
+        Span<byte> sizeSpan = stackalloc byte[4];
+        buffer.Slice(0, 4).CopyTo(sizeSpan);
+        var frameSize = BinaryPrimitives.ReadInt32BigEndian(sizeSpan);
+
+        // If the full frame is available, don't start partial — let TryReadResponse handle it
+        if (buffer.Length >= 4 + frameSize)
+            return false;
+
+        // Read correlation ID (first 4 bytes of payload, at offset 4)
+        Span<byte> corrSpan = stackalloc byte[4];
+        buffer.Slice(4, 4).CopyTo(corrSpan);
+        var correlationId = BinaryPrimitives.ReadInt32BigEndian(corrSpan);
+
+        // Rent response buffer
+        byte[] responseArray;
+        bool isPooled;
+        if (frameSize <= responseBufferPool.MaxArrayLength)
+        {
+            responseArray = responseBufferPool.Pool.Rent(frameSize);
+            isPooled = true;
+        }
+        else
+        {
+            responseArray = new byte[frameSize];
+            isPooled = false;
+        }
+
+        // Copy all available payload (skip the 4-byte size header, it's not part of the response)
+        var availablePayload = (int)(buffer.Length - 4);
+        buffer.Slice(4, availablePayload).CopyTo(responseArray);
+
+        context = new PartialFrameContext
+        {
+            Buffer = responseArray,
+            FrameSize = frameSize,
+            Offset = availablePayload,
+            CorrelationId = correlationId,
+            IsPooled = isPooled
+        };
+
+        // Consume everything from the pipe buffer
+        buffer = buffer.Slice(buffer.End);
+        return true;
+    }
+
+    /// <summary>
+    /// Copies available data from the pipe into the partial frame buffer.
+    /// Returns true when the frame is complete.
+    /// </summary>
+    internal static bool ContinuePartialFrame(
+        ref ReadOnlySequence<byte> buffer,
+        ref PartialFrameContext context)
+    {
+        var remaining = context.Remaining;
+        var available = (int)Math.Min(buffer.Length, remaining);
+
+        if (available > 0)
+        {
+            buffer.Slice(0, available).CopyTo(context.Buffer.AsSpan(context.Offset));
+            context.Offset += available;
+            buffer = buffer.Slice(available);
+        }
+
+        return context.Remaining == 0;
+    }
 }
 
 /// <summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorStateTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorStateTests.cs
@@ -351,6 +351,10 @@ public sealed class ConsumerCoordinatorStateTests : IAsyncDisposable
                 Port = 9092
             }));
 
+        // Return error code in response instead of throwing from callback.
+        // NSubstitute callback exceptions on ValueTask<T> methods are unreliable
+        // on some platforms, causing test timeouts. The coordinator checks
+        // response.ErrorCode and throws its own GroupException internally.
         _connection.SendAsync<JoinGroupRequest, JoinGroupResponse>(
                 Arg.Any<JoinGroupRequest>(),
                 Arg.Any<short>(),
@@ -360,10 +364,14 @@ public sealed class ConsumerCoordinatorStateTests : IAsyncDisposable
                 callCount++;
                 if (callCount == 1)
                 {
-                    throw new GroupException(errorCode, $"{errorCode}")
+                    return ValueTask.FromResult(new JoinGroupResponse
                     {
-                        GroupId = "test-group"
-                    };
+                        ErrorCode = errorCode,
+                        MemberId = string.Empty,
+                        GenerationId = -1,
+                        Leader = string.Empty,
+                        Members = []
+                    });
                 }
 
                 return ValueTask.FromResult(new JoinGroupResponse
@@ -522,9 +530,13 @@ public sealed class ConsumerCoordinatorStateTests : IAsyncDisposable
             .Returns(_ =>
             {
                 callCount++;
+                // Use ValueTask.FromException instead of throwing directly from callback.
+                // NSubstitute callback exceptions on ValueTask<T> methods are unreliable
+                // on some platforms, causing test timeouts.
                 if (callCount == 1)
                 {
-                    throw new ObjectDisposedException("Connection disposed");
+                    return ValueTask.FromException<FindCoordinatorResponse>(
+                        new ObjectDisposedException("Connection disposed"));
                 }
 
                 return ValueTask.FromResult(new FindCoordinatorResponse

--- a/tests/Dekaf.Tests.Unit/Networking/IncrementalFrameConsumptionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/IncrementalFrameConsumptionTests.cs
@@ -1,0 +1,222 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using Dekaf.Networking;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public sealed class IncrementalFrameConsumptionTests
+{
+    [Test]
+    public async Task TryStartPartialFrame_LargeFrame_RentsBufferAndCopiesAvailableData()
+    {
+        var correlationId = 99;
+        var totalPayloadSize = 1_048_576; // 1 MB
+        var availableAfterHeader = 65_536; // 64 KB available beyond the 4-byte size header
+
+        var frameData = BuildPartialFrame(correlationId, totalPayloadSize, availableAfterHeader);
+        var buffer = new ReadOnlySequence<byte>(frameData);
+
+        var context = new KafkaConnection.PartialFrameContext();
+        var started = KafkaConnection.TryStartPartialFrame(
+            ref buffer, ref context, ResponseBufferPool.Default);
+
+        await Assert.That(started).IsTrue();
+        await Assert.That(context.FrameSize).IsEqualTo(totalPayloadSize);
+        await Assert.That(context.Offset).IsEqualTo(availableAfterHeader);
+        await Assert.That(context.CorrelationId).IsEqualTo(correlationId);
+        await Assert.That(buffer.Length).IsEqualTo(0);
+
+        ReturnBuffer(ref context);
+    }
+
+    [Test]
+    public async Task TryStartPartialFrame_FullFrameAvailable_ReturnsFalse()
+    {
+        // If the complete frame fits, TryStartPartialFrame should return false
+        // (let TryReadResponse handle it instead)
+        var frame = BuildCompleteFrame(42, 100);
+        var buffer = new ReadOnlySequence<byte>(frame);
+
+        var context = new KafkaConnection.PartialFrameContext();
+        var started = KafkaConnection.TryStartPartialFrame(
+            ref buffer, ref context, ResponseBufferPool.Default);
+
+        await Assert.That(started).IsFalse();
+        await Assert.That(context.IsActive).IsFalse();
+    }
+
+    [Test]
+    public async Task TryStartPartialFrame_LessThan8Bytes_ReturnsFalse()
+    {
+        // Need at least 8 bytes (4 size + 4 correlation ID)
+        var buffer = new ReadOnlySequence<byte>(new byte[7]);
+
+        var context = new KafkaConnection.PartialFrameContext();
+        var started = KafkaConnection.TryStartPartialFrame(
+            ref buffer, ref context, ResponseBufferPool.Default);
+
+        await Assert.That(started).IsFalse();
+    }
+
+    [Test]
+    public async Task ContinuePartialFrame_CompletesAssembly()
+    {
+        var totalSize = 200;
+        var firstChunk = 50;
+        var secondChunk = 150;
+
+        // Build full payload with a recognizable pattern
+        var fullPayload = new byte[totalSize];
+        for (var i = 0; i < totalSize; i++)
+            fullPayload[i] = (byte)(i % 251); // prime to avoid period alignment
+
+        // Simulate: first chunk already copied
+        var responseArray = new byte[totalSize];
+        Array.Copy(fullPayload, 0, responseArray, 0, firstChunk);
+
+        var context = new KafkaConnection.PartialFrameContext
+        {
+            Buffer = responseArray,
+            FrameSize = totalSize,
+            Offset = firstChunk,
+            CorrelationId = 77,
+            IsPooled = false
+        };
+
+        // Provide remaining data
+        var remaining = new ReadOnlySequence<byte>(fullPayload.AsMemory(firstChunk, secondChunk));
+        var completed = KafkaConnection.ContinuePartialFrame(ref remaining, ref context);
+
+        await Assert.That(completed).IsTrue();
+        await Assert.That(context.Offset).IsEqualTo(totalSize);
+        await Assert.That(remaining.Length).IsEqualTo(0);
+        // Verify data integrity
+        await Assert.That(responseArray.AsSpan(0, totalSize).SequenceEqual(fullPayload)).IsTrue();
+    }
+
+    [Test]
+    public async Task ContinuePartialFrame_PartialData_CopiesAndReturnsFalse()
+    {
+        var totalSize = 1000;
+        var alreadyCopied = 100;
+        var newChunk = 300;
+
+        var context = new KafkaConnection.PartialFrameContext
+        {
+            Buffer = new byte[totalSize],
+            FrameSize = totalSize,
+            Offset = alreadyCopied,
+            CorrelationId = 1,
+            IsPooled = false
+        };
+
+        var chunkData = new byte[newChunk];
+        var buffer = new ReadOnlySequence<byte>(chunkData);
+        var completed = KafkaConnection.ContinuePartialFrame(ref buffer, ref context);
+
+        await Assert.That(completed).IsFalse();
+        await Assert.That(context.Offset).IsEqualTo(400); // 100 + 300
+        await Assert.That(buffer.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ContinuePartialFrame_MultipleChunks_AssemblesCorrectly()
+    {
+        var totalSize = 500;
+        var payload = new byte[totalSize];
+        for (var i = 0; i < totalSize; i++)
+            payload[i] = (byte)(i % 251);
+
+        var responseArray = new byte[totalSize];
+        var context = new KafkaConnection.PartialFrameContext
+        {
+            Buffer = responseArray,
+            FrameSize = totalSize,
+            Offset = 0,
+            CorrelationId = 5,
+            IsPooled = false
+        };
+
+        // Feed in 5 chunks of 100 bytes each
+        for (var chunk = 0; chunk < 5; chunk++)
+        {
+            var data = new ReadOnlySequence<byte>(payload.AsMemory(chunk * 100, 100));
+            var completed = KafkaConnection.ContinuePartialFrame(ref data, ref context);
+
+            if (chunk < 4)
+                await Assert.That(completed).IsFalse();
+            else
+                await Assert.That(completed).IsTrue();
+        }
+
+        await Assert.That(responseArray.AsSpan(0, totalSize).SequenceEqual(payload)).IsTrue();
+    }
+
+    [Test]
+    public async Task TryStartPartialFrame_CorrelationId_PreservedCorrectly()
+    {
+        var correlationId = int.MaxValue; // edge case
+        var frameData = BuildPartialFrame(correlationId, 10000, 100);
+        var buffer = new ReadOnlySequence<byte>(frameData);
+
+        var context = new KafkaConnection.PartialFrameContext();
+        KafkaConnection.TryStartPartialFrame(ref buffer, ref context, ResponseBufferPool.Default);
+
+        await Assert.That(context.CorrelationId).IsEqualTo(correlationId);
+
+        ReturnBuffer(ref context);
+    }
+
+    [Test]
+    public async Task ContinuePartialFrame_ExtraDataBeyondFrame_OnlyConsumesNeeded()
+    {
+        var totalSize = 100;
+        var alreadyCopied = 50;
+        var bufferWithExtra = new byte[200]; // 200 bytes available but only 50 needed
+
+        var context = new KafkaConnection.PartialFrameContext
+        {
+            Buffer = new byte[totalSize],
+            FrameSize = totalSize,
+            Offset = alreadyCopied,
+            CorrelationId = 1,
+            IsPooled = false
+        };
+
+        var buffer = new ReadOnlySequence<byte>(bufferWithExtra);
+        var completed = KafkaConnection.ContinuePartialFrame(ref buffer, ref context);
+
+        await Assert.That(completed).IsTrue();
+        await Assert.That(context.Offset).IsEqualTo(totalSize);
+        // Should have consumed only 50 bytes, leaving 150
+        await Assert.That(buffer.Length).IsEqualTo(150);
+    }
+
+    private static byte[] BuildCompleteFrame(int correlationId, int payloadSize)
+    {
+        var frame = new byte[4 + payloadSize];
+        BinaryPrimitives.WriteInt32BigEndian(frame, payloadSize);
+        BinaryPrimitives.WriteInt32BigEndian(frame.AsSpan(4), correlationId);
+        for (var i = 8; i < frame.Length; i++)
+            frame[i] = (byte)(i % 256);
+        return frame;
+    }
+
+    private static byte[] BuildPartialFrame(int correlationId, int totalPayloadSize, int availablePayload)
+    {
+        var frame = new byte[4 + availablePayload];
+        BinaryPrimitives.WriteInt32BigEndian(frame, totalPayloadSize);
+        if (availablePayload >= 4)
+            BinaryPrimitives.WriteInt32BigEndian(frame.AsSpan(4), correlationId);
+        for (var i = 8; i < frame.Length; i++)
+            frame[i] = (byte)(i % 256);
+        return frame;
+    }
+
+    private static void ReturnBuffer(ref KafkaConnection.PartialFrameContext context)
+    {
+        if (context.IsPooled && context.Buffer is not null)
+            ResponseBufferPool.Default.Pool.Return(context.Buffer);
+        context = default;
+    }
+}


### PR DESCRIPTION
## Summary

- **Root cause**: When a Kafka fetch response (e.g., 24 MB) exceeds the pipe's pause threshold (4 MB), `TryReadResponse` requires the entire frame in the pipe buffer before parsing. The pipe writer repeatedly pauses/resumes (~312 cycles for a 24 MB response), collapsing TCP receive windows and reducing consumer throughput from ~400K to ~97K msg/s.
- **Fix**: Instead of requiring the full frame before parsing, the receive loop now copies response data incrementally into a `PooledResponseBuffer` as it arrives, consuming each chunk from the pipe. This keeps the pipe buffer small regardless of response size.
- **Replaces PR #800's approach**: PR 800 threaded a `maxPipelinePauseThreshold` parameter through constructor chains to raise the threshold for consumer connections. This PR eliminates the need for any parameter by changing the behavior — works for any response size with a single 4 MB cap for all connections.
- **Fixes 3 flaky CI tests**: `ConsumerCoordinatorStateTests` tests that threw exceptions from NSubstitute `ValueTask<T>` callbacks — replaced with error response codes and `ValueTask.FromException<T>()`.

## Approach

Three-phase receive loop:
1. **Continue partial frame** — if a partial frame is being assembled, copy available data and consume from pipe
2. **Fast path** — process complete responses via existing `TryReadResponse` (unchanged for small responses like producer acks)
3. **Start partial assembly** — if frame header present but payload incomplete, rent a response buffer, copy what's available, and begin incremental assembly

## Test plan

- [x] All 3459 unit tests pass
- [x] 8 new unit tests for `TryStartPartialFrame`, `ContinuePartialFrame`, and `PartialFrameContext`
- [x] Spec compliance review: PASS
- [x] Code quality review: Approved
- [ ] Integration tests with Docker (CI)
- [ ] Stress tests to verify throughput restoration