### PR TITLE
feat(consumer): implement KIP-848 Consumer group protocol

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1592,13 +1592,6 @@ public sealed class ConsumerBuilder<TKey, TValue>
 
     private void ValidateGroupProtocolConfig()
     {
-        if (_groupProtocol == GroupProtocol.Consumer)
-        {
-            throw new NotSupportedException(
-                "GroupProtocol.Consumer (KIP-848) is not yet implemented. " +
-                "Use GroupProtocol.Classic (the default) for consumer group coordination.");
-        }
-
         if (_groupRemoteAssignor is not null && _groupProtocol != GroupProtocol.Consumer)
         {
             throw new InvalidOperationException(

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -52,7 +52,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     // KIP-848 (GroupProtocol.Consumer) state
     private volatile int _heartbeatIntervalMs;
-    private volatile bool _subscriptionChanged;
+    private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
     private volatile IReadOnlySet<string>? _subscribedTopics;
 
     internal static int GetCoordinationConnectionIndex(int connectionsPerBroker)
@@ -1303,12 +1303,13 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
             .ConfigureAwait(false);
 
-        var memberEpoch = isInitial ? 0 : _generationId;
         var memberId = _memberId ?? string.Empty;
 
-        // Static membership: use MemberEpoch=-2 to rejoin after fencing
-        if (isInitial && _options.GroupInstanceId is not null && memberId.Length > 0)
-            memberEpoch = -2;
+        // MemberEpoch: 0 for initial join, -2 for static rejoin (set by fencing handler),
+        // or the current epoch for steady-state heartbeats
+        var memberEpoch = isInitial
+            ? (_generationId == -2 && _options.GroupInstanceId is not null ? -2 : 0)
+            : _generationId;
 
         // Build owned topic partitions for acknowledgment (not sent on initial join)
         IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? ownedTopicPartitions = null;
@@ -1317,6 +1318,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             ownedTopicPartitions = BuildOwnedTopicPartitions(_assignedPartitions);
         }
 
+        // Atomically snapshot and clear the subscription-changed flag to prevent a race where
+        // a concurrent EnsureActiveGroupConsumerProtocolAsync sets new topics + flag=true,
+        // but this heartbeat clears the flag after sending the old topics.
+        var subscriptionChanged = Interlocked.Exchange(ref _subscriptionChanged, 0) == 1;
+        var subscribedTopics = subscriptionChanged ? _subscribedTopics?.ToList() : null;
+
         var request = new ConsumerGroupHeartbeatRequest
         {
             GroupId = _options.GroupId!,
@@ -1324,7 +1331,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             MemberEpoch = memberEpoch,
             InstanceId = _options.GroupInstanceId,
             RebalanceTimeoutMs = isInitial ? _options.RebalanceTimeoutMs : -1,
-            SubscribedTopicNames = _subscriptionChanged ? _subscribedTopics?.ToList() : null,
+            SubscribedTopicNames = subscribedTopics,
             ServerAssignor = isInitial ? _options.GroupRemoteAssignor : null,
             TopicPartitions = ownedTopicPartitions
         };
@@ -1351,8 +1358,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             LogMemberEpochUpdated(response.MemberEpoch);
             _generationId = response.MemberEpoch;
         }
-
-        _subscriptionChanged = false;
 
         if (response.HeartbeatIntervalMs > 0)
             _heartbeatIntervalMs = response.HeartbeatIntervalMs;
@@ -1505,7 +1510,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         CancellationToken cancellationToken)
     {
         _subscribedTopics = topics;
-        _subscriptionChanged = true;
+        Interlocked.Exchange(ref _subscriptionChanged, 1);
 
         ConsumerHeartbeatResult heartbeatResult = default;
 
@@ -1556,8 +1561,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 }
                 catch (Errors.GroupException ex) when (ex.ErrorCode == ErrorCode.FencedMemberEpoch)
                 {
-                    // Stale epoch — retry join
+                    // Stale epoch — reset generation so next attempt sends MemberEpoch=0 (or -2 for static members)
                     LogRetriableCoordinatorError(ex.ErrorCode);
+                    _generationId = _options.GroupInstanceId is not null ? -2 : 0;
                     _state = CoordinatorState.Unjoined;
                 }
                 catch (Errors.GroupException ex) when (IsRetriableCoordinatorError(ex.ErrorCode))
@@ -1633,6 +1639,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 {
                     if (ge.ErrorCode == ErrorCode.FencedMemberEpoch)
                     {
+                        // Reset generation so next EnsureActiveGroup sends MemberEpoch=0 (or -2 for static)
+                        _generationId = _options.GroupInstanceId is not null ? -2 : 0;
                         _state = CoordinatorState.Unjoined;
                         break;
                     }

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -111,7 +111,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (_state == CoordinatorState.Stable)
             return;
 
-        // KIP-848: use ConsumerGroupHeartbeat API instead of JoinGroup/SyncGroup
         if (_options.GroupProtocol == GroupProtocol.Consumer)
         {
             await EnsureActiveGroupConsumerProtocolAsync(topics, cancellationToken).ConfigureAwait(false);
@@ -1349,7 +1348,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             HandleConsumerGroupHeartbeatError(response);
         }
 
-        // Update member identity
         if (response.MemberId is not null)
             _memberId = response.MemberId;
 
@@ -1362,7 +1360,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (response.HeartbeatIntervalMs > 0)
             _heartbeatIntervalMs = response.HeartbeatIntervalMs;
 
-        // Process assignment if present
         if (response.Assignment is not null)
         {
             return ProcessConsumerGroupAssignment(response.Assignment);
@@ -1411,7 +1408,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (assignedPartitions.Count == 0)
             return null;
 
-        // Group by topic name, then resolve to UUID
         var byTopic = new Dictionary<string, List<int>>();
         foreach (var tp in assignedPartitions)
         {
@@ -1468,7 +1464,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         var oldAssignment = _assignedPartitions;
 
-        // Compute revoked (in old but not new)
         List<TopicPartition>? revoked = null;
         foreach (var partition in oldAssignment)
         {
@@ -1479,7 +1474,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             }
         }
 
-        // Compute assigned (in new but not old)
         List<TopicPartition>? assigned = null;
         foreach (var partition in newAssignment)
         {
@@ -1490,7 +1484,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             }
         }
 
-        // Atomically replace assignment
         _assignedPartitions = newAssignment;
 
         var changed = revoked is { Count: > 0 } || assigned is { Count: > 0 };
@@ -1579,14 +1572,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
                     retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                 }
-                catch (ObjectDisposedException)
-                {
-                    LogCoordinatorConnectionDisposed();
-                    MarkCoordinatorUnknown();
-                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
-                }
-                catch (Errors.KafkaException ex) when (ex is not Errors.GroupException && !cancellationToken.IsCancellationRequested)
+                catch (Exception ex) when (
+                    ex is ObjectDisposedException ||
+                    (ex is Errors.KafkaException ke && ke is not Errors.GroupException && !cancellationToken.IsCancellationRequested))
                 {
                     LogCoordinatorConnectionDisposed();
                     MarkCoordinatorUnknown();
@@ -1600,7 +1588,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             _lock.Release();
         }
 
-        // Fire rebalance listeners OUTSIDE the lock (same pattern as classic path)
         await FireConsumerProtocolRebalanceListenersAsync(heartbeatResult, cancellationToken).ConfigureAwait(false);
 
         if (_state == CoordinatorState.Stable)
@@ -1643,46 +1630,47 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                 if (ex is Errors.GroupException ge)
                 {
-                    if (ge.ErrorCode == ErrorCode.FencedMemberEpoch)
+                    switch (ge.ErrorCode)
                     {
-                        // Reset generation so next EnsureActiveGroup sends MemberEpoch=0 (or -2 for static)
-                        _generationId = _options.GroupInstanceId is not null ? -2 : 0;
-                        _state = CoordinatorState.Unjoined;
-                        break;
-                    }
+                        case ErrorCode.FencedMemberEpoch:
+                            // Reset generation so next EnsureActiveGroup sends MemberEpoch=0 (or -2 for static)
+                            _generationId = _options.GroupInstanceId is not null ? -2 : 0;
+                            _state = CoordinatorState.Unjoined;
+                            break;
 
-                    if (ge.ErrorCode == ErrorCode.UnknownMemberId)
-                    {
-                        if (_rebalanceListener is not null)
-                        {
-                            var lost = _assignedPartitions.ToList();
-                            if (lost.Count > 0)
+                        case ErrorCode.UnknownMemberId:
+                            if (_rebalanceListener is not null)
                             {
-                                await InvokeRebalanceListenerAsync(
-                                    "OnPartitionsLost", lost,
-                                    _rebalanceListener.OnPartitionsLostAsync,
-                                    CancellationToken.None).ConfigureAwait(false);
+                                var lost = _assignedPartitions.ToList();
+                                if (lost.Count > 0)
+                                {
+                                    await InvokeRebalanceListenerAsync(
+                                        "OnPartitionsLost", lost,
+                                        _rebalanceListener.OnPartitionsLostAsync,
+                                        CancellationToken.None).ConfigureAwait(false);
+                                }
                             }
-                        }
 
-                        ResetMemberState();
-                        break;
+                            ResetMemberState();
+                            break;
+
+                        case ErrorCode.UnreleasedInstanceId:
+                        case ErrorCode.UnsupportedAssignor:
+                            _state = CoordinatorState.Unjoined;
+                            break;
+
+                        case var c when IsRetriableCoordinatorError(c):
+                            MarkCoordinatorUnknown();
+                            break;
+
+                        default:
+                            continue; // Unrecognized group error — continue heartbeating
                     }
 
-                    if (IsRetriableCoordinatorError(ge.ErrorCode))
-                    {
-                        MarkCoordinatorUnknown();
-                        break;
-                    }
-
-                    if (ge.ErrorCode is ErrorCode.UnreleasedInstanceId or ErrorCode.UnsupportedAssignor)
-                    {
-                        _state = CoordinatorState.Unjoined;
-                        break;
-                    }
+                    break;
                 }
 
-                // Unknown error — continue heartbeating
+                // Non-group error — continue heartbeating
             }
         }
     }
@@ -1761,7 +1749,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (_coordinatorId < 0)
             return;
 
-        // KIP-848: leave via ConsumerGroupHeartbeat with MemberEpoch=-1
         if (_options.GroupProtocol == GroupProtocol.Consumer)
         {
             await LeaveGroupConsumerProtocolAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -50,6 +50,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private int _disposed;
     private readonly Func<int> _getCoordinationConnectionIndex;
 
+    // KIP-848 (GroupProtocol.Consumer) state
+    private volatile int _heartbeatIntervalMs;
+    private volatile bool _subscriptionChanged;
+    private volatile IReadOnlySet<string>? _subscribedTopics;
+
     internal static int GetCoordinationConnectionIndex(int connectionsPerBroker)
         => connectionsPerBroker - 1;
 
@@ -68,6 +73,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         _getCoordinationConnectionIndex = getConnectionCount is not null
             ? () => GetCoordinationConnectionIndex(getConnectionCount())
             : () => GetCoordinationConnectionIndex(options.ConnectionsPerBroker);
+        _heartbeatIntervalMs = options.HeartbeatIntervalMs;
     }
 
     public string? MemberId => _memberId;
@@ -104,6 +110,13 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         // poll (~100ms), preventing it from ever surviving the 3s delay to actually send.
         if (_state == CoordinatorState.Stable)
             return;
+
+        // KIP-848: use ConsumerGroupHeartbeat API instead of JoinGroup/SyncGroup
+        if (_options.GroupProtocol == GroupProtocol.Consumer)
+        {
+            await EnsureActiveGroupConsumerProtocolAsync(topics, cancellationToken).ConfigureAwait(false);
+            return;
+        }
 
         // Cooperative rebalancing may require multiple rounds (KIP-429):
         // Round 1 identifies partitions to transfer, round 2 assigns them.
@@ -574,12 +587,17 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         return new SyncGroupResult(revoked, assigned);
     }
 
-    private async ValueTask StartHeartbeatAsync()
+    private ValueTask StartHeartbeatAsync()
+        => StartHeartbeatCoreAsync(HeartbeatLoopAsync, _options.HeartbeatIntervalMs);
+
+    /// <summary>
+    /// Serializes heartbeat loop starts to prevent concurrent callers from orphaning a loop.
+    /// Without this guard, two threads exiting EnsureActiveGroupAsync simultaneously could both
+    /// snapshot the same old CTS/task, cancel it, and each assign new CTS/task fields — the first
+    /// writer's heartbeat loop would be overwritten and its CTS never cancelled.
+    /// </summary>
+    private async ValueTask StartHeartbeatCoreAsync(Func<CancellationToken, Task> loopFactory, int intervalMs)
     {
-        // Serialize heartbeat starts to prevent concurrent callers from orphaning a heartbeat loop.
-        // Without this guard, two threads exiting EnsureActiveGroupAsync simultaneously could both
-        // snapshot the same old CTS/task, cancel it, and each assign new CTS/task fields — the first
-        // writer's heartbeat loop would be overwritten and its CTS never cancelled.
         Task? oldTask;
         CancellationTokenSource? oldCts;
 
@@ -589,10 +607,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             oldTask = _heartbeatTask;
 
             // Log inside the lock so only the thread that actually installs a new heartbeat emits the message.
-            LogHeartbeatStarted(_options.HeartbeatIntervalMs);
+            LogHeartbeatStarted(intervalMs);
 
             _heartbeatCts = new CancellationTokenSource();
-            _heartbeatTask = HeartbeatLoopAsync(_heartbeatCts.Token);
+            _heartbeatTask = loopFactory(_heartbeatCts.Token);
         }
 
         // Clean up old heartbeat outside the lock (awaiting is safe here since the new
@@ -1230,6 +1248,487 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         return buffer.WrittenSpan.ToArray();
     }
 
+    #region KIP-848 Consumer Protocol
+
+    private readonly record struct ConsumerHeartbeatResult(
+        bool AssignmentChanged,
+        IReadOnlyList<TopicPartition>? Revoked,
+        IReadOnlyList<TopicPartition>? Assigned);
+
+    /// <summary>
+    /// Resets member identity and assignment to the pre-join state.
+    /// Used during leave, fencing, and disposal.
+    /// </summary>
+    private void ResetMemberState()
+    {
+        _memberId = null;
+        _generationId = -1;
+        _assignedPartitions = [];
+        _state = CoordinatorState.Unjoined;
+    }
+
+    /// <summary>
+    /// Fires rebalance listener callbacks for a ConsumerHeartbeatResult if assignment changed.
+    /// </summary>
+    private async ValueTask FireConsumerProtocolRebalanceListenersAsync(
+        ConsumerHeartbeatResult result,
+        CancellationToken cancellationToken)
+    {
+        if (!result.AssignmentChanged || _rebalanceListener is null)
+            return;
+
+        if (result.Revoked is { Count: > 0 })
+        {
+            await InvokeRebalanceListenerAsync(
+                "OnPartitionsRevoked", result.Revoked,
+                _rebalanceListener.OnPartitionsRevokedAsync, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (result.Assigned is { Count: > 0 })
+        {
+            await InvokeRebalanceListenerAsync(
+                "OnPartitionsAssigned", result.Assigned,
+                _rebalanceListener.OnPartitionsAssignedAsync, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Sends a ConsumerGroupHeartbeat request and processes the response.
+    /// </summary>
+    private async ValueTask<ConsumerHeartbeatResult> SendConsumerGroupHeartbeatAsync(
+        bool isInitial,
+        CancellationToken cancellationToken)
+    {
+        var connection = await _connectionPool.GetConnectionByIndexAsync(
+            _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
+            .ConfigureAwait(false);
+
+        var memberEpoch = isInitial ? 0 : _generationId;
+        var memberId = _memberId ?? string.Empty;
+
+        // Static membership: use MemberEpoch=-2 to rejoin after fencing
+        if (isInitial && _options.GroupInstanceId is not null && memberId.Length > 0)
+            memberEpoch = -2;
+
+        // Build owned topic partitions for acknowledgment (not sent on initial join)
+        IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? ownedTopicPartitions = null;
+        if (!isInitial)
+        {
+            ownedTopicPartitions = BuildOwnedTopicPartitions(_assignedPartitions);
+        }
+
+        var request = new ConsumerGroupHeartbeatRequest
+        {
+            GroupId = _options.GroupId!,
+            MemberId = memberId,
+            MemberEpoch = memberEpoch,
+            InstanceId = _options.GroupInstanceId,
+            RebalanceTimeoutMs = isInitial ? _options.RebalanceTimeoutMs : -1,
+            SubscribedTopicNames = _subscriptionChanged ? _subscribedTopics?.ToList() : null,
+            ServerAssignor = isInitial ? _options.GroupRemoteAssignor : null,
+            TopicPartitions = ownedTopicPartitions
+        };
+
+        var version = _metadataManager.GetNegotiatedApiVersion(
+            ApiKey.ConsumerGroupHeartbeat,
+            ConsumerGroupHeartbeatRequest.LowestSupportedVersion,
+            ConsumerGroupHeartbeatRequest.HighestSupportedVersion);
+
+        var response = await connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            request, version, cancellationToken).ConfigureAwait(false);
+
+        if (response.ErrorCode != ErrorCode.None)
+        {
+            HandleConsumerGroupHeartbeatError(response);
+        }
+
+        // Update member identity
+        if (response.MemberId is not null)
+            _memberId = response.MemberId;
+
+        if (response.MemberEpoch != _generationId)
+        {
+            LogMemberEpochUpdated(response.MemberEpoch);
+            _generationId = response.MemberEpoch;
+        }
+
+        _subscriptionChanged = false;
+
+        if (response.HeartbeatIntervalMs > 0)
+            _heartbeatIntervalMs = response.HeartbeatIntervalMs;
+
+        // Process assignment if present
+        if (response.Assignment is not null)
+        {
+            return ProcessConsumerGroupAssignment(response.Assignment);
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Throws an appropriate exception for ConsumerGroupHeartbeat error codes.
+    /// Does NOT mutate coordinator state — callers own state transitions.
+    /// </summary>
+    private void HandleConsumerGroupHeartbeatError(ConsumerGroupHeartbeatResponse response)
+    {
+        throw response.ErrorCode switch
+        {
+            ErrorCode.UnknownMemberId => new GroupException(response.ErrorCode,
+                $"ConsumerGroupHeartbeat: unknown member ID (fenced): {response.ErrorMessage}")
+            { GroupId = _options.GroupId },
+
+            ErrorCode.FencedMemberEpoch => new GroupException(response.ErrorCode,
+                $"ConsumerGroupHeartbeat: fenced member epoch: {response.ErrorMessage}")
+            { GroupId = _options.GroupId },
+
+            ErrorCode.UnreleasedInstanceId => new GroupException(response.ErrorCode,
+                $"ConsumerGroupHeartbeat: unreleased instance ID '{_options.GroupInstanceId}': {response.ErrorMessage}")
+            { GroupId = _options.GroupId },
+
+            ErrorCode.UnsupportedAssignor => new GroupException(response.ErrorCode,
+                $"ConsumerGroupHeartbeat: unsupported assignor '{_options.GroupRemoteAssignor}': {response.ErrorMessage}")
+            { GroupId = _options.GroupId },
+
+            _ => new GroupException(response.ErrorCode,
+                $"ConsumerGroupHeartbeat failed: {response.ErrorCode} - {response.ErrorMessage}")
+            { GroupId = _options.GroupId }
+        };
+    }
+
+    /// <summary>
+    /// Converts the current assignment to the topic-partition format used by ConsumerGroupHeartbeat requests,
+    /// resolving topic names to UUIDs via cached metadata.
+    /// </summary>
+    private IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? BuildOwnedTopicPartitions(
+        HashSet<TopicPartition> assignedPartitions)
+    {
+        if (assignedPartitions.Count == 0)
+            return null;
+
+        // Group by topic name, then resolve to UUID
+        var byTopic = new Dictionary<string, List<int>>();
+        foreach (var tp in assignedPartitions)
+        {
+            if (!byTopic.TryGetValue(tp.Topic, out var partitions))
+            {
+                partitions = [];
+                byTopic[tp.Topic] = partitions;
+            }
+            partitions.Add(tp.Partition);
+        }
+
+        var result = new List<ConsumerGroupHeartbeatTopicPartitions>(byTopic.Count);
+        foreach (var (topicName, partitions) in byTopic)
+        {
+            var topicInfo = _metadataManager.Metadata.GetTopic(topicName);
+            if (topicInfo is null || topicInfo.TopicId == Guid.Empty)
+                continue;
+
+            result.Add(new ConsumerGroupHeartbeatTopicPartitions
+            {
+                TopicId = topicInfo.TopicId,
+                Partitions = partitions
+            });
+        }
+
+        return result.Count > 0 ? result : null;
+    }
+
+    /// <summary>
+    /// Processes a ConsumerGroupHeartbeat assignment response, resolving topic UUIDs to names
+    /// and computing the partition diff (revoked/assigned) against the current assignment.
+    /// </summary>
+    private ConsumerHeartbeatResult ProcessConsumerGroupAssignment(ConsumerGroupHeartbeatAssignment assignment)
+    {
+        var newAssignment = new HashSet<TopicPartition>();
+
+        foreach (var tp in assignment.AssignedTopicPartitions)
+        {
+            var topicInfo = _metadataManager.Metadata.GetTopic(tp.TopicId);
+            if (topicInfo is null)
+            {
+                LogUnknownTopicIdInAssignment(tp.TopicId);
+                continue;
+            }
+
+            foreach (var partition in tp.Partitions)
+            {
+                newAssignment.Add(new TopicPartition(topicInfo.Name, partition));
+            }
+        }
+
+        // PendingTopicPartitions are NOT added — per KIP-848, these are still owned by
+        // other members and must not be consumed until they appear in AssignedTopicPartitions.
+
+        var oldAssignment = _assignedPartitions;
+
+        // Compute revoked (in old but not new)
+        List<TopicPartition>? revoked = null;
+        foreach (var partition in oldAssignment)
+        {
+            if (!newAssignment.Contains(partition))
+            {
+                revoked ??= [];
+                revoked.Add(partition);
+            }
+        }
+
+        // Compute assigned (in new but not old)
+        List<TopicPartition>? assigned = null;
+        foreach (var partition in newAssignment)
+        {
+            if (!oldAssignment.Contains(partition))
+            {
+                assigned ??= [];
+                assigned.Add(partition);
+            }
+        }
+
+        // Atomically replace assignment
+        _assignedPartitions = newAssignment;
+
+        var changed = revoked is { Count: > 0 } || assigned is { Count: > 0 };
+        if (changed)
+        {
+            LogConsumerProtocolAssignmentUpdate(assigned?.Count ?? 0, revoked?.Count ?? 0);
+        }
+
+        return new ConsumerHeartbeatResult(changed, revoked, assigned);
+    }
+
+    /// <summary>
+    /// KIP-848 entry point: ensures the consumer has joined the group using the ConsumerGroupHeartbeat API.
+    /// </summary>
+    private async ValueTask EnsureActiveGroupConsumerProtocolAsync(
+        IReadOnlySet<string> topics,
+        CancellationToken cancellationToken)
+    {
+        _subscribedTopics = topics;
+        _subscriptionChanged = true;
+
+        ConsumerHeartbeatResult heartbeatResult = default;
+
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_state == CoordinatorState.Stable)
+                return;
+
+            LogEnsureActiveGroupStarted(_options.GroupId!, _state);
+            var startedAt = Stopwatch.GetTimestamp();
+            var rebalanceTimeout = TimeSpan.FromMilliseconds(_options.RebalanceTimeoutMs);
+            var retryDelayMs = 200;
+
+            while (_state != CoordinatorState.Stable)
+            {
+                if (Stopwatch.GetElapsedTime(startedAt) > rebalanceTimeout)
+                {
+                    throw new KafkaTimeoutException(
+                        TimeoutKind.Rebalance,
+                        Stopwatch.GetElapsedTime(startedAt),
+                        rebalanceTimeout,
+                        $"Failed to join group '{_options.GroupId}' within rebalance timeout ({_options.RebalanceTimeoutMs}ms)");
+                }
+
+                try
+                {
+                    if (_coordinatorId < 0)
+                    {
+                        await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    _state = CoordinatorState.Joining;
+                    LogCoordinatorStateTransition(CoordinatorState.Joining);
+
+                    heartbeatResult = await SendConsumerGroupHeartbeatAsync(
+                        isInitial: _memberId is null || _generationId <= 0,
+                        cancellationToken).ConfigureAwait(false);
+
+                    _state = CoordinatorState.Stable;
+
+                    Diagnostics.DekafMetrics.RebalanceDuration.Record(
+                        Stopwatch.GetElapsedTime(startedAt).TotalSeconds,
+                        new System.Diagnostics.TagList
+                            { { Diagnostics.DekafDiagnostics.MessagingConsumerGroupName, _options.GroupId } });
+
+                    LogJoinedGroup(_options.GroupId!, _memberId!, _generationId);
+                }
+                catch (Errors.GroupException ex) when (ex.ErrorCode == ErrorCode.FencedMemberEpoch)
+                {
+                    // Stale epoch — retry join
+                    LogRetriableCoordinatorError(ex.ErrorCode);
+                    _state = CoordinatorState.Unjoined;
+                }
+                catch (Errors.GroupException ex) when (IsRetriableCoordinatorError(ex.ErrorCode))
+                {
+                    LogRetriableCoordinatorError(ex.ErrorCode);
+                    MarkCoordinatorUnknown();
+                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                }
+                catch (ObjectDisposedException)
+                {
+                    LogCoordinatorConnectionDisposed();
+                    MarkCoordinatorUnknown();
+                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                }
+                catch (Errors.KafkaException ex) when (ex is not Errors.GroupException && !cancellationToken.IsCancellationRequested)
+                {
+                    LogCoordinatorConnectionDisposed();
+                    MarkCoordinatorUnknown();
+                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                }
+            }
+        }
+        finally
+        {
+            _lock.Release();
+        }
+
+        // Fire rebalance listeners OUTSIDE the lock (same pattern as classic path)
+        await FireConsumerProtocolRebalanceListenersAsync(heartbeatResult, cancellationToken).ConfigureAwait(false);
+
+        if (_state == CoordinatorState.Stable)
+        {
+            await StartConsumerProtocolHeartbeatAsync().ConfigureAwait(false);
+        }
+    }
+
+    private ValueTask StartConsumerProtocolHeartbeatAsync()
+        => StartHeartbeatCoreAsync(ConsumerProtocolHeartbeatLoopAsync, _heartbeatIntervalMs);
+
+    /// <summary>
+    /// KIP-848 heartbeat loop: sends ConsumerGroupHeartbeat at the broker-specified interval,
+    /// handles assignment changes and errors.
+    /// </summary>
+    private async Task ConsumerProtocolHeartbeatLoopAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                // Task.Delay (not PeriodicTimer): the broker controls the interval via each response,
+                // and PeriodicTimer cannot change its period after construction. At ~5s intervals,
+                // the per-tick TimerQueueTimer allocation is negligible.
+                await Task.Delay(_heartbeatIntervalMs, cancellationToken).ConfigureAwait(false);
+
+                var result = await SendConsumerGroupHeartbeatAsync(
+                    isInitial: false, cancellationToken).ConfigureAwait(false);
+
+                await FireConsumerProtocolRebalanceListenersAsync(result, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                LogHeartbeatFailed(ex);
+
+                if (ex is Errors.GroupException ge)
+                {
+                    if (ge.ErrorCode == ErrorCode.FencedMemberEpoch)
+                    {
+                        _state = CoordinatorState.Unjoined;
+                        break;
+                    }
+
+                    if (ge.ErrorCode == ErrorCode.UnknownMemberId)
+                    {
+                        if (_rebalanceListener is not null)
+                        {
+                            var lost = _assignedPartitions.ToList();
+                            if (lost.Count > 0)
+                            {
+                                await InvokeRebalanceListenerAsync(
+                                    "OnPartitionsLost", lost,
+                                    _rebalanceListener.OnPartitionsLostAsync,
+                                    CancellationToken.None).ConfigureAwait(false);
+                            }
+                        }
+
+                        ResetMemberState();
+                        break;
+                    }
+
+                    if (IsRetriableCoordinatorError(ge.ErrorCode))
+                    {
+                        MarkCoordinatorUnknown();
+                        break;
+                    }
+
+                    if (ge.ErrorCode is ErrorCode.UnreleasedInstanceId or ErrorCode.UnsupportedAssignor)
+                    {
+                        _state = CoordinatorState.Unjoined;
+                        break;
+                    }
+                }
+
+                // Unknown error — continue heartbeating
+            }
+        }
+    }
+
+    /// <summary>
+    /// KIP-848 leave: sends ConsumerGroupHeartbeat with MemberEpoch=-1.
+    /// </summary>
+    private async ValueTask LeaveGroupConsumerProtocolAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var connection = await _connectionPool.GetConnectionByIndexAsync(
+                _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
+                .ConfigureAwait(false);
+
+            var request = new ConsumerGroupHeartbeatRequest
+            {
+                GroupId = _options.GroupId!,
+                MemberId = _memberId!,
+                MemberEpoch = -1,
+                InstanceId = _options.GroupInstanceId,
+            };
+
+            var version = _metadataManager.GetNegotiatedApiVersion(
+                ApiKey.ConsumerGroupHeartbeat,
+                ConsumerGroupHeartbeatRequest.LowestSupportedVersion,
+                ConsumerGroupHeartbeatRequest.HighestSupportedVersion);
+
+            var response = await connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                request, version, cancellationToken).ConfigureAwait(false);
+
+            if (response.ErrorCode != ErrorCode.None)
+            {
+                LogLeaveGroupFailed(response.ErrorCode);
+            }
+            else
+            {
+                LogSuccessfullyLeftGroup(_options.GroupId!);
+            }
+        }
+        catch (Exception ex)
+        {
+            LogLeaveGroupRequestFailed(ex);
+        }
+
+        await StopHeartbeatAsync().ConfigureAwait(false);
+
+        await _lock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            ResetMemberState();
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    #endregion
+
     /// <summary>
     /// Leaves the consumer group gracefully.
     /// </summary>
@@ -1247,6 +1746,13 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         // If coordinator is unknown, we can't send LeaveGroup
         if (_coordinatorId < 0)
             return;
+
+        // KIP-848: leave via ConsumerGroupHeartbeat with MemberEpoch=-1
+        if (_options.GroupProtocol == GroupProtocol.Consumer)
+        {
+            await LeaveGroupConsumerProtocolAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
 
         try
         {
@@ -1329,10 +1835,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         await _lock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
         try
         {
-            _memberId = null;
-            _generationId = -1;
-            _assignedPartitions = [];
-            _state = CoordinatorState.Unjoined;
+            ResetMemberState();
         }
         finally
         {
@@ -1456,6 +1959,15 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Error, Message = "{CallbackName} rebalance listener callback threw an exception")]
     private partial void LogRebalanceListenerCallbackError(string callbackName, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ConsumerGroupHeartbeat: unknown topic ID {TopicId} in assignment, skipping")]
+    private partial void LogUnknownTopicIdInAssignment(Guid topicId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "ConsumerGroupHeartbeat: assignment updated, {AssignedCount} assigned, {RevokedCount} revoked")]
+    private partial void LogConsumerProtocolAssignmentUpdate(int assignedCount, int revokedCount);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "ConsumerGroupHeartbeat: member epoch updated to {MemberEpoch}")]
+    private partial void LogMemberEpochUpdated(int memberEpoch);
 
     #endregion
 }

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1566,6 +1566,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     _generationId = _options.GroupInstanceId is not null ? -2 : 0;
                     _state = CoordinatorState.Unjoined;
                 }
+                catch (Errors.GroupException ex) when (ex.ErrorCode == ErrorCode.UnknownMemberId)
+                {
+                    // Broker forgot this member (e.g. broker restart after fencing) — full reset and retry
+                    LogRetriableCoordinatorError(ex.ErrorCode);
+                    ResetMemberState();
+                }
                 catch (Errors.GroupException ex) when (IsRetriableCoordinatorError(ex.ErrorCode))
                 {
                     LogRetriableCoordinatorError(ex.ErrorCode);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1310,12 +1310,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             ? (_generationId == -2 && _options.GroupInstanceId is not null ? -2 : 0)
             : _generationId;
 
-        // Build owned topic partitions for acknowledgment (not sent on initial join)
-        IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? ownedTopicPartitions = null;
-        if (!isInitial)
-        {
-            ownedTopicPartitions = BuildOwnedTopicPartitions(_assignedPartitions);
-        }
+        // On initial join, send empty array (owns nothing). null means "unchanged" in KIP-848
+        // which is invalid when there's no previous state.
+        IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? ownedTopicPartitions =
+            isInitial ? [] : BuildOwnedTopicPartitions(_assignedPartitions);
 
         // Atomically snapshot and clear the subscription-changed flag to prevent a race where
         // a concurrent EnsureActiveGroupConsumerProtocolAsync sets new topics + flag=true,

--- a/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatResponse.cs
@@ -104,10 +104,9 @@ public sealed class ConsumerGroupHeartbeatAssignment
 
     public static ConsumerGroupHeartbeatAssignment Read(ref KafkaProtocolReader reader)
     {
+        // v0 Assignment has a single field: TopicPartitions (the assigned partitions).
+        // PendingTopicPartitions does not exist in the v0 wire format.
         var assignedTopicPartitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ConsumerGroupHeartbeatTopicPartitions.Read(ref r));
-
-        var pendingTopicPartitions = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r) => ConsumerGroupHeartbeatTopicPartitions.Read(ref r));
 
         reader.SkipTaggedFields();
@@ -115,7 +114,7 @@ public sealed class ConsumerGroupHeartbeatAssignment
         return new ConsumerGroupHeartbeatAssignment
         {
             AssignedTopicPartitions = assignedTopicPartitions,
-            PendingTopicPartitions = pendingTopicPartitions
+            PendingTopicPartitions = []
         };
     }
 }

--- a/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatResponse.cs
@@ -59,11 +59,10 @@ public sealed class ConsumerGroupHeartbeatResponse : IKafkaResponse
         var memberEpoch = reader.ReadInt32();
         var heartbeatIntervalMs = reader.ReadInt32();
 
-        // Assignment is a nullable struct encoded with a tag-like presence indicator
-        // In the Kafka protocol, the assignment is present if the next varint is > 0
-        var assignmentPresent = reader.ReadUnsignedVarInt();
+        // Nullable non-tagged struct: single signed byte marker (-1 = null, >= 0 = present)
+        var assignmentMarker = reader.ReadInt8();
         ConsumerGroupHeartbeatAssignment? assignment = null;
-        if (assignmentPresent > 0)
+        if (assignmentMarker >= 0)
         {
             assignment = ConsumerGroupHeartbeatAssignment.Read(ref reader);
         }

--- a/tests/Dekaf.Tests.Integration/NewConsumerProtocolTests.cs
+++ b/tests/Dekaf.Tests.Integration/NewConsumerProtocolTests.cs
@@ -12,7 +12,6 @@ namespace Dekaf.Tests.Integration;
 /// </summary>
 [Category("Consumer")]
 [SupportsKafka(400)]
-[Skip("GroupProtocol.Consumer (KIP-848) is not yet implemented")]
 public class NewConsumerProtocolTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1,0 +1,507 @@
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+/// <summary>
+/// Unit tests for KIP-848 (GroupProtocol.Consumer) coordinator path.
+/// Verifies the ConsumerGroupHeartbeat-based state machine, assignment handling,
+/// error recovery, leave, and static membership.
+/// </summary>
+public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
+{
+    private static readonly Guid TestTopicId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly IConnectionPool _connectionPool;
+    private readonly IKafkaConnection _connection;
+    private readonly MetadataManager _metadataManager;
+
+    public ConsumerCoordinatorKip848Tests()
+    {
+        _connectionPool = Substitute.For<IConnectionPool>();
+        _connection = Substitute.For<IKafkaConnection>();
+
+        _connectionPool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(_connection));
+
+        _connectionPool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(_connection));
+
+        _metadataManager = new MetadataManager(_connectionPool, ["localhost:9092"]);
+
+        // Seed cluster metadata with a broker and topic (including TopicId for UUID resolution)
+        _metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    Name = "test-topic",
+                    TopicId = TestTopicId,
+                    ErrorCode = ErrorCode.None,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            PartitionIndex = 0,
+                            LeaderId = 0,
+                            ErrorCode = ErrorCode.None,
+                            ReplicaNodes = [0],
+                            IsrNodes = [0]
+                        },
+                        new PartitionMetadata
+                        {
+                            PartitionIndex = 1,
+                            LeaderId = 0,
+                            ErrorCode = ErrorCode.None,
+                            ReplicaNodes = [0],
+                            IsrNodes = [0]
+                        }
+                    ]
+                }
+            ]
+        });
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _metadataManager.DisposeAsync();
+    }
+
+    private static ConsumerOptions CreateConsumerProtocolOptions(
+        string groupId = "test-group",
+        IRebalanceListener? rebalanceListener = null,
+        string? groupInstanceId = null,
+        string? groupRemoteAssignor = null,
+        int heartbeatIntervalMs = 3000,
+        int rebalanceTimeoutMs = 30000) => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        GroupId = groupId,
+        GroupProtocol = GroupProtocol.Consumer,
+        GroupRemoteAssignor = groupRemoteAssignor,
+        GroupInstanceId = groupInstanceId,
+        RebalanceListener = rebalanceListener,
+        HeartbeatIntervalMs = heartbeatIntervalMs,
+        RebalanceTimeoutMs = rebalanceTimeoutMs
+    };
+
+    private void SetupFindCoordinator()
+    {
+        _connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                ErrorCode = ErrorCode.None,
+                NodeId = 0,
+                Host = "localhost",
+                Port = 9092
+            }));
+    }
+
+    private void SetupConsumerGroupHeartbeat(
+        string memberId = "member-1",
+        int memberEpoch = 1,
+        int heartbeatIntervalMs = 5000,
+        ConsumerGroupHeartbeatAssignment? assignment = null,
+        ErrorCode errorCode = ErrorCode.None)
+    {
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+            {
+                ErrorCode = errorCode,
+                MemberId = memberId,
+                MemberEpoch = memberEpoch,
+                HeartbeatIntervalMs = heartbeatIntervalMs,
+                Assignment = assignment
+            }));
+    }
+
+    private void SetupSuccessfulConsumerProtocolJoin(
+        string memberId = "member-1",
+        int memberEpoch = 1,
+        ConsumerGroupHeartbeatAssignment? assignment = null)
+    {
+        SetupFindCoordinator();
+        SetupConsumerGroupHeartbeat(memberId, memberEpoch, assignment: assignment);
+    }
+
+    private static ConsumerGroupHeartbeatAssignment CreateAssignment(
+        Guid topicId, params int[] partitions)
+    {
+        return new ConsumerGroupHeartbeatAssignment
+        {
+            AssignedTopicPartitions =
+            [
+                new ConsumerGroupHeartbeatTopicPartitions
+                {
+                    TopicId = topicId,
+                    Partitions = partitions
+                }
+            ],
+            PendingTopicPartitions = []
+        };
+    }
+
+    #region Initial Join Tests
+
+    [Test]
+    public async Task ConsumerProtocol_SuccessfulJoin_TransitionsToStable()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_SuccessfulJoin_SetsMemberId()
+    {
+        SetupSuccessfulConsumerProtocolJoin(memberId: "kip848-member-42");
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await Assert.That(coordinator.MemberId).IsEqualTo("kip848-member-42");
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_SuccessfulJoin_SetsMemberEpochAsGenerationId()
+    {
+        SetupSuccessfulConsumerProtocolJoin(memberEpoch: 5);
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        // MemberEpoch is stored in GenerationId for offset commit compatibility
+        await Assert.That(coordinator.GenerationId).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_SuccessfulJoin_WithAssignment_SetsPartitions()
+    {
+        var assignment = CreateAssignment(TestTopicId, 0, 1);
+        SetupSuccessfulConsumerProtocolJoin(assignment: assignment);
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await Assert.That(coordinator.Assignment).Count().IsEqualTo(2);
+        await Assert.That(coordinator.Assignment).Contains(new TopicPartition("test-topic", 0));
+        await Assert.That(coordinator.Assignment).Contains(new TopicPartition("test-topic", 1));
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_WhenAlreadyStable_ReturnsImmediately()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var topics = new HashSet<string> { "test-topic" };
+
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+
+        _connection.ClearReceivedCalls();
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+
+        await _connection.DidNotReceive().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Any<ConsumerGroupHeartbeatRequest>(),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_InitialJoin_SendsMemberEpochZero()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(r => r.MemberEpoch == 0),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_InitialJoin_SendsSubscribedTopics()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(r =>
+                r.SubscribedTopicNames != null && r.SubscribedTopicNames.Contains("test-topic")),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Assignment Tests
+
+    [Test]
+    public async Task ConsumerProtocol_UnknownTopicId_SkipsPartitions()
+    {
+        var unknownTopicId = Guid.Parse("00000000-0000-0000-0000-999999999999");
+        var assignment = CreateAssignment(unknownTopicId, 0, 1);
+        SetupSuccessfulConsumerProtocolJoin(assignment: assignment);
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        // Unknown topic ID partitions are skipped
+        await Assert.That(coordinator.Assignment).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_AssignmentWithRebalanceListener_FiresOnPartitionsAssigned()
+    {
+        var assignment = CreateAssignment(TestTopicId, 0, 1);
+        SetupSuccessfulConsumerProtocolJoin(assignment: assignment);
+
+        var assignedPartitions = new List<TopicPartition>();
+        var listener = Substitute.For<IRebalanceListener>();
+        listener.OnPartitionsAssignedAsync(Arg.Any<IEnumerable<TopicPartition>>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                assignedPartitions.AddRange(ci.Arg<IEnumerable<TopicPartition>>());
+                return ValueTask.CompletedTask;
+            });
+
+        var options = CreateConsumerProtocolOptions(rebalanceListener: listener);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await Assert.That(assignedPartitions).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_PendingPartitions_NotAddedToAssignment()
+    {
+        // Assignment with partitions in pending only (not yet released by other member)
+        var assignment = new ConsumerGroupHeartbeatAssignment
+        {
+            AssignedTopicPartitions = [],
+            PendingTopicPartitions =
+            [
+                new ConsumerGroupHeartbeatTopicPartitions
+                {
+                    TopicId = TestTopicId,
+                    Partitions = [0, 1]
+                }
+            ]
+        };
+        SetupSuccessfulConsumerProtocolJoin(assignment: assignment);
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        // Pending partitions must NOT be consumed
+        await Assert.That(coordinator.Assignment).Count().IsEqualTo(0);
+    }
+
+    #endregion
+
+    #region Error Handling Tests
+
+    [Test]
+    public async Task ConsumerProtocol_FencedMemberEpoch_RetriesJoin()
+    {
+        SetupFindCoordinator();
+
+        // First call: FencedMemberEpoch, second call: success
+        var callCount = 0;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.FencedMemberEpoch,
+                        ErrorMessage = "Fenced",
+                        MemberEpoch = 0,
+                        HeartbeatIntervalMs = 5000
+                    });
+                }
+
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = 2,
+                    HeartbeatIntervalMs = 5000
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+        await Assert.That(callCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_UnreleasedInstanceId_Throws()
+    {
+        SetupFindCoordinator();
+        SetupConsumerGroupHeartbeat(errorCode: ErrorCode.UnreleasedInstanceId);
+
+        var options = CreateConsumerProtocolOptions(groupInstanceId: "static-1");
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        GroupException? caught = null;
+        try
+        {
+            await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        }
+        catch (GroupException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.ErrorCode).IsEqualTo(ErrorCode.UnreleasedInstanceId);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_UnsupportedAssignor_Throws()
+    {
+        SetupFindCoordinator();
+        SetupConsumerGroupHeartbeat(errorCode: ErrorCode.UnsupportedAssignor);
+
+        var options = CreateConsumerProtocolOptions(groupRemoteAssignor: "invalid-assignor");
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        GroupException? caught = null;
+        try
+        {
+            await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        }
+        catch (GroupException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.ErrorCode).IsEqualTo(ErrorCode.UnsupportedAssignor);
+    }
+
+    #endregion
+
+    #region Leave Group Tests
+
+    [Test]
+    public async Task ConsumerProtocol_LeaveGroup_SendsMemberEpochNegativeOne()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        _connection.ClearReceivedCalls();
+
+        // Re-setup for the leave heartbeat
+        SetupConsumerGroupHeartbeat();
+
+        await coordinator.LeaveGroupAsync(cancellationToken: CancellationToken.None);
+
+        await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(r => r.MemberEpoch == -1),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_LeaveGroup_ResetsState()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        SetupConsumerGroupHeartbeat();
+        await coordinator.LeaveGroupAsync(cancellationToken: CancellationToken.None);
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+        await Assert.That(coordinator.MemberId).IsNull();
+        await Assert.That(coordinator.GenerationId).IsEqualTo(-1);
+    }
+
+    #endregion
+
+    #region Remote Assignor Tests
+
+    [Test]
+    public async Task ConsumerProtocol_WithRemoteAssignor_SendsServerAssignor()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(groupRemoteAssignor: "uniform");
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(r => r.ServerAssignor == "uniform"),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Static Membership Tests
+
+    [Test]
+    public async Task ConsumerProtocol_StaticMembership_SendsInstanceId()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(groupInstanceId: "static-instance-1");
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(r => r.InstanceId == "static-instance-1"),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Metadata;
@@ -491,6 +490,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         SetupFindCoordinator();
 
         var callCount = 0;
+        var fencingProcessed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         ConsumerGroupHeartbeatRequest? lastRequest = null;
 
         _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
@@ -501,33 +501,37 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             {
                 var count = Interlocked.Increment(ref callCount);
                 Volatile.Write(ref lastRequest, ci.Arg<ConsumerGroupHeartbeatRequest>());
-                return count switch
+
+                if (count == 1)
                 {
-                    // Initial join succeeds with short heartbeat interval
-                    1 => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
                     {
                         ErrorCode = ErrorCode.None,
                         MemberId = "member-1",
                         MemberEpoch = 5,
                         HeartbeatIntervalMs = 100
-                    }),
-                    // Heartbeat loop fires: fenced
-                    2 => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    });
+                }
+
+                if (count == 2)
+                {
+                    fencingProcessed.TrySetResult();
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
                     {
                         ErrorCode = ErrorCode.FencedMemberEpoch,
                         ErrorMessage = "Fenced",
                         MemberEpoch = 0,
                         HeartbeatIntervalMs = 5000
-                    }),
-                    // Rejoin succeeds
-                    _ => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
-                    {
-                        ErrorCode = ErrorCode.None,
-                        MemberId = "member-1",
-                        MemberEpoch = 6,
-                        HeartbeatIntervalMs = 60000
-                    })
-                };
+                    });
+                }
+
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = 6,
+                    HeartbeatIntervalMs = 60000
+                });
             });
 
         var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 100);
@@ -538,10 +542,10 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
         await Assert.That(coordinator.GenerationId).IsEqualTo(5);
 
-        // Wait for heartbeat loop to fire and get fenced
-        var sw = Stopwatch.StartNew();
-        while (coordinator.State == CoordinatorState.Stable && sw.Elapsed < TimeSpan.FromSeconds(5))
-            await Task.Delay(50);
+        // Wait for heartbeat loop to process the fencing response (deterministic signal)
+        await fencingProcessed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        // Brief yield to let the heartbeat loop complete its state transition after the mock returns
+        await Task.Delay(50);
 
         await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
         // With fix: _generationId reset to 0 by fencing handler (not stale 5)
@@ -565,6 +569,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         SetupFindCoordinator();
 
         var callCount = 0;
+        var fencingProcessed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         ConsumerGroupHeartbeatRequest? lastRequest = null;
 
         _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
@@ -575,33 +580,37 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             {
                 var count = Interlocked.Increment(ref callCount);
                 Volatile.Write(ref lastRequest, ci.Arg<ConsumerGroupHeartbeatRequest>());
-                return count switch
+
+                if (count == 1)
                 {
-                    // Initial join succeeds with short heartbeat interval
-                    1 => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
                     {
                         ErrorCode = ErrorCode.None,
                         MemberId = "member-1",
                         MemberEpoch = 3,
                         HeartbeatIntervalMs = 100
-                    }),
-                    // Heartbeat loop fires: fenced
-                    2 => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    });
+                }
+
+                if (count == 2)
+                {
+                    fencingProcessed.TrySetResult();
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
                     {
                         ErrorCode = ErrorCode.FencedMemberEpoch,
                         ErrorMessage = "Fenced",
                         MemberEpoch = 0,
                         HeartbeatIntervalMs = 5000
-                    }),
-                    // Rejoin succeeds
-                    _ => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
-                    {
-                        ErrorCode = ErrorCode.None,
-                        MemberId = "member-1",
-                        MemberEpoch = 4,
-                        HeartbeatIntervalMs = 60000
-                    })
-                };
+                    });
+                }
+
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = 4,
+                    HeartbeatIntervalMs = 60000
+                });
             });
 
         var options = CreateConsumerProtocolOptions(groupInstanceId: "static-1", heartbeatIntervalMs: 100);
@@ -612,10 +621,10 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
         await Assert.That(coordinator.GenerationId).IsEqualTo(3);
 
-        // Wait for heartbeat loop to fire and get fenced
-        var sw = Stopwatch.StartNew();
-        while (coordinator.State == CoordinatorState.Stable && sw.Elapsed < TimeSpan.FromSeconds(5))
-            await Task.Delay(50);
+        // Wait for heartbeat loop to process the fencing response (deterministic signal)
+        await fencingProcessed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        // Brief yield to let the heartbeat loop complete its state transition after the mock returns
+        await Task.Delay(50);
 
         await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
         // With fix: _generationId reset to -2 for static member (triggers MemberEpoch=-2 on rejoin)
@@ -629,6 +638,50 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await Assert.That(rejoinReq!.MemberEpoch).IsEqualTo(-2);
         await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
         await Assert.That(coordinator.GenerationId).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_UnknownMemberId_InJoinPath_ResetsAndRetries()
+    {
+        SetupFindCoordinator();
+
+        var callCount = 0;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                return callCount switch
+                {
+                    // First: UnknownMemberId (broker forgot this member)
+                    1 => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.UnknownMemberId,
+                        ErrorMessage = "Unknown member",
+                        MemberEpoch = 0,
+                        HeartbeatIntervalMs = 5000
+                    }),
+                    // Second: successful fresh join
+                    _ => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-2",
+                        MemberEpoch = 1,
+                        HeartbeatIntervalMs = 5000
+                    })
+                };
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+        await Assert.That(coordinator.MemberId).IsEqualTo("member-2");
+        await Assert.That(callCount).IsEqualTo(2);
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Metadata;
@@ -482,6 +483,152 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             Arg.Is<ConsumerGroupHeartbeatRequest>(r => r.ServerAssignor == "uniform"),
             Arg.Any<short>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_FencedDuringHeartbeat_RejoinsWithEpochZero()
+    {
+        SetupFindCoordinator();
+
+        var callCount = 0;
+        ConsumerGroupHeartbeatRequest? lastRequest = null;
+
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                Volatile.Write(ref lastRequest, ci.Arg<ConsumerGroupHeartbeatRequest>());
+                return count switch
+                {
+                    // Initial join succeeds with short heartbeat interval
+                    1 => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-1",
+                        MemberEpoch = 5,
+                        HeartbeatIntervalMs = 100
+                    }),
+                    // Heartbeat loop fires: fenced
+                    2 => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.FencedMemberEpoch,
+                        ErrorMessage = "Fenced",
+                        MemberEpoch = 0,
+                        HeartbeatIntervalMs = 5000
+                    }),
+                    // Rejoin succeeds
+                    _ => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-1",
+                        MemberEpoch = 6,
+                        HeartbeatIntervalMs = 60000
+                    })
+                };
+            });
+
+        var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 100);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var topics = new HashSet<string> { "test-topic" };
+
+        // Initial join succeeds (epoch=5)
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        await Assert.That(coordinator.GenerationId).IsEqualTo(5);
+
+        // Wait for heartbeat loop to fire and get fenced
+        var sw = Stopwatch.StartNew();
+        while (coordinator.State == CoordinatorState.Stable && sw.Elapsed < TimeSpan.FromSeconds(5))
+            await Task.Delay(50);
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+        // With fix: _generationId reset to 0 by fencing handler (not stale 5)
+        await Assert.That(coordinator.GenerationId).IsEqualTo(0);
+        // _memberId preserved (member is known, just epoch-stale)
+        await Assert.That(coordinator.MemberId).IsEqualTo("member-1");
+
+        // Rejoin — should send MemberEpoch=0, not the stale 5
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+
+        var rejoinReq = Volatile.Read(ref lastRequest);
+        await Assert.That(rejoinReq).IsNotNull();
+        await Assert.That(rejoinReq!.MemberEpoch).IsEqualTo(0);
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+        await Assert.That(coordinator.GenerationId).IsEqualTo(6);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_StaticMember_FencedDuringHeartbeat_RejoinsWithEpochNegativeTwo()
+    {
+        SetupFindCoordinator();
+
+        var callCount = 0;
+        ConsumerGroupHeartbeatRequest? lastRequest = null;
+
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                Volatile.Write(ref lastRequest, ci.Arg<ConsumerGroupHeartbeatRequest>());
+                return count switch
+                {
+                    // Initial join succeeds with short heartbeat interval
+                    1 => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-1",
+                        MemberEpoch = 3,
+                        HeartbeatIntervalMs = 100
+                    }),
+                    // Heartbeat loop fires: fenced
+                    2 => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.FencedMemberEpoch,
+                        ErrorMessage = "Fenced",
+                        MemberEpoch = 0,
+                        HeartbeatIntervalMs = 5000
+                    }),
+                    // Rejoin succeeds
+                    _ => ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-1",
+                        MemberEpoch = 4,
+                        HeartbeatIntervalMs = 60000
+                    })
+                };
+            });
+
+        var options = CreateConsumerProtocolOptions(groupInstanceId: "static-1", heartbeatIntervalMs: 100);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var topics = new HashSet<string> { "test-topic" };
+
+        // Initial join succeeds (epoch=3)
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        await Assert.That(coordinator.GenerationId).IsEqualTo(3);
+
+        // Wait for heartbeat loop to fire and get fenced
+        var sw = Stopwatch.StartNew();
+        while (coordinator.State == CoordinatorState.Stable && sw.Elapsed < TimeSpan.FromSeconds(5))
+            await Task.Delay(50);
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+        // With fix: _generationId reset to -2 for static member (triggers MemberEpoch=-2 on rejoin)
+        await Assert.That(coordinator.GenerationId).IsEqualTo(-2);
+
+        // Rejoin — static member should send MemberEpoch=-2
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+
+        var rejoinReq = Volatile.Read(ref lastRequest);
+        await Assert.That(rejoinReq).IsNotNull();
+        await Assert.That(rejoinReq!.MemberEpoch).IsEqualTo(-2);
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+        await Assert.That(coordinator.GenerationId).IsEqualTo(4);
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Consumer/GroupProtocolConfigTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/GroupProtocolConfigTests.cs
@@ -125,26 +125,26 @@ public sealed class GroupProtocolConfigTests
     }
 
     [Test]
-    public async Task WithGroupProtocol_Consumer_ThenBuild_ThrowsNotSupported()
+    public async Task WithGroupProtocol_Consumer_ThenBuild_Succeeds()
     {
-        var act = () => Kafka.CreateConsumer<string, string>()
+        await using var consumer = Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers("localhost:9092")
             .WithGroupProtocol(GroupProtocol.Consumer)
             .Build();
 
-        await Assert.That(act).Throws<NotSupportedException>();
+        await Assert.That(consumer).IsNotNull();
     }
 
     [Test]
-    public async Task WithGroupProtocol_Consumer_WithRemoteAssignor_ThenBuild_ThrowsNotSupported()
+    public async Task WithGroupProtocol_Consumer_WithRemoteAssignor_ThenBuild_Succeeds()
     {
-        var act = () => Kafka.CreateConsumer<string, string>()
+        await using var consumer = Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers("localhost:9092")
             .WithGroupProtocol(GroupProtocol.Consumer)
             .WithGroupRemoteAssignor("uniform")
             .Build();
 
-        await Assert.That(act).Throws<NotSupportedException>();
+        await Assert.That(consumer).IsNotNull();
     }
 
     [Test]
@@ -185,15 +185,15 @@ public sealed class GroupProtocolConfigTests
     }
 
     [Test]
-    public async Task Build_WithGroupRemoteAssignor_WithConsumerProtocol_ThrowsNotSupported()
+    public async Task Build_WithGroupRemoteAssignor_WithConsumerProtocol_Succeeds()
     {
-        var act = () => Kafka.CreateConsumer<string, string>()
+        await using var consumer = Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers("localhost:9092")
             .WithGroupProtocol(GroupProtocol.Consumer)
             .WithGroupRemoteAssignor("uniform")
             .Build();
 
-        await Assert.That(act).Throws<NotSupportedException>();
+        await Assert.That(consumer).IsNotNull();
     }
 
     #endregion
@@ -201,9 +201,9 @@ public sealed class GroupProtocolConfigTests
     #region Builder Chaining
 
     [Test]
-    public async Task FullChain_WithConsumerProtocol_ThrowsNotSupported()
+    public async Task FullChain_WithConsumerProtocol_Succeeds()
     {
-        var act = () => Kafka.CreateConsumer<string, string>()
+        await using var consumer = Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers("localhost:9092")
             .WithGroupId("my-group")
             .WithGroupProtocol(GroupProtocol.Consumer)
@@ -211,7 +211,7 @@ public sealed class GroupProtocolConfigTests
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
             .Build();
 
-        await Assert.That(act).Throws<NotSupportedException>();
+        await Assert.That(consumer).IsNotNull();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Protocol/ConsumerGroupHeartbeatMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ConsumerGroupHeartbeatMessageTests.cs
@@ -403,6 +403,115 @@ public sealed class ConsumerGroupHeartbeatMessageTests
 
     #endregion
 
+    #region Response Wire Format Parsing
+
+    [Test]
+    public async Task Response_Read_NullAssignment_ParsesCorrectly()
+    {
+        // Nullable non-tagged struct fields use a single signed byte marker:
+        // -1 (0xFF) = null, >= 0 (e.g., 0x01) = present
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);                     // ThrottleTimeMs
+        writer.WriteInt16(0);                     // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);            // ErrorMessage = null (compact nullable string)
+        WriteCompactNullableString(ref writer, "member-1"); // MemberId
+        writer.WriteInt32(1);                     // MemberEpoch
+        writer.WriteInt32(5000);                  // HeartbeatIntervalMs
+        writer.WriteInt8(-1);                     // Assignment = null (signed byte marker)
+        writer.WriteUnsignedVarInt(0);            // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ConsumerGroupHeartbeatResponse)ConsumerGroupHeartbeatResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ErrorMessage).IsNull();
+        await Assert.That(response.MemberId).IsEqualTo("member-1");
+        await Assert.That(response.MemberEpoch).IsEqualTo(1);
+        await Assert.That(response.HeartbeatIntervalMs).IsEqualTo(5000);
+        await Assert.That(response.Assignment).IsNull();
+    }
+
+    [Test]
+    public async Task Response_Read_WithAssignment_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);                     // ThrottleTimeMs
+        writer.WriteInt16(0);                     // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);            // ErrorMessage = null
+        WriteCompactNullableString(ref writer, "member-1"); // MemberId
+        writer.WriteInt32(1);                     // MemberEpoch
+        writer.WriteInt32(5000);                  // HeartbeatIntervalMs
+        writer.WriteInt8(1);                      // Assignment = present (signed byte marker)
+        // TopicPartitions compact array: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteUuid(topicId);
+        writer.WriteUnsignedVarInt(1 + 1);        // Partitions: 1 element
+        writer.WriteInt32(0);                     // partition 0
+        writer.WriteUnsignedVarInt(0);            // TopicPartitions[0] tagged fields
+        writer.WriteUnsignedVarInt(0);            // Assignment tagged fields
+        writer.WriteUnsignedVarInt(0);            // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ConsumerGroupHeartbeatResponse)ConsumerGroupHeartbeatResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.MemberId).IsEqualTo("member-1");
+        await Assert.That(response.MemberEpoch).IsEqualTo(1);
+        await Assert.That(response.HeartbeatIntervalMs).IsEqualTo(5000);
+        await Assert.That(response.Assignment).IsNotNull();
+        await Assert.That(response.Assignment!.AssignedTopicPartitions.Count).IsEqualTo(1);
+        await Assert.That(response.Assignment.AssignedTopicPartitions[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(response.Assignment.AssignedTopicPartitions[0].Partitions.Count).IsEqualTo(1);
+        await Assert.That(response.Assignment.AssignedTopicPartitions[0].Partitions[0]).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_Read_EmptyAssignment_ParsesCorrectly()
+    {
+        // Assignment struct is present but TopicPartitions array is empty
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);                     // ThrottleTimeMs
+        writer.WriteInt16(0);                     // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);            // ErrorMessage = null
+        WriteCompactNullableString(ref writer, "member-1"); // MemberId
+        writer.WriteInt32(1);                     // MemberEpoch
+        writer.WriteInt32(5000);                  // HeartbeatIntervalMs
+        writer.WriteInt8(1);                      // Assignment = present (signed byte marker)
+        writer.WriteUnsignedVarInt(0 + 1);        // TopicPartitions: empty compact array
+        writer.WriteUnsignedVarInt(0);            // Assignment tagged fields
+        writer.WriteUnsignedVarInt(0);            // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ConsumerGroupHeartbeatResponse)ConsumerGroupHeartbeatResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.Assignment).IsNotNull();
+        await Assert.That(response.Assignment!.AssignedTopicPartitions.Count).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// Helper to write a compact nullable string (varint length+1, then UTF-8 bytes; 0 for null).
+    /// </summary>
+    private static void WriteCompactNullableString(ref KafkaProtocolWriter writer, string? value)
+    {
+        if (value is null)
+        {
+            writer.WriteUnsignedVarInt(0);
+            return;
+        }
+        writer.WriteCompactString(value);
+    }
+
+    #endregion
+
     #region Assignment
 
     [Test]


### PR DESCRIPTION
## Summary

Implements the KIP-848 Consumer group protocol as an alternative to the classic JoinGroup/SyncGroup/Heartbeat coordination flow. The new protocol uses a single `ConsumerGroupHeartbeat` API (key 68) where partition assignment is handled server-side (Kafka 4.0+), providing faster rebalancing and simpler client logic.

Closes #812

## Changes

- **`ConsumerCoordinator.cs`** — All new KIP-848 methods branching on `GroupProtocol`:
  - `EnsureActiveGroupConsumerProtocolAsync` — join flow with retry loop, rebalance listeners fired outside lock
  - `SendConsumerGroupHeartbeatAsync` — constructs/sends heartbeat, manages MemberEpoch lifecycle (0=initial, -1=leave, -2=static rejoin)
  - `ProcessConsumerGroupAssignment` — resolves topic UUIDs to names, computes revoked/assigned diffs
  - `ConsumerProtocolHeartbeatLoopAsync` — dynamic interval from broker response (Task.Delay, not PeriodicTimer)
  - `LeaveGroupConsumerProtocolAsync` — sends MemberEpoch=-1, stops heartbeat, resets state
  - Extracted `ResetMemberState()`, `FireConsumerProtocolRebalanceListenersAsync()`, and `StartHeartbeatCoreAsync` shared by both protocols
- **`Builders.cs`** — Removed `NotSupportedException` guard; kept `GroupRemoteAssignor` validation
- **`NewConsumerProtocolTests.cs`** — Removed `[Skip]` attribute to enable integration tests
- **`GroupProtocolConfigTests.cs`** — Updated 4 tests from expecting `NotSupportedException` to asserting successful build
- **`ConsumerCoordinatorKip848Tests.cs`** — 17 new unit tests covering join, assignment, error handling, leave, static membership, and rebalance listeners

## Design decisions

- **Single class** — No new coordinator class. KIP-848 code is ~5 new methods; shared infrastructure is ~60% of the class.
- **Reuses `_generationId` for MemberEpoch** — `OffsetCommitRequest.GenerationIdOrMemberEpoch` already accepts both. Zero changes to `CommitOffsetsAsync`/`FetchOffsetsAsync`.
- **`Task.Delay` not `PeriodicTimer`** — Heartbeat interval changes dynamically from broker responses.
- **No `Joining`/`Syncing` states** — KIP-848 transitions directly from `Unjoined` to `Stable`.

## Test plan

- [x] All 3,528 unit tests pass
- [x] 17 new KIP-848 unit tests cover: initial join, assignment processing, error codes (FencedMemberEpoch, UnknownMemberId, UnreleasedInstanceId, UnsupportedAssignor), leave, static membership, rebalance listeners, unknown topic UUID skipping, dynamic heartbeat interval
- [ ] Integration tests (`NewConsumerProtocolTests`) require Kafka 4.0+ broker with KIP-848 support