### PR TITLE
fix(consumer): complete per-partition state cleanup during rebalance

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -27,6 +27,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private volatile int _generationId = -1;
     private string? _leaderId;
     private IReadOnlyList<JoinGroupResponseMember>? _groupMembers;
+    // Volatile ensures cross-thread visibility of the reference. Thread-safety relies on
+    // all writes replacing the reference entirely (never in-place mutation) — verified at
+    // every assignment site: ParseAssignment (line ~524) and DisposeAsync (line ~1306).
     private volatile HashSet<TopicPartition> _assignedPartitions = [];
     private readonly SemaphoreSlim _lock = new(1, 1);
     private readonly object _heartbeatGuard = new();
@@ -72,6 +75,15 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     public bool IsLeader => _memberId is not null && _memberId == _leaderId;
     public CoordinatorState State => _state;
     public IReadOnlySet<TopicPartition> Assignment => _assignedPartitions;
+
+    /// <summary>
+    /// Forces the coordinator to rejoin the group on the next
+    /// <see cref="EnsureActiveGroupAsync"/> call by transitioning to <see cref="CoordinatorState.Unjoined"/>.
+    /// </summary>
+    internal void RequestRejoin()
+    {
+        _state = CoordinatorState.Unjoined;
+    }
 
     /// <summary>
     /// Ensures the consumer has joined the group.

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -316,7 +316,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
-            var connection = await _connectionPool.GetConnectionByIndexAsync(brokers[0].NodeId, _getCoordinationConnectionIndex(), cancellationToken)
+            // Cycle through brokers on retries to avoid wasting all attempts on one slow broker.
+            var broker = brokers[attempt % brokers.Count];
+            var connection = await _connectionPool.GetConnectionByIndexAsync(broker.NodeId, _getCoordinationConnectionIndex(), cancellationToken)
                 .ConfigureAwait(false);
 
             // Use negotiated API version
@@ -635,7 +637,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                         && _state == CoordinatorState.Stable
                         && ge.ErrorCode is ErrorCode.UnknownMemberId or ErrorCode.IllegalGeneration)
                     {
-                        var lostPartitions = _assignedPartitions.ToList();
+                        // Volatile.Read ensures we see the latest reference even without _lock —
+                        // _assignedPartitions is replaced (not mutated) under _lock, and
+                        // reference assignment is atomic, so the snapshot is a stable HashSet.
+                        var lostPartitions = Volatile.Read(ref _assignedPartitions).ToList();
                         if (lostPartitions.Count > 0)
                         {
                             try

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -27,7 +27,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private volatile int _generationId = -1;
     private string? _leaderId;
     private IReadOnlyList<JoinGroupResponseMember>? _groupMembers;
-    private HashSet<TopicPartition> _assignedPartitions = [];
+    private volatile HashSet<TopicPartition> _assignedPartitions = [];
     private readonly SemaphoreSlim _lock = new(1, 1);
     private readonly object _heartbeatGuard = new();
     private CancellationTokenSource? _heartbeatCts;
@@ -637,10 +637,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                         && _state == CoordinatorState.Stable
                         && ge.ErrorCode is ErrorCode.UnknownMemberId or ErrorCode.IllegalGeneration)
                     {
-                        // Volatile.Read ensures we see the latest reference even without _lock —
-                        // _assignedPartitions is replaced (not mutated) under _lock, and
-                        // reference assignment is atomic, so the snapshot is a stable HashSet.
-                        var lostPartitions = Volatile.Read(ref _assignedPartitions).ToList();
+                        var lostPartitions = _assignedPartitions.ToList();
                         if (lostPartitions.Count > 0)
                         {
                             try

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -704,6 +704,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     public IReadOnlySet<TopicPartition> Assignment => _assignmentSnapshot;
     public string? MemberId => _coordinator?.MemberId;
     public IReadOnlySet<TopicPartition> Paused => _pausedSnapshot;
+    /// <summary>
+    /// Forces the coordinator to rejoin the group on the next <see cref="EnsureAssignmentAsync"/> call.
+    /// No-op when the consumer has no group coordinator (manual assignment mode).
+    /// </summary>
+    internal void RequestRejoin() => _coordinator?.RequestRejoin();
 
     /// <summary>
     /// Gets the consumer group metadata for use with transactional producers.
@@ -906,15 +911,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
     public IKafkaConsumer<TKey, TValue> IncrementalUnassign(IEnumerable<TopicPartition> partitions)
     {
+        // Materialize once: the enumerable is iterated three times (assignment removal,
+        // state cleanup, fetch buffer clear) and a forward-only sequence would silently
+        // yield zero items on the second and third passes.
+        var partitionList = partitions as IReadOnlyList<TopicPartition> ?? partitions.ToList();
+
         var hadPaused = false;
         SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
         try
         {
-            foreach (var partition in partitions)
+            foreach (var partition in partitionList)
             {
                 _assignment.Remove(partition);
             }
-            hadPaused = RemovePartitionState(partitions);
+            hadPaused = RemovePartitionState(partitionList);
 
             PublishAssignmentSnapshot();
         }
@@ -924,7 +934,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         }
 
         // Clear any pending fetch data for the removed partitions
-        ClearFetchBufferForPartitions(partitions);
+        ClearFetchBufferForPartitions(partitionList);
 
         if (hadPaused)
             PublishPausedSnapshot();

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -450,7 +450,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     private volatile IReadOnlySet<TopicPartition> _pausedSnapshot = new HashSet<TopicPartition>();
 
     // Pattern subscription support
-    private Func<string, bool>? _topicFilter;
+    private volatile Func<string, bool>? _topicFilter;
     private long _lastFilterRefreshTicks;
 
     // Thread-safety notes:

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -881,6 +881,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 _positions.TryRemove(partition, out _);
                 _fetchPositions.TryRemove(partition, out _);
                 _committed.TryRemove(partition, out _);
+                _watermarks.TryRemove(partition, out _);
+                _highWatermarks.TryRemove(partition, out _);
+                _eofEmitted.TryRemove(partition, out _);
             }
 
             PublishAssignmentSnapshot();
@@ -2527,6 +2530,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
     private async ValueTask EnsureAssignmentAsync(CancellationToken cancellationToken)
     {
+        // Refresh pattern subscription BEFORE acquiring the lock — RefreshFilteredTopicsAsync
+        // only touches thread-safe structures (ConcurrentDictionary, volatile snapshots,
+        // MetadataManager with its own locking) and involves a network call that would block
+        // both the consume loop and prefetch loop if done under _assignmentLock.
+        if (_topicFilter is not null)
+        {
+            await RefreshFilteredTopicsAsync(cancellationToken).ConfigureAwait(false);
+        }
+
         // Serialize the write path: both ConsumeAsync and PrefetchLoopAsync call this method
         // concurrently. Without synchronization, concurrent access to non-thread-safe
         // _assignment HashSet causes NullReferenceException during enumeration.
@@ -2534,12 +2546,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         await SemaphoreHelper.AcquireOrThrowDisposedAsync(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>), cancellationToken).ConfigureAwait(false);
         try
         {
-            // If a pattern filter is active, refresh the subscription from metadata
-            if (_topicFilter is not null)
-            {
-                await RefreshFilteredTopicsAsync(cancellationToken).ConfigureAwait(false);
-            }
-
             if (!_subscription.IsEmpty && _coordinator is not null)
             {
                 await _coordinator.EnsureActiveGroupAsync(_subscriptionSnapshot, cancellationToken).ConfigureAwait(false);
@@ -2591,11 +2597,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 // Clean up state for removed partitions
                 if (removedPartitions is not null)
                 {
+                    var hadPaused = false;
                     foreach (var partition in removedPartitions)
                     {
                         _highWatermarks.TryRemove(partition, out _);
                         _positions.TryRemove(partition, out _);
                         _fetchPositions.TryRemove(partition, out _);
+                        _committed.TryRemove(partition, out _);
+                        _watermarks.TryRemove(partition, out _);
+                        hadPaused |= _paused.TryRemove(partition, out _);
                     }
 
                     // Clean up EOF state
@@ -2603,6 +2613,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                     {
                         _eofEmitted.TryRemove(partition, out _);
                     }
+
+                    if (hadPaused)
+                        PublishPausedSnapshot();
                 }
 
                 // Initialize positions for new partitions

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -877,14 +877,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             foreach (var partition in partitions)
             {
                 _assignment.Remove(partition);
-                _paused.TryRemove(partition, out _);
-                _positions.TryRemove(partition, out _);
-                _fetchPositions.TryRemove(partition, out _);
-                _committed.TryRemove(partition, out _);
-                _watermarks.TryRemove(partition, out _);
-                _highWatermarks.TryRemove(partition, out _);
-                _eofEmitted.TryRemove(partition, out _);
             }
+            RemovePartitionState(partitions);
 
             PublishAssignmentSnapshot();
         }
@@ -2145,6 +2139,26 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         return this;
     }
 
+    /// <summary>
+    /// Removes per-partition tracking state for the given partitions.
+    /// Returns true if any partition was in the paused set.
+    /// </summary>
+    private bool RemovePartitionState(IEnumerable<TopicPartition> partitions)
+    {
+        var hadPaused = false;
+        foreach (var partition in partitions)
+        {
+            _positions.TryRemove(partition, out _);
+            _fetchPositions.TryRemove(partition, out _);
+            _committed.TryRemove(partition, out _);
+            _highWatermarks.TryRemove(partition, out _);
+            _watermarks.TryRemove(partition, out _);
+            _eofEmitted.TryRemove(partition, out _);
+            hadPaused |= _paused.TryRemove(partition, out _);
+        }
+        return hadPaused;
+    }
+
     private void ClearFetchBuffer()
     {
         // Dispose and clear pending fetches to release pooled memory
@@ -2598,24 +2612,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 // Clean up state for removed partitions
                 if (removedPartitions is not null)
                 {
-                    var hadPaused = false;
-                    foreach (var partition in removedPartitions)
-                    {
-                        _highWatermarks.TryRemove(partition, out _);
-                        _positions.TryRemove(partition, out _);
-                        _fetchPositions.TryRemove(partition, out _);
-                        _committed.TryRemove(partition, out _);
-                        _watermarks.TryRemove(partition, out _);
-                        hadPaused |= _paused.TryRemove(partition, out _);
-                    }
-
-                    // Clean up EOF state
-                    foreach (var partition in removedPartitions)
-                    {
-                        _eofEmitted.TryRemove(partition, out _);
-                    }
-
-                    if (hadPaused)
+                    if (RemovePartitionState(removedPartitions))
                         PublishPausedSnapshot();
                 }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -551,40 +551,33 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         IDeserializer<TValue> valueDeserializer,
         ILoggerFactory? loggerFactory = null,
         MetadataOptions? metadataOptions = null)
+        : this(options, keyDeserializer, valueDeserializer,
+            CreateInfrastructure(options, loggerFactory, metadataOptions),
+            loggerFactory)
     {
-        _options = options;
-        _currentQueuedMaxBytes = (long)((ulong)options.QueuedMaxMessagesKbytes * 1024UL);
-        _keyDeserializer = keyDeserializer;
-        _valueDeserializer = valueDeserializer;
+    }
 
-        // Derive consumer pool sizes from configuration
-        // Use 64 as default partition count estimate — covers most workloads.
-        // PendingFetchData uses a ratchet, so this only increases over time.
-        var consumerSizes = PoolSizing.ForConsumer(maxPartitionCount: 64);
-        PendingFetchData.RatchetPoolSize(consumerSizes.FetchDataPool);
-        _ctsPool = new CancellationTokenSourcePool(consumerSizes.CancellationTokenSources);
-        _logger = loggerFactory?.CreateLogger<KafkaConsumer<TKey, TValue>>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaConsumer<TKey, TValue>>.Instance;
+    /// <summary>
+    /// Internal constructor for unit testing — accepts pre-built infrastructure dependencies
+    /// so tests can inject mock <see cref="IConnectionPool"/> and <see cref="MetadataManager"/>.
+    /// </summary>
+    internal KafkaConsumer(
+        ConsumerOptions options,
+        IDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer,
+        IConnectionPool connectionPool,
+        MetadataManager metadataManager,
+        ILoggerFactory? loggerFactory = null)
+        : this(options, keyDeserializer, valueDeserializer,
+            (connectionPool, metadataManager),
+            loggerFactory)
+    {
+    }
 
-        ArgumentOutOfRangeException.ThrowIfLessThan(options.ConnectionsPerBroker, 1);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(options.ConnectionsPerBroker, options.MaxConnectionsPerBroker);
-
-        GcConfigurationCheck.WarnIfWorkstationGc(_logger);
-
-        // Initialize interceptors from options
-        if (options.Interceptors is { Count: > 0 })
-        {
-            var interceptors = new IConsumerInterceptor<TKey, TValue>[options.Interceptors.Count];
-            for (var i = 0; i < options.Interceptors.Count; i++)
-            {
-                interceptors[i] = (IConsumerInterceptor<TKey, TValue>)options.Interceptors[i];
-            }
-            _interceptors = interceptors;
-        }
-
-        // Consumer connections use the default MaxInFlightRequestsPerConnection (5).
-        // Unlike the producer, consumers don't expose this setting — fetch requests are
-        // inherently sequential per partition, so the default is appropriate.
-        _connectionPool = new ConnectionPool(
+    private static (IConnectionPool, MetadataManager) CreateInfrastructure(
+        ConsumerOptions options, ILoggerFactory? loggerFactory, MetadataOptions? metadataOptions)
+    {
+        var connectionPool = new ConnectionPool(
             options.ClientId,
             new ConnectionOptions
             {
@@ -604,11 +597,53 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             connectionsPerBroker: options.ConnectionsPerBroker,
             ResponseBufferPool.Create(options.FetchMaxBytes));
 
-        _metadataManager = new MetadataManager(
-            _connectionPool,
+        var metadataManager = new MetadataManager(
+            connectionPool,
             options.BootstrapServers,
             options: metadataOptions,
             logger: loggerFactory?.CreateLogger<MetadataManager>());
+
+        return (connectionPool, metadataManager);
+    }
+
+    private KafkaConsumer(
+        ConsumerOptions options,
+        IDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer,
+        (IConnectionPool Pool, MetadataManager Metadata) infrastructure,
+        ILoggerFactory? loggerFactory)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.ConnectionsPerBroker, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(options.ConnectionsPerBroker, options.MaxConnectionsPerBroker);
+
+        _options = options;
+        _currentQueuedMaxBytes = (long)((ulong)options.QueuedMaxMessagesKbytes * 1024UL);
+        _keyDeserializer = keyDeserializer;
+        _valueDeserializer = valueDeserializer;
+
+        // Derive consumer pool sizes from configuration
+        // Use 64 as default partition count estimate — covers most workloads.
+        // PendingFetchData uses a ratchet, so this only increases over time.
+        var consumerSizes = PoolSizing.ForConsumer(maxPartitionCount: 64);
+        PendingFetchData.RatchetPoolSize(consumerSizes.FetchDataPool);
+        _ctsPool = new CancellationTokenSourcePool(consumerSizes.CancellationTokenSources);
+        _logger = loggerFactory?.CreateLogger<KafkaConsumer<TKey, TValue>>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaConsumer<TKey, TValue>>.Instance;
+
+        GcConfigurationCheck.WarnIfWorkstationGc(_logger);
+
+        // Initialize interceptors from options
+        if (options.Interceptors is { Count: > 0 })
+        {
+            var interceptors = new IConsumerInterceptor<TKey, TValue>[options.Interceptors.Count];
+            for (var i = 0; i < options.Interceptors.Count; i++)
+            {
+                interceptors[i] = (IConsumerInterceptor<TKey, TValue>)options.Interceptors[i];
+            }
+            _interceptors = interceptors;
+        }
+
+        _connectionPool = infrastructure.Pool;
+        _metadataManager = infrastructure.Metadata;
 
         _compressionCodecs = CompressionCodecRegistry.Default;
 
@@ -871,6 +906,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
     public IKafkaConsumer<TKey, TValue> IncrementalUnassign(IEnumerable<TopicPartition> partitions)
     {
+        var hadPaused = false;
         SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
         try
         {
@@ -878,7 +914,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             {
                 _assignment.Remove(partition);
             }
-            RemovePartitionState(partitions);
+            hadPaused = RemovePartitionState(partitions);
 
             PublishAssignmentSnapshot();
         }
@@ -890,7 +926,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         // Clear any pending fetch data for the removed partitions
         ClearFetchBufferForPartitions(partitions);
 
-        PublishPausedSnapshot();
+        if (hadPaused)
+            PublishPausedSnapshot();
         InvalidatePartitionCache();
         InvalidateFetchRequestCache();
         return this;
@@ -2541,7 +2578,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         return changed;
     }
 
-    private async ValueTask EnsureAssignmentAsync(CancellationToken cancellationToken)
+    internal async ValueTask EnsureAssignmentAsync(CancellationToken cancellationToken)
     {
         // Refresh pattern subscription BEFORE acquiring the lock — RefreshFilteredTopicsAsync
         // only touches thread-safe structures (ConcurrentDictionary, volatile snapshots,

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2468,7 +2468,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     /// Rate-limited to avoid excessive metadata requests (30 second interval).
     /// </summary>
     /// <returns>True if the subscription changed.</returns>
-    private async ValueTask<bool> RefreshFilteredTopicsAsync(CancellationToken cancellationToken)
+    private async ValueTask<bool> RefreshFilteredTopicsAsync(Func<string, bool> filter, CancellationToken cancellationToken)
     {
         const long refreshIntervalTicks = 30 * TimeSpan.TicksPerSecond;
 
@@ -2487,7 +2487,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         await _metadataManager.RefreshMetadataAsync(cancellationToken).ConfigureAwait(false);
 
         var allTopics = _metadataManager.Metadata.GetTopics();
-        var filter = _topicFilter!;
         var changed = false;
 
         // Build new subscription from matching topics
@@ -2534,9 +2533,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         // only touches thread-safe structures (ConcurrentDictionary, volatile snapshots,
         // MetadataManager with its own locking) and involves a network call that would block
         // both the consume loop and prefetch loop if done under _assignmentLock.
-        if (_topicFilter is not null)
+        // Capture to local to avoid TOCTOU: Subscribe() can set _topicFilter = null concurrently.
+        var topicFilter = _topicFilter;
+        if (topicFilter is not null)
         {
-            await RefreshFilteredTopicsAsync(cancellationToken).ConfigureAwait(false);
+            await RefreshFilteredTopicsAsync(topicFilter, cancellationToken).ConfigureAwait(false);
         }
 
         // Serialize the write path: both ConsumeAsync and PrefetchLoopAsync call this method

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorStateTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorStateTests.cs
@@ -606,6 +606,131 @@ public sealed class ConsumerCoordinatorStateTests : IAsyncDisposable
         }).Throws<ObjectDisposedException>();
     }
 
+    [Test]
+    public async Task FindCoordinator_CyclesThroughBrokersOnRetry()
+    {
+        // Arrange: two brokers — broker 0 returns CoordinatorNotAvailable, broker 1 succeeds.
+        // This verifies the attempt % brokers.Count cycling logic.
+        var connection0 = Substitute.For<IKafkaConnection>();
+        var connection1 = Substitute.For<IKafkaConnection>();
+
+        // Override the default connection pool mock: route by the brokerId (first arg).
+        _connectionPool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var brokerId = callInfo.ArgAt<int>(0);
+                return ValueTask.FromResult(brokerId == 1 ? connection1 : connection0);
+            });
+
+        // Seed metadata with 2 brokers
+        _metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 },
+                new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9093 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    Name = "test-topic",
+                    ErrorCode = ErrorCode.None,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            PartitionIndex = 0,
+                            LeaderId = 0,
+                            ErrorCode = ErrorCode.None,
+                            ReplicaNodes = [0],
+                            IsrNodes = [0]
+                        }
+                    ]
+                }
+            ]
+        });
+
+        // Broker 0: always returns CoordinatorNotAvailable.
+        // Host must be set because the v0-v3 response path reads it before checking the error code.
+        connection0.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                ErrorCode = ErrorCode.CoordinatorNotAvailable,
+                Host = "",
+                NodeId = -1,
+                Port = -1
+            }));
+
+        // Broker 1: succeeds
+        connection1.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                ErrorCode = ErrorCode.None,
+                NodeId = 0,
+                Host = "localhost",
+                Port = 9092
+            }));
+
+        // JoinGroup/SyncGroup/Heartbeat go via the coordinator connection (NodeId 0)
+        connection0.SendAsync<JoinGroupRequest, JoinGroupResponse>(
+                Arg.Any<JoinGroupRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new JoinGroupResponse
+            {
+                ErrorCode = ErrorCode.None,
+                MemberId = "member-1",
+                GenerationId = 1,
+                Leader = "member-1",
+                Members = []
+            }));
+
+        connection0.SendAsync<SyncGroupRequest, SyncGroupResponse>(
+                Arg.Any<SyncGroupRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new SyncGroupResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Assignment = []
+            }));
+
+        connection0.SendAsync<HeartbeatRequest, HeartbeatResponse>(
+                Arg.Any<HeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new HeartbeatResponse
+            {
+                ErrorCode = ErrorCode.None
+            }));
+
+        var options = CreateOptions(rebalanceTimeoutMs: 10000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        // Act
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        // Assert: broker 0 received a FindCoordinator call (and failed), broker 1 also received one (and succeeded)
+        await connection0.Received().SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+            Arg.Any<FindCoordinatorRequest>(),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+
+        await connection1.Received().SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+            Arg.Any<FindCoordinatorRequest>(),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+    }
+
     #endregion
 
     #region Heartbeat Error Handling and State Transitions

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorStateTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorStateTests.cs
@@ -3,7 +3,7 @@ using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
-using Dekaf.Producer; // TopicPartition is defined in this namespace
+using Dekaf.Producer;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using NSubstitute;
@@ -1124,35 +1124,8 @@ public sealed class ConsumerCoordinatorStateTests : IAsyncDisposable
         }
     }
 
-    /// <summary>
-    /// Builds a consumer protocol assignment byte array containing the given topic-partitions.
-    /// Uses the same wire format as ConsumerCoordinator.BuildAssignmentData.
-    /// </summary>
     private static byte[] BuildAssignmentData(string topic, int[] partitions)
-    {
-        var buffer = new System.Buffers.ArrayBufferWriter<byte>();
-        var writer = new KafkaProtocolWriter(buffer);
-
-        // Version
-        writer.WriteInt16(0);
-
-        // Topics array
-        var topicAssignments = new List<(string Topic, int[] Partitions)> { (topic, partitions) };
-        writer.WriteArray(
-            topicAssignments,
-            (ref KafkaProtocolWriter w, (string Topic, int[] Partitions) tp) =>
-            {
-                w.WriteString(tp.Topic);
-                w.WriteArray(
-                    tp.Partitions,
-                    (ref KafkaProtocolWriter w2, int partition) => w2.WriteInt32(partition));
-            });
-
-        // User data
-        writer.WriteBytes([]);
-
-        return buffer.WrittenSpan.ToArray();
-    }
+        => ConsumerTestHelpers.BuildAssignmentData(topic, partitions);
 
     #endregion
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerTestHelpers.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerTestHelpers.cs
@@ -1,0 +1,40 @@
+using System.Buffers;
+using Dekaf.Protocol;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+/// <summary>
+/// Shared helpers for consumer unit tests.
+/// </summary>
+internal static class ConsumerTestHelpers
+{
+    /// <summary>
+    /// Builds a consumer protocol assignment byte array containing the given topic-partitions.
+    /// Uses the same wire format as ConsumerCoordinator.BuildAssignmentData.
+    /// </summary>
+    internal static byte[] BuildAssignmentData(string topic, int[] partitions)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        // Version
+        writer.WriteInt16(0);
+
+        // Topics array
+        var topicAssignments = new List<(string Topic, int[] Partitions)> { (topic, partitions) };
+        writer.WriteArray(
+            topicAssignments,
+            (ref KafkaProtocolWriter w, (string Topic, int[] Partitions) tp) =>
+            {
+                w.WriteString(tp.Topic);
+                w.WriteArray(
+                    tp.Partitions,
+                    (ref KafkaProtocolWriter w2, int partition) => w2.WriteInt32(partition));
+            });
+
+        // User data
+        writer.WriteBytes([]);
+
+        return buffer.WrittenSpan.ToArray();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/IncrementalAssignmentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/IncrementalAssignmentTests.cs
@@ -240,9 +240,10 @@ public class IncrementalAssignmentTests
             new TopicPartition("topic1", 0),
             new TopicPartition("topic1", 1));
 
-        // Watermark offsets are not set via public API (they come from fetch responses),
-        // so after IncrementalUnassign the cache entry should be absent.
-        // Verify baseline: no watermarks cached for either partition.
+        // Limitation: _watermarks is only populated by fetch responses (private path),
+        // so this test can only verify the public API returns null — it cannot inject a
+        // stale entry to prove TryRemove fires. Full regression coverage requires an
+        // integration test with a real Kafka broker.
         await Assert.That(consumer.GetWatermarkOffsets(new TopicPartition("topic1", 0))).IsNull();
         await Assert.That(consumer.GetWatermarkOffsets(new TopicPartition("topic1", 1))).IsNull();
 

--- a/tests/Dekaf.Tests.Unit/Consumer/IncrementalAssignmentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/IncrementalAssignmentTests.cs
@@ -228,7 +228,7 @@ public class IncrementalAssignmentTests
     }
 
     [Test]
-    public async Task IncrementalUnassign_ClearsWatermarkOffsetsForRemovedPartitions()
+    public async Task GetWatermarkOffsets_ReturnsNull_WhenPartitionNeverFetched()
     {
         // Arrange
         await using var consumer = new KafkaConsumer<string, string>(

--- a/tests/Dekaf.Tests.Unit/Consumer/IncrementalAssignmentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/IncrementalAssignmentTests.cs
@@ -228,6 +228,57 @@ public class IncrementalAssignmentTests
     }
 
     [Test]
+    public async Task IncrementalUnassign_ClearsWatermarkOffsetsForRemovedPartitions()
+    {
+        // Arrange
+        await using var consumer = new KafkaConsumer<string, string>(
+            CreateTestOptions(),
+            Serializers.String,
+            Serializers.String);
+
+        consumer.Assign(
+            new TopicPartition("topic1", 0),
+            new TopicPartition("topic1", 1));
+
+        // Watermark offsets are not set via public API (they come from fetch responses),
+        // so after IncrementalUnassign the cache entry should be absent.
+        // Verify baseline: no watermarks cached for either partition.
+        await Assert.That(consumer.GetWatermarkOffsets(new TopicPartition("topic1", 0))).IsNull();
+        await Assert.That(consumer.GetWatermarkOffsets(new TopicPartition("topic1", 1))).IsNull();
+
+        // Act
+        consumer.IncrementalUnassign(new[] { new TopicPartition("topic1", 1) });
+
+        // Assert - GetWatermarkOffsets should still return null (no stale entry)
+        await Assert.That(consumer.GetWatermarkOffsets(new TopicPartition("topic1", 1))).IsNull();
+    }
+
+    [Test]
+    public async Task IncrementalUnassign_RetainsPausedStateForKeptPartitions()
+    {
+        // Arrange
+        await using var consumer = new KafkaConsumer<string, string>(
+            CreateTestOptions(),
+            Serializers.String,
+            Serializers.String);
+
+        consumer.Assign(
+            new TopicPartition("topic1", 0),
+            new TopicPartition("topic1", 1),
+            new TopicPartition("topic1", 2));
+
+        consumer.Pause(new TopicPartition("topic1", 0));
+        consumer.Pause(new TopicPartition("topic1", 1));
+
+        // Act - remove only partition 1
+        consumer.IncrementalUnassign(new[] { new TopicPartition("topic1", 1) });
+
+        // Assert - partition 0 should still be paused, partition 1 should not
+        await Assert.That(consumer.Paused.Contains(new TopicPartition("topic1", 0))).IsTrue();
+        await Assert.That(consumer.Paused.Contains(new TopicPartition("topic1", 1))).IsFalse();
+    }
+
+    [Test]
     public async Task IncrementalUnassign_ClearsPositionForRemovedPartitions()
     {
         // Arrange

--- a/tests/Dekaf.Tests.Unit/Consumer/RebalanceCleanupTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/RebalanceCleanupTests.cs
@@ -222,38 +222,10 @@ public sealed class RebalanceCleanupTests : IAsyncDisposable
                 Members = []
             }));
 
-        // Make heartbeat trigger a rebalance so the coordinator transitions to Unjoined.
-        // Returns RebalanceInProgress once (triggering re-join), then success on subsequent calls.
-        var heartbeatRebalanceTriggered = 0;
-        _connection.SendAsync<HeartbeatRequest, HeartbeatResponse>(
-                Arg.Any<HeartbeatRequest>(),
-                Arg.Any<short>(),
-                Arg.Any<CancellationToken>())
-            .Returns(_ =>
-            {
-                if (Interlocked.CompareExchange(ref heartbeatRebalanceTriggered, 1, 0) == 0)
-                {
-                    return ValueTask.FromResult(new HeartbeatResponse
-                    {
-                        ErrorCode = ErrorCode.RebalanceInProgress
-                    });
-                }
-
-                return ValueTask.FromResult(new HeartbeatResponse
-                {
-                    ErrorCode = ErrorCode.None
-                });
-            });
-
-        // Poll until the heartbeat-triggered rebalance completes asynchronously
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        while (sw.Elapsed < TimeSpan.FromSeconds(5))
-        {
-            await consumer.EnsureAssignmentAsync(CancellationToken.None);
-            if (consumer.Assignment.Count != 3)
-                break;
-            await Task.Delay(50);
-        }
+        // Force the coordinator to Unjoined so the next EnsureAssignmentAsync re-joins
+        // deterministically — no dependency on the heartbeat background thread's timing.
+        consumer.RequestRejoin();
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
 
         // Assert: partition 1 was revoked — its paused state must be cleaned up
         await Assert.That(consumer.Assignment).Count().IsEqualTo(2);

--- a/tests/Dekaf.Tests.Unit/Consumer/RebalanceCleanupTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/RebalanceCleanupTests.cs
@@ -1,0 +1,273 @@
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+/// <summary>
+/// Regression tests for per-partition state cleanup during broker-initiated rebalances.
+/// These tests exercise the <c>EnsureAssignmentAsync → RemovePartitionState</c> path
+/// that fires when the coordinator returns a changed assignment after a group rebalance.
+/// </summary>
+public sealed class RebalanceCleanupTests : IAsyncDisposable
+{
+    private readonly IConnectionPool _connectionPool;
+    private readonly IKafkaConnection _connection;
+    private readonly MetadataManager _metadataManager;
+
+    public RebalanceCleanupTests()
+    {
+        _connectionPool = Substitute.For<IConnectionPool>();
+        _connection = Substitute.For<IKafkaConnection>();
+
+        _connectionPool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(_connection));
+
+        _connectionPool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(_connection));
+
+        _metadataManager = new MetadataManager(_connectionPool, ["localhost:9092"]);
+
+        _metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    Name = "test-topic",
+                    ErrorCode = ErrorCode.None,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            PartitionIndex = 0, LeaderId = 0, ErrorCode = ErrorCode.None,
+                            ReplicaNodes = [0], IsrNodes = [0]
+                        },
+                        new PartitionMetadata
+                        {
+                            PartitionIndex = 1, LeaderId = 0, ErrorCode = ErrorCode.None,
+                            ReplicaNodes = [0], IsrNodes = [0]
+                        },
+                        new PartitionMetadata
+                        {
+                            PartitionIndex = 2, LeaderId = 0, ErrorCode = ErrorCode.None,
+                            ReplicaNodes = [0], IsrNodes = [0]
+                        }
+                    ]
+                }
+            ]
+        });
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _metadataManager.DisposeAsync();
+    }
+
+    private static ConsumerOptions CreateOptions(int heartbeatIntervalMs = 50) => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        GroupId = "test-group",
+        ClientId = "test-consumer",
+        HeartbeatIntervalMs = heartbeatIntervalMs
+    };
+
+    /// <summary>
+    /// Sets up the mock connection for a successful JoinGroup/SyncGroup flow
+    /// with the given assignment data. Heartbeat returns success.
+    /// </summary>
+    private void SetupJoinFlow(byte[] assignmentData)
+    {
+        _connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                ErrorCode = ErrorCode.None,
+                NodeId = 0,
+                Host = "localhost",
+                Port = 9092
+            }));
+
+        _connection.SendAsync<JoinGroupRequest, JoinGroupResponse>(
+                Arg.Any<JoinGroupRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new JoinGroupResponse
+            {
+                ErrorCode = ErrorCode.None,
+                MemberId = "member-1",
+                GenerationId = 1,
+                Leader = "member-1",
+                Members = []
+            }));
+
+        _connection.SendAsync<SyncGroupRequest, SyncGroupResponse>(
+                Arg.Any<SyncGroupRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new SyncGroupResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Assignment = assignmentData
+            }));
+
+        _connection.SendAsync<HeartbeatRequest, HeartbeatResponse>(
+                Arg.Any<HeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new HeartbeatResponse
+            {
+                ErrorCode = ErrorCode.None
+            }));
+
+        // OffsetFetch returns committed offsets for all partitions so InitializePositionsAsync
+        // doesn't fall through to GetResetOffsetAsync (which requires ListOffsets mocks).
+        _connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
+                Arg.Any<OffsetFetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.ArgAt<OffsetFetchRequest>(0);
+                var topics = new List<OffsetFetchResponseTopic>();
+                if (request.Topics is not null)
+                {
+                    foreach (var topic in request.Topics)
+                    {
+                        var partitions = new List<OffsetFetchResponsePartition>();
+                        foreach (var idx in topic.PartitionIndexes)
+                        {
+                            partitions.Add(new OffsetFetchResponsePartition
+                            {
+                                PartitionIndex = idx,
+                                CommittedOffset = 0,
+                                ErrorCode = ErrorCode.None
+                            });
+                        }
+                        topics.Add(new OffsetFetchResponseTopic
+                        {
+                            Name = topic.Name,
+                            Partitions = partitions
+                        });
+                    }
+                }
+                return ValueTask.FromResult(new OffsetFetchResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    Topics = topics
+                });
+            });
+    }
+
+    [Test]
+    public async Task EnsureAssignment_RebalanceRevokesPartition_ClearsPausedState()
+    {
+        // Arrange: initial assignment = partitions [0, 1, 2]
+        var initialAssignment = BuildAssignmentData("test-topic", [0, 1, 2]);
+        SetupJoinFlow(initialAssignment);
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            CreateOptions(),
+            Serializers.String,
+            Serializers.String,
+            _connectionPool,
+            _metadataManager);
+
+        consumer.Subscribe("test-topic");
+
+        // First EnsureAssignmentAsync — picks up assignment [0, 1, 2]
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        await Assert.That(consumer.Assignment).Count().IsEqualTo(3);
+
+        // Pause partition 1
+        consumer.Pause(new TopicPartition("test-topic", 1));
+        await Assert.That(consumer.Paused.Contains(new TopicPartition("test-topic", 1))).IsTrue();
+
+        // Re-stub SyncGroup with a smaller assignment: partitions [0, 2] only
+        var rebalancedAssignment = BuildAssignmentData("test-topic", [0, 2]);
+
+        _connection.SendAsync<SyncGroupRequest, SyncGroupResponse>(
+                Arg.Any<SyncGroupRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new SyncGroupResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Assignment = rebalancedAssignment
+            }));
+
+        _connection.SendAsync<JoinGroupRequest, JoinGroupResponse>(
+                Arg.Any<JoinGroupRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new JoinGroupResponse
+            {
+                ErrorCode = ErrorCode.None,
+                MemberId = "member-1",
+                GenerationId = 2,
+                Leader = "member-1",
+                Members = []
+            }));
+
+        // Make heartbeat trigger a rebalance so the coordinator transitions to Unjoined.
+        // Returns RebalanceInProgress once (triggering re-join), then success on subsequent calls.
+        var heartbeatRebalanceTriggered = 0;
+        _connection.SendAsync<HeartbeatRequest, HeartbeatResponse>(
+                Arg.Any<HeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.CompareExchange(ref heartbeatRebalanceTriggered, 1, 0) == 0)
+                {
+                    return ValueTask.FromResult(new HeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.RebalanceInProgress
+                    });
+                }
+
+                return ValueTask.FromResult(new HeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None
+                });
+            });
+
+        // Poll until the heartbeat-triggered rebalance completes asynchronously
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            await consumer.EnsureAssignmentAsync(CancellationToken.None);
+            if (consumer.Assignment.Count != 3)
+                break;
+            await Task.Delay(50);
+        }
+
+        // Assert: partition 1 was revoked — its paused state must be cleaned up
+        await Assert.That(consumer.Assignment).Count().IsEqualTo(2);
+        await Assert.That(consumer.Assignment.Contains(new TopicPartition("test-topic", 0))).IsTrue();
+        await Assert.That(consumer.Assignment.Contains(new TopicPartition("test-topic", 2))).IsTrue();
+
+        // This is the critical assertion: paused state must not survive rebalance
+        await Assert.That(consumer.Paused.Contains(new TopicPartition("test-topic", 1))).IsFalse();
+
+        // Position for the removed partition should also be cleared
+        var position = consumer.GetPosition(new TopicPartition("test-topic", 1));
+        await Assert.That(position).IsNull();
+    }
+
+    private static byte[] BuildAssignmentData(string topic, int[] partitions)
+        => ConsumerTestHelpers.BuildAssignmentData(topic, partitions);
+}


### PR DESCRIPTION
## Summary

- **Fix stale state after group rebalance**: `_committed`, `_watermarks`, and `_paused` were not cleaned up in `EnsureAssignmentAsync` when partitions were revoked, causing stale entries to accumulate and paused partitions to silently remain paused after reassignment. `IncrementalUnassign` was also missing `_highWatermarks`, `_watermarks`, and `_eofEmitted` cleanup. Both paths now use a shared `RemovePartitionState` helper for consistent per-partition cleanup.
- **Fix FindCoordinator broker selection**: All 5 retry attempts targeted `brokers[0]`. Now cycles through available brokers to avoid wasting retry budget on one slow node.
- **Harden cross-thread field visibility**: Made `_assignedPartitions` volatile (heartbeat reads it without `_lock`) and `_topicFilter` volatile (read in `EnsureAssignmentAsync`, written in `Subscribe`/`Unsubscribe`).
- **Narrow lock scope in EnsureAssignmentAsync**: Moved `RefreshFilteredTopicsAsync` (network I/O) before `_assignmentLock` acquisition since it only touches thread-safe structures, preventing both consume and prefetch loops from stalling during slow metadata responses. Also fixed TOCTOU on `_topicFilter` by capturing to local before the null check.

## Test plan

- [x] All consumer unit tests pass (`ConsumerCoordinatorStateTests`, `PrefetchPipelineRunnerTests`, `IncrementalAssignmentTests`)
- [x] New test: `FindCoordinator_CyclesThroughBrokersOnRetry` — verifies broker cycling with 2 brokers
- [x] New test: `IncrementalUnassign_RetainsPausedStateForKeptPartitions` — verifies selective pause cleanup
- [ ] Integration tests with Docker (manual verification)