### PR TITLE
perf(producer): pooled IValueTaskSource eliminates slow-path allocations

### DIFF
--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -31,6 +31,7 @@ internal static class PoolSizing
         public required int ValueTaskSources { get; init; }
         public required int MaxRetainedBufferSize { get; init; }
         public required int InflightEntries { get; init; }
+        public required int PendingAppends { get; init; }
     }
 
     internal readonly record struct ConnectionPoolSizes
@@ -75,12 +76,15 @@ internal static class PoolSizing
         var bufferDerivedEntries = (long)maxBatches * InflightEntriesPerBatch;
         var inflightEntries = Math.Max(peakInflightEntries, bufferDerivedEntries);
 
+        var pendingAppends = Math.Clamp(clampedMaxConns * clampedMaxInFlight * 4, 64, 1024);
+
         return new ProducerPoolSizes
         {
             ValueTaskSources = Math.Clamp(estimatedMessages, MinValueTaskSources, MaxValueTaskSources),
             // Floor at 256KB to avoid ArrayPool thrash from frequent grow/shrink on modest workloads.
             MaxRetainedBufferSize = Math.Max(batchSize, 256 * 1024),
             InflightEntries = (int)Math.Clamp(inflightEntries, 128L, 16384L),
+            PendingAppends = pendingAppends,
         };
     }
 

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -151,26 +151,42 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     }
 
     /// <summary>
-    /// Attempts to complete the operation successfully (called by drain when memory is available).
+    /// Claims ownership of this operation (CAS from pending to completed).
+    /// Called by <see cref="RecordAccumulator.DrainPendingAppends"/> BEFORE calling
+    /// <see cref="RecordAccumulator.AppendAfterReservation"/> to prevent timeout/cancel
+    /// from cleaning up resources while the drain is using them.
     /// </summary>
-    /// <param name="result">The result of the append operation.</param>
-    /// <returns>True if this call won the completion race; false if already completed.</returns>
-    public bool TryComplete(bool result)
+    /// <returns>True if this call won the race; false if timeout/cancel/dispose already completed it.</returns>
+    public bool TryClaim()
     {
         if (Interlocked.CompareExchange(ref _completed, 1, 0) != 0)
             return false;
 
         DisarmTimerAndCancellation();
-        _core.SetResult(result);
         return true;
     }
 
     /// <summary>
+    /// Sets the successful result after <see cref="TryClaim"/> + AppendAfterReservation.
+    /// Must only be called after <see cref="TryClaim"/> returned true.
+    /// Resources are consumed by AppendAfterReservation — no cleanup needed.
+    /// </summary>
+    public void CompleteResult(bool result) => _core.SetResult(result);
+
+    /// <summary>
+    /// Sets an exception result after <see cref="TryClaim"/> + failed AppendAfterReservation.
+    /// Must only be called after <see cref="TryClaim"/> returned true.
+    /// AppendAfterReservation handles its own resource cleanup on throw.
+    /// </summary>
+    public void CompleteException(Exception exception) => _core.SetException(exception);
+
+    /// <summary>
     /// Attempts to fail the operation with an exception (timeout, cancellation, disposal).
-    /// Cleans up owned resources (PooledMemory, headers, pending produce count) on success.
+    /// Cleans up owned resources (PooledMemory, headers, pending produce count) since
+    /// drain will not process this operation.
     /// </summary>
     /// <param name="exception">The exception to complete with.</param>
-    /// <returns>True if this call won the completion race; false if already completed.</returns>
+    /// <returns>True if this call won the completion race; false if drain already claimed it.</returns>
     public bool TryFail(Exception exception)
     {
         if (Interlocked.CompareExchange(ref _completed, 1, 0) != 0)

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -52,7 +52,6 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     private readonly Timer _timer;
     private CancellationTokenRegistration _cancellationRegistration;
     private long _startTicks;
-    private long _deadline;
     private RecordAccumulator _accumulator = null!;
 
     // Pool return
@@ -107,7 +106,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         Action<RecordMetadata, Exception?>? callback,
         int recordSize,
         long startTicks,
-        long deadline,
+        long deadlineTickCount,
         RecordAccumulator accumulator,
         PendingAppendPool pool,
         CancellationToken cancellationToken)
@@ -123,12 +122,11 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _callback = callback;
         _recordSize = recordSize;
         _startTicks = startTicks;
-        _deadline = deadline;
         _accumulator = accumulator;
         _pool = pool;
 
         // Arm timeout timer. Compute remaining ms from deadline.
-        var remainingMs = deadline - Environment.TickCount64;
+        var remainingMs = deadlineTickCount - Environment.TickCount64;
         if (remainingMs > 0)
         {
             _timer.Change(remainingMs, Timeout.Infinite);

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -51,6 +51,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     // Timeout / cancellation state
     private readonly Timer _timer;
     private CancellationTokenRegistration _cancellationRegistration;
+    private CancellationToken _cancellationToken;
     private long _startTicks;
     private RecordAccumulator _accumulator = null!;
 
@@ -122,6 +123,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _callback = callback;
         _recordSize = recordSize;
         _startTicks = startTicks;
+        _cancellationToken = cancellationToken;
         _accumulator = accumulator;
         _pool = pool;
 
@@ -195,13 +197,36 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         // Clean up owned resources since drain will not process this operation
         _key.Return();
         _value.Return();
-        RecordAccumulator.ReturnPooledHeadersInternal(_headers);
+        RecordAccumulator.ReturnPooledHeaders(_headers);
 
         if (_completionSource is not null)
             _accumulator.DecrementPendingAwaitedProduceCount();
 
         _core.SetException(exception);
         return true;
+    }
+
+    /// <summary>
+    /// Manually returns this instance to the pool when TryFail succeeded but the caller
+    /// bypasses the normal GetResult path (e.g., returning ValueTask.FromException directly).
+    /// Must only be called after TryFail returned true.
+    /// </summary>
+    internal void ReturnToPoolAfterTryFail()
+    {
+        // Clear references to avoid rooting objects
+        _topic = null!;
+        _key = default;
+        _value = default;
+        _headers = null;
+        _completionSource = null;
+        _callback = null;
+        _cancellationToken = default;
+        _accumulator = null!;
+
+        // Reset core (consumes the exception set by TryFail) and return to pool
+        _core.Reset();
+        Volatile.Write(ref _completed, 0);
+        _pool.Return(this);
     }
 
     private void OnTimeout()
@@ -223,7 +248,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
 
     private void OnCancellation()
     {
-        TryFail(new OperationCanceledException());
+        TryFail(new OperationCanceledException(_cancellationToken));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -252,6 +277,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
             _headers = null;
             _completionSource = null;
             _callback = null;
+            _cancellationToken = default;
             _accumulator = null!;
 
             // Reset for reuse

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -19,7 +19,7 @@ namespace Dekaf.Producer;
 /// <para>
 /// Completion is driven by one of four sources (CAS on <c>_completed</c> ensures exactly one wins):
 /// <list type="bullet">
-///   <item><see cref="TryComplete"/> — called by <see cref="RecordAccumulator.DrainPendingAppends"/>
+///   <item><see cref="TryClaim"/> — called by <see cref="RecordAccumulator.DrainPendingAppends"/>
 ///   when buffer space is freed.</item>
 ///   <item>Timeout — <see cref="_timer"/> fires when max.block.ms deadline expires.</item>
 ///   <item>Cancellation — <see cref="CancellationToken.Register"/> callback.</item>
@@ -211,23 +211,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     /// bypasses the normal GetResult path (e.g., returning ValueTask.FromException directly).
     /// Must only be called after TryFail returned true.
     /// </summary>
-    internal void ReturnToPoolAfterTryFail()
-    {
-        // Clear references to avoid rooting objects
-        _topic = null!;
-        _key = default;
-        _value = default;
-        _headers = null;
-        _completionSource = null;
-        _callback = null;
-        _cancellationToken = default;
-        _accumulator = null!;
-
-        // Reset core (consumes the exception set by TryFail) and return to pool
-        _core.Reset();
-        Volatile.Write(ref _completed, 0);
-        _pool.Return(this);
-    }
+    internal void ReturnToPoolAfterTryFail() => ResetAndReturnToPool();
 
     private void OnTimeout()
     {
@@ -251,6 +235,27 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         TryFail(new OperationCanceledException(_cancellationToken));
     }
 
+    /// <summary>
+    /// Clears all references, resets the core for reuse, and returns to the pool.
+    /// Shared by <see cref="IValueTaskSource{T}.GetResult"/> and <see cref="ReturnToPoolAfterTryFail"/>.
+    /// </summary>
+    private void ResetAndReturnToPool()
+    {
+        // Clear references to avoid rooting objects across pool rentals
+        _topic = null!;
+        _key = default;
+        _value = default;
+        _headers = null;
+        _completionSource = null;
+        _callback = null;
+        _cancellationToken = default;
+        _accumulator = null!;
+
+        Volatile.Write(ref _completed, 0);
+        _core.Reset();
+        _pool.Return(this);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void DisarmTimerAndCancellation()
     {
@@ -270,20 +275,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         }
         finally
         {
-            // Clear references before returning to pool to avoid rooting objects
-            _topic = null!;
-            _key = default;
-            _value = default;
-            _headers = null;
-            _completionSource = null;
-            _callback = null;
-            _cancellationToken = default;
-            _accumulator = null!;
-
-            // Reset for reuse
-            Volatile.Write(ref _completed, 0);
-            _core.Reset();
-            _pool.Return(this);
+            ResetAndReturnToPool();
         }
     }
 

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -1,0 +1,259 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks.Sources;
+using Dekaf.Errors;
+using Dekaf.Serialization;
+
+namespace Dekaf.Producer;
+
+/// <summary>
+/// Pooled <see cref="IValueTaskSource{T}"/> that replaces the async state machine
+/// on the producer slow path (buffer full / backpressure).
+/// </summary>
+/// <remarks>
+/// <para>
+/// When <see cref="RecordAccumulator.TryReserveMemory"/> fails, instead of entering an
+/// <c>async ValueTask&lt;bool&gt;</c> method (which allocates ~200+ bytes for the compiler-generated
+/// state machine), the caller rents a <see cref="PendingAppend"/> from a pool, stores all
+/// append parameters, enqueues it, and returns <c>new ValueTask&lt;bool&gt;(op, op.Version)</c>.
+/// </para>
+/// <para>
+/// Completion is driven by one of four sources (CAS on <c>_completed</c> ensures exactly one wins):
+/// <list type="bullet">
+///   <item><see cref="TryComplete"/> — called by <see cref="RecordAccumulator.DrainPendingAppends"/>
+///   when buffer space is freed.</item>
+///   <item>Timeout — <see cref="_timer"/> fires when max.block.ms deadline expires.</item>
+///   <item>Cancellation — <see cref="CancellationToken.Register"/> callback.</item>
+///   <item>Disposal — <see cref="TryFail"/> called during <see cref="RecordAccumulator.DisposeAsync"/>.</item>
+/// </list>
+/// </para>
+/// <para>
+/// The <see cref="Timer"/> is allocated once in the constructor and reused via <c>Change()</c>
+/// across rentals, avoiding per-message timer allocation.
+/// </para>
+/// </remarks>
+internal sealed class PendingAppend : IValueTaskSource<bool>
+{
+    private ManualResetValueTaskSourceCore<bool> _core;
+    private int _completed; // 0 = pending, 1 = completed (CAS guard)
+
+    // Append parameters — stored on Initialize, consumed by drain
+    private string _topic = null!;
+    private int _partition;
+    private long _timestamp;
+    private PooledMemory _key;
+    private PooledMemory _value;
+    private Header[]? _headers;
+    private int _headerCount;
+    private PooledValueTaskSource<RecordMetadata>? _completionSource;
+    private Action<RecordMetadata, Exception?>? _callback;
+    private int _recordSize;
+
+    // Timeout / cancellation state
+    private readonly Timer _timer;
+    private CancellationTokenRegistration _cancellationRegistration;
+    private long _startTicks;
+    private long _deadline;
+    private RecordAccumulator _accumulator = null!;
+
+    // Pool return
+    private PendingAppendPool _pool = null!;
+
+    /// <summary>
+    /// Gets the current version token for <see cref="ValueTask{T}"/> binding.
+    /// </summary>
+    public short Version => _core.Version;
+
+    /// <summary>
+    /// Whether this operation has been completed (drain, timeout, cancel, or dispose).
+    /// </summary>
+    public bool IsCompleted => Volatile.Read(ref _completed) != 0;
+
+    // Expose stored parameters for DrainPendingAppends
+    internal string Topic => _topic;
+    internal int Partition => _partition;
+    internal long Timestamp => _timestamp;
+    internal PooledMemory Key => _key;
+    internal PooledMemory Value => _value;
+    internal Header[]? Headers => _headers;
+    internal int HeaderCount => _headerCount;
+    internal PooledValueTaskSource<RecordMetadata>? CompletionSource => _completionSource;
+    internal Action<RecordMetadata, Exception?>? Callback => _callback;
+    internal int RecordSize => _recordSize;
+
+    public PendingAppend()
+    {
+        // Allocate timer once; it starts dormant (Timeout.Infinite).
+        // Reused across pool rentals via Change().
+        _timer = new Timer(static state =>
+        {
+            var self = (PendingAppend)state!;
+            self.OnTimeout();
+        }, this, Timeout.Infinite, Timeout.Infinite);
+    }
+
+    /// <summary>
+    /// Initializes this instance for a new append operation.
+    /// Must be called after renting from the pool and before enqueuing.
+    /// </summary>
+    internal void Initialize(
+        string topic,
+        int partition,
+        long timestamp,
+        PooledMemory key,
+        PooledMemory value,
+        Header[]? headers,
+        int headerCount,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
+        Action<RecordMetadata, Exception?>? callback,
+        int recordSize,
+        long startTicks,
+        long deadline,
+        RecordAccumulator accumulator,
+        PendingAppendPool pool,
+        CancellationToken cancellationToken)
+    {
+        _topic = topic;
+        _partition = partition;
+        _timestamp = timestamp;
+        _key = key;
+        _value = value;
+        _headers = headers;
+        _headerCount = headerCount;
+        _completionSource = completionSource;
+        _callback = callback;
+        _recordSize = recordSize;
+        _startTicks = startTicks;
+        _deadline = deadline;
+        _accumulator = accumulator;
+        _pool = pool;
+
+        // Arm timeout timer. Compute remaining ms from deadline.
+        var remainingMs = deadline - Environment.TickCount64;
+        if (remainingMs > 0)
+        {
+            _timer.Change(remainingMs, Timeout.Infinite);
+        }
+        else
+        {
+            // Already expired — fire immediately
+            _timer.Change(0, Timeout.Infinite);
+        }
+
+        // Register cancellation callback (zero-alloc if token is not cancellable)
+        if (cancellationToken.CanBeCanceled)
+        {
+            _cancellationRegistration = cancellationToken.Register(static state =>
+            {
+                var self = (PendingAppend)state!;
+                self.OnCancellation();
+            }, this);
+        }
+    }
+
+    /// <summary>
+    /// Attempts to complete the operation successfully (called by drain when memory is available).
+    /// </summary>
+    /// <param name="result">The result of the append operation.</param>
+    /// <returns>True if this call won the completion race; false if already completed.</returns>
+    public bool TryComplete(bool result)
+    {
+        if (Interlocked.CompareExchange(ref _completed, 1, 0) != 0)
+            return false;
+
+        DisarmTimerAndCancellation();
+        _core.SetResult(result);
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to fail the operation with an exception (timeout, cancellation, disposal).
+    /// Cleans up owned resources (PooledMemory, headers, pending produce count) on success.
+    /// </summary>
+    /// <param name="exception">The exception to complete with.</param>
+    /// <returns>True if this call won the completion race; false if already completed.</returns>
+    public bool TryFail(Exception exception)
+    {
+        if (Interlocked.CompareExchange(ref _completed, 1, 0) != 0)
+            return false;
+
+        DisarmTimerAndCancellation();
+
+        // Clean up owned resources since drain will not process this operation
+        _key.Return();
+        _value.Return();
+        RecordAccumulator.ReturnPooledHeadersInternal(_headers);
+
+        if (_completionSource is not null)
+            _accumulator.DecrementPendingAwaitedProduceCount();
+
+        _core.SetException(exception);
+        return true;
+    }
+
+    private void OnTimeout()
+    {
+        var configured = TimeSpan.FromMilliseconds(_accumulator.MaxBlockMsOption);
+        var elapsed = TimeSpan.FromMilliseconds(Environment.TickCount64 - _startTicks);
+
+        var exception = new KafkaTimeoutException(
+            TimeoutKind.MaxBlock,
+            elapsed,
+            configured,
+            $"Failed to allocate buffer within max.block.ms ({_accumulator.MaxBlockMsOption}ms). " +
+            $"Requested {_recordSize} bytes, current usage: {_accumulator.BufferedBytes}/{_accumulator.MaxBufferMemory} bytes. " +
+            $"Producer is generating messages faster than the network can send them. " +
+            $"Consider: increasing BufferMemory, increasing MaxBlockMs, reducing production rate, or checking network connectivity.");
+
+        TryFail(exception);
+    }
+
+    private void OnCancellation()
+    {
+        TryFail(new OperationCanceledException());
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void DisarmTimerAndCancellation()
+    {
+        // Disarm timer (dormant until next rental)
+        _timer.Change(Timeout.Infinite, Timeout.Infinite);
+
+        // Dispose cancellation registration
+        _cancellationRegistration.Dispose();
+        _cancellationRegistration = default;
+    }
+
+    bool IValueTaskSource<bool>.GetResult(short token)
+    {
+        try
+        {
+            return _core.GetResult(token);
+        }
+        finally
+        {
+            // Clear references before returning to pool to avoid rooting objects
+            _topic = null!;
+            _key = default;
+            _value = default;
+            _headers = null;
+            _completionSource = null;
+            _callback = null;
+            _accumulator = null!;
+
+            // Reset for reuse
+            Volatile.Write(ref _completed, 0);
+            _core.Reset();
+            _pool.Return(this);
+        }
+    }
+
+    ValueTaskSourceStatus IValueTaskSource<bool>.GetStatus(short token)
+    {
+        return _core.GetStatus(token);
+    }
+
+    void IValueTaskSource<bool>.OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+    {
+        _core.OnCompleted(continuation, state, token, flags);
+    }
+}

--- a/src/Dekaf/Producer/PendingAppendPool.cs
+++ b/src/Dekaf/Producer/PendingAppendPool.cs
@@ -1,0 +1,68 @@
+using System.Runtime.CompilerServices;
+using Dekaf.Internal;
+
+namespace Dekaf.Producer;
+
+/// <summary>
+/// Thread-safe bounded pool for <see cref="PendingAppend"/> instances.
+/// Uses <see cref="LockFreeStack{T}"/> for zero-allocation Rent/Return in steady state.
+/// </summary>
+/// <remarks>
+/// Follows the same pattern as <see cref="ValueTaskSourcePool{T}"/>.
+/// When the pool is empty, new instances are created on demand.
+/// When returning to a full pool, instances are discarded (GC reclaims).
+/// Pre-warming fills the pool at construction time to avoid cold-start allocations.
+/// </remarks>
+internal sealed class PendingAppendPool
+{
+    private readonly LockFreeStack<PendingAppend> _stack;
+
+    /// <summary>
+    /// Creates a new pool with the specified maximum size.
+    /// </summary>
+    /// <param name="maxPoolSize">Maximum number of instances to keep in the pool.</param>
+    public PendingAppendPool(int maxPoolSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPoolSize);
+        _stack = new LockFreeStack<PendingAppend>(maxPoolSize);
+    }
+
+    /// <summary>
+    /// Gets a <see cref="PendingAppend"/> from the pool, or creates a new one if empty.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public PendingAppend Rent()
+    {
+        if (_stack.TryPop(out var item))
+            return item;
+
+        return new PendingAppend();
+    }
+
+    /// <summary>
+    /// Returns a <see cref="PendingAppend"/> to the pool for reuse.
+    /// If the pool is full, the instance is discarded.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Return(PendingAppend item)
+    {
+        _stack.TryPush(item);
+    }
+
+    /// <summary>
+    /// Pre-allocates instances to avoid cold-start allocation bursts.
+    /// </summary>
+    /// <param name="count">Number of instances to pre-allocate.</param>
+    public void PreWarm(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            _stack.TryPush(new PendingAppend());
+        }
+    }
+
+    /// <summary>
+    /// Gets the approximate number of instances currently in the pool.
+    /// </summary>
+    public int ApproximateCount => _stack.Count;
+}

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2298,13 +2298,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Cold path for <see cref="AppendFromSpansAsync"/>: waits for memory reservation then appends
-    /// using the pre-copied <see cref="PooledMemory"/> data.
-    /// The reservation loop is inlined to avoid allocating a second async state machine.
-    /// </summary>
-    /// <summary>
     /// Zero-allocation slow path for span-based append using pooled <see cref="PendingAppend"/>.
-    /// The spans are already copied to <see cref="PooledMemory"/> by the caller.
+    /// Delegates to <see cref="AppendSlowPathPooled"/> with null completionSource.
     /// </summary>
     private ValueTask<bool> AppendFromSpansSlowPathPooled(
         string topic,
@@ -2318,39 +2313,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int recordSize,
         CancellationToken cancellationToken)
     {
-        if (Volatile.Read(ref _disposed) != 0)
-        {
-            keyPooled.Return();
-            valuePooled.Return();
-            ReturnPooledHeaders(headers);
-            return new ValueTask<bool>(false);
-        }
-
-        if (cancellationToken.IsCancellationRequested)
-        {
-            keyPooled.Return();
-            valuePooled.Return();
-            ReturnPooledHeaders(headers);
-            return ValueTask.FromException<bool>(new OperationCanceledException(cancellationToken));
-        }
-
-        var (startTicks, deadline) = BeginReservationWait(recordSize);
-
-        var op = _pendingAppendPool.Rent();
-        // Span-based path has no completionSource (fire-and-forget with callback)
-        op.Initialize(topic, partition, timestamp, keyPooled, valuePooled, headers, headerCount,
-            null, callback, recordSize, startTicks, deadline,
-            this, _pendingAppendPool, cancellationToken);
-
-        _pendingAppends.Enqueue(op);
-
-        // Try immediate serve — memory may have been freed between TryReserveMemory and now
-        DrainPendingAppends();
-
-        return new ValueTask<bool>(op, op.Version);
+        return AppendSlowPathPooled(topic, partition, timestamp, keyPooled, valuePooled,
+            headers, headerCount, null, callback, recordSize, cancellationToken);
     }
-
-
 
     /// <summary>
     /// Copies a ReadOnlySpan to a PooledMemory backed by ArrayPool.

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1506,61 +1506,79 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         try
         {
-            while (_pendingAppends.TryPeek(out var op))
+            while (true)
             {
-                // Skip already-completed operations (timeout/cancel/dispose won the race)
-                if (op.IsCompleted)
+                var madeProgress = false;
+
+                while (_pendingAppends.TryPeek(out var op))
                 {
+                    // Skip already-completed operations (timeout/cancel/dispose won the race)
+                    if (op.IsCompleted)
+                    {
+                        _pendingAppends.TryDequeue(out _);
+                        madeProgress = true;
+                        continue;
+                    }
+
+                    // Try to reserve memory for this operation
+                    if (!TryReserveMemory(op.RecordSize))
+                        break; // No space — stop draining, next ReleaseMemory will retry
+
+                    // Dequeue — we own the reservation now
                     _pendingAppends.TryDequeue(out _);
-                    continue;
+                    madeProgress = true;
+
+                    // Claim the operation with CAS BEFORE touching resources.
+                    // This prevents timeout/cancel from cleaning up key/value/headers
+                    // while AppendAfterReservation is using them.
+                    if (!op.TryClaim())
+                    {
+                        // Timeout/cancel won the race and already cleaned up resources.
+                        // Release the memory reservation we made above.
+                        ReleaseMemoryWithoutDrain(op.RecordSize);
+                        continue;
+                    }
+
+                    try
+                    {
+                        var result = AppendAfterReservation(
+                            op.Topic, op.Partition, op.Timestamp,
+                            op.Key, op.Value, op.Headers, op.HeaderCount,
+                            op.CompletionSource, op.Callback, op.RecordSize);
+
+                        op.CompleteResult(result);
+                    }
+                    catch (Exception ex)
+                    {
+                        // AppendAfterReservation handles its own resource cleanup on throw
+                        op.CompleteException(ex);
+                    }
                 }
 
-                // Try to reserve memory for this operation
-                if (!TryReserveMemory(op.RecordSize))
-                    break; // No space — stop draining, next ReleaseMemory will retry
+                // Release the drain lock before re-checking so a concurrent ReleaseMemory
+                // can enter if we decide not to loop again.
+                Volatile.Write(ref _draining, 0);
 
-                // Dequeue — we own the reservation now
-                _pendingAppends.TryDequeue(out _);
-
-                // Claim the operation with CAS BEFORE touching resources.
-                // This prevents timeout/cancel from cleaning up key/value/headers
-                // while AppendAfterReservation is using them.
-                if (!op.TryClaim())
+                // Re-check: a ReleaseMemory may have arrived while we held the drain lock,
+                // and new pending items may have been enqueued. Only re-enter if we made
+                // progress last round (prevents infinite loop when head item can't be served).
+                if (!madeProgress
+                    || _pendingAppends.IsEmpty
+                    || (ulong)Volatile.Read(ref _bufferedBytes) >= (ulong)Volatile.Read(ref _maxBufferMemory))
                 {
-                    // Timeout/cancel won the race and already cleaned up resources.
-                    // Release the memory reservation we made above.
-                    ReleaseMemoryWithoutDrain(op.RecordSize);
-                    continue;
+                    return;
                 }
 
-                try
-                {
-                    var result = AppendAfterReservation(
-                        op.Topic, op.Partition, op.Timestamp,
-                        op.Key, op.Value, op.Headers, op.HeaderCount,
-                        op.CompletionSource, op.Callback, op.RecordSize);
-
-                    op.CompleteResult(result);
-                }
-                catch (Exception ex)
-                {
-                    // AppendAfterReservation handles its own resource cleanup on throw
-                    op.CompleteException(ex);
-                }
+                // Re-acquire the drain lock for another pass
+                if (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
+                    return; // Another thread took over
             }
         }
         finally
         {
+            // Ensure drain lock is released even on exception (inner loop already releases
+            // on normal exit, but exception path needs the finally).
             Volatile.Write(ref _draining, 0);
-        }
-
-        // Re-check: a ReleaseMemory may have arrived while we held the drain lock,
-        // and new pending items may have been enqueued. If there's available space,
-        // re-enter to serve them.
-        if (!_pendingAppends.IsEmpty
-            && (ulong)Volatile.Read(ref _bufferedBytes) < (ulong)Volatile.Read(ref _maxBufferMemory))
-        {
-            DrainPendingAppends();
         }
     }
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1522,10 +1522,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 // Dequeue — we own the reservation now
                 _pendingAppends.TryDequeue(out _);
 
-                // If the operation was completed between Peek and here, release the reservation
-                if (op.IsCompleted)
+                // Claim the operation with CAS BEFORE touching resources.
+                // This prevents timeout/cancel from cleaning up key/value/headers
+                // while AppendAfterReservation is using them.
+                if (!op.TryClaim())
                 {
-                    ReleaseMemory(op.RecordSize);
+                    // Timeout/cancel won the race and already cleaned up resources.
+                    // Release the memory reservation we made above.
+                    ReleaseMemoryWithoutDrain(op.RecordSize);
                     continue;
                 }
 
@@ -1536,15 +1540,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         op.Key, op.Value, op.Headers, op.HeaderCount,
                         op.CompletionSource, op.Callback, op.RecordSize);
 
-                    // Complete the pending operation — if it was already completed
-                    // (timeout/cancel), AppendAfterReservation already took ownership
-                    // of the resources, so no cleanup is needed.
-                    op.TryComplete(result);
+                    op.CompleteResult(result);
                 }
                 catch (Exception ex)
                 {
                     // AppendAfterReservation handles its own resource cleanup on throw
-                    op.TryFail(ex);
+                    op.CompleteException(ex);
                 }
             }
         }
@@ -2036,7 +2037,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             return new ValueTask<bool>(false);
         }
 
-        cancellationToken.ThrowIfCancellationRequested();
+        if (cancellationToken.IsCancellationRequested)
+        {
+            key.Return();
+            value.Return();
+            ReturnPooledHeaders(headers);
+            return ValueTask.FromException<bool>(new OperationCanceledException(cancellationToken));
+        }
 
         var (startTicks, deadline) = BeginReservationWait(recordSize);
 
@@ -2376,7 +2383,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             return new ValueTask<bool>(false);
         }
 
-        cancellationToken.ThrowIfCancellationRequested();
+        if (cancellationToken.IsCancellationRequested)
+        {
+            keyPooled.Return();
+            valuePooled.Return();
+            ReturnPooledHeaders(headers);
+            return ValueTask.FromException<bool>(new OperationCanceledException(cancellationToken));
+        }
 
         var (startTicks, deadline) = BeginReservationWait(recordSize);
 
@@ -2877,6 +2890,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         // Signal that space is available — wake async waiters via semaphore.
         SignalBufferSpaceAvailable();
+    }
+
+    /// <summary>
+    /// Releases reserved buffer memory without triggering <see cref="DrainPendingAppends"/>.
+    /// Used inside <see cref="DrainPendingAppends"/> when a claimed operation was already
+    /// completed by timeout/cancel and the memory reservation must be returned.
+    /// Avoids infinite recursion: ReleaseMemory → DrainPendingAppends → ReleaseMemoryWithoutDrain.
+    /// </summary>
+    private void ReleaseMemoryWithoutDrain(int size)
+    {
+        Interlocked.Add(ref _bufferedBytes, -size);
+        // No drain or signal — we're already inside the drain loop.
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1508,15 +1508,19 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             while (true)
             {
+                // Bail if accumulator is being disposed — DisposeAsync will drain the queue.
+                if (Volatile.Read(ref _disposed) != 0)
+                    return;
+
                 var madeProgress = false;
 
                 while (_pendingAppends.TryPeek(out var op))
                 {
-                    // Skip already-completed operations (timeout/cancel/dispose won the race)
+                    // Skip already-completed operations (timeout/cancel/dispose won the race).
+                    // Don't set madeProgress — clearing expired ops doesn't free memory.
                     if (op.IsCompleted)
                     {
                         _pendingAppends.TryDequeue(out _);
-                        madeProgress = true;
                         continue;
                     }
 
@@ -2052,7 +2056,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             key.Return();
             value.Return();
             ReturnPooledHeaders(headers);
-            return new ValueTask<bool>(false);
+            return ValueTask.FromException<bool>(new ObjectDisposedException(nameof(RecordAccumulator)));
         }
 
         if (cancellationToken.IsCancellationRequested)
@@ -2071,6 +2075,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             this, _pendingAppendPool, cancellationToken);
 
         _pendingAppends.Enqueue(op);
+
+        // Close TOCTOU window: if DisposeAsync ran between the _disposed check above and the
+        // Enqueue, this op would sit in the queue until its timer fires. Fail it promptly.
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            if (op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator))))
+                return ValueTask.FromException<bool>(new ObjectDisposedException(nameof(RecordAccumulator)));
+        }
 
         // Try immediate serve — memory may have been freed between TryReserveMemory and now
         DrainPendingAppends();
@@ -3381,11 +3393,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // Wake async waiters blocked in ReserveMemoryAsync so they recheck _disposed.
         SignalBufferSpaceAvailable();
 
-        // Drain and fail all queued PendingAppend operations
+        // Acquire the drain lock to prevent concurrent DrainPendingAppends from
+        // dequeuing ops while we're clearing the queue (avoids TryPeek/TryDequeue mismatch).
+        var spinWait = new SpinWait();
+        while (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
+            spinWait.SpinOnce();
+
         while (_pendingAppends.TryDequeue(out var op))
         {
             op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator)));
         }
+
+        Volatile.Write(ref _draining, 0);
 
         // Cancel the disposal token to interrupt any remaining blocked operations
         // (e.g., append workers, metadata waits). Do this AFTER graceful shutdown attempt

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1000,6 +1000,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private volatile TaskCompletionSource _bufferSpaceSignal = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int _bufferSpaceWaiters; // Number of threads waiting on _bufferSpaceSignal
 
+    // Pooled slow path: replaces async state machine allocation with a pooled IValueTaskSource<bool>.
+    // When TryReserveMemory fails, PendingAppend instances are enqueued here and drained by ReleaseMemory.
+    private readonly PendingAppendPool _pendingAppendPool;
+    private readonly ConcurrentQueue<PendingAppend> _pendingAppends = new();
+    private int _draining; // CAS guard for DrainPendingAppends
+
     /// <summary>
     /// Per-partition state matching Java's Deque&lt;ProducerBatch&gt; design.
     /// The deque holds sealed ReadyBatches waiting to be drained by the sender loop.
@@ -1481,6 +1487,83 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
+    /// Drains the <see cref="_pendingAppends"/> queue, serving queued operations FIFO
+    /// when buffer memory becomes available. Called from <see cref="ReleaseMemory"/>.
+    /// </summary>
+    /// <remarks>
+    /// CAS on <c>_draining</c> ensures only one thread drains at a time. After releasing
+    /// the drain lock, we re-check for pending items with available memory to prevent
+    /// missed signals (a release could arrive while we hold the lock).
+    /// </remarks>
+    internal void DrainPendingAppends()
+    {
+        if (_pendingAppends.IsEmpty)
+            return;
+
+        // Only one thread drains at a time — others return immediately.
+        if (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
+            return;
+
+        try
+        {
+            while (_pendingAppends.TryPeek(out var op))
+            {
+                // Skip already-completed operations (timeout/cancel/dispose won the race)
+                if (op.IsCompleted)
+                {
+                    _pendingAppends.TryDequeue(out _);
+                    continue;
+                }
+
+                // Try to reserve memory for this operation
+                if (!TryReserveMemory(op.RecordSize))
+                    break; // No space — stop draining, next ReleaseMemory will retry
+
+                // Dequeue — we own the reservation now
+                _pendingAppends.TryDequeue(out _);
+
+                // If the operation was completed between Peek and here, release the reservation
+                if (op.IsCompleted)
+                {
+                    ReleaseMemory(op.RecordSize);
+                    continue;
+                }
+
+                try
+                {
+                    var result = AppendAfterReservation(
+                        op.Topic, op.Partition, op.Timestamp,
+                        op.Key, op.Value, op.Headers, op.HeaderCount,
+                        op.CompletionSource, op.Callback, op.RecordSize);
+
+                    // Complete the pending operation — if it was already completed
+                    // (timeout/cancel), AppendAfterReservation already took ownership
+                    // of the resources, so no cleanup is needed.
+                    op.TryComplete(result);
+                }
+                catch (Exception ex)
+                {
+                    // AppendAfterReservation handles its own resource cleanup on throw
+                    op.TryFail(ex);
+                }
+            }
+        }
+        finally
+        {
+            Volatile.Write(ref _draining, 0);
+        }
+
+        // Re-check: a ReleaseMemory may have arrived while we held the drain lock,
+        // and new pending items may have been enqueued. If there's available space,
+        // re-enter to serve them.
+        if (!_pendingAppends.IsEmpty
+            && (ulong)Volatile.Read(ref _bufferedBytes) < (ulong)Volatile.Read(ref _maxBufferMemory))
+        {
+            DrainPendingAppends();
+        }
+    }
+
+    /// <summary>
     /// Broadcasts a buffer-space-available signal, waking ALL async waiters simultaneously.
     /// Completes the current TCS and swaps in a fresh one for future waiters.
     /// This is O(1) wake latency vs the O(N) serial convoy of SemaphoreSlim.
@@ -1528,6 +1611,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         _batchPool = new PartitionBatchPool(options, maxPoolSize: poolSize);
         _batchPool.SetReadyBatchPool(_readyBatchPool); // Wire up pools
         _maxBufferMemory = (long)options.BufferMemory;
+
+        // PendingAppend pool for the zero-allocation slow path.
+        // Pool size scales with max connections × max in-flight.
+        var producerPoolSizes = PoolSizing.ForProducer(options.BufferMemory, options.BatchSize,
+            options.MaxInFlightRequestsPerConnection, options.MaxConnectionsPerBroker);
+        _pendingAppendPool = new PendingAppendPool(producerPoolSizes.PendingAppends);
+        _pendingAppendPool.PreWarm(Math.Min(producerPoolSizes.PendingAppends / 4, 32));
 
         // Pre-warm a small number of pool entries to cover initial burst without
         // excessive upfront memory usage. The pools grow lazily on demand after this.
@@ -1844,8 +1934,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             return new ValueTask<bool>(AppendAfterReservation(topic, partition, timestamp, key, value,
                 headers, headerCount, completionSource, callback, recordSize));
 
-        // Cold path: buffer full, await async reservation (backpressure)
-        return AppendSlowPath(topic, partition, timestamp, key, value,
+        // Cold path: buffer full — enqueue pooled PendingAppend (zero async state machine allocation)
+        return AppendSlowPathPooled(topic, partition, timestamp, key, value,
             headers, headerCount, completionSource, callback, recordSize, cancellationToken);
     }
 
@@ -1920,7 +2010,50 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return true;
     }
 
-    private async ValueTask<bool> AppendSlowPath(
+    /// <summary>
+    /// Zero-allocation slow path using pooled <see cref="PendingAppend"/>.
+    /// Enqueues the operation and returns a <see cref="ValueTask{T}"/> backed by the pooled source.
+    /// Drain serves it when <see cref="ReleaseMemory"/> frees buffer space.
+    /// </summary>
+    private ValueTask<bool> AppendSlowPathPooled(
+        string topic,
+        int partition,
+        long timestamp,
+        PooledMemory key,
+        PooledMemory value,
+        Header[]? headers,
+        int headerCount,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
+        Action<RecordMetadata, Exception?>? callback,
+        int recordSize,
+        CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            key.Return();
+            value.Return();
+            ReturnPooledHeaders(headers);
+            return new ValueTask<bool>(false);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var (startTicks, deadline) = BeginReservationWait(recordSize);
+
+        var op = _pendingAppendPool.Rent();
+        op.Initialize(topic, partition, timestamp, key, value, headers, headerCount,
+            completionSource, callback, recordSize, startTicks, deadline,
+            this, _pendingAppendPool, cancellationToken);
+
+        _pendingAppends.Enqueue(op);
+
+        // Try immediate serve — memory may have been freed between TryReserveMemory and now
+        DrainPendingAppends();
+
+        return new ValueTask<bool>(op, op.Version);
+    }
+
+    private async ValueTask<bool> AppendSlowPathLegacy(
         string topic,
         int partition,
         long timestamp,
@@ -2146,7 +2279,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var keyPooled = keyIsNull ? PooledMemory.Null : CopySpanToPooledMemory(keyData);
         var valuePooled = valueIsNull ? PooledMemory.Null : CopySpanToPooledMemory(valueData);
 
-        return AppendFromSpansAsyncSlowPath(topic, partition, timestamp, keyPooled, valuePooled,
+        return AppendFromSpansSlowPathPooled(topic, partition, timestamp, keyPooled, valuePooled,
             headers, headerCount, callback, recordSize, cancellationToken);
     }
 
@@ -2219,7 +2352,49 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// using the pre-copied <see cref="PooledMemory"/> data.
     /// The reservation loop is inlined to avoid allocating a second async state machine.
     /// </summary>
-    private async ValueTask<bool> AppendFromSpansAsyncSlowPath(
+    /// <summary>
+    /// Zero-allocation slow path for span-based append using pooled <see cref="PendingAppend"/>.
+    /// The spans are already copied to <see cref="PooledMemory"/> by the caller.
+    /// </summary>
+    private ValueTask<bool> AppendFromSpansSlowPathPooled(
+        string topic,
+        int partition,
+        long timestamp,
+        PooledMemory keyPooled,
+        PooledMemory valuePooled,
+        Header[]? headers,
+        int headerCount,
+        Action<RecordMetadata, Exception?>? callback,
+        int recordSize,
+        CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            keyPooled.Return();
+            valuePooled.Return();
+            ReturnPooledHeaders(headers);
+            return new ValueTask<bool>(false);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var (startTicks, deadline) = BeginReservationWait(recordSize);
+
+        var op = _pendingAppendPool.Rent();
+        // Span-based path has no completionSource (fire-and-forget with callback)
+        op.Initialize(topic, partition, timestamp, keyPooled, valuePooled, headers, headerCount,
+            null, callback, recordSize, startTicks, deadline,
+            this, _pendingAppendPool, cancellationToken);
+
+        _pendingAppends.Enqueue(op);
+
+        // Try immediate serve — memory may have been freed between TryReserveMemory and now
+        DrainPendingAppends();
+
+        return new ValueTask<bool>(op, op.Version);
+    }
+
+    private async ValueTask<bool> AppendFromSpansAsyncSlowPathLegacy(
         string topic,
         int partition,
         long timestamp,
@@ -2420,6 +2595,25 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     public ulong MaxBufferMemory => (ulong)Volatile.Read(ref _maxBufferMemory);
 
     /// <summary>
+    /// The configured max.block.ms value. Exposed for <see cref="PendingAppend"/> timeout diagnostics.
+    /// </summary>
+    internal int MaxBlockMsOption => _options.MaxBlockMs;
+
+    /// <summary>
+    /// Exposes <see cref="ReturnPooledHeaders"/> for <see cref="PendingAppend"/> resource cleanup.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ReturnPooledHeadersInternal(Header[]? headers) => ReturnPooledHeaders(headers);
+
+    /// <summary>
+    /// Decrements the pending awaited produce count. Called by <see cref="PendingAppend"/>
+    /// when it fails before drain processes the operation.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void DecrementPendingAwaitedProduceCount() =>
+        Interlocked.Decrement(ref _pendingAwaitedProduceCount);
+
+    /// <summary>
     /// Atomically updates the maximum buffer memory limit. Used by the global
     /// memory budget for dynamic rebalancing.
     /// Growing the limit signals waiting producers so they re-check immediately.
@@ -2544,8 +2738,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// and the max.block.ms deadline. Must be called after <see cref="BeginReservationWait"/>.
     /// </summary>
     /// <remarks>
-    /// The two production slow paths (<see cref="AppendSlowPath"/> and
-    /// <see cref="AppendFromSpansAsyncSlowPath"/>) inline this loop body to avoid allocating
+    /// The two legacy production slow paths (<see cref="AppendSlowPathLegacy"/> and
+    /// <see cref="AppendFromSpansAsyncSlowPathLegacy"/>) inline this loop body to avoid allocating
     /// a second async state machine per cold-path message. This method is the canonical
     /// version used by <see cref="ReserveMemoryAsync"/> (called from tests).
     /// KEEP IN SYNC: any changes here must be mirrored in both inlined copies.
@@ -2676,6 +2870,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 $"reservation/release mismatch bug.");
 #endif
         }
+
+        // First try to serve queued PendingAppend operations with the freed space.
+        // This avoids the TCS allocation + async wakeup overhead when pending ops exist.
+        DrainPendingAppends();
 
         // Signal that space is available — wake async waiters via semaphore.
         SignalBufferSpaceAvailable();
@@ -3322,6 +3520,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         // Wake async waiters blocked in ReserveMemoryAsync so they recheck _disposed.
         SignalBufferSpaceAvailable();
+
+        // Drain and fail all queued PendingAppend operations
+        while (_pendingAppends.TryDequeue(out var op))
+        {
+            op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator)));
+        }
 
         // Cancel the disposal token to interrupt any remaining blocked operations
         // (e.g., append workers, metadata waits). Do this AFTER graceful shutdown attempt

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1830,7 +1830,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ReturnPooledHeaders(Header[]? headers)
+    internal static void ReturnPooledHeaders(Header[]? headers)
     {
         if (headers is not null)
             ProducerContainerPools.Headers.Return(headers);
@@ -2080,8 +2080,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // Enqueue, this op would sit in the queue until its timer fires. Fail it promptly.
         if (Volatile.Read(ref _disposed) != 0)
         {
-            if (op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator))))
-                return ValueTask.FromException<bool>(new ObjectDisposedException(nameof(RecordAccumulator)));
+            var disposedException = new ObjectDisposedException(nameof(RecordAccumulator));
+            if (op.TryFail(disposedException))
+            {
+                // Caller gets a pre-built exception ValueTask, so nobody will call GetResult
+                // on this op. Manually return it to the pool to avoid leaking.
+                op.ReturnToPoolAfterTryFail();
+                return ValueTask.FromException<bool>(disposedException);
+            }
         }
 
         // Try immediate serve — memory may have been freed between TryReserveMemory and now
@@ -2460,12 +2466,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// The configured max.block.ms value. Exposed for <see cref="PendingAppend"/> timeout diagnostics.
     /// </summary>
     internal int MaxBlockMsOption => _options.MaxBlockMs;
-
-    /// <summary>
-    /// Exposes <see cref="ReturnPooledHeaders"/> for <see cref="PendingAppend"/> resource cleanup.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void ReturnPooledHeadersInternal(Header[]? headers) => ReturnPooledHeaders(headers);
 
     /// <summary>
     /// Decrements the pending awaited produce count. Called by <see cref="PendingAppend"/>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2078,81 +2078,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return new ValueTask<bool>(op, op.Version);
     }
 
-    private async ValueTask<bool> AppendSlowPathLegacy(
-        string topic,
-        int partition,
-        long timestamp,
-        PooledMemory key,
-        PooledMemory value,
-        Header[]? headers,
-        int headerCount,
-        PooledValueTaskSource<RecordMetadata>? completionSource,
-        Action<RecordMetadata, Exception?>? callback,
-        int recordSize,
-        CancellationToken cancellationToken)
-    {
-        // Inlined reservation loop — avoids allocating a second async state machine
-        // for ReserveMemoryAsync. One state machine instead of two per cold-path message.
-        // KEEP IN SYNC with WaitForReservationAsync and the other inlined copy.
-        var (startTicks, deadline) = BeginReservationWait(recordSize);
-
-        try
-        {
-            while (!TryReserveMemory(recordSize))
-            {
-                if (Volatile.Read(ref _disposed) != 0)
-                    throw new ObjectDisposedException(nameof(RecordAccumulator));
-
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var remainingMs = deadline - Environment.TickCount64;
-                if (remainingMs <= 0)
-                    ThrowBufferMemoryTimeout(recordSize, startTicks);
-
-                Interlocked.Increment(ref _bufferSpaceWaiters);
-
-                // Re-check AFTER incrementing to close the missed-signal window.
-                // Without this, ReleaseMemory can see waiters=0 and skip the signal.
-                if ((ulong)Volatile.Read(ref _bufferedBytes) < (ulong)Volatile.Read(ref _maxBufferMemory))
-                {
-                    Interlocked.Decrement(ref _bufferSpaceWaiters);
-                    continue; // space likely available, re-evaluate TryReserveMemory
-                }
-
-                try
-                {
-                    await _bufferSpaceSignal.Task.WaitAsync(
-                        TimeSpan.FromMilliseconds(Math.Min(remainingMs, int.MaxValue)),
-                        cancellationToken
-                    ).ConfigureAwait(false);
-                }
-                catch (TimeoutException)
-                {
-                    // Timed out waiting for signal — loop back and re-check.
-                }
-                catch (OperationCanceledException) when (Volatile.Read(ref _disposed) != 0)
-                {
-                    throw new ObjectDisposedException(nameof(RecordAccumulator));
-                }
-                finally
-                {
-                    Interlocked.Decrement(ref _bufferSpaceWaiters);
-                }
-            }
-        }
-        catch
-        {
-            key.Return();
-            value.Return();
-            ReturnPooledHeaders(headers);
-            throw;
-        }
-
-        return AppendAfterReservation(topic, partition, timestamp, key, value,
-            headers, headerCount, completionSource, callback, recordSize);
-    }
-
-
     /// <summary>
     /// Non-blocking variant of Append for the ProduceAsync fast path.
     /// Returns false when buffer is full (caller falls back to async slow path)
@@ -2425,78 +2350,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return new ValueTask<bool>(op, op.Version);
     }
 
-    private async ValueTask<bool> AppendFromSpansAsyncSlowPathLegacy(
-        string topic,
-        int partition,
-        long timestamp,
-        PooledMemory keyPooled,
-        PooledMemory valuePooled,
-        Header[]? headers,
-        int headerCount,
-        Action<RecordMetadata, Exception?>? callback,
-        int recordSize,
-        CancellationToken cancellationToken)
-    {
-        // Inlined reservation loop — avoids allocating a second async state machine
-        // for ReserveMemoryAsync. One state machine instead of two per cold-path message.
-        // KEEP IN SYNC with WaitForReservationAsync and the other inlined copy.
-        var (startTicks, deadline) = BeginReservationWait(recordSize);
 
-        try
-        {
-            while (!TryReserveMemory(recordSize))
-            {
-                if (Volatile.Read(ref _disposed) != 0)
-                    throw new ObjectDisposedException(nameof(RecordAccumulator));
-
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var remainingMs = deadline - Environment.TickCount64;
-                if (remainingMs <= 0)
-                    ThrowBufferMemoryTimeout(recordSize, startTicks);
-
-                Interlocked.Increment(ref _bufferSpaceWaiters);
-
-                // Re-check AFTER incrementing to close the missed-signal window.
-                // Without this, ReleaseMemory can see waiters=0 and skip the signal.
-                if ((ulong)Volatile.Read(ref _bufferedBytes) < (ulong)Volatile.Read(ref _maxBufferMemory))
-                {
-                    Interlocked.Decrement(ref _bufferSpaceWaiters);
-                    continue; // space likely available, re-evaluate TryReserveMemory
-                }
-
-                try
-                {
-                    await _bufferSpaceSignal.Task.WaitAsync(
-                        TimeSpan.FromMilliseconds(Math.Min(remainingMs, int.MaxValue)),
-                        cancellationToken
-                    ).ConfigureAwait(false);
-                }
-                catch (TimeoutException)
-                {
-                    // Timed out waiting for signal — loop back and re-check.
-                }
-                catch (OperationCanceledException) when (Volatile.Read(ref _disposed) != 0)
-                {
-                    throw new ObjectDisposedException(nameof(RecordAccumulator));
-                }
-                finally
-                {
-                    Interlocked.Decrement(ref _bufferSpaceWaiters);
-                }
-            }
-        }
-        catch
-        {
-            keyPooled.Return();
-            valuePooled.Return();
-            ReturnPooledHeaders(headers);
-            throw;
-        }
-
-        return AppendAfterReservation(topic, partition, timestamp, keyPooled, valuePooled,
-            headers, headerCount, null, callback, recordSize);
-    }
 
     /// <summary>
     /// Copies a ReadOnlySpan to a PooledMemory backed by ArrayPool.
@@ -2769,11 +2623,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// and the max.block.ms deadline. Must be called after <see cref="BeginReservationWait"/>.
     /// </summary>
     /// <remarks>
-    /// The two legacy production slow paths (<see cref="AppendSlowPathLegacy"/> and
-    /// <see cref="AppendFromSpansAsyncSlowPathLegacy"/>) inline this loop body to avoid allocating
-    /// a second async state machine per cold-path message. This method is the canonical
-    /// version used by <see cref="ReserveMemoryAsync"/> (called from tests).
-    /// KEEP IN SYNC: any changes here must be mirrored in both inlined copies.
+    /// Used by <see cref="ReserveMemoryAsync"/> (called from tests).
+    /// The production slow paths now use the pooled <see cref="PendingAppend"/> mechanism
+    /// instead of inlining this loop.
     /// </remarks>
     private async ValueTask WaitForReservationAsync(int recordSize, long startTicks, long deadline,
         CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1822,7 +1822,7 @@ public class RecordAccumulatorTests
                 if (bufferedBytes > 0)
                     accumulator.ReleaseMemory(bufferedBytes);
 
-                await Task.Delay(1);
+                await Task.Yield();
             }
 
             // The append should complete successfully

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1811,13 +1811,19 @@ public class RecordAccumulatorTests
                     largeValue, valueIsNull: false,
                     null, 0, null, CancellationToken.None));
 
-            // Yield to let the background task enqueue the PendingAppend
-            for (var i = 0; i < 100 && !appendTask.IsCompleted; i++)
-                await Task.Yield();
+            // Release enough memory to serve the pending append.
+            // Use a retry loop: if the background task hasn't enqueued yet,
+            // ReleaseMemory won't drain anything, but the task's own
+            // DrainPendingAppends call after Enqueue will pick it up.
+            // We retry to cover the case where memory was released before the enqueue.
+            while (!appendTask.IsCompleted)
+            {
+                var bufferedBytes = (int)accumulator.BufferedBytes;
+                if (bufferedBytes > 0)
+                    accumulator.ReleaseMemory(bufferedBytes);
 
-            // Release enough memory to serve the pending append
-            var bufferedBytes = (int)accumulator.BufferedBytes;
-            accumulator.ReleaseMemory(bufferedBytes);
+                await Task.Delay(1);
+            }
 
             // The append should complete successfully
             var result = await appendTask.WaitAsync(TimeSpan.FromSeconds(5));

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1782,5 +1782,52 @@ public class RecordAccumulatorTests
         }
     }
 
+    [Test]
+    public async Task AppendFromSpansAsync_SlowPath_CompletesWhenMemoryReleased()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            BufferMemory = 4096,
+            BatchSize = 4096,
+            LingerMs = 10,
+            MaxBlockMs = 5000
+        };
+        var accumulator = new RecordAccumulator(options);
+
+        try
+        {
+            // Fill buffer via hot path
+            await FillBufferViaHotPath(accumulator, 100);
+
+            var largeValue = new byte[2048];
+
+            // Start an append that will block in the slow path
+            var appendTask = Task.Run(async () =>
+                await accumulator.AppendFromSpansAsync(
+                    "test-topic", 0,
+                    DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                    largeValue, valueIsNull: false,
+                    null, 0, null, CancellationToken.None));
+
+            // Yield to let the background task enqueue the PendingAppend
+            for (var i = 0; i < 100 && !appendTask.IsCompleted; i++)
+                await Task.Yield();
+
+            // Release enough memory to serve the pending append
+            var bufferedBytes = (int)accumulator.BufferedBytes;
+            accumulator.ReleaseMemory(bufferedBytes);
+
+            // The append should complete successfully
+            var result = await appendTask.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(result).IsTrue();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Summary

- Replaces the async state machine on the producer slow path (buffer full / backpressure) with a pooled `IValueTaskSource<bool>` (`PendingAppend`), eliminating ~200+ bytes of allocation per message when the buffer is full
- Adds `PendingAppendPool` backed by `LockFreeStack<T>` for zero-allocation rent/return in steady state
- Implements CAS-guarded drain mechanism in `RecordAccumulator` that serves queued operations FIFO when `ReleaseMemory` frees buffer space
- Handles completion races between drain, timeout, cancellation, and disposal via `TryClaim`/`TryFail` CAS pattern

**Motivation:** Stress tests showed the idempotent producer with a single connection allocated ~410 GB in 15 minutes (vs 3.28 GB with 3 connections) due to per-message async state machine allocations on the slow path.

## Test plan

- [x] All 3475 unit tests pass
- [x] New test `AppendFromSpansAsync_SlowPath_CompletesWhenMemoryReleased` verifies drain mechanism
- [ ] Run stress tests to verify allocation reduction with single-connection idempotent producer
- [ ] Verify no regression in multi-connection scenarios