### PR TITLE
perf(consumer): defer _positions writes to batch boundary in auto-commit mode

### DIFF
--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -119,6 +119,8 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
 
     /// <summary>
     /// Gets the current position (next offset to consume) for a partition.
+    /// In auto-commit mode, reflects the last fully-processed batch boundary;
+    /// for per-message accuracy, use manual commit mode.
     /// </summary>
     long? GetPosition(TopicPartition partition);
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1089,6 +1089,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
                             pending.TrackConsumed(offset, messageBytes);
 
+                            // Update consumed position per-message so GetPosition()/CommitAsync()
+                            // reflect the latest message the app has seen, even mid-batch.
+                            // Required for manual commit and graceful shutdown patterns.
+                            _positions[pending.TopicPartition] = offset + 1;
+
                             // Apply OnConsume interceptors before yielding to user
                             // Uses hoisted hasInterceptors to skip method call when no interceptors
                             if (hasInterceptors)
@@ -1123,24 +1128,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                     previousActivity?.Dispose();
                     previousActivity = null;
 
-                    // Batch-level position updates (once per partition-fetch, not per message).
-                    // _positions is deferred here to avoid a ConcurrentDictionary write per
-                    // message (~60-100ns each). Auto-commit reads _positions periodically
-                    // (every 5s), so batch-granularity is sufficient. On early break, the
-                    // finally block below flushes _positions from LastYieldedOffset.
-                    // _fetchPositions controls where the next fetch request starts from.
+                    // Batch-level position flush: _positions was already updated per-message
+                    // above; _fetchPositions is updated here once per partition-fetch.
                     // In prefetch mode, the prefetch thread already advances _fetchPositions
-                    // via UpdateFetchPositionsFromPrefetch — including for faulted fetches,
-                    // since _fetchPositions was set at prefetch time before the fault occurred.
-                    if (pending.LastYieldedOffset >= 0)
-                    {
-                        _positions[pending.TopicPartition] = pending.LastYieldedOffset + 1;
-
-                        if (!_prefetchEnabled)
-                        {
-                            _fetchPositions[pending.TopicPartition] = pending.LastYieldedOffset + 1;
-                        }
-                    }
+                    // via UpdateFetchPositionsFromPrefetch, so we skip it here.
+                    FlushConsumedPositions(pending);
 
                     // Record consumer metrics per-fetch instead of per-message.
                     // PendingFetchData already tracks MessageCount and TotalBytesConsumed,
@@ -1171,13 +1163,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 if (_pendingFetches.Count > 0)
                 {
                     var current = _pendingFetches.Peek();
-                    if (current.LastYieldedOffset >= 0)
-                    {
-                        _positions[current.TopicPartition] = current.LastYieldedOffset + 1;
-
-                        if (!_prefetchEnabled)
-                            _fetchPositions[current.TopicPartition] = current.LastYieldedOffset + 1;
-                    }
+                    FlushConsumedPositions(current);
 
                     if (metricsEnabled && current.MessageCount > 0)
                         EmitFetchMetrics(current);
@@ -1299,15 +1285,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                     yield return batch;
 
                     // After caller finishes iterating: update positions once per batch
-                    if (pending.LastYieldedOffset >= 0)
-                    {
-                        _positions[pending.TopicPartition] = pending.LastYieldedOffset + 1;
-
-                        if (!_prefetchEnabled)
-                        {
-                            _fetchPositions[pending.TopicPartition] = pending.LastYieldedOffset + 1;
-                        }
-                    }
+                    FlushConsumedPositions(pending);
 
                     // Record consumer metrics per-fetch
                     if (metricsEnabled && pending.MessageCount > 0)
@@ -1441,15 +1419,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                     yield return batch;
 
                     // After caller finishes iterating: update positions once per batch
-                    if (pending.LastYieldedOffset >= 0)
-                    {
-                        _positions[pending.TopicPartition] = pending.LastYieldedOffset + 1;
-
-                        if (!_prefetchEnabled)
-                        {
-                            _fetchPositions[pending.TopicPartition] = pending.LastYieldedOffset + 1;
-                        }
-                    }
+                    FlushConsumedPositions(pending);
 
                     // Record consumer metrics per-fetch
                     if (metricsEnabled && pending.MessageCount > 0)
@@ -1866,6 +1836,27 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
         // If no pending items were created but we have a memory owner, dispose it
         memoryOwner?.Dispose();
+    }
+
+    /// <summary>
+    /// Updates <see cref="_positions"/> and, when not in prefetch mode, <see cref="_fetchPositions"/>
+    /// from the given pending fetch data. Called at batch boundaries and in finally blocks.
+    /// In prefetch mode, <see cref="_fetchPositions"/> is managed by <see cref="UpdateFetchPositionsFromPrefetch"/>.
+    /// </summary>
+    private void FlushConsumedPositions(PendingFetchData pending)
+    {
+        if (pending.LastYieldedOffset < 0)
+            return;
+
+        var tp = pending.TopicPartition;
+        var nextOffset = pending.LastYieldedOffset + 1;
+
+        _positions[tp] = nextOffset;
+
+        if (!_prefetchEnabled)
+        {
+            _fetchPositions[tp] = nextOffset;
+        }
     }
 
     private void UpdateFetchPositionsFromPrefetch(PendingFetchData pending)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1089,11 +1089,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
                             pending.TrackConsumed(offset, messageBytes);
 
-                            // Update consumed position per-message so GetPosition()/CommitAsync()
-                            // reflect the latest message the app has seen, even mid-batch.
-                            // Required for manual commit and graceful shutdown patterns.
-                            _positions[pending.TopicPartition] = offset + 1;
-
                             // Apply OnConsume interceptors before yielding to user
                             // Uses hoisted hasInterceptors to skip method call when no interceptors
                             if (hasInterceptors)
@@ -1128,14 +1123,23 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                     previousActivity?.Dispose();
                     previousActivity = null;
 
-                    // Batch-level fetch position update (once per partition-fetch, not per message).
+                    // Batch-level position updates (once per partition-fetch, not per message).
+                    // _positions is deferred here to avoid a ConcurrentDictionary write per
+                    // message (~60-100ns each). Auto-commit reads _positions periodically
+                    // (every 5s), so batch-granularity is sufficient. On early break, the
+                    // finally block below flushes _positions from LastYieldedOffset.
                     // _fetchPositions controls where the next fetch request starts from.
                     // In prefetch mode, the prefetch thread already advances _fetchPositions
                     // via UpdateFetchPositionsFromPrefetch — including for faulted fetches,
                     // since _fetchPositions was set at prefetch time before the fault occurred.
-                    if (pending.LastYieldedOffset >= 0 && !_prefetchEnabled)
+                    if (pending.LastYieldedOffset >= 0)
                     {
-                        _fetchPositions[pending.TopicPartition] = pending.LastYieldedOffset + 1;
+                        _positions[pending.TopicPartition] = pending.LastYieldedOffset + 1;
+
+                        if (!_prefetchEnabled)
+                        {
+                            _fetchPositions[pending.TopicPartition] = pending.LastYieldedOffset + 1;
+                        }
                     }
 
                     // Record consumer metrics per-fetch instead of per-message.
@@ -1161,15 +1165,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 // Ensure activity is disposed if caller breaks out of enumeration early
                 previousActivity?.Dispose();
 
-                // Flush fetch position and metrics for any partially-iterated pending fetch.
+                // Flush positions and metrics for any partially-iterated pending fetch.
                 // Only relevant when the caller breaks early or an exception propagates;
                 // on normal loop exit _pendingFetches is empty and this is a no-op.
-                // _positions is already up-to-date (written per-message above).
                 if (_pendingFetches.Count > 0)
                 {
                     var current = _pendingFetches.Peek();
-                    if (current.LastYieldedOffset >= 0 && !_prefetchEnabled)
-                        _fetchPositions[current.TopicPartition] = current.LastYieldedOffset + 1;
+                    if (current.LastYieldedOffset >= 0)
+                    {
+                        _positions[current.TopicPartition] = current.LastYieldedOffset + 1;
+
+                        if (!_prefetchEnabled)
+                            _fetchPositions[current.TopicPartition] = current.LastYieldedOffset + 1;
+                    }
 
                     if (metricsEnabled && current.MessageCount > 0)
                         EmitFetchMetrics(current);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1131,10 +1131,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                     previousActivity?.Dispose();
                     previousActivity = null;
 
-                    // Batch-level position flush: _positions was already updated per-message
-                    // above; _fetchPositions is updated here once per partition-fetch.
-                    // In prefetch mode, the prefetch thread already advances _fetchPositions
-                    // via UpdateFetchPositionsFromPrefetch, so we skip it here.
+                    // Batch-level position flush. In manual-commit mode _positions was
+                    // already updated per-message; in auto-commit mode this is the first
+                    // _positions write. _fetchPositions is updated here once per partition-fetch
+                    // (in prefetch mode it is managed by UpdateFetchPositionsFromPrefetch).
                     FlushConsumedPositions(pending);
 
                     // Record consumer metrics per-fetch instead of per-message.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1000,6 +1000,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 var hasTraceListeners = Diagnostics.DekafDiagnostics.Source.HasListeners();
                 var hasInterceptors = _interceptors is not null;
                 var rawTrackingEnabled = _rawRecordTrackingEnabled;
+                var manualCommit = _options.OffsetCommitMode == OffsetCommitMode.Manual;
 
                 while (_pendingFetches.Count > 0)
                 {
@@ -1089,10 +1090,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
                             pending.TrackConsumed(offset, messageBytes);
 
-                            // Update consumed position per-message so GetPosition()/CommitAsync()
-                            // reflect the latest message the app has seen, even mid-batch.
-                            // Required for manual commit and graceful shutdown patterns.
-                            _positions[pending.TopicPartition] = offset + 1;
+                            // Manual-commit: update _positions per-message so GetPosition()/
+                            // CommitAsync() reflect the latest message mid-batch.
+                            // Auto-commit: skip per-message write (~60-100ns ConcurrentDictionary
+                            // cost); _positions is flushed once per batch in FlushConsumedPositions().
+                            if (manualCommit)
+                                _positions[pending.TopicPartition] = offset + 1;
 
                             // Apply OnConsume interceptors before yielding to user
                             // Uses hoisted hasInterceptors to skip method call when no interceptors

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorStateTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorStateTests.cs
@@ -403,7 +403,9 @@ public sealed class ConsumerCoordinatorStateTests : IAsyncDisposable
                 ErrorCode = ErrorCode.None
             }));
 
-        var options = CreateOptions();
+        // Use a shorter rebalance timeout: the test only needs 1 retry (~200ms delay),
+        // but on slow CI runners (threadpool starvation) the default 30s can be exceeded.
+        var options = CreateOptions(rebalanceTimeoutMs: 10000);
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
 
         await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
@@ -580,7 +582,9 @@ public sealed class ConsumerCoordinatorStateTests : IAsyncDisposable
                 ErrorCode = ErrorCode.None
             }));
 
-        var options = CreateOptions();
+        // Use a shorter rebalance timeout: the test only needs 1 retry (~200ms delay),
+        // but on slow CI runners (threadpool starvation) the default 30s can be exceeded.
+        var options = CreateOptions(rebalanceTimeoutMs: 10000);
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
 
         await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);

--- a/tests/Dekaf.Tests.Unit/Consumer/PrefetchPipelineRunnerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PrefetchPipelineRunnerTests.cs
@@ -1511,6 +1511,9 @@ public class PrefetchPipelineRunnerTests
         var completeCalled = false;
         var fetchCount = 0;
         var loggedErrors = new List<Exception>();
+        // Deterministic cancellation: cancel as soon as the faulted fetch is queued,
+        // instead of relying on a time-based CTS that may exceed CI runner capacity.
+        using var cts = new CancellationTokenSource();
 
         var runner = CreateRunner(
             prefetchRecords: ct =>
@@ -1525,9 +1528,10 @@ public class PrefetchPipelineRunnerTests
             },
             ensureAssignment: ct =>
             {
-                // Cancel after first iteration to trigger disposal path
+                // Cancel deterministically after the faulted fetch is queued
                 if (fetchCount >= 2)
-                    ct.ThrowIfCancellationRequested();
+                    cts.Cancel();
+                ct.ThrowIfCancellationRequested();
                 return ValueTask.CompletedTask;
             },
             assignmentCount: 1,
@@ -1536,7 +1540,6 @@ public class PrefetchPipelineRunnerTests
             onComplete: _ => completeCalled = true,
             logError: ex => loggedErrors.Add(ex));
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await runner.RunAsync(cts.Token);
 
         // Exception from in-flight fetch was observed (logged), not leaked


### PR DESCRIPTION
## Summary

- **Skip per-message `_positions` ConcurrentDictionary write in auto-commit mode.** Auto-commit reads `_positions` every ~5s, so batch-granularity updates via `FlushConsumedPositions()` are sufficient. This eliminates ~60-100ns of hash computation + bucket lock per message in the hot path.
- **Manual-commit retains per-message writes** so `GetPosition()` and `CommitAsync()` reflect the latest consumed offset mid-batch.
- **Extract `FlushConsumedPositions()` helper** consolidating position update logic across 4 call sites (batch boundary, finally block, ConsumeBatchAsync, ConsumeRawBatchAsync).
- **Fix finally-block gap**: previously the early-break path only flushed `_fetchPositions`, now also flushes `_positions`.

## Design

The optimization uses a hoisted boolean (`var manualCommit = ...`) evaluated once per `ConsumeAsync()` call. In auto-commit mode, `_positions` is written once per partition-fetch batch (~1000 messages) instead of per message. `FlushConsumedPositions()` at the batch boundary and in the finally block ensures `_positions` is always consistent when the consume loop yields control.

## Test plan

- [x] All 3,506 unit tests pass (1 pre-existing failure in BufferMemoryTests unrelated to this change)
- [ ] Integration tests pass in CI
- [ ] Stress test comparison shows throughput improvement for auto-commit consumers

Tracking deeper structural improvements in #809.