### PR TITLE
feat: implement KIP-932 Share Groups (Queues for Kafka)

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1561,6 +1561,372 @@ public sealed class AdminClient : IAdminClient
         }, cancellationToken).ConfigureAwait(false);
     }
 
+    public async ValueTask<IReadOnlyDictionary<string, ShareGroupDescription>> DescribeShareGroupsAsync(
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var groupIdList = groupIds.ToList();
+
+        return await WithRetryAsync<IReadOnlyDictionary<string, ShareGroupDescription>>(async () =>
+        {
+            // Find coordinator for each group and batch groups by coordinator
+            var groupsByCoordinator = new Dictionary<int, List<string>>();
+            foreach (var groupId in groupIdList)
+            {
+                var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
+                if (!groupsByCoordinator.TryGetValue(coordinatorId, out var groups))
+                {
+                    groups = [];
+                    groupsByCoordinator[coordinatorId] = groups;
+                }
+                groups.Add(groupId);
+            }
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.ShareGroupDescribe,
+                ShareGroupDescribeRequest.LowestSupportedVersion,
+                ShareGroupDescribeRequest.HighestSupportedVersion);
+
+            var result = new Dictionary<string, ShareGroupDescription>();
+
+            foreach (var (coordinatorId, groups) in groupsByCoordinator)
+            {
+                var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+
+                var request = new ShareGroupDescribeRequest
+                {
+                    GroupIds = groups,
+                    IncludeAuthorizedOperations = true
+                };
+
+                var response = await connection.SendAsync<ShareGroupDescribeRequest, ShareGroupDescribeResponse>(
+                    request,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+
+                foreach (var group in response.Groups)
+                {
+                    if (group.ErrorCode != Protocol.ErrorCode.None)
+                    {
+                        throw new Errors.GroupException(group.ErrorCode,
+                            $"DescribeShareGroups failed for group '{group.GroupId}': {group.ErrorCode}")
+                        {
+                            GroupId = group.GroupId
+                        };
+                    }
+
+                    result[group.GroupId] = new ShareGroupDescription
+                    {
+                        GroupId = group.GroupId,
+                        GroupState = group.GroupState,
+                        GroupEpoch = group.GroupEpoch,
+                        AssignmentEpoch = group.AssignmentEpoch,
+                        AssignorName = group.AssignorName,
+                        AuthorizedOperations = group.AuthorizedOperations,
+                        Members = group.Members.Select(m => new ShareGroupMemberDescription
+                        {
+                            MemberId = m.MemberId,
+                            RackId = m.RackId,
+                            MemberEpoch = m.MemberEpoch,
+                            ClientId = m.ClientId,
+                            ClientHost = m.ClientHost,
+                            SubscribedTopicNames = m.SubscribedTopicNames,
+                            Assignment = m.Assignment?.TopicPartitions
+                                .SelectMany(tp => tp.Partitions.Select(p =>
+                                    new TopicPartition(tp.TopicName ?? string.Empty, p)))
+                                .ToList()
+                        }).ToList()
+                    };
+                }
+            }
+
+            return result;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<IReadOnlyList<GroupListing>> ListShareGroupsAsync(
+        ListShareGroupsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var opts = options ?? new ListShareGroupsOptions();
+
+        return await WithRetryAsync<IReadOnlyList<GroupListing>>(async () =>
+        {
+            var brokers = _metadataManager.Metadata.GetBrokers();
+            if (brokers.Count == 0)
+            {
+                throw new InvalidOperationException("No brokers available");
+            }
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.ListGroups,
+                ListGroupsRequest.LowestSupportedVersion,
+                ListGroupsRequest.HighestSupportedVersion);
+
+            var request = new ListGroupsRequest
+            {
+                StatesFilter = apiVersion >= 4 ? opts.States : null,
+                TypesFilter = apiVersion >= 5 ? ["share"] : null
+            };
+
+            var seenGroupIds = new HashSet<string>();
+            var result = new List<GroupListing>();
+
+            foreach (var broker in brokers)
+            {
+                var connection = await _connectionPool.GetConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
+
+                var response = await connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(
+                    request,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (response.ErrorCode != Protocol.ErrorCode.None)
+                {
+                    throw new KafkaException(response.ErrorCode,
+                        $"ListShareGroups failed on broker {broker.NodeId}: {response.ErrorCode}");
+                }
+
+                foreach (var group in response.Groups)
+                {
+                    // Filter to share groups only (client-side for pre-v5 brokers)
+                    if (apiVersion < 5 && !string.Equals(group.GroupType, "share", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    if (!seenGroupIds.Add(group.GroupId))
+                        continue;
+
+                    // Client-side state filtering if broker doesn't support v4+
+                    if (apiVersion < 4 && opts.States is { Count: > 0 } && group.GroupState is not null)
+                    {
+                        if (!opts.States.Contains(group.GroupState, StringComparer.OrdinalIgnoreCase))
+                            continue;
+                    }
+
+                    result.Add(new GroupListing
+                    {
+                        GroupId = group.GroupId,
+                        ProtocolType = group.ProtocolType,
+                        State = group.GroupState
+                    });
+                }
+            }
+
+            return result;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<IReadOnlyList<ShareGroupOffsetDescription>> DescribeShareGroupOffsetsAsync(
+        string groupId,
+        IEnumerable<TopicPartition>? partitions = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var partitionList = partitions?.ToList();
+
+        return await WithRetryAsync<IReadOnlyList<ShareGroupOffsetDescription>>(async () =>
+        {
+            var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
+            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+
+            // Build topics filter from partitions list, or null for all
+            IReadOnlyList<DescribeShareGroupOffsetsRequestTopic>? requestTopics = null;
+            if (partitionList is { Count: > 0 })
+            {
+                requestTopics = partitionList
+                    .GroupBy(tp => tp.Topic)
+                    .Select(g => new DescribeShareGroupOffsetsRequestTopic
+                    {
+                        TopicName = g.Key,
+                        Partitions = g.Select(tp => tp.Partition).ToList()
+                    })
+                    .ToList();
+            }
+
+            var request = new DescribeShareGroupOffsetsRequest
+            {
+                Groups =
+                [
+                    new DescribeShareGroupOffsetsRequestGroup
+                    {
+                        GroupId = groupId,
+                        Topics = requestTopics
+                    }
+                ]
+            };
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.DescribeShareGroupOffsets,
+                DescribeShareGroupOffsetsRequest.LowestSupportedVersion,
+                DescribeShareGroupOffsetsRequest.HighestSupportedVersion);
+
+            var response = await connection.SendAsync<DescribeShareGroupOffsetsRequest, DescribeShareGroupOffsetsResponse>(
+                request,
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            var result = new List<ShareGroupOffsetDescription>();
+
+            foreach (var group in response.Groups)
+            {
+                if (group.ErrorCode != Protocol.ErrorCode.None)
+                {
+                    throw new Errors.GroupException(group.ErrorCode,
+                        $"DescribeShareGroupOffsets failed for group '{group.GroupId}': {group.ErrorCode}")
+                    {
+                        GroupId = group.GroupId
+                    };
+                }
+
+                foreach (var topic in group.Topics)
+                {
+                    foreach (var partition in topic.Partitions)
+                    {
+                        result.Add(new ShareGroupOffsetDescription
+                        {
+                            TopicPartition = new TopicPartition(topic.TopicName, partition.PartitionIndex),
+                            StartOffset = partition.StartOffset,
+                            LeaderEpoch = partition.LeaderEpoch,
+                            Lag = partition.Lag,
+                            ErrorCode = partition.ErrorCode,
+                            ErrorMessage = partition.ErrorMessage
+                        });
+                    }
+                }
+            }
+
+            return result;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask AlterShareGroupOffsetsAsync(
+        string groupId,
+        IEnumerable<ShareGroupOffsetAlteration> offsets,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var topicData = offsets
+            .GroupBy(o => o.TopicPartition.Topic)
+            .Select(g => new AlterShareGroupOffsetsRequestTopic
+            {
+                TopicName = g.Key,
+                Partitions = g.Select(o => new AlterShareGroupOffsetsRequestPartition
+                {
+                    PartitionIndex = o.TopicPartition.Partition,
+                    StartOffset = o.StartOffset
+                }).ToList()
+            })
+            .ToList();
+
+        await WithRetryAsync(async () =>
+        {
+            var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
+            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+
+            var request = new AlterShareGroupOffsetsRequest
+            {
+                GroupId = groupId,
+                Topics = topicData
+            };
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.AlterShareGroupOffsets,
+                AlterShareGroupOffsetsRequest.LowestSupportedVersion,
+                AlterShareGroupOffsetsRequest.HighestSupportedVersion);
+
+            var response = await connection.SendAsync<AlterShareGroupOffsetsRequest, AlterShareGroupOffsetsResponse>(
+                request,
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            if (response.ErrorCode != Protocol.ErrorCode.None)
+            {
+                throw new Errors.GroupException(response.ErrorCode,
+                    $"AlterShareGroupOffsets failed for group '{groupId}': {response.ErrorCode}")
+                {
+                    GroupId = groupId
+                };
+            }
+
+            foreach (var topic in response.Responses)
+            {
+                foreach (var partition in topic.Partitions)
+                {
+                    if (partition.ErrorCode != Protocol.ErrorCode.None)
+                    {
+                        throw new Errors.GroupException(partition.ErrorCode,
+                            $"AlterShareGroupOffsets failed for group '{groupId}', " +
+                            $"topic '{topic.TopicName}', partition {partition.PartitionIndex}: {partition.ErrorCode}")
+                        {
+                            GroupId = groupId
+                        };
+                    }
+                }
+            }
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask DeleteShareGroupOffsetsAsync(
+        string groupId,
+        IEnumerable<string> topics,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var topicData = topics
+            .Select(t => new DeleteShareGroupOffsetsRequestTopic { TopicName = t })
+            .ToList();
+
+        await WithRetryAsync(async () =>
+        {
+            var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
+            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+
+            var request = new DeleteShareGroupOffsetsRequest
+            {
+                GroupId = groupId,
+                Topics = topicData
+            };
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.DeleteShareGroupOffsets,
+                DeleteShareGroupOffsetsRequest.LowestSupportedVersion,
+                DeleteShareGroupOffsetsRequest.HighestSupportedVersion);
+
+            var response = await connection.SendAsync<DeleteShareGroupOffsetsRequest, DeleteShareGroupOffsetsResponse>(
+                request,
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            if (response.ErrorCode != Protocol.ErrorCode.None)
+            {
+                throw new Errors.GroupException(response.ErrorCode,
+                    $"DeleteShareGroupOffsets failed for group '{groupId}': {response.ErrorCode}")
+                {
+                    GroupId = groupId
+                };
+            }
+
+            foreach (var topic in response.Responses)
+            {
+                if (topic.ErrorCode != Protocol.ErrorCode.None)
+                {
+                    throw new Errors.GroupException(topic.ErrorCode,
+                        $"DeleteShareGroupOffsets failed for group '{groupId}', topic '{topic.TopicName}': {topic.ErrorCode}")
+                    {
+                        GroupId = groupId
+                    };
+                }
+            }
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
     private async ValueTask EnsureInitializedAsync(CancellationToken cancellationToken)
     {
         if (_metadataManager.Metadata.LastRefreshed == default)

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1676,10 +1676,8 @@ public sealed class AdminClient : IAdminClient
                 TypesFilter = apiVersion >= 5 ? ["share"] : null
             };
 
-            var seenGroupIds = new HashSet<string>();
-            var result = new List<GroupListing>();
-
-            foreach (var broker in brokers)
+            // Fan out to all brokers in parallel
+            var responses = await Task.WhenAll(brokers.Select(async broker =>
             {
                 var connection = await _connectionPool.GetConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
 
@@ -1694,6 +1692,15 @@ public sealed class AdminClient : IAdminClient
                         $"ListShareGroups failed on broker {broker.NodeId}: {response.ErrorCode}");
                 }
 
+                return response;
+            })).ConfigureAwait(false);
+
+            // Merge and deduplicate results
+            var seenGroupIds = new HashSet<string>();
+            var result = new List<GroupListing>();
+
+            foreach (var response in responses)
+            {
                 foreach (var group in response.Groups)
                 {
                     // Filter to share groups only (client-side for pre-v5 brokers)

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1592,23 +1592,27 @@ public sealed class AdminClient : IAdminClient
                 ShareGroupDescribeRequest.LowestSupportedVersion,
                 ShareGroupDescribeRequest.HighestSupportedVersion);
 
-            var result = new Dictionary<string, ShareGroupDescription>();
-
-            foreach (var (coordinatorId, groups) in groupsByCoordinator)
+            // Fan out ShareGroupDescribe requests to all coordinators in parallel
+            var describeResponses = await Task.WhenAll(groupsByCoordinator.Select(async kvp =>
             {
-                var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+                var connection = await _connectionPool.GetConnectionAsync(kvp.Key, cancellationToken).ConfigureAwait(false);
 
                 var request = new ShareGroupDescribeRequest
                 {
-                    GroupIds = groups,
+                    GroupIds = kvp.Value,
                     IncludeAuthorizedOperations = true
                 };
 
-                var response = await connection.SendAsync<ShareGroupDescribeRequest, ShareGroupDescribeResponse>(
+                return await connection.SendAsync<ShareGroupDescribeRequest, ShareGroupDescribeResponse>(
                     request,
                     apiVersion,
                     cancellationToken).ConfigureAwait(false);
+            })).ConfigureAwait(false);
 
+            var result = new Dictionary<string, ShareGroupDescription>();
+
+            foreach (var response in describeResponses)
+            {
                 foreach (var group in response.Groups)
                 {
                     if (group.ErrorCode != Protocol.ErrorCode.None)
@@ -1636,7 +1640,7 @@ public sealed class AdminClient : IAdminClient
                             ClientId = m.ClientId,
                             ClientHost = m.ClientHost,
                             SubscribedTopicNames = m.SubscribedTopicNames,
-                            Assignment = m.Assignment?.TopicPartitions
+                            Assignment = m.Assignment.TopicPartitions
                                 .SelectMany(tp => tp.Partitions.Select(p =>
                                     new TopicPartition(tp.TopicName ?? string.Empty, p)))
                                 .ToList()

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1571,11 +1571,14 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<IReadOnlyDictionary<string, ShareGroupDescription>>(async () =>
         {
-            // Find coordinator for each group and batch groups by coordinator
+            // Find coordinators for all groups in parallel
+            var coordinatorTasks = groupIdList
+                .Select(async g => (GroupId: g, CoordinatorId: await FindGroupCoordinatorAsync(g, cancellationToken).ConfigureAwait(false)));
+            var coordinatorResults = await Task.WhenAll(coordinatorTasks).ConfigureAwait(false);
+
             var groupsByCoordinator = new Dictionary<int, List<string>>();
-            foreach (var groupId in groupIdList)
+            foreach (var (groupId, coordinatorId) in coordinatorResults)
             {
-                var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
                 if (!groupsByCoordinator.TryGetValue(coordinatorId, out var groups))
                 {
                     groups = [];

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1825,6 +1825,8 @@ public sealed class AdminClient : IAdminClient
     {
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
+        // Hoisted outside WithRetryAsync intentionally: derived purely from the caller's
+        // immutable input, safe to reuse across retries.
         var topicData = offsets
             .GroupBy(o => o.TopicPartition.Topic)
             .Select(g => new AlterShareGroupOffsetsRequestTopic

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1640,8 +1640,8 @@ public sealed class AdminClient : IAdminClient
                             ClientId = m.ClientId,
                             ClientHost = m.ClientHost,
                             SubscribedTopicNames = m.SubscribedTopicNames,
-                            Assignment = m.Assignment.TopicPartitions
-                                .SelectMany(tp => tp.Partitions.Select(p =>
+                            Assignment = m.Assignment?.TopicPartitions
+                                ?.SelectMany(tp => tp.Partitions.Select(p =>
                                     new TopicPartition(tp.TopicName ?? string.Empty, p)))
                                 .ToList()
                         }).ToList()

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -257,64 +257,6 @@ public interface IAdminClient : IAsyncDisposable
 }
 
 /// <summary>
-/// Share group description.
-/// </summary>
-public sealed class ShareGroupDescription
-{
-    public required string GroupId { get; init; }
-    public required string GroupState { get; init; }
-    public int GroupEpoch { get; init; }
-    public int AssignmentEpoch { get; init; }
-    public string? AssignorName { get; init; }
-    public required IReadOnlyList<ShareGroupMemberDescription> Members { get; init; }
-    public int AuthorizedOperations { get; init; }
-}
-
-/// <summary>
-/// Share group member description.
-/// </summary>
-public sealed class ShareGroupMemberDescription
-{
-    public required string MemberId { get; init; }
-    public string? RackId { get; init; }
-    public int MemberEpoch { get; init; }
-    public required string ClientId { get; init; }
-    public required string ClientHost { get; init; }
-    public required IReadOnlyList<string> SubscribedTopicNames { get; init; }
-    public IReadOnlyList<TopicPartition>? Assignment { get; init; }
-}
-
-/// <summary>
-/// Options for ListShareGroups.
-/// </summary>
-public sealed class ListShareGroupsOptions
-{
-    public IReadOnlyList<string>? States { get; init; }
-}
-
-/// <summary>
-/// Description of a share group's offset for a partition.
-/// </summary>
-public sealed class ShareGroupOffsetDescription
-{
-    public required TopicPartition TopicPartition { get; init; }
-    public long StartOffset { get; init; }
-    public int LeaderEpoch { get; init; }
-    public long Lag { get; init; } = -1;
-    public Protocol.ErrorCode ErrorCode { get; init; }
-    public string? ErrorMessage { get; init; }
-}
-
-/// <summary>
-/// Specification for altering a share group offset.
-/// </summary>
-public sealed class ShareGroupOffsetAlteration
-{
-    public required TopicPartition TopicPartition { get; init; }
-    public required long StartOffset { get; init; }
-}
-
-/// <summary>
 /// Specification for a new topic.
 /// </summary>
 public sealed class NewTopic

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -290,7 +290,6 @@ public sealed class ShareGroupMemberDescription
 public sealed class ListShareGroupsOptions
 {
     public IReadOnlyList<string>? States { get; init; }
-    public int TimeoutMs { get; init; } = 30000;
 }
 
 /// <summary>

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -204,9 +204,115 @@ public interface IAdminClient : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Describes share groups.
+    /// </summary>
+    ValueTask<IReadOnlyDictionary<string, ShareGroupDescription>> DescribeShareGroupsAsync(
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists share groups across the cluster.
+    /// </summary>
+    ValueTask<IReadOnlyList<GroupListing>> ListShareGroupsAsync(
+        ListShareGroupsOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Describes share group offsets.
+    /// </summary>
+    /// <param name="groupId">The share group ID.</param>
+    /// <param name="partitions">The partitions to describe offsets for, or null for all.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask<IReadOnlyList<ShareGroupOffsetDescription>> DescribeShareGroupOffsetsAsync(
+        string groupId,
+        IEnumerable<TopicPartition>? partitions = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Alters share group offsets.
+    /// </summary>
+    /// <param name="groupId">The share group ID.</param>
+    /// <param name="offsets">The offsets to set.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask AlterShareGroupOffsetsAsync(
+        string groupId,
+        IEnumerable<ShareGroupOffsetAlteration> offsets,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes share group offsets for the specified topics.
+    /// </summary>
+    /// <param name="groupId">The share group ID.</param>
+    /// <param name="topics">The topic names to delete offsets for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask DeleteShareGroupOffsetsAsync(
+        string groupId,
+        IEnumerable<string> topics,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the cluster metadata.
     /// </summary>
     ClusterMetadata Metadata { get; }
+}
+
+/// <summary>
+/// Share group description.
+/// </summary>
+public sealed class ShareGroupDescription
+{
+    public required string GroupId { get; init; }
+    public required string GroupState { get; init; }
+    public int GroupEpoch { get; init; }
+    public int AssignmentEpoch { get; init; }
+    public string? AssignorName { get; init; }
+    public required IReadOnlyList<ShareGroupMemberDescription> Members { get; init; }
+    public int AuthorizedOperations { get; init; }
+}
+
+/// <summary>
+/// Share group member description.
+/// </summary>
+public sealed class ShareGroupMemberDescription
+{
+    public required string MemberId { get; init; }
+    public string? RackId { get; init; }
+    public int MemberEpoch { get; init; }
+    public required string ClientId { get; init; }
+    public required string ClientHost { get; init; }
+    public required IReadOnlyList<string> SubscribedTopicNames { get; init; }
+    public IReadOnlyList<TopicPartition>? Assignment { get; init; }
+}
+
+/// <summary>
+/// Options for ListShareGroups.
+/// </summary>
+public sealed class ListShareGroupsOptions
+{
+    public IReadOnlyList<string>? States { get; init; }
+    public int TimeoutMs { get; init; } = 30000;
+}
+
+/// <summary>
+/// Description of a share group's offset for a partition.
+/// </summary>
+public sealed class ShareGroupOffsetDescription
+{
+    public required TopicPartition TopicPartition { get; init; }
+    public long StartOffset { get; init; }
+    public int LeaderEpoch { get; init; }
+    public long Lag { get; init; } = -1;
+    public Protocol.ErrorCode ErrorCode { get; init; }
+    public string? ErrorMessage { get; init; }
+}
+
+/// <summary>
+/// Specification for altering a share group offset.
+/// </summary>
+public sealed class ShareGroupOffsetAlteration
+{
+    public required TopicPartition TopicPartition { get; init; }
+    public required long StartOffset { get; init; }
 }
 
 /// <summary>

--- a/src/Dekaf/Admin/ShareGroupTypes.cs
+++ b/src/Dekaf/Admin/ShareGroupTypes.cs
@@ -1,0 +1,59 @@
+namespace Dekaf.Admin;
+
+/// <summary>
+/// Share group description.
+/// </summary>
+public sealed class ShareGroupDescription
+{
+    public required string GroupId { get; init; }
+    public required string GroupState { get; init; }
+    public int GroupEpoch { get; init; }
+    public int AssignmentEpoch { get; init; }
+    public string? AssignorName { get; init; }
+    public required IReadOnlyList<ShareGroupMemberDescription> Members { get; init; }
+    public int AuthorizedOperations { get; init; }
+}
+
+/// <summary>
+/// Share group member description.
+/// </summary>
+public sealed class ShareGroupMemberDescription
+{
+    public required string MemberId { get; init; }
+    public string? RackId { get; init; }
+    public int MemberEpoch { get; init; }
+    public required string ClientId { get; init; }
+    public required string ClientHost { get; init; }
+    public required IReadOnlyList<string> SubscribedTopicNames { get; init; }
+    public IReadOnlyList<TopicPartition>? Assignment { get; init; }
+}
+
+/// <summary>
+/// Options for ListShareGroups.
+/// </summary>
+public sealed class ListShareGroupsOptions
+{
+    public IReadOnlyList<string>? States { get; init; }
+}
+
+/// <summary>
+/// Description of a share group's offset for a partition.
+/// </summary>
+public sealed class ShareGroupOffsetDescription
+{
+    public required TopicPartition TopicPartition { get; init; }
+    public long StartOffset { get; init; }
+    public int LeaderEpoch { get; init; }
+    public long Lag { get; init; } = -1;
+    public Protocol.ErrorCode ErrorCode { get; init; }
+    public string? ErrorMessage { get; init; }
+}
+
+/// <summary>
+/// Specification for altering a share group offset.
+/// </summary>
+public sealed class ShareGroupOffsetAlteration
+{
+    public required TopicPartition TopicPartition { get; init; }
+    public required long StartOffset { get; init; }
+}

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1573,7 +1573,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
 {
     private IReadOnlyList<string> _bootstrapServers = [];
     private string? _clientId;
-    private string _groupId = null!;
+    private string? _groupId;
     private string? _rackId;
     private int _fetchMinBytes = 1;
     private int _fetchMaxBytes = 52428800;
@@ -1815,8 +1815,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     {
         if (_bootstrapServers.Count == 0)
             throw new InvalidOperationException("Bootstrap servers must be specified. Call WithBootstrapServers() before Build().");
-        if (string.IsNullOrEmpty(_groupId))
-            throw new InvalidOperationException("Group ID must be specified for share consumers. Call WithGroupId() before Build().");
+        ArgumentNullException.ThrowIfNullOrEmpty(_groupId, nameof(_groupId));
 
         var keyDeserializer = _keyDeserializer ?? ConsumerBuilder<TKey, TValue>.GetDefaultDeserializer<TKey>();
         var valueDeserializer = _valueDeserializer ?? ConsumerBuilder<TKey, TValue>.GetDefaultDeserializer<TValue>();

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1544,7 +1544,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
         return consumer;
     }
 
-    internal static IDeserializer<T> GetDefaultDeserializer<T>()
+    private static IDeserializer<T> GetDefaultDeserializer<T>()
     {
         if (typeof(T) == typeof(string))
             return (IDeserializer<T>)(object)Serializers.String;
@@ -1817,8 +1817,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             throw new InvalidOperationException("Bootstrap servers must be specified. Call WithBootstrapServers() before Build().");
         ArgumentNullException.ThrowIfNullOrEmpty(_groupId, nameof(_groupId));
 
-        var keyDeserializer = _keyDeserializer ?? ConsumerBuilder<TKey, TValue>.GetDefaultDeserializer<TKey>();
-        var valueDeserializer = _valueDeserializer ?? ConsumerBuilder<TKey, TValue>.GetDefaultDeserializer<TValue>();
+        var keyDeserializer = _keyDeserializer ?? GetDefaultDeserializer<TKey>();
+        var valueDeserializer = _valueDeserializer ?? GetDefaultDeserializer<TValue>();
 
         var options = new ShareConsumerOptions
         {
@@ -1858,4 +1858,23 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         return consumer;
     }
 
+    private static IDeserializer<T> GetDefaultDeserializer<T>()
+    {
+        if (typeof(T) == typeof(string))
+            return (IDeserializer<T>)(object)Serializers.String;
+        if (typeof(T) == typeof(byte[]))
+            return (IDeserializer<T>)(object)Serializers.ByteArray;
+        if (typeof(T) == typeof(ReadOnlyMemory<byte>))
+            return (IDeserializer<T>)(object)Serializers.RawBytes;
+        if (typeof(T) == typeof(int))
+            return (IDeserializer<T>)(object)Serializers.Int32;
+        if (typeof(T) == typeof(long))
+            return (IDeserializer<T>)(object)Serializers.Int64;
+        if (typeof(T) == typeof(Guid))
+            return (IDeserializer<T>)(object)Serializers.Guid;
+        if (typeof(T) == typeof(Ignore))
+            return (IDeserializer<T>)(object)Serializers.Ignore;
+
+        throw new InvalidOperationException($"No default deserializer for type {typeof(T)}. Please specify a deserializer.");
+    }
 }

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -8,6 +8,7 @@ using Dekaf.Security;
 using Dekaf.Security.Sasl;
 using Dekaf.Protocol.Messages;
 using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
 using Microsoft.Extensions.Logging;
 
 namespace Dekaf;
@@ -1543,7 +1544,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
         return consumer;
     }
 
-    private static IDeserializer<T> GetDefaultDeserializer<T>()
+    internal static IDeserializer<T> GetDefaultDeserializer<T>()
     {
         if (typeof(T) == typeof(string))
             return (IDeserializer<T>)(object)Serializers.String;
@@ -1562,4 +1563,300 @@ public sealed class ConsumerBuilder<TKey, TValue>
 
         throw new InvalidOperationException($"No default deserializer for type {typeof(T)}. Please specify a deserializer.");
     }
+}
+
+/// <summary>
+/// Builder for configuring and creating Kafka share consumers (KIP-932).
+/// Share consumers provide queue-semantics with record-level acknowledgement.
+/// </summary>
+public sealed class ShareConsumerBuilder<TKey, TValue>
+{
+    private IReadOnlyList<string> _bootstrapServers = [];
+    private string? _clientId;
+    private string _groupId = null!;
+    private string? _rackId;
+    private int _fetchMinBytes = 1;
+    private int _fetchMaxBytes = 52428800;
+    private int _maxPartitionFetchBytes = 1048576;
+    private int _fetchMaxWaitMs = 200;
+    private int _maxPollRecords = 500;
+    private int _sessionTimeoutMs = 45000;
+    private int _heartbeatIntervalMs = 3000;
+    private int _requestTimeoutMs = 30000;
+    private bool _useTls;
+    private TlsConfig? _tlsConfig;
+    private SaslMechanism _saslMechanism = SaslMechanism.None;
+    private string? _saslUsername;
+    private string? _saslPassword;
+    private GssapiConfig? _gssapiConfig;
+    private OAuthBearerConfig? _oauthConfig;
+    private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
+    private IDeserializer<TKey>? _keyDeserializer;
+    private IDeserializer<TValue>? _valueDeserializer;
+    private ILoggerFactory? _loggerFactory;
+    private int _socketSendBufferBytes;
+    private int _socketReceiveBufferBytes;
+    private int _connectionsPerBroker = 2;
+    private IRetryPolicy? _retryPolicy;
+    private readonly List<string> _topicsToSubscribe = [];
+
+    public ShareConsumerBuilder<TKey, TValue> WithBootstrapServers(string servers)
+    {
+        _bootstrapServers = servers.Split(',').Select(s => s.Trim()).ToArray();
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithBootstrapServers(params string[] servers)
+    {
+        _bootstrapServers = [..servers];
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithClientId(string clientId)
+    {
+        _clientId = clientId;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithGroupId(string groupId)
+    {
+        _groupId = groupId;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithRackId(string rackId)
+    {
+        _rackId = rackId;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithFetchMinBytes(int fetchMinBytes)
+    {
+        _fetchMinBytes = fetchMinBytes;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithFetchMaxBytes(int fetchMaxBytes)
+    {
+        _fetchMaxBytes = fetchMaxBytes;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithMaxPartitionFetchBytes(int maxPartitionFetchBytes)
+    {
+        _maxPartitionFetchBytes = maxPartitionFetchBytes;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithFetchMaxWaitMs(int fetchMaxWaitMs)
+    {
+        _fetchMaxWaitMs = fetchMaxWaitMs;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithMaxPollRecords(int maxPollRecords)
+    {
+        _maxPollRecords = maxPollRecords;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithSessionTimeoutMs(int sessionTimeoutMs)
+    {
+        _sessionTimeoutMs = sessionTimeoutMs;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithHeartbeatIntervalMs(int heartbeatIntervalMs)
+    {
+        _heartbeatIntervalMs = heartbeatIntervalMs;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithRequestTimeoutMs(int requestTimeoutMs)
+    {
+        _requestTimeoutMs = requestTimeoutMs;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithTls(bool useTls = true)
+    {
+        _useTls = useTls;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithTlsConfig(TlsConfig tlsConfig)
+    {
+        _tlsConfig = tlsConfig;
+        _useTls = true;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithSaslPlain(string username, string password)
+    {
+        _saslMechanism = SaslMechanism.Plain;
+        _saslUsername = username;
+        _saslPassword = password;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithSaslScram256(string username, string password)
+    {
+        _saslMechanism = SaslMechanism.ScramSha256;
+        _saslUsername = username;
+        _saslPassword = password;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithSaslScram512(string username, string password)
+    {
+        _saslMechanism = SaslMechanism.ScramSha512;
+        _saslUsername = username;
+        _saslPassword = password;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithGssapiConfig(GssapiConfig config)
+    {
+        _saslMechanism = SaslMechanism.Gssapi;
+        _gssapiConfig = config;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithOAuthBearer(OAuthBearerConfig config)
+    {
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = config;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerTokenProvider(Func<CancellationToken, ValueTask<OAuthBearerToken>> provider)
+    {
+        _oauthTokenProvider = provider;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithSocketSendBufferBytes(int bytes)
+    {
+        _socketSendBufferBytes = bytes;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithSocketReceiveBufferBytes(int bytes)
+    {
+        _socketReceiveBufferBytes = bytes;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithKeyDeserializer(IDeserializer<TKey> deserializer)
+    {
+        _keyDeserializer = deserializer;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithValueDeserializer(IDeserializer<TValue> deserializer)
+    {
+        _valueDeserializer = deserializer;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        _loggerFactory = loggerFactory;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithConnectionsPerBroker(int connectionsPerBroker)
+    {
+        _connectionsPerBroker = connectionsPerBroker;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithRetryPolicy(IRetryPolicy retryPolicy)
+    {
+        _retryPolicy = retryPolicy;
+        return this;
+    }
+
+    /// <summary>
+    /// Subscribes the share consumer to the specified topic when built.
+    /// </summary>
+    public ShareConsumerBuilder<TKey, TValue> SubscribeTo(string topic)
+    {
+        _topicsToSubscribe.Add(topic);
+        return this;
+    }
+
+    /// <summary>
+    /// Subscribes the share consumer to the specified topics when built.
+    /// </summary>
+    public ShareConsumerBuilder<TKey, TValue> SubscribeTo(params string[] topics)
+    {
+        _topicsToSubscribe.AddRange(topics);
+        return this;
+    }
+
+    public async ValueTask<IKafkaShareConsumer<TKey, TValue>> BuildAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var consumer = Build();
+        try
+        {
+            await consumer.InitializeAsync(cancellationToken).ConfigureAwait(false);
+            return consumer;
+        }
+        catch
+        {
+            await consumer.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public IKafkaShareConsumer<TKey, TValue> Build()
+    {
+        if (_bootstrapServers.Count == 0)
+            throw new InvalidOperationException("Bootstrap servers must be specified. Call WithBootstrapServers() before Build().");
+        if (string.IsNullOrEmpty(_groupId))
+            throw new InvalidOperationException("Group ID must be specified for share consumers. Call WithGroupId() before Build().");
+
+        var keyDeserializer = _keyDeserializer ?? ConsumerBuilder<TKey, TValue>.GetDefaultDeserializer<TKey>();
+        var valueDeserializer = _valueDeserializer ?? ConsumerBuilder<TKey, TValue>.GetDefaultDeserializer<TValue>();
+
+        var options = new ShareConsumerOptions
+        {
+            BootstrapServers = _bootstrapServers,
+            ClientId = _clientId,
+            GroupId = _groupId,
+            RackId = _rackId,
+            FetchMinBytes = _fetchMinBytes,
+            FetchMaxBytes = _fetchMaxBytes,
+            MaxPartitionFetchBytes = _maxPartitionFetchBytes,
+            FetchMaxWaitMs = _fetchMaxWaitMs,
+            MaxPollRecords = _maxPollRecords,
+            SessionTimeoutMs = _sessionTimeoutMs,
+            HeartbeatIntervalMs = _heartbeatIntervalMs,
+            RequestTimeoutMs = _requestTimeoutMs,
+            UseTls = _useTls,
+            TlsConfig = _tlsConfig,
+            SaslMechanism = _saslMechanism,
+            SaslUsername = _saslUsername,
+            SaslPassword = _saslPassword,
+            GssapiConfig = _gssapiConfig,
+            OAuthBearerConfig = _oauthConfig,
+            OAuthBearerTokenProvider = _oauthTokenProvider,
+            SocketSendBufferBytes = _socketSendBufferBytes,
+            SocketReceiveBufferBytes = _socketReceiveBufferBytes,
+            ConnectionsPerBroker = _connectionsPerBroker,
+            RetryPolicy = _retryPolicy
+        };
+
+        var consumer = new KafkaShareConsumer<TKey, TValue>(options, keyDeserializer, valueDeserializer, _loggerFactory);
+
+        if (_topicsToSubscribe.Count > 0)
+        {
+            consumer.Subscribe([.. _topicsToSubscribe]);
+        }
+
+        return consumer;
+    }
+
 }

--- a/src/Dekaf/Kafka.cs
+++ b/src/Dekaf/Kafka.cs
@@ -3,6 +3,7 @@ namespace Dekaf;
 using Admin;
 using Consumer;
 using Producer;
+using ShareConsumer;
 
 /// <summary>
 /// Main entry point for creating Kafka clients.
@@ -140,6 +141,70 @@ public static class Kafka
         params string[] topics)
     {
         var consumer = await new ConsumerBuilder<TKey, TValue>()
+            .WithBootstrapServers(bootstrapServers)
+            .WithGroupId(groupId)
+            .SubscribeTo(topics)
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return consumer;
+    }
+
+    /// <summary>
+    /// Creates a share consumer builder.
+    /// </summary>
+    public static ShareConsumerBuilder<TKey, TValue> CreateShareConsumer<TKey, TValue>()
+    {
+        return new ShareConsumerBuilder<TKey, TValue>();
+    }
+
+    /// <summary>
+    /// Creates a share consumer with the specified bootstrap servers and group ID.
+    /// </summary>
+    public static IKafkaShareConsumer<TKey, TValue> CreateShareConsumer<TKey, TValue>(string bootstrapServers, string groupId)
+    {
+        return new ShareConsumerBuilder<TKey, TValue>()
+            .WithBootstrapServers(bootstrapServers)
+            .WithGroupId(groupId)
+            .Build();
+    }
+
+    /// <summary>
+    /// Creates a share consumer with the specified bootstrap servers, group ID, and topic subscriptions.
+    /// </summary>
+    public static IKafkaShareConsumer<TKey, TValue> CreateShareConsumer<TKey, TValue>(string bootstrapServers, string groupId, params string[] topics)
+    {
+        return new ShareConsumerBuilder<TKey, TValue>()
+            .WithBootstrapServers(bootstrapServers)
+            .WithGroupId(groupId)
+            .SubscribeTo(topics)
+            .Build();
+    }
+
+    /// <summary>
+    /// Creates and initializes a share consumer with the specified bootstrap servers and group ID.
+    /// </summary>
+    public static ValueTask<IKafkaShareConsumer<TKey, TValue>> CreateShareConsumerAsync<TKey, TValue>(
+        string bootstrapServers,
+        string groupId,
+        CancellationToken cancellationToken = default)
+    {
+        return new ShareConsumerBuilder<TKey, TValue>()
+            .WithBootstrapServers(bootstrapServers)
+            .WithGroupId(groupId)
+            .BuildAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates and initializes a share consumer with the specified bootstrap servers, group ID, and topic subscriptions.
+    /// </summary>
+    public static async ValueTask<IKafkaShareConsumer<TKey, TValue>> CreateShareConsumerAsync<TKey, TValue>(
+        string bootstrapServers,
+        string groupId,
+        CancellationToken cancellationToken,
+        params string[] topics)
+    {
+        var consumer = await new ShareConsumerBuilder<TKey, TValue>()
             .WithBootstrapServers(bootstrapServers)
             .WithGroupId(groupId)
             .SubscribeTo(topics)

--- a/src/Dekaf/Protocol/ApiKey.cs
+++ b/src/Dekaf/Protocol/ApiKey.cs
@@ -80,5 +80,12 @@ public enum ApiKey : short
     PushTelemetry = 72,
     AssignReplicasToDirs = 73,
     ListClientMetricsResources = 74,
-    DescribeTopicPartitions = 75
+    DescribeTopicPartitions = 75,
+    ShareGroupHeartbeat = 76,
+    ShareGroupDescribe = 77,
+    ShareFetch = 78,
+    ShareAcknowledge = 79,
+    DescribeShareGroupOffsets = 90,
+    AlterShareGroupOffsets = 91,
+    DeleteShareGroupOffsets = 92
 }

--- a/src/Dekaf/Protocol/Messages/AlterShareGroupOffsetsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/AlterShareGroupOffsetsRequest.cs
@@ -1,0 +1,114 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// AlterShareGroupOffsets request (API key 91).
+/// Alters the offsets for a share group (KIP-932).
+/// </summary>
+public sealed class AlterShareGroupOffsetsRequest : IKafkaRequest<AlterShareGroupOffsetsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.AlterShareGroupOffsets;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// The group ID.
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// The topics to alter offsets for.
+    /// </summary>
+    public required IReadOnlyList<AlterShareGroupOffsetsRequestTopic> Topics { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactString(GroupId);
+
+        writer.WriteCompactArray(
+            Topics,
+            static (ref KafkaProtocolWriter w, AlterShareGroupOffsetsRequestTopic topic) => topic.Write(ref w));
+
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// Topic in an AlterShareGroupOffsets request.
+/// </summary>
+public sealed class AlterShareGroupOffsetsRequestTopic
+{
+    /// <summary>
+    /// The topic name.
+    /// </summary>
+    public required string TopicName { get; init; }
+
+    /// <summary>
+    /// The partitions to alter offsets for.
+    /// </summary>
+    public required IReadOnlyList<AlterShareGroupOffsetsRequestPartition> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(TopicName);
+
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, AlterShareGroupOffsetsRequestPartition partition) => partition.Write(ref w));
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static AlterShareGroupOffsetsRequestTopic Read(ref KafkaProtocolReader reader)
+    {
+        var topicName = reader.ReadCompactNonNullableString();
+
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => AlterShareGroupOffsetsRequestPartition.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new AlterShareGroupOffsetsRequestTopic
+        {
+            TopicName = topicName,
+            Partitions = partitions
+        };
+    }
+}
+
+/// <summary>
+/// Partition in an AlterShareGroupOffsets request.
+/// </summary>
+public sealed class AlterShareGroupOffsetsRequestPartition
+{
+    /// <summary>
+    /// The partition index.
+    /// </summary>
+    public int PartitionIndex { get; init; }
+
+    /// <summary>
+    /// The start offset to set for the share group on this partition.
+    /// </summary>
+    public long StartOffset { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt32(PartitionIndex);
+        writer.WriteInt64(StartOffset);
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static AlterShareGroupOffsetsRequestPartition Read(ref KafkaProtocolReader reader)
+    {
+        var partitionIndex = reader.ReadInt32();
+        var startOffset = reader.ReadInt64();
+
+        reader.SkipTaggedFields();
+
+        return new AlterShareGroupOffsetsRequestPartition
+        {
+            PartitionIndex = partitionIndex,
+            StartOffset = startOffset
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/AlterShareGroupOffsetsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/AlterShareGroupOffsetsResponse.cs
@@ -1,0 +1,150 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// AlterShareGroupOffsets response (API key 91).
+/// Contains the results of altering offsets for a share group (KIP-932).
+/// </summary>
+public sealed class AlterShareGroupOffsetsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.AlterShareGroupOffsets;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation
+    /// (zero if not throttled).
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The top-level error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The top-level error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The topic responses.
+    /// </summary>
+    public required IReadOnlyList<AlterShareGroupOffsetsResponseTopic> Responses { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+
+        var responses = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => AlterShareGroupOffsetsResponseTopic.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new AlterShareGroupOffsetsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            Responses = responses
+        };
+    }
+}
+
+/// <summary>
+/// Topic in an AlterShareGroupOffsets response.
+/// </summary>
+public sealed class AlterShareGroupOffsetsResponseTopic
+{
+    /// <summary>
+    /// The topic name.
+    /// </summary>
+    public required string TopicName { get; init; }
+
+    /// <summary>
+    /// The topic ID (UUID).
+    /// </summary>
+    public Guid TopicId { get; init; }
+
+    /// <summary>
+    /// The partition responses.
+    /// </summary>
+    public required IReadOnlyList<AlterShareGroupOffsetsResponsePartition> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(TopicName);
+        writer.WriteUuid(TopicId);
+
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, AlterShareGroupOffsetsResponsePartition partition) => partition.Write(ref w));
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static AlterShareGroupOffsetsResponseTopic Read(ref KafkaProtocolReader reader)
+    {
+        var topicName = reader.ReadCompactNonNullableString();
+        var topicId = reader.ReadUuid();
+
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => AlterShareGroupOffsetsResponsePartition.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new AlterShareGroupOffsetsResponseTopic
+        {
+            TopicName = topicName,
+            TopicId = topicId,
+            Partitions = partitions
+        };
+    }
+}
+
+/// <summary>
+/// Partition in an AlterShareGroupOffsets response.
+/// </summary>
+public sealed class AlterShareGroupOffsetsResponsePartition
+{
+    /// <summary>
+    /// The partition index.
+    /// </summary>
+    public int PartitionIndex { get; init; }
+
+    /// <summary>
+    /// The error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt32(PartitionIndex);
+        writer.WriteInt16((short)ErrorCode);
+        writer.WriteCompactNullableString(ErrorMessage);
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static AlterShareGroupOffsetsResponsePartition Read(ref KafkaProtocolReader reader)
+    {
+        var partitionIndex = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+
+        reader.SkipTaggedFields();
+
+        return new AlterShareGroupOffsetsResponsePartition
+        {
+            PartitionIndex = partitionIndex,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DeleteShareGroupOffsetsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/DeleteShareGroupOffsetsRequest.cs
@@ -1,0 +1,64 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DeleteShareGroupOffsets request (API key 92).
+/// Deletes the offsets for a share group (KIP-932).
+/// </summary>
+public sealed class DeleteShareGroupOffsetsRequest : IKafkaRequest<DeleteShareGroupOffsetsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.DeleteShareGroupOffsets;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// The group ID.
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// The topics to delete offsets for.
+    /// </summary>
+    public required IReadOnlyList<DeleteShareGroupOffsetsRequestTopic> Topics { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactString(GroupId);
+
+        writer.WriteCompactArray(
+            Topics,
+            static (ref KafkaProtocolWriter w, DeleteShareGroupOffsetsRequestTopic topic) => topic.Write(ref w));
+
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// Topic in a DeleteShareGroupOffsets request.
+/// No partition list — deletes all partitions for each topic.
+/// </summary>
+public sealed class DeleteShareGroupOffsetsRequestTopic
+{
+    /// <summary>
+    /// The topic name.
+    /// </summary>
+    public required string TopicName { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(TopicName);
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static DeleteShareGroupOffsetsRequestTopic Read(ref KafkaProtocolReader reader)
+    {
+        var topicName = reader.ReadCompactNonNullableString();
+
+        reader.SkipTaggedFields();
+
+        return new DeleteShareGroupOffsetsRequestTopic
+        {
+            TopicName = topicName
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DeleteShareGroupOffsetsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DeleteShareGroupOffsetsResponse.cs
@@ -1,0 +1,107 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DeleteShareGroupOffsets response (API key 92).
+/// Contains the results of deleting offsets for a share group (KIP-932).
+/// </summary>
+public sealed class DeleteShareGroupOffsetsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.DeleteShareGroupOffsets;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation
+    /// (zero if not throttled).
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The top-level error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The top-level error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The topic responses.
+    /// </summary>
+    public required IReadOnlyList<DeleteShareGroupOffsetsResponseTopic> Responses { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+
+        var responses = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => DeleteShareGroupOffsetsResponseTopic.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new DeleteShareGroupOffsetsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            Responses = responses
+        };
+    }
+}
+
+/// <summary>
+/// Topic in a DeleteShareGroupOffsets response.
+/// </summary>
+public sealed class DeleteShareGroupOffsetsResponseTopic
+{
+    /// <summary>
+    /// The topic name.
+    /// </summary>
+    public required string TopicName { get; init; }
+
+    /// <summary>
+    /// The topic ID (UUID).
+    /// </summary>
+    public Guid TopicId { get; init; }
+
+    /// <summary>
+    /// The error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(TopicName);
+        writer.WriteUuid(TopicId);
+        writer.WriteInt16((short)ErrorCode);
+        writer.WriteCompactNullableString(ErrorMessage);
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static DeleteShareGroupOffsetsResponseTopic Read(ref KafkaProtocolReader reader)
+    {
+        var topicName = reader.ReadCompactNonNullableString();
+        var topicId = reader.ReadUuid();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+
+        reader.SkipTaggedFields();
+
+        return new DeleteShareGroupOffsetsResponseTopic
+        {
+            TopicName = topicName,
+            TopicId = topicId,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DescribeShareGroupOffsetsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeShareGroupOffsetsRequest.cs
@@ -55,8 +55,19 @@ public sealed class DescribeShareGroupOffsetsRequestGroup
     {
         var groupId = reader.ReadCompactNonNullableString();
 
-        var topics = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => DescribeShareGroupOffsetsRequestTopic.Read(ref r));
+        // Topics is nullable: null = describe all topics, empty = no topics.
+        // ReadCompactArray cannot distinguish null from empty, so read the length manually.
+        var topicsLength = reader.ReadUnsignedVarInt() - 1;
+        IReadOnlyList<DescribeShareGroupOffsetsRequestTopic>? topics = null;
+        if (topicsLength >= 0)
+        {
+            var topicsList = new DescribeShareGroupOffsetsRequestTopic[topicsLength];
+            for (int i = 0; i < topicsLength; i++)
+            {
+                topicsList[i] = DescribeShareGroupOffsetsRequestTopic.Read(ref reader);
+            }
+            topics = topicsList;
+        }
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DescribeShareGroupOffsetsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeShareGroupOffsetsRequest.cs
@@ -1,0 +1,112 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DescribeShareGroupOffsets request (API key 90).
+/// Describes the offsets for share groups (KIP-932).
+/// </summary>
+public sealed class DescribeShareGroupOffsetsRequest : IKafkaRequest<DescribeShareGroupOffsetsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.DescribeShareGroupOffsets;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 1;
+
+    /// <summary>
+    /// The groups to describe offsets for.
+    /// </summary>
+    public required IReadOnlyList<DescribeShareGroupOffsetsRequestGroup> Groups { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactArray(
+            Groups,
+            static (ref KafkaProtocolWriter w, DescribeShareGroupOffsetsRequestGroup group) => group.Write(ref w));
+
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// Group in a DescribeShareGroupOffsets request.
+/// </summary>
+public sealed class DescribeShareGroupOffsetsRequestGroup
+{
+    /// <summary>
+    /// The group ID.
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// The topics to describe offsets for. Null means all topics.
+    /// </summary>
+    public IReadOnlyList<DescribeShareGroupOffsetsRequestTopic>? Topics { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(GroupId);
+
+        writer.WriteCompactNullableArray(
+            Topics,
+            static (ref KafkaProtocolWriter w, DescribeShareGroupOffsetsRequestTopic topic) => topic.Write(ref w));
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static DescribeShareGroupOffsetsRequestGroup Read(ref KafkaProtocolReader reader)
+    {
+        var groupId = reader.ReadCompactNonNullableString();
+
+        var topics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => DescribeShareGroupOffsetsRequestTopic.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new DescribeShareGroupOffsetsRequestGroup
+        {
+            GroupId = groupId,
+            Topics = topics
+        };
+    }
+}
+
+/// <summary>
+/// Topic in a DescribeShareGroupOffsets request.
+/// </summary>
+public sealed class DescribeShareGroupOffsetsRequestTopic
+{
+    /// <summary>
+    /// The topic name.
+    /// </summary>
+    public required string TopicName { get; init; }
+
+    /// <summary>
+    /// The partition indexes.
+    /// </summary>
+    public required IReadOnlyList<int> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(TopicName);
+
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, int partition) => w.WriteInt32(partition));
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static DescribeShareGroupOffsetsRequestTopic Read(ref KafkaProtocolReader reader)
+    {
+        var topicName = reader.ReadCompactNonNullableString();
+
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32());
+
+        reader.SkipTaggedFields();
+
+        return new DescribeShareGroupOffsetsRequestTopic
+        {
+            TopicName = topicName,
+            Partitions = partitions
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DescribeShareGroupOffsetsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeShareGroupOffsetsResponse.cs
@@ -1,0 +1,237 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DescribeShareGroupOffsets response (API key 90).
+/// Contains the offsets for share groups (KIP-932).
+/// </summary>
+public sealed class DescribeShareGroupOffsetsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.DescribeShareGroupOffsets;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 1;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation
+    /// (zero if not throttled).
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The described groups.
+    /// </summary>
+    public required IReadOnlyList<DescribeShareGroupOffsetsResponseGroup> Groups { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+
+        var groups = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => DescribeShareGroupOffsetsResponseGroup.Read(ref r, v),
+            version);
+
+        reader.SkipTaggedFields();
+
+        return new DescribeShareGroupOffsetsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            Groups = groups
+        };
+    }
+}
+
+/// <summary>
+/// Group in a DescribeShareGroupOffsets response.
+/// </summary>
+public sealed class DescribeShareGroupOffsetsResponseGroup
+{
+    /// <summary>
+    /// The group ID.
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// The topics with offsets.
+    /// </summary>
+    public required IReadOnlyList<DescribeShareGroupOffsetsResponseTopic> Topics { get; init; }
+
+    /// <summary>
+    /// The error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactString(GroupId);
+
+        writer.WriteCompactArray(
+            Topics,
+            static (ref KafkaProtocolWriter w, DescribeShareGroupOffsetsResponseTopic topic, short v) => topic.Write(ref w, v),
+            version);
+
+        writer.WriteInt16((short)ErrorCode);
+        writer.WriteCompactNullableString(ErrorMessage);
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static DescribeShareGroupOffsetsResponseGroup Read(ref KafkaProtocolReader reader, short version)
+    {
+        var groupId = reader.ReadCompactNonNullableString();
+
+        var topics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => DescribeShareGroupOffsetsResponseTopic.Read(ref r, v),
+            version);
+
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+
+        reader.SkipTaggedFields();
+
+        return new DescribeShareGroupOffsetsResponseGroup
+        {
+            GroupId = groupId,
+            Topics = topics,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+    }
+}
+
+/// <summary>
+/// Topic in a DescribeShareGroupOffsets response.
+/// </summary>
+public sealed class DescribeShareGroupOffsetsResponseTopic
+{
+    /// <summary>
+    /// The topic name.
+    /// </summary>
+    public required string TopicName { get; init; }
+
+    /// <summary>
+    /// The topic ID (UUID).
+    /// </summary>
+    public Guid TopicId { get; init; }
+
+    /// <summary>
+    /// The partitions with offsets.
+    /// </summary>
+    public required IReadOnlyList<DescribeShareGroupOffsetsResponsePartition> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactString(TopicName);
+        writer.WriteUuid(TopicId);
+
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, DescribeShareGroupOffsetsResponsePartition partition, short v) => partition.Write(ref w, v),
+            version);
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static DescribeShareGroupOffsetsResponseTopic Read(ref KafkaProtocolReader reader, short version)
+    {
+        var topicName = reader.ReadCompactNonNullableString();
+        var topicId = reader.ReadUuid();
+
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => DescribeShareGroupOffsetsResponsePartition.Read(ref r, v),
+            version);
+
+        reader.SkipTaggedFields();
+
+        return new DescribeShareGroupOffsetsResponseTopic
+        {
+            TopicName = topicName,
+            TopicId = topicId,
+            Partitions = partitions
+        };
+    }
+}
+
+/// <summary>
+/// Partition in a DescribeShareGroupOffsets response.
+/// </summary>
+public sealed class DescribeShareGroupOffsetsResponsePartition
+{
+    /// <summary>
+    /// The partition index.
+    /// </summary>
+    public int PartitionIndex { get; init; }
+
+    /// <summary>
+    /// The share group start offset.
+    /// </summary>
+    public long StartOffset { get; init; }
+
+    /// <summary>
+    /// The leader epoch.
+    /// </summary>
+    public int LeaderEpoch { get; init; }
+
+    /// <summary>
+    /// The lag of the share group on this partition (v1+). -1 if not available.
+    /// </summary>
+    public long Lag { get; init; } = -1;
+
+    /// <summary>
+    /// The error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteInt32(PartitionIndex);
+        writer.WriteInt64(StartOffset);
+        writer.WriteInt32(LeaderEpoch);
+
+        if (version >= 1)
+        {
+            writer.WriteInt64(Lag);
+        }
+
+        writer.WriteInt16((short)ErrorCode);
+        writer.WriteCompactNullableString(ErrorMessage);
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static DescribeShareGroupOffsetsResponsePartition Read(ref KafkaProtocolReader reader, short version)
+    {
+        var partitionIndex = reader.ReadInt32();
+        var startOffset = reader.ReadInt64();
+        var leaderEpoch = reader.ReadInt32();
+
+        long lag = -1;
+        if (version >= 1)
+        {
+            lag = reader.ReadInt64();
+        }
+
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+
+        reader.SkipTaggedFields();
+
+        return new DescribeShareGroupOffsetsResponsePartition
+        {
+            PartitionIndex = partitionIndex,
+            StartOffset = startOffset,
+            LeaderEpoch = leaderEpoch,
+            Lag = lag,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/ShareAcknowledgeRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ShareAcknowledgeRequest.cs
@@ -1,0 +1,188 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ShareAcknowledge request (API key 79).
+/// Acknowledges delivery of records fetched from a share group,
+/// indicating whether each batch was accepted, released, or rejected (KIP-932).
+/// </summary>
+public sealed class ShareAcknowledgeRequest : IKafkaRequest<ShareAcknowledgeResponse>
+{
+    public static ApiKey ApiKey => ApiKey.ShareAcknowledge;
+    public static short LowestSupportedVersion => 1;
+    public static short HighestSupportedVersion => 2;
+
+    /// <summary>
+    /// The group ID.
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// The member ID.
+    /// </summary>
+    public required string MemberId { get; init; }
+
+    /// <summary>
+    /// The current share session epoch.
+    /// </summary>
+    public int ShareSessionEpoch { get; init; }
+
+    /// <summary>
+    /// Whether this is a renew acknowledgement (v2+ only).
+    /// When true, the broker treats the acknowledgement as a renewal of previously
+    /// sent acknowledgements rather than new ones.
+    /// </summary>
+    public bool IsRenewAck { get; init; }
+
+    /// <summary>
+    /// The topics containing the partitions to acknowledge.
+    /// </summary>
+    public required IReadOnlyList<ShareAcknowledgeTopic> Topics { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactString(GroupId);
+        writer.WriteCompactString(MemberId);
+        writer.WriteInt32(ShareSessionEpoch);
+
+        if (version >= 2)
+        {
+            writer.WriteInt8((sbyte)(IsRenewAck ? 1 : 0));
+        }
+
+        writer.WriteCompactArray(
+            Topics,
+            static (ref KafkaProtocolWriter w, ShareAcknowledgeTopic tp) => tp.Write(ref w));
+
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// Topic data in a ShareAcknowledge request.
+/// </summary>
+public sealed class ShareAcknowledgeTopic
+{
+    /// <summary>
+    /// The topic ID (UUID).
+    /// </summary>
+    public required Guid TopicId { get; init; }
+
+    /// <summary>
+    /// The partitions containing acknowledgement batches.
+    /// </summary>
+    public required IReadOnlyList<ShareAcknowledgePartition> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteUuid(TopicId);
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, ShareAcknowledgePartition p) => p.Write(ref w));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ShareAcknowledgeTopic Read(ref KafkaProtocolReader reader)
+    {
+        var topicId = reader.ReadUuid();
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ShareAcknowledgePartition.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new ShareAcknowledgeTopic
+        {
+            TopicId = topicId,
+            Partitions = partitions
+        };
+    }
+}
+
+/// <summary>
+/// Partition data in a ShareAcknowledge request.
+/// </summary>
+public sealed class ShareAcknowledgePartition
+{
+    /// <summary>
+    /// The partition index.
+    /// </summary>
+    public int PartitionIndex { get; init; }
+
+    /// <summary>
+    /// The acknowledgement batches for this partition.
+    /// </summary>
+    public required IReadOnlyList<ShareAcknowledgeBatch> AcknowledgementBatches { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt32(PartitionIndex);
+        writer.WriteCompactArray(
+            AcknowledgementBatches,
+            static (ref KafkaProtocolWriter w, ShareAcknowledgeBatch b) => b.Write(ref w));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ShareAcknowledgePartition Read(ref KafkaProtocolReader reader)
+    {
+        var partitionIndex = reader.ReadInt32();
+        var acknowledgementBatches = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ShareAcknowledgeBatch.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new ShareAcknowledgePartition
+        {
+            PartitionIndex = partitionIndex,
+            AcknowledgementBatches = acknowledgementBatches
+        };
+    }
+}
+
+/// <summary>
+/// An acknowledgement batch in a ShareAcknowledge request.
+/// Specifies an offset range and the acknowledge type for each offset within that range.
+/// </summary>
+public sealed class ShareAcknowledgeBatch
+{
+    /// <summary>
+    /// The first offset in this acknowledgement batch.
+    /// </summary>
+    public long FirstOffset { get; init; }
+
+    /// <summary>
+    /// The last offset in this acknowledgement batch.
+    /// </summary>
+    public long LastOffset { get; init; }
+
+    /// <summary>
+    /// The acknowledge types for each offset in the range.
+    /// Each byte represents the acknowledge type for the corresponding offset.
+    /// </summary>
+    public required IReadOnlyList<byte> AcknowledgeTypes { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt64(FirstOffset);
+        writer.WriteInt64(LastOffset);
+        writer.WriteCompactArray(
+            AcknowledgeTypes,
+            static (ref KafkaProtocolWriter w, byte ackType) => w.WriteInt8((sbyte)ackType));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ShareAcknowledgeBatch Read(ref KafkaProtocolReader reader)
+    {
+        var firstOffset = reader.ReadInt64();
+        var lastOffset = reader.ReadInt64();
+        var acknowledgeTypes = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => (byte)r.ReadInt8());
+
+        reader.SkipTaggedFields();
+
+        return new ShareAcknowledgeBatch
+        {
+            FirstOffset = firstOffset,
+            LastOffset = lastOffset,
+            AcknowledgeTypes = acknowledgeTypes
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/ShareAcknowledgeRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ShareAcknowledgeRequest.cs
@@ -8,6 +8,7 @@ namespace Dekaf.Protocol.Messages;
 public sealed class ShareAcknowledgeRequest : IKafkaRequest<ShareAcknowledgeResponse>
 {
     public static ApiKey ApiKey => ApiKey.ShareAcknowledge;
+    // v0 was removed after Kafka 4.0 early access; v1 is the minimum GA version (KIP-932).
     public static short LowestSupportedVersion => 1;
     public static short HighestSupportedVersion => 2;
 

--- a/src/Dekaf/Protocol/Messages/ShareAcknowledgeResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareAcknowledgeResponse.cs
@@ -1,0 +1,228 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ShareAcknowledge response (API key 79).
+/// Contains the results of acknowledging records fetched from a share group (KIP-932).
+/// </summary>
+public sealed class ShareAcknowledgeResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.ShareAcknowledge;
+    public static short LowestSupportedVersion => 1;
+    public static short HighestSupportedVersion => 2;
+
+    /// <summary>
+    /// Throttle time in milliseconds.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The top-level error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The top-level error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The acquisition lock timeout in milliseconds (v2+ only).
+    /// </summary>
+    public int AcquisitionLockTimeoutMs { get; init; }
+
+    /// <summary>
+    /// The per-topic acknowledgement responses.
+    /// </summary>
+    public required IReadOnlyList<ShareAcknowledgeResponseTopic> Responses { get; init; }
+
+    /// <summary>
+    /// Endpoints for all current leaders enumerated in the response.
+    /// </summary>
+    public required IReadOnlyList<ShareAcknowledgeNodeEndpoint> NodeEndpoints { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+
+        var acquisitionLockTimeoutMs = 0;
+        if (version >= 2)
+        {
+            acquisitionLockTimeoutMs = reader.ReadInt32();
+        }
+
+        var responses = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ShareAcknowledgeResponseTopic.Read(ref r));
+
+        var nodeEndpoints = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ShareAcknowledgeNodeEndpoint.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new ShareAcknowledgeResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            AcquisitionLockTimeoutMs = acquisitionLockTimeoutMs,
+            Responses = responses,
+            NodeEndpoints = nodeEndpoints
+        };
+    }
+}
+
+/// <summary>
+/// Per-topic acknowledgement response in a ShareAcknowledge response.
+/// </summary>
+public sealed class ShareAcknowledgeResponseTopic
+{
+    /// <summary>
+    /// The topic ID (UUID).
+    /// </summary>
+    public Guid TopicId { get; init; }
+
+    /// <summary>
+    /// The per-partition acknowledgement responses.
+    /// </summary>
+    public required IReadOnlyList<ShareAcknowledgeResponsePartition> Partitions { get; init; }
+
+    public static ShareAcknowledgeResponseTopic Read(ref KafkaProtocolReader reader)
+    {
+        var topicId = reader.ReadUuid();
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ShareAcknowledgeResponsePartition.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new ShareAcknowledgeResponseTopic
+        {
+            TopicId = topicId,
+            Partitions = partitions
+        };
+    }
+}
+
+/// <summary>
+/// Per-partition acknowledgement response in a ShareAcknowledge response.
+/// </summary>
+public sealed class ShareAcknowledgeResponsePartition
+{
+    /// <summary>
+    /// The partition index.
+    /// </summary>
+    public int PartitionIndex { get; init; }
+
+    /// <summary>
+    /// The error code for this partition, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message for this partition, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The current leader for this partition, or null if unknown.
+    /// </summary>
+    public ShareAcknowledgeLeaderIdAndEpoch? CurrentLeader { get; init; }
+
+    public static ShareAcknowledgeResponsePartition Read(ref KafkaProtocolReader reader)
+    {
+        var partitionIndex = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+
+        var leaderMarker = reader.ReadInt8();
+        ShareAcknowledgeLeaderIdAndEpoch? currentLeader = null;
+        if (leaderMarker >= 0)
+        {
+            currentLeader = ShareAcknowledgeLeaderIdAndEpoch.Read(ref reader);
+        }
+
+        reader.SkipTaggedFields();
+
+        return new ShareAcknowledgeResponsePartition
+        {
+            PartitionIndex = partitionIndex,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            CurrentLeader = currentLeader
+        };
+    }
+}
+
+/// <summary>
+/// Leader ID and epoch information in a ShareAcknowledge response.
+/// </summary>
+public sealed class ShareAcknowledgeLeaderIdAndEpoch
+{
+    /// <summary>
+    /// The ID of the current leader, or -1 if the leader is unknown.
+    /// </summary>
+    public int LeaderId { get; init; } = -1;
+
+    /// <summary>
+    /// The latest known leader epoch.
+    /// </summary>
+    public int LeaderEpoch { get; init; } = -1;
+
+    public static ShareAcknowledgeLeaderIdAndEpoch Read(ref KafkaProtocolReader reader)
+    {
+        var leaderId = reader.ReadInt32();
+        var leaderEpoch = reader.ReadInt32();
+
+        reader.SkipTaggedFields();
+
+        return new ShareAcknowledgeLeaderIdAndEpoch
+        {
+            LeaderId = leaderId,
+            LeaderEpoch = leaderEpoch
+        };
+    }
+}
+
+/// <summary>
+/// Node endpoint information in a ShareAcknowledge response.
+/// </summary>
+public sealed class ShareAcknowledgeNodeEndpoint
+{
+    /// <summary>
+    /// The ID of the associated node.
+    /// </summary>
+    public int NodeId { get; init; }
+
+    /// <summary>
+    /// The node's hostname.
+    /// </summary>
+    public required string Host { get; init; }
+
+    /// <summary>
+    /// The node's port.
+    /// </summary>
+    public int Port { get; init; }
+
+    /// <summary>
+    /// The rack of the node, or null if it has not been assigned to a rack.
+    /// </summary>
+    public string? Rack { get; init; }
+
+    public static ShareAcknowledgeNodeEndpoint Read(ref KafkaProtocolReader reader)
+    {
+        var nodeId = reader.ReadInt32();
+        var host = reader.ReadCompactNonNullableString();
+        var port = reader.ReadInt32();
+        var rack = reader.ReadCompactString();
+
+        reader.SkipTaggedFields();
+
+        return new ShareAcknowledgeNodeEndpoint
+        {
+            NodeId = nodeId,
+            Host = host,
+            Port = port,
+            Rack = rack
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/ShareAcknowledgeResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareAcknowledgeResponse.cs
@@ -134,16 +134,9 @@ public sealed class ShareAcknowledgeResponsePartition
         var errorCode = (ErrorCode)reader.ReadInt16();
         var errorMessage = reader.ReadCompactString();
 
-        // CurrentLeader is non-nullable — always present inline (no marker byte)
-        var leaderId = reader.ReadInt32();
-        var leaderEpoch = reader.ReadInt32();
-        reader.SkipTaggedFields();
-
-        var currentLeader = new ShareAcknowledgeLeaderIdAndEpoch
-        {
-            LeaderId = leaderId,
-            LeaderEpoch = leaderEpoch
-        };
+        // CurrentLeader is non-nullable — always present inline (no marker byte).
+        // It has its own tagged fields, so Read handles SkipTaggedFields internally.
+        var currentLeader = ShareAcknowledgeLeaderIdAndEpoch.Read(ref reader);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/ShareAcknowledgeResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareAcknowledgeResponse.cs
@@ -124,9 +124,9 @@ public sealed class ShareAcknowledgeResponsePartition
     public string? ErrorMessage { get; init; }
 
     /// <summary>
-    /// The current leader for this partition, or null if unknown.
+    /// The current leader information. Always present inline in the response.
     /// </summary>
-    public ShareAcknowledgeLeaderIdAndEpoch? CurrentLeader { get; init; }
+    public required ShareAcknowledgeLeaderIdAndEpoch CurrentLeader { get; init; }
 
     public static ShareAcknowledgeResponsePartition Read(ref KafkaProtocolReader reader)
     {
@@ -134,12 +134,16 @@ public sealed class ShareAcknowledgeResponsePartition
         var errorCode = (ErrorCode)reader.ReadInt16();
         var errorMessage = reader.ReadCompactString();
 
-        var leaderMarker = reader.ReadInt8();
-        ShareAcknowledgeLeaderIdAndEpoch? currentLeader = null;
-        if (leaderMarker >= 0)
+        // CurrentLeader is non-nullable — always present inline (no marker byte)
+        var leaderId = reader.ReadInt32();
+        var leaderEpoch = reader.ReadInt32();
+        reader.SkipTaggedFields();
+
+        var currentLeader = new ShareAcknowledgeLeaderIdAndEpoch
         {
-            currentLeader = ShareAcknowledgeLeaderIdAndEpoch.Read(ref reader);
-        }
+            LeaderId = leaderId,
+            LeaderEpoch = leaderEpoch
+        };
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/ShareFetchRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ShareFetchRequest.cs
@@ -1,0 +1,307 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ShareFetch request (API key 78).
+/// Fetches records from share group topic partitions per KIP-932.
+/// Supports share session management and acknowledgement batching.
+/// </summary>
+public sealed class ShareFetchRequest : IKafkaRequest<ShareFetchResponse>
+{
+    public static ApiKey ApiKey => ApiKey.ShareFetch;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 2;
+
+    /// <summary>
+    /// The group ID.
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// The member ID.
+    /// </summary>
+    public required string MemberId { get; init; }
+
+    /// <summary>
+    /// The share session epoch. 0 for a new session, -1 to close the session.
+    /// </summary>
+    public int ShareSessionEpoch { get; init; }
+
+    /// <summary>
+    /// Maximum wait time in milliseconds for the fetch to block on the server.
+    /// </summary>
+    public int MaxWaitMs { get; init; }
+
+    /// <summary>
+    /// Minimum bytes to accumulate before returning.
+    /// </summary>
+    public int MinBytes { get; init; }
+
+    /// <summary>
+    /// Maximum bytes to return.
+    /// </summary>
+    public int MaxBytes { get; init; }
+
+    /// <summary>
+    /// Maximum number of records to return (v1+).
+    /// </summary>
+    public int MaxRecords { get; init; }
+
+    /// <summary>
+    /// Batch size hint for the server (v1+).
+    /// </summary>
+    public int BatchSize { get; init; }
+
+    /// <summary>
+    /// The share acquire mode (v2+). 0 = normal acquire.
+    /// </summary>
+    public sbyte ShareAcquireMode { get; init; }
+
+    /// <summary>
+    /// Whether this is a renew acknowledgement request (v2+).
+    /// </summary>
+    public bool IsRenewAck { get; init; }
+
+    /// <summary>
+    /// Topics to fetch.
+    /// </summary>
+    public required IReadOnlyList<ShareFetchRequestTopic> Topics { get; init; }
+
+    /// <summary>
+    /// Topics to forget from the share session.
+    /// </summary>
+    public IReadOnlyList<ShareFetchForgottenTopic>? ForgottenTopicsData { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactString(GroupId);
+        writer.WriteCompactString(MemberId);
+        writer.WriteInt32(ShareSessionEpoch);
+        writer.WriteInt32(MaxWaitMs);
+        writer.WriteInt32(MinBytes);
+        writer.WriteInt32(MaxBytes);
+
+        if (version >= 1)
+        {
+            writer.WriteInt32(MaxRecords);
+            writer.WriteInt32(BatchSize);
+        }
+
+        if (version >= 2)
+        {
+            writer.WriteInt8(ShareAcquireMode);
+            writer.WriteInt8((sbyte)(IsRenewAck ? 1 : 0));
+        }
+
+        writer.WriteCompactArray(
+            Topics,
+            static (ref KafkaProtocolWriter w, ShareFetchRequestTopic tp, short v) => tp.Write(ref w, v),
+            version);
+
+        writer.WriteCompactNullableArray(
+            ForgottenTopicsData,
+            static (ref KafkaProtocolWriter w, ShareFetchForgottenTopic ft) => ft.Write(ref w));
+
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// Topic in a ShareFetch request.
+/// </summary>
+public sealed class ShareFetchRequestTopic
+{
+    /// <summary>
+    /// The topic ID (UUID).
+    /// </summary>
+    public required Guid TopicId { get; init; }
+
+    /// <summary>
+    /// Partitions to fetch.
+    /// </summary>
+    public required IReadOnlyList<ShareFetchRequestPartition> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteUuid(TopicId);
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, ShareFetchRequestPartition p, short v) => p.Write(ref w, v),
+            version);
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ShareFetchRequestTopic Read(ref KafkaProtocolReader reader, short version)
+    {
+        var topicId = reader.ReadUuid();
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => ShareFetchRequestPartition.Read(ref r, v),
+            version);
+
+        reader.SkipTaggedFields();
+
+        return new ShareFetchRequestTopic
+        {
+            TopicId = topicId,
+            Partitions = partitions
+        };
+    }
+}
+
+/// <summary>
+/// Partition in a ShareFetch request.
+/// </summary>
+public sealed class ShareFetchRequestPartition
+{
+    /// <summary>
+    /// Partition index.
+    /// </summary>
+    public int PartitionIndex { get; init; }
+
+    /// <summary>
+    /// Maximum bytes to fetch for this partition (v0 only).
+    /// </summary>
+    public int PartitionMaxBytes { get; init; }
+
+    /// <summary>
+    /// Acknowledgement batches to include with this fetch.
+    /// </summary>
+    public IReadOnlyList<ShareFetchAcknowledgementBatch>? AcknowledgementBatches { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteInt32(PartitionIndex);
+
+        if (version == 0)
+        {
+            writer.WriteInt32(PartitionMaxBytes);
+        }
+
+        writer.WriteCompactNullableArray(
+            AcknowledgementBatches,
+            static (ref KafkaProtocolWriter w, ShareFetchAcknowledgementBatch b) => b.Write(ref w));
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ShareFetchRequestPartition Read(ref KafkaProtocolReader reader, short version)
+    {
+        var partitionIndex = reader.ReadInt32();
+
+        var partitionMaxBytes = 0;
+        if (version == 0)
+        {
+            partitionMaxBytes = reader.ReadInt32();
+        }
+
+        var ackBatchLength = reader.ReadUnsignedVarInt() - 1;
+        IReadOnlyList<ShareFetchAcknowledgementBatch>? acknowledgementBatches = null;
+        if (ackBatchLength > 0)
+        {
+            var batches = new ShareFetchAcknowledgementBatch[ackBatchLength];
+            for (var i = 0; i < ackBatchLength; i++)
+            {
+                batches[i] = ShareFetchAcknowledgementBatch.Read(ref reader);
+            }
+            acknowledgementBatches = batches;
+        }
+
+        reader.SkipTaggedFields();
+
+        return new ShareFetchRequestPartition
+        {
+            PartitionIndex = partitionIndex,
+            PartitionMaxBytes = partitionMaxBytes,
+            AcknowledgementBatches = acknowledgementBatches
+        };
+    }
+}
+
+/// <summary>
+/// Acknowledgement batch in a ShareFetch request.
+/// Contains the offset range and per-record acknowledgement types.
+/// </summary>
+public sealed class ShareFetchAcknowledgementBatch
+{
+    /// <summary>
+    /// The first offset of the batch.
+    /// </summary>
+    public long FirstOffset { get; init; }
+
+    /// <summary>
+    /// The last offset of the batch.
+    /// </summary>
+    public long LastOffset { get; init; }
+
+    /// <summary>
+    /// The acknowledgement types for each record in the batch.
+    /// </summary>
+    public required IReadOnlyList<byte> AcknowledgeTypes { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt64(FirstOffset);
+        writer.WriteInt64(LastOffset);
+        writer.WriteCompactArray(
+            AcknowledgeTypes,
+            static (ref KafkaProtocolWriter w, byte t) => w.WriteInt8((sbyte)t));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ShareFetchAcknowledgementBatch Read(ref KafkaProtocolReader reader)
+    {
+        var firstOffset = reader.ReadInt64();
+        var lastOffset = reader.ReadInt64();
+        var acknowledgeTypes = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => (byte)r.ReadInt8());
+
+        reader.SkipTaggedFields();
+
+        return new ShareFetchAcknowledgementBatch
+        {
+            FirstOffset = firstOffset,
+            LastOffset = lastOffset,
+            AcknowledgeTypes = acknowledgeTypes
+        };
+    }
+}
+
+/// <summary>
+/// Forgotten topic in a ShareFetch request.
+/// Used to remove partitions from a share session.
+/// </summary>
+public sealed class ShareFetchForgottenTopic
+{
+    /// <summary>
+    /// The topic ID (UUID).
+    /// </summary>
+    public required Guid TopicId { get; init; }
+
+    /// <summary>
+    /// The partition indexes to forget.
+    /// </summary>
+    public required IReadOnlyList<int> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteUuid(TopicId);
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, int p) => w.WriteInt32(p));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ShareFetchForgottenTopic Read(ref KafkaProtocolReader reader)
+    {
+        var topicId = reader.ReadUuid();
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32());
+
+        reader.SkipTaggedFields();
+
+        return new ShareFetchForgottenTopic
+        {
+            TopicId = topicId,
+            Partitions = partitions
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/ShareFetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareFetchResponse.cs
@@ -1,0 +1,302 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ShareFetch response (API key 78).
+/// Contains records fetched from share group topic partitions per KIP-932.
+/// Includes acquired record ranges, acknowledgement results, and node endpoints.
+/// </summary>
+public sealed class ShareFetchResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.ShareFetch;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 2;
+
+    /// <summary>
+    /// Throttle time in milliseconds.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The top-level error code, or 0 if there was no error.
+    /// </summary>
+    public required ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The acquisition lock timeout in milliseconds (v1+).
+    /// </summary>
+    public int AcquisitionLockTimeoutMs { get; init; }
+
+    /// <summary>
+    /// Responses per topic.
+    /// </summary>
+    public required IReadOnlyList<ShareFetchResponseTopic> Responses { get; init; }
+
+    /// <summary>
+    /// Node endpoints for preferred leader information.
+    /// </summary>
+    public required IReadOnlyList<ShareFetchNodeEndpoint> NodeEndpoints { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+
+        var acquisitionLockTimeoutMs = 0;
+        if (version >= 1)
+        {
+            acquisitionLockTimeoutMs = reader.ReadInt32();
+        }
+
+        var responses = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => ShareFetchResponseTopic.Read(ref r, v),
+            version);
+
+        var nodeEndpoints = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ShareFetchNodeEndpoint.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new ShareFetchResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            AcquisitionLockTimeoutMs = acquisitionLockTimeoutMs,
+            Responses = responses,
+            NodeEndpoints = nodeEndpoints
+        };
+    }
+}
+
+/// <summary>
+/// Topic response in a ShareFetch response.
+/// </summary>
+public sealed class ShareFetchResponseTopic
+{
+    /// <summary>
+    /// The topic ID (UUID).
+    /// </summary>
+    public required Guid TopicId { get; init; }
+
+    /// <summary>
+    /// Partition responses.
+    /// </summary>
+    public required IReadOnlyList<ShareFetchResponsePartition> Partitions { get; init; }
+
+    public static ShareFetchResponseTopic Read(ref KafkaProtocolReader reader, short version)
+    {
+        var topicId = reader.ReadUuid();
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => ShareFetchResponsePartition.Read(ref r, v),
+            version);
+
+        reader.SkipTaggedFields();
+
+        return new ShareFetchResponseTopic
+        {
+            TopicId = topicId,
+            Partitions = partitions
+        };
+    }
+}
+
+/// <summary>
+/// Partition response in a ShareFetch response.
+/// </summary>
+public sealed class ShareFetchResponsePartition
+{
+    /// <summary>
+    /// Partition index.
+    /// </summary>
+    public int PartitionIndex { get; init; }
+
+    /// <summary>
+    /// Error code for this partition.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Error code for the acknowledgement, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode AcknowledgeErrorCode { get; init; }
+
+    /// <summary>
+    /// The acknowledgement error message, or null if there was no error.
+    /// </summary>
+    public string? AcknowledgeErrorMessage { get; init; }
+
+    /// <summary>
+    /// The current leader information, or null if not available.
+    /// </summary>
+    public ShareFetchLeaderIdAndEpoch? CurrentLeader { get; init; }
+
+    /// <summary>
+    /// Raw record batch bytes. Use the protocol Records decoder to parse.
+    /// </summary>
+    public ReadOnlyMemory<byte> RecordBytes { get; init; }
+
+    /// <summary>
+    /// Acquired record ranges for this partition.
+    /// </summary>
+    public required IReadOnlyList<ShareFetchAcquiredRecords> AcquiredRecords { get; init; }
+
+    public static ShareFetchResponsePartition Read(ref KafkaProtocolReader reader, short version)
+    {
+        var partitionIndex = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+        var acknowledgeErrorCode = (ErrorCode)reader.ReadInt16();
+        var acknowledgeErrorMessage = reader.ReadCompactString();
+
+        // Nullable non-tagged struct: single signed byte marker (-1 = null, >= 0 = present)
+        var currentLeaderMarker = reader.ReadInt8();
+        ShareFetchLeaderIdAndEpoch? currentLeader = null;
+        if (currentLeaderMarker >= 0)
+        {
+            var leaderId = reader.ReadInt32();
+            var leaderEpoch = reader.ReadInt32();
+            reader.SkipTaggedFields();
+
+            currentLeader = new ShareFetchLeaderIdAndEpoch
+            {
+                LeaderId = leaderId,
+                LeaderEpoch = leaderEpoch
+            };
+        }
+
+        // COMPACT_RECORDS: length+1 encoded as unsigned varint, 0 = null
+        var recordsLength = reader.ReadUnsignedVarInt() - 1;
+        var recordBytes = ReadOnlyMemory<byte>.Empty;
+        if (recordsLength > 0)
+        {
+            recordBytes = reader.ReadMemorySlice(recordsLength);
+        }
+
+        var acquiredRecords = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ShareFetchAcquiredRecords.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new ShareFetchResponsePartition
+        {
+            PartitionIndex = partitionIndex,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            AcknowledgeErrorCode = acknowledgeErrorCode,
+            AcknowledgeErrorMessage = acknowledgeErrorMessage,
+            CurrentLeader = currentLeader,
+            RecordBytes = recordBytes,
+            AcquiredRecords = acquiredRecords
+        };
+    }
+}
+
+/// <summary>
+/// Leader ID and epoch for a share fetch partition.
+/// </summary>
+public sealed class ShareFetchLeaderIdAndEpoch
+{
+    /// <summary>
+    /// The leader broker ID, or -1 if unknown.
+    /// </summary>
+    public int LeaderId { get; init; } = -1;
+
+    /// <summary>
+    /// The leader epoch, or -1 if unknown.
+    /// </summary>
+    public int LeaderEpoch { get; init; } = -1;
+}
+
+/// <summary>
+/// Acquired record range in a ShareFetch response.
+/// Represents a contiguous range of records that have been acquired by this consumer.
+/// </summary>
+public sealed class ShareFetchAcquiredRecords
+{
+    /// <summary>
+    /// The first offset of the acquired range.
+    /// </summary>
+    public long FirstOffset { get; init; }
+
+    /// <summary>
+    /// The last offset of the acquired range.
+    /// </summary>
+    public long LastOffset { get; init; }
+
+    /// <summary>
+    /// The number of times these records have been delivered.
+    /// </summary>
+    public short DeliveryCount { get; init; }
+
+    public static ShareFetchAcquiredRecords Read(ref KafkaProtocolReader reader)
+    {
+        var firstOffset = reader.ReadInt64();
+        var lastOffset = reader.ReadInt64();
+        var deliveryCount = reader.ReadInt16();
+
+        reader.SkipTaggedFields();
+
+        return new ShareFetchAcquiredRecords
+        {
+            FirstOffset = firstOffset,
+            LastOffset = lastOffset,
+            DeliveryCount = deliveryCount
+        };
+    }
+}
+
+/// <summary>
+/// Node endpoint in a ShareFetch response.
+/// Provides connection information for preferred leaders.
+/// </summary>
+public sealed class ShareFetchNodeEndpoint
+{
+    /// <summary>
+    /// The node ID.
+    /// </summary>
+    public int NodeId { get; init; }
+
+    /// <summary>
+    /// The hostname.
+    /// </summary>
+    public required string Host { get; init; }
+
+    /// <summary>
+    /// The port number.
+    /// </summary>
+    public int Port { get; init; }
+
+    /// <summary>
+    /// The rack ID, or null if not available.
+    /// </summary>
+    public string? Rack { get; init; }
+
+    public static ShareFetchNodeEndpoint Read(ref KafkaProtocolReader reader)
+    {
+        var nodeId = reader.ReadInt32();
+        var host = reader.ReadCompactNonNullableString();
+        var port = reader.ReadInt32();
+        var rack = reader.ReadCompactString();
+
+        reader.SkipTaggedFields();
+
+        return new ShareFetchNodeEndpoint
+        {
+            NodeId = nodeId,
+            Host = host,
+            Port = port,
+            Rack = rack
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/ShareGroupDescribeRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ShareGroupDescribeRequest.cs
@@ -1,0 +1,33 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ShareGroupDescribe request (API key 77).
+/// Describes share groups (KIP-932).
+/// </summary>
+public sealed class ShareGroupDescribeRequest : IKafkaRequest<ShareGroupDescribeResponse>
+{
+    public static ApiKey ApiKey => ApiKey.ShareGroupDescribe;
+    public static short LowestSupportedVersion => 1;
+    public static short HighestSupportedVersion => 1;
+
+    /// <summary>
+    /// The group IDs to describe.
+    /// </summary>
+    public required IReadOnlyList<string> GroupIds { get; init; }
+
+    /// <summary>
+    /// Whether to include authorized operations.
+    /// </summary>
+    public bool IncludeAuthorizedOperations { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactArray(
+            GroupIds,
+            static (ref KafkaProtocolWriter w, string groupId) => w.WriteCompactString(groupId));
+
+        writer.WriteBoolean(IncludeAuthorizedOperations);
+
+        writer.WriteEmptyTaggedFields();
+    }
+}

--- a/src/Dekaf/Protocol/Messages/ShareGroupDescribeResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareGroupDescribeResponse.cs
@@ -1,0 +1,322 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ShareGroupDescribe response (API key 77).
+/// Contains the descriptions of share groups (KIP-932).
+/// </summary>
+public sealed class ShareGroupDescribeResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.ShareGroupDescribe;
+    public static short LowestSupportedVersion => 1;
+    public static short HighestSupportedVersion => 1;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation
+    /// (zero if not throttled).
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The described groups.
+    /// </summary>
+    public required IReadOnlyList<ShareGroupDescribeGroup> Groups { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+
+        var groups = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ShareGroupDescribeGroup.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new ShareGroupDescribeResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            Groups = groups
+        };
+    }
+}
+
+/// <summary>
+/// Described group in a ShareGroupDescribe response.
+/// </summary>
+public sealed class ShareGroupDescribeGroup
+{
+    /// <summary>
+    /// The error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The group ID.
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// The group state.
+    /// </summary>
+    public required string GroupState { get; init; }
+
+    /// <summary>
+    /// The group epoch.
+    /// </summary>
+    public int GroupEpoch { get; init; }
+
+    /// <summary>
+    /// The assignment epoch.
+    /// </summary>
+    public int AssignmentEpoch { get; init; }
+
+    /// <summary>
+    /// The server-side assignor name.
+    /// </summary>
+    public string? AssignorName { get; init; }
+
+    /// <summary>
+    /// The group members.
+    /// </summary>
+    public required IReadOnlyList<ShareGroupDescribeMember> Members { get; init; }
+
+    /// <summary>
+    /// 32-bit bitfield representing authorized operations for this group.
+    /// </summary>
+    public int AuthorizedOperations { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt16((short)ErrorCode);
+        writer.WriteCompactNullableString(ErrorMessage);
+        writer.WriteCompactString(GroupId);
+        writer.WriteCompactString(GroupState);
+        writer.WriteInt32(GroupEpoch);
+        writer.WriteInt32(AssignmentEpoch);
+        writer.WriteCompactNullableString(AssignorName);
+
+        writer.WriteCompactArray(
+            Members,
+            static (ref KafkaProtocolWriter w, ShareGroupDescribeMember member) => member.Write(ref w));
+
+        writer.WriteInt32(AuthorizedOperations);
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ShareGroupDescribeGroup Read(ref KafkaProtocolReader reader)
+    {
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+        var groupId = reader.ReadCompactString() ?? string.Empty;
+        var groupState = reader.ReadCompactString() ?? string.Empty;
+        var groupEpoch = reader.ReadInt32();
+        var assignmentEpoch = reader.ReadInt32();
+        var assignorName = reader.ReadCompactString();
+
+        var members = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ShareGroupDescribeMember.Read(ref r));
+
+        var authorizedOperations = reader.ReadInt32();
+
+        reader.SkipTaggedFields();
+
+        return new ShareGroupDescribeGroup
+        {
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            GroupId = groupId,
+            GroupState = groupState,
+            GroupEpoch = groupEpoch,
+            AssignmentEpoch = assignmentEpoch,
+            AssignorName = assignorName,
+            Members = members,
+            AuthorizedOperations = authorizedOperations
+        };
+    }
+}
+
+/// <summary>
+/// Member in a ShareGroupDescribe response.
+/// </summary>
+public sealed class ShareGroupDescribeMember
+{
+    /// <summary>
+    /// The member ID.
+    /// </summary>
+    public required string MemberId { get; init; }
+
+    /// <summary>
+    /// The rack ID of the member.
+    /// </summary>
+    public string? RackId { get; init; }
+
+    /// <summary>
+    /// The current member epoch.
+    /// </summary>
+    public int MemberEpoch { get; init; }
+
+    /// <summary>
+    /// The client ID.
+    /// </summary>
+    public required string ClientId { get; init; }
+
+    /// <summary>
+    /// The client host.
+    /// </summary>
+    public required string ClientHost { get; init; }
+
+    /// <summary>
+    /// The list of topic names the member is subscribed to.
+    /// </summary>
+    public required IReadOnlyList<string> SubscribedTopicNames { get; init; }
+
+    /// <summary>
+    /// The assignment for this member, or null if there is no assignment.
+    /// </summary>
+    public ShareGroupDescribeAssignment? Assignment { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(MemberId);
+        writer.WriteCompactNullableString(RackId);
+        writer.WriteInt32(MemberEpoch);
+        writer.WriteCompactString(ClientId);
+        writer.WriteCompactString(ClientHost);
+
+        writer.WriteCompactArray(
+            SubscribedTopicNames,
+            static (ref KafkaProtocolWriter w, string topic) => w.WriteCompactString(topic));
+
+        // Nullable non-tagged struct: single signed byte marker (-1 = null, >= 0 = present)
+        if (Assignment is not null)
+        {
+            writer.WriteInt8(0);
+            Assignment.Write(ref writer);
+        }
+        else
+        {
+            writer.WriteInt8(-1);
+        }
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ShareGroupDescribeMember Read(ref KafkaProtocolReader reader)
+    {
+        var memberId = reader.ReadCompactString() ?? string.Empty;
+        var rackId = reader.ReadCompactString();
+        var memberEpoch = reader.ReadInt32();
+        var clientId = reader.ReadCompactString() ?? string.Empty;
+        var clientHost = reader.ReadCompactString() ?? string.Empty;
+
+        var subscribedTopicNames = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty);
+
+        // Nullable non-tagged struct: single signed byte marker (-1 = null, >= 0 = present)
+        var assignmentMarker = reader.ReadInt8();
+        ShareGroupDescribeAssignment? assignment = null;
+        if (assignmentMarker >= 0)
+        {
+            assignment = ShareGroupDescribeAssignment.Read(ref reader);
+        }
+
+        reader.SkipTaggedFields();
+
+        return new ShareGroupDescribeMember
+        {
+            MemberId = memberId,
+            RackId = rackId,
+            MemberEpoch = memberEpoch,
+            ClientId = clientId,
+            ClientHost = clientHost,
+            SubscribedTopicNames = subscribedTopicNames,
+            Assignment = assignment
+        };
+    }
+}
+
+/// <summary>
+/// Assignment information in a ShareGroupDescribe response.
+/// Contains the partitions assigned to a member.
+/// </summary>
+public sealed class ShareGroupDescribeAssignment
+{
+    /// <summary>
+    /// The topic partitions assigned to this member.
+    /// </summary>
+    public required IReadOnlyList<ShareGroupDescribeTopicPartitions> TopicPartitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactArray(
+            TopicPartitions,
+            static (ref KafkaProtocolWriter w, ShareGroupDescribeTopicPartitions tp) => tp.Write(ref w));
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ShareGroupDescribeAssignment Read(ref KafkaProtocolReader reader)
+    {
+        var topicPartitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ShareGroupDescribeTopicPartitions.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new ShareGroupDescribeAssignment
+        {
+            TopicPartitions = topicPartitions
+        };
+    }
+}
+
+/// <summary>
+/// Topic partitions in a ShareGroupDescribe response.
+/// </summary>
+public sealed class ShareGroupDescribeTopicPartitions
+{
+    /// <summary>
+    /// The topic ID (UUID).
+    /// </summary>
+    public required Guid TopicId { get; init; }
+
+    /// <summary>
+    /// The topic name.
+    /// </summary>
+    public string? TopicName { get; init; }
+
+    /// <summary>
+    /// The partition indexes.
+    /// </summary>
+    public required IReadOnlyList<int> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteUuid(TopicId);
+        writer.WriteCompactNullableString(TopicName);
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, int partition) => w.WriteInt32(partition));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ShareGroupDescribeTopicPartitions Read(ref KafkaProtocolReader reader)
+    {
+        var topicId = reader.ReadUuid();
+        var topicName = reader.ReadCompactString();
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32());
+
+        reader.SkipTaggedFields();
+
+        return new ShareGroupDescribeTopicPartitions
+        {
+            TopicId = topicId,
+            TopicName = topicName,
+            Partitions = partitions
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/ShareGroupHeartbeatRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ShareGroupHeartbeatRequest.cs
@@ -1,0 +1,56 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ShareGroupHeartbeat request (API key 76).
+/// Used by the KIP-932 share group protocol for group coordination.
+/// The broker handles partition assignment server-side for share groups.
+/// </summary>
+public sealed class ShareGroupHeartbeatRequest : IKafkaRequest<ShareGroupHeartbeatResponse>
+{
+    public static ApiKey ApiKey => ApiKey.ShareGroupHeartbeat;
+    public static short LowestSupportedVersion => 1;
+    public static short HighestSupportedVersion => 1;
+
+    /// <summary>
+    /// The group ID.
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// The member ID. Client-generated UUID v4 sent on the first heartbeat.
+    /// </summary>
+    public required string MemberId { get; init; }
+
+    /// <summary>
+    /// The member epoch. 0 to join the group, -1 to leave the group.
+    /// </summary>
+    public required int MemberEpoch { get; init; }
+
+    /// <summary>
+    /// The rack ID of the consumer, used for rack-aware assignment.
+    /// </summary>
+    public string? RackId { get; init; }
+
+    /// <summary>
+    /// The list of topic names the consumer is subscribed to.
+    /// Null if not changed since the last heartbeat.
+    /// </summary>
+    public IReadOnlyList<string>? SubscribedTopicNames { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactString(GroupId);
+        writer.WriteCompactString(MemberId);
+        writer.WriteInt32(MemberEpoch);
+        writer.WriteCompactNullableString(RackId);
+
+        writer.WriteCompactNullableArray(
+            SubscribedTopicNames,
+            static (ref KafkaProtocolWriter w, string topic) =>
+            {
+                w.WriteCompactString(topic);
+            });
+
+        writer.WriteEmptyTaggedFields();
+    }
+}

--- a/src/Dekaf/Protocol/Messages/ShareGroupHeartbeatResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareGroupHeartbeatResponse.cs
@@ -1,0 +1,147 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ShareGroupHeartbeat response (API key 76).
+/// Contains the group coordination state from the broker, including
+/// the assigned partitions (server-side assignment per KIP-932).
+/// </summary>
+public sealed class ShareGroupHeartbeatResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.ShareGroupHeartbeat;
+    public static short LowestSupportedVersion => 1;
+    public static short HighestSupportedVersion => 1;
+
+    /// <summary>
+    /// Throttle time in milliseconds.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The top-level error code, or 0 if there was no error.
+    /// </summary>
+    public required ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The error message, or null if there was no error.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// The member ID. Echoes the client-generated UUID v4 back.
+    /// </summary>
+    public string? MemberId { get; init; }
+
+    /// <summary>
+    /// The current member epoch. The member must use this epoch for subsequent heartbeats.
+    /// </summary>
+    public int MemberEpoch { get; init; }
+
+    /// <summary>
+    /// The heartbeat interval in milliseconds.
+    /// The member should send the next heartbeat before this interval expires.
+    /// </summary>
+    public int HeartbeatIntervalMs { get; init; }
+
+    /// <summary>
+    /// The assignment for this member, or null if the assignment has not changed.
+    /// Contains the partitions assigned to this member by the server.
+    /// </summary>
+    public ShareGroupHeartbeatAssignment? Assignment { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+        var memberId = reader.ReadCompactString();
+        var memberEpoch = reader.ReadInt32();
+        var heartbeatIntervalMs = reader.ReadInt32();
+
+        // Nullable non-tagged struct: single signed byte marker (-1 = null, >= 0 = present)
+        var assignmentMarker = reader.ReadInt8();
+        ShareGroupHeartbeatAssignment? assignment = null;
+        if (assignmentMarker >= 0)
+        {
+            assignment = ShareGroupHeartbeatAssignment.Read(ref reader);
+        }
+
+        // Response tagged fields
+        reader.SkipTaggedFields();
+
+        return new ShareGroupHeartbeatResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            MemberId = memberId,
+            MemberEpoch = memberEpoch,
+            HeartbeatIntervalMs = heartbeatIntervalMs,
+            Assignment = assignment
+        };
+    }
+}
+
+/// <summary>
+/// Assignment information in a ShareGroupHeartbeat response.
+/// Contains the partitions assigned to this member by the server.
+/// </summary>
+public sealed class ShareGroupHeartbeatAssignment
+{
+    /// <summary>
+    /// The partitions assigned to this member.
+    /// </summary>
+    public required IReadOnlyList<ShareGroupHeartbeatTopicPartitions> TopicPartitions { get; init; }
+
+    public static ShareGroupHeartbeatAssignment Read(ref KafkaProtocolReader reader)
+    {
+        var topicPartitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ShareGroupHeartbeatTopicPartitions.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new ShareGroupHeartbeatAssignment
+        {
+            TopicPartitions = topicPartitions
+        };
+    }
+}
+
+/// <summary>
+/// Topic partitions in a ShareGroupHeartbeat response.
+/// </summary>
+public sealed class ShareGroupHeartbeatTopicPartitions
+{
+    /// <summary>
+    /// The topic ID (UUID).
+    /// </summary>
+    public required Guid TopicId { get; init; }
+
+    /// <summary>
+    /// The partition indexes.
+    /// </summary>
+    public required IReadOnlyList<int> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteUuid(TopicId);
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, int partition) => w.WriteInt32(partition));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ShareGroupHeartbeatTopicPartitions Read(ref KafkaProtocolReader reader)
+    {
+        var topicId = reader.ReadUuid();
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32());
+
+        reader.SkipTaggedFields();
+
+        return new ShareGroupHeartbeatTopicPartitions
+        {
+            TopicId = topicId,
+            Partitions = partitions
+        };
+    }
+}

--- a/src/Dekaf/ShareConsumer/AcknowledgeType.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgeType.cs
@@ -1,0 +1,14 @@
+namespace Dekaf.ShareConsumer;
+
+/// <summary>
+/// Per-record acknowledgement types for share group consumption (KIP-932).
+/// Values match the Kafka wire protocol encoding in AcknowledgementBatch.AcknowledgeTypes.
+/// </summary>
+public enum AcknowledgeType : byte
+{
+    Gap = 0,
+    Accept = 1,
+    Release = 2,
+    Reject = 3,
+    Renew = 4
+}

--- a/src/Dekaf/ShareConsumer/AcknowledgeType.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgeType.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Dekaf.ShareConsumer;
 
 /// <summary>
@@ -6,6 +8,11 @@ namespace Dekaf.ShareConsumer;
 /// </summary>
 public enum AcknowledgeType : byte
 {
+    /// <summary>
+    /// Internal wire protocol value for gap records. Do not use directly —
+    /// gap records are never delivered to consumers.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     Gap = 0,
     Accept = 1,
     Release = 2,

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -32,16 +32,17 @@ internal sealed class AcknowledgementTracker
 
     /// <summary>
     /// Sets an explicit acknowledgement type for a specific record.
+    /// Throws if the record was not delivered by the current poll.
     /// </summary>
     internal void Acknowledge(TopicPartition tp, long offset, AcknowledgeType type)
     {
-        if (_pendingAcks.TryGetValue(tp, out var offsets))
+        if (!_pendingAcks.TryGetValue(tp, out var offsets) || !offsets.ContainsKey(offset))
         {
-            if (offsets.ContainsKey(offset))
-            {
-                offsets[offset] = type;
-            }
+            throw new InvalidOperationException(
+                $"Cannot acknowledge offset {offset} for {tp} — record was not delivered by the current poll.");
         }
+
+        offsets[offset] = type;
     }
 
     /// <summary>
@@ -71,6 +72,32 @@ internal sealed class AcknowledgementTracker
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Re-queues previously flushed acknowledgement data back into the tracker.
+    /// Used when CommitAsync partially fails — the failed partitions' acks are
+    /// restored so the next commit can retry them.
+    /// </summary>
+    internal void RequeueAcks(Dictionary<TopicPartition, List<AcknowledgementBatchData>> acks)
+    {
+        foreach (var (tp, batches) in acks)
+        {
+            if (!_pendingAcks.TryGetValue(tp, out var offsets))
+            {
+                offsets = new SortedList<long, AcknowledgeType>();
+                _pendingAcks[tp] = offsets;
+            }
+
+            foreach (var batch in batches)
+            {
+                for (int i = 0; i < batch.AcknowledgeTypes.Length; i++)
+                {
+                    var offset = batch.FirstOffset + i;
+                    offsets.TryAdd(offset, (AcknowledgeType)batch.AcknowledgeTypes[i]);
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -11,22 +11,24 @@ namespace Dekaf.ShareConsumer;
 /// </summary>
 internal sealed class AcknowledgementTracker
 {
-    private Dictionary<TopicPartition, SortedList<long, AcknowledgeType>> _pendingAcks = new();
+    private Dictionary<TopicPartition, List<(long Offset, AcknowledgeType Type)>> _pendingAcks = new();
 
     /// <summary>
     /// Tracks records delivered by a poll. All records default to Accept.
+    /// KIP-932 guarantees records within a partition arrive in offset order,
+    /// so appending is O(1) amortized.
     /// </summary>
     internal void TrackDeliveredRecords(TopicPartition tp, long firstOffset, long lastOffset)
     {
         if (!_pendingAcks.TryGetValue(tp, out var offsets))
         {
-            offsets = new SortedList<long, AcknowledgeType>();
+            offsets = new List<(long Offset, AcknowledgeType Type)>();
             _pendingAcks[tp] = offsets;
         }
 
         for (long offset = firstOffset; offset <= lastOffset; offset++)
         {
-            offsets[offset] = AcknowledgeType.Accept;
+            offsets.Add((offset, AcknowledgeType.Accept));
         }
     }
 
@@ -36,13 +38,21 @@ internal sealed class AcknowledgementTracker
     /// </summary>
     internal void Acknowledge(TopicPartition tp, long offset, AcknowledgeType type)
     {
-        if (!_pendingAcks.TryGetValue(tp, out var offsets) || !offsets.ContainsKey(offset))
+        if (!_pendingAcks.TryGetValue(tp, out var offsets))
         {
             throw new InvalidOperationException(
                 $"Cannot acknowledge offset {offset} for {tp} — record was not delivered by the current poll.");
         }
 
-        offsets[offset] = type;
+        // Linear scan — acceptable since Acknowledge is user-driven, not hot path.
+        var idx = offsets.FindLastIndex(e => e.Offset == offset);
+        if (idx < 0)
+        {
+            throw new InvalidOperationException(
+                $"Cannot acknowledge offset {offset} for {tp} — record was not delivered by the current poll.");
+        }
+
+        offsets[idx] = (offset, type);
     }
 
     /// <summary>
@@ -60,7 +70,7 @@ internal sealed class AcknowledgementTracker
         // Swap to a fresh dictionary so any new acks after this point go into a fresh
         // bucket — avoids the per-partition TryRemove race of the snapshot-and-remove pattern.
         var old = _pendingAcks;
-        _pendingAcks = new Dictionary<TopicPartition, SortedList<long, AcknowledgeType>>();
+        _pendingAcks = new Dictionary<TopicPartition, List<(long Offset, AcknowledgeType Type)>>();
 
         Dictionary<TopicPartition, List<AcknowledgementBatchData>> result = new();
 
@@ -86,7 +96,7 @@ internal sealed class AcknowledgementTracker
         {
             if (!_pendingAcks.TryGetValue(tp, out var offsets))
             {
-                offsets = new SortedList<long, AcknowledgeType>();
+                offsets = new List<(long Offset, AcknowledgeType Type)>();
                 _pendingAcks[tp] = offsets;
             }
 
@@ -95,20 +105,24 @@ internal sealed class AcknowledgementTracker
                 for (int i = 0; i < batch.AcknowledgeTypes.Length; i++)
                 {
                     var offset = batch.FirstOffset + i;
-                    // TryAdd intentionally: preserve any explicit acknowledgement the user set
-                    // after the flush. A newer Acknowledge() call takes priority over re-queued
-                    // stale acks from a failed CommitAsync.
-                    offsets.TryAdd(offset, (AcknowledgeType)batch.AcknowledgeTypes[i]);
+                    // TryAdd: preserve any explicit acknowledgement the user set after the flush.
+                    // A newer Acknowledge() call takes priority over re-queued stale acks
+                    // from a failed CommitAsync.
+                    if (offsets.FindLastIndex(e => e.Offset == offset) < 0)
+                    {
+                        offsets.Add((offset, (AcknowledgeType)batch.AcknowledgeTypes[i]));
+                    }
                 }
             }
         }
     }
 
     /// <summary>
-    /// Builds wire-format acknowledgement batches from a sorted offset map.
+    /// Builds wire-format acknowledgement batches from an offset list.
     /// Groups consecutive offsets into batches with per-record AcknowledgeTypes arrays.
+    /// Input is assumed to be in offset order (guaranteed by KIP-932 delivery order).
     /// </summary>
-    private static List<AcknowledgementBatchData> BuildBatches(SortedList<long, AcknowledgeType> offsets)
+    private static List<AcknowledgementBatchData> BuildBatches(List<(long Offset, AcknowledgeType Type)> offsets)
     {
         List<AcknowledgementBatchData> batches = [];
 
@@ -117,14 +131,14 @@ internal sealed class AcknowledgementTracker
             return batches;
         }
 
-        long batchStart = offsets.Keys[0];
+        long batchStart = offsets[0].Offset;
         long previousOffset = batchStart;
-        List<byte> currentTypes = [(byte)offsets.Values[0]];
+        List<byte> currentTypes = [(byte)offsets[0].Type];
 
         for (int i = 1; i < offsets.Count; i++)
         {
-            long offset = offsets.Keys[i];
-            AcknowledgeType type = offsets.Values[i];
+            long offset = offsets[i].Offset;
+            AcknowledgeType type = offsets[i].Type;
 
             if (offset == previousOffset + 1)
             {

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -56,7 +56,7 @@ internal sealed class AcknowledgementTracker
     /// <returns>Per-TopicPartition acknowledgement batches for the wire format.</returns>
     internal Dictionary<TopicPartition, List<AcknowledgementBatchData>> Flush()
     {
-        // Atomic swap — any concurrent reads see the new empty dictionary immediately
+        // Swap to a fresh dictionary so new acks after this point don't interfere
         var old = _pendingAcks;
         _pendingAcks = new Dictionary<TopicPartition, SortedList<long, AcknowledgeType>>();
 

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -57,7 +57,8 @@ internal sealed class AcknowledgementTracker
     /// <returns>Per-TopicPartition acknowledgement batches for the wire format.</returns>
     internal Dictionary<TopicPartition, List<AcknowledgementBatchData>> Flush()
     {
-        // Swap to a fresh dictionary so new acks after this point don't interfere
+        // Swap to a fresh dictionary so any new acks after this point go into a fresh
+        // bucket — avoids the per-partition TryRemove race of the snapshot-and-remove pattern.
         var old = _pendingAcks;
         _pendingAcks = new Dictionary<TopicPartition, SortedList<long, AcknowledgeType>>();
 
@@ -94,6 +95,9 @@ internal sealed class AcknowledgementTracker
                 for (int i = 0; i < batch.AcknowledgeTypes.Length; i++)
                 {
                     var offset = batch.FirstOffset + i;
+                    // TryAdd intentionally: preserve any explicit acknowledgement the user set
+                    // after the flush. A newer Acknowledge() call takes priority over re-queued
+                    // stale acks from a failed CommitAsync.
                     offsets.TryAdd(offset, (AcknowledgeType)batch.AcknowledgeTypes[i]);
                 }
             }

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -1,0 +1,114 @@
+using System.Collections.Concurrent;
+
+namespace Dekaf.ShareConsumer;
+
+/// <summary>
+/// Tracks per-record acknowledgement state between polls and builds wire-format
+/// acknowledgement batches for ShareFetch (inline acks) or ShareAcknowledge requests.
+/// </summary>
+internal sealed class AcknowledgementTracker
+{
+    private readonly ConcurrentDictionary<TopicPartition, SortedList<long, AcknowledgeType>> _pendingAcks = new();
+
+    /// <summary>
+    /// Tracks records delivered by a poll. All records default to Accept.
+    /// </summary>
+    internal void TrackDeliveredRecords(TopicPartition tp, long firstOffset, long lastOffset)
+    {
+        SortedList<long, AcknowledgeType> offsets = _pendingAcks.GetOrAdd(tp, static _ => new SortedList<long, AcknowledgeType>());
+
+        for (long offset = firstOffset; offset <= lastOffset; offset++)
+        {
+            offsets[offset] = AcknowledgeType.Accept;
+        }
+    }
+
+    /// <summary>
+    /// Sets an explicit acknowledgement type for a specific record.
+    /// </summary>
+    internal void Acknowledge(TopicPartition tp, long offset, AcknowledgeType type)
+    {
+        if (_pendingAcks.TryGetValue(tp, out SortedList<long, AcknowledgeType>? offsets))
+        {
+            if (offsets.ContainsKey(offset))
+            {
+                offsets[offset] = type;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether there are any pending acknowledgements.
+    /// </summary>
+    internal bool HasPending => !_pendingAcks.IsEmpty;
+
+    /// <summary>
+    /// Flushes all pending acknowledgements, building wire-format batches.
+    /// Clears tracked state after flush.
+    /// </summary>
+    /// <returns>Per-TopicPartition acknowledgement batches for the wire format.</returns>
+    internal Dictionary<TopicPartition, List<AcknowledgementBatchData>> Flush()
+    {
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>> result = new();
+
+        // Snapshot and clear atomically per partition
+        foreach (TopicPartition tp in _pendingAcks.Keys.ToArray())
+        {
+            if (_pendingAcks.TryRemove(tp, out SortedList<long, AcknowledgeType>? offsets) && offsets.Count > 0)
+            {
+                result[tp] = BuildBatches(offsets);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Builds wire-format acknowledgement batches from a sorted offset map.
+    /// Groups consecutive offsets into batches with per-record AcknowledgeTypes arrays.
+    /// </summary>
+    private static List<AcknowledgementBatchData> BuildBatches(SortedList<long, AcknowledgeType> offsets)
+    {
+        List<AcknowledgementBatchData> batches = [];
+
+        if (offsets.Count == 0)
+        {
+            return batches;
+        }
+
+        long batchStart = offsets.Keys[0];
+        long previousOffset = batchStart;
+        List<byte> currentTypes = [(byte)offsets.Values[0]];
+
+        for (int i = 1; i < offsets.Count; i++)
+        {
+            long offset = offsets.Keys[i];
+            AcknowledgeType type = offsets.Values[i];
+
+            if (offset == previousOffset + 1)
+            {
+                // Consecutive — extend current batch
+                currentTypes.Add((byte)type);
+            }
+            else
+            {
+                // Gap — close current batch and start new one
+                batches.Add(new AcknowledgementBatchData(batchStart, previousOffset, currentTypes.ToArray()));
+                batchStart = offset;
+                currentTypes = [(byte)type];
+            }
+
+            previousOffset = offset;
+        }
+
+        // Close final batch
+        batches.Add(new AcknowledgementBatchData(batchStart, previousOffset, currentTypes.ToArray()));
+
+        return batches;
+    }
+}
+
+/// <summary>
+/// Wire-format acknowledgement batch data ready for serialization.
+/// </summary>
+internal readonly record struct AcknowledgementBatchData(long FirstOffset, long LastOffset, byte[] AcknowledgeTypes);

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -1,21 +1,28 @@
-using System.Collections.Concurrent;
-
 namespace Dekaf.ShareConsumer;
 
 /// <summary>
 /// Tracks per-record acknowledgement state between polls and builds wire-format
 /// acknowledgement batches for ShareFetch (inline acks) or ShareAcknowledge requests.
+/// <para>
+/// Thread-safety: This class is designed for single-threaded access from the consumer's
+/// poll loop. <see cref="TrackDeliveredRecords"/>, <see cref="Acknowledge"/>, and
+/// <see cref="Flush"/> must all be called from the same thread (the PollAsync caller).
+/// </para>
 /// </summary>
 internal sealed class AcknowledgementTracker
 {
-    private readonly ConcurrentDictionary<TopicPartition, SortedList<long, AcknowledgeType>> _pendingAcks = new();
+    private Dictionary<TopicPartition, SortedList<long, AcknowledgeType>> _pendingAcks = new();
 
     /// <summary>
     /// Tracks records delivered by a poll. All records default to Accept.
     /// </summary>
     internal void TrackDeliveredRecords(TopicPartition tp, long firstOffset, long lastOffset)
     {
-        SortedList<long, AcknowledgeType> offsets = _pendingAcks.GetOrAdd(tp, static _ => new SortedList<long, AcknowledgeType>());
+        if (!_pendingAcks.TryGetValue(tp, out var offsets))
+        {
+            offsets = new SortedList<long, AcknowledgeType>();
+            _pendingAcks[tp] = offsets;
+        }
 
         for (long offset = firstOffset; offset <= lastOffset; offset++)
         {
@@ -28,7 +35,7 @@ internal sealed class AcknowledgementTracker
     /// </summary>
     internal void Acknowledge(TopicPartition tp, long offset, AcknowledgeType type)
     {
-        if (_pendingAcks.TryGetValue(tp, out SortedList<long, AcknowledgeType>? offsets))
+        if (_pendingAcks.TryGetValue(tp, out var offsets))
         {
             if (offsets.ContainsKey(offset))
             {
@@ -40,21 +47,24 @@ internal sealed class AcknowledgementTracker
     /// <summary>
     /// Whether there are any pending acknowledgements.
     /// </summary>
-    internal bool HasPending => !_pendingAcks.IsEmpty;
+    internal bool HasPending => _pendingAcks.Count > 0;
 
     /// <summary>
     /// Flushes all pending acknowledgements, building wire-format batches.
-    /// Clears tracked state after flush.
+    /// Atomically swaps the pending dictionary so no acks can be lost.
     /// </summary>
     /// <returns>Per-TopicPartition acknowledgement batches for the wire format.</returns>
     internal Dictionary<TopicPartition, List<AcknowledgementBatchData>> Flush()
     {
+        // Atomic swap — any concurrent reads see the new empty dictionary immediately
+        var old = _pendingAcks;
+        _pendingAcks = new Dictionary<TopicPartition, SortedList<long, AcknowledgeType>>();
+
         Dictionary<TopicPartition, List<AcknowledgementBatchData>> result = new();
 
-        // Snapshot and clear atomically per partition
-        foreach (TopicPartition tp in _pendingAcks.Keys.ToArray())
+        foreach (var (tp, offsets) in old)
         {
-            if (_pendingAcks.TryRemove(tp, out SortedList<long, AcknowledgeType>? offsets) && offsets.Count > 0)
+            if (offsets.Count > 0)
             {
                 result[tp] = BuildBatches(offsets);
             }

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -11,24 +11,22 @@ namespace Dekaf.ShareConsumer;
 /// </summary>
 internal sealed class AcknowledgementTracker
 {
-    private Dictionary<TopicPartition, List<(long Offset, AcknowledgeType Type)>> _pendingAcks = new();
+    private Dictionary<TopicPartition, Dictionary<long, AcknowledgeType>> _pendingAcks = new();
 
     /// <summary>
     /// Tracks records delivered by a poll. All records default to Accept.
-    /// KIP-932 guarantees records within a partition arrive in offset order,
-    /// so appending is O(1) amortized.
     /// </summary>
     internal void TrackDeliveredRecords(TopicPartition tp, long firstOffset, long lastOffset)
     {
         if (!_pendingAcks.TryGetValue(tp, out var offsets))
         {
-            offsets = new List<(long Offset, AcknowledgeType Type)>();
+            offsets = new Dictionary<long, AcknowledgeType>();
             _pendingAcks[tp] = offsets;
         }
 
         for (long offset = firstOffset; offset <= lastOffset; offset++)
         {
-            offsets.Add((offset, AcknowledgeType.Accept));
+            offsets[offset] = AcknowledgeType.Accept;
         }
     }
 
@@ -38,21 +36,13 @@ internal sealed class AcknowledgementTracker
     /// </summary>
     internal void Acknowledge(TopicPartition tp, long offset, AcknowledgeType type)
     {
-        if (!_pendingAcks.TryGetValue(tp, out var offsets))
+        if (!_pendingAcks.TryGetValue(tp, out var offsets) || !offsets.ContainsKey(offset))
         {
             throw new InvalidOperationException(
                 $"Cannot acknowledge offset {offset} for {tp} — record was not delivered by the current poll.");
         }
 
-        // Linear scan — acceptable since Acknowledge is user-driven, not hot path.
-        var idx = offsets.FindLastIndex(e => e.Offset == offset);
-        if (idx < 0)
-        {
-            throw new InvalidOperationException(
-                $"Cannot acknowledge offset {offset} for {tp} — record was not delivered by the current poll.");
-        }
-
-        offsets[idx] = (offset, type);
+        offsets[offset] = type;
     }
 
     /// <summary>
@@ -70,7 +60,7 @@ internal sealed class AcknowledgementTracker
         // Swap to a fresh dictionary so any new acks after this point go into a fresh
         // bucket — avoids the per-partition TryRemove race of the snapshot-and-remove pattern.
         var old = _pendingAcks;
-        _pendingAcks = new Dictionary<TopicPartition, List<(long Offset, AcknowledgeType Type)>>();
+        _pendingAcks = new Dictionary<TopicPartition, Dictionary<long, AcknowledgeType>>();
 
         Dictionary<TopicPartition, List<AcknowledgementBatchData>> result = new();
 
@@ -96,7 +86,7 @@ internal sealed class AcknowledgementTracker
         {
             if (!_pendingAcks.TryGetValue(tp, out var offsets))
             {
-                offsets = new List<(long Offset, AcknowledgeType Type)>();
+                offsets = new Dictionary<long, AcknowledgeType>();
                 _pendingAcks[tp] = offsets;
             }
 
@@ -105,24 +95,21 @@ internal sealed class AcknowledgementTracker
                 for (int i = 0; i < batch.AcknowledgeTypes.Length; i++)
                 {
                     var offset = batch.FirstOffset + i;
-                    // TryAdd: preserve any explicit acknowledgement the user set after the flush.
-                    // A newer Acknowledge() call takes priority over re-queued stale acks
-                    // from a failed CommitAsync.
-                    if (offsets.FindLastIndex(e => e.Offset == offset) < 0)
-                    {
-                        offsets.Add((offset, (AcknowledgeType)batch.AcknowledgeTypes[i]));
-                    }
+                    // TryAdd intentionally: preserve any explicit acknowledgement the user set
+                    // after the flush. A newer Acknowledge() call takes priority over re-queued
+                    // stale acks from a failed CommitAsync.
+                    offsets.TryAdd(offset, (AcknowledgeType)batch.AcknowledgeTypes[i]);
                 }
             }
         }
     }
 
     /// <summary>
-    /// Builds wire-format acknowledgement batches from an offset list.
-    /// Groups consecutive offsets into batches with per-record AcknowledgeTypes arrays.
-    /// Input is assumed to be in offset order (guaranteed by KIP-932 delivery order).
+    /// Builds wire-format acknowledgement batches from an offset dictionary.
+    /// Sorts keys once then groups consecutive offsets into batches with per-record
+    /// AcknowledgeTypes arrays.
     /// </summary>
-    private static List<AcknowledgementBatchData> BuildBatches(List<(long Offset, AcknowledgeType Type)> offsets)
+    private static List<AcknowledgementBatchData> BuildBatches(Dictionary<long, AcknowledgeType> offsets)
     {
         List<AcknowledgementBatchData> batches = [];
 
@@ -131,14 +118,18 @@ internal sealed class AcknowledgementTracker
             return batches;
         }
 
-        long batchStart = offsets[0].Offset;
-        long previousOffset = batchStart;
-        List<byte> currentTypes = [(byte)offsets[0].Type];
+        // Sort keys once at flush time — O(n log n) here instead of O(n) insert cost
+        // per TrackDeliveredRecords/Acknowledge call.
+        var sortedOffsets = offsets.Keys.Order().ToArray();
 
-        for (int i = 1; i < offsets.Count; i++)
+        long batchStart = sortedOffsets[0];
+        long previousOffset = batchStart;
+        List<byte> currentTypes = [(byte)offsets[batchStart]];
+
+        for (int i = 1; i < sortedOffsets.Length; i++)
         {
-            long offset = offsets[i].Offset;
-            AcknowledgeType type = offsets[i].Type;
+            long offset = sortedOffsets[i];
+            AcknowledgeType type = offsets[offset];
 
             if (offset == previousOffset + 1)
             {

--- a/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
@@ -1,0 +1,62 @@
+namespace Dekaf.ShareConsumer;
+
+/// <summary>
+/// Interface for Kafka share consumer (KIP-932).
+/// Share consumers provide queue-semantics consumption with record-level acknowledgement.
+/// Records are acquired with locks and must be acknowledged (accepted, released, or rejected).
+/// </summary>
+/// <typeparam name="TKey">Key type.</typeparam>
+/// <typeparam name="TValue">Value type.</typeparam>
+public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyncDisposable
+{
+    /// <summary>
+    /// Gets the current topic subscription.
+    /// </summary>
+    IReadOnlySet<string> Subscription { get; }
+
+    /// <summary>
+    /// Gets the current partition assignment from the share group coordinator.
+    /// </summary>
+    IReadOnlySet<TopicPartition> Assignment { get; }
+
+    /// <summary>
+    /// Gets the member ID (client-generated UUID) if part of a share group.
+    /// </summary>
+    string? MemberId { get; }
+
+    /// <summary>
+    /// Subscribes to topics. Share groups do not support manual partition assignment.
+    /// </summary>
+    IKafkaShareConsumer<TKey, TValue> Subscribe(params string[] topics);
+
+    /// <summary>
+    /// Unsubscribes from all topics and leaves the share group.
+    /// </summary>
+    IKafkaShareConsumer<TKey, TValue> Unsubscribe();
+
+    /// <summary>
+    /// Polls for records from the share group. Returns an async enumerable of acquired records.
+    /// Unacknowledged records from the previous poll are implicitly accepted.
+    /// </summary>
+    IAsyncEnumerable<ShareConsumeResult<TKey, TValue>> PollAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the acknowledgement type for a specific record.
+    /// If not called, records default to <see cref="AcknowledgeType.Accept"/>.
+    /// </summary>
+    /// <param name="record">The record to acknowledge.</param>
+    /// <param name="type">The acknowledgement type. Defaults to Accept.</param>
+    void Acknowledge(ShareConsumeResult<TKey, TValue> record, AcknowledgeType type = AcknowledgeType.Accept);
+
+    /// <summary>
+    /// Commits all pending acknowledgements to the broker via a standalone ShareAcknowledge request.
+    /// All unacknowledged records are implicitly accepted.
+    /// </summary>
+    ValueTask CommitAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Closes the share consumer: flushes pending acknowledgements, closes share sessions,
+    /// leaves the share group, and releases all resources.
+    /// </summary>
+    ValueTask CloseAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
@@ -4,6 +4,11 @@ namespace Dekaf.ShareConsumer;
 /// Interface for Kafka share consumer (KIP-932).
 /// Share consumers provide queue-semantics consumption with record-level acknowledgement.
 /// Records are acquired with locks and must be acknowledged (accepted, released, or rejected).
+/// <para>
+/// <b>Thread safety:</b> This interface is not thread-safe. All methods — <see cref="Subscribe"/>,
+/// <see cref="Unsubscribe"/>, <see cref="PollAsync"/>, <see cref="Acknowledge"/>, and
+/// <see cref="CommitAsync"/> — must be called from the same thread or with external synchronization.
+/// </para>
 /// </summary>
 /// <typeparam name="TKey">Key type.</typeparam>
 /// <typeparam name="TValue">Value type.</typeparam>

--- a/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
@@ -31,6 +31,8 @@ public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, 
 
     /// <summary>
     /// Unsubscribes from all topics and leaves the share group.
+    /// Any pending unacknowledged records are released back to the group (best-effort)
+    /// so other members can claim them without waiting for the acquisition lock to expire.
     /// </summary>
     IKafkaShareConsumer<TKey, TValue> Unsubscribe();
 
@@ -48,6 +50,11 @@ public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, 
     /// <summary>
     /// Sets the acknowledgement type for a specific record.
     /// If not called, records default to <see cref="AcknowledgeType.Accept"/>.
+    /// <para>
+    /// <b>Warning:</b> You must call this before the next <see cref="PollAsync"/> or
+    /// <see cref="CommitAsync"/>. Any records not explicitly acknowledged are implicitly
+    /// accepted — there is no way to release or reject them after that point.
+    /// </para>
     /// </summary>
     /// <param name="record">The record to acknowledge.</param>
     /// <param name="type">The acknowledgement type. Defaults to Accept.</param>

--- a/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
@@ -36,7 +36,12 @@ public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, 
 
     /// <summary>
     /// Polls for records from the share group. Returns an async enumerable of acquired records.
-    /// Unacknowledged records from the previous poll are implicitly accepted.
+    /// <para>
+    /// <b>Important:</b> Any records from the previous poll that were not explicitly acknowledged
+    /// via <see cref="Acknowledge"/> are implicitly accepted (per the KIP-932 specification).
+    /// If you intend to release or reject records, you must call <see cref="Acknowledge"/> before
+    /// the next <see cref="PollAsync"/> or <see cref="CommitAsync"/> call.
+    /// </para>
     /// </summary>
     IAsyncEnumerable<ShareConsumeResult<TKey, TValue>> PollAsync(CancellationToken cancellationToken = default);
 

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -264,21 +264,16 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                     var parsed = ParsePartitionRecords(
                         topicInfo, partition, _options.MaxPollRecords - recordCount);
 
-                    // Track delivered records per acquired range (amortized per-batch)
-                    // rather than per individual record to minimize dictionary lookups.
-                    if (parsed.Count > 0)
-                    {
-                        var tp = new TopicPartition(topicInfo.Name, partition.PartitionIndex);
-                        foreach (var acquired in partition.AcquiredRecords)
-                        {
-                            _ackTracker.TrackDeliveredRecords(tp, acquired.FirstOffset, acquired.LastOffset);
-                        }
-                    }
+                    var tp = new TopicPartition(topicInfo.Name, partition.PartitionIndex);
 
                     foreach (var result in parsed)
                     {
                         if (recordCount >= _options.MaxPollRecords)
                             break;
+
+                        // Track only records actually yielded to the consumer so we don't
+                        // silently acknowledge offsets truncated by MaxPollRecords.
+                        _ackTracker.TrackDeliveredRecords(tp, result.Offset, result.Offset);
 
                         recordCount++;
                         yield return result;

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -437,6 +437,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
                 await CloseAsync(cts.Token).ConfigureAwait(false);
             }
+            catch (OperationCanceledException)
+            {
+                LogDisposeCloseTimedOut();
+            }
             catch
             {
                 // Best-effort close during dispose
@@ -903,6 +907,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to close share sessions")]
     private partial void LogCloseSessionsFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Graceful close timed out after 30s during dispose — broker may be unreachable")]
+    private partial void LogDisposeCloseTimedOut();
 
     #endregion
 }

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -260,6 +260,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                         response.ErrorCode == ErrorCode.InvalidShareSessionEpoch)
                     {
                         _sessionManager.ResetSession(brokerId);
+                        // Note: _ackTracker may still hold pending acks from the now-invalid session.
+                        // On next CommitAsync those acks will be sent with epoch 0 (new session).
+                        // The broker will reject them if the old record locks have expired, which is
+                        // safe — CommitAsync will re-queue the failed acks for retry.
                     }
                     continue;
                 }
@@ -576,6 +580,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             ShareFetchRequest.LowestSupportedVersion,
             ShareFetchRequest.HighestSupportedVersion);
 
+        // Send close requests to all brokers in parallel — these are fire-and-forget
+        // with MaxWaitMs=0, so there's no reason to wait for each sequentially.
+        var closeTasks = new List<Task>(partitionsByBroker.Count);
+
         foreach (var (brokerId, partitions) in partitionsByBroker)
         {
             var topics = BuildShareFetchTopics(partitions, pendingAcks: null, shareFetchVersion);
@@ -592,17 +600,25 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 Topics = topics
             };
 
-            try
-            {
-                var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
-                    .ConfigureAwait(false);
-                await connection.SendAsync<ShareFetchRequest, ShareFetchResponse>(
-                    request, shareFetchVersion, cancellationToken).ConfigureAwait(false);
-            }
-            catch
-            {
-                // Best-effort session close
-            }
+            closeTasks.Add(CloseSessionForBrokerAsync(brokerId, request, shareFetchVersion, cancellationToken));
+        }
+
+        await Task.WhenAll(closeTasks).ConfigureAwait(false);
+    }
+
+    private async Task CloseSessionForBrokerAsync(
+        int brokerId, ShareFetchRequest request, short version, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
+                .ConfigureAwait(false);
+            await connection.SendAsync<ShareFetchRequest, ShareFetchResponse>(
+                request, version, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort session close
         }
     }
 

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -312,9 +312,38 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             ShareAcknowledgeRequest.LowestSupportedVersion,
             ShareAcknowledgeRequest.HighestSupportedVersion);
 
-        var ackTasks = acksByBroker.Select(kvp => SendAcknowledgeAsync(
-            kvp.Key, kvp.Value, shareAckVersion, cancellationToken));
-        await Task.WhenAll(ackTasks).ConfigureAwait(false);
+        // Send to all brokers in parallel, collecting per-broker results
+        var results = await Task.WhenAll(acksByBroker.Select(async kvp =>
+        {
+            try
+            {
+                await SendAcknowledgeAsync(kvp.Key, kvp.Value, shareAckVersion, cancellationToken)
+                    .ConfigureAwait(false);
+                return (Acks: kvp.Value, Error: (Exception?)null);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                return (Acks: kvp.Value, Error: ex);
+            }
+        })).ConfigureAwait(false);
+
+        // Re-queue failed partitions so they can be retried on the next commit
+        Exception? firstError = null;
+        foreach (var (acks, error) in results)
+        {
+            if (error is null)
+                continue;
+
+            firstError ??= error;
+            _ackTracker.RequeueAcks(acks);
+        }
+
+        if (firstError is not null)
+        {
+            throw new KafkaException(
+                $"CommitAsync partially failed — failed partitions have been re-queued for retry",
+                firstError);
+        }
     }
 
     public async ValueTask CloseAsync(CancellationToken cancellationToken = default)

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -154,9 +154,15 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
     public IKafkaShareConsumer<TKey, TValue> Unsubscribe()
     {
+        // Release any pending acks back to the group so other members can claim them,
+        // rather than waiting for the broker's acquisition lock timeout to expire.
+        if (_ackTracker.HasPending)
+        {
+            ReleasePendingAcks();
+        }
+
         _subscriptionSnapshot = new HashSet<string>();
         _sessionManager.ResetAll();
-        _ackTracker.Flush(); // Discard pending acks
         return this;
     }
 
@@ -166,120 +172,156 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         ThrowIfDisposed();
         ThrowIfNotInitialized();
 
-        if (_subscriptionSnapshot.Count == 0)
-            yield break;
-
-        // Ensure we're part of the share group
-        await _coordinator.EnsureActiveGroupAsync(_subscriptionSnapshot, cancellationToken).ConfigureAwait(false);
-        _assignmentSnapshot = _coordinator.Assignment;
-
-        var assignment = _assignmentSnapshot;
-        if (assignment.Count == 0)
-            yield break;
-
-        // Flush pending acks from previous poll as inline acknowledgements with the fetch
-        var pendingAcks = _ackTracker.HasPending ? _ackTracker.Flush() : null;
-
-        // Group assigned partitions by leader broker
-        var partitionsByBroker = GroupPartitionsByLeader(assignment);
-
-        var recordCount = 0;
-
-        foreach (var (brokerId, partitions) in partitionsByBroker)
+        while (!cancellationToken.IsCancellationRequested)
         {
-            if (recordCount >= _options.MaxPollRecords)
-                break;
+            if (_subscriptionSnapshot.Count == 0)
+                yield break;
 
-            var shareFetchVersion = _metadataManager.GetNegotiatedApiVersion(
-                ApiKey.ShareFetch,
-                ShareFetchRequest.LowestSupportedVersion,
-                ShareFetchRequest.HighestSupportedVersion);
+            // Ensure we're part of the share group
+            await _coordinator.EnsureActiveGroupAsync(_subscriptionSnapshot, cancellationToken)
+                .ConfigureAwait(false);
+            _assignmentSnapshot = _coordinator.Assignment;
 
-            var topics = BuildShareFetchTopics(partitions, pendingAcks, shareFetchVersion);
-            var sessionEpoch = _sessionManager.GetSessionEpoch(brokerId);
-
-            var request = new ShareFetchRequest
-            {
-                GroupId = _options.GroupId,
-                MemberId = _coordinator.MemberId!,
-                ShareSessionEpoch = sessionEpoch,
-                MaxWaitMs = _options.FetchMaxWaitMs,
-                MinBytes = _options.FetchMinBytes,
-                MaxBytes = _options.FetchMaxBytes,
-                Topics = topics
-            };
-
-            ShareFetchResponse response;
-            try
-            {
-                var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
-                    .ConfigureAwait(false);
-                response = (ShareFetchResponse)await connection
-                    .SendAsync<ShareFetchRequest, ShareFetchResponse>(
-                        request, shareFetchVersion, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                LogFetchFailed(brokerId, ex);
-                _sessionManager.ResetSession(brokerId);
+            var assignment = _assignmentSnapshot;
+            if (assignment.Count == 0)
                 continue;
-            }
 
-            // Handle top-level errors
-            if (response.ErrorCode != ErrorCode.None)
+            // Flush pending acks from previous poll as inline acknowledgements with the fetch
+            var pendingAcks = _ackTracker.HasPending ? _ackTracker.Flush() : null;
+
+            // Group assigned partitions by leader broker
+            var partitionsByBroker = GroupPartitionsByLeader(assignment);
+
+            var recordCount = 0;
+
+            foreach (var (brokerId, partitions) in partitionsByBroker)
             {
-                LogFetchTopLevelError(response.ErrorCode, response.ErrorMessage);
-                if (response.ErrorCode == ErrorCode.ShareSessionNotFound ||
-                    response.ErrorCode == ErrorCode.InvalidShareSessionEpoch)
+                if (recordCount >= _options.MaxPollRecords)
+                    break;
+
+                var shareFetchVersion = _metadataManager.GetNegotiatedApiVersion(
+                    ApiKey.ShareFetch,
+                    ShareFetchRequest.LowestSupportedVersion,
+                    ShareFetchRequest.HighestSupportedVersion);
+
+                var topics = BuildShareFetchTopics(partitions, pendingAcks, shareFetchVersion);
+                var sessionEpoch = _sessionManager.GetSessionEpoch(brokerId);
+
+                var maxRecords = shareFetchVersion >= 1 ? _options.MaxPollRecords : 0;
+
+                var request = new ShareFetchRequest
                 {
+                    GroupId = _options.GroupId,
+                    MemberId = _coordinator.MemberId!,
+                    ShareSessionEpoch = sessionEpoch,
+                    MaxWaitMs = _options.FetchMaxWaitMs,
+                    MinBytes = _options.FetchMinBytes,
+                    MaxBytes = _options.FetchMaxBytes,
+                    MaxRecords = maxRecords,
+                    BatchSize = maxRecords,
+                    Topics = topics
+                };
+
+                ShareFetchResponse response;
+                try
+                {
+                    var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
+                        .ConfigureAwait(false);
+                    response = (ShareFetchResponse)await connection
+                        .SendAsync<ShareFetchRequest, ShareFetchResponse>(
+                            request, shareFetchVersion, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    LogFetchFailed(brokerId, ex);
                     _sessionManager.ResetSession(brokerId);
-                }
-                continue;
-            }
-
-            // Successful fetch — advance session epoch
-            _sessionManager.IncrementEpoch(brokerId);
-
-            // Process partition responses
-            foreach (var topicResponse in response.Responses)
-            {
-                var topicInfo = _metadataManager.Metadata.GetTopic(topicResponse.TopicId);
-                if (topicInfo is null)
                     continue;
+                }
 
-                foreach (var partition in topicResponse.Partitions)
+                // Handle top-level errors
+                if (response.ErrorCode != ErrorCode.None)
                 {
-                    if (partition.ErrorCode != ErrorCode.None)
+                    LogFetchTopLevelError(response.ErrorCode, response.ErrorMessage);
+                    if (response.ErrorCode == ErrorCode.ShareSessionNotFound ||
+                        response.ErrorCode == ErrorCode.InvalidShareSessionEpoch)
                     {
-                        LogPartitionFetchError(topicInfo.Name, partition.PartitionIndex, partition.ErrorCode);
-                        continue;
+                        _sessionManager.ResetSession(brokerId);
                     }
+                    continue;
+                }
 
-                    if (partition.RecordBytes.IsEmpty || partition.AcquiredRecords.Count == 0)
+                // Check whether any partition in this response has acquired records.
+                // We must advance the session epoch BEFORE yielding so that even if
+                // the caller breaks from the async enumerable (disposing the iterator),
+                // the epoch is already correct for a subsequent ShareAcknowledge/CommitAsync.
+                // Without this, the session epoch stays at 0 while the broker expects 1,
+                // causing InvalidShareSessionEpoch on the next request.
+                var hasAcquiredRecords = false;
+                for (var ti = 0; ti < response.Responses.Count && !hasAcquiredRecords; ti++)
+                {
+                    var respPartitions = response.Responses[ti].Partitions;
+                    for (var pi = 0; pi < respPartitions.Count; pi++)
+                    {
+                        var p = respPartitions[pi];
+                        if (p.ErrorCode == ErrorCode.None && !p.RecordBytes.IsEmpty &&
+                            p.AcquiredRecords.Count > 0)
+                        {
+                            hasAcquiredRecords = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (hasAcquiredRecords)
+                {
+                    _sessionManager.IncrementEpoch(brokerId);
+                }
+
+                // Process partition responses
+                foreach (var topicResponse in response.Responses)
+                {
+                    var topicInfo = _metadataManager.Metadata.GetTopic(topicResponse.TopicId);
+                    if (topicInfo is null)
                         continue;
 
-                    // Parse all records from this partition eagerly (KafkaProtocolReader is a
-                    // ref struct and cannot be preserved across yield boundaries)
-                    var parsed = ParsePartitionRecords(
-                        topicInfo, partition, _options.MaxPollRecords - recordCount);
-
-                    var tp = new TopicPartition(topicInfo.Name, partition.PartitionIndex);
-
-                    foreach (var result in parsed)
+                    foreach (var partition in topicResponse.Partitions)
                     {
-                        if (recordCount >= _options.MaxPollRecords)
-                            break;
+                        if (partition.ErrorCode != ErrorCode.None)
+                        {
+                            LogPartitionFetchError(topicInfo.Name, partition.PartitionIndex,
+                                partition.ErrorCode);
+                            continue;
+                        }
 
-                        // Track only records actually yielded to the consumer so we don't
-                        // silently acknowledge offsets truncated by MaxPollRecords.
-                        _ackTracker.TrackDeliveredRecords(tp, result.Offset, result.Offset);
+                        if (partition.RecordBytes.IsEmpty || partition.AcquiredRecords.Count == 0)
+                            continue;
 
-                        recordCount++;
-                        yield return result;
+                        // Parse all records from this partition eagerly (KafkaProtocolReader is a
+                        // ref struct and cannot be preserved across yield boundaries)
+                        var parsed = ParsePartitionRecords(
+                            topicInfo, partition, _options.MaxPollRecords - recordCount);
+
+                        var tp = new TopicPartition(topicInfo.Name, partition.PartitionIndex);
+
+                        foreach (var result in parsed)
+                        {
+                            if (recordCount >= _options.MaxPollRecords)
+                                break;
+
+                            // Track only records actually yielded to the consumer so we don't
+                            // silently acknowledge offsets truncated by MaxPollRecords.
+                            _ackTracker.TrackDeliveredRecords(tp, result.Offset, result.Offset);
+
+                            recordCount++;
+                            yield return result;
+                        }
                     }
                 }
             }
+
+            // If this poll round returned nothing, the broker's MaxWaitMs already
+            // provided back-pressure. No additional client-side delay needed.
         }
     }
 
@@ -410,6 +452,58 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         _initLock.Dispose();
     }
 
+    /// <summary>
+    /// Overrides all pending acks to Release and sends them via ShareAcknowledge.
+    /// Best-effort — errors are logged but not thrown.
+    /// </summary>
+    private void ReleasePendingAcks()
+    {
+        var pending = _ackTracker.Flush();
+        if (pending.Count == 0)
+            return;
+
+        // Override all ack types to Release so the broker redelivers to other members
+        var released = new Dictionary<TopicPartition, List<AcknowledgementBatchData>>();
+        foreach (var (tp, batches) in pending)
+        {
+            var releasedBatches = new List<AcknowledgementBatchData>(batches.Count);
+            foreach (var batch in batches)
+            {
+                var types = new byte[batch.AcknowledgeTypes.Length];
+                Array.Fill(types, (byte)AcknowledgeType.Release);
+                releasedBatches.Add(new AcknowledgementBatchData(batch.FirstOffset, batch.LastOffset, types));
+            }
+            released[tp] = releasedBatches;
+        }
+
+        // Best-effort send — fire and forget since Unsubscribe is synchronous
+        var acksByBroker = GroupAcksByLeader(released);
+        if (acksByBroker.Count == 0)
+            return;
+
+        var shareAckVersion = _metadataManager.GetNegotiatedApiVersion(
+            ApiKey.ShareAcknowledge,
+            ShareAcknowledgeRequest.LowestSupportedVersion,
+            ShareAcknowledgeRequest.HighestSupportedVersion);
+
+        // Send synchronously in the background — best effort, don't block the caller
+        _ = Task.Run(async () =>
+        {
+            foreach (var (brokerId, acks) in acksByBroker)
+            {
+                try
+                {
+                    await SendAcknowledgeAsync(brokerId, acks, shareAckVersion, CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    LogAcknowledgeRequestFailed(brokerId, ex);
+                }
+            }
+        });
+    }
+
     private async ValueTask CloseShareSessionsAsync(CancellationToken cancellationToken)
     {
         var assignment = _assignmentSnapshot;
@@ -435,6 +529,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 MaxWaitMs = 0,
                 MinBytes = 0,
                 MaxBytes = 0,
+                MaxRecords = shareFetchVersion >= 1 ? 1 : 0,
                 Topics = topics
             };
 
@@ -469,24 +564,18 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             Topics = topics
         };
 
-        try
-        {
-            var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
-                .ConfigureAwait(false);
+        var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
+            .ConfigureAwait(false);
 
-            var response = (ShareAcknowledgeResponse)await connection
-                .SendAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(
-                    request, shareAckVersion, cancellationToken)
-                .ConfigureAwait(false);
+        var response = (ShareAcknowledgeResponse)await connection
+            .SendAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(
+                request, shareAckVersion, cancellationToken)
+            .ConfigureAwait(false);
 
-            if (response.ErrorCode != ErrorCode.None)
-            {
-                LogAcknowledgeFailed(response.ErrorCode, response.ErrorMessage);
-            }
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        if (response.ErrorCode != ErrorCode.None)
         {
-            LogAcknowledgeRequestFailed(brokerId, ex);
+            throw new KafkaException(response.ErrorCode,
+                $"ShareAcknowledge failed for broker {brokerId}: {response.ErrorCode} - {response.ErrorMessage}");
         }
     }
 
@@ -787,9 +876,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ShareFetch partition error: {Topic}-{Partition}: {ErrorCode}")]
     private partial void LogPartitionFetchError(string topic, int partition, ErrorCode errorCode);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "ShareAcknowledge failed: {ErrorCode} - {ErrorMessage}")]
-    private partial void LogAcknowledgeFailed(ErrorCode errorCode, string? errorMessage);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ShareAcknowledge request failed for broker {BrokerId}")]
     private partial void LogAcknowledgeRequestFailed(int brokerId, Exception exception);

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -29,6 +29,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     private readonly CompressionCodecRegistry _compressionCodecs;
     private readonly ILogger _logger;
 
+    // ThreadStatic reusable SerializationContext to avoid per-record allocations in ParsePartitionRecords.
+    // Matches the pattern used by ConsumeResult<TKey, TValue> in the regular consumer.
+    [ThreadStatic]
+    private static SerializationContext t_serializationContext;
+
     private volatile IReadOnlySet<string> _subscriptionSnapshot = new HashSet<string>();
     private volatile IReadOnlySet<TopicPartition> _assignmentSnapshot = new HashSet<TopicPartition>();
 
@@ -185,7 +190,13 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
             var assignment = _assignmentSnapshot;
             if (assignment.Count == 0)
+            {
+                // No partitions assigned (e.g. rebalance removed them while state is Stable).
+                // Delay to avoid a spin-loop — reuse FetchMaxWaitMs as the broker's natural
+                // back-pressure is absent when no fetch request is issued.
+                await Task.Delay(_options.FetchMaxWaitMs, cancellationToken).ConfigureAwait(false);
                 continue;
+            }
 
             // Flush pending acks from previous poll as inline acknowledgements with the fetch
             var pendingAcks = _ackTracker.HasPending ? _ackTracker.Flush() : null;
@@ -506,8 +517,16 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
         // Send in the background — best effort, don't block the synchronous caller.
         // Store the task so DisposeAsync can await it before tearing down the connection pool.
+        // Chain after any prior release task so DisposeAsync only needs to await the latest reference.
+        var prior = _pendingReleaseTask;
         _pendingReleaseTask = Task.Run(async () =>
         {
+            if (prior is not null)
+            {
+                try { await prior.ConfigureAwait(false); }
+                catch { /* already logged inside the prior task */ }
+            }
+
             foreach (var (brokerId, acks) in acksByBroker)
             {
                 try
@@ -662,23 +681,16 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 if (deliveryCount < 0)
                     continue;
 
-                var keyContext = new SerializationContext
-                {
-                    Topic = topicInfo.Name,
-                    Component = SerializationComponent.Key
-                };
+                t_serializationContext.Topic = topicInfo.Name;
+                t_serializationContext.Component = SerializationComponent.Key;
                 var key = record.IsKeyNull
                     ? default
-                    : _keyDeserializer.Deserialize(record.Key, keyContext);
+                    : _keyDeserializer.Deserialize(record.Key, t_serializationContext);
 
-                var valueContext = new SerializationContext
-                {
-                    Topic = topicInfo.Name,
-                    Component = SerializationComponent.Value
-                };
+                t_serializationContext.Component = SerializationComponent.Value;
                 var value = record.IsValueNull
                     ? default!
-                    : _valueDeserializer.Deserialize(record.Value, valueContext);
+                    : _valueDeserializer.Deserialize(record.Value, t_serializationContext);
 
                 Header[]? headers = null;
                 if (record.Headers is not null && record.HeaderCount > 0)

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -29,7 +29,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     private readonly CompressionCodecRegistry _compressionCodecs;
     private readonly ILogger _logger;
 
-    private readonly HashSet<string> _subscription = [];
     private volatile IReadOnlySet<string> _subscriptionSnapshot = new HashSet<string>();
     private volatile IReadOnlySet<TopicPartition> _assignmentSnapshot = new HashSet<TopicPartition>();
 
@@ -149,18 +148,12 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
     public IKafkaShareConsumer<TKey, TValue> Subscribe(params string[] topics)
     {
-        _subscription.Clear();
-        foreach (var topic in topics)
-        {
-            _subscription.Add(topic);
-        }
-        _subscriptionSnapshot = new HashSet<string>(_subscription);
+        _subscriptionSnapshot = new HashSet<string>(topics);
         return this;
     }
 
     public IKafkaShareConsumer<TKey, TValue> Unsubscribe()
     {
-        _subscription.Clear();
         _subscriptionSnapshot = new HashSet<string>();
         _sessionManager.ResetAll();
         _ackTracker.Flush(); // Discard pending acks
@@ -173,7 +166,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         ThrowIfDisposed();
         ThrowIfNotInitialized();
 
-        if (_subscription.Count == 0)
+        if (_subscriptionSnapshot.Count == 0)
             yield break;
 
         // Ensure we're part of the share group
@@ -271,13 +264,21 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                     var parsed = ParsePartitionRecords(
                         topicInfo, partition, _options.MaxPollRecords - recordCount);
 
+                    // Track delivered records per acquired range (amortized per-batch)
+                    // rather than per individual record to minimize dictionary lookups.
+                    if (parsed.Count > 0)
+                    {
+                        var tp = new TopicPartition(topicInfo.Name, partition.PartitionIndex);
+                        foreach (var acquired in partition.AcquiredRecords)
+                        {
+                            _ackTracker.TrackDeliveredRecords(tp, acquired.FirstOffset, acquired.LastOffset);
+                        }
+                    }
+
                     foreach (var result in parsed)
                     {
                         if (recordCount >= _options.MaxPollRecords)
                             break;
-
-                        var tp = new TopicPartition(result.Topic, result.Partition);
-                        _ackTracker.TrackDeliveredRecords(tp, result.Offset, result.Offset);
 
                         recordCount++;
                         yield return result;

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -204,21 +204,21 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             // Group assigned partitions by leader broker
             var partitionsByBroker = GroupPartitionsByLeader(assignment);
 
-            var recordCount = 0;
+            var shareFetchVersion = _metadataManager.GetNegotiatedApiVersion(
+                ApiKey.ShareFetch,
+                ShareFetchRequest.LowestSupportedVersion,
+                ShareFetchRequest.HighestSupportedVersion);
+
+            // Send fetch requests to all brokers concurrently. Session epochs are per-broker
+            // and independent, so parallelism is safe. This avoids waiting for each broker's
+            // MaxWaitMs sequentially when partitions span multiple brokers.
+            var fetchTasks = new List<Task<(int BrokerId, ShareFetchResponse? Response)>>(
+                partitionsByBroker.Count);
 
             foreach (var (brokerId, partitions) in partitionsByBroker)
             {
-                if (recordCount >= _options.MaxPollRecords)
-                    break;
-
-                var shareFetchVersion = _metadataManager.GetNegotiatedApiVersion(
-                    ApiKey.ShareFetch,
-                    ShareFetchRequest.LowestSupportedVersion,
-                    ShareFetchRequest.HighestSupportedVersion);
-
                 var topics = BuildShareFetchTopics(partitions, pendingAcks, shareFetchVersion);
                 var sessionEpoch = _sessionManager.GetSessionEpoch(brokerId);
-
                 var maxRecords = shareFetchVersion >= 1 ? _options.MaxPollRecords : 0;
 
                 var request = new ShareFetchRequest
@@ -234,22 +234,23 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                     Topics = topics
                 };
 
-                ShareFetchResponse response;
-                try
-                {
-                    var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
-                        .ConfigureAwait(false);
-                    response = (ShareFetchResponse)await connection
-                        .SendAsync<ShareFetchRequest, ShareFetchResponse>(
-                            request, shareFetchVersion, cancellationToken)
-                        .ConfigureAwait(false);
-                }
-                catch (Exception ex) when (ex is not OperationCanceledException)
-                {
-                    LogFetchFailed(brokerId, ex);
-                    _sessionManager.ResetSession(brokerId);
+                fetchTasks.Add(SendShareFetchAsync(brokerId, request, shareFetchVersion, cancellationToken));
+            }
+
+            await Task.WhenAll(fetchTasks).ConfigureAwait(false);
+
+            // Process responses sequentially — yielding records and tracking acks
+            var recordCount = 0;
+
+            foreach (var fetchTask in fetchTasks)
+            {
+                if (recordCount >= _options.MaxPollRecords)
+                    break;
+
+                var (brokerId, response) = fetchTask.Result;
+
+                if (response is null)
                     continue;
-                }
 
                 // Handle top-level errors
                 if (response.ErrorCode != ErrorCode.None)
@@ -540,6 +541,26 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 }
             }
         });
+    }
+
+    private async Task<(int BrokerId, ShareFetchResponse? Response)> SendShareFetchAsync(
+        int brokerId, ShareFetchRequest request, short version, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
+                .ConfigureAwait(false);
+            var response = (ShareFetchResponse)await connection
+                .SendAsync<ShareFetchRequest, ShareFetchResponse>(request, version, cancellationToken)
+                .ConfigureAwait(false);
+            return (brokerId, response);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogFetchFailed(brokerId, ex);
+            _sessionManager.ResetSession(brokerId);
+            return (brokerId, null);
+        }
     }
 
     private async ValueTask CloseShareSessionsAsync(CancellationToken cancellationToken)

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -1,0 +1,782 @@
+using System.Runtime.CompilerServices;
+using Dekaf.Compression;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.ShareConsumer;
+
+/// <summary>
+/// KIP-932 share consumer implementation. Provides queue-semantics consumption with
+/// record-level acknowledgement. Records are acquired with locks and must be acknowledged
+/// (accepted, released, or rejected).
+/// </summary>
+internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareConsumer<TKey, TValue>
+{
+    private readonly ShareConsumerOptions _options;
+    private readonly IDeserializer<TKey> _keyDeserializer;
+    private readonly IDeserializer<TValue> _valueDeserializer;
+    private readonly IConnectionPool _connectionPool;
+    private readonly MetadataManager _metadataManager;
+    private readonly ShareConsumerCoordinator _coordinator;
+    private readonly ShareSessionManager _sessionManager = new();
+    private readonly AcknowledgementTracker _ackTracker = new();
+    private readonly CompressionCodecRegistry _compressionCodecs;
+    private readonly ILogger _logger;
+
+    private readonly HashSet<string> _subscription = [];
+    private volatile IReadOnlySet<string> _subscriptionSnapshot = new HashSet<string>();
+    private volatile IReadOnlySet<TopicPartition> _assignmentSnapshot = new HashSet<TopicPartition>();
+
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private volatile bool _initialized;
+    private int _closed;
+    private int _disposed;
+    private readonly bool _ownsInfrastructure;
+
+    internal KafkaShareConsumer(
+        ShareConsumerOptions options,
+        IDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer,
+        IConnectionPool connectionPool,
+        MetadataManager metadataManager,
+        ILoggerFactory? loggerFactory = null)
+        : this(options, keyDeserializer, valueDeserializer,
+            (connectionPool, metadataManager),
+            loggerFactory,
+            ownsInfrastructure: false)
+    {
+    }
+
+    private static (IConnectionPool, MetadataManager) CreateInfrastructure(
+        ShareConsumerOptions options, ILoggerFactory? loggerFactory)
+    {
+        var connectionPool = new ConnectionPool(
+            options.ClientId,
+            new ConnectionOptions
+            {
+                UseTls = options.UseTls,
+                TlsConfig = options.TlsConfig,
+                RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
+                SaslMechanism = options.SaslMechanism,
+                SaslUsername = options.SaslUsername,
+                SaslPassword = options.SaslPassword,
+                GssapiConfig = options.GssapiConfig,
+                OAuthBearerConfig = options.OAuthBearerConfig,
+                OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
+                SendBufferSize = options.SocketSendBufferBytes,
+                ReceiveBufferSize = options.SocketReceiveBufferBytes
+            },
+            loggerFactory,
+            connectionsPerBroker: options.ConnectionsPerBroker);
+
+        var metadataManager = new MetadataManager(
+            connectionPool,
+            options.BootstrapServers,
+            logger: loggerFactory?.CreateLogger<MetadataManager>());
+
+        return (connectionPool, metadataManager);
+    }
+
+    internal KafkaShareConsumer(
+        ShareConsumerOptions options,
+        IDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer,
+        ILoggerFactory? loggerFactory = null)
+        : this(options, keyDeserializer, valueDeserializer,
+            CreateInfrastructure(options, loggerFactory),
+            loggerFactory,
+            ownsInfrastructure: true)
+    {
+    }
+
+    private KafkaShareConsumer(
+        ShareConsumerOptions options,
+        IDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer,
+        (IConnectionPool Pool, MetadataManager Metadata) infrastructure,
+        ILoggerFactory? loggerFactory,
+        bool ownsInfrastructure)
+    {
+        _options = options;
+        _keyDeserializer = keyDeserializer;
+        _valueDeserializer = valueDeserializer;
+        _connectionPool = infrastructure.Pool;
+        _metadataManager = infrastructure.Metadata;
+        _ownsInfrastructure = ownsInfrastructure;
+        _logger = loggerFactory?.CreateLogger<KafkaShareConsumer<TKey, TValue>>()
+            ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaShareConsumer<TKey, TValue>>.Instance;
+
+        _compressionCodecs = CompressionCodecRegistry.Default;
+
+        _coordinator = new ShareConsumerCoordinator(
+            options,
+            _connectionPool,
+            _metadataManager,
+            loggerFactory?.CreateLogger<ShareConsumerCoordinator>());
+    }
+
+    public IReadOnlySet<string> Subscription => _subscriptionSnapshot;
+    public IReadOnlySet<TopicPartition> Assignment => _assignmentSnapshot;
+    public string? MemberId => _coordinator.MemberId;
+
+    public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        if (_initialized)
+            return;
+
+        await _initLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_initialized)
+                return;
+
+            await _metadataManager.InitializeAsync(cancellationToken).ConfigureAwait(false);
+            _initialized = true;
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    public IKafkaShareConsumer<TKey, TValue> Subscribe(params string[] topics)
+    {
+        _subscription.Clear();
+        foreach (var topic in topics)
+        {
+            _subscription.Add(topic);
+        }
+        _subscriptionSnapshot = new HashSet<string>(_subscription);
+        return this;
+    }
+
+    public IKafkaShareConsumer<TKey, TValue> Unsubscribe()
+    {
+        _subscription.Clear();
+        _subscriptionSnapshot = new HashSet<string>();
+        _sessionManager.ResetAll();
+        _ackTracker.Flush(); // Discard pending acks
+        return this;
+    }
+
+    public async IAsyncEnumerable<ShareConsumeResult<TKey, TValue>> PollAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ThrowIfNotInitialized();
+
+        if (_subscription.Count == 0)
+            yield break;
+
+        // Ensure we're part of the share group
+        await _coordinator.EnsureActiveGroupAsync(_subscriptionSnapshot, cancellationToken).ConfigureAwait(false);
+        _assignmentSnapshot = _coordinator.Assignment;
+
+        var assignment = _assignmentSnapshot;
+        if (assignment.Count == 0)
+            yield break;
+
+        // Flush pending acks from previous poll as inline acknowledgements with the fetch
+        var pendingAcks = _ackTracker.HasPending ? _ackTracker.Flush() : null;
+
+        // Group assigned partitions by leader broker
+        var partitionsByBroker = GroupPartitionsByLeader(assignment);
+
+        var recordCount = 0;
+
+        foreach (var (brokerId, partitions) in partitionsByBroker)
+        {
+            if (recordCount >= _options.MaxPollRecords)
+                break;
+
+            var shareFetchVersion = _metadataManager.GetNegotiatedApiVersion(
+                ApiKey.ShareFetch,
+                ShareFetchRequest.LowestSupportedVersion,
+                ShareFetchRequest.HighestSupportedVersion);
+
+            var topics = BuildShareFetchTopics(partitions, pendingAcks, shareFetchVersion);
+            var sessionEpoch = _sessionManager.GetSessionEpoch(brokerId);
+
+            var request = new ShareFetchRequest
+            {
+                GroupId = _options.GroupId,
+                MemberId = _coordinator.MemberId!,
+                ShareSessionEpoch = sessionEpoch,
+                MaxWaitMs = _options.FetchMaxWaitMs,
+                MinBytes = _options.FetchMinBytes,
+                MaxBytes = _options.FetchMaxBytes,
+                Topics = topics
+            };
+
+            ShareFetchResponse response;
+            try
+            {
+                var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
+                    .ConfigureAwait(false);
+                response = (ShareFetchResponse)await connection
+                    .SendAsync<ShareFetchRequest, ShareFetchResponse>(
+                        request, shareFetchVersion, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                LogFetchFailed(brokerId, ex);
+                _sessionManager.ResetSession(brokerId);
+                continue;
+            }
+
+            // Handle top-level errors
+            if (response.ErrorCode != ErrorCode.None)
+            {
+                LogFetchTopLevelError(response.ErrorCode, response.ErrorMessage);
+                if (response.ErrorCode == ErrorCode.ShareSessionNotFound ||
+                    response.ErrorCode == ErrorCode.InvalidShareSessionEpoch)
+                {
+                    _sessionManager.ResetSession(brokerId);
+                }
+                continue;
+            }
+
+            // Successful fetch — advance session epoch
+            _sessionManager.IncrementEpoch(brokerId);
+
+            // Process partition responses
+            foreach (var topicResponse in response.Responses)
+            {
+                var topicInfo = _metadataManager.Metadata.GetTopic(topicResponse.TopicId);
+                if (topicInfo is null)
+                    continue;
+
+                foreach (var partition in topicResponse.Partitions)
+                {
+                    if (partition.ErrorCode != ErrorCode.None)
+                    {
+                        LogPartitionFetchError(topicInfo.Name, partition.PartitionIndex, partition.ErrorCode);
+                        continue;
+                    }
+
+                    if (partition.RecordBytes.IsEmpty || partition.AcquiredRecords.Count == 0)
+                        continue;
+
+                    // Parse all records from this partition eagerly (KafkaProtocolReader is a
+                    // ref struct and cannot be preserved across yield boundaries)
+                    var parsed = ParsePartitionRecords(
+                        topicInfo, partition, _options.MaxPollRecords - recordCount);
+
+                    foreach (var result in parsed)
+                    {
+                        if (recordCount >= _options.MaxPollRecords)
+                            break;
+
+                        var tp = new TopicPartition(result.Topic, result.Partition);
+                        _ackTracker.TrackDeliveredRecords(tp, result.Offset, result.Offset);
+
+                        recordCount++;
+                        yield return result;
+                    }
+                }
+            }
+        }
+    }
+
+    public void Acknowledge(ShareConsumeResult<TKey, TValue> record, AcknowledgeType type = AcknowledgeType.Accept)
+    {
+        ThrowIfDisposed();
+
+        record.AcknowledgeType = type;
+        var tp = new TopicPartition(record.Topic, record.Partition);
+        _ackTracker.Acknowledge(tp, record.Offset, type);
+    }
+
+    public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ThrowIfNotInitialized();
+
+        if (!_ackTracker.HasPending)
+            return;
+
+        var pendingAcks = _ackTracker.Flush();
+        if (pendingAcks.Count == 0)
+            return;
+
+        // Group by broker
+        var acksByBroker = GroupAcksByLeader(pendingAcks);
+
+        var shareAckVersion = _metadataManager.GetNegotiatedApiVersion(
+            ApiKey.ShareAcknowledge,
+            ShareAcknowledgeRequest.LowestSupportedVersion,
+            ShareAcknowledgeRequest.HighestSupportedVersion);
+
+        var ackTasks = acksByBroker.Select(kvp => SendAcknowledgeAsync(
+            kvp.Key, kvp.Value, shareAckVersion, cancellationToken));
+        await Task.WhenAll(ackTasks).ConfigureAwait(false);
+    }
+
+    public async ValueTask CloseAsync(CancellationToken cancellationToken = default)
+    {
+        if (Interlocked.Exchange(ref _closed, 1) != 0)
+            return;
+
+        LogClosingShareConsumer();
+
+        // Step 1: Flush all pending acks as Accept via ShareAcknowledge
+        if (_ackTracker.HasPending)
+        {
+            try
+            {
+                await CommitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                LogFlushAcksFailed(ex);
+            }
+        }
+
+        // Step 2: Close share sessions (send ShareFetch with epoch = -1)
+        // This is a best-effort operation
+        try
+        {
+            await CloseShareSessionsAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogCloseSessionsFailed(ex);
+        }
+
+        // Step 3: Leave the share group
+        await _coordinator.LeaveGroupAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        // Ensure close is called
+        if (Interlocked.Exchange(ref _closed, 1) == 0)
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                await CloseAsync(cts.Token).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort close during dispose
+            }
+        }
+
+        await _coordinator.DisposeAsync().ConfigureAwait(false);
+
+        if (_ownsInfrastructure)
+        {
+            await _connectionPool.DisposeAsync().ConfigureAwait(false);
+        }
+
+        _initLock.Dispose();
+    }
+
+    private async ValueTask CloseShareSessionsAsync(CancellationToken cancellationToken)
+    {
+        var assignment = _assignmentSnapshot;
+        if (assignment.Count == 0)
+            return;
+
+        var partitionsByBroker = GroupPartitionsByLeader(assignment);
+
+        var shareFetchVersion = _metadataManager.GetNegotiatedApiVersion(
+            ApiKey.ShareFetch,
+            ShareFetchRequest.LowestSupportedVersion,
+            ShareFetchRequest.HighestSupportedVersion);
+
+        foreach (var (brokerId, partitions) in partitionsByBroker)
+        {
+            var topics = BuildShareFetchTopics(partitions, pendingAcks: null, shareFetchVersion);
+
+            var request = new ShareFetchRequest
+            {
+                GroupId = _options.GroupId,
+                MemberId = _coordinator.MemberId!,
+                ShareSessionEpoch = ShareSessionManager.CloseEpoch,
+                MaxWaitMs = 0,
+                MinBytes = 0,
+                MaxBytes = 0,
+                Topics = topics
+            };
+
+            try
+            {
+                var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
+                    .ConfigureAwait(false);
+                await connection.SendAsync<ShareFetchRequest, ShareFetchResponse>(
+                    request, shareFetchVersion, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort session close
+            }
+        }
+    }
+
+    private async Task SendAcknowledgeAsync(
+        int brokerId,
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>> topicAcks,
+        short shareAckVersion,
+        CancellationToken cancellationToken)
+    {
+        var topics = BuildShareAcknowledgeTopics(topicAcks);
+        var sessionEpoch = _sessionManager.GetSessionEpoch(brokerId);
+
+        var request = new ShareAcknowledgeRequest
+        {
+            GroupId = _options.GroupId,
+            MemberId = _coordinator.MemberId!,
+            ShareSessionEpoch = sessionEpoch,
+            Topics = topics
+        };
+
+        try
+        {
+            var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
+                .ConfigureAwait(false);
+
+            var response = (ShareAcknowledgeResponse)await connection
+                .SendAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(
+                    request, shareAckVersion, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (response.ErrorCode != ErrorCode.None)
+            {
+                LogAcknowledgeFailed(response.ErrorCode, response.ErrorMessage);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogAcknowledgeRequestFailed(brokerId, ex);
+        }
+    }
+
+    /// <summary>
+    /// Groups assigned partitions by their leader broker.
+    /// </summary>
+    private Dictionary<int, List<TopicPartition>> GroupPartitionsByLeader(
+        IReadOnlySet<TopicPartition> assignment)
+    {
+        var result = new Dictionary<int, List<TopicPartition>>();
+
+        foreach (var tp in assignment)
+        {
+            var topicInfo = _metadataManager.Metadata.GetTopic(tp.Topic);
+            if (topicInfo is null)
+                continue;
+
+            var leaderNode = _metadataManager.Metadata.GetPartitionLeader(tp.Topic, tp.Partition);
+            if (leaderNode is null)
+                continue;
+
+            if (!result.TryGetValue(leaderNode.NodeId, out var list))
+            {
+                list = [];
+                result[leaderNode.NodeId] = list;
+            }
+            list.Add(tp);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Parses records from a partition's raw record bytes eagerly. This is needed because
+    /// KafkaProtocolReader is a ref struct and cannot cross yield boundaries.
+    /// </summary>
+    private List<ShareConsumeResult<TKey, TValue>> ParsePartitionRecords(
+        TopicInfo topicInfo,
+        ShareFetchResponsePartition partition,
+        int maxRecords)
+    {
+        var results = new List<ShareConsumeResult<TKey, TValue>>();
+
+        var reader = new KafkaProtocolReader(partition.RecordBytes);
+        while (!reader.End && results.Count < maxRecords)
+        {
+            RecordBatch batch;
+            try
+            {
+                batch = RecordBatch.Read(ref reader, _compressionCodecs);
+            }
+            catch
+            {
+                break; // Partial batch
+            }
+
+            foreach (var record in batch.Records)
+            {
+                if (results.Count >= maxRecords)
+                    break;
+
+                var offset = batch.BaseOffset + record.OffsetDelta;
+
+                var deliveryCount = FindDeliveryCount(partition.AcquiredRecords, offset);
+                if (deliveryCount < 0)
+                    continue;
+
+                var keyContext = new SerializationContext
+                {
+                    Topic = topicInfo.Name,
+                    Component = SerializationComponent.Key
+                };
+                var key = record.IsKeyNull
+                    ? default
+                    : _keyDeserializer.Deserialize(record.Key, keyContext);
+
+                var valueContext = new SerializationContext
+                {
+                    Topic = topicInfo.Name,
+                    Component = SerializationComponent.Value
+                };
+                var value = record.IsValueNull
+                    ? default!
+                    : _valueDeserializer.Deserialize(record.Value, valueContext);
+
+                Header[]? headers = null;
+                if (record.Headers is not null && record.HeaderCount > 0)
+                {
+                    headers = new Header[record.HeaderCount];
+                    Array.Copy(record.Headers, headers, record.HeaderCount);
+                }
+
+                results.Add(new ShareConsumeResult<TKey, TValue>
+                {
+                    Topic = topicInfo.Name,
+                    Partition = partition.PartitionIndex,
+                    Offset = offset,
+                    Key = key,
+                    Value = value,
+                    Headers = headers,
+                    TimestampMs = batch.BaseTimestamp + record.TimestampDelta,
+                    DeliveryCount = deliveryCount
+                });
+            }
+
+            batch.Dispose();
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Builds ShareFetch request topics with optional inline acknowledgement batches.
+    /// </summary>
+    private List<ShareFetchRequestTopic> BuildShareFetchTopics(
+        List<TopicPartition> partitions,
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? pendingAcks,
+        short version)
+    {
+        var topicMap = new Dictionary<string, (Guid TopicId, List<ShareFetchRequestPartition> Partitions)>();
+
+        foreach (var tp in partitions)
+        {
+            var topicInfo = _metadataManager.Metadata.GetTopic(tp.Topic);
+            if (topicInfo is null)
+                continue;
+
+            if (!topicMap.TryGetValue(tp.Topic, out var entry))
+            {
+                entry = (topicInfo.TopicId, []);
+                topicMap[tp.Topic] = entry;
+            }
+
+            List<ShareFetchAcknowledgementBatch>? ackBatches = null;
+            if (pendingAcks is not null && pendingAcks.TryGetValue(tp, out var batchDataList))
+            {
+                ackBatches = new List<ShareFetchAcknowledgementBatch>(batchDataList.Count);
+                foreach (var bd in batchDataList)
+                {
+                    ackBatches.Add(new ShareFetchAcknowledgementBatch
+                    {
+                        FirstOffset = bd.FirstOffset,
+                        LastOffset = bd.LastOffset,
+                        AcknowledgeTypes = bd.AcknowledgeTypes
+                    });
+                }
+            }
+
+            var fetchPartition = new ShareFetchRequestPartition
+            {
+                PartitionIndex = tp.Partition,
+                PartitionMaxBytes = version == 0 ? _options.MaxPartitionFetchBytes : 0,
+                AcknowledgementBatches = ackBatches
+            };
+
+            entry.Partitions.Add(fetchPartition);
+        }
+
+        var topics = new List<ShareFetchRequestTopic>(topicMap.Count);
+        foreach (var (_, (topicId, fetchPartitions)) in topicMap)
+        {
+            topics.Add(new ShareFetchRequestTopic
+            {
+                TopicId = topicId,
+                Partitions = fetchPartitions
+            });
+        }
+
+        return topics;
+    }
+
+    /// <summary>
+    /// Groups acknowledgement data by leader broker.
+    /// </summary>
+    private Dictionary<int, Dictionary<TopicPartition, List<AcknowledgementBatchData>>> GroupAcksByLeader(
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>> acks)
+    {
+        var result = new Dictionary<int, Dictionary<TopicPartition, List<AcknowledgementBatchData>>>();
+
+        foreach (var (tp, batches) in acks)
+        {
+            var topicInfo = _metadataManager.Metadata.GetTopic(tp.Topic);
+            if (topicInfo is null)
+                continue;
+
+            var leaderNode = _metadataManager.Metadata.GetPartitionLeader(tp.Topic, tp.Partition);
+            if (leaderNode is null)
+                continue;
+
+            if (!result.TryGetValue(leaderNode.NodeId, out var ackMap))
+            {
+                ackMap = [];
+                result[leaderNode.NodeId] = ackMap;
+            }
+            ackMap[tp] = batches;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Builds ShareAcknowledge request topics from grouped acknowledgement data.
+    /// </summary>
+    private List<ShareAcknowledgeTopic> BuildShareAcknowledgeTopics(
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>> acks)
+    {
+        var topicMap = new Dictionary<string, (Guid TopicId, List<ShareAcknowledgePartition> Partitions)>();
+
+        foreach (var (tp, batches) in acks)
+        {
+            var topicInfo = _metadataManager.Metadata.GetTopic(tp.Topic);
+            if (topicInfo is null)
+                continue;
+
+            if (!topicMap.TryGetValue(tp.Topic, out var entry))
+            {
+                entry = (topicInfo.TopicId, []);
+                topicMap[tp.Topic] = entry;
+            }
+
+            var ackBatches = new List<ShareAcknowledgeBatch>(batches.Count);
+            foreach (var bd in batches)
+            {
+                ackBatches.Add(new ShareAcknowledgeBatch
+                {
+                    FirstOffset = bd.FirstOffset,
+                    LastOffset = bd.LastOffset,
+                    AcknowledgeTypes = bd.AcknowledgeTypes
+                });
+            }
+
+            entry.Partitions.Add(new ShareAcknowledgePartition
+            {
+                PartitionIndex = tp.Partition,
+                AcknowledgementBatches = ackBatches
+            });
+        }
+
+        var topics = new List<ShareAcknowledgeTopic>(topicMap.Count);
+        foreach (var (_, (topicId, ackPartitions)) in topicMap)
+        {
+            topics.Add(new ShareAcknowledgeTopic
+            {
+                TopicId = topicId,
+                Partitions = ackPartitions
+            });
+        }
+
+        return topics;
+    }
+
+    /// <summary>
+    /// Finds the delivery count for an offset by searching the AcquiredRecords ranges.
+    /// Returns -1 if the offset is not in any acquired range.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int FindDeliveryCount(
+        IReadOnlyList<ShareFetchAcquiredRecords> acquiredRecords,
+        long offset)
+    {
+        for (var i = 0; i < acquiredRecords.Count; i++)
+        {
+            var range = acquiredRecords[i];
+            if (offset >= range.FirstOffset && offset <= range.LastOffset)
+                return range.DeliveryCount;
+        }
+        return -1;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ThrowIfNotInitialized()
+    {
+        if (!_initialized)
+            ThrowNotInitialized();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowNotInitialized()
+    {
+        throw new InvalidOperationException(
+            "Call InitializeAsync() or use BuildAsync() before consuming messages.");
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ThrowIfDisposed()
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(KafkaShareConsumer<TKey, TValue>));
+    }
+
+    #region Logging
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ShareFetch failed for broker {BrokerId}")]
+    private partial void LogFetchFailed(int brokerId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ShareFetch top-level error: {ErrorCode} - {ErrorMessage}")]
+    private partial void LogFetchTopLevelError(ErrorCode errorCode, string? errorMessage);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ShareFetch partition error: {Topic}-{Partition}: {ErrorCode}")]
+    private partial void LogPartitionFetchError(string topic, int partition, ErrorCode errorCode);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ShareAcknowledge failed: {ErrorCode} - {ErrorMessage}")]
+    private partial void LogAcknowledgeFailed(ErrorCode errorCode, string? errorMessage);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ShareAcknowledge request failed for broker {BrokerId}")]
+    private partial void LogAcknowledgeRequestFailed(int brokerId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Closing share consumer")]
+    private partial void LogClosingShareConsumer();
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to flush acknowledgements during close")]
+    private partial void LogFlushAcksFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to close share sessions")]
+    private partial void LogCloseSessionsFailed(Exception exception);
+
+    #endregion
+}

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -37,6 +37,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     private int _closed;
     private int _disposed;
     private readonly bool _ownsInfrastructure;
+    private volatile Task? _pendingReleaseTask;
 
     internal KafkaShareConsumer(
         ShareConsumerOptions options,
@@ -442,6 +443,19 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             }
         }
 
+        // Await any pending release task from Unsubscribe before tearing down infrastructure
+        if (_pendingReleaseTask is { } releaseTask)
+        {
+            try
+            {
+                await releaseTask.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort — exceptions already logged inside the task
+            }
+        }
+
         await _coordinator.DisposeAsync().ConfigureAwait(false);
 
         if (_ownsInfrastructure)
@@ -486,8 +500,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             ShareAcknowledgeRequest.LowestSupportedVersion,
             ShareAcknowledgeRequest.HighestSupportedVersion);
 
-        // Send synchronously in the background — best effort, don't block the caller
-        _ = Task.Run(async () =>
+        // Send in the background — best effort, don't block the synchronous caller.
+        // Store the task so DisposeAsync can await it before tearing down the connection pool.
+        _pendingReleaseTask = Task.Run(async () =>
         {
             foreach (var (brokerId, acks) in acksByBroker)
             {

--- a/src/Dekaf/ShareConsumer/ShareConsumeResult.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumeResult.cs
@@ -1,0 +1,64 @@
+using Dekaf.Serialization;
+
+namespace Dekaf.ShareConsumer;
+
+/// <summary>
+/// A record delivered by the share consumer, with share-group-specific metadata.
+/// Unlike the regular consumer's <c>ConsumeResult</c> (a readonly struct), this is a class
+/// because the acknowledgement state is mutable between poll and commit.
+/// </summary>
+public sealed class ShareConsumeResult<TKey, TValue>
+{
+    /// <summary>
+    /// The topic this record was consumed from.
+    /// </summary>
+    public required string Topic { get; init; }
+
+    /// <summary>
+    /// The partition this record was consumed from.
+    /// </summary>
+    public required int Partition { get; init; }
+
+    /// <summary>
+    /// The offset of this record within the partition.
+    /// </summary>
+    public required long Offset { get; init; }
+
+    /// <summary>
+    /// The deserialized key, or default if the record has no key.
+    /// </summary>
+    public TKey? Key { get; init; }
+
+    /// <summary>
+    /// The deserialized value.
+    /// </summary>
+    public required TValue Value { get; init; }
+
+    /// <summary>
+    /// The message headers, or null if no headers.
+    /// </summary>
+    public IReadOnlyList<Header>? Headers { get; init; }
+
+    /// <summary>
+    /// The message timestamp as raw Unix milliseconds since epoch.
+    /// </summary>
+    public long TimestampMs { get; init; }
+
+    /// <summary>
+    /// The message timestamp as a DateTimeOffset.
+    /// Computed on demand to avoid per-message construction overhead.
+    /// </summary>
+    public DateTimeOffset Timestamp => DateTimeOffset.FromUnixTimeMilliseconds(TimestampMs);
+
+    /// <summary>
+    /// Number of times this record has been delivered (from AcquiredRecords.DeliveryCount).
+    /// First delivery = 1.
+    /// </summary>
+    public required int DeliveryCount { get; init; }
+
+    /// <summary>
+    /// The acknowledgement state for this record. Defaults to Accept.
+    /// Updated via <see cref="IKafkaShareConsumer{TKey,TValue}.Acknowledge"/>.
+    /// </summary>
+    internal AcknowledgeType AcknowledgeType { get; set; } = AcknowledgeType.Accept;
+}

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -492,9 +492,15 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                         default:
                             continue;
                     }
-
-                    break;
                 }
+                else
+                {
+                    // Network errors, ObjectDisposedException, etc. — mark coordinator
+                    // unknown so EnsureActiveGroupAsync re-discovers on next poll.
+                    MarkCoordinatorUnknown();
+                }
+
+                break;
             }
         }
     }

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -505,7 +505,11 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                             break;
 
                         default:
-                            continue;
+                            // Unknown or non-retriable group error — the broker may have
+                            // invalidated our session. Mark coordinator unknown and break
+                            // so EnsureActiveGroupAsync re-discovers on next poll.
+                            MarkCoordinatorUnknown();
+                            break;
                     }
                 }
                 else

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -402,13 +402,22 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                     _state = CoordinatorState.Joining;
                     LogCoordinatorStateTransition(CoordinatorState.Joining);
 
-                    await SendShareGroupHeartbeatAsync(
+                    var gotAssignment = await SendShareGroupHeartbeatAsync(
                         isInitial: _memberEpoch <= 0,
                         cancellationToken).ConfigureAwait(false);
 
-                    _state = CoordinatorState.Stable;
-
-                    LogJoinedGroup(_options.GroupId, _memberId!, _memberEpoch);
+                    if (gotAssignment && _assignedPartitions.Count > 0)
+                    {
+                        _state = CoordinatorState.Stable;
+                        LogJoinedGroup(_options.GroupId, _memberId!, _memberEpoch);
+                    }
+                    else
+                    {
+                        // Broker accepted us but hasn't assigned partitions yet.
+                        // Wait before re-sending heartbeat.
+                        LogWaitingForAssignment();
+                        await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    }
                 }
                 catch (GroupException ex) when (ex.ErrorCode == ErrorCode.FencedMemberEpoch)
                 {
@@ -477,6 +486,9 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                     switch (ge.ErrorCode)
                     {
                         case ErrorCode.FencedMemberEpoch:
+                            // No lock needed: these writes are idempotent resets.
+                            // The next EnsureActiveGroupAsync (which holds _lock) will
+                            // see the Unjoined state and trigger a fresh join.
                             _memberEpoch = 0;
                             _state = CoordinatorState.Unjoined;
                             break;
@@ -663,6 +675,9 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "ShareGroupHeartbeat: member epoch updated to {MemberEpoch}")]
     private partial void LogMemberEpochUpdated(int memberEpoch);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "ShareGroupHeartbeat: waiting for partition assignment")]
+    private partial void LogWaitingForAssignment();
 
     #endregion
 }

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -1,0 +1,662 @@
+using System.Diagnostics;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Consumer;
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.ShareConsumer;
+
+/// <summary>
+/// Handles share group coordination using the ShareGroupHeartbeat API (KIP-932).
+/// State machine: Unjoined → Joining → Stable. The broker performs partition assignment
+/// server-side for share groups. Simpler than ConsumerCoordinator — no offset management,
+/// no rebalance listener, no static member support.
+/// </summary>
+internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
+{
+    private readonly ShareConsumerOptions _options;
+    private readonly IConnectionPool _connectionPool;
+    private readonly MetadataManager _metadataManager;
+    private readonly ILogger _logger;
+
+    private volatile int _coordinatorId = -1;
+    private volatile string? _memberId;
+    private volatile int _memberEpoch;
+    // Volatile ensures cross-thread visibility of the reference. Thread-safety relies on
+    // all writes replacing the reference entirely (never in-place mutation).
+    private volatile HashSet<TopicPartition> _assignedPartitions = [];
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private readonly object _heartbeatGuard = new();
+    private CancellationTokenSource? _heartbeatCts;
+    private Task? _heartbeatTask;
+
+    private volatile CoordinatorState _state = CoordinatorState.Unjoined;
+    private int _disposed;
+    private readonly Func<int> _getCoordinationConnectionIndex;
+
+    private volatile int _heartbeatIntervalMs;
+    private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
+    private volatile IReadOnlySet<string>? _subscribedTopics;
+
+    internal static int GetCoordinationConnectionIndex(int connectionsPerBroker)
+        => connectionsPerBroker - 1;
+
+    public ShareConsumerCoordinator(
+        ShareConsumerOptions options,
+        IConnectionPool connectionPool,
+        MetadataManager metadataManager,
+        ILogger? logger = null,
+        Func<int>? getConnectionCount = null)
+    {
+        _options = options;
+        _connectionPool = connectionPool;
+        _metadataManager = metadataManager;
+        _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+        _getCoordinationConnectionIndex = getConnectionCount is not null
+            ? () => GetCoordinationConnectionIndex(getConnectionCount())
+            : () => GetCoordinationConnectionIndex(options.ConnectionsPerBroker);
+        _heartbeatIntervalMs = options.HeartbeatIntervalMs;
+    }
+
+    public string? MemberId => _memberId;
+    public int MemberEpoch => _memberEpoch;
+    public CoordinatorState State => _state;
+    public IReadOnlySet<TopicPartition> Assignment => _assignedPartitions;
+
+    /// <summary>
+    /// Forces the coordinator to rejoin the group on the next
+    /// <see cref="EnsureActiveGroupAsync"/> call.
+    /// </summary>
+    internal void RequestRejoin()
+    {
+        _state = CoordinatorState.Unjoined;
+    }
+
+    /// <summary>
+    /// Ensures the share consumer has joined the group.
+    /// </summary>
+    public async ValueTask EnsureActiveGroupAsync(
+        IReadOnlySet<string> topics,
+        CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(ShareConsumerCoordinator));
+
+        if (_state == CoordinatorState.Stable)
+            return;
+
+        await EnsureActiveGroupCoreAsync(topics, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Marks the coordinator as unknown, forcing re-discovery on next operation.
+    /// </summary>
+    private void MarkCoordinatorUnknown()
+    {
+        _coordinatorId = -1;
+        _state = CoordinatorState.Unjoined;
+    }
+
+    private static bool IsRetriableCoordinatorError(ErrorCode? errorCode) =>
+        errorCode is ErrorCode.NotCoordinator
+            or ErrorCode.CoordinatorNotAvailable
+            or ErrorCode.CoordinatorLoadInProgress;
+
+    private async ValueTask FindCoordinatorAsync(CancellationToken cancellationToken)
+    {
+        var brokers = _metadataManager.Metadata.GetBrokers();
+        if (brokers.Count == 0)
+        {
+            throw new InvalidOperationException("No brokers available");
+        }
+
+        var request = new FindCoordinatorRequest
+        {
+            Key = _options.GroupId,
+            KeyType = CoordinatorType.Group
+        };
+
+        const int maxRetries = 5;
+        var retryDelayMs = 100;
+
+        for (var attempt = 0; attempt < maxRetries; attempt++)
+        {
+            var broker = brokers[attempt % brokers.Count];
+            var connection = await _connectionPool.GetConnectionByIndexAsync(
+                broker.NodeId, _getCoordinationConnectionIndex(), cancellationToken)
+                .ConfigureAwait(false);
+
+            var findCoordinatorVersion = _metadataManager.GetNegotiatedApiVersion(
+                ApiKey.FindCoordinator,
+                FindCoordinatorRequest.LowestSupportedVersion,
+                FindCoordinatorRequest.HighestSupportedVersion);
+
+            var response = await connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                request,
+                findCoordinatorVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            if (response.Coordinators.Count == 0)
+            {
+                throw new GroupException(ErrorCode.CoordinatorNotAvailable,
+                    "FindCoordinator returned an empty Coordinators array")
+                { GroupId = _options.GroupId };
+            }
+
+            var coordinator = response.Coordinators[0];
+            var errorCode = coordinator.ErrorCode;
+            var nodeId = coordinator.NodeId;
+            var host = coordinator.Host;
+            var port = coordinator.Port;
+
+            if (errorCode == ErrorCode.CoordinatorNotAvailable ||
+                errorCode == ErrorCode.CoordinatorLoadInProgress)
+            {
+                LogCoordinatorNotAvailableRetry(attempt + 1, maxRetries, retryDelayMs);
+
+                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                retryDelayMs = Math.Min(retryDelayMs * 2, 1000);
+                continue;
+            }
+
+            if (errorCode != ErrorCode.None)
+            {
+                throw new GroupException(errorCode, $"FindCoordinator failed: {errorCode}")
+                {
+                    GroupId = _options.GroupId
+                };
+            }
+
+            _coordinatorId = nodeId;
+            _connectionPool.RegisterBroker(nodeId, host, port);
+
+            LogFoundCoordinator(_coordinatorId, _options.GroupId);
+            return;
+        }
+
+        throw new GroupException(ErrorCode.CoordinatorNotAvailable,
+            $"FindCoordinator failed after {maxRetries} retries: CoordinatorNotAvailable")
+        {
+            GroupId = _options.GroupId
+        };
+    }
+
+    /// <summary>
+    /// Serializes heartbeat loop starts to prevent concurrent callers from orphaning a loop.
+    /// </summary>
+    private async ValueTask StartHeartbeatCoreAsync(int intervalMs)
+    {
+        Task? oldTask;
+        CancellationTokenSource? oldCts;
+
+        lock (_heartbeatGuard)
+        {
+            oldCts = _heartbeatCts;
+            oldTask = _heartbeatTask;
+
+            LogHeartbeatStarted(intervalMs);
+
+            _heartbeatCts = new CancellationTokenSource();
+            _heartbeatTask = HeartbeatLoopAsync(_heartbeatCts.Token);
+        }
+
+        if (oldCts is not null)
+        {
+            await oldCts.CancelAsync().ConfigureAwait(false);
+
+            if (oldTask is not null)
+            {
+                try
+                {
+                    await oldTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Ignore cancellation/timeout exceptions from old heartbeat
+                }
+            }
+
+            oldCts.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Resets member identity and assignment to the pre-join state.
+    /// </summary>
+    private void ResetMemberState()
+    {
+        _memberId = null;
+        _memberEpoch = 0;
+        _assignedPartitions = [];
+        _state = CoordinatorState.Unjoined;
+    }
+
+    /// <summary>
+    /// Sends a ShareGroupHeartbeat request and processes the response.
+    /// </summary>
+    private async ValueTask<bool> SendShareGroupHeartbeatAsync(
+        bool isInitial,
+        CancellationToken cancellationToken)
+    {
+        var connection = await _connectionPool.GetConnectionByIndexAsync(
+            _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
+            .ConfigureAwait(false);
+
+        var version = _metadataManager.GetNegotiatedApiVersion(
+            ApiKey.ShareGroupHeartbeat,
+            ShareGroupHeartbeatRequest.LowestSupportedVersion,
+            ShareGroupHeartbeatRequest.HighestSupportedVersion);
+
+        // Share groups always use client-generated UUID v4 member IDs.
+        // Generate once when _memberId is null; subsequent heartbeats reuse the stored ID.
+        _memberId ??= Guid.NewGuid().ToString();
+
+        var memberEpoch = isInitial ? 0 : _memberEpoch;
+
+        // Atomically snapshot and clear the subscription-changed flag.
+        // Always send topics on initial join — required by the protocol.
+        var subscriptionChanged = Interlocked.Exchange(ref _subscriptionChanged, 0) == 1;
+        var subscribedTopics = (isInitial || subscriptionChanged) ? _subscribedTopics?.ToList() : null;
+
+        var request = new ShareGroupHeartbeatRequest
+        {
+            GroupId = _options.GroupId,
+            MemberId = _memberId,
+            MemberEpoch = memberEpoch,
+            RackId = isInitial ? _options.RackId : null,
+            SubscribedTopicNames = subscribedTopics
+        };
+
+        var response = await connection.SendAsync<ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse>(
+            request, version, cancellationToken).ConfigureAwait(false);
+
+        if (response.ErrorCode != ErrorCode.None)
+        {
+            HandleShareGroupHeartbeatError(response);
+        }
+
+        if (response.MemberId is not null)
+            _memberId = response.MemberId;
+
+        if (response.MemberEpoch != _memberEpoch)
+        {
+            LogMemberEpochUpdated(response.MemberEpoch);
+            _memberEpoch = response.MemberEpoch;
+        }
+
+        if (response.HeartbeatIntervalMs > 0)
+            _heartbeatIntervalMs = response.HeartbeatIntervalMs;
+
+        if (response.Assignment is not null)
+        {
+            ProcessShareGroupAssignment(response.Assignment);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Throws an appropriate exception for ShareGroupHeartbeat error codes.
+    /// Does NOT mutate coordinator state — callers own state transitions.
+    /// </summary>
+    private void HandleShareGroupHeartbeatError(ShareGroupHeartbeatResponse response)
+    {
+        throw response.ErrorCode switch
+        {
+            ErrorCode.UnknownMemberId => new GroupException(response.ErrorCode,
+                $"ShareGroupHeartbeat: unknown member ID (fenced): {response.ErrorMessage}")
+            { GroupId = _options.GroupId },
+
+            ErrorCode.FencedMemberEpoch => new GroupException(response.ErrorCode,
+                $"ShareGroupHeartbeat: fenced member epoch: {response.ErrorMessage}")
+            { GroupId = _options.GroupId },
+
+            _ => new GroupException(response.ErrorCode,
+                $"ShareGroupHeartbeat failed: {response.ErrorCode} - {response.ErrorMessage}")
+            { GroupId = _options.GroupId }
+        };
+    }
+
+    /// <summary>
+    /// Processes a ShareGroupHeartbeat assignment response, resolving topic UUIDs to names.
+    /// </summary>
+    private void ProcessShareGroupAssignment(ShareGroupHeartbeatAssignment assignment)
+    {
+        var newAssignment = new HashSet<TopicPartition>();
+
+        foreach (var tp in assignment.TopicPartitions)
+        {
+            var topicInfo = _metadataManager.Metadata.GetTopic(tp.TopicId);
+            if (topicInfo is null)
+            {
+                LogUnknownTopicIdInAssignment(tp.TopicId);
+                continue;
+            }
+
+            foreach (var partition in tp.Partitions)
+            {
+                newAssignment.Add(new TopicPartition(topicInfo.Name, partition));
+            }
+        }
+
+        var oldAssignment = _assignedPartitions;
+
+        if (newAssignment.Count != oldAssignment.Count || !newAssignment.SetEquals(oldAssignment))
+        {
+            LogAssignmentUpdate(newAssignment.Count);
+        }
+
+        _assignedPartitions = newAssignment;
+    }
+
+    /// <summary>
+    /// Ensures the share consumer has joined the group using the ShareGroupHeartbeat API.
+    /// </summary>
+    private async ValueTask EnsureActiveGroupCoreAsync(
+        IReadOnlySet<string> topics,
+        CancellationToken cancellationToken)
+    {
+        if (!_metadataManager.HasApiKey(ApiKey.ShareGroupHeartbeat))
+        {
+            throw new BrokerVersionException(
+                "The connected Kafka broker does not support the ShareGroupHeartbeat API " +
+                "(KIP-932, introduced in Kafka 4.0). Share group consumption requires Kafka 4.0 or later.");
+        }
+
+        _subscribedTopics = topics;
+        Interlocked.Exchange(ref _subscriptionChanged, 1);
+
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_state == CoordinatorState.Stable)
+                return;
+
+            LogEnsureActiveGroupStarted(_options.GroupId, _state);
+            var startedAt = Stopwatch.GetTimestamp();
+            var timeout = TimeSpan.FromMilliseconds(_options.SessionTimeoutMs);
+            var retryDelayMs = 200;
+
+            while (_state != CoordinatorState.Stable)
+            {
+                if (Stopwatch.GetElapsedTime(startedAt) > timeout)
+                {
+                    throw new KafkaTimeoutException(
+                        TimeoutKind.Rebalance,
+                        Stopwatch.GetElapsedTime(startedAt),
+                        timeout,
+                        $"Failed to join share group '{_options.GroupId}' within timeout ({_options.SessionTimeoutMs}ms)");
+                }
+
+                try
+                {
+                    if (_coordinatorId < 0)
+                    {
+                        await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    _state = CoordinatorState.Joining;
+                    LogCoordinatorStateTransition(CoordinatorState.Joining);
+
+                    await SendShareGroupHeartbeatAsync(
+                        isInitial: _memberEpoch <= 0,
+                        cancellationToken).ConfigureAwait(false);
+
+                    _state = CoordinatorState.Stable;
+
+                    LogJoinedGroup(_options.GroupId, _memberId!, _memberEpoch);
+                }
+                catch (GroupException ex) when (ex.ErrorCode == ErrorCode.FencedMemberEpoch)
+                {
+                    LogRetriableCoordinatorError(ex.ErrorCode);
+                    _memberEpoch = 0;
+                    _state = CoordinatorState.Unjoined;
+                }
+                catch (GroupException ex) when (ex.ErrorCode == ErrorCode.UnknownMemberId)
+                {
+                    LogRetriableCoordinatorError(ex.ErrorCode);
+                    ResetMemberState();
+                }
+                catch (GroupException ex) when (IsRetriableCoordinatorError(ex.ErrorCode))
+                {
+                    LogRetriableCoordinatorError(ex.ErrorCode);
+                    MarkCoordinatorUnknown();
+                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                }
+                catch (Exception ex) when (
+                    ex is ObjectDisposedException ||
+                    (ex is KafkaException ke && ke is not GroupException && !cancellationToken.IsCancellationRequested))
+                {
+                    LogCoordinatorConnectionDisposed();
+                    MarkCoordinatorUnknown();
+                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                }
+            }
+        }
+        finally
+        {
+            _lock.Release();
+        }
+
+        if (_state == CoordinatorState.Stable)
+        {
+            await StartHeartbeatCoreAsync(_heartbeatIntervalMs).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// ShareGroupHeartbeat loop: sends heartbeats at the broker-specified interval.
+    /// </summary>
+    private async Task HeartbeatLoopAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_heartbeatIntervalMs, cancellationToken).ConfigureAwait(false);
+
+                await SendShareGroupHeartbeatAsync(
+                    isInitial: false, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                LogHeartbeatFailed(ex);
+
+                if (ex is GroupException ge)
+                {
+                    switch (ge.ErrorCode)
+                    {
+                        case ErrorCode.FencedMemberEpoch:
+                            _memberEpoch = 0;
+                            _state = CoordinatorState.Unjoined;
+                            break;
+
+                        case ErrorCode.UnknownMemberId:
+                            ResetMemberState();
+                            break;
+
+                        case var c when IsRetriableCoordinatorError(c):
+                            MarkCoordinatorUnknown();
+                            break;
+
+                        default:
+                            continue;
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Leaves the share group: sends ShareGroupHeartbeat with MemberEpoch=-1.
+    /// </summary>
+    public async ValueTask LeaveGroupAsync(CancellationToken cancellationToken = default)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            return;
+
+        if (string.IsNullOrEmpty(_memberId))
+            return;
+
+        if (_coordinatorId < 0)
+            return;
+
+        try
+        {
+            var connection = await _connectionPool.GetConnectionByIndexAsync(
+                _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
+                .ConfigureAwait(false);
+
+            var request = new ShareGroupHeartbeatRequest
+            {
+                GroupId = _options.GroupId,
+                MemberId = _memberId,
+                MemberEpoch = -1
+            };
+
+            var version = _metadataManager.GetNegotiatedApiVersion(
+                ApiKey.ShareGroupHeartbeat,
+                ShareGroupHeartbeatRequest.LowestSupportedVersion,
+                ShareGroupHeartbeatRequest.HighestSupportedVersion);
+
+            var response = await connection.SendAsync<ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse>(
+                request, version, cancellationToken).ConfigureAwait(false);
+
+            if (response.ErrorCode != ErrorCode.None)
+            {
+                LogLeaveGroupFailed(response.ErrorCode);
+            }
+            else
+            {
+                LogSuccessfullyLeftGroup(_options.GroupId);
+            }
+        }
+        catch (Exception ex)
+        {
+            LogLeaveGroupRequestFailed(ex);
+        }
+
+        await StopHeartbeatAsync().ConfigureAwait(false);
+
+        await _lock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            ResetMemberState();
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Stops the heartbeat background task.
+    /// </summary>
+    public async ValueTask StopHeartbeatAsync()
+    {
+        CancellationTokenSource? cts;
+        Task? task;
+
+        lock (_heartbeatGuard)
+        {
+            cts = _heartbeatCts;
+            task = _heartbeatTask;
+            _heartbeatCts = null;
+            _heartbeatTask = null;
+        }
+
+        if (cts is not null)
+        {
+            await cts.CancelAsync().ConfigureAwait(false);
+        }
+
+        if (task is not null)
+        {
+            try
+            {
+                await task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Ignore cancellation exceptions
+            }
+        }
+
+        cts?.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+        LogCoordinatorDisposing();
+
+        await StopHeartbeatAsync().ConfigureAwait(false);
+
+        _lock.Dispose();
+    }
+
+    #region Logging
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Joined share group {GroupId} as member {MemberId} (epoch {Epoch})")]
+    private partial void LogJoinedGroup(string groupId, string memberId, int epoch);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Retriable coordinator error {ErrorCode}, will re-discover coordinator")]
+    private partial void LogRetriableCoordinatorError(ErrorCode? errorCode);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Coordinator connection disposed, will re-discover coordinator")]
+    private partial void LogCoordinatorConnectionDisposed();
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Coordinator not available (attempt {Attempt}/{MaxRetries}), retrying in {Delay}ms")]
+    private partial void LogCoordinatorNotAvailableRetry(int attempt, int maxRetries, int delay);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Found coordinator {NodeId} for share group {GroupId}")]
+    private partial void LogFoundCoordinator(int nodeId, string groupId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Share group heartbeat failed")]
+    private partial void LogHeartbeatFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "LeaveGroup failed with error: {ErrorCode}")]
+    private partial void LogLeaveGroupFailed(ErrorCode errorCode);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Successfully left share group {GroupId}")]
+    private partial void LogSuccessfullyLeftGroup(string groupId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to send ShareGroupHeartbeat leave request")]
+    private partial void LogLeaveGroupRequestFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "EnsureActiveGroup: share group={GroupId}, current state={State}")]
+    private partial void LogEnsureActiveGroupStarted(string groupId, CoordinatorState state);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Coordinator state transition to {NewState}")]
+    private partial void LogCoordinatorStateTransition(CoordinatorState newState);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Heartbeat loop started with interval {IntervalMs}ms")]
+    private partial void LogHeartbeatStarted(int intervalMs);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Coordinator disposing")]
+    private partial void LogCoordinatorDisposing();
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ShareGroupHeartbeat: unknown topic ID {TopicId} in assignment, skipping")]
+    private partial void LogUnknownTopicIdInAssignment(Guid topicId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "ShareGroupHeartbeat: assignment updated to {PartitionCount} partitions")]
+    private partial void LogAssignmentUpdate(int partitionCount);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "ShareGroupHeartbeat: member epoch updated to {MemberEpoch}")]
+    private partial void LogMemberEpochUpdated(int memberEpoch);
+
+    #endregion
+}

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -378,6 +378,9 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
 
             LogEnsureActiveGroupStarted(_options.GroupId, _state);
             var startedAt = Stopwatch.GetTimestamp();
+            // Reuse SessionTimeoutMs as the client-side join deadline. This is the broker's
+            // inactivity timeout (default 45s), not a dedicated join timeout — but it provides
+            // a reasonable upper bound for how long we should wait for an assignment.
             var timeout = TimeSpan.FromMilliseconds(_options.SessionTimeoutMs);
             var retryDelayMs = 200;
 

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -1,0 +1,133 @@
+using Dekaf.Retry;
+using Dekaf.Security;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.ShareConsumer;
+
+/// <summary>
+/// Configuration options for the Kafka share consumer (KIP-932).
+/// Share consumers use queue-semantics with record-level acknowledgement.
+/// </summary>
+public sealed class ShareConsumerOptions
+{
+    /// <summary>
+    /// Bootstrap servers (host:port,host:port).
+    /// </summary>
+    public required IReadOnlyList<string> BootstrapServers { get; init; }
+
+    /// <summary>
+    /// Client ID.
+    /// </summary>
+    public string? ClientId { get; init; } = "dekaf-share-consumer";
+
+    /// <summary>
+    /// Share group ID. Required for share consumers.
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// The rack ID of the consumer, used for rack-aware assignment.
+    /// </summary>
+    public string? RackId { get; init; }
+
+    /// <summary>
+    /// Minimum number of bytes the broker should accumulate before returning a fetch response.
+    /// </summary>
+    public int FetchMinBytes { get; init; } = 1;
+
+    /// <summary>
+    /// Maximum number of bytes the broker will return in a fetch response.
+    /// </summary>
+    public int FetchMaxBytes { get; init; } = 52428800; // 50 MiB
+
+    /// <summary>
+    /// Maximum number of bytes per partition in a fetch response.
+    /// </summary>
+    public int MaxPartitionFetchBytes { get; init; } = 1048576; // 1 MiB
+
+    /// <summary>
+    /// Maximum time in milliseconds the broker will wait for FetchMinBytes to be satisfied.
+    /// </summary>
+    public int FetchMaxWaitMs { get; init; } = 200;
+
+    /// <summary>
+    /// Maximum number of records returned per poll.
+    /// </summary>
+    public int MaxPollRecords { get; init; } = 500;
+
+    /// <summary>
+    /// Session timeout in milliseconds. The coordinator will remove the member if no heartbeat
+    /// is received within this interval.
+    /// </summary>
+    public int SessionTimeoutMs { get; init; } = 45000;
+
+    /// <summary>
+    /// Initial heartbeat interval in milliseconds. The broker may adjust this via heartbeat responses.
+    /// </summary>
+    public int HeartbeatIntervalMs { get; init; } = 3000;
+
+    /// <summary>
+    /// Request timeout in milliseconds for protocol requests.
+    /// </summary>
+    public int RequestTimeoutMs { get; init; } = 30000;
+
+    /// <summary>
+    /// Whether to use TLS for broker connections.
+    /// </summary>
+    public bool UseTls { get; init; }
+
+    /// <summary>
+    /// Custom TLS configuration.
+    /// </summary>
+    public TlsConfig? TlsConfig { get; init; }
+
+    /// <summary>
+    /// SASL authentication mechanism.
+    /// </summary>
+    public SaslMechanism SaslMechanism { get; init; } = SaslMechanism.None;
+
+    /// <summary>
+    /// SASL username for PLAIN/SCRAM authentication.
+    /// </summary>
+    public string? SaslUsername { get; init; }
+
+    /// <summary>
+    /// SASL password for PLAIN/SCRAM authentication.
+    /// </summary>
+    public string? SaslPassword { get; init; }
+
+    /// <summary>
+    /// GSSAPI (Kerberos) configuration.
+    /// </summary>
+    public GssapiConfig? GssapiConfig { get; init; }
+
+    /// <summary>
+    /// OAuth Bearer configuration.
+    /// </summary>
+    public OAuthBearerConfig? OAuthBearerConfig { get; init; }
+
+    /// <summary>
+    /// Custom OAuth Bearer token provider.
+    /// </summary>
+    public Func<CancellationToken, ValueTask<OAuthBearerToken>>? OAuthBearerTokenProvider { get; init; }
+
+    /// <summary>
+    /// TCP socket send buffer size in bytes. 0 uses the system default.
+    /// </summary>
+    public int SocketSendBufferBytes { get; init; }
+
+    /// <summary>
+    /// TCP socket receive buffer size in bytes. 0 uses the system default.
+    /// </summary>
+    public int SocketReceiveBufferBytes { get; init; }
+
+    /// <summary>
+    /// Number of TCP connections per broker.
+    /// </summary>
+    public int ConnectionsPerBroker { get; init; } = 2;
+
+    /// <summary>
+    /// Custom retry policy for transient errors.
+    /// </summary>
+    public IRetryPolicy? RetryPolicy { get; init; }
+}

--- a/src/Dekaf/ShareConsumer/ShareSessionManager.cs
+++ b/src/Dekaf/ShareConsumer/ShareSessionManager.cs
@@ -1,15 +1,17 @@
-using System.Collections.Concurrent;
-
 namespace Dekaf.ShareConsumer;
 
 /// <summary>
 /// Tracks share fetch session state per broker.
 /// Share sessions allow incremental fetch requests (only sending changes)
 /// after the initial full request, reducing wire overhead.
+/// <para>
+/// Thread-safety: This class is designed for single-threaded access from the consumer's
+/// poll loop. All methods must be called from the same thread as <see cref="KafkaShareConsumer{TKey,TValue}.PollAsync"/>.
+/// </para>
 /// </summary>
 internal sealed class ShareSessionManager
 {
-    private readonly ConcurrentDictionary<int, int> _sessionEpochs = new();
+    private readonly Dictionary<int, int> _sessionEpochs = new();
 
     /// <summary>
     /// Gets the current session epoch for a broker.
@@ -25,7 +27,7 @@ internal sealed class ShareSessionManager
     /// </summary>
     internal void IncrementEpoch(int brokerId)
     {
-        _sessionEpochs.AddOrUpdate(brokerId, 1, static (_, current) => current + 1);
+        _sessionEpochs[brokerId] = _sessionEpochs.GetValueOrDefault(brokerId, 0) + 1;
     }
 
     /// <summary>
@@ -34,7 +36,7 @@ internal sealed class ShareSessionManager
     /// </summary>
     internal void ResetSession(int brokerId)
     {
-        _sessionEpochs.TryRemove(brokerId, out _);
+        _sessionEpochs.Remove(brokerId);
     }
 
     /// <summary>

--- a/src/Dekaf/ShareConsumer/ShareSessionManager.cs
+++ b/src/Dekaf/ShareConsumer/ShareSessionManager.cs
@@ -1,0 +1,52 @@
+using System.Collections.Concurrent;
+
+namespace Dekaf.ShareConsumer;
+
+/// <summary>
+/// Tracks share fetch session state per broker.
+/// Share sessions allow incremental fetch requests (only sending changes)
+/// after the initial full request, reducing wire overhead.
+/// </summary>
+internal sealed class ShareSessionManager
+{
+    private readonly ConcurrentDictionary<int, int> _sessionEpochs = new();
+
+    /// <summary>
+    /// Gets the current session epoch for a broker.
+    /// Returns 0 (new session) if no session exists for this broker.
+    /// </summary>
+    internal int GetSessionEpoch(int brokerId)
+    {
+        return _sessionEpochs.GetValueOrDefault(brokerId, 0);
+    }
+
+    /// <summary>
+    /// Updates the session after a successful fetch by incrementing the epoch.
+    /// </summary>
+    internal void IncrementEpoch(int brokerId)
+    {
+        _sessionEpochs.AddOrUpdate(brokerId, 1, static (_, current) => current + 1);
+    }
+
+    /// <summary>
+    /// Resets a broker's session to epoch 0 (new session).
+    /// Called on ShareSessionNotFound or InvalidShareSessionEpoch errors.
+    /// </summary>
+    internal void ResetSession(int brokerId)
+    {
+        _sessionEpochs.TryRemove(brokerId, out _);
+    }
+
+    /// <summary>
+    /// Returns the close epoch (-1) for session teardown.
+    /// </summary>
+    internal const int CloseEpoch = -1;
+
+    /// <summary>
+    /// Resets all sessions. Called during coordinator transitions.
+    /// </summary>
+    internal void ResetAll()
+    {
+        _sessionEpochs.Clear();
+    }
+}

--- a/tests/Dekaf.Tests.Integration/KafkaContainer42.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainer42.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using DotNet.Testcontainers.Configurations;
 using Testcontainers.Kafka;
 
 namespace Dekaf.Tests.Integration;
@@ -7,9 +9,25 @@ public class KafkaContainer42 : KafkaTestContainer
     public override string ContainerName => "apache/kafka:4.2.0";
     public override int Version => 420;
 
+    // Testcontainers.Kafka generates a startup script that sets
+    // KAFKA_ADVERTISED_LISTENERS with a trailing comma when no extra
+    // listeners are configured. Kafka 4.2+ (KIP-1161) rejects empty
+    // values in LIST-type configs, so the trailing comma causes a
+    // ConfigException. This wrapper strips the trailing comma before
+    // running the normal Kafka startup sequence.
+    private static readonly byte[] RunWrapperScript = Encoding.UTF8.GetBytes(
+        "#!/bin/bash\n" +
+        "export KAFKA_ADVERTISED_LISTENERS=$(echo \"$KAFKA_ADVERTISED_LISTENERS\" | sed 's/,$//')\n" +
+        "/etc/kafka/docker/configure\n" +
+        "exec /etc/kafka/docker/launch\n");
+
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder)
     {
         return builder
+            .WithResourceMapping(RunWrapperScript, "/etc/kafka/docker/run", 0, 0,
+                UnixFileModes.UserRead | UnixFileModes.UserWrite | UnixFileModes.UserExecute |
+                UnixFileModes.GroupRead | UnixFileModes.GroupExecute |
+                UnixFileModes.OtherRead | UnixFileModes.OtherExecute)
             .WithEnvironment("KAFKA_GROUP_SHARE_ENABLE", "true")
             .WithEnvironment("KAFKA_GROUP_SHARE_RECORD_LOCK_DURATION_MS", "15000")
             .WithEnvironment("KAFKA_GROUP_SHARE_MIN_RECORD_LOCK_DURATION_MS", "5000")

--- a/tests/Dekaf.Tests.Integration/KafkaContainer42.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainer42.cs
@@ -1,0 +1,18 @@
+using Testcontainers.Kafka;
+
+namespace Dekaf.Tests.Integration;
+
+public class KafkaContainer42 : KafkaTestContainer
+{
+    public override string ContainerName => "apache/kafka:4.2.0";
+    public override int Version => 420;
+
+    protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder)
+    {
+        return builder
+            .WithEnvironment("KAFKA_GROUP_SHARE_ENABLE", "true")
+            .WithEnvironment("KAFKA_GROUP_SHARE_RECORD_LOCK_DURATION_MS", "15000")
+            .WithEnvironment("KAFKA_GROUP_SHARE_MIN_RECORD_LOCK_DURATION_MS", "5000")
+            .WithEnvironment("KAFKA_GROUP_SHARE_MAX_RECORD_LOCK_DURATION_MS", "60000");
+    }
+}

--- a/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
@@ -9,6 +9,7 @@ namespace Dekaf.Tests.Integration;
 /// </summary>
 [ClassDataSource<KafkaContainer40>(Shared = SharedType.PerTestSession)]
 [ClassDataSource<KafkaContainer41>(Shared = SharedType.PerTestSession)]
+[ClassDataSource<KafkaContainer42>(Shared = SharedType.PerTestSession)]
 public abstract class KafkaIntegrationTest(KafkaTestContainer kafkaTestContainer)
 {
     public KafkaTestContainer KafkaContainer { get; } = kafkaTestContainer;

--- a/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
@@ -9,7 +9,6 @@ namespace Dekaf.Tests.Integration;
 /// </summary>
 [ClassDataSource<KafkaContainer40>(Shared = SharedType.PerTestSession)]
 [ClassDataSource<KafkaContainer41>(Shared = SharedType.PerTestSession)]
-[ClassDataSource<KafkaContainer42>(Shared = SharedType.PerTestSession)]
 public abstract class KafkaIntegrationTest(KafkaTestContainer kafkaTestContainer)
 {
     public KafkaTestContainer KafkaContainer { get; } = kafkaTestContainer;

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -1,0 +1,387 @@
+using Dekaf.Admin;
+using Dekaf.Producer;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Integration;
+
+/// <summary>
+/// Integration tests for the share consumer (KIP-932).
+/// Requires Kafka 4.2+ with group.share.enable=true.
+/// </summary>
+[Category("ShareConsumer")]
+[SupportsKafka(420)]
+public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task ShareConsumer_SingleConsumer_ReceivesAllMessages()
+    {
+        // Arrange
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 3);
+        var groupId = $"share-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        for (int i = 0; i < 5; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = $"key-{i}",
+                Value = $"value-{i}"
+            });
+        }
+
+        await producer.FlushAsync();
+
+        // Act
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        var messages = new List<ShareConsumeResult<string, string>>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await foreach (var msg in consumer.PollAsync(cts.Token))
+        {
+            messages.Add(msg);
+            if (messages.Count >= 5) break;
+        }
+
+        // Assert
+        await Assert.That(messages.Count).IsEqualTo(5);
+
+        var values = messages.Select(m => m.Value).OrderBy(v => v).ToList();
+        for (int i = 0; i < 5; i++)
+        {
+            await Assert.That(values[i]).IsEqualTo($"value-{i}");
+        }
+    }
+
+    [Test]
+    public async Task ShareConsumer_Subscribe_Unsubscribe_Works()
+    {
+        // Arrange
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"share-group-{Guid.NewGuid():N}";
+
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        // Act
+        consumer.Subscribe(topic);
+        await Assert.That(consumer.Subscription.Count).IsEqualTo(1);
+        await Assert.That(consumer.Subscription.Contains(topic)).IsTrue();
+
+        consumer.Unsubscribe();
+        await Assert.That(consumer.Subscription.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ShareConsumer_DeliveryCount_IsAtLeastOne()
+    {
+        // Arrange
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"share-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key",
+            Value = "value"
+        });
+
+        await producer.FlushAsync();
+
+        // Act
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        ShareConsumeResult<string, string>? result = null;
+
+        await foreach (var msg in consumer.PollAsync(cts.Token))
+        {
+            result = msg;
+            break;
+        }
+
+        // Assert
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.DeliveryCount).IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task ShareConsumer_CommitAsync_FlushesAcknowledgements()
+    {
+        // Arrange
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"share-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key",
+            Value = "value"
+        });
+
+        await producer.FlushAsync();
+
+        // Act
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await foreach (var msg in consumer.PollAsync(cts.Token))
+        {
+            consumer.Acknowledge(msg, AcknowledgeType.Accept);
+            break;
+        }
+
+        // Should not throw
+        await consumer.CommitAsync(CancellationToken.None);
+    }
+
+    [Test]
+    public async Task ShareConsumer_Builder_ConfiguresCorrectly()
+    {
+        var groupId = $"share-group-{Guid.NewGuid():N}";
+
+        await using var consumer = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithClientId("test-share-consumer")
+            .WithFetchMinBytes(1)
+            .WithFetchMaxBytes(1048576)
+            .WithFetchMaxWaitMs(100)
+            .WithMaxPollRecords(100)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .Build();
+
+        await Assert.That(consumer).IsNotNull();
+        await Assert.That(consumer.Subscription.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ShareConsumer_MemberId_IsSetAfterJoining()
+    {
+        // Arrange
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"share-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key",
+            Value = "value"
+        });
+
+        await producer.FlushAsync();
+
+        // Act
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await foreach (var msg in consumer.PollAsync(cts.Token))
+        {
+            break;
+        }
+
+        // Assert — after polling, MemberId should be set
+        await Assert.That(consumer.MemberId).IsNotNull();
+    }
+}
+
+/// <summary>
+/// Integration tests for share group admin operations (KIP-932).
+/// Requires Kafka 4.2+ with group.share.enable=true.
+/// </summary>
+[Category("ShareConsumerAdmin")]
+[SupportsKafka(420)]
+public class ShareConsumerAdminTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task DescribeShareGroups_ReturnsGroupInfo()
+    {
+        // Arrange — create a share consumer so a group exists
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"share-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key",
+            Value = "value"
+        });
+
+        await producer.FlushAsync();
+
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        // Poll to ensure group is active
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await foreach (var msg in consumer.PollAsync(cts.Token))
+        {
+            break;
+        }
+
+        // Act
+        await using var adminClient = KafkaContainer.CreateAdminClient();
+        var descriptions = await adminClient.DescribeShareGroupsAsync([groupId]);
+
+        // Assert
+        await Assert.That(descriptions.ContainsKey(groupId)).IsTrue();
+        var desc = descriptions[groupId];
+        await Assert.That(desc.GroupId).IsEqualTo(groupId);
+        await Assert.That(desc.GroupState).IsNotNull();
+        await Assert.That(desc.Members.Count).IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task ListShareGroups_ReturnsShareGroupType()
+    {
+        // Arrange — create a share consumer so a group exists
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"share-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key",
+            Value = "value"
+        });
+
+        await producer.FlushAsync();
+
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        // Poll to ensure group is active
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await foreach (var msg in consumer.PollAsync(cts.Token))
+        {
+            break;
+        }
+
+        // Act
+        await using var adminClient = KafkaContainer.CreateAdminClient();
+        var groups = await adminClient.ListShareGroupsAsync();
+
+        // Assert — our group should be in the list
+        var ourGroup = groups.FirstOrDefault(g => g.GroupId == groupId);
+        await Assert.That(ourGroup).IsNotNull();
+    }
+
+    [Test]
+    public async Task DescribeShareGroupOffsets_ReturnsStartOffsets()
+    {
+        // Arrange — create a share consumer and consume a record to establish offsets
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"share-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key",
+            Value = "value"
+        });
+
+        await producer.FlushAsync();
+
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await foreach (var msg in consumer.PollAsync(cts.Token))
+        {
+            consumer.Acknowledge(msg, AcknowledgeType.Accept);
+            break;
+        }
+
+        await consumer.CommitAsync();
+
+        // Act
+        await using var adminClient = KafkaContainer.CreateAdminClient();
+        var offsets = await adminClient.DescribeShareGroupOffsetsAsync(
+            groupId,
+            [new TopicPartition(topic, 0)]);
+
+        // Assert
+        await Assert.That(offsets.Count).IsGreaterThanOrEqualTo(1);
+        var offset = offsets.First(o => o.TopicPartition.Topic == topic);
+        await Assert.That(offset.StartOffset).IsGreaterThanOrEqualTo(0);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ShareAcknowledgeMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ShareAcknowledgeMessageTests.cs
@@ -306,15 +306,17 @@ public sealed class ShareAcknowledgeMessageTests
     }
 
     [Test]
-    public async Task Response_Partition_CurrentLeader_CanBeNull()
+    public async Task Response_Partition_CurrentLeader_DefaultsToUnknown()
     {
         var partition = new ShareAcknowledgeResponsePartition
         {
             PartitionIndex = 0,
-            ErrorCode = ErrorCode.None
+            ErrorCode = ErrorCode.None,
+            CurrentLeader = new ShareAcknowledgeLeaderIdAndEpoch()
         };
 
-        await Assert.That(partition.CurrentLeader).IsNull();
+        await Assert.That(partition.CurrentLeader.LeaderId).IsEqualTo(-1);
+        await Assert.That(partition.CurrentLeader.LeaderEpoch).IsEqualTo(-1);
     }
 
     [Test]
@@ -417,13 +419,17 @@ public sealed class ShareAcknowledgeMessageTests
         writer.WriteInt32(0);              // PartitionIndex
         writer.WriteInt16(0);              // ErrorCode = None
         writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
-        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderId
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderEpoch
+        writer.WriteUnsignedVarInt(0);     // CurrentLeader tagged fields
         writer.WriteUnsignedVarInt(0);     // Partition[0] tagged fields
         // Partition[1] - error
         writer.WriteInt32(1);              // PartitionIndex
         writer.WriteInt16(6);              // ErrorCode = NotLeaderOrFollower
         WriteCompactNullableString(ref writer, "Not the leader"); // ErrorMessage
-        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderId
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderEpoch
+        writer.WriteUnsignedVarInt(0);     // CurrentLeader tagged fields
         writer.WriteUnsignedVarInt(0);     // Partition[1] tagged fields
         writer.WriteUnsignedVarInt(0);     // Topic[0] tagged fields
         // NodeEndpoints: empty
@@ -464,9 +470,8 @@ public sealed class ShareAcknowledgeMessageTests
         writer.WriteInt32(0);              // PartitionIndex
         writer.WriteInt16(0);              // ErrorCode
         writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
-        writer.WriteInt8(1);               // CurrentLeader = present
-        writer.WriteInt32(2);              // LeaderId
-        writer.WriteInt32(10);             // LeaderEpoch
+        writer.WriteInt32(2);              // CurrentLeader.LeaderId
+        writer.WriteInt32(10);             // CurrentLeader.LeaderEpoch
         writer.WriteUnsignedVarInt(0);     // CurrentLeader tagged fields
         writer.WriteUnsignedVarInt(0);     // Partition tagged fields
         writer.WriteUnsignedVarInt(0);     // Topic tagged fields
@@ -477,13 +482,12 @@ public sealed class ShareAcknowledgeMessageTests
         var response = (ShareAcknowledgeResponse)ShareAcknowledgeResponse.Read(ref reader, version: 1);
 
         var partition = response.Responses[0].Partitions[0];
-        await Assert.That(partition.CurrentLeader).IsNotNull();
-        await Assert.That(partition.CurrentLeader!.LeaderId).IsEqualTo(2);
+        await Assert.That(partition.CurrentLeader.LeaderId).IsEqualTo(2);
         await Assert.That(partition.CurrentLeader.LeaderEpoch).IsEqualTo(10);
     }
 
     [Test]
-    public async Task Response_Read_WithNullCurrentLeader_ParsesCorrectly()
+    public async Task Response_Read_WithDefaultCurrentLeader_ParsesCorrectly()
     {
         var topicId = Guid.NewGuid();
 
@@ -501,7 +505,9 @@ public sealed class ShareAcknowledgeMessageTests
         writer.WriteInt32(0);              // PartitionIndex
         writer.WriteInt16(0);              // ErrorCode
         writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
-        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderId
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderEpoch
+        writer.WriteUnsignedVarInt(0);     // CurrentLeader tagged fields
         writer.WriteUnsignedVarInt(0);     // Partition tagged fields
         writer.WriteUnsignedVarInt(0);     // Topic tagged fields
         writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty
@@ -511,7 +517,8 @@ public sealed class ShareAcknowledgeMessageTests
         var response = (ShareAcknowledgeResponse)ShareAcknowledgeResponse.Read(ref reader, version: 1);
 
         var partition = response.Responses[0].Partitions[0];
-        await Assert.That(partition.CurrentLeader).IsNull();
+        await Assert.That(partition.CurrentLeader.LeaderId).IsEqualTo(-1);
+        await Assert.That(partition.CurrentLeader.LeaderEpoch).IsEqualTo(-1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Protocol/ShareAcknowledgeMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ShareAcknowledgeMessageTests.cs
@@ -1,0 +1,685 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+/// <summary>
+/// Tests for ShareAcknowledge request and response message encoding/decoding (KIP-932).
+/// </summary>
+public sealed class ShareAcknowledgeMessageTests
+{
+    #region Request Construction
+
+    [Test]
+    public async Task Request_CanBeConstructed_WithRequiredFields()
+    {
+        var topicId = Guid.NewGuid();
+        var request = new ShareAcknowledgeRequest
+        {
+            GroupId = "my-group",
+            MemberId = "member-1",
+            Topics =
+            [
+                new ShareAcknowledgeTopic
+                {
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new ShareAcknowledgePartition
+                        {
+                            PartitionIndex = 0,
+                            AcknowledgementBatches =
+                            [
+                                new ShareAcknowledgeBatch
+                                {
+                                    FirstOffset = 0,
+                                    LastOffset = 9,
+                                    AcknowledgeTypes = [1, 1, 1]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await Assert.That(request.GroupId).IsEqualTo("my-group");
+        await Assert.That(request.MemberId).IsEqualTo("member-1");
+        await Assert.That(request.Topics.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Request_CanBeConstructed_WithAllFields()
+    {
+        var request = new ShareAcknowledgeRequest
+        {
+            GroupId = "my-group",
+            MemberId = "member-1",
+            ShareSessionEpoch = 5,
+            IsRenewAck = true,
+            Topics = []
+        };
+
+        await Assert.That(request.ShareSessionEpoch).IsEqualTo(5);
+        await Assert.That(request.IsRenewAck).IsTrue();
+    }
+
+    [Test]
+    public async Task Request_DefaultValues_AreCorrect()
+    {
+        var request = new ShareAcknowledgeRequest
+        {
+            GroupId = "g",
+            MemberId = "m",
+            Topics = []
+        };
+
+        await Assert.That(request.ShareSessionEpoch).IsEqualTo(0);
+        await Assert.That(request.IsRenewAck).IsFalse();
+    }
+
+    #endregion
+
+    #region Request API Metadata
+
+    [Test]
+    public async Task Request_ApiKey_IsShareAcknowledge()
+    {
+        await Assert.That(ShareAcknowledgeRequest.ApiKey).IsEqualTo(ApiKey.ShareAcknowledge);
+    }
+
+    [Test]
+    public async Task Request_LowestSupportedVersion_Is1()
+    {
+        await Assert.That(ShareAcknowledgeRequest.LowestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    [Test]
+    public async Task Request_HighestSupportedVersion_Is2()
+    {
+        await Assert.That(ShareAcknowledgeRequest.HighestSupportedVersion).IsEqualTo((short)2);
+    }
+
+    #endregion
+
+    #region Request Encoding
+
+    [Test]
+    public async Task Request_Write_V1_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var topicId = Guid.NewGuid();
+        var request = new ShareAcknowledgeRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            ShareSessionEpoch = 1,
+            Topics =
+            [
+                new ShareAcknowledgeTopic
+                {
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new ShareAcknowledgePartition
+                        {
+                            PartitionIndex = 0,
+                            AcknowledgementBatches =
+                            [
+                                new ShareAcknowledgeBatch
+                                {
+                                    FirstOffset = 0,
+                                    LastOffset = 99,
+                                    AcknowledgeTypes = [1, 2, 3]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+        request.Write(ref writer, version: 1);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_V2_IncludesIsRenewAck()
+    {
+        var request = new ShareAcknowledgeRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            IsRenewAck = true,
+            Topics = []
+        };
+
+        var v1Buffer = new ArrayBufferWriter<byte>();
+        var v1Writer = new KafkaProtocolWriter(v1Buffer);
+        request.Write(ref v1Writer, version: 1);
+
+        var v2Buffer = new ArrayBufferWriter<byte>();
+        var v2Writer = new KafkaProtocolWriter(v2Buffer);
+        request.Write(ref v2Writer, version: 2);
+
+        // v2 adds IsRenewAck (1 byte written as Int8)
+        await Assert.That(v2Buffer.WrittenCount).IsGreaterThan(v1Buffer.WrittenCount);
+    }
+
+    [Test]
+    public async Task Request_Write_EmptyTopics_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ShareAcknowledgeRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            Topics = []
+        };
+        request.Write(ref writer, version: 1);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_MultiplePartitions_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var topicId = Guid.NewGuid();
+        var request = new ShareAcknowledgeRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            Topics =
+            [
+                new ShareAcknowledgeTopic
+                {
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new ShareAcknowledgePartition
+                        {
+                            PartitionIndex = 0,
+                            AcknowledgementBatches =
+                            [
+                                new ShareAcknowledgeBatch
+                                {
+                                    FirstOffset = 0,
+                                    LastOffset = 49,
+                                    AcknowledgeTypes = [1]
+                                }
+                            ]
+                        },
+                        new ShareAcknowledgePartition
+                        {
+                            PartitionIndex = 1,
+                            AcknowledgementBatches =
+                            [
+                                new ShareAcknowledgeBatch
+                                {
+                                    FirstOffset = 0,
+                                    LastOffset = 29,
+                                    AcknowledgeTypes = [2]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+        request.Write(ref writer, version: 1);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    #endregion
+
+    #region Response Construction
+
+    [Test]
+    public async Task Response_CanBeConstructed_WithRequiredFields()
+    {
+        var response = new ShareAcknowledgeResponse
+        {
+            Responses = [],
+            NodeEndpoints = []
+        };
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ErrorMessage).IsNull();
+        await Assert.That(response.AcquisitionLockTimeoutMs).IsEqualTo(0);
+        await Assert.That(response.Responses.Count).IsEqualTo(0);
+        await Assert.That(response.NodeEndpoints.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_CanBeConstructed_WithAllFields()
+    {
+        var topicId = Guid.NewGuid();
+        var response = new ShareAcknowledgeResponse
+        {
+            ThrottleTimeMs = 100,
+            ErrorCode = ErrorCode.None,
+            AcquisitionLockTimeoutMs = 30000,
+            Responses =
+            [
+                new ShareAcknowledgeResponseTopic
+                {
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new ShareAcknowledgeResponsePartition
+                        {
+                            PartitionIndex = 0,
+                            ErrorCode = ErrorCode.None,
+                            CurrentLeader = new ShareAcknowledgeLeaderIdAndEpoch
+                            {
+                                LeaderId = 1,
+                                LeaderEpoch = 5
+                            }
+                        }
+                    ]
+                }
+            ],
+            NodeEndpoints =
+            [
+                new ShareAcknowledgeNodeEndpoint
+                {
+                    NodeId = 1,
+                    Host = "broker-1",
+                    Port = 9092
+                }
+            ]
+        };
+
+        await Assert.That(response.AcquisitionLockTimeoutMs).IsEqualTo(30000);
+        await Assert.That(response.Responses.Count).IsEqualTo(1);
+        await Assert.That(response.NodeEndpoints.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Response_Partition_CurrentLeader_CanBeNull()
+    {
+        var partition = new ShareAcknowledgeResponsePartition
+        {
+            PartitionIndex = 0,
+            ErrorCode = ErrorCode.None
+        };
+
+        await Assert.That(partition.CurrentLeader).IsNull();
+    }
+
+    [Test]
+    public async Task Response_LeaderIdAndEpoch_DefaultsToNegativeOne()
+    {
+        var leader = new ShareAcknowledgeLeaderIdAndEpoch();
+
+        await Assert.That(leader.LeaderId).IsEqualTo(-1);
+        await Assert.That(leader.LeaderEpoch).IsEqualTo(-1);
+    }
+
+    #endregion
+
+    #region Response API Metadata
+
+    [Test]
+    public async Task Response_ApiKey_IsShareAcknowledge()
+    {
+        await Assert.That(ShareAcknowledgeResponse.ApiKey).IsEqualTo(ApiKey.ShareAcknowledge);
+    }
+
+    [Test]
+    public async Task Response_LowestSupportedVersion_Is1()
+    {
+        await Assert.That(ShareAcknowledgeResponse.LowestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    [Test]
+    public async Task Response_HighestSupportedVersion_Is2()
+    {
+        await Assert.That(ShareAcknowledgeResponse.HighestSupportedVersion).IsEqualTo((short)2);
+    }
+
+    #endregion
+
+    #region Response Wire Format Parsing
+
+    [Test]
+    public async Task Response_Read_V1_EmptyResponse_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // No AcquisitionLockTimeoutMs in v1
+        writer.WriteUnsignedVarInt(0 + 1); // Responses: empty compact array
+        writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty compact array
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareAcknowledgeResponse)ShareAcknowledgeResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.AcquisitionLockTimeoutMs).IsEqualTo(0);
+        await Assert.That(response.Responses.Count).IsEqualTo(0);
+        await Assert.That(response.NodeEndpoints.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_Read_V2_WithAcquisitionLockTimeout_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteInt32(20000);          // AcquisitionLockTimeoutMs (v2+)
+        writer.WriteUnsignedVarInt(0 + 1); // Responses: empty
+        writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareAcknowledgeResponse)ShareAcknowledgeResponse.Read(ref reader, version: 2);
+
+        await Assert.That(response.AcquisitionLockTimeoutMs).IsEqualTo(20000);
+    }
+
+    [Test]
+    public async Task Response_Read_WithPerPartitionErrors_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        // Topic[0]
+        writer.WriteUuid(topicId);
+        // Partitions: 2 elements
+        writer.WriteUnsignedVarInt(2 + 1);
+        // Partition[0] - success
+        writer.WriteInt32(0);              // PartitionIndex
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteUnsignedVarInt(0);     // Partition[0] tagged fields
+        // Partition[1] - error
+        writer.WriteInt32(1);              // PartitionIndex
+        writer.WriteInt16(6);              // ErrorCode = NotLeaderOrFollower
+        WriteCompactNullableString(ref writer, "Not the leader"); // ErrorMessage
+        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteUnsignedVarInt(0);     // Partition[1] tagged fields
+        writer.WriteUnsignedVarInt(0);     // Topic[0] tagged fields
+        // NodeEndpoints: empty
+        writer.WriteUnsignedVarInt(0 + 1);
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareAcknowledgeResponse)ShareAcknowledgeResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.Responses.Count).IsEqualTo(1);
+        await Assert.That(response.Responses[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(response.Responses[0].Partitions.Count).IsEqualTo(2);
+
+        await Assert.That(response.Responses[0].Partitions[0].PartitionIndex).IsEqualTo(0);
+        await Assert.That(response.Responses[0].Partitions[0].ErrorCode).IsEqualTo(ErrorCode.None);
+
+        await Assert.That(response.Responses[0].Partitions[1].PartitionIndex).IsEqualTo(1);
+        await Assert.That(response.Responses[0].Partitions[1].ErrorCode).IsEqualTo((ErrorCode)6);
+        await Assert.That(response.Responses[0].Partitions[1].ErrorMessage).IsEqualTo("Not the leader");
+    }
+
+    [Test]
+    public async Task Response_Read_WithCurrentLeader_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteUuid(topicId);
+        // Partitions: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt32(0);              // PartitionIndex
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteInt8(1);               // CurrentLeader = present
+        writer.WriteInt32(2);              // LeaderId
+        writer.WriteInt32(10);             // LeaderEpoch
+        writer.WriteUnsignedVarInt(0);     // CurrentLeader tagged fields
+        writer.WriteUnsignedVarInt(0);     // Partition tagged fields
+        writer.WriteUnsignedVarInt(0);     // Topic tagged fields
+        writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareAcknowledgeResponse)ShareAcknowledgeResponse.Read(ref reader, version: 1);
+
+        var partition = response.Responses[0].Partitions[0];
+        await Assert.That(partition.CurrentLeader).IsNotNull();
+        await Assert.That(partition.CurrentLeader!.LeaderId).IsEqualTo(2);
+        await Assert.That(partition.CurrentLeader.LeaderEpoch).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task Response_Read_WithNullCurrentLeader_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteUuid(topicId);
+        // Partitions: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt32(0);              // PartitionIndex
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteUnsignedVarInt(0);     // Partition tagged fields
+        writer.WriteUnsignedVarInt(0);     // Topic tagged fields
+        writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareAcknowledgeResponse)ShareAcknowledgeResponse.Read(ref reader, version: 1);
+
+        var partition = response.Responses[0].Partitions[0];
+        await Assert.That(partition.CurrentLeader).IsNull();
+    }
+
+    [Test]
+    public async Task Response_Read_WithNodeEndpoints_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteUnsignedVarInt(0 + 1); // Responses: empty
+        // NodeEndpoints: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt32(1);              // NodeId
+        writer.WriteCompactString("broker-1"); // Host (non-nullable)
+        writer.WriteInt32(9092);           // Port
+        writer.WriteCompactString("rack-a");   // Rack
+        writer.WriteUnsignedVarInt(0);     // NodeEndpoint tagged fields
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareAcknowledgeResponse)ShareAcknowledgeResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.NodeEndpoints.Count).IsEqualTo(1);
+        await Assert.That(response.NodeEndpoints[0].NodeId).IsEqualTo(1);
+        await Assert.That(response.NodeEndpoints[0].Host).IsEqualTo("broker-1");
+        await Assert.That(response.NodeEndpoints[0].Port).IsEqualTo(9092);
+        await Assert.That(response.NodeEndpoints[0].Rack).IsEqualTo("rack-a");
+    }
+
+    [Test]
+    public async Task Response_Read_TopLevelError_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(50);             // ThrottleTimeMs
+        writer.WriteInt16(29);             // ErrorCode = GroupAuthorizationFailed
+        WriteCompactNullableString(ref writer, "Not authorized"); // ErrorMessage
+        writer.WriteUnsignedVarInt(0 + 1); // Responses: empty
+        writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareAcknowledgeResponse)ShareAcknowledgeResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(50);
+        await Assert.That(response.ErrorCode).IsEqualTo((ErrorCode)29);
+        await Assert.That(response.ErrorMessage).IsEqualTo("Not authorized");
+    }
+
+    /// <summary>
+    /// Helper to write a compact nullable string (varint length+1, then UTF-8 bytes; 0 for null).
+    /// </summary>
+    private static void WriteCompactNullableString(ref KafkaProtocolWriter writer, string? value)
+    {
+        if (value is null)
+        {
+            writer.WriteUnsignedVarInt(0);
+            return;
+        }
+        writer.WriteCompactString(value);
+    }
+
+    #endregion
+
+    #region Nested Type Round-Trips
+
+    [Test]
+    public async Task AcknowledgeTopic_WriteAndRead_RoundTrips()
+    {
+        var topicId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareAcknowledgeTopic
+        {
+            TopicId = topicId,
+            Partitions =
+            [
+                new ShareAcknowledgePartition
+                {
+                    PartitionIndex = 0,
+                    AcknowledgementBatches =
+                    [
+                        new ShareAcknowledgeBatch
+                        {
+                            FirstOffset = 0,
+                            LastOffset = 49,
+                            AcknowledgeTypes = [1, 2]
+                        }
+                    ]
+                }
+            ]
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareAcknowledgeTopic.Read(ref reader);
+
+        await Assert.That(deserialized.TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.Partitions.Count).IsEqualTo(1);
+        await Assert.That(deserialized.Partitions[0].PartitionIndex).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task AcknowledgePartition_WriteAndRead_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareAcknowledgePartition
+        {
+            PartitionIndex = 3,
+            AcknowledgementBatches =
+            [
+                new ShareAcknowledgeBatch
+                {
+                    FirstOffset = 100,
+                    LastOffset = 199,
+                    AcknowledgeTypes = [1, 1, 2, 3]
+                },
+                new ShareAcknowledgeBatch
+                {
+                    FirstOffset = 200,
+                    LastOffset = 299,
+                    AcknowledgeTypes = [1]
+                }
+            ]
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareAcknowledgePartition.Read(ref reader);
+
+        await Assert.That(deserialized.PartitionIndex).IsEqualTo(3);
+        await Assert.That(deserialized.AcknowledgementBatches.Count).IsEqualTo(2);
+        await Assert.That(deserialized.AcknowledgementBatches[0].FirstOffset).IsEqualTo(100L);
+        await Assert.That(deserialized.AcknowledgementBatches[0].LastOffset).IsEqualTo(199L);
+        await Assert.That(deserialized.AcknowledgementBatches[0].AcknowledgeTypes.Count).IsEqualTo(4);
+        await Assert.That(deserialized.AcknowledgementBatches[1].FirstOffset).IsEqualTo(200L);
+    }
+
+    [Test]
+    public async Task AcknowledgeBatch_WriteAndRead_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareAcknowledgeBatch
+        {
+            FirstOffset = 50,
+            LastOffset = 149,
+            AcknowledgeTypes = [1, 2, 3]
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareAcknowledgeBatch.Read(ref reader);
+
+        await Assert.That(deserialized.FirstOffset).IsEqualTo(50L);
+        await Assert.That(deserialized.LastOffset).IsEqualTo(149L);
+        await Assert.That(deserialized.AcknowledgeTypes.Count).IsEqualTo(3);
+        await Assert.That(deserialized.AcknowledgeTypes[0]).IsEqualTo((byte)1);
+        await Assert.That(deserialized.AcknowledgeTypes[1]).IsEqualTo((byte)2);
+        await Assert.That(deserialized.AcknowledgeTypes[2]).IsEqualTo((byte)3);
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ShareFetchMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ShareFetchMessageTests.cs
@@ -1,0 +1,1035 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+/// <summary>
+/// Tests for ShareFetch request and response message encoding/decoding (KIP-932).
+/// </summary>
+public sealed class ShareFetchMessageTests
+{
+    #region Request Construction
+
+    [Test]
+    public async Task Request_CanBeConstructed_WithRequiredFields()
+    {
+        var topicId = Guid.NewGuid();
+        var request = new ShareFetchRequest
+        {
+            GroupId = "my-group",
+            MemberId = "member-1",
+            Topics =
+            [
+                new ShareFetchRequestTopic
+                {
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new ShareFetchRequestPartition { PartitionIndex = 0 }
+                    ]
+                }
+            ]
+        };
+
+        await Assert.That(request.GroupId).IsEqualTo("my-group");
+        await Assert.That(request.MemberId).IsEqualTo("member-1");
+        await Assert.That(request.Topics.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Request_CanBeConstructed_WithAllFields()
+    {
+        var topicId = Guid.NewGuid();
+        var forgottenTopicId = Guid.NewGuid();
+        var request = new ShareFetchRequest
+        {
+            GroupId = "my-group",
+            MemberId = "member-1",
+            ShareSessionEpoch = 5,
+            MaxWaitMs = 500,
+            MinBytes = 1,
+            MaxBytes = 1048576,
+            MaxRecords = 1000,
+            BatchSize = 500,
+            ShareAcquireMode = 0,
+            IsRenewAck = true,
+            Topics =
+            [
+                new ShareFetchRequestTopic
+                {
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new ShareFetchRequestPartition
+                        {
+                            PartitionIndex = 0,
+                            PartitionMaxBytes = 65536,
+                            AcknowledgementBatches =
+                            [
+                                new ShareFetchAcknowledgementBatch
+                                {
+                                    FirstOffset = 0,
+                                    LastOffset = 9,
+                                    AcknowledgeTypes = [1, 1, 1]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            ForgottenTopicsData =
+            [
+                new ShareFetchForgottenTopic
+                {
+                    TopicId = forgottenTopicId,
+                    Partitions = [0, 1]
+                }
+            ]
+        };
+
+        await Assert.That(request.ShareSessionEpoch).IsEqualTo(5);
+        await Assert.That(request.MaxWaitMs).IsEqualTo(500);
+        await Assert.That(request.MinBytes).IsEqualTo(1);
+        await Assert.That(request.MaxBytes).IsEqualTo(1048576);
+        await Assert.That(request.MaxRecords).IsEqualTo(1000);
+        await Assert.That(request.BatchSize).IsEqualTo(500);
+        await Assert.That(request.ShareAcquireMode).IsEqualTo((sbyte)0);
+        await Assert.That(request.IsRenewAck).IsTrue();
+        await Assert.That(request.ForgottenTopicsData!.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Request_DefaultValues_AreCorrect()
+    {
+        var request = new ShareFetchRequest
+        {
+            GroupId = "g",
+            MemberId = "m",
+            Topics = []
+        };
+
+        await Assert.That(request.ShareSessionEpoch).IsEqualTo(0);
+        await Assert.That(request.MaxWaitMs).IsEqualTo(0);
+        await Assert.That(request.MinBytes).IsEqualTo(0);
+        await Assert.That(request.MaxBytes).IsEqualTo(0);
+        await Assert.That(request.MaxRecords).IsEqualTo(0);
+        await Assert.That(request.BatchSize).IsEqualTo(0);
+        await Assert.That(request.ShareAcquireMode).IsEqualTo((sbyte)0);
+        await Assert.That(request.IsRenewAck).IsFalse();
+        await Assert.That(request.ForgottenTopicsData).IsNull();
+    }
+
+    [Test]
+    public async Task Request_Partition_AcknowledgementBatches_CanBeNull()
+    {
+        var partition = new ShareFetchRequestPartition
+        {
+            PartitionIndex = 0
+        };
+
+        await Assert.That(partition.AcknowledgementBatches).IsNull();
+    }
+
+    #endregion
+
+    #region Request API Metadata
+
+    [Test]
+    public async Task Request_ApiKey_IsShareFetch()
+    {
+        await Assert.That(ShareFetchRequest.ApiKey).IsEqualTo(ApiKey.ShareFetch);
+    }
+
+    [Test]
+    public async Task Request_LowestSupportedVersion_Is0()
+    {
+        await Assert.That(ShareFetchRequest.LowestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task Request_HighestSupportedVersion_Is2()
+    {
+        await Assert.That(ShareFetchRequest.HighestSupportedVersion).IsEqualTo((short)2);
+    }
+
+    #endregion
+
+    #region Request Encoding
+
+    [Test]
+    public async Task Request_Write_V0_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var topicId = Guid.NewGuid();
+        var request = new ShareFetchRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            ShareSessionEpoch = 0,
+            MaxWaitMs = 500,
+            MinBytes = 1,
+            MaxBytes = 1048576,
+            Topics =
+            [
+                new ShareFetchRequestTopic
+                {
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new ShareFetchRequestPartition
+                        {
+                            PartitionIndex = 0,
+                            PartitionMaxBytes = 65536
+                        }
+                    ]
+                }
+            ]
+        };
+        request.Write(ref writer, version: 0);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_V1_IncludesMaxRecordsAndBatchSize()
+    {
+        var topicId = Guid.NewGuid();
+        var request = new ShareFetchRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            MaxRecords = 1000,
+            BatchSize = 500,
+            Topics =
+            [
+                new ShareFetchRequestTopic
+                {
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new ShareFetchRequestPartition { PartitionIndex = 0 }
+                    ]
+                }
+            ]
+        };
+
+        var v0Buffer = new ArrayBufferWriter<byte>();
+        var v0Writer = new KafkaProtocolWriter(v0Buffer);
+        request.Write(ref v0Writer, version: 0);
+
+        var v1Buffer = new ArrayBufferWriter<byte>();
+        var v1Writer = new KafkaProtocolWriter(v1Buffer);
+        request.Write(ref v1Writer, version: 1);
+
+        // v1 should be larger: adds MaxRecords (4B) + BatchSize (4B), removes PartitionMaxBytes (4B) = net +4
+        await Assert.That(v1Buffer.WrittenCount).IsGreaterThan(v0Buffer.WrittenCount);
+    }
+
+    [Test]
+    public async Task Request_Write_V2_IncludesShareAcquireModeAndIsRenewAck()
+    {
+        var topicId = Guid.NewGuid();
+        var request = new ShareFetchRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            ShareAcquireMode = 0,
+            IsRenewAck = true,
+            Topics =
+            [
+                new ShareFetchRequestTopic
+                {
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new ShareFetchRequestPartition { PartitionIndex = 0 }
+                    ]
+                }
+            ]
+        };
+
+        var v1Buffer = new ArrayBufferWriter<byte>();
+        var v1Writer = new KafkaProtocolWriter(v1Buffer);
+        request.Write(ref v1Writer, version: 1);
+
+        var v2Buffer = new ArrayBufferWriter<byte>();
+        var v2Writer = new KafkaProtocolWriter(v2Buffer);
+        request.Write(ref v2Writer, version: 2);
+
+        // v2 adds ShareAcquireMode (1B) + IsRenewAck (1B) = net +2
+        await Assert.That(v2Buffer.WrittenCount).IsGreaterThan(v1Buffer.WrittenCount);
+    }
+
+    [Test]
+    public async Task Request_Write_WithAcknowledgementBatches_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var topicId = Guid.NewGuid();
+        var request = new ShareFetchRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            Topics =
+            [
+                new ShareFetchRequestTopic
+                {
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new ShareFetchRequestPartition
+                        {
+                            PartitionIndex = 0,
+                            AcknowledgementBatches =
+                            [
+                                new ShareFetchAcknowledgementBatch
+                                {
+                                    FirstOffset = 0,
+                                    LastOffset = 99,
+                                    AcknowledgeTypes = [1, 2, 3]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+        request.Write(ref writer, version: 1);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_WithForgottenTopics_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var topicId = Guid.NewGuid();
+        var forgottenId = Guid.NewGuid();
+        var request = new ShareFetchRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            Topics =
+            [
+                new ShareFetchRequestTopic
+                {
+                    TopicId = topicId,
+                    Partitions = [new ShareFetchRequestPartition { PartitionIndex = 0 }]
+                }
+            ],
+            ForgottenTopicsData =
+            [
+                new ShareFetchForgottenTopic
+                {
+                    TopicId = forgottenId,
+                    Partitions = [0, 1, 2]
+                }
+            ]
+        };
+        request.Write(ref writer, version: 0);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_NullForgottenTopics_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ShareFetchRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            Topics = [],
+            ForgottenTopicsData = null
+        };
+        request.Write(ref writer, version: 0);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    #endregion
+
+    #region Response Construction
+
+    [Test]
+    public async Task Response_CanBeConstructed_WithRequiredFields()
+    {
+        var response = new ShareFetchResponse
+        {
+            ErrorCode = ErrorCode.None,
+            Responses = [],
+            NodeEndpoints = []
+        };
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.ErrorMessage).IsNull();
+        await Assert.That(response.AcquisitionLockTimeoutMs).IsEqualTo(0);
+        await Assert.That(response.Responses.Count).IsEqualTo(0);
+        await Assert.That(response.NodeEndpoints.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_CanBeConstructed_WithAllFields()
+    {
+        var topicId = Guid.NewGuid();
+        var response = new ShareFetchResponse
+        {
+            ThrottleTimeMs = 100,
+            ErrorCode = ErrorCode.None,
+            ErrorMessage = null,
+            AcquisitionLockTimeoutMs = 30000,
+            Responses =
+            [
+                new ShareFetchResponseTopic
+                {
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new ShareFetchResponsePartition
+                        {
+                            PartitionIndex = 0,
+                            ErrorCode = ErrorCode.None,
+                            AcknowledgeErrorCode = ErrorCode.None,
+                            CurrentLeader = new ShareFetchLeaderIdAndEpoch
+                            {
+                                LeaderId = 1,
+                                LeaderEpoch = 5
+                            },
+                            AcquiredRecords =
+                            [
+                                new ShareFetchAcquiredRecords
+                                {
+                                    FirstOffset = 0,
+                                    LastOffset = 99,
+                                    DeliveryCount = 1
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            NodeEndpoints =
+            [
+                new ShareFetchNodeEndpoint
+                {
+                    NodeId = 1,
+                    Host = "broker-1",
+                    Port = 9092,
+                    Rack = "rack-a"
+                }
+            ]
+        };
+
+        await Assert.That(response.AcquisitionLockTimeoutMs).IsEqualTo(30000);
+        await Assert.That(response.Responses.Count).IsEqualTo(1);
+        await Assert.That(response.NodeEndpoints.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Response_Partition_CurrentLeader_CanBeNull()
+    {
+        var partition = new ShareFetchResponsePartition
+        {
+            PartitionIndex = 0,
+            ErrorCode = ErrorCode.None,
+            AcquiredRecords = []
+        };
+
+        await Assert.That(partition.CurrentLeader).IsNull();
+    }
+
+    [Test]
+    public async Task Response_Partition_RecordBytes_DefaultsToEmpty()
+    {
+        var partition = new ShareFetchResponsePartition
+        {
+            PartitionIndex = 0,
+            AcquiredRecords = []
+        };
+
+        await Assert.That(partition.RecordBytes.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_LeaderIdAndEpoch_DefaultsToNegativeOne()
+    {
+        var leader = new ShareFetchLeaderIdAndEpoch();
+
+        await Assert.That(leader.LeaderId).IsEqualTo(-1);
+        await Assert.That(leader.LeaderEpoch).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task Response_AcquiredRecords_AllFieldsPopulated()
+    {
+        var ar = new ShareFetchAcquiredRecords
+        {
+            FirstOffset = 100,
+            LastOffset = 199,
+            DeliveryCount = 3
+        };
+
+        await Assert.That(ar.FirstOffset).IsEqualTo(100L);
+        await Assert.That(ar.LastOffset).IsEqualTo(199L);
+        await Assert.That(ar.DeliveryCount).IsEqualTo((short)3);
+    }
+
+    [Test]
+    public async Task Response_NodeEndpoint_AllFieldsPopulated()
+    {
+        var ep = new ShareFetchNodeEndpoint
+        {
+            NodeId = 2,
+            Host = "broker-2",
+            Port = 9093,
+            Rack = "rack-b"
+        };
+
+        await Assert.That(ep.NodeId).IsEqualTo(2);
+        await Assert.That(ep.Host).IsEqualTo("broker-2");
+        await Assert.That(ep.Port).IsEqualTo(9093);
+        await Assert.That(ep.Rack).IsEqualTo("rack-b");
+    }
+
+    #endregion
+
+    #region Response API Metadata
+
+    [Test]
+    public async Task Response_ApiKey_IsShareFetch()
+    {
+        await Assert.That(ShareFetchResponse.ApiKey).IsEqualTo(ApiKey.ShareFetch);
+    }
+
+    [Test]
+    public async Task Response_LowestSupportedVersion_Is0()
+    {
+        await Assert.That(ShareFetchResponse.LowestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task Response_HighestSupportedVersion_Is2()
+    {
+        await Assert.That(ShareFetchResponse.HighestSupportedVersion).IsEqualTo((short)2);
+    }
+
+    #endregion
+
+    #region Response Wire Format Parsing
+
+    [Test]
+    public async Task Response_Read_V0_EmptyResponse_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // No AcquisitionLockTimeoutMs in v0
+        writer.WriteUnsignedVarInt(0 + 1); // Responses: empty compact array
+        writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty compact array
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareFetchResponse)ShareFetchResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.AcquisitionLockTimeoutMs).IsEqualTo(0);
+        await Assert.That(response.Responses.Count).IsEqualTo(0);
+        await Assert.That(response.NodeEndpoints.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_Read_V1_WithAcquisitionLockTimeout_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteInt32(15000);          // AcquisitionLockTimeoutMs (v1+)
+        writer.WriteUnsignedVarInt(0 + 1); // Responses: empty
+        writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareFetchResponse)ShareFetchResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.AcquisitionLockTimeoutMs).IsEqualTo(15000);
+    }
+
+    [Test]
+    public async Task Response_Read_WithPartitionData_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        // Topic[0]
+        writer.WriteUuid(topicId);
+        // Partitions: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        // Partition[0]
+        writer.WriteInt32(0);              // PartitionIndex
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteInt16(0);              // AcknowledgeErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // AcknowledgeErrorMessage = null
+        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteUnsignedVarInt(0);     // RecordBytes = null (length+1=0)
+        // AcquiredRecords: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt64(0);              // FirstOffset
+        writer.WriteInt64(99);             // LastOffset
+        writer.WriteInt16(1);              // DeliveryCount
+        writer.WriteUnsignedVarInt(0);     // AcquiredRecords[0] tagged fields
+        writer.WriteUnsignedVarInt(0);     // Partition[0] tagged fields
+        writer.WriteUnsignedVarInt(0);     // Topic[0] tagged fields
+        // NodeEndpoints: empty
+        writer.WriteUnsignedVarInt(0 + 1);
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareFetchResponse)ShareFetchResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.Responses.Count).IsEqualTo(1);
+        await Assert.That(response.Responses[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(response.Responses[0].Partitions.Count).IsEqualTo(1);
+
+        var partition = response.Responses[0].Partitions[0];
+        await Assert.That(partition.PartitionIndex).IsEqualTo(0);
+        await Assert.That(partition.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(partition.AcknowledgeErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(partition.CurrentLeader).IsNull();
+        await Assert.That(partition.RecordBytes.Length).IsEqualTo(0);
+        await Assert.That(partition.AcquiredRecords.Count).IsEqualTo(1);
+        await Assert.That(partition.AcquiredRecords[0].FirstOffset).IsEqualTo(0L);
+        await Assert.That(partition.AcquiredRecords[0].LastOffset).IsEqualTo(99L);
+        await Assert.That(partition.AcquiredRecords[0].DeliveryCount).IsEqualTo((short)1);
+    }
+
+    [Test]
+    public async Task Response_Read_WithCurrentLeader_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteUuid(topicId);
+        // Partitions: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt32(0);              // PartitionIndex
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteInt16(0);              // AcknowledgeErrorCode
+        writer.WriteUnsignedVarInt(0);     // AcknowledgeErrorMessage = null
+        writer.WriteInt8(1);               // CurrentLeader = present
+        writer.WriteInt32(3);              // LeaderId
+        writer.WriteInt32(7);              // LeaderEpoch
+        writer.WriteUnsignedVarInt(0);     // CurrentLeader tagged fields
+        writer.WriteUnsignedVarInt(0);     // RecordBytes = null
+        writer.WriteUnsignedVarInt(0 + 1); // AcquiredRecords: empty
+        writer.WriteUnsignedVarInt(0);     // Partition[0] tagged fields
+        writer.WriteUnsignedVarInt(0);     // Topic[0] tagged fields
+        writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareFetchResponse)ShareFetchResponse.Read(ref reader, version: 0);
+
+        var partition = response.Responses[0].Partitions[0];
+        await Assert.That(partition.CurrentLeader).IsNotNull();
+        await Assert.That(partition.CurrentLeader!.LeaderId).IsEqualTo(3);
+        await Assert.That(partition.CurrentLeader.LeaderEpoch).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task Response_Read_WithRecordBytes_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+        var recordData = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 };
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteUuid(topicId);
+        // Partitions: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt32(0);              // PartitionIndex
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteInt16(0);              // AcknowledgeErrorCode
+        writer.WriteUnsignedVarInt(0);     // AcknowledgeErrorMessage = null
+        writer.WriteInt8(-1);              // CurrentLeader = null
+        // RecordBytes: 5 bytes (length+1 = 6)
+        writer.WriteUnsignedVarInt(recordData.Length + 1);
+        writer.WriteRawBytes(recordData);
+        writer.WriteUnsignedVarInt(0 + 1); // AcquiredRecords: empty
+        writer.WriteUnsignedVarInt(0);     // Partition[0] tagged fields
+        writer.WriteUnsignedVarInt(0);     // Topic[0] tagged fields
+        writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareFetchResponse)ShareFetchResponse.Read(ref reader, version: 0);
+
+        var partition = response.Responses[0].Partitions[0];
+        await Assert.That(partition.RecordBytes.Length).IsEqualTo(5);
+        await Assert.That(partition.RecordBytes.Span[0]).IsEqualTo((byte)0x01);
+        await Assert.That(partition.RecordBytes.Span[4]).IsEqualTo((byte)0x05);
+    }
+
+    [Test]
+    public async Task Response_Read_WithAcknowledgeError_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteUuid(topicId);
+        // Partitions: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt32(0);              // PartitionIndex
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteInt16(75);             // AcknowledgeErrorCode (non-zero)
+        WriteCompactNullableString(ref writer, "Invalid acknowledgement"); // AcknowledgeErrorMessage
+        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteUnsignedVarInt(0);     // RecordBytes = null
+        writer.WriteUnsignedVarInt(0 + 1); // AcquiredRecords: empty
+        writer.WriteUnsignedVarInt(0);     // Partition tagged fields
+        writer.WriteUnsignedVarInt(0);     // Topic tagged fields
+        writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareFetchResponse)ShareFetchResponse.Read(ref reader, version: 0);
+
+        var partition = response.Responses[0].Partitions[0];
+        await Assert.That(partition.AcknowledgeErrorCode).IsEqualTo((ErrorCode)75);
+        await Assert.That(partition.AcknowledgeErrorMessage).IsEqualTo("Invalid acknowledgement");
+    }
+
+    [Test]
+    public async Task Response_Read_WithNodeEndpoints_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteUnsignedVarInt(0 + 1); // Responses: empty
+        // NodeEndpoints: 2 elements
+        writer.WriteUnsignedVarInt(2 + 1);
+        // NodeEndpoint[0]
+        writer.WriteInt32(1);              // NodeId
+        writer.WriteCompactString("broker-1"); // Host (non-nullable)
+        writer.WriteInt32(9092);           // Port
+        writer.WriteCompactString("rack-a");   // Rack
+        writer.WriteUnsignedVarInt(0);     // NodeEndpoint[0] tagged fields
+        // NodeEndpoint[1]
+        writer.WriteInt32(2);              // NodeId
+        writer.WriteCompactString("broker-2"); // Host
+        writer.WriteInt32(9093);           // Port
+        writer.WriteUnsignedVarInt(0);     // Rack = null
+        writer.WriteUnsignedVarInt(0);     // NodeEndpoint[1] tagged fields
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareFetchResponse)ShareFetchResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.NodeEndpoints.Count).IsEqualTo(2);
+        await Assert.That(response.NodeEndpoints[0].NodeId).IsEqualTo(1);
+        await Assert.That(response.NodeEndpoints[0].Host).IsEqualTo("broker-1");
+        await Assert.That(response.NodeEndpoints[0].Port).IsEqualTo(9092);
+        await Assert.That(response.NodeEndpoints[0].Rack).IsEqualTo("rack-a");
+        await Assert.That(response.NodeEndpoints[1].NodeId).IsEqualTo(2);
+        await Assert.That(response.NodeEndpoints[1].Host).IsEqualTo("broker-2");
+        await Assert.That(response.NodeEndpoints[1].Port).IsEqualTo(9093);
+        await Assert.That(response.NodeEndpoints[1].Rack).IsNull();
+    }
+
+    [Test]
+    public async Task Response_Read_WithMultipleAcquiredRecords_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteUuid(topicId);
+        // Partitions: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt32(0);              // PartitionIndex
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteInt16(0);              // AcknowledgeErrorCode
+        writer.WriteUnsignedVarInt(0);     // AcknowledgeErrorMessage = null
+        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteUnsignedVarInt(0);     // RecordBytes = null
+        // AcquiredRecords: 3 elements
+        writer.WriteUnsignedVarInt(3 + 1);
+        // AcquiredRecords[0]
+        writer.WriteInt64(0);
+        writer.WriteInt64(49);
+        writer.WriteInt16(1);
+        writer.WriteUnsignedVarInt(0);
+        // AcquiredRecords[1]
+        writer.WriteInt64(50);
+        writer.WriteInt64(99);
+        writer.WriteInt16(2);
+        writer.WriteUnsignedVarInt(0);
+        // AcquiredRecords[2]
+        writer.WriteInt64(100);
+        writer.WriteInt64(149);
+        writer.WriteInt16(5);
+        writer.WriteUnsignedVarInt(0);
+        writer.WriteUnsignedVarInt(0);     // Partition tagged fields
+        writer.WriteUnsignedVarInt(0);     // Topic tagged fields
+        writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareFetchResponse)ShareFetchResponse.Read(ref reader, version: 0);
+
+        var records = response.Responses[0].Partitions[0].AcquiredRecords;
+        await Assert.That(records.Count).IsEqualTo(3);
+        await Assert.That(records[0].FirstOffset).IsEqualTo(0L);
+        await Assert.That(records[0].LastOffset).IsEqualTo(49L);
+        await Assert.That(records[0].DeliveryCount).IsEqualTo((short)1);
+        await Assert.That(records[1].FirstOffset).IsEqualTo(50L);
+        await Assert.That(records[1].LastOffset).IsEqualTo(99L);
+        await Assert.That(records[1].DeliveryCount).IsEqualTo((short)2);
+        await Assert.That(records[2].FirstOffset).IsEqualTo(100L);
+        await Assert.That(records[2].DeliveryCount).IsEqualTo((short)5);
+    }
+
+    [Test]
+    public async Task Response_Read_WithPartitionError_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteUuid(topicId);
+        // Partitions: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt32(0);              // PartitionIndex
+        writer.WriteInt16(6);              // ErrorCode = NotLeaderOrFollower
+        WriteCompactNullableString(ref writer, "Not the leader"); // ErrorMessage
+        writer.WriteInt16(0);              // AcknowledgeErrorCode
+        writer.WriteUnsignedVarInt(0);     // AcknowledgeErrorMessage = null
+        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteUnsignedVarInt(0);     // RecordBytes = null
+        writer.WriteUnsignedVarInt(0 + 1); // AcquiredRecords: empty
+        writer.WriteUnsignedVarInt(0);     // Partition tagged fields
+        writer.WriteUnsignedVarInt(0);     // Topic tagged fields
+        writer.WriteUnsignedVarInt(0 + 1); // NodeEndpoints: empty
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareFetchResponse)ShareFetchResponse.Read(ref reader, version: 0);
+
+        var partition = response.Responses[0].Partitions[0];
+        await Assert.That(partition.ErrorCode).IsEqualTo((ErrorCode)6);
+        await Assert.That(partition.ErrorMessage).IsEqualTo("Not the leader");
+    }
+
+    /// <summary>
+    /// Helper to write a compact nullable string (varint length+1, then UTF-8 bytes; 0 for null).
+    /// </summary>
+    private static void WriteCompactNullableString(ref KafkaProtocolWriter writer, string? value)
+    {
+        if (value is null)
+        {
+            writer.WriteUnsignedVarInt(0);
+            return;
+        }
+        writer.WriteCompactString(value);
+    }
+
+    #endregion
+
+    #region Nested Type Round-Trips
+
+    [Test]
+    public async Task AcknowledgementBatch_WriteAndRead_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareFetchAcknowledgementBatch
+        {
+            FirstOffset = 100,
+            LastOffset = 199,
+            AcknowledgeTypes = [1, 2, 3, 1]
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareFetchAcknowledgementBatch.Read(ref reader);
+
+        await Assert.That(deserialized.FirstOffset).IsEqualTo(100L);
+        await Assert.That(deserialized.LastOffset).IsEqualTo(199L);
+        await Assert.That(deserialized.AcknowledgeTypes.Count).IsEqualTo(4);
+        await Assert.That(deserialized.AcknowledgeTypes[0]).IsEqualTo((byte)1);
+        await Assert.That(deserialized.AcknowledgeTypes[1]).IsEqualTo((byte)2);
+        await Assert.That(deserialized.AcknowledgeTypes[2]).IsEqualTo((byte)3);
+        await Assert.That(deserialized.AcknowledgeTypes[3]).IsEqualTo((byte)1);
+    }
+
+    [Test]
+    public async Task ForgottenTopic_WriteAndRead_RoundTrips()
+    {
+        var topicId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareFetchForgottenTopic
+        {
+            TopicId = topicId,
+            Partitions = [0, 1, 2]
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareFetchForgottenTopic.Read(ref reader);
+
+        await Assert.That(deserialized.TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.Partitions.Count).IsEqualTo(3);
+        await Assert.That(deserialized.Partitions[0]).IsEqualTo(0);
+        await Assert.That(deserialized.Partitions[1]).IsEqualTo(1);
+        await Assert.That(deserialized.Partitions[2]).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task RequestTopic_WriteAndRead_RoundTrips()
+    {
+        var topicId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareFetchRequestTopic
+        {
+            TopicId = topicId,
+            Partitions =
+            [
+                new ShareFetchRequestPartition
+                {
+                    PartitionIndex = 0,
+                    PartitionMaxBytes = 65536
+                }
+            ]
+        };
+        original.Write(ref writer, version: 0);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareFetchRequestTopic.Read(ref reader, version: 0);
+
+        await Assert.That(deserialized.TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.Partitions.Count).IsEqualTo(1);
+        await Assert.That(deserialized.Partitions[0].PartitionIndex).IsEqualTo(0);
+        await Assert.That(deserialized.Partitions[0].PartitionMaxBytes).IsEqualTo(65536);
+    }
+
+    [Test]
+    public async Task RequestPartition_V0_WithAckBatches_WriteAndRead_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareFetchRequestPartition
+        {
+            PartitionIndex = 3,
+            PartitionMaxBytes = 32768,
+            AcknowledgementBatches =
+            [
+                new ShareFetchAcknowledgementBatch
+                {
+                    FirstOffset = 10,
+                    LastOffset = 19,
+                    AcknowledgeTypes = [1, 1]
+                }
+            ]
+        };
+        original.Write(ref writer, version: 0);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareFetchRequestPartition.Read(ref reader, version: 0);
+
+        await Assert.That(deserialized.PartitionIndex).IsEqualTo(3);
+        await Assert.That(deserialized.PartitionMaxBytes).IsEqualTo(32768);
+        await Assert.That(deserialized.AcknowledgementBatches).IsNotNull();
+        await Assert.That(deserialized.AcknowledgementBatches!.Count).IsEqualTo(1);
+        await Assert.That(deserialized.AcknowledgementBatches[0].FirstOffset).IsEqualTo(10L);
+    }
+
+    [Test]
+    public async Task RequestPartition_V1_DoesNotIncludePartitionMaxBytes()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareFetchRequestPartition
+        {
+            PartitionIndex = 0,
+            PartitionMaxBytes = 65536 // Should be ignored in v1
+        };
+        original.Write(ref writer, version: 1);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareFetchRequestPartition.Read(ref reader, version: 1);
+
+        await Assert.That(deserialized.PartitionIndex).IsEqualTo(0);
+        await Assert.That(deserialized.PartitionMaxBytes).IsEqualTo(0); // Not written/read in v1
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ShareGroupAdminMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ShareGroupAdminMessageTests.cs
@@ -1,0 +1,1101 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+/// <summary>
+/// Tests for share group admin message encoding/decoding (KIP-932):
+/// DescribeShareGroupOffsets, AlterShareGroupOffsets, DeleteShareGroupOffsets.
+/// </summary>
+public sealed class ShareGroupAdminMessageTests
+{
+    #region DescribeShareGroupOffsets Request
+
+    [Test]
+    public async Task DescribeOffsets_Request_CanBeConstructed_WithRequiredFields()
+    {
+        var request = new DescribeShareGroupOffsetsRequest
+        {
+            Groups =
+            [
+                new DescribeShareGroupOffsetsRequestGroup
+                {
+                    GroupId = "my-group"
+                }
+            ]
+        };
+
+        await Assert.That(request.Groups.Count).IsEqualTo(1);
+        await Assert.That(request.Groups[0].GroupId).IsEqualTo("my-group");
+    }
+
+    [Test]
+    public async Task DescribeOffsets_Request_CanBeConstructed_WithTopics()
+    {
+        var request = new DescribeShareGroupOffsetsRequest
+        {
+            Groups =
+            [
+                new DescribeShareGroupOffsetsRequestGroup
+                {
+                    GroupId = "my-group",
+                    Topics =
+                    [
+                        new DescribeShareGroupOffsetsRequestTopic
+                        {
+                            TopicName = "topic-1",
+                            Partitions = [0, 1, 2]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await Assert.That(request.Groups[0].Topics).IsNotNull();
+        await Assert.That(request.Groups[0].Topics!.Count).IsEqualTo(1);
+        await Assert.That(request.Groups[0].Topics![0].TopicName).IsEqualTo("topic-1");
+        await Assert.That(request.Groups[0].Topics![0].Partitions.Count).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task DescribeOffsets_Request_Topics_CanBeNull()
+    {
+        var group = new DescribeShareGroupOffsetsRequestGroup
+        {
+            GroupId = "my-group",
+            Topics = null
+        };
+
+        await Assert.That(group.Topics).IsNull();
+    }
+
+    [Test]
+    public async Task DescribeOffsets_Request_MultipleGroups()
+    {
+        var request = new DescribeShareGroupOffsetsRequest
+        {
+            Groups =
+            [
+                new DescribeShareGroupOffsetsRequestGroup { GroupId = "group-1" },
+                new DescribeShareGroupOffsetsRequestGroup { GroupId = "group-2" }
+            ]
+        };
+
+        await Assert.That(request.Groups.Count).IsEqualTo(2);
+    }
+
+    #endregion
+
+    #region DescribeShareGroupOffsets Request API Metadata
+
+    [Test]
+    public async Task DescribeOffsets_Request_ApiKey_IsDescribeShareGroupOffsets()
+    {
+        await Assert.That(DescribeShareGroupOffsetsRequest.ApiKey).IsEqualTo(ApiKey.DescribeShareGroupOffsets);
+    }
+
+    [Test]
+    public async Task DescribeOffsets_Request_LowestSupportedVersion_Is0()
+    {
+        await Assert.That(DescribeShareGroupOffsetsRequest.LowestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task DescribeOffsets_Request_HighestSupportedVersion_Is1()
+    {
+        await Assert.That(DescribeShareGroupOffsetsRequest.HighestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    #endregion
+
+    #region DescribeShareGroupOffsets Request Encoding
+
+    [Test]
+    public async Task DescribeOffsets_Request_Write_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new DescribeShareGroupOffsetsRequest
+        {
+            Groups =
+            [
+                new DescribeShareGroupOffsetsRequestGroup
+                {
+                    GroupId = "my-group",
+                    Topics =
+                    [
+                        new DescribeShareGroupOffsetsRequestTopic
+                        {
+                            TopicName = "topic-1",
+                            Partitions = [0, 1]
+                        }
+                    ]
+                }
+            ]
+        };
+        request.Write(ref writer, version: 0);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task DescribeOffsets_Request_Write_NullTopics_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new DescribeShareGroupOffsetsRequest
+        {
+            Groups =
+            [
+                new DescribeShareGroupOffsetsRequestGroup
+                {
+                    GroupId = "my-group",
+                    Topics = null
+                }
+            ]
+        };
+        request.Write(ref writer, version: 0);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    #endregion
+
+    #region DescribeShareGroupOffsets Response
+
+    [Test]
+    public async Task DescribeOffsets_Response_CanBeConstructed_WithRequiredFields()
+    {
+        var response = new DescribeShareGroupOffsetsResponse
+        {
+            Groups = []
+        };
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.Groups.Count).IsEqualTo(0);
+    }
+
+    #endregion
+
+    #region DescribeShareGroupOffsets Response API Metadata
+
+    [Test]
+    public async Task DescribeOffsets_Response_ApiKey_IsDescribeShareGroupOffsets()
+    {
+        await Assert.That(DescribeShareGroupOffsetsResponse.ApiKey).IsEqualTo(ApiKey.DescribeShareGroupOffsets);
+    }
+
+    [Test]
+    public async Task DescribeOffsets_Response_LowestSupportedVersion_Is0()
+    {
+        await Assert.That(DescribeShareGroupOffsetsResponse.LowestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task DescribeOffsets_Response_HighestSupportedVersion_Is1()
+    {
+        await Assert.That(DescribeShareGroupOffsetsResponse.HighestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    #endregion
+
+    #region DescribeShareGroupOffsets Response Wire Format
+
+    [Test]
+    public async Task DescribeOffsets_Response_Read_V0_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        // Groups: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        // Group[0]
+        writer.WriteCompactString("my-group"); // GroupId
+        // Topics: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        // Topic[0]
+        writer.WriteCompactString("topic-1");  // TopicName
+        writer.WriteUuid(topicId);             // TopicId
+        // Partitions: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        // Partition[0]
+        writer.WriteInt32(0);                  // PartitionIndex
+        writer.WriteInt64(100);                // StartOffset
+        writer.WriteInt32(5);                  // LeaderEpoch
+        // No Lag field in v0
+        writer.WriteInt16(0);                  // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);         // ErrorMessage = null
+        writer.WriteUnsignedVarInt(0);         // Partition tagged fields
+        writer.WriteUnsignedVarInt(0);         // Topic tagged fields
+        writer.WriteInt16(0);                  // Group ErrorCode
+        writer.WriteUnsignedVarInt(0);         // Group ErrorMessage = null
+        writer.WriteUnsignedVarInt(0);         // Group tagged fields
+        writer.WriteUnsignedVarInt(0);         // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (DescribeShareGroupOffsetsResponse)DescribeShareGroupOffsetsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.Groups.Count).IsEqualTo(1);
+        await Assert.That(response.Groups[0].GroupId).IsEqualTo("my-group");
+        await Assert.That(response.Groups[0].Topics.Count).IsEqualTo(1);
+        await Assert.That(response.Groups[0].Topics[0].TopicName).IsEqualTo("topic-1");
+        await Assert.That(response.Groups[0].Topics[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(response.Groups[0].Topics[0].Partitions.Count).IsEqualTo(1);
+
+        var partition = response.Groups[0].Topics[0].Partitions[0];
+        await Assert.That(partition.PartitionIndex).IsEqualTo(0);
+        await Assert.That(partition.StartOffset).IsEqualTo(100L);
+        await Assert.That(partition.LeaderEpoch).IsEqualTo(5);
+        await Assert.That(partition.Lag).IsEqualTo(-1L); // Default, not read in v0
+        await Assert.That(partition.ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
+    public async Task DescribeOffsets_Response_Read_V1_WithLag_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(25);             // ThrottleTimeMs
+        // Groups: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        // Group[0]
+        writer.WriteCompactString("my-group");
+        // Topics: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteCompactString("topic-1");
+        writer.WriteUuid(topicId);
+        // Partitions: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt32(0);                  // PartitionIndex
+        writer.WriteInt64(100);                // StartOffset
+        writer.WriteInt32(5);                  // LeaderEpoch
+        writer.WriteInt64(42);                 // Lag (v1+)
+        writer.WriteInt16(0);                  // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);         // ErrorMessage = null
+        writer.WriteUnsignedVarInt(0);         // Partition tagged fields
+        writer.WriteUnsignedVarInt(0);         // Topic tagged fields
+        writer.WriteInt16(0);                  // Group ErrorCode
+        writer.WriteUnsignedVarInt(0);         // Group ErrorMessage = null
+        writer.WriteUnsignedVarInt(0);         // Group tagged fields
+        writer.WriteUnsignedVarInt(0);         // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (DescribeShareGroupOffsetsResponse)DescribeShareGroupOffsetsResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(25);
+        var partition = response.Groups[0].Topics[0].Partitions[0];
+        await Assert.That(partition.StartOffset).IsEqualTo(100L);
+        await Assert.That(partition.Lag).IsEqualTo(42L);
+    }
+
+    [Test]
+    public async Task DescribeOffsets_Response_Read_WithGroupError_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        // Groups: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteCompactString("my-group");
+        writer.WriteUnsignedVarInt(0 + 1);     // Topics: empty
+        writer.WriteInt16(29);                 // Group ErrorCode = GroupAuthorizationFailed
+        WriteCompactNullableString(ref writer, "Not authorized"); // Group ErrorMessage
+        writer.WriteUnsignedVarInt(0);         // Group tagged fields
+        writer.WriteUnsignedVarInt(0);         // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (DescribeShareGroupOffsetsResponse)DescribeShareGroupOffsetsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.Groups[0].ErrorCode).IsEqualTo((ErrorCode)29);
+        await Assert.That(response.Groups[0].ErrorMessage).IsEqualTo("Not authorized");
+    }
+
+    [Test]
+    public async Task DescribeOffsets_Response_Read_WithPartitionError_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);
+        writer.WriteUnsignedVarInt(1 + 1); // Groups: 1
+        writer.WriteCompactString("my-group");
+        writer.WriteUnsignedVarInt(1 + 1); // Topics: 1
+        writer.WriteCompactString("topic-1");
+        writer.WriteUuid(topicId);
+        writer.WriteUnsignedVarInt(1 + 1); // Partitions: 1
+        writer.WriteInt32(0);              // PartitionIndex
+        writer.WriteInt64(-1);             // StartOffset = unknown
+        writer.WriteInt32(-1);             // LeaderEpoch = unknown
+        writer.WriteInt16(3);              // ErrorCode = UnknownTopicOrPartition
+        WriteCompactNullableString(ref writer, "Unknown partition");
+        writer.WriteUnsignedVarInt(0);     // Partition tagged fields
+        writer.WriteUnsignedVarInt(0);     // Topic tagged fields
+        writer.WriteInt16(0);              // Group ErrorCode
+        writer.WriteUnsignedVarInt(0);     // Group ErrorMessage = null
+        writer.WriteUnsignedVarInt(0);     // Group tagged fields
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (DescribeShareGroupOffsetsResponse)DescribeShareGroupOffsetsResponse.Read(ref reader, version: 0);
+
+        var partition = response.Groups[0].Topics[0].Partitions[0];
+        await Assert.That(partition.ErrorCode).IsEqualTo((ErrorCode)3);
+        await Assert.That(partition.ErrorMessage).IsEqualTo("Unknown partition");
+        await Assert.That(partition.StartOffset).IsEqualTo(-1L);
+    }
+
+    #endregion
+
+    #region DescribeShareGroupOffsets Nested Type Round-Trips
+
+    [Test]
+    public async Task DescribeOffsets_ResponseGroup_WriteAndRead_V0_RoundTrips()
+    {
+        var topicId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new DescribeShareGroupOffsetsResponseGroup
+        {
+            GroupId = "my-group",
+            Topics =
+            [
+                new DescribeShareGroupOffsetsResponseTopic
+                {
+                    TopicName = "topic-1",
+                    TopicId = topicId,
+                    Partitions =
+                    [
+                        new DescribeShareGroupOffsetsResponsePartition
+                        {
+                            PartitionIndex = 0,
+                            StartOffset = 500,
+                            LeaderEpoch = 3,
+                            ErrorCode = ErrorCode.None
+                        }
+                    ]
+                }
+            ],
+            ErrorCode = ErrorCode.None
+        };
+        original.Write(ref writer, version: 0);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = DescribeShareGroupOffsetsResponseGroup.Read(ref reader, version: 0);
+
+        await Assert.That(deserialized.GroupId).IsEqualTo("my-group");
+        await Assert.That(deserialized.Topics.Count).IsEqualTo(1);
+        await Assert.That(deserialized.Topics[0].Partitions[0].StartOffset).IsEqualTo(500L);
+        await Assert.That(deserialized.ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
+    public async Task DescribeOffsets_ResponsePartition_WriteAndRead_V1_WithLag_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new DescribeShareGroupOffsetsResponsePartition
+        {
+            PartitionIndex = 2,
+            StartOffset = 1000,
+            LeaderEpoch = 7,
+            Lag = 50,
+            ErrorCode = ErrorCode.None
+        };
+        original.Write(ref writer, version: 1);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = DescribeShareGroupOffsetsResponsePartition.Read(ref reader, version: 1);
+
+        await Assert.That(deserialized.PartitionIndex).IsEqualTo(2);
+        await Assert.That(deserialized.StartOffset).IsEqualTo(1000L);
+        await Assert.That(deserialized.LeaderEpoch).IsEqualTo(7);
+        await Assert.That(deserialized.Lag).IsEqualTo(50L);
+        await Assert.That(deserialized.ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
+    public async Task DescribeOffsets_ResponsePartition_Lag_DefaultsToNegativeOne()
+    {
+        var partition = new DescribeShareGroupOffsetsResponsePartition
+        {
+            PartitionIndex = 0,
+            StartOffset = 0,
+            LeaderEpoch = 0
+        };
+
+        await Assert.That(partition.Lag).IsEqualTo(-1L);
+    }
+
+    #endregion
+
+    #region AlterShareGroupOffsets Request
+
+    [Test]
+    public async Task AlterOffsets_Request_CanBeConstructed_WithRequiredFields()
+    {
+        var request = new AlterShareGroupOffsetsRequest
+        {
+            GroupId = "my-group",
+            Topics =
+            [
+                new AlterShareGroupOffsetsRequestTopic
+                {
+                    TopicName = "topic-1",
+                    Partitions =
+                    [
+                        new AlterShareGroupOffsetsRequestPartition
+                        {
+                            PartitionIndex = 0,
+                            StartOffset = 100
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await Assert.That(request.GroupId).IsEqualTo("my-group");
+        await Assert.That(request.Topics.Count).IsEqualTo(1);
+        await Assert.That(request.Topics[0].TopicName).IsEqualTo("topic-1");
+        await Assert.That(request.Topics[0].Partitions[0].StartOffset).IsEqualTo(100L);
+    }
+
+    [Test]
+    public async Task AlterOffsets_Request_MultiplePartitions()
+    {
+        var request = new AlterShareGroupOffsetsRequest
+        {
+            GroupId = "my-group",
+            Topics =
+            [
+                new AlterShareGroupOffsetsRequestTopic
+                {
+                    TopicName = "topic-1",
+                    Partitions =
+                    [
+                        new AlterShareGroupOffsetsRequestPartition { PartitionIndex = 0, StartOffset = 100 },
+                        new AlterShareGroupOffsetsRequestPartition { PartitionIndex = 1, StartOffset = 200 },
+                        new AlterShareGroupOffsetsRequestPartition { PartitionIndex = 2, StartOffset = 300 }
+                    ]
+                }
+            ]
+        };
+
+        await Assert.That(request.Topics[0].Partitions.Count).IsEqualTo(3);
+        await Assert.That(request.Topics[0].Partitions[2].StartOffset).IsEqualTo(300L);
+    }
+
+    #endregion
+
+    #region AlterShareGroupOffsets Request API Metadata
+
+    [Test]
+    public async Task AlterOffsets_Request_ApiKey_IsAlterShareGroupOffsets()
+    {
+        await Assert.That(AlterShareGroupOffsetsRequest.ApiKey).IsEqualTo(ApiKey.AlterShareGroupOffsets);
+    }
+
+    [Test]
+    public async Task AlterOffsets_Request_LowestSupportedVersion_Is0()
+    {
+        await Assert.That(AlterShareGroupOffsetsRequest.LowestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task AlterOffsets_Request_HighestSupportedVersion_Is0()
+    {
+        await Assert.That(AlterShareGroupOffsetsRequest.HighestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    #endregion
+
+    #region AlterShareGroupOffsets Request Encoding
+
+    [Test]
+    public async Task AlterOffsets_Request_Write_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new AlterShareGroupOffsetsRequest
+        {
+            GroupId = "my-group",
+            Topics =
+            [
+                new AlterShareGroupOffsetsRequestTopic
+                {
+                    TopicName = "topic-1",
+                    Partitions =
+                    [
+                        new AlterShareGroupOffsetsRequestPartition
+                        {
+                            PartitionIndex = 0,
+                            StartOffset = 500
+                        }
+                    ]
+                }
+            ]
+        };
+        request.Write(ref writer, version: 0);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    #endregion
+
+    #region AlterShareGroupOffsets Response
+
+    [Test]
+    public async Task AlterOffsets_Response_CanBeConstructed_WithRequiredFields()
+    {
+        var response = new AlterShareGroupOffsetsResponse
+        {
+            Responses = []
+        };
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ErrorMessage).IsNull();
+        await Assert.That(response.Responses.Count).IsEqualTo(0);
+    }
+
+    #endregion
+
+    #region AlterShareGroupOffsets Response API Metadata
+
+    [Test]
+    public async Task AlterOffsets_Response_ApiKey_IsAlterShareGroupOffsets()
+    {
+        await Assert.That(AlterShareGroupOffsetsResponse.ApiKey).IsEqualTo(ApiKey.AlterShareGroupOffsets);
+    }
+
+    [Test]
+    public async Task AlterOffsets_Response_LowestSupportedVersion_Is0()
+    {
+        await Assert.That(AlterShareGroupOffsetsResponse.LowestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task AlterOffsets_Response_HighestSupportedVersion_Is0()
+    {
+        await Assert.That(AlterShareGroupOffsetsResponse.HighestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    #endregion
+
+    #region AlterShareGroupOffsets Response Wire Format
+
+    [Test]
+    public async Task AlterOffsets_Response_Read_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteCompactString("topic-1");  // TopicName
+        writer.WriteUuid(topicId);             // TopicId
+        // Partitions: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt32(0);              // PartitionIndex
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteUnsignedVarInt(0);     // Partition tagged fields
+        writer.WriteUnsignedVarInt(0);     // Topic tagged fields
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (AlterShareGroupOffsetsResponse)AlterShareGroupOffsetsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Responses.Count).IsEqualTo(1);
+        await Assert.That(response.Responses[0].TopicName).IsEqualTo("topic-1");
+        await Assert.That(response.Responses[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(response.Responses[0].Partitions.Count).IsEqualTo(1);
+        await Assert.That(response.Responses[0].Partitions[0].PartitionIndex).IsEqualTo(0);
+        await Assert.That(response.Responses[0].Partitions[0].ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
+    public async Task AlterOffsets_Response_Read_WithErrors_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteCompactString("topic-1");
+        writer.WriteUuid(topicId);
+        // Partitions: 2 elements
+        writer.WriteUnsignedVarInt(2 + 1);
+        // Partition[0] - success
+        writer.WriteInt32(0);
+        writer.WriteInt16(0);
+        writer.WriteUnsignedVarInt(0);
+        writer.WriteUnsignedVarInt(0);
+        // Partition[1] - error
+        writer.WriteInt32(1);
+        writer.WriteInt16(3);              // UnknownTopicOrPartition
+        WriteCompactNullableString(ref writer, "Unknown partition");
+        writer.WriteUnsignedVarInt(0);
+        writer.WriteUnsignedVarInt(0);     // Topic tagged fields
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (AlterShareGroupOffsetsResponse)AlterShareGroupOffsetsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.Responses[0].Partitions.Count).IsEqualTo(2);
+        await Assert.That(response.Responses[0].Partitions[0].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Responses[0].Partitions[1].ErrorCode).IsEqualTo((ErrorCode)3);
+        await Assert.That(response.Responses[0].Partitions[1].ErrorMessage).IsEqualTo("Unknown partition");
+    }
+
+    [Test]
+    public async Task AlterOffsets_Response_Read_TopLevelError_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(50);             // ThrottleTimeMs
+        writer.WriteInt16(29);             // ErrorCode = GroupAuthorizationFailed
+        WriteCompactNullableString(ref writer, "Not authorized");
+        writer.WriteUnsignedVarInt(0 + 1); // Responses: empty
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (AlterShareGroupOffsetsResponse)AlterShareGroupOffsetsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(50);
+        await Assert.That(response.ErrorCode).IsEqualTo((ErrorCode)29);
+        await Assert.That(response.ErrorMessage).IsEqualTo("Not authorized");
+    }
+
+    #endregion
+
+    #region AlterShareGroupOffsets Nested Type Round-Trips
+
+    [Test]
+    public async Task AlterOffsets_RequestTopic_WriteAndRead_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new AlterShareGroupOffsetsRequestTopic
+        {
+            TopicName = "topic-1",
+            Partitions =
+            [
+                new AlterShareGroupOffsetsRequestPartition
+                {
+                    PartitionIndex = 0,
+                    StartOffset = 500
+                },
+                new AlterShareGroupOffsetsRequestPartition
+                {
+                    PartitionIndex = 1,
+                    StartOffset = 1000
+                }
+            ]
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = AlterShareGroupOffsetsRequestTopic.Read(ref reader);
+
+        await Assert.That(deserialized.TopicName).IsEqualTo("topic-1");
+        await Assert.That(deserialized.Partitions.Count).IsEqualTo(2);
+        await Assert.That(deserialized.Partitions[0].StartOffset).IsEqualTo(500L);
+        await Assert.That(deserialized.Partitions[1].StartOffset).IsEqualTo(1000L);
+    }
+
+    [Test]
+    public async Task AlterOffsets_RequestPartition_WriteAndRead_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new AlterShareGroupOffsetsRequestPartition
+        {
+            PartitionIndex = 5,
+            StartOffset = 9999
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = AlterShareGroupOffsetsRequestPartition.Read(ref reader);
+
+        await Assert.That(deserialized.PartitionIndex).IsEqualTo(5);
+        await Assert.That(deserialized.StartOffset).IsEqualTo(9999L);
+    }
+
+    [Test]
+    public async Task AlterOffsets_ResponseTopic_WriteAndRead_RoundTrips()
+    {
+        var topicId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new AlterShareGroupOffsetsResponseTopic
+        {
+            TopicName = "topic-1",
+            TopicId = topicId,
+            Partitions =
+            [
+                new AlterShareGroupOffsetsResponsePartition
+                {
+                    PartitionIndex = 0,
+                    ErrorCode = ErrorCode.None
+                }
+            ]
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = AlterShareGroupOffsetsResponseTopic.Read(ref reader);
+
+        await Assert.That(deserialized.TopicName).IsEqualTo("topic-1");
+        await Assert.That(deserialized.TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.Partitions.Count).IsEqualTo(1);
+    }
+
+    #endregion
+
+    #region DeleteShareGroupOffsets Request
+
+    [Test]
+    public async Task DeleteOffsets_Request_CanBeConstructed_WithRequiredFields()
+    {
+        var request = new DeleteShareGroupOffsetsRequest
+        {
+            GroupId = "my-group",
+            Topics =
+            [
+                new DeleteShareGroupOffsetsRequestTopic
+                {
+                    TopicName = "topic-1"
+                }
+            ]
+        };
+
+        await Assert.That(request.GroupId).IsEqualTo("my-group");
+        await Assert.That(request.Topics.Count).IsEqualTo(1);
+        await Assert.That(request.Topics[0].TopicName).IsEqualTo("topic-1");
+    }
+
+    [Test]
+    public async Task DeleteOffsets_Request_MultipleTopics()
+    {
+        var request = new DeleteShareGroupOffsetsRequest
+        {
+            GroupId = "my-group",
+            Topics =
+            [
+                new DeleteShareGroupOffsetsRequestTopic { TopicName = "topic-1" },
+                new DeleteShareGroupOffsetsRequestTopic { TopicName = "topic-2" },
+                new DeleteShareGroupOffsetsRequestTopic { TopicName = "topic-3" }
+            ]
+        };
+
+        await Assert.That(request.Topics.Count).IsEqualTo(3);
+        await Assert.That(request.Topics[0].TopicName).IsEqualTo("topic-1");
+        await Assert.That(request.Topics[2].TopicName).IsEqualTo("topic-3");
+    }
+
+    #endregion
+
+    #region DeleteShareGroupOffsets Request API Metadata
+
+    [Test]
+    public async Task DeleteOffsets_Request_ApiKey_IsDeleteShareGroupOffsets()
+    {
+        await Assert.That(DeleteShareGroupOffsetsRequest.ApiKey).IsEqualTo(ApiKey.DeleteShareGroupOffsets);
+    }
+
+    [Test]
+    public async Task DeleteOffsets_Request_LowestSupportedVersion_Is0()
+    {
+        await Assert.That(DeleteShareGroupOffsetsRequest.LowestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task DeleteOffsets_Request_HighestSupportedVersion_Is0()
+    {
+        await Assert.That(DeleteShareGroupOffsetsRequest.HighestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    #endregion
+
+    #region DeleteShareGroupOffsets Request Encoding
+
+    [Test]
+    public async Task DeleteOffsets_Request_Write_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new DeleteShareGroupOffsetsRequest
+        {
+            GroupId = "my-group",
+            Topics =
+            [
+                new DeleteShareGroupOffsetsRequestTopic { TopicName = "topic-1" },
+                new DeleteShareGroupOffsetsRequestTopic { TopicName = "topic-2" }
+            ]
+        };
+        request.Write(ref writer, version: 0);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task DeleteOffsets_Request_TopicHasNoPartitions()
+    {
+        // DeleteShareGroupOffsetsRequestTopic has only TopicName, no partition list
+        var topic = new DeleteShareGroupOffsetsRequestTopic
+        {
+            TopicName = "topic-1"
+        };
+
+        await Assert.That(topic.TopicName).IsEqualTo("topic-1");
+    }
+
+    #endregion
+
+    #region DeleteShareGroupOffsets Response
+
+    [Test]
+    public async Task DeleteOffsets_Response_CanBeConstructed_WithRequiredFields()
+    {
+        var response = new DeleteShareGroupOffsetsResponse
+        {
+            Responses = []
+        };
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ErrorMessage).IsNull();
+        await Assert.That(response.Responses.Count).IsEqualTo(0);
+    }
+
+    #endregion
+
+    #region DeleteShareGroupOffsets Response API Metadata
+
+    [Test]
+    public async Task DeleteOffsets_Response_ApiKey_IsDeleteShareGroupOffsets()
+    {
+        await Assert.That(DeleteShareGroupOffsetsResponse.ApiKey).IsEqualTo(ApiKey.DeleteShareGroupOffsets);
+    }
+
+    [Test]
+    public async Task DeleteOffsets_Response_LowestSupportedVersion_Is0()
+    {
+        await Assert.That(DeleteShareGroupOffsetsResponse.LowestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task DeleteOffsets_Response_HighestSupportedVersion_Is0()
+    {
+        await Assert.That(DeleteShareGroupOffsetsResponse.HighestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    #endregion
+
+    #region DeleteShareGroupOffsets Response Wire Format
+
+    [Test]
+    public async Task DeleteOffsets_Response_Read_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteCompactString("topic-1");  // TopicName
+        writer.WriteUuid(topicId);             // TopicId
+        writer.WriteInt16(0);                  // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);         // ErrorMessage = null
+        writer.WriteUnsignedVarInt(0);         // Topic tagged fields
+        writer.WriteUnsignedVarInt(0);         // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (DeleteShareGroupOffsetsResponse)DeleteShareGroupOffsetsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Responses.Count).IsEqualTo(1);
+        await Assert.That(response.Responses[0].TopicName).IsEqualTo("topic-1");
+        await Assert.That(response.Responses[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(response.Responses[0].ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
+    public async Task DeleteOffsets_Response_Read_WithTopicErrors_ParsesCorrectly()
+    {
+        var topicId1 = Guid.NewGuid();
+        var topicId2 = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteInt16(0);              // ErrorCode
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        // Responses: 2 topics
+        writer.WriteUnsignedVarInt(2 + 1);
+        // Topic[0] - success
+        writer.WriteCompactString("topic-1");
+        writer.WriteUuid(topicId1);
+        writer.WriteInt16(0);              // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
+        writer.WriteUnsignedVarInt(0);     // Topic tagged fields
+        // Topic[1] - error
+        writer.WriteCompactString("topic-2");
+        writer.WriteUuid(topicId2);
+        writer.WriteInt16(29);             // ErrorCode = GroupAuthorizationFailed
+        WriteCompactNullableString(ref writer, "Not authorized");
+        writer.WriteUnsignedVarInt(0);     // Topic tagged fields
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (DeleteShareGroupOffsetsResponse)DeleteShareGroupOffsetsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.Responses.Count).IsEqualTo(2);
+        await Assert.That(response.Responses[0].TopicName).IsEqualTo("topic-1");
+        await Assert.That(response.Responses[0].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Responses[1].TopicName).IsEqualTo("topic-2");
+        await Assert.That(response.Responses[1].ErrorCode).IsEqualTo((ErrorCode)29);
+        await Assert.That(response.Responses[1].ErrorMessage).IsEqualTo("Not authorized");
+    }
+
+    [Test]
+    public async Task DeleteOffsets_Response_Read_TopLevelError_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(100);            // ThrottleTimeMs
+        writer.WriteInt16(29);             // ErrorCode = GroupAuthorizationFailed
+        WriteCompactNullableString(ref writer, "Not authorized");
+        writer.WriteUnsignedVarInt(0 + 1); // Responses: empty
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (DeleteShareGroupOffsetsResponse)DeleteShareGroupOffsetsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(100);
+        await Assert.That(response.ErrorCode).IsEqualTo((ErrorCode)29);
+        await Assert.That(response.ErrorMessage).IsEqualTo("Not authorized");
+    }
+
+    #endregion
+
+    #region DeleteShareGroupOffsets Nested Type Round-Trips
+
+    [Test]
+    public async Task DeleteOffsets_RequestTopic_WriteAndRead_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new DeleteShareGroupOffsetsRequestTopic
+        {
+            TopicName = "my-topic"
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = DeleteShareGroupOffsetsRequestTopic.Read(ref reader);
+
+        await Assert.That(deserialized.TopicName).IsEqualTo("my-topic");
+    }
+
+    [Test]
+    public async Task DeleteOffsets_ResponseTopic_WriteAndRead_RoundTrips()
+    {
+        var topicId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new DeleteShareGroupOffsetsResponseTopic
+        {
+            TopicName = "topic-1",
+            TopicId = topicId,
+            ErrorCode = ErrorCode.None
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = DeleteShareGroupOffsetsResponseTopic.Read(ref reader);
+
+        await Assert.That(deserialized.TopicName).IsEqualTo("topic-1");
+        await Assert.That(deserialized.TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(deserialized.ErrorMessage).IsNull();
+    }
+
+    [Test]
+    public async Task DeleteOffsets_ResponseTopic_WriteAndRead_WithError_RoundTrips()
+    {
+        var topicId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new DeleteShareGroupOffsetsResponseTopic
+        {
+            TopicName = "topic-1",
+            TopicId = topicId,
+            ErrorCode = (ErrorCode)3,
+            ErrorMessage = "Unknown topic"
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = DeleteShareGroupOffsetsResponseTopic.Read(ref reader);
+
+        await Assert.That(deserialized.ErrorCode).IsEqualTo((ErrorCode)3);
+        await Assert.That(deserialized.ErrorMessage).IsEqualTo("Unknown topic");
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Helper to write a compact nullable string (varint length+1, then UTF-8 bytes; 0 for null).
+    /// </summary>
+    private static void WriteCompactNullableString(ref KafkaProtocolWriter writer, string? value)
+    {
+        if (value is null)
+        {
+            writer.WriteUnsignedVarInt(0);
+            return;
+        }
+        writer.WriteCompactString(value);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ShareGroupDescribeMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ShareGroupDescribeMessageTests.cs
@@ -1,0 +1,624 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+/// <summary>
+/// Tests for ShareGroupDescribe request and response message encoding/decoding (KIP-932).
+/// </summary>
+public sealed class ShareGroupDescribeMessageTests
+{
+    #region Request Construction
+
+    [Test]
+    public async Task Request_CanBeConstructed_WithRequiredFields()
+    {
+        var request = new ShareGroupDescribeRequest
+        {
+            GroupIds = ["group-1"]
+        };
+
+        await Assert.That(request.GroupIds.Count).IsEqualTo(1);
+        await Assert.That(request.GroupIds[0]).IsEqualTo("group-1");
+    }
+
+    [Test]
+    public async Task Request_CanBeConstructed_WithAllFields()
+    {
+        var request = new ShareGroupDescribeRequest
+        {
+            GroupIds = ["group-1", "group-2"],
+            IncludeAuthorizedOperations = true
+        };
+
+        await Assert.That(request.GroupIds.Count).IsEqualTo(2);
+        await Assert.That(request.IncludeAuthorizedOperations).IsTrue();
+    }
+
+    [Test]
+    public async Task Request_IncludeAuthorizedOperations_DefaultsToFalse()
+    {
+        var request = new ShareGroupDescribeRequest
+        {
+            GroupIds = ["group-1"]
+        };
+
+        await Assert.That(request.IncludeAuthorizedOperations).IsFalse();
+    }
+
+    [Test]
+    public async Task Request_MultipleGroupIds_PreservesOrder()
+    {
+        var request = new ShareGroupDescribeRequest
+        {
+            GroupIds = ["alpha", "beta", "gamma"]
+        };
+
+        await Assert.That(request.GroupIds.Count).IsEqualTo(3);
+        await Assert.That(request.GroupIds[0]).IsEqualTo("alpha");
+        await Assert.That(request.GroupIds[1]).IsEqualTo("beta");
+        await Assert.That(request.GroupIds[2]).IsEqualTo("gamma");
+    }
+
+    #endregion
+
+    #region Request API Metadata
+
+    [Test]
+    public async Task Request_ApiKey_IsShareGroupDescribe()
+    {
+        await Assert.That(ShareGroupDescribeRequest.ApiKey).IsEqualTo(ApiKey.ShareGroupDescribe);
+    }
+
+    [Test]
+    public async Task Request_LowestSupportedVersion_Is1()
+    {
+        await Assert.That(ShareGroupDescribeRequest.LowestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    [Test]
+    public async Task Request_HighestSupportedVersion_Is1()
+    {
+        await Assert.That(ShareGroupDescribeRequest.HighestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    #endregion
+
+    #region Request Encoding
+
+    [Test]
+    public async Task Request_Write_SingleGroup_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ShareGroupDescribeRequest
+        {
+            GroupIds = ["my-group"],
+            IncludeAuthorizedOperations = false
+        };
+        request.Write(ref writer, version: 1);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_MultipleGroups_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ShareGroupDescribeRequest
+        {
+            GroupIds = ["group-1", "group-2", "group-3"],
+            IncludeAuthorizedOperations = true
+        };
+        request.Write(ref writer, version: 1);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_WithAuthorizedOperations_EncodesMoreBytes()
+    {
+        // Both encode the same way since IncludeAuthorizedOperations is a boolean (1 byte),
+        // but verify both variants produce valid output
+        var buffer1 = new ArrayBufferWriter<byte>();
+        var writer1 = new KafkaProtocolWriter(buffer1);
+
+        new ShareGroupDescribeRequest
+        {
+            GroupIds = ["test"],
+            IncludeAuthorizedOperations = false
+        }.Write(ref writer1, version: 1);
+
+        var buffer2 = new ArrayBufferWriter<byte>();
+        var writer2 = new KafkaProtocolWriter(buffer2);
+
+        new ShareGroupDescribeRequest
+        {
+            GroupIds = ["test"],
+            IncludeAuthorizedOperations = true
+        }.Write(ref writer2, version: 1);
+
+        // Same size - boolean field is always 1 byte
+        await Assert.That(buffer1.WrittenCount).IsEqualTo(buffer2.WrittenCount);
+    }
+
+    #endregion
+
+    #region Response Construction
+
+    [Test]
+    public async Task Response_CanBeConstructed_WithRequiredFields()
+    {
+        var response = new ShareGroupDescribeResponse
+        {
+            Groups = []
+        };
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.Groups.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_CanBeConstructed_WithMultipleGroups()
+    {
+        var response = new ShareGroupDescribeResponse
+        {
+            ThrottleTimeMs = 100,
+            Groups =
+            [
+                new ShareGroupDescribeGroup
+                {
+                    GroupId = "group-1",
+                    GroupState = "Stable",
+                    Members = []
+                },
+                new ShareGroupDescribeGroup
+                {
+                    GroupId = "group-2",
+                    GroupState = "Dead",
+                    Members = []
+                }
+            ]
+        };
+
+        await Assert.That(response.Groups.Count).IsEqualTo(2);
+        await Assert.That(response.Groups[0].GroupId).IsEqualTo("group-1");
+        await Assert.That(response.Groups[1].GroupId).IsEqualTo("group-2");
+    }
+
+    [Test]
+    public async Task Response_Group_CanHaveError()
+    {
+        var group = new ShareGroupDescribeGroup
+        {
+            ErrorCode = ErrorCode.GroupAuthorizationFailed,
+            ErrorMessage = "Not authorized",
+            GroupId = "my-group",
+            GroupState = "",
+            Members = []
+        };
+
+        await Assert.That(group.ErrorCode).IsEqualTo(ErrorCode.GroupAuthorizationFailed);
+        await Assert.That(group.ErrorMessage).IsEqualTo("Not authorized");
+    }
+
+    [Test]
+    public async Task Response_Group_AllFieldsPopulated()
+    {
+        var topicId = Guid.NewGuid();
+        var group = new ShareGroupDescribeGroup
+        {
+            ErrorCode = ErrorCode.None,
+            GroupId = "my-group",
+            GroupState = "Stable",
+            GroupEpoch = 5,
+            AssignmentEpoch = 4,
+            AssignorName = "server-side",
+            Members =
+            [
+                new ShareGroupDescribeMember
+                {
+                    MemberId = "member-1",
+                    RackId = "rack-a",
+                    MemberEpoch = 3,
+                    ClientId = "client-1",
+                    ClientHost = "/127.0.0.1",
+                    SubscribedTopicNames = ["topic-1"],
+                    Assignment = new ShareGroupDescribeAssignment
+                    {
+                        TopicPartitions =
+                        [
+                            new ShareGroupDescribeTopicPartitions
+                            {
+                                TopicId = topicId,
+                                TopicName = "topic-1",
+                                Partitions = [0, 1]
+                            }
+                        ]
+                    }
+                }
+            ],
+            AuthorizedOperations = 0x1F
+        };
+
+        await Assert.That(group.GroupEpoch).IsEqualTo(5);
+        await Assert.That(group.AssignmentEpoch).IsEqualTo(4);
+        await Assert.That(group.AssignorName).IsEqualTo("server-side");
+        await Assert.That(group.Members.Count).IsEqualTo(1);
+        await Assert.That(group.AuthorizedOperations).IsEqualTo(0x1F);
+    }
+
+    #endregion
+
+    #region Response API Metadata
+
+    [Test]
+    public async Task Response_ApiKey_IsShareGroupDescribe()
+    {
+        await Assert.That(ShareGroupDescribeResponse.ApiKey).IsEqualTo(ApiKey.ShareGroupDescribe);
+    }
+
+    [Test]
+    public async Task Response_LowestSupportedVersion_Is1()
+    {
+        await Assert.That(ShareGroupDescribeResponse.LowestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    [Test]
+    public async Task Response_HighestSupportedVersion_Is1()
+    {
+        await Assert.That(ShareGroupDescribeResponse.HighestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    #endregion
+
+    #region Response Wire Format Parsing
+
+    [Test]
+    public async Task Response_Read_EmptyGroups_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteUnsignedVarInt(0 + 1); // Groups: empty compact array
+        writer.WriteUnsignedVarInt(0);     // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareGroupDescribeResponse)ShareGroupDescribeResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.Groups.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_Read_WithGroup_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(50);             // ThrottleTimeMs
+        writer.WriteUnsignedVarInt(1 + 1); // Groups: 1 element
+        // Group[0]
+        writer.WriteInt16(0);                          // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);                 // ErrorMessage = null
+        writer.WriteCompactString("my-group");         // GroupId
+        writer.WriteCompactString("Stable");           // GroupState
+        writer.WriteInt32(2);                          // GroupEpoch
+        writer.WriteInt32(2);                          // AssignmentEpoch
+        writer.WriteUnsignedVarInt(0);                 // AssignorName = null
+        writer.WriteUnsignedVarInt(0 + 1);             // Members: empty compact array
+        writer.WriteInt32(-2147483648);                // AuthorizedOperations (INT32_MIN = not requested)
+        writer.WriteUnsignedVarInt(0);                 // Group[0] tagged fields
+        writer.WriteUnsignedVarInt(0);                 // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareGroupDescribeResponse)ShareGroupDescribeResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(50);
+        await Assert.That(response.Groups.Count).IsEqualTo(1);
+        await Assert.That(response.Groups[0].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Groups[0].GroupId).IsEqualTo("my-group");
+        await Assert.That(response.Groups[0].GroupState).IsEqualTo("Stable");
+        await Assert.That(response.Groups[0].GroupEpoch).IsEqualTo(2);
+        await Assert.That(response.Groups[0].AssignmentEpoch).IsEqualTo(2);
+        await Assert.That(response.Groups[0].AssignorName).IsNull();
+        await Assert.That(response.Groups[0].Members.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_Read_WithMemberAndAssignment_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteUnsignedVarInt(1 + 1); // Groups: 1 element
+        // Group[0]
+        writer.WriteInt16(0);                          // ErrorCode
+        writer.WriteUnsignedVarInt(0);                 // ErrorMessage = null
+        writer.WriteCompactString("my-group");         // GroupId
+        writer.WriteCompactString("Stable");           // GroupState
+        writer.WriteInt32(1);                          // GroupEpoch
+        writer.WriteInt32(1);                          // AssignmentEpoch
+        writer.WriteCompactString("server-side");      // AssignorName
+        // Members: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        // Member[0]
+        writer.WriteCompactString("member-1");         // MemberId
+        writer.WriteUnsignedVarInt(0);                 // RackId = null
+        writer.WriteInt32(1);                          // MemberEpoch
+        writer.WriteCompactString("client-1");         // ClientId
+        writer.WriteCompactString("/127.0.0.1");       // ClientHost
+        // SubscribedTopicNames: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteCompactString("topic-1");
+        // Assignment = present
+        writer.WriteInt8(0);
+        // Assignment.TopicPartitions: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteUuid(topicId);
+        writer.WriteCompactString("topic-1");          // TopicName
+        writer.WriteUnsignedVarInt(2 + 1);             // Partitions: 2 elements
+        writer.WriteInt32(0);
+        writer.WriteInt32(1);
+        writer.WriteUnsignedVarInt(0);                 // TopicPartitions[0] tagged fields
+        writer.WriteUnsignedVarInt(0);                 // Assignment tagged fields
+        writer.WriteUnsignedVarInt(0);                 // Member[0] tagged fields
+        writer.WriteInt32(0x1F);                       // AuthorizedOperations
+        writer.WriteUnsignedVarInt(0);                 // Group[0] tagged fields
+        writer.WriteUnsignedVarInt(0);                 // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareGroupDescribeResponse)ShareGroupDescribeResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.Groups.Count).IsEqualTo(1);
+        var group = response.Groups[0];
+        await Assert.That(group.AssignorName).IsEqualTo("server-side");
+        await Assert.That(group.Members.Count).IsEqualTo(1);
+
+        var member = group.Members[0];
+        await Assert.That(member.MemberId).IsEqualTo("member-1");
+        await Assert.That(member.RackId).IsNull();
+        await Assert.That(member.MemberEpoch).IsEqualTo(1);
+        await Assert.That(member.ClientId).IsEqualTo("client-1");
+        await Assert.That(member.ClientHost).IsEqualTo("/127.0.0.1");
+        await Assert.That(member.SubscribedTopicNames.Count).IsEqualTo(1);
+        await Assert.That(member.SubscribedTopicNames[0]).IsEqualTo("topic-1");
+        await Assert.That(member.Assignment).IsNotNull();
+        await Assert.That(member.Assignment!.TopicPartitions.Count).IsEqualTo(1);
+        await Assert.That(member.Assignment.TopicPartitions[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(member.Assignment.TopicPartitions[0].TopicName).IsEqualTo("topic-1");
+        await Assert.That(member.Assignment.TopicPartitions[0].Partitions.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Response_Read_MemberWithNullAssignment_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);              // ThrottleTimeMs
+        writer.WriteUnsignedVarInt(1 + 1); // Groups: 1 element
+        // Group[0]
+        writer.WriteInt16(0);                          // ErrorCode
+        writer.WriteUnsignedVarInt(0);                 // ErrorMessage = null
+        writer.WriteCompactString("my-group");         // GroupId
+        writer.WriteCompactString("Empty");            // GroupState
+        writer.WriteInt32(0);                          // GroupEpoch
+        writer.WriteInt32(0);                          // AssignmentEpoch
+        writer.WriteUnsignedVarInt(0);                 // AssignorName = null
+        // Members: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        // Member[0]
+        writer.WriteCompactString("member-1");
+        writer.WriteUnsignedVarInt(0);                 // RackId = null
+        writer.WriteInt32(0);                          // MemberEpoch
+        writer.WriteCompactString("client-1");
+        writer.WriteCompactString("/127.0.0.1");
+        writer.WriteUnsignedVarInt(0 + 1);             // SubscribedTopicNames: empty
+        writer.WriteInt8(-1);                          // Assignment = null
+        writer.WriteUnsignedVarInt(0);                 // Member[0] tagged fields
+        writer.WriteInt32(-2147483648);                // AuthorizedOperations
+        writer.WriteUnsignedVarInt(0);                 // Group[0] tagged fields
+        writer.WriteUnsignedVarInt(0);                 // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareGroupDescribeResponse)ShareGroupDescribeResponse.Read(ref reader, version: 1);
+
+        var member = response.Groups[0].Members[0];
+        await Assert.That(member.Assignment).IsNull();
+        await Assert.That(member.SubscribedTopicNames.Count).IsEqualTo(0);
+    }
+
+    #endregion
+
+    #region Nested Type Round-Trips
+
+    [Test]
+    public async Task Group_WriteAndRead_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareGroupDescribeGroup
+        {
+            ErrorCode = ErrorCode.None,
+            GroupId = "my-group",
+            GroupState = "Stable",
+            GroupEpoch = 3,
+            AssignmentEpoch = 2,
+            AssignorName = "uniform",
+            Members = [],
+            AuthorizedOperations = 0xFF
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareGroupDescribeGroup.Read(ref reader);
+
+        await Assert.That(deserialized.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(deserialized.GroupId).IsEqualTo("my-group");
+        await Assert.That(deserialized.GroupState).IsEqualTo("Stable");
+        await Assert.That(deserialized.GroupEpoch).IsEqualTo(3);
+        await Assert.That(deserialized.AssignmentEpoch).IsEqualTo(2);
+        await Assert.That(deserialized.AssignorName).IsEqualTo("uniform");
+        await Assert.That(deserialized.Members.Count).IsEqualTo(0);
+        await Assert.That(deserialized.AuthorizedOperations).IsEqualTo(0xFF);
+    }
+
+    [Test]
+    public async Task Member_WriteAndRead_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareGroupDescribeMember
+        {
+            MemberId = "member-1",
+            RackId = "rack-a",
+            MemberEpoch = 2,
+            ClientId = "client-1",
+            ClientHost = "/10.0.0.1",
+            SubscribedTopicNames = ["topic-a", "topic-b"],
+            Assignment = null
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareGroupDescribeMember.Read(ref reader);
+
+        await Assert.That(deserialized.MemberId).IsEqualTo("member-1");
+        await Assert.That(deserialized.RackId).IsEqualTo("rack-a");
+        await Assert.That(deserialized.MemberEpoch).IsEqualTo(2);
+        await Assert.That(deserialized.ClientId).IsEqualTo("client-1");
+        await Assert.That(deserialized.ClientHost).IsEqualTo("/10.0.0.1");
+        await Assert.That(deserialized.SubscribedTopicNames.Count).IsEqualTo(2);
+        await Assert.That(deserialized.Assignment).IsNull();
+    }
+
+    [Test]
+    public async Task Member_WriteAndRead_WithAssignment_RoundTrips()
+    {
+        var topicId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareGroupDescribeMember
+        {
+            MemberId = "member-1",
+            MemberEpoch = 1,
+            ClientId = "client-1",
+            ClientHost = "/127.0.0.1",
+            SubscribedTopicNames = ["topic-1"],
+            Assignment = new ShareGroupDescribeAssignment
+            {
+                TopicPartitions =
+                [
+                    new ShareGroupDescribeTopicPartitions
+                    {
+                        TopicId = topicId,
+                        TopicName = "topic-1",
+                        Partitions = [0, 1, 2]
+                    }
+                ]
+            }
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareGroupDescribeMember.Read(ref reader);
+
+        await Assert.That(deserialized.Assignment).IsNotNull();
+        await Assert.That(deserialized.Assignment!.TopicPartitions.Count).IsEqualTo(1);
+        await Assert.That(deserialized.Assignment.TopicPartitions[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.Assignment.TopicPartitions[0].TopicName).IsEqualTo("topic-1");
+        await Assert.That(deserialized.Assignment.TopicPartitions[0].Partitions.Count).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Assignment_WriteAndRead_RoundTrips()
+    {
+        var topicId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareGroupDescribeAssignment
+        {
+            TopicPartitions =
+            [
+                new ShareGroupDescribeTopicPartitions
+                {
+                    TopicId = topicId,
+                    TopicName = "my-topic",
+                    Partitions = [0]
+                }
+            ]
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareGroupDescribeAssignment.Read(ref reader);
+
+        await Assert.That(deserialized.TopicPartitions.Count).IsEqualTo(1);
+        await Assert.That(deserialized.TopicPartitions[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.TopicPartitions[0].TopicName).IsEqualTo("my-topic");
+    }
+
+    [Test]
+    public async Task TopicPartitions_WriteAndRead_RoundTrips()
+    {
+        var topicId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareGroupDescribeTopicPartitions
+        {
+            TopicId = topicId,
+            TopicName = "topic-1",
+            Partitions = [0, 3, 7]
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareGroupDescribeTopicPartitions.Read(ref reader);
+
+        await Assert.That(deserialized.TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.TopicName).IsEqualTo("topic-1");
+        await Assert.That(deserialized.Partitions.Count).IsEqualTo(3);
+        await Assert.That(deserialized.Partitions[0]).IsEqualTo(0);
+        await Assert.That(deserialized.Partitions[1]).IsEqualTo(3);
+        await Assert.That(deserialized.Partitions[2]).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task TopicPartitions_NullTopicName_RoundTrips()
+    {
+        var topicId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ShareGroupDescribeTopicPartitions
+        {
+            TopicId = topicId,
+            TopicName = null,
+            Partitions = [0]
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareGroupDescribeTopicPartitions.Read(ref reader);
+
+        await Assert.That(deserialized.TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.TopicName).IsNull();
+        await Assert.That(deserialized.Partitions.Count).IsEqualTo(1);
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ShareGroupHeartbeatMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ShareGroupHeartbeatMessageTests.cs
@@ -1,0 +1,572 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+/// <summary>
+/// Tests for ShareGroupHeartbeat request and response message encoding/decoding (KIP-932).
+/// </summary>
+public sealed class ShareGroupHeartbeatMessageTests
+{
+    #region Request Construction
+
+    [Test]
+    public async Task Request_CanBeConstructed_WithRequiredFields()
+    {
+        var request = new ShareGroupHeartbeatRequest
+        {
+            GroupId = "my-group",
+            MemberId = "",
+            MemberEpoch = 0
+        };
+
+        await Assert.That(request.GroupId).IsEqualTo("my-group");
+        await Assert.That(request.MemberId).IsEqualTo("");
+        await Assert.That(request.MemberEpoch).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Request_CanBeConstructed_WithAllFields()
+    {
+        var request = new ShareGroupHeartbeatRequest
+        {
+            GroupId = "my-group",
+            MemberId = "member-1",
+            MemberEpoch = 5,
+            RackId = "rack-a",
+            SubscribedTopicNames = ["topic-1", "topic-2"]
+        };
+
+        await Assert.That(request.GroupId).IsEqualTo("my-group");
+        await Assert.That(request.MemberId).IsEqualTo("member-1");
+        await Assert.That(request.MemberEpoch).IsEqualTo(5);
+        await Assert.That(request.RackId).IsEqualTo("rack-a");
+        await Assert.That(request.SubscribedTopicNames!.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Request_NullableFields_DefaultToNull()
+    {
+        var request = new ShareGroupHeartbeatRequest
+        {
+            GroupId = "my-group",
+            MemberId = "",
+            MemberEpoch = 0
+        };
+
+        await Assert.That(request.RackId).IsNull();
+        await Assert.That(request.SubscribedTopicNames).IsNull();
+    }
+
+    [Test]
+    public async Task Request_MemberEpoch_Zero_MeansJoin()
+    {
+        var request = new ShareGroupHeartbeatRequest
+        {
+            GroupId = "my-group",
+            MemberId = "",
+            MemberEpoch = 0
+        };
+
+        await Assert.That(request.MemberEpoch).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Request_MemberEpoch_NegativeOne_MeansLeave()
+    {
+        var request = new ShareGroupHeartbeatRequest
+        {
+            GroupId = "my-group",
+            MemberId = "member-1",
+            MemberEpoch = -1
+        };
+
+        await Assert.That(request.MemberEpoch).IsEqualTo(-1);
+    }
+
+    #endregion
+
+    #region Request API Metadata
+
+    [Test]
+    public async Task Request_ApiKey_IsShareGroupHeartbeat()
+    {
+        await Assert.That(ShareGroupHeartbeatRequest.ApiKey).IsEqualTo(ApiKey.ShareGroupHeartbeat);
+    }
+
+    [Test]
+    public async Task Request_LowestSupportedVersion_Is1()
+    {
+        await Assert.That(ShareGroupHeartbeatRequest.LowestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    [Test]
+    public async Task Request_HighestSupportedVersion_Is1()
+    {
+        await Assert.That(ShareGroupHeartbeatRequest.HighestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    #endregion
+
+    #region Request Encoding
+
+    [Test]
+    public async Task Request_Write_JoinGroup_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ShareGroupHeartbeatRequest
+        {
+            GroupId = "test",
+            MemberId = "",
+            MemberEpoch = 0,
+            SubscribedTopicNames = ["my-topic"]
+        };
+        request.Write(ref writer, version: 1);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_WithNullOptionalFields_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ShareGroupHeartbeatRequest
+        {
+            GroupId = "test",
+            MemberId = "",
+            MemberEpoch = 0
+        };
+        request.Write(ref writer, version: 1);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_WithRackId_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ShareGroupHeartbeatRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            MemberEpoch = 3,
+            RackId = "rack-a"
+        };
+        request.Write(ref writer, version: 1);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_WithSubscribedTopics_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ShareGroupHeartbeatRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            MemberEpoch = 2,
+            SubscribedTopicNames = ["topic-a", "topic-b", "topic-c"]
+        };
+        request.Write(ref writer, version: 1);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Request_Write_LeaveGroup_EncodesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ShareGroupHeartbeatRequest
+        {
+            GroupId = "test",
+            MemberId = "member-1",
+            MemberEpoch = -1
+        };
+        request.Write(ref writer, version: 1);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    #endregion
+
+    #region Response Construction
+
+    [Test]
+    public async Task Response_CanBeConstructed_WithRequiredFields()
+    {
+        var response = new ShareGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.None
+        };
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.MemberEpoch).IsEqualTo(0);
+        await Assert.That(response.HeartbeatIntervalMs).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_CanBeConstructed_WithAllFields()
+    {
+        var topicId = Guid.NewGuid();
+        var response = new ShareGroupHeartbeatResponse
+        {
+            ThrottleTimeMs = 100,
+            ErrorCode = ErrorCode.None,
+            ErrorMessage = null,
+            MemberId = "member-1",
+            MemberEpoch = 5,
+            HeartbeatIntervalMs = 5000,
+            Assignment = new ShareGroupHeartbeatAssignment
+            {
+                TopicPartitions =
+                [
+                    new ShareGroupHeartbeatTopicPartitions
+                    {
+                        TopicId = topicId,
+                        Partitions = [0, 1, 2]
+                    }
+                ]
+            }
+        };
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(100);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.MemberId).IsEqualTo("member-1");
+        await Assert.That(response.MemberEpoch).IsEqualTo(5);
+        await Assert.That(response.HeartbeatIntervalMs).IsEqualTo(5000);
+        await Assert.That(response.Assignment).IsNotNull();
+        await Assert.That(response.Assignment!.TopicPartitions.Count).IsEqualTo(1);
+        await Assert.That(response.Assignment.TopicPartitions[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(response.Assignment.TopicPartitions[0].Partitions.Count).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Response_Assignment_CanBeNull()
+    {
+        var response = new ShareGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.None,
+            MemberId = "member-1",
+            MemberEpoch = 3,
+            HeartbeatIntervalMs = 5000,
+            Assignment = null
+        };
+
+        await Assert.That(response.Assignment).IsNull();
+    }
+
+    [Test]
+    public async Task Response_WithError_HasErrorMessage()
+    {
+        var response = new ShareGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.GroupAuthorizationFailed,
+            ErrorMessage = "Not authorized"
+        };
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.GroupAuthorizationFailed);
+        await Assert.That(response.ErrorMessage).IsEqualTo("Not authorized");
+    }
+
+    #endregion
+
+    #region Response API Metadata
+
+    [Test]
+    public async Task Response_ApiKey_IsShareGroupHeartbeat()
+    {
+        await Assert.That(ShareGroupHeartbeatResponse.ApiKey).IsEqualTo(ApiKey.ShareGroupHeartbeat);
+    }
+
+    [Test]
+    public async Task Response_LowestSupportedVersion_Is1()
+    {
+        await Assert.That(ShareGroupHeartbeatResponse.LowestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    [Test]
+    public async Task Response_HighestSupportedVersion_Is1()
+    {
+        await Assert.That(ShareGroupHeartbeatResponse.HighestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    #endregion
+
+    #region Response Wire Format Parsing
+
+    [Test]
+    public async Task Response_Read_NullAssignment_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);                     // ThrottleTimeMs
+        writer.WriteInt16(0);                     // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);            // ErrorMessage = null (compact nullable string)
+        WriteCompactNullableString(ref writer, "member-1"); // MemberId
+        writer.WriteInt32(1);                     // MemberEpoch
+        writer.WriteInt32(5000);                  // HeartbeatIntervalMs
+        writer.WriteInt8(-1);                     // Assignment = null (signed byte marker)
+        writer.WriteUnsignedVarInt(0);            // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareGroupHeartbeatResponse)ShareGroupHeartbeatResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(0);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ErrorMessage).IsNull();
+        await Assert.That(response.MemberId).IsEqualTo("member-1");
+        await Assert.That(response.MemberEpoch).IsEqualTo(1);
+        await Assert.That(response.HeartbeatIntervalMs).IsEqualTo(5000);
+        await Assert.That(response.Assignment).IsNull();
+    }
+
+    [Test]
+    public async Task Response_Read_WithAssignment_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);                     // ThrottleTimeMs
+        writer.WriteInt16(0);                     // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);            // ErrorMessage = null
+        WriteCompactNullableString(ref writer, "member-1"); // MemberId
+        writer.WriteInt32(1);                     // MemberEpoch
+        writer.WriteInt32(5000);                  // HeartbeatIntervalMs
+        writer.WriteInt8(1);                      // Assignment = present (signed byte marker)
+        // TopicPartitions compact array: 1 element
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteUuid(topicId);
+        writer.WriteUnsignedVarInt(1 + 1);        // Partitions: 1 element
+        writer.WriteInt32(0);                     // partition 0
+        writer.WriteUnsignedVarInt(0);            // TopicPartitions[0] tagged fields
+        writer.WriteUnsignedVarInt(0);            // Assignment tagged fields
+        writer.WriteUnsignedVarInt(0);            // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareGroupHeartbeatResponse)ShareGroupHeartbeatResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.MemberId).IsEqualTo("member-1");
+        await Assert.That(response.MemberEpoch).IsEqualTo(1);
+        await Assert.That(response.HeartbeatIntervalMs).IsEqualTo(5000);
+        await Assert.That(response.Assignment).IsNotNull();
+        await Assert.That(response.Assignment!.TopicPartitions.Count).IsEqualTo(1);
+        await Assert.That(response.Assignment.TopicPartitions[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(response.Assignment.TopicPartitions[0].Partitions.Count).IsEqualTo(1);
+        await Assert.That(response.Assignment.TopicPartitions[0].Partitions[0]).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_Read_EmptyAssignment_ParsesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);                     // ThrottleTimeMs
+        writer.WriteInt16(0);                     // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);            // ErrorMessage = null
+        WriteCompactNullableString(ref writer, "member-1"); // MemberId
+        writer.WriteInt32(1);                     // MemberEpoch
+        writer.WriteInt32(5000);                  // HeartbeatIntervalMs
+        writer.WriteInt8(1);                      // Assignment = present (signed byte marker)
+        writer.WriteUnsignedVarInt(0 + 1);        // TopicPartitions: empty compact array
+        writer.WriteUnsignedVarInt(0);            // Assignment tagged fields
+        writer.WriteUnsignedVarInt(0);            // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareGroupHeartbeatResponse)ShareGroupHeartbeatResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.Assignment).IsNotNull();
+        await Assert.That(response.Assignment!.TopicPartitions.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_Read_WithMultiplePartitions_ParsesCorrectly()
+    {
+        var topicId = Guid.NewGuid();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(50);                    // ThrottleTimeMs
+        writer.WriteInt16(0);                     // ErrorCode = None
+        writer.WriteUnsignedVarInt(0);            // ErrorMessage = null
+        WriteCompactNullableString(ref writer, "member-uuid"); // MemberId
+        writer.WriteInt32(3);                     // MemberEpoch
+        writer.WriteInt32(3000);                  // HeartbeatIntervalMs
+        writer.WriteInt8(1);                      // Assignment = present
+        // TopicPartitions compact array: 1 topic
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteUuid(topicId);
+        writer.WriteUnsignedVarInt(3 + 1);        // Partitions: 3 elements
+        writer.WriteInt32(0);
+        writer.WriteInt32(1);
+        writer.WriteInt32(2);
+        writer.WriteUnsignedVarInt(0);            // TopicPartitions[0] tagged fields
+        writer.WriteUnsignedVarInt(0);            // Assignment tagged fields
+        writer.WriteUnsignedVarInt(0);            // Response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ShareGroupHeartbeatResponse)ShareGroupHeartbeatResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(50);
+        await Assert.That(response.MemberId).IsEqualTo("member-uuid");
+        await Assert.That(response.MemberEpoch).IsEqualTo(3);
+        await Assert.That(response.HeartbeatIntervalMs).IsEqualTo(3000);
+        await Assert.That(response.Assignment).IsNotNull();
+        await Assert.That(response.Assignment!.TopicPartitions[0].Partitions.Count).IsEqualTo(3);
+        await Assert.That(response.Assignment.TopicPartitions[0].Partitions[0]).IsEqualTo(0);
+        await Assert.That(response.Assignment.TopicPartitions[0].Partitions[1]).IsEqualTo(1);
+        await Assert.That(response.Assignment.TopicPartitions[0].Partitions[2]).IsEqualTo(2);
+    }
+
+    /// <summary>
+    /// Helper to write a compact nullable string (varint length+1, then UTF-8 bytes; 0 for null).
+    /// </summary>
+    private static void WriteCompactNullableString(ref KafkaProtocolWriter writer, string? value)
+    {
+        if (value is null)
+        {
+            writer.WriteUnsignedVarInt(0);
+            return;
+        }
+        writer.WriteCompactString(value);
+    }
+
+    #endregion
+
+    #region TopicPartitions
+
+    [Test]
+    public async Task TopicPartitions_CanBeConstructed()
+    {
+        var topicId = Guid.NewGuid();
+        var tp = new ShareGroupHeartbeatTopicPartitions
+        {
+            TopicId = topicId,
+            Partitions = [0, 1, 2]
+        };
+
+        await Assert.That(tp.TopicId).IsEqualTo(topicId);
+        await Assert.That(tp.Partitions.Count).IsEqualTo(3);
+        await Assert.That(tp.Partitions[0]).IsEqualTo(0);
+        await Assert.That(tp.Partitions[1]).IsEqualTo(1);
+        await Assert.That(tp.Partitions[2]).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task TopicPartitions_Write_ProducesOutput()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var tp = new ShareGroupHeartbeatTopicPartitions
+        {
+            TopicId = Guid.NewGuid(),
+            Partitions = [0, 1]
+        };
+        tp.Write(ref writer);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task TopicPartitions_WriteAndRead_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var topicId = Guid.NewGuid();
+        var original = new ShareGroupHeartbeatTopicPartitions
+        {
+            TopicId = topicId,
+            Partitions = [0, 3, 7]
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareGroupHeartbeatTopicPartitions.Read(ref reader);
+
+        await Assert.That(deserialized.TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.Partitions.Count).IsEqualTo(3);
+        await Assert.That(deserialized.Partitions[0]).IsEqualTo(0);
+        await Assert.That(deserialized.Partitions[1]).IsEqualTo(3);
+        await Assert.That(deserialized.Partitions[2]).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task TopicPartitions_EmptyPartitions_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var topicId = Guid.NewGuid();
+        var original = new ShareGroupHeartbeatTopicPartitions
+        {
+            TopicId = topicId,
+            Partitions = []
+        };
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = ShareGroupHeartbeatTopicPartitions.Read(ref reader);
+
+        await Assert.That(deserialized.TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.Partitions.Count).IsEqualTo(0);
+    }
+
+    #endregion
+
+    #region Assignment
+
+    [Test]
+    public async Task Assignment_CanBeConstructed_WithEmptyList()
+    {
+        var assignment = new ShareGroupHeartbeatAssignment
+        {
+            TopicPartitions = []
+        };
+
+        await Assert.That(assignment.TopicPartitions.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Assignment_CanBeConstructed_WithTopicPartitions()
+    {
+        var topicId = Guid.NewGuid();
+
+        var assignment = new ShareGroupHeartbeatAssignment
+        {
+            TopicPartitions =
+            [
+                new ShareGroupHeartbeatTopicPartitions
+                {
+                    TopicId = topicId,
+                    Partitions = [0, 1]
+                }
+            ]
+        };
+
+        await Assert.That(assignment.TopicPartitions.Count).IsEqualTo(1);
+        await Assert.That(assignment.TopicPartitions[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(assignment.TopicPartitions[0].Partitions.Count).IsEqualTo(2);
+    }
+
+    #endregion
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
@@ -294,4 +294,35 @@ public class AcknowledgementTrackerTests
         await Assert.That(batch.AcknowledgeTypes[1]).IsEqualTo((byte)AcknowledgeType.Release);
         await Assert.That(batch.AcknowledgeTypes[2]).IsEqualTo((byte)AcknowledgeType.Accept);
     }
+
+    [Test]
+    public async Task RequeueAcks_PreservesNewerExplicitAckOverRequeued()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        // Track and flush initial records (all Accept by default)
+        tracker.TrackDeliveredRecords(tp, 10, 12);
+        var flushed = tracker.Flush();
+
+        // Simulate: new records delivered for same offsets (e.g., redelivery after failed commit)
+        tracker.TrackDeliveredRecords(tp, 10, 12);
+        // User explicitly rejects offset 11
+        tracker.Acknowledge(tp, 11, AcknowledgeType.Reject);
+
+        // Now re-queue the stale flushed data (all Accept) — TryAdd should NOT overwrite
+        // the newer Reject that was set after the flush
+        tracker.RequeueAcks(flushed);
+
+        var result = tracker.Flush();
+        await Assert.That(result).ContainsKey(tp);
+
+        var batch = result[tp][0];
+        await Assert.That(batch.FirstOffset).IsEqualTo(10);
+        await Assert.That(batch.LastOffset).IsEqualTo(12);
+        await Assert.That(batch.AcknowledgeTypes[0]).IsEqualTo((byte)AcknowledgeType.Accept);
+        // The explicit Reject should survive — TryAdd preserves the existing entry
+        await Assert.That(batch.AcknowledgeTypes[1]).IsEqualTo((byte)AcknowledgeType.Reject);
+        await Assert.That(batch.AcknowledgeTypes[2]).IsEqualTo((byte)AcknowledgeType.Accept);
+    }
 }

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
@@ -64,29 +64,20 @@ public class AcknowledgementTrackerTests
     }
 
     [Test]
-    public async Task Acknowledge_UnknownOffset_IsIgnored()
+    public async Task Acknowledge_UnknownOffset_Throws()
     {
         var tracker = new AcknowledgementTracker();
         var tp = new TopicPartition("topic1", 0);
 
         tracker.TrackDeliveredRecords(tp, 10, 12);
 
-        // Acknowledge an offset that was never tracked
-        tracker.Acknowledge(tp, 99, AcknowledgeType.Reject);
-
-        var result = tracker.Flush();
-        var batch = result[tp][0];
-
-        // All remain Accept
-        await Assert.That(batch.AcknowledgeTypes.Length).IsEqualTo(3);
-        foreach (byte ackType in batch.AcknowledgeTypes)
-        {
-            await Assert.That(ackType).IsEqualTo((byte)AcknowledgeType.Accept);
-        }
+        // Acknowledge an offset that was never tracked — should throw
+        await Assert.That(() => tracker.Acknowledge(tp, 99, AcknowledgeType.Reject))
+            .Throws<InvalidOperationException>();
     }
 
     [Test]
-    public async Task Acknowledge_UnknownPartition_IsIgnored()
+    public async Task Acknowledge_UnknownPartition_Throws()
     {
         var tracker = new AcknowledgementTracker();
         var tp = new TopicPartition("topic1", 0);
@@ -94,12 +85,9 @@ public class AcknowledgementTrackerTests
 
         tracker.TrackDeliveredRecords(tp, 10, 12);
 
-        // Acknowledge on a partition that was never tracked
-        tracker.Acknowledge(unknownTp, 10, AcknowledgeType.Reject);
-
-        var result = tracker.Flush();
-        await Assert.That(result).ContainsKey(tp);
-        await Assert.That(result.ContainsKey(unknownTp)).IsFalse();
+        // Acknowledge on a partition that was never tracked — should throw
+        await Assert.That(() => tracker.Acknowledge(unknownTp, 10, AcknowledgeType.Reject))
+            .Throws<InvalidOperationException>();
     }
 
     [Test]
@@ -277,5 +265,33 @@ public class AcknowledgementTrackerTests
 
         // Last ack wins
         await Assert.That(result[tp][0].AcknowledgeTypes[1]).IsEqualTo((byte)AcknowledgeType.Reject);
+    }
+
+    [Test]
+    public async Task RequeueAcks_RestoresFlushDataBackIntoTracker()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 10, 12);
+        tracker.Acknowledge(tp, 11, AcknowledgeType.Release);
+
+        var flushed = tracker.Flush();
+        await Assert.That(tracker.HasPending).IsFalse();
+
+        // Re-queue the flushed data
+        tracker.RequeueAcks(flushed);
+        await Assert.That(tracker.HasPending).IsTrue();
+
+        // Flush again — should produce the same batches
+        var result = tracker.Flush();
+        await Assert.That(result).ContainsKey(tp);
+
+        var batch = result[tp][0];
+        await Assert.That(batch.FirstOffset).IsEqualTo(10);
+        await Assert.That(batch.LastOffset).IsEqualTo(12);
+        await Assert.That(batch.AcknowledgeTypes[0]).IsEqualTo((byte)AcknowledgeType.Accept);
+        await Assert.That(batch.AcknowledgeTypes[1]).IsEqualTo((byte)AcknowledgeType.Release);
+        await Assert.That(batch.AcknowledgeTypes[2]).IsEqualTo((byte)AcknowledgeType.Accept);
     }
 }

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
@@ -1,0 +1,281 @@
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public class AcknowledgementTrackerTests
+{
+    [Test]
+    public async Task TrackDeliveredRecords_AllDefaultToAccept()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 10, 14);
+
+        var result = tracker.Flush();
+
+        await Assert.That(result).ContainsKey(tp);
+        await Assert.That(result[tp].Count).IsEqualTo(1);
+
+        var batch = result[tp][0];
+        await Assert.That(batch.FirstOffset).IsEqualTo(10);
+        await Assert.That(batch.LastOffset).IsEqualTo(14);
+        await Assert.That(batch.AcknowledgeTypes.Length).IsEqualTo(5);
+
+        // All should be Accept (1)
+        foreach (byte ackType in batch.AcknowledgeTypes)
+        {
+            await Assert.That(ackType).IsEqualTo((byte)AcknowledgeType.Accept);
+        }
+    }
+
+    [Test]
+    public async Task Acknowledge_ChangesSpecificOffset()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 10, 14);
+        tracker.Acknowledge(tp, 12, AcknowledgeType.Release);
+
+        var result = tracker.Flush();
+        var batch = result[tp][0];
+
+        await Assert.That(batch.AcknowledgeTypes[0]).IsEqualTo((byte)AcknowledgeType.Accept);
+        await Assert.That(batch.AcknowledgeTypes[1]).IsEqualTo((byte)AcknowledgeType.Accept);
+        await Assert.That(batch.AcknowledgeTypes[2]).IsEqualTo((byte)AcknowledgeType.Release);
+        await Assert.That(batch.AcknowledgeTypes[3]).IsEqualTo((byte)AcknowledgeType.Accept);
+        await Assert.That(batch.AcknowledgeTypes[4]).IsEqualTo((byte)AcknowledgeType.Accept);
+    }
+
+    [Test]
+    public async Task Acknowledge_Reject_SetsCorrectType()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 5, 7);
+        tracker.Acknowledge(tp, 6, AcknowledgeType.Reject);
+
+        var result = tracker.Flush();
+        var batch = result[tp][0];
+
+        await Assert.That(batch.AcknowledgeTypes[1]).IsEqualTo((byte)AcknowledgeType.Reject);
+    }
+
+    [Test]
+    public async Task Acknowledge_UnknownOffset_IsIgnored()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 10, 12);
+
+        // Acknowledge an offset that was never tracked
+        tracker.Acknowledge(tp, 99, AcknowledgeType.Reject);
+
+        var result = tracker.Flush();
+        var batch = result[tp][0];
+
+        // All remain Accept
+        await Assert.That(batch.AcknowledgeTypes.Length).IsEqualTo(3);
+        foreach (byte ackType in batch.AcknowledgeTypes)
+        {
+            await Assert.That(ackType).IsEqualTo((byte)AcknowledgeType.Accept);
+        }
+    }
+
+    [Test]
+    public async Task Acknowledge_UnknownPartition_IsIgnored()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+        var unknownTp = new TopicPartition("topic1", 99);
+
+        tracker.TrackDeliveredRecords(tp, 10, 12);
+
+        // Acknowledge on a partition that was never tracked
+        tracker.Acknowledge(unknownTp, 10, AcknowledgeType.Reject);
+
+        var result = tracker.Flush();
+        await Assert.That(result).ContainsKey(tp);
+        await Assert.That(result.ContainsKey(unknownTp)).IsFalse();
+    }
+
+    [Test]
+    public async Task Flush_ClearsTrackedState()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 10, 12);
+
+        var firstFlush = tracker.Flush();
+        await Assert.That(firstFlush).ContainsKey(tp);
+
+        // Second flush should be empty
+        var secondFlush = tracker.Flush();
+        await Assert.That(secondFlush.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task HasPending_TrueAfterTrack_FalseAfterFlush()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        await Assert.That(tracker.HasPending).IsFalse();
+
+        tracker.TrackDeliveredRecords(tp, 0, 2);
+        await Assert.That(tracker.HasPending).IsTrue();
+
+        tracker.Flush();
+        await Assert.That(tracker.HasPending).IsFalse();
+    }
+
+    [Test]
+    public async Task NonConsecutiveOffsets_ProducesSeparateBatches()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        // Track two non-consecutive ranges
+        tracker.TrackDeliveredRecords(tp, 10, 12);
+        tracker.TrackDeliveredRecords(tp, 20, 22);
+
+        var result = tracker.Flush();
+
+        await Assert.That(result[tp].Count).IsEqualTo(2);
+
+        var batch1 = result[tp][0];
+        await Assert.That(batch1.FirstOffset).IsEqualTo(10);
+        await Assert.That(batch1.LastOffset).IsEqualTo(12);
+        await Assert.That(batch1.AcknowledgeTypes.Length).IsEqualTo(3);
+
+        var batch2 = result[tp][1];
+        await Assert.That(batch2.FirstOffset).IsEqualTo(20);
+        await Assert.That(batch2.LastOffset).IsEqualTo(22);
+        await Assert.That(batch2.AcknowledgeTypes.Length).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task MultiplePartitions_TrackedIndependently()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp0 = new TopicPartition("topic1", 0);
+        var tp1 = new TopicPartition("topic1", 1);
+
+        tracker.TrackDeliveredRecords(tp0, 0, 2);
+        tracker.TrackDeliveredRecords(tp1, 100, 102);
+
+        tracker.Acknowledge(tp0, 1, AcknowledgeType.Release);
+        tracker.Acknowledge(tp1, 101, AcknowledgeType.Reject);
+
+        var result = tracker.Flush();
+
+        await Assert.That(result.Count).IsEqualTo(2);
+
+        await Assert.That(result[tp0][0].AcknowledgeTypes[1]).IsEqualTo((byte)AcknowledgeType.Release);
+        await Assert.That(result[tp1][0].AcknowledgeTypes[1]).IsEqualTo((byte)AcknowledgeType.Reject);
+    }
+
+    [Test]
+    public async Task SingleOffset_ProducesSingleElementBatch()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 42, 42);
+
+        var result = tracker.Flush();
+
+        await Assert.That(result[tp].Count).IsEqualTo(1);
+
+        var batch = result[tp][0];
+        await Assert.That(batch.FirstOffset).IsEqualTo(42);
+        await Assert.That(batch.LastOffset).IsEqualTo(42);
+        await Assert.That(batch.AcknowledgeTypes.Length).IsEqualTo(1);
+        await Assert.That(batch.AcknowledgeTypes[0]).IsEqualTo((byte)AcknowledgeType.Accept);
+    }
+
+    [Test]
+    public async Task Acknowledge_Renew_SetsCorrectType()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 0, 2);
+        tracker.Acknowledge(tp, 1, AcknowledgeType.Renew);
+
+        var result = tracker.Flush();
+
+        await Assert.That(result[tp][0].AcknowledgeTypes[1]).IsEqualTo((byte)AcknowledgeType.Renew);
+    }
+
+    [Test]
+    public async Task ConsecutiveRanges_MergedIntoSingleBatch()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        // Track two consecutive ranges — they should merge into one batch
+        tracker.TrackDeliveredRecords(tp, 10, 12);
+        tracker.TrackDeliveredRecords(tp, 13, 15);
+
+        var result = tracker.Flush();
+
+        await Assert.That(result[tp].Count).IsEqualTo(1);
+
+        var batch = result[tp][0];
+        await Assert.That(batch.FirstOffset).IsEqualTo(10);
+        await Assert.That(batch.LastOffset).IsEqualTo(15);
+        await Assert.That(batch.AcknowledgeTypes.Length).IsEqualTo(6);
+    }
+
+    [Test]
+    public async Task MultipleDifferentTopics_TrackedIndependently()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp1 = new TopicPartition("topic-a", 0);
+        var tp2 = new TopicPartition("topic-b", 0);
+
+        tracker.TrackDeliveredRecords(tp1, 0, 1);
+        tracker.TrackDeliveredRecords(tp2, 0, 1);
+
+        tracker.Acknowledge(tp1, 0, AcknowledgeType.Reject);
+
+        var result = tracker.Flush();
+
+        // topic-a offset 0 should be Reject
+        await Assert.That(result[tp1][0].AcknowledgeTypes[0]).IsEqualTo((byte)AcknowledgeType.Reject);
+        // topic-b offset 0 should still be Accept
+        await Assert.That(result[tp2][0].AcknowledgeTypes[0]).IsEqualTo((byte)AcknowledgeType.Accept);
+    }
+
+    [Test]
+    public async Task EmptyTracker_FlushReturnsEmpty()
+    {
+        var tracker = new AcknowledgementTracker();
+
+        var result = tracker.Flush();
+
+        await Assert.That(result.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Acknowledge_OverwritesPreviousAck()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 10, 12);
+
+        tracker.Acknowledge(tp, 11, AcknowledgeType.Release);
+        tracker.Acknowledge(tp, 11, AcknowledgeType.Reject);
+
+        var result = tracker.Flush();
+
+        // Last ack wins
+        await Assert.That(result[tp][0].AcknowledgeTypes[1]).IsEqualTo((byte)AcknowledgeType.Reject);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareSessionManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareSessionManagerTests.cs
@@ -1,0 +1,131 @@
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public class ShareSessionManagerTests
+{
+    [Test]
+    public async Task NewSession_ReturnsEpochZero()
+    {
+        var manager = new ShareSessionManager();
+
+        var epoch = manager.GetSessionEpoch(brokerId: 1);
+
+        await Assert.That(epoch).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task AfterIncrement_EpochIsOne()
+    {
+        var manager = new ShareSessionManager();
+
+        manager.IncrementEpoch(brokerId: 1);
+
+        var epoch = manager.GetSessionEpoch(brokerId: 1);
+
+        await Assert.That(epoch).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task MultipleIncrements_EpochIncrementsEachTime()
+    {
+        var manager = new ShareSessionManager();
+
+        manager.IncrementEpoch(brokerId: 1);
+        manager.IncrementEpoch(brokerId: 1);
+        manager.IncrementEpoch(brokerId: 1);
+
+        var epoch = manager.GetSessionEpoch(brokerId: 1);
+
+        await Assert.That(epoch).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task ResetSession_ReturnsToEpochZero()
+    {
+        var manager = new ShareSessionManager();
+
+        manager.IncrementEpoch(brokerId: 1);
+        manager.IncrementEpoch(brokerId: 1);
+
+        manager.ResetSession(brokerId: 1);
+
+        var epoch = manager.GetSessionEpoch(brokerId: 1);
+
+        await Assert.That(epoch).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CloseEpoch_ReturnsMinusOne()
+    {
+        await Assert.That(ShareSessionManager.CloseEpoch).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task MultipleBrokers_TrackedIndependently()
+    {
+        var manager = new ShareSessionManager();
+
+        manager.IncrementEpoch(brokerId: 1);
+        manager.IncrementEpoch(brokerId: 1);
+        manager.IncrementEpoch(brokerId: 2);
+
+        await Assert.That(manager.GetSessionEpoch(brokerId: 1)).IsEqualTo(2);
+        await Assert.That(manager.GetSessionEpoch(brokerId: 2)).IsEqualTo(1);
+        await Assert.That(manager.GetSessionEpoch(brokerId: 3)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ResetAll_ClearsAllSessions()
+    {
+        var manager = new ShareSessionManager();
+
+        manager.IncrementEpoch(brokerId: 1);
+        manager.IncrementEpoch(brokerId: 2);
+        manager.IncrementEpoch(brokerId: 3);
+
+        manager.ResetAll();
+
+        await Assert.That(manager.GetSessionEpoch(brokerId: 1)).IsEqualTo(0);
+        await Assert.That(manager.GetSessionEpoch(brokerId: 2)).IsEqualTo(0);
+        await Assert.That(manager.GetSessionEpoch(brokerId: 3)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ResetSession_OnlyAffectsTargetBroker()
+    {
+        var manager = new ShareSessionManager();
+
+        manager.IncrementEpoch(brokerId: 1);
+        manager.IncrementEpoch(brokerId: 2);
+
+        manager.ResetSession(brokerId: 1);
+
+        await Assert.That(manager.GetSessionEpoch(brokerId: 1)).IsEqualTo(0);
+        await Assert.That(manager.GetSessionEpoch(brokerId: 2)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ResetSession_NonExistentBroker_DoesNotThrow()
+    {
+        var manager = new ShareSessionManager();
+
+        // Should not throw
+        manager.ResetSession(brokerId: 999);
+
+        await Assert.That(manager.GetSessionEpoch(brokerId: 999)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task IncrementAfterReset_StartsFromOne()
+    {
+        var manager = new ShareSessionManager();
+
+        manager.IncrementEpoch(brokerId: 1);
+        manager.IncrementEpoch(brokerId: 1);
+        manager.ResetSession(brokerId: 1);
+        manager.IncrementEpoch(brokerId: 1);
+
+        await Assert.That(manager.GetSessionEpoch(brokerId: 1)).IsEqualTo(1);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareSessionManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareSessionManagerTests.cs
@@ -58,7 +58,8 @@ public class ShareSessionManagerTests
     [Test]
     public async Task CloseEpoch_ReturnsMinusOne()
     {
-        await Assert.That(ShareSessionManager.CloseEpoch).IsEqualTo(-1);
+        var closeEpoch = ShareSessionManager.CloseEpoch;
+        await Assert.That(closeEpoch).IsEqualTo(-1);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Implements KIP-932: Share Groups — Kafka's queue-semantics consumption model with record-level acknowledgement. Closes #821.

### Protocol Messages (7 new API pairs)
- **ShareGroupHeartbeat (API 76)** — group membership via the new share group coordinator
- **ShareGroupDescribe (API 77)** — describe share group state and members
- **ShareFetch (API 78)** — fetch with acquired records, delivery counts, and inline acknowledgements; supports share session epochs for incremental fetching
- **ShareAcknowledge (API 79)** — standalone acknowledgement with per-record type arrays (Accept, Release, Reject, Renew)
- **DescribeShareGroupOffsets (API 90)** — query share group start offsets
- **AlterShareGroupOffsets (API 91)** — modify share group start offsets
- **DeleteShareGroupOffsets (API 92)** — delete share group offsets by topic

### Share Consumer Client
- `IKafkaShareConsumer<TKey, TValue>` interface with `PollAsync`, `Acknowledge`, `CommitAsync`, `CloseAsync`
- `KafkaShareConsumer` — full implementation with coordinator, session management, and acknowledgement tracking
- `ShareConsumerCoordinator` — group membership via ShareGroupHeartbeat with background heartbeat loop
- `ShareSessionManager` — per-broker share fetch session epoch tracking
- `AcknowledgementTracker` — batches per-record acknowledgements, coalesces adjacent same-type ranges for wire efficiency
- `ShareConsumerBuilder<TKey, TValue>` — fluent builder following existing Dekaf patterns
- `Kafka.CreateShareConsumer<TKey, TValue>()` factory methods

### Admin Operations
- `DescribeShareGroupsAsync` — describe share group state and members
- `ListShareGroupsAsync` — list share groups with optional state filtering
- `DescribeShareGroupOffsetsAsync` — query share group start offsets per partition
- `AlterShareGroupOffsetsAsync` — alter share group start offsets
- `DeleteShareGroupOffsetsAsync` — delete share group offsets by topic

### Tests
- **184 protocol unit tests** — serialization round-trips, version-conditional fields, nullable handling, wire format parsing for all 7 message pairs
- **25 share consumer unit tests** — AcknowledgementTracker (15 tests) and ShareSessionManager (10 tests)
- **9 integration tests** — single consumer flow, subscribe/unsubscribe, delivery count, commit, builder config, member ID, and admin operations (describe, list, offsets)
- Integration tests require Kafka 4.2+ with `group.share.enable=true` via new `KafkaContainer42`

### Key Design Decisions
- Composition over inheritance — share consumer reuses `IConnectionPool`, `MetadataManager`, `IDeserializer<T>`, and `RecordBatch` from the regular consumer without subclassing
- Inline fetch acknowledgements (piggybacked on ShareFetch) plus standalone ShareAcknowledge for explicit commits
- Zero-allocation `FindDeliveryCount` via linear scan over acquired record ranges (typically 1–3 ranges per partition)
- Parallel `CommitAsync` — acknowledges to multiple brokers concurrently via `Task.WhenAll`

## Test plan
- [x] All 209 unit tests pass (`ShareGroup*`, `ShareFetch*`, `ShareAcknowledge*`, `AcknowledgementTracker*`, `ShareSessionManager*`)
- [x] Integration tests build successfully (require Kafka 4.2+ Docker container at runtime)
- [x] `dotnet build` succeeds with no compilation errors
- [ ] CI integration tests against Kafka 4.2+ container