### PR TITLE
feat: implement KIP-890 Transactions V2 (server-side fencing)

### DIFF
--- a/docs/plans/2026-04-13-kip890-transactions-v2-design.md
+++ b/docs/plans/2026-04-13-kip890-transactions-v2-design.md
@@ -1,0 +1,94 @@
+# KIP-890: Transactions V2 (Server-Side Fencing) — Design
+
+**Issue:** #818
+**KIP:** https://cwiki.apache.org/confluence/display/KAFKA/KIP-890%3A+Transactions+Server-Side+Defense
+**Date:** 2026-04-13
+
+## Overview
+
+Implement KIP-890 Transactions V2, which introduces server-side fencing for transactional producers. Kafka 4.0+ brokers support TV2 natively, enabling more efficient transactional workflows: implicit partition registration, epoch bumps via EndTxn response, and elimination of the post-abort InitProducerId round-trip.
+
+## 1. TV2 Capability Detection
+
+**MetadataManager** gains finalized feature storage. `NegotiateApiVersionsAsync` already parses `FinalizedFeatures` from `ApiVersionsResponse` but discards them. Store them:
+
+- New field: `private volatile IReadOnlyList<FinalizedFeature>? _finalizedFeatures`
+- New method: `internal short GetFinalizedFeatureVersion(string featureName)` — iterates `_finalizedFeatures`, returns `MaxVersionLevel` for matching name, or `0` if absent
+- In `NegotiateApiVersionsAsync`, after existing API version processing: `_finalizedFeatures = response.FinalizedFeatures`
+
+**KafkaProducer** latches per-transaction. In `BeginTransaction()`:
+
+- New field: `internal bool _currentTransactionUsesTV2`
+- Set at transaction start: `_currentTransactionUsesTV2 = _metadataManager.GetFinalizedFeatureVersion("transaction.version") >= 2`
+- Never changes mid-transaction — all downstream logic checks this single field
+
+## 2. EndTxn v4 Response — Epoch Bump
+
+**EndTxnResponse** currently only reads `ThrottleTimeMs` and `ErrorCode`, skipping tagged fields. In v4, the broker returns bumped `ProducerId` and `ProducerEpoch` as tagged fields (tags 0 and 1).
+
+Changes:
+- Add `public long ProducerId { get; init; } = -1` and `public short ProducerEpoch { get; init; } = -1` to `EndTxnResponse`
+- Replace `reader.SkipTaggedFields()` with explicit tag parsing: tag 0 → `ReadInt64()` (ProducerId), tag 1 → `ReadInt16()` (ProducerEpoch), default → `Skip(size)`
+
+**KafkaProducer.EndTransactionAsync** uses these values. On success, if TV2 is active and the response contains a valid ProducerId (`>= 0`):
+- Update `_producerId` and `_producerEpoch`
+- Update `_accumulator.ProducerId` and `_accumulator.ProducerEpoch`
+- Reset sequence numbers via `_accumulator.ResetSequenceNumbers()`
+
+## 3. Abort Flow Change
+
+Currently `AbortAsync` calls `EndTransactionAsync` then `ReinitializeProducerIdAsync` (network round-trip). In TV2, `EndTransactionAsync` already applied the bumped epoch from the response, so the re-init is unnecessary.
+
+In `Transaction.AbortAsync`:
+- After `EndTransactionAsync(committed: false)`, check `_currentTransactionUsesTV2`
+- TV1: call `ReinitializeProducerIdAsync` (existing behavior)
+- TV2: skip — epoch already updated
+
+This is the main latency win: abort-to-next-transaction eliminates one network round-trip.
+
+Commit flow is structurally unchanged — it already doesn't call `ReinitializeProducerIdAsync`. But `EndTransactionAsync` will now apply the bumped epoch from v4 on commit too.
+
+## 4. Implicit AddPartitionsToTxn
+
+~~Originally planned to skip `AddPartitionsToTxn` in TV2 based on the assumption that the broker registers partitions implicitly. This was incorrect — Kafka 4.0+ still requires explicit `AddPartitionsToTxn` before the Produce request. Omitting it causes `NotMemberOfTenant` errors.~~
+
+**No change:** `AddPartitionsToTxn` is always sent regardless of TV2. KIP-890 only changes epoch management and error classification, not partition registration.
+
+## 5. Error Classification
+
+New `TransactionErrorClassification` enum: `Retriable`, `Abortable`, `Fatal`.
+
+New `TransactionErrorClassifier.Classify(ErrorCode, bool tv2)` static method:
+- **Fatal (always):** `ProducerFenced`, `TransactionalIdAuthorizationFailed`, `TransactionCoordinatorFenced`
+- **Fatal (TV2 only) / Abortable (TV1):** `InvalidProducerIdMapping` (error code 49)
+- **Retriable:** `CoordinatorLoadInProgress`, `CoordinatorNotAvailable`, `NotCoordinator`, `ConcurrentTransactions`
+- **Default:** `Abortable` (unknown errors abort the transaction)
+
+Refactor error handling in `EndTransactionAsync`, `AddPartitionsToTransactionAsync`, and `ReinitializeProducerIdAsync` to use `Classify()` instead of inline `if` chains. Existing `IsRetriable()` extension on `ErrorCode` stays unchanged for non-transactional use.
+
+## 6. Files to Change
+
+| File | Change |
+|------|--------|
+| `src/Dekaf/Metadata/MetadataManager.cs` | Store `_finalizedFeatures`, add `GetFinalizedFeatureVersion()` |
+| `src/Dekaf/Protocol/Messages/EndTxnResponse.cs` | Parse tagged fields for ProducerId/ProducerEpoch in v4 |
+| `src/Dekaf/Producer/KafkaProducer.cs` | Add `_currentTransactionUsesTV2` field, latch in `BeginTransaction()`, use in `EndTransactionAsync()` |
+| `src/Dekaf/Producer/KafkaProducer.cs` (Transaction inner class) | Conditional `ReinitializeProducerIdAsync` skip in `AbortAsync()` |
+| `src/Dekaf/Producer/TransactionErrorClassifier.cs` | New file: `TransactionErrorClassification` enum + `Classify()` method |
+| `src/Dekaf/Producer/KafkaProducer.cs` | Refactor error handling to use `TransactionErrorClassifier` |
+
+## 7. Testing
+
+**Unit tests:**
+- EndTxn v4 response parsing: verify ProducerId/ProducerEpoch from tagged fields, v3 backward compatibility (defaults to -1)
+- `TransactionErrorClassifier.Classify`: all error codes in TV1 and TV2, especially `InvalidProducerIdMapping` classification change
+- `MetadataManager.GetFinalizedFeatureVersion`: feature present, absent, version thresholds
+
+**Integration tests (Kafka 4.0+ via Testcontainers):**
+- Produce → commit → verify epoch bump → produce again in new transaction
+- Produce → abort → verify no InitProducerId call → produce again
+- V1 fallback: verify abort still calls InitProducerId when `transaction.version < 2`
+
+**Protocol tests:**
+- EndTxn v4 round-trip serialization with tagged fields
+- Existing v3 tests remain unchanged

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -27,6 +27,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
     private volatile short _metadataApiVersion = -1;
     private readonly ConcurrentDictionary<ApiKey, (short MinVersion, short MaxVersion)> _brokerApiVersions = new();
     private readonly ConcurrentDictionary<(ApiKey, short, short), short> _negotiatedVersionCache = new();
+    private volatile IReadOnlyList<FinalizedFeature>? _finalizedFeatures;
     private int _disposed;
     private readonly CancellationTokenSource _disposalCts = new();
     private CancellationTokenSource? _backgroundRefreshCts;
@@ -131,6 +132,24 @@ public sealed partial class MetadataManager : IAsyncDisposable
         // Cache it (benign race - same value computed)
         _negotiatedVersionCache.TryAdd(cacheKey, negotiated);
         return negotiated;
+    }
+
+    /// <summary>
+    /// Returns the max finalized version for a broker feature, or 0 if the feature is not present.
+    /// </summary>
+    internal short GetFinalizedFeatureVersion(string featureName)
+    {
+        var features = _finalizedFeatures;
+        if (features is null)
+            return 0;
+
+        foreach (var feature in features)
+        {
+            if (feature.Name == featureName)
+                return feature.MaxVersionLevel;
+        }
+
+        return 0;
     }
 
     /// <summary>
@@ -732,6 +751,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
         // Set metadata version last (acts as a signal that negotiation is complete)
         _metadataApiVersion = newMetadataVersion;
+
+        _finalizedFeatures = response.FinalizedFeatures;
 
         LogNegotiatedApiVersion(_metadataApiVersion);
     }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1532,6 +1532,18 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             if (response.ErrorCode == ErrorCode.None)
             {
+                // TV2 (v4+): broker returns bumped ProducerId/Epoch in EndTxn response.
+                // Apply them so the next transaction uses the new identity without
+                // a separate InitProducerId round-trip.
+                if (_currentTransactionUsesTV2 && response.ProducerId >= 0)
+                {
+                    _producerId = response.ProducerId;
+                    _producerEpoch = response.ProducerEpoch;
+                    _accumulator.ProducerId = _producerId;
+                    _accumulator.ProducerEpoch = _producerEpoch;
+                    _accumulator.ResetSequenceNumbers();
+                }
+
                 return;
             }
 
@@ -3120,10 +3132,13 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
         {
             await _producer.EndTransactionAsync(committed: false, cancellationToken).ConfigureAwait(false);
 
-            // After abort, the broker bumps the epoch (KIP-360). Re-initialize the
-            // producer ID to get the new epoch; otherwise the next transaction will
-            // fail with InvalidProducerIdMapping.
-            await _producer.ReinitializeProducerIdAsync(cancellationToken).ConfigureAwait(false);
+            // TV1: broker doesn't return bumped epoch in EndTxn, so we must call
+            // InitProducerId to get it (KIP-360).
+            // TV2: EndTxn v4 response already contained the bumped epoch — skip.
+            if (!_producer._currentTransactionUsesTV2)
+            {
+                await _producer.ReinitializeProducerIdAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             _aborted = true;
         }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -82,6 +82,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly System.Threading.Lock _epochBumpLock = new();
     internal readonly System.Threading.Lock _partitionsInTransactionLock = new();
     internal readonly HashSet<TopicPartition> _partitionsInTransaction = [];
+    internal bool _currentTransactionUsesTV2;
 
     // In-flight batch tracker for coordinated retry with multiple in-flight batches per partition.
     // Always initialized but only actively used for idempotent producers. Non-idempotent producers
@@ -1185,6 +1186,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         _transactionState = TransactionState.InTransaction;
+        _currentTransactionUsesTV2 = _metadataManager.GetFinalizedFeatureVersion("transaction.version") >= 2;
         lock (_partitionsInTransactionLock)
         {
             _partitionsInTransaction.Clear();
@@ -2028,11 +2030,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             needsRegistration = _partitionsInTransaction.Add(topicPartition);
         }
 
-        if (needsRegistration)
-        {
-            await AddPartitionsToTransactionAsync([topicPartition], cancellationToken)
-                .ConfigureAwait(false);
-        }
+        if (!needsRegistration)
+            return;
+
+        // TV2: broker registers partitions implicitly on first Produce request.
+        // Local tracking (above) is still needed for SendOffsetsToTransaction.
+        if (_currentTransactionUsesTV2)
+            return;
+
+        await AddPartitionsToTransactionAsync([topicPartition], cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private async Task LingerLoopAsync(CancellationToken cancellationToken)

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -82,7 +82,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly System.Threading.Lock _epochBumpLock = new();
     internal readonly System.Threading.Lock _partitionsInTransactionLock = new();
     internal readonly HashSet<TopicPartition> _partitionsInTransaction = [];
-    internal bool _currentTransactionUsesTV2;
+    internal volatile bool _currentTransactionUsesTV2;
 
     // In-flight batch tracker for coordinated retry with multiple in-flight batches per partition.
     // Always initialized but only actively used for idempotent producers. Non-idempotent producers
@@ -146,6 +146,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         public byte[]? KeySerializationBuffer;
         public byte[]? ValueSerializationBuffer;
     }
+
+    private const string TransactionVersionFeature = "transaction.version";
 
     // Default sizes match typical key/value sizes to avoid growth in common cases
     private const int DefaultKeyBufferSize = 512;
@@ -1186,7 +1188,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         _transactionState = TransactionState.InTransaction;
-        _currentTransactionUsesTV2 = _metadataManager.GetFinalizedFeatureVersion("transaction.version") >= 2;
+        _currentTransactionUsesTV2 = _metadataManager.GetFinalizedFeatureVersion(TransactionVersionFeature) >= 2;
         lock (_partitionsInTransactionLock)
         {
             _partitionsInTransaction.Clear();
@@ -1296,7 +1298,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 };
             }
 
-            // Success — update PID/epoch
             _producerId = response.ProducerId;
             _producerEpoch = response.ProducerEpoch;
 

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1547,43 +1547,40 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 return;
             }
 
-            if (response.ErrorCode == ErrorCode.ProducerFenced ||
-                response.ErrorCode == ErrorCode.TransactionalIdAuthorizationFailed)
+            var classification = TransactionErrorClassifier.Classify(response.ErrorCode, _currentTransactionUsesTV2);
+
+            switch (classification)
             {
-                _transactionState = TransactionState.FatalError;
-                throw new TransactionException(response.ErrorCode,
-                    $"EndTxn ({(committed ? "commit" : "abort")}) failed: {response.ErrorCode}")
-                {
-                    TransactionalId = _options.TransactionalId
-                };
+                case TransactionErrorClassification.Fatal:
+                    _transactionState = TransactionState.FatalError;
+                    throw new TransactionException(response.ErrorCode,
+                        $"EndTxn ({(committed ? "commit" : "abort")}) failed: {response.ErrorCode}")
+                    {
+                        TransactionalId = _options.TransactionalId
+                    };
+
+                case TransactionErrorClassification.Retriable:
+                    if (response.ErrorCode == ErrorCode.NotCoordinator)
+                    {
+                        LogEndTxnNotCoordinator(attempt + 1, maxRetries);
+                        await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                        retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                        await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    LogEndTxnRetriableError(response.ErrorCode, attempt + 1, maxRetries, retryDelayMs);
+                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                    continue;
+
+                default: // Abortable or unknown
+                    throw new TransactionException(response.ErrorCode,
+                        $"EndTxn ({(committed ? "commit" : "abort")}) failed: {response.ErrorCode}")
+                    {
+                        TransactionalId = _options.TransactionalId
+                    };
             }
-
-            if (response.ErrorCode is ErrorCode.CoordinatorLoadInProgress
-                or ErrorCode.CoordinatorNotAvailable
-                or ErrorCode.ConcurrentTransactions)
-            {
-                LogEndTxnRetriableError(response.ErrorCode, attempt + 1, maxRetries, retryDelayMs);
-
-                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
-                continue;
-            }
-
-            if (response.ErrorCode == ErrorCode.NotCoordinator)
-            {
-                LogEndTxnNotCoordinator(attempt + 1, maxRetries);
-
-                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
-                await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
-                continue;
-            }
-
-            throw new TransactionException(response.ErrorCode,
-                $"EndTxn ({(committed ? "commit" : "abort")}) failed: {response.ErrorCode}")
-            {
-                TransactionalId = _options.TransactionalId
-            };
         }
 
         throw new TransactionException(ErrorCode.CoordinatorLoadInProgress,

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2043,11 +2043,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         if (!needsRegistration)
             return;
 
-        // TV2: broker registers partitions implicitly on first Produce request.
-        // Local tracking (above) is still needed for SendOffsetsToTransaction.
-        if (_currentTransactionUsesTV2)
-            return;
-
         await AddPartitionsToTransactionAsync([topicPartition], cancellationToken)
             .ConfigureAwait(false);
     }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1536,6 +1536,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 // TV2 (v4+): broker returns bumped ProducerId/Epoch in EndTxn response.
                 // Apply them so the next transaction uses the new identity without
                 // a separate InitProducerId round-trip.
+                // Safe without _epochBumpLock: EndTxn is called only after FlushAsync
+                // drains all in-flight batches, so no BrokerSender is active.
                 if (_currentTransactionUsesTV2 && response.ProducerId >= 0)
                 {
                     _producerId = response.ProducerId;

--- a/src/Dekaf/Producer/TransactionErrorClassifier.cs
+++ b/src/Dekaf/Producer/TransactionErrorClassifier.cs
@@ -1,0 +1,32 @@
+namespace Dekaf.Producer;
+
+internal enum TransactionErrorClassification
+{
+    Retriable,
+    Abortable,
+    Fatal
+}
+
+internal static class TransactionErrorClassifier
+{
+    internal static TransactionErrorClassification Classify(Protocol.ErrorCode errorCode, bool tv2)
+    {
+        return errorCode switch
+        {
+            Protocol.ErrorCode.ProducerFenced => TransactionErrorClassification.Fatal,
+            Protocol.ErrorCode.TransactionalIdAuthorizationFailed => TransactionErrorClassification.Fatal,
+            Protocol.ErrorCode.TransactionCoordinatorFenced => TransactionErrorClassification.Fatal,
+
+            Protocol.ErrorCode.InvalidProducerIdMapping => tv2
+                ? TransactionErrorClassification.Fatal
+                : TransactionErrorClassification.Abortable,
+
+            Protocol.ErrorCode.CoordinatorLoadInProgress => TransactionErrorClassification.Retriable,
+            Protocol.ErrorCode.CoordinatorNotAvailable => TransactionErrorClassification.Retriable,
+            Protocol.ErrorCode.NotCoordinator => TransactionErrorClassification.Retriable,
+            Protocol.ErrorCode.ConcurrentTransactions => TransactionErrorClassification.Retriable,
+
+            _ => TransactionErrorClassification.Abortable
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/EndTxnResponse.cs
+++ b/src/Dekaf/Protocol/Messages/EndTxnResponse.cs
@@ -19,6 +19,16 @@ public sealed class EndTxnResponse : IKafkaResponse
     /// </summary>
     public required ErrorCode ErrorCode { get; init; }
 
+    /// <summary>
+    /// The bumped producer ID (v4+, KIP-890). -1 if not present.
+    /// </summary>
+    public long ProducerId { get; init; } = -1;
+
+    /// <summary>
+    /// The bumped producer epoch (v4+, KIP-890). -1 if not present.
+    /// </summary>
+    public short ProducerEpoch { get; init; } = -1;
+
     public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
     {
         var isFlexible = version >= 3;
@@ -26,15 +36,37 @@ public sealed class EndTxnResponse : IKafkaResponse
         var throttleTimeMs = reader.ReadInt32();
         var errorCode = (ErrorCode)reader.ReadInt16();
 
+        var producerId = -1L;
+        var producerEpoch = (short)-1;
+
         if (isFlexible)
         {
-            reader.SkipTaggedFields();
+            var numTaggedFields = reader.ReadUnsignedVarInt();
+            for (var i = 0; i < numTaggedFields; i++)
+            {
+                var tag = reader.ReadUnsignedVarInt();
+                var size = reader.ReadUnsignedVarInt();
+                switch (tag)
+                {
+                    case 0:
+                        producerId = reader.ReadInt64();
+                        break;
+                    case 1:
+                        producerEpoch = reader.ReadInt16();
+                        break;
+                    default:
+                        reader.Skip(size);
+                        break;
+                }
+            }
         }
 
         return new EndTxnResponse
         {
             ThrottleTimeMs = throttleTimeMs,
-            ErrorCode = errorCode
+            ErrorCode = errorCode,
+            ProducerId = producerId,
+            ProducerEpoch = producerEpoch
         };
     }
 }

--- a/tests/Dekaf.Tests.Integration/TransactionV2Tests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionV2Tests.cs
@@ -1,0 +1,176 @@
+using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Integration;
+
+/// <summary>
+/// Integration tests for KIP-890 Transactions V2 behavior.
+/// TV2 features (implicit AddPartitionsToTxn, EndTxn epoch bump, skip post-abort InitProducerId)
+/// are automatically active when connected to Kafka 4.0+ brokers that support transaction.version >= 2.
+/// </summary>
+[Category("Transaction")]
+public class TransactionV2Tests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task Transaction_Commit_ThenNewTransaction_Succeeds()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var txnId = $"txn-v2-commit-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId(txnId)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.InitTransactionsAsync();
+
+        // First transaction: produce and commit
+        await using (var txn = producer.BeginTransaction())
+        {
+            await txn.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic, Key = "k1", Value = "v1"
+            }, CancellationToken.None);
+
+            await txn.CommitAsync();
+        }
+
+        // Second transaction: should succeed with bumped epoch
+        await using (var txn = producer.BeginTransaction())
+        {
+            await txn.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic, Key = "k2", Value = "v2"
+            }, CancellationToken.None);
+
+            await txn.CommitAsync();
+        }
+
+        // Verify both messages are visible
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"txn-v2-consumer-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(Consumer.AutoOffsetReset.Earliest)
+            .WithIsolationLevel(IsolationLevel.ReadCommitted)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        var messages = await ConsumeMessagesAsync(consumer, 2);
+
+        await Assert.That(messages).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Transaction_Abort_ThenNewTransaction_Succeeds()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var txnId = $"txn-v2-abort-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId(txnId)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.InitTransactionsAsync();
+
+        // First transaction: produce and abort
+        await using (var txn = producer.BeginTransaction())
+        {
+            await txn.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic, Key = "aborted-key", Value = "aborted-value"
+            }, CancellationToken.None);
+
+            await txn.AbortAsync();
+        }
+
+        // Second transaction after abort: should succeed
+        // In TV2, this does NOT call InitProducerId -- the epoch bump from EndTxn is sufficient
+        await using (var txn = producer.BeginTransaction())
+        {
+            await txn.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic, Key = "committed-key", Value = "committed-value"
+            }, CancellationToken.None);
+
+            await txn.CommitAsync();
+        }
+
+        // Verify only committed message visible
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"txn-v2-abort-consumer-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(Consumer.AutoOffsetReset.Earliest)
+            .WithIsolationLevel(IsolationLevel.ReadCommitted)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var consumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+
+        await Assert.That(consumed).IsNotNull();
+        await Assert.That(consumed!.Value.Value).IsEqualTo("committed-value");
+    }
+
+    [Test]
+    public async Task Transaction_MultipleAborts_ThenCommit_Succeeds()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var txnId = $"txn-v2-multi-abort-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId(txnId)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.InitTransactionsAsync();
+
+        // Three aborted transactions in a row
+        for (var i = 0; i < 3; i++)
+        {
+            await using var txn = producer.BeginTransaction();
+            await txn.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic, Key = $"aborted-{i}", Value = $"aborted-{i}"
+            }, CancellationToken.None);
+            await txn.AbortAsync();
+        }
+
+        // Fourth transaction: commit
+        await using (var txn = producer.BeginTransaction())
+        {
+            await txn.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic, Key = "final", Value = "final-value"
+            }, CancellationToken.None);
+            await txn.CommitAsync();
+        }
+
+        // Verify only the committed message is visible
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"txn-v2-multi-abort-consumer-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(Consumer.AutoOffsetReset.Earliest)
+            .WithIsolationLevel(IsolationLevel.ReadCommitted)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var consumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+
+        await Assert.That(consumed).IsNotNull();
+        await Assert.That(consumed!.Value.Value).IsEqualTo("final-value");
+    }
+}

--- a/tests/Dekaf.Tests.Integration/TransactionV2Tests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionV2Tests.cs
@@ -5,7 +5,7 @@ namespace Dekaf.Tests.Integration;
 
 /// <summary>
 /// Integration tests for KIP-890 Transactions V2 behavior.
-/// TV2 features (implicit AddPartitionsToTxn, EndTxn epoch bump, skip post-abort InitProducerId)
+/// TV2 features (EndTxn epoch bump, skip post-abort InitProducerId)
 /// are automatically active when connected to Kafka 4.0+ brokers that support transaction.version >= 2.
 /// </summary>
 [Category("Transaction")]

--- a/tests/Dekaf.Tests.Integration/TransactionV2Tests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionV2Tests.cs
@@ -113,8 +113,7 @@ public class TransactionV2Tests(KafkaTestContainer kafka) : KafkaIntegrationTest
 
         consumer.Subscribe(topic);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        var consumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+        var consumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
 
         await Assert.That(consumed).IsNotNull();
         await Assert.That(consumed!.Value.Value).IsEqualTo("committed-value");
@@ -167,8 +166,7 @@ public class TransactionV2Tests(KafkaTestContainer kafka) : KafkaIntegrationTest
 
         consumer.Subscribe(topic);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        var consumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+        var consumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
 
         await Assert.That(consumed).IsNotNull();
         await Assert.That(consumed!.Value.Value).IsEqualTo("final-value");

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionErrorClassifierTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionErrorClassifierTests.cs
@@ -1,0 +1,55 @@
+using Dekaf.Producer;
+using Dekaf.Protocol;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public sealed class TransactionErrorClassifierTests
+{
+    [Test]
+    [Arguments(ErrorCode.ProducerFenced)]
+    [Arguments(ErrorCode.TransactionalIdAuthorizationFailed)]
+    [Arguments(ErrorCode.TransactionCoordinatorFenced)]
+    public async Task AlwaysFatal_ReturnsFatal_RegardlessOfTv2(ErrorCode errorCode)
+    {
+        var v1 = TransactionErrorClassifier.Classify(errorCode, tv2: false);
+        var v2 = TransactionErrorClassifier.Classify(errorCode, tv2: true);
+
+        await Assert.That(v1).IsEqualTo(TransactionErrorClassification.Fatal);
+        await Assert.That(v2).IsEqualTo(TransactionErrorClassification.Fatal);
+    }
+
+    [Test]
+    [Arguments(ErrorCode.CoordinatorLoadInProgress)]
+    [Arguments(ErrorCode.CoordinatorNotAvailable)]
+    [Arguments(ErrorCode.NotCoordinator)]
+    [Arguments(ErrorCode.ConcurrentTransactions)]
+    public async Task Retriable_ReturnsRetriable_RegardlessOfTv2(ErrorCode errorCode)
+    {
+        var v1 = TransactionErrorClassifier.Classify(errorCode, tv2: false);
+        var v2 = TransactionErrorClassifier.Classify(errorCode, tv2: true);
+
+        await Assert.That(v1).IsEqualTo(TransactionErrorClassification.Retriable);
+        await Assert.That(v2).IsEqualTo(TransactionErrorClassification.Retriable);
+    }
+
+    [Test]
+    public async Task InvalidProducerIdMapping_Abortable_InV1()
+    {
+        var result = TransactionErrorClassifier.Classify(ErrorCode.InvalidProducerIdMapping, tv2: false);
+        await Assert.That(result).IsEqualTo(TransactionErrorClassification.Abortable);
+    }
+
+    [Test]
+    public async Task InvalidProducerIdMapping_Fatal_InV2()
+    {
+        var result = TransactionErrorClassifier.Classify(ErrorCode.InvalidProducerIdMapping, tv2: true);
+        await Assert.That(result).IsEqualTo(TransactionErrorClassification.Fatal);
+    }
+
+    [Test]
+    public async Task UnknownError_DefaultsToAbortable()
+    {
+        var result = TransactionErrorClassifier.Classify(ErrorCode.UnknownServerError, tv2: false);
+        await Assert.That(result).IsEqualTo(TransactionErrorClassification.Abortable);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/TransactionProtocolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/TransactionProtocolTests.cs
@@ -541,6 +541,72 @@ public sealed class TransactionProtocolTests
         await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.InvalidTxnState);
     }
 
+    [Test]
+    public async Task EndTxnResponse_V4_WithEpochBump_ReadsCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        // ThrottleTimeMs
+        writer.WriteInt32(10);
+        // ErrorCode = None
+        writer.WriteInt16(0);
+        // Tagged fields: 2 fields
+        writer.WriteUnsignedVarInt(2);
+        // Tag 0: ProducerId (INT64 = 8 bytes)
+        writer.WriteUnsignedVarInt(0); // tag
+        writer.WriteUnsignedVarInt(8); // size
+        writer.WriteInt64(42L);
+        // Tag 1: ProducerEpoch (INT16 = 2 bytes)
+        writer.WriteUnsignedVarInt(1); // tag
+        writer.WriteUnsignedVarInt(2); // size
+        writer.WriteInt16(7);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (EndTxnResponse)EndTxnResponse.Read(ref reader, version: 4);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(10);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ProducerId).IsEqualTo(42L);
+        await Assert.That(response.ProducerEpoch).IsEqualTo((short)7);
+    }
+
+    [Test]
+    public async Task EndTxnResponse_V4_NoTaggedFields_DefaultsToMinusOne()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);
+        writer.WriteInt16(0);
+        writer.WriteEmptyTaggedFields();
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (EndTxnResponse)EndTxnResponse.Read(ref reader, version: 4);
+
+        await Assert.That(response.ProducerId).IsEqualTo(-1L);
+        await Assert.That(response.ProducerEpoch).IsEqualTo((short)-1);
+    }
+
+    [Test]
+    public async Task EndTxnResponse_V3_BackwardCompatible_NoEpochFields()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(25);
+        writer.WriteInt16((short)ErrorCode.InvalidTxnState);
+        writer.WriteEmptyTaggedFields();
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (EndTxnResponse)EndTxnResponse.Read(ref reader, version: 3);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(25);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.InvalidTxnState);
+        await Assert.That(response.ProducerId).IsEqualTo(-1L);
+        await Assert.That(response.ProducerEpoch).IsEqualTo((short)-1);
+    }
+
     #endregion
 
     #region TxnOffsetCommit Tests


### PR DESCRIPTION
## Summary

Implements [KIP-890: Transactions V2](https://cwiki.apache.org/confluence/display/KAFKA/KIP-890%3A+Transactions+Server-Side+Defense) for Kafka 4.0+ brokers, enabling server-side fencing for transactional producers.

Closes #818

### Changes

- **TV2 capability detection**: `MetadataManager` stores finalized features from `ApiVersionsResponse` and exposes `GetFinalizedFeatureVersion()`. The producer latches `_currentTransactionUsesTV2` per-transaction in `BeginTransaction()` to prevent mid-transaction behavior changes during rolling upgrades.
- **EndTxn v4 epoch bump**: `EndTxnResponse` now parses tagged fields (tag 0 = ProducerId, tag 1 = ProducerEpoch) from v4 responses. On success, the producer applies the bumped identity so the next transaction uses it immediately.
- **Skip post-abort InitProducerId**: In TV2, `Transaction.AbortAsync` no longer calls `ReinitializeProducerIdAsync` — the bumped epoch from the EndTxn v4 response is sufficient. This eliminates one network round-trip per abort.
- **Centralized error classification**: New `TransactionErrorClassifier` with `Classify(errorCode, tv2)` replaces inline if-chains in `EndTransactionAsync`. `InvalidProducerIdMapping` is now fatal in TV2 (abortable in TV1), per the KIP.

### Files changed

| File | Change |
|------|--------|
| `MetadataManager.cs` | Store `_finalizedFeatures`, add `GetFinalizedFeatureVersion()` |
| `EndTxnResponse.cs` | Parse v4 tagged fields for ProducerId/ProducerEpoch |
| `KafkaProducer.cs` | TV2 latch, epoch bump on EndTxn success, conditional abort reinit, error classifier integration |
| `TransactionErrorClassifier.cs` | New: enum + `Classify()` method |
| `TransactionErrorClassifierTests.cs` | New: 5 tests / 10 cases covering all classifications |
| `TransactionProtocolTests.cs` | 3 new tests: v4 epoch bump, v4 no tags, v3 backward compat |
| `TransactionV2Tests.cs` | New: 3 integration tests (commit+new txn, abort+new txn, multi-abort+commit) |

## Test plan

- [x] Unit tests: `TransactionErrorClassifier` — all error codes classified correctly in TV1 and TV2
- [x] Unit tests: `EndTxnResponse` v4 parsing — epoch bump fields, empty tags, v3 backward compat
- [x] Integration tests: commit → new transaction, abort → new transaction, multiple aborts → commit
- [x] All CI checks passing (build, unit tests, all integration test suites)