### PR TITLE
fix(protocol): correct inline struct deserialization for ShareFetch and ShareGroupDescribe

### DIFF
--- a/src/Dekaf/Protocol/Messages/ShareFetchRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ShareFetchRequest.cs
@@ -97,8 +97,8 @@ public sealed class ShareFetchRequest : IKafkaRequest<ShareFetchResponse>
             static (ref KafkaProtocolWriter w, ShareFetchRequestTopic tp, short v) => tp.Write(ref w, v),
             version);
 
-        writer.WriteCompactNullableArray(
-            ForgottenTopicsData,
+        writer.WriteCompactArray(
+            ForgottenTopicsData ?? [],
             static (ref KafkaProtocolWriter w, ShareFetchForgottenTopic ft) => ft.Write(ref w));
 
         writer.WriteEmptyTaggedFields();
@@ -176,8 +176,8 @@ public sealed class ShareFetchRequestPartition
             writer.WriteInt32(PartitionMaxBytes);
         }
 
-        writer.WriteCompactNullableArray(
-            AcknowledgementBatches,
+        writer.WriteCompactArray(
+            AcknowledgementBatches ?? [],
             static (ref KafkaProtocolWriter w, ShareFetchAcknowledgementBatch b) => b.Write(ref w));
 
         writer.WriteEmptyTaggedFields();
@@ -193,17 +193,8 @@ public sealed class ShareFetchRequestPartition
             partitionMaxBytes = reader.ReadInt32();
         }
 
-        var ackBatchLength = reader.ReadUnsignedVarInt() - 1;
-        IReadOnlyList<ShareFetchAcknowledgementBatch>? acknowledgementBatches = null;
-        if (ackBatchLength > 0)
-        {
-            var batches = new ShareFetchAcknowledgementBatch[ackBatchLength];
-            for (var i = 0; i < ackBatchLength; i++)
-            {
-                batches[i] = ShareFetchAcknowledgementBatch.Read(ref reader);
-            }
-            acknowledgementBatches = batches;
-        }
+        var acknowledgementBatches = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ShareFetchAcknowledgementBatch.Read(ref r));
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/ShareFetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareFetchResponse.cs
@@ -137,9 +137,9 @@ public sealed class ShareFetchResponsePartition
     public string? AcknowledgeErrorMessage { get; init; }
 
     /// <summary>
-    /// The current leader information, or null if not available.
+    /// The current leader information. Always present inline in the response.
     /// </summary>
-    public ShareFetchLeaderIdAndEpoch? CurrentLeader { get; init; }
+    public required ShareFetchLeaderIdAndEpoch CurrentLeader { get; init; }
 
     /// <summary>
     /// Raw record batch bytes. Use the protocol Records decoder to parse.
@@ -159,21 +159,16 @@ public sealed class ShareFetchResponsePartition
         var acknowledgeErrorCode = (ErrorCode)reader.ReadInt16();
         var acknowledgeErrorMessage = reader.ReadCompactString();
 
-        // Nullable non-tagged struct: single signed byte marker (-1 = null, >= 0 = present)
-        var currentLeaderMarker = reader.ReadInt8();
-        ShareFetchLeaderIdAndEpoch? currentLeader = null;
-        if (currentLeaderMarker >= 0)
-        {
-            var leaderId = reader.ReadInt32();
-            var leaderEpoch = reader.ReadInt32();
-            reader.SkipTaggedFields();
+        // CurrentLeader is non-nullable — always present inline (no marker byte)
+        var leaderId = reader.ReadInt32();
+        var leaderEpoch = reader.ReadInt32();
+        reader.SkipTaggedFields();
 
-            currentLeader = new ShareFetchLeaderIdAndEpoch
-            {
-                LeaderId = leaderId,
-                LeaderEpoch = leaderEpoch
-            };
-        }
+        var currentLeader = new ShareFetchLeaderIdAndEpoch
+        {
+            LeaderId = leaderId,
+            LeaderEpoch = leaderEpoch
+        };
 
         // COMPACT_RECORDS: length+1 encoded as unsigned varint, 0 = null
         var recordsLength = reader.ReadUnsignedVarInt() - 1;

--- a/src/Dekaf/Protocol/Messages/ShareGroupDescribeResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareGroupDescribeResponse.cs
@@ -175,9 +175,9 @@ public sealed class ShareGroupDescribeMember
     public required IReadOnlyList<string> SubscribedTopicNames { get; init; }
 
     /// <summary>
-    /// The assignment for this member, or null if there is no assignment.
+    /// The assignment for this member.
     /// </summary>
-    public ShareGroupDescribeAssignment? Assignment { get; init; }
+    public required ShareGroupDescribeAssignment Assignment { get; init; }
 
     public void Write(ref KafkaProtocolWriter writer)
     {
@@ -191,16 +191,7 @@ public sealed class ShareGroupDescribeMember
             SubscribedTopicNames,
             static (ref KafkaProtocolWriter w, string topic) => w.WriteCompactString(topic));
 
-        // Nullable non-tagged struct: single signed byte marker (-1 = null, >= 0 = present)
-        if (Assignment is not null)
-        {
-            writer.WriteInt8(0);
-            Assignment.Write(ref writer);
-        }
-        else
-        {
-            writer.WriteInt8(-1);
-        }
+        Assignment.Write(ref writer);
 
         writer.WriteEmptyTaggedFields();
     }
@@ -216,13 +207,7 @@ public sealed class ShareGroupDescribeMember
         var subscribedTopicNames = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty);
 
-        // Nullable non-tagged struct: single signed byte marker (-1 = null, >= 0 = present)
-        var assignmentMarker = reader.ReadInt8();
-        ShareGroupDescribeAssignment? assignment = null;
-        if (assignmentMarker >= 0)
-        {
-            assignment = ShareGroupDescribeAssignment.Read(ref reader);
-        }
+        var assignment = ShareGroupDescribeAssignment.Read(ref reader);
 
         reader.SkipTaggedFields();
 

--- a/tests/Dekaf.Tests.Integration/KafkaContainer42.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainer42.cs
@@ -28,9 +28,19 @@ public class KafkaContainer42 : KafkaTestContainer
                 UnixFileModes.UserRead | UnixFileModes.UserWrite | UnixFileModes.UserExecute |
                 UnixFileModes.GroupRead | UnixFileModes.GroupExecute |
                 UnixFileModes.OtherRead | UnixFileModes.OtherExecute)
+            // Enable share groups (KIP-932). Requires two pieces:
+            // 1. group.share.enable — gates the share group client protocol
+            // 2. group.coordinator.rebalance.protocols must include "share"
+            //    for the coordinator to handle share group state
             .WithEnvironment("KAFKA_GROUP_SHARE_ENABLE", "true")
+            .WithEnvironment("KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS", "classic,consumer,share")
             .WithEnvironment("KAFKA_GROUP_SHARE_RECORD_LOCK_DURATION_MS", "15000")
             .WithEnvironment("KAFKA_GROUP_SHARE_MIN_RECORD_LOCK_DURATION_MS", "5000")
-            .WithEnvironment("KAFKA_GROUP_SHARE_MAX_RECORD_LOCK_DURATION_MS", "60000");
+            .WithEnvironment("KAFKA_GROUP_SHARE_MAX_RECORD_LOCK_DURATION_MS", "60000")
+            // Single-broker: the internal __share_group_state topic requires settings
+            // compatible with a single-node cluster.
+            .WithEnvironment("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR", "1")
+            .WithEnvironment("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR", "1")
+            .WithEnvironment("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_NUM_PARTITIONS", "3");
     }
 }

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -7,6 +7,12 @@ namespace Dekaf.Tests.Integration;
 /// <summary>
 /// Integration tests for the share consumer (KIP-932).
 /// Requires Kafka 4.2+ with group.share.enable=true.
+///
+/// Share groups use a Share Partition Start Offset (SPSO) that is set when the
+/// share coordinator first initializes a share-partition. Records must be produced
+/// AFTER the consumer has joined the group for them to be within the acquisition
+/// window. All tests follow this pattern: subscribe, start polling (triggers group
+/// join), produce in background, receive messages.
 /// </summary>
 [Category("ShareConsumer")]
 [SupportsKafka(420)]
@@ -15,7 +21,6 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
     [Test]
     public async Task ShareConsumer_SingleConsumer_ReceivesAllMessages()
     {
-        // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 3);
         var groupId = $"share-group-{Guid.NewGuid():N}";
 
@@ -24,19 +29,6 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        for (int i = 0; i < 5; i++)
-        {
-            await producer.ProduceAsync(new ProducerMessage<string, string>
-            {
-                Topic = topic,
-                Key = $"key-{i}",
-                Value = $"value-{i}"
-            });
-        }
-
-        await producer.FlushAsync();
-
-        // Act
         await using var consumer = await Kafka.CreateShareConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithGroupId(groupId)
@@ -45,16 +37,23 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
 
         consumer.Subscribe(topic);
 
+        var produceTask = ProduceAfterDelayAsync(producer, topic, count: 5);
+
         var messages = new List<ShareConsumeResult<string, string>>();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        await foreach (var msg in consumer.PollAsync(cts.Token))
+        try
         {
-            messages.Add(msg);
-            if (messages.Count >= 5) break;
+            await foreach (var msg in consumer.PollAsync(cts.Token))
+            {
+                messages.Add(msg);
+                if (messages.Count >= 5) break;
+            }
         }
+        catch (OperationCanceledException) { }
 
-        // Assert
+        await produceTask;
+
         await Assert.That(messages.Count).IsEqualTo(5);
 
         var values = messages.Select(m => m.Value).OrderBy(v => v).ToList();
@@ -67,7 +66,6 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
     [Test]
     public async Task ShareConsumer_Subscribe_Unsubscribe_Works()
     {
-        // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync();
         var groupId = $"share-group-{Guid.NewGuid():N}";
 
@@ -77,7 +75,6 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        // Act
         consumer.Subscribe(topic);
         await Assert.That(consumer.Subscription.Count).IsEqualTo(1);
         await Assert.That(consumer.Subscription.Contains(topic)).IsTrue();
@@ -89,7 +86,6 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
     [Test]
     public async Task ShareConsumer_DeliveryCount_IsAtLeastOne()
     {
-        // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync();
         var groupId = $"share-group-{Guid.NewGuid():N}";
 
@@ -98,16 +94,6 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        await producer.ProduceAsync(new ProducerMessage<string, string>
-        {
-            Topic = topic,
-            Key = "key",
-            Value = "value"
-        });
-
-        await producer.FlushAsync();
-
-        // Act
         await using var consumer = await Kafka.CreateShareConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithGroupId(groupId)
@@ -116,16 +102,23 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
 
         consumer.Subscribe(topic);
 
+        var produceTask = ProduceAfterDelayAsync(producer, topic, count: 1);
+
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         ShareConsumeResult<string, string>? result = null;
 
-        await foreach (var msg in consumer.PollAsync(cts.Token))
+        try
         {
-            result = msg;
-            break;
+            await foreach (var msg in consumer.PollAsync(cts.Token))
+            {
+                result = msg;
+                break;
+            }
         }
+        catch (OperationCanceledException) { }
 
-        // Assert
+        await produceTask;
+
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.DeliveryCount).IsGreaterThanOrEqualTo(1);
     }
@@ -133,7 +126,6 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
     [Test]
     public async Task ShareConsumer_CommitAsync_FlushesAcknowledgements()
     {
-        // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync();
         var groupId = $"share-group-{Guid.NewGuid():N}";
 
@@ -142,16 +134,6 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        await producer.ProduceAsync(new ProducerMessage<string, string>
-        {
-            Topic = topic,
-            Key = "key",
-            Value = "value"
-        });
-
-        await producer.FlushAsync();
-
-        // Act
         await using var consumer = await Kafka.CreateShareConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithGroupId(groupId)
@@ -160,13 +142,21 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
 
         consumer.Subscribe(topic);
 
+        var produceTask = ProduceAfterDelayAsync(producer, topic, count: 1);
+
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        await foreach (var msg in consumer.PollAsync(cts.Token))
+        try
         {
-            consumer.Acknowledge(msg, AcknowledgeType.Accept);
-            break;
+            await foreach (var msg in consumer.PollAsync(cts.Token))
+            {
+                consumer.Acknowledge(msg, AcknowledgeType.Accept);
+                break;
+            }
         }
+        catch (OperationCanceledException) { }
+
+        await produceTask;
 
         // Should not throw
         await consumer.CommitAsync(CancellationToken.None);
@@ -195,7 +185,6 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
     [Test]
     public async Task ShareConsumer_MemberId_IsSetAfterJoining()
     {
-        // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync();
         var groupId = $"share-group-{Guid.NewGuid():N}";
 
@@ -204,16 +193,6 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        await producer.ProduceAsync(new ProducerMessage<string, string>
-        {
-            Topic = topic,
-            Key = "key",
-            Value = "value"
-        });
-
-        await producer.FlushAsync();
-
-        // Act
         await using var consumer = await Kafka.CreateShareConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithGroupId(groupId)
@@ -222,16 +201,29 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
 
         consumer.Subscribe(topic);
 
+        var produceTask = ProduceAfterDelayAsync(producer, topic, count: 1);
+
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        await foreach (var msg in consumer.PollAsync(cts.Token))
+        try
         {
-            break;
+            await foreach (var msg in consumer.PollAsync(cts.Token))
+            {
+                break;
+            }
         }
+        catch (OperationCanceledException) { }
 
-        // Assert — after polling, MemberId should be set
+        await produceTask;
+
+        // After polling, MemberId should be set
         await Assert.That(consumer.MemberId).IsNotNull();
     }
+
+    private static Task ProduceAfterDelayAsync(
+        IKafkaProducer<string, string> producer, string topic, int count,
+        int delayMs = 5000)
+        => ShareConsumerTestHelper.ProduceAfterDelayAsync(producer, topic, count, delayMs);
 }
 
 /// <summary>
@@ -254,15 +246,6 @@ public class ShareConsumerAdminTests(KafkaTestContainer kafka) : KafkaIntegratio
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        await producer.ProduceAsync(new ProducerMessage<string, string>
-        {
-            Topic = topic,
-            Key = "key",
-            Value = "value"
-        });
-
-        await producer.FlushAsync();
-
         await using var consumer = await Kafka.CreateShareConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithGroupId(groupId)
@@ -271,12 +254,21 @@ public class ShareConsumerAdminTests(KafkaTestContainer kafka) : KafkaIntegratio
 
         consumer.Subscribe(topic);
 
-        // Poll to ensure group is active
+        var produceTask = ProduceAfterDelayAsync(producer, topic);
+
+        // Poll to ensure group is active and has received a message
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        await foreach (var msg in consumer.PollAsync(cts.Token))
+
+        try
         {
-            break;
+            await foreach (var msg in consumer.PollAsync(cts.Token))
+            {
+                break;
+            }
         }
+        catch (OperationCanceledException) { }
+
+        await produceTask;
 
         // Act
         await using var adminClient = KafkaContainer.CreateAdminClient();
@@ -302,15 +294,6 @@ public class ShareConsumerAdminTests(KafkaTestContainer kafka) : KafkaIntegratio
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        await producer.ProduceAsync(new ProducerMessage<string, string>
-        {
-            Topic = topic,
-            Key = "key",
-            Value = "value"
-        });
-
-        await producer.FlushAsync();
-
         await using var consumer = await Kafka.CreateShareConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithGroupId(groupId)
@@ -319,12 +302,21 @@ public class ShareConsumerAdminTests(KafkaTestContainer kafka) : KafkaIntegratio
 
         consumer.Subscribe(topic);
 
+        var produceTask = ProduceAfterDelayAsync(producer, topic);
+
         // Poll to ensure group is active
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        await foreach (var msg in consumer.PollAsync(cts.Token))
+
+        try
         {
-            break;
+            await foreach (var msg in consumer.PollAsync(cts.Token))
+            {
+                break;
+            }
         }
+        catch (OperationCanceledException) { }
+
+        await produceTask;
 
         // Act
         await using var adminClient = KafkaContainer.CreateAdminClient();
@@ -347,15 +339,6 @@ public class ShareConsumerAdminTests(KafkaTestContainer kafka) : KafkaIntegratio
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        await producer.ProduceAsync(new ProducerMessage<string, string>
-        {
-            Topic = topic,
-            Key = "key",
-            Value = "value"
-        });
-
-        await producer.FlushAsync();
-
         await using var consumer = await Kafka.CreateShareConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithGroupId(groupId)
@@ -364,12 +347,21 @@ public class ShareConsumerAdminTests(KafkaTestContainer kafka) : KafkaIntegratio
 
         consumer.Subscribe(topic);
 
+        var produceTask = ProduceAfterDelayAsync(producer, topic);
+
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        await foreach (var msg in consumer.PollAsync(cts.Token))
+
+        try
         {
-            consumer.Acknowledge(msg, AcknowledgeType.Accept);
-            break;
+            await foreach (var msg in consumer.PollAsync(cts.Token))
+            {
+                consumer.Acknowledge(msg, AcknowledgeType.Accept);
+                break;
+            }
         }
+        catch (OperationCanceledException) { }
+
+        await produceTask;
 
         await consumer.CommitAsync();
 
@@ -383,5 +375,37 @@ public class ShareConsumerAdminTests(KafkaTestContainer kafka) : KafkaIntegratio
         await Assert.That(offsets.Count).IsGreaterThanOrEqualTo(1);
         var offset = offsets.First(o => o.TopicPartition.Topic == topic);
         await Assert.That(offset.StartOffset).IsGreaterThanOrEqualTo(0);
+    }
+
+    private static Task ProduceAfterDelayAsync(
+        IKafkaProducer<string, string> producer, string topic, int delayMs = 5000)
+        => ShareConsumerTestHelper.ProduceAfterDelayAsync(producer, topic, count: 1, delayMs);
+}
+
+/// <summary>
+/// Shared helper for share consumer integration tests.
+/// Produces messages after a delay to allow the share consumer to join the group
+/// and initialize share partitions. This is necessary because share groups start
+/// from the Share Partition Start Offset (SPSO), which is set when the share
+/// coordinator first loads the partition.
+/// </summary>
+internal static class ShareConsumerTestHelper
+{
+    internal static async Task ProduceAfterDelayAsync(
+        IKafkaProducer<string, string> producer, string topic, int count,
+        int delayMs = 5000)
+    {
+        await Task.Delay(delayMs);
+        for (int i = 0; i < count; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = $"key-{i}",
+                Value = $"value-{i}"
+            });
+        }
+
+        await producer.FlushAsync();
     }
 }

--- a/tests/Dekaf.Tests.Unit/Protocol/ShareFetchMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ShareFetchMessageTests.cs
@@ -435,16 +435,18 @@ public sealed class ShareFetchMessageTests
     }
 
     [Test]
-    public async Task Response_Partition_CurrentLeader_CanBeNull()
+    public async Task Response_Partition_CurrentLeader_DefaultsToUnknown()
     {
         var partition = new ShareFetchResponsePartition
         {
             PartitionIndex = 0,
             ErrorCode = ErrorCode.None,
+            CurrentLeader = new ShareFetchLeaderIdAndEpoch(),
             AcquiredRecords = []
         };
 
-        await Assert.That(partition.CurrentLeader).IsNull();
+        await Assert.That(partition.CurrentLeader.LeaderId).IsEqualTo(-1);
+        await Assert.That(partition.CurrentLeader.LeaderEpoch).IsEqualTo(-1);
     }
 
     [Test]
@@ -453,6 +455,7 @@ public sealed class ShareFetchMessageTests
         var partition = new ShareFetchResponsePartition
         {
             PartitionIndex = 0,
+            CurrentLeader = new ShareFetchLeaderIdAndEpoch(),
             AcquiredRecords = []
         };
 
@@ -593,7 +596,9 @@ public sealed class ShareFetchMessageTests
         writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
         writer.WriteInt16(0);              // AcknowledgeErrorCode = None
         writer.WriteUnsignedVarInt(0);     // AcknowledgeErrorMessage = null
-        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderId (default)
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderEpoch (default)
+        writer.WriteUnsignedVarInt(0);     // CurrentLeader tagged fields
         writer.WriteUnsignedVarInt(0);     // RecordBytes = null (length+1=0)
         // AcquiredRecords: 1 element
         writer.WriteUnsignedVarInt(1 + 1);
@@ -618,7 +623,9 @@ public sealed class ShareFetchMessageTests
         await Assert.That(partition.PartitionIndex).IsEqualTo(0);
         await Assert.That(partition.ErrorCode).IsEqualTo(ErrorCode.None);
         await Assert.That(partition.AcknowledgeErrorCode).IsEqualTo(ErrorCode.None);
-        await Assert.That(partition.CurrentLeader).IsNull();
+        await Assert.That(partition.CurrentLeader).IsNotNull();
+        await Assert.That(partition.CurrentLeader!.LeaderId).IsEqualTo(-1);
+        await Assert.That(partition.CurrentLeader.LeaderEpoch).IsEqualTo(-1);
         await Assert.That(partition.RecordBytes.Length).IsEqualTo(0);
         await Assert.That(partition.AcquiredRecords.Count).IsEqualTo(1);
         await Assert.That(partition.AcquiredRecords[0].FirstOffset).IsEqualTo(0L);
@@ -647,9 +654,8 @@ public sealed class ShareFetchMessageTests
         writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
         writer.WriteInt16(0);              // AcknowledgeErrorCode
         writer.WriteUnsignedVarInt(0);     // AcknowledgeErrorMessage = null
-        writer.WriteInt8(1);               // CurrentLeader = present
-        writer.WriteInt32(3);              // LeaderId
-        writer.WriteInt32(7);              // LeaderEpoch
+        writer.WriteInt32(3);              // CurrentLeader.LeaderId
+        writer.WriteInt32(7);              // CurrentLeader.LeaderEpoch
         writer.WriteUnsignedVarInt(0);     // CurrentLeader tagged fields
         writer.WriteUnsignedVarInt(0);     // RecordBytes = null
         writer.WriteUnsignedVarInt(0 + 1); // AcquiredRecords: empty
@@ -689,7 +695,9 @@ public sealed class ShareFetchMessageTests
         writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
         writer.WriteInt16(0);              // AcknowledgeErrorCode
         writer.WriteUnsignedVarInt(0);     // AcknowledgeErrorMessage = null
-        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderId (default)
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderEpoch (default)
+        writer.WriteUnsignedVarInt(0);     // CurrentLeader tagged fields
         // RecordBytes: 5 bytes (length+1 = 6)
         writer.WriteUnsignedVarInt(recordData.Length + 1);
         writer.WriteRawBytes(recordData);
@@ -729,7 +737,9 @@ public sealed class ShareFetchMessageTests
         writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
         writer.WriteInt16(75);             // AcknowledgeErrorCode (non-zero)
         WriteCompactNullableString(ref writer, "Invalid acknowledgement"); // AcknowledgeErrorMessage
-        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderId (default)
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderEpoch (default)
+        writer.WriteUnsignedVarInt(0);     // CurrentLeader tagged fields
         writer.WriteUnsignedVarInt(0);     // RecordBytes = null
         writer.WriteUnsignedVarInt(0 + 1); // AcquiredRecords: empty
         writer.WriteUnsignedVarInt(0);     // Partition tagged fields
@@ -806,7 +816,9 @@ public sealed class ShareFetchMessageTests
         writer.WriteUnsignedVarInt(0);     // ErrorMessage = null
         writer.WriteInt16(0);              // AcknowledgeErrorCode
         writer.WriteUnsignedVarInt(0);     // AcknowledgeErrorMessage = null
-        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderId (default)
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderEpoch (default)
+        writer.WriteUnsignedVarInt(0);     // CurrentLeader tagged fields
         writer.WriteUnsignedVarInt(0);     // RecordBytes = null
         // AcquiredRecords: 3 elements
         writer.WriteUnsignedVarInt(3 + 1);
@@ -866,7 +878,9 @@ public sealed class ShareFetchMessageTests
         WriteCompactNullableString(ref writer, "Not the leader"); // ErrorMessage
         writer.WriteInt16(0);              // AcknowledgeErrorCode
         writer.WriteUnsignedVarInt(0);     // AcknowledgeErrorMessage = null
-        writer.WriteInt8(-1);              // CurrentLeader = null
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderId (default)
+        writer.WriteInt32(-1);             // CurrentLeader.LeaderEpoch (default)
+        writer.WriteUnsignedVarInt(0);     // CurrentLeader tagged fields
         writer.WriteUnsignedVarInt(0);     // RecordBytes = null
         writer.WriteUnsignedVarInt(0 + 1); // AcquiredRecords: empty
         writer.WriteUnsignedVarInt(0);     // Partition tagged fields

--- a/tests/Dekaf.Tests.Unit/Protocol/ShareGroupDescribeMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ShareGroupDescribeMessageTests.cs
@@ -359,8 +359,7 @@ public sealed class ShareGroupDescribeMessageTests
         // SubscribedTopicNames: 1 element
         writer.WriteUnsignedVarInt(1 + 1);
         writer.WriteCompactString("topic-1");
-        // Assignment = present
-        writer.WriteInt8(0);
+        // Assignment (inline, no marker byte)
         // Assignment.TopicPartitions: 1 element
         writer.WriteUnsignedVarInt(1 + 1);
         writer.WriteUuid(topicId);
@@ -399,7 +398,7 @@ public sealed class ShareGroupDescribeMessageTests
     }
 
     [Test]
-    public async Task Response_Read_MemberWithNullAssignment_ParsesCorrectly()
+    public async Task Response_Read_MemberWithEmptyAssignment_ParsesCorrectly()
     {
         var buffer = new ArrayBufferWriter<byte>();
         var writer = new KafkaProtocolWriter(buffer);
@@ -423,7 +422,9 @@ public sealed class ShareGroupDescribeMessageTests
         writer.WriteCompactString("client-1");
         writer.WriteCompactString("/127.0.0.1");
         writer.WriteUnsignedVarInt(0 + 1);             // SubscribedTopicNames: empty
-        writer.WriteInt8(-1);                          // Assignment = null
+        // Assignment (inline, no marker byte)
+        writer.WriteUnsignedVarInt(0 + 1);             // Assignment.TopicPartitions: empty compact array
+        writer.WriteUnsignedVarInt(0);                 // Assignment tagged fields
         writer.WriteUnsignedVarInt(0);                 // Member[0] tagged fields
         writer.WriteInt32(-2147483648);                // AuthorizedOperations
         writer.WriteUnsignedVarInt(0);                 // Group[0] tagged fields
@@ -433,7 +434,7 @@ public sealed class ShareGroupDescribeMessageTests
         var response = (ShareGroupDescribeResponse)ShareGroupDescribeResponse.Read(ref reader, version: 1);
 
         var member = response.Groups[0].Members[0];
-        await Assert.That(member.Assignment).IsNull();
+        await Assert.That(member.Assignment.TopicPartitions.Count).IsEqualTo(0);
         await Assert.That(member.SubscribedTopicNames.Count).IsEqualTo(0);
     }
 
@@ -487,7 +488,10 @@ public sealed class ShareGroupDescribeMessageTests
             ClientId = "client-1",
             ClientHost = "/10.0.0.1",
             SubscribedTopicNames = ["topic-a", "topic-b"],
-            Assignment = null
+            Assignment = new ShareGroupDescribeAssignment
+            {
+                TopicPartitions = []
+            }
         };
         original.Write(ref writer);
 
@@ -500,7 +504,7 @@ public sealed class ShareGroupDescribeMessageTests
         await Assert.That(deserialized.ClientId).IsEqualTo("client-1");
         await Assert.That(deserialized.ClientHost).IsEqualTo("/10.0.0.1");
         await Assert.That(deserialized.SubscribedTopicNames.Count).IsEqualTo(2);
-        await Assert.That(deserialized.Assignment).IsNull();
+        await Assert.That(deserialized.Assignment.TopicPartitions.Count).IsEqualTo(0);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- **ShareFetchResponse.CurrentLeader** and **ShareGroupDescribeResponse.Assignment** were deserialized using a signed-byte marker pattern, but these structs have no `nullableVersions` in the Kafka schema — they are always present inline with no marker byte. The marker read was consuming the first byte of the struct's data (e.g. the high byte of `LeaderId`), causing silent data corruption that happened to work because leader IDs are small numbers.
- **ShareFetchRequest**: `ForgottenTopicsData` and `AcknowledgementBatches` used `WriteCompactNullableArray` but are not nullable on the wire. Switched to `WriteCompactArray` with `?? []` fallback. Simplified ack batch reading to use `ReadCompactArray`.
- Updated unit tests to match corrected wire format (inline fields instead of marker bytes).
- Updated integration tests for KafkaContainer42 and share consumer flows.

These changes were developed during PR #836 review but were not included in the final merge.

## Test plan

- [x] All 184 share group unit tests pass locally
- [ ] CI: Build & Unit Test
- [ ] CI: Integration Tests
- [ ] CI: Code Quality