### PR TITLE
feat(transactions): KIP-1050 standardized transaction error handling

### DIFF
--- a/src/Dekaf/Errors/KafkaException.cs
+++ b/src/Dekaf/Errors/KafkaException.cs
@@ -291,7 +291,15 @@ public sealed class GroupException : KafkaException
 /// <summary>
 /// Exception thrown when a transaction operation fails.
 /// </summary>
-public sealed class TransactionException : KafkaException
+/// <remarks>
+/// KIP-1050 categorizes transaction errors so callers can react consistently.
+/// The category is expressed through the concrete type:
+/// <see cref="AbortableTransactionException"/> (abort the current transaction, then reuse
+/// the producer) and <see cref="FatalTransactionException"/> (close the producer and create
+/// a new instance). A plain <see cref="TransactionException"/> carries no specific recovery
+/// requirement.
+/// </remarks>
+public class TransactionException : KafkaException
 {
     public TransactionException() : base()
     {
@@ -313,6 +321,54 @@ public sealed class TransactionException : KafkaException
     /// The transactional ID.
     /// </summary>
     public string? TransactionalId { get; init; }
+}
+
+/// <summary>
+/// Exception thrown when a transactional operation fails with an abortable error.
+/// The current transaction is broken and must be rolled back by calling
+/// <c>AbortAsync()</c>; the producer remains usable for a new transaction afterward.
+/// </summary>
+public sealed class AbortableTransactionException : TransactionException
+{
+    public AbortableTransactionException() : base()
+    {
+    }
+
+    public AbortableTransactionException(string message) : base(message)
+    {
+    }
+
+    public AbortableTransactionException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    public AbortableTransactionException(ErrorCode errorCode, string message) : base(errorCode, message)
+    {
+    }
+}
+
+/// <summary>
+/// Exception thrown when a transactional operation fails with a fatal error, such as the
+/// producer being fenced. The producer is irrecoverably broken and must be closed; create a
+/// new producer instance to continue producing transactionally.
+/// </summary>
+public sealed class FatalTransactionException : TransactionException
+{
+    public FatalTransactionException() : base()
+    {
+    }
+
+    public FatalTransactionException(string message) : base(message)
+    {
+    }
+
+    public FatalTransactionException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    public FatalTransactionException(ErrorCode errorCode, string message) : base(errorCode, message)
+    {
+    }
 }
 
 /// <summary>

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -78,6 +78,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private volatile bool _idempotentInitialized;
     private int _transactionCoordinatorId = -1;
     internal volatile TransactionState _transactionState = TransactionState.Uninitialized;
+    // The error code that drove the transaction into AbortableError/FatalError, surfaced by
+    // the fail-fast produce guard for context. ErrorCode is short-backed, so volatile is valid.
+    internal volatile ErrorCode _lastTransactionError = ErrorCode.None;
     private readonly SemaphoreSlim _transactionLock = new(1, 1);
     private readonly System.Threading.Lock _epochBumpLock = new();
     internal readonly System.Threading.Lock _partitionsInTransactionLock = new();
@@ -362,6 +365,31 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             throw new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>));
 
         ThrowIfNotInitialized();
+
+        // KIP-1050 fail-fast: once a transaction is broken, reject new produces so the caller must
+        // abort (abortable) or close the producer (fatal) before continuing. Single volatile read
+        // on the hot path; only transactional producers ever reach the error states.
+        if (_options.TransactionalId is not null)
+        {
+            var txnState = _transactionState;
+            if (txnState == TransactionState.AbortableError)
+            {
+                throw new AbortableTransactionException(_lastTransactionError,
+                    "Cannot produce: the current transaction has an abortable error and must be aborted.")
+                {
+                    TransactionalId = _options.TransactionalId
+                };
+            }
+
+            if (txnState == TransactionState.FatalError)
+            {
+                throw new FatalTransactionException(_lastTransactionError,
+                    "Cannot produce: the producer is in a fatal error state and must be closed.")
+                {
+                    TransactionalId = _options.TransactionalId
+                };
+            }
+        }
 
         // Check cancellation upfront before any work
         cancellationToken.ThrowIfCancellationRequested();
@@ -1175,6 +1203,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 "Producer is in a fatal error state and cannot begin new transactions.");
         }
 
+        if (_transactionState == TransactionState.AbortableError)
+        {
+            throw new InvalidOperationException(
+                "The current transaction has an abortable error. Call AbortAsync() before beginning a new transaction.");
+        }
+
         if (_transactionState == TransactionState.InTransaction)
         {
             throw new InvalidOperationException(
@@ -1188,6 +1222,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         _transactionState = TransactionState.InTransaction;
+        _lastTransactionError = ErrorCode.None;
         _currentTransactionUsesTV2 = _metadataManager.GetFinalizedFeatureVersion(TransactionVersionFeature) >= 2;
         lock (_partitionsInTransactionLock)
         {
@@ -1229,6 +1264,46 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// Re-initializes the producer ID/epoch via the transaction coordinator.
     /// Called after abort to get the bumped epoch (KIP-360), and during initial setup.
     /// </summary>
+    /// <summary>
+    /// Builds the transaction exception whose type reflects the KIP-1050 classification, and
+    /// records the error code for the fail-fast produce guard. Does not change transaction state.
+    /// </summary>
+    private TransactionException CreateTransactionException(
+        ErrorCode errorCode, TransactionErrorClassification classification, string message)
+    {
+        _lastTransactionError = errorCode;
+        return classification switch
+        {
+            TransactionErrorClassification.Fatal =>
+                new FatalTransactionException(errorCode, message) { TransactionalId = _options.TransactionalId },
+            TransactionErrorClassification.Abortable =>
+                new AbortableTransactionException(errorCode, message) { TransactionalId = _options.TransactionalId },
+            _ =>
+                new TransactionException(errorCode, message) { TransactionalId = _options.TransactionalId },
+        };
+    }
+
+    /// <summary>
+    /// Handles a non-<see cref="ErrorCode.None"/> transactional error. Returns normally when the error
+    /// is retriable (the caller should back off and retry). For fatal errors it transitions to
+    /// <see cref="TransactionState.FatalError"/> and for abortable errors to
+    /// <see cref="TransactionState.AbortableError"/>, then throws the matching typed exception.
+    /// </summary>
+    private void ThrowIfNonRetriableTransactionError(ErrorCode errorCode, string operation, bool tv2)
+    {
+        var classification = TransactionErrorClassifier.Classify(errorCode, tv2);
+        if (classification == TransactionErrorClassification.Retriable)
+        {
+            return;
+        }
+
+        _transactionState = classification == TransactionErrorClassification.Fatal
+            ? TransactionState.FatalError
+            : TransactionState.AbortableError;
+
+        throw CreateTransactionException(errorCode, classification, $"{operation} failed: {errorCode}");
+    }
+
     internal async ValueTask ReinitializeProducerIdAsync(CancellationToken cancellationToken)
     {
         const int maxRetries = 10;
@@ -1257,45 +1332,38 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     request, initProducerIdVersion, cancellationToken)
                 .ConfigureAwait(false);
 
-            if (response.ErrorCode == ErrorCode.ProducerFenced ||
-                response.ErrorCode == ErrorCode.TransactionalIdAuthorizationFailed)
-            {
-                _transactionState = TransactionState.FatalError;
-                throw new TransactionException(response.ErrorCode,
-                    $"InitProducerId failed with fatal error: {response.ErrorCode}")
-                {
-                    TransactionalId = _options.TransactionalId
-                };
-            }
-
-            if (response.ErrorCode is ErrorCode.CoordinatorLoadInProgress
-                or ErrorCode.CoordinatorNotAvailable
-                or ErrorCode.ConcurrentTransactions)
-            {
-                LogInitProducerIdRetriableError(response.ErrorCode, attempt + 1, maxRetries, retryDelayMs);
-
-                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
-                continue;
-            }
-
-            if (response.ErrorCode == ErrorCode.NotCoordinator)
-            {
-                LogInitProducerIdNotCoordinator(attempt + 1, maxRetries);
-
-                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
-                await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
-                continue;
-            }
-
             if (response.ErrorCode != ErrorCode.None)
             {
-                throw new TransactionException(response.ErrorCode,
-                    $"InitProducerId failed: {response.ErrorCode}")
+                var classification = TransactionErrorClassifier.Classify(response.ErrorCode, _currentTransactionUsesTV2);
+
+                if (classification == TransactionErrorClassification.Retriable)
                 {
-                    TransactionalId = _options.TransactionalId
-                };
+                    if (response.ErrorCode == ErrorCode.NotCoordinator)
+                    {
+                        LogInitProducerIdNotCoordinator(attempt + 1, maxRetries);
+
+                        await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                        retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                        await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    LogInitProducerIdRetriableError(response.ErrorCode, attempt + 1, maxRetries, retryDelayMs);
+
+                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                    continue;
+                }
+
+                // InitProducerId runs before a transaction is active, so abortable errors do not
+                // transition to AbortableError; only fatal errors mark the producer unusable.
+                if (classification == TransactionErrorClassification.Fatal)
+                {
+                    _transactionState = TransactionState.FatalError;
+                }
+
+                throw CreateTransactionException(response.ErrorCode, classification,
+                    $"InitProducerId failed: {response.ErrorCode}");
             }
 
             _producerId = response.ProducerId;
@@ -1478,11 +1546,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             if (firstNonRetriableError.HasValue)
             {
-                throw new TransactionException(firstNonRetriableError.Value,
-                    $"AddPartitionsToTxn failed for {errorContext}: {firstNonRetriableError.Value}")
-                {
-                    TransactionalId = _options.TransactionalId
-                };
+                // Runs on the BrokerSender background path: transitioning to AbortableError/FatalError
+                // here is what makes subsequent ProduceAsync calls fail fast. This error is not in the
+                // classifier's retriable set, so the call always throws (never returns).
+                ThrowIfNonRetriableTransactionError(
+                    firstNonRetriableError.Value,
+                    $"AddPartitionsToTxn for {errorContext}",
+                    _currentTransactionUsesTV2);
             }
 
             if (!hasRetriableError)
@@ -1552,38 +1622,26 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             var classification = TransactionErrorClassifier.Classify(response.ErrorCode, _currentTransactionUsesTV2);
 
-            switch (classification)
+            if (classification == TransactionErrorClassification.Retriable)
             {
-                case TransactionErrorClassification.Fatal:
-                    _transactionState = TransactionState.FatalError;
-                    throw new TransactionException(response.ErrorCode,
-                        $"EndTxn ({(committed ? "commit" : "abort")}) failed: {response.ErrorCode}")
-                    {
-                        TransactionalId = _options.TransactionalId
-                    };
-
-                case TransactionErrorClassification.Retriable:
-                    if (response.ErrorCode == ErrorCode.NotCoordinator)
-                    {
-                        LogEndTxnNotCoordinator(attempt + 1, maxRetries);
-                        await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                        retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
-                        await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
-                        continue;
-                    }
-
-                    LogEndTxnRetriableError(response.ErrorCode, attempt + 1, maxRetries, retryDelayMs);
+                if (response.ErrorCode == ErrorCode.NotCoordinator)
+                {
+                    LogEndTxnNotCoordinator(attempt + 1, maxRetries);
                     await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
                     retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                    await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
                     continue;
+                }
 
-                default: // Abortable or unknown
-                    throw new TransactionException(response.ErrorCode,
-                        $"EndTxn ({(committed ? "commit" : "abort")}) failed: {response.ErrorCode}")
-                    {
-                        TransactionalId = _options.TransactionalId
-                    };
+                LogEndTxnRetriableError(response.ErrorCode, attempt + 1, maxRetries, retryDelayMs);
+                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                continue;
             }
+
+            // Fatal or abortable: transition state and throw the matching typed exception.
+            ThrowIfNonRetriableTransactionError(response.ErrorCode,
+                $"EndTxn ({(committed ? "commit" : "abort")})", _currentTransactionUsesTV2);
         }
 
         throw new TransactionException(ErrorCode.CoordinatorLoadInProgress,
@@ -1593,17 +1651,21 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         };
     }
 
-    internal ValueTask SendOffsetsToTransactionInternalAsync(
+    internal async ValueTask SendOffsetsToTransactionInternalAsync(
         IEnumerable<TopicPartitionOffset> offsets,
         string consumerGroupId,
         CancellationToken cancellationToken)
     {
-        // The entire three-step sequence (AddOffsetsToTxn -> FindCoordinator -> TxnOffsetCommit)
-        // is wrapped in a single retry lambda. If Step 1 succeeds but Step 2 or 3 fails, the
-        // retry re-executes Step 1. This is safe because AddOffsetsToTxn is idempotent in Kafka's
-        // transaction protocol — calling it multiple times with the same group ID within the same
-        // transaction epoch has no additional effect.
-        return RetryHelper.WithRetryAsync(async () =>
+        // The three-step sequence (AddOffsetsToTxn -> FindCoordinator -> TxnOffsetCommit) is retried
+        // as a unit. If a later step fails, the retry re-executes Step 1 — safe because AddOffsetsToTxn
+        // is idempotent within a transaction epoch. Errors are classified through
+        // TransactionErrorClassifier (the single source of retriability for transactional ops) rather
+        // than RetryHelper, whose IsRetriable predicate does not cover codes like ConcurrentTransactions.
+        const int maxRetries = 5;
+        var retryDelayMs = 100;
+        var tv2 = _currentTransactionUsesTV2;
+
+        for (var attempt = 0; attempt < maxRetries; attempt++)
         {
             // Step 1: Add offsets to the transaction via the transaction coordinator
             var connection = await _connectionPool.GetConnectionAsync(_transactionCoordinatorId, cancellationToken)
@@ -1629,11 +1691,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             if (addOffsetsResponse.ErrorCode != ErrorCode.None)
             {
-                throw new TransactionException(addOffsetsResponse.ErrorCode,
-                    $"AddOffsetsToTxn failed: {addOffsetsResponse.ErrorCode}")
-                {
-                    TransactionalId = _options.TransactionalId
-                };
+                // Retriable -> back off and restart the sequence; fatal/abortable -> throws typed exception.
+                ThrowIfNonRetriableTransactionError(addOffsetsResponse.ErrorCode, "AddOffsetsToTxn", tv2);
+                if (addOffsetsResponse.ErrorCode == ErrorCode.NotCoordinator)
+                    await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                continue;
             }
 
             // Step 2: Find the group coordinator
@@ -1659,11 +1723,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             if (findCoordResponse.Coordinators.Count == 0)
             {
-                throw new TransactionException(ErrorCode.CoordinatorNotAvailable,
-                    "FindCoordinator returned an empty Coordinators array")
-                {
-                    TransactionalId = _options.TransactionalId
-                };
+                // Treat an empty coordinator set as transiently unavailable and retry.
+                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                continue;
             }
 
             var coord = findCoordResponse.Coordinators[0];
@@ -1671,11 +1734,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             if (coord.ErrorCode != ErrorCode.None)
             {
-                throw new TransactionException(coord.ErrorCode,
-                    $"FindCoordinator for consumer group '{consumerGroupId}' failed: {coord.ErrorCode}")
-                {
-                    TransactionalId = _options.TransactionalId
-                };
+                ThrowIfNonRetriableTransactionError(coord.ErrorCode,
+                    $"FindCoordinator for consumer group '{consumerGroupId}'", tv2);
+                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                continue;
             }
 
             // Step 3: Send TxnOffsetCommit to the group coordinator
@@ -1727,22 +1790,43 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     txnOffsetCommitRequest, txnOffsetCommitVersion, cancellationToken)
                 .ConfigureAwait(false);
 
-            // Check for errors
+            // Check for errors across all partitions
+            ErrorCode? commitError = null;
+            string? commitContext = null;
             foreach (var topicResult in txnOffsetCommitResponse.Topics)
             {
                 foreach (var partitionResult in topicResult.Partitions)
                 {
                     if (partitionResult.ErrorCode != ErrorCode.None)
                     {
-                        throw new TransactionException(partitionResult.ErrorCode,
-                            $"TxnOffsetCommit failed for {topicResult.Name}-{partitionResult.PartitionIndex}: {partitionResult.ErrorCode}")
-                        {
-                            TransactionalId = _options.TransactionalId
-                        };
+                        commitError = partitionResult.ErrorCode;
+                        commitContext = $"TxnOffsetCommit for {topicResult.Name}-{partitionResult.PartitionIndex}";
+                        break;
                     }
                 }
+
+                if (commitError.HasValue)
+                    break;
             }
-        }, _metadataManager, cancellationToken);
+
+            if (commitError.HasValue)
+            {
+                ThrowIfNonRetriableTransactionError(commitError.Value, commitContext!, tv2);
+                if (commitError.Value == ErrorCode.NotCoordinator)
+                    await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                continue;
+            }
+
+            return; // All three steps succeeded
+        }
+
+        throw new TransactionException(ErrorCode.CoordinatorLoadInProgress,
+            $"SendOffsetsToTransaction failed after {maxRetries} retries")
+        {
+            TransactionalId = _options.TransactionalId
+        };
     }
 
     /// <inheritdoc />
@@ -3128,7 +3212,13 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
             {
                 _producer._partitionsInTransaction.Clear();
             }
-            _producer._transactionState = TransactionState.Ready;
+
+            // Preserve an error state set while ending the transaction (fail-fast relies on it);
+            // otherwise return to Ready for the next transaction.
+            if (_producer._transactionState is not (TransactionState.AbortableError or TransactionState.FatalError))
+            {
+                _producer._transactionState = TransactionState.Ready;
+            }
         }
     }
 
@@ -3161,7 +3251,13 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
             {
                 _producer._partitionsInTransaction.Clear();
             }
-            _producer._transactionState = TransactionState.Ready;
+
+            // A successful abort clears the abortable state; only leave the producer non-Ready if
+            // ending the transaction itself failed fatally/abortably.
+            if (_producer._transactionState is not (TransactionState.AbortableError or TransactionState.FatalError))
+            {
+                _producer._transactionState = TransactionState.Ready;
+            }
         }
     }
 
@@ -3182,9 +3278,9 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
     public async ValueTask DisposeAsync()
     {
         if (!_committed && !_aborted && !_producer.IsDisposed
-            && _producer._transactionState == TransactionState.InTransaction)
+            && _producer._transactionState is TransactionState.InTransaction or TransactionState.AbortableError)
         {
-            // Abort on dispose if not completed and transaction is actually in progress
+            // Abort on dispose if not completed and a transaction is in progress or abortable
             try
             {
                 await AbortAsync().ConfigureAwait(false);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1620,28 +1620,24 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 return;
             }
 
-            var classification = TransactionErrorClassifier.Classify(response.ErrorCode, _currentTransactionUsesTV2);
+            // Fatal or abortable errors transition state and throw the matching typed exception;
+            // this returns only for retriable errors, which are handled with backoff below.
+            ThrowIfNonRetriableTransactionError(response.ErrorCode,
+                $"EndTxn ({(committed ? "commit" : "abort")})", _currentTransactionUsesTV2);
 
-            if (classification == TransactionErrorClassification.Retriable)
+            if (response.ErrorCode == ErrorCode.NotCoordinator)
             {
-                if (response.ErrorCode == ErrorCode.NotCoordinator)
-                {
-                    LogEndTxnNotCoordinator(attempt + 1, maxRetries);
-                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
-                    await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
-                    continue;
-                }
-
-                LogEndTxnRetriableError(response.ErrorCode, attempt + 1, maxRetries, retryDelayMs);
+                LogEndTxnNotCoordinator(attempt + 1, maxRetries);
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
                 retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+                await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
                 continue;
             }
 
-            // Fatal or abortable: transition state and throw the matching typed exception.
-            ThrowIfNonRetriableTransactionError(response.ErrorCode,
-                $"EndTxn ({(committed ? "commit" : "abort")})", _currentTransactionUsesTV2);
+            LogEndTxnRetriableError(response.ErrorCode, attempt + 1, maxRetries, retryDelayMs);
+            await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+            retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
+            continue;
         }
 
         throw new TransactionException(ErrorCode.CoordinatorLoadInProgress,
@@ -3208,17 +3204,25 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
         }
         finally
         {
-            lock (_producer._partitionsInTransactionLock)
-            {
-                _producer._partitionsInTransaction.Clear();
-            }
+            FinalizeTransactionState();
+        }
+    }
 
-            // Preserve an error state set while ending the transaction (fail-fast relies on it);
-            // otherwise return to Ready for the next transaction.
-            if (_producer._transactionState is not (TransactionState.AbortableError or TransactionState.FatalError))
-            {
-                _producer._transactionState = TransactionState.Ready;
-            }
+    /// <summary>
+    /// Clears the transaction's partition set and returns the producer to
+    /// <see cref="TransactionState.Ready"/> for the next transaction — unless ending the transaction
+    /// left it in an error state, which the fail-fast produce guard relies on being preserved.
+    /// </summary>
+    private void FinalizeTransactionState()
+    {
+        lock (_producer._partitionsInTransactionLock)
+        {
+            _producer._partitionsInTransaction.Clear();
+        }
+
+        if (_producer._transactionState is not (TransactionState.AbortableError or TransactionState.FatalError))
+        {
+            _producer._transactionState = TransactionState.Ready;
         }
     }
 
@@ -3247,17 +3251,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
         }
         finally
         {
-            lock (_producer._partitionsInTransactionLock)
-            {
-                _producer._partitionsInTransaction.Clear();
-            }
-
-            // A successful abort clears the abortable state; only leave the producer non-Ready if
-            // ending the transaction itself failed fatally/abortably.
-            if (_producer._transactionState is not (TransactionState.AbortableError or TransactionState.FatalError))
-            {
-                _producer._transactionState = TransactionState.Ready;
-            }
+            FinalizeTransactionState();
         }
     }
 

--- a/src/Dekaf/Producer/TransactionErrorClassifier.cs
+++ b/src/Dekaf/Producer/TransactionErrorClassifier.cs
@@ -13,18 +13,33 @@ internal static class TransactionErrorClassifier
     {
         return errorCode switch
         {
+            // Fatal (application-recoverable per KIP-1050): the producer is fenced or
+            // irrecoverably broken and must be closed; a new instance is required.
             Protocol.ErrorCode.ProducerFenced => TransactionErrorClassification.Fatal,
             Protocol.ErrorCode.TransactionalIdAuthorizationFailed => TransactionErrorClassification.Fatal,
             Protocol.ErrorCode.TransactionCoordinatorFenced => TransactionErrorClassification.Fatal,
+            Protocol.ErrorCode.InvalidProducerEpoch => TransactionErrorClassification.Fatal,
+            Protocol.ErrorCode.FencedInstanceId => TransactionErrorClassification.Fatal,
+            Protocol.ErrorCode.UnknownMemberId => TransactionErrorClassification.Fatal,
+            Protocol.ErrorCode.IllegalGeneration => TransactionErrorClassification.Fatal,
 
+            // In Transactions V2 (KIP-890) an unexpected producer-id mapping is fatal;
+            // in V1 the transaction can still be aborted.
             Protocol.ErrorCode.InvalidProducerIdMapping => tv2
                 ? TransactionErrorClassification.Fatal
                 : TransactionErrorClassification.Abortable,
 
+            // Retriable: transient coordinator/transaction state; retry with backoff.
             Protocol.ErrorCode.CoordinatorLoadInProgress => TransactionErrorClassification.Retriable,
             Protocol.ErrorCode.CoordinatorNotAvailable => TransactionErrorClassification.Retriable,
             Protocol.ErrorCode.NotCoordinator => TransactionErrorClassification.Retriable,
             Protocol.ErrorCode.ConcurrentTransactions => TransactionErrorClassification.Retriable,
+
+            // Abortable: the current transaction is broken and must be aborted, but the
+            // producer stays usable for a new transaction. TransactionAbortable is the
+            // dedicated KIP-890 signal; the default below also lands here per KIP-1050.
+            Protocol.ErrorCode.TransactionAbortable => TransactionErrorClassification.Abortable,
+            Protocol.ErrorCode.InvalidTxnState => TransactionErrorClassification.Abortable,
 
             _ => TransactionErrorClassification.Abortable
         };

--- a/src/Dekaf/Producer/TransactionState.cs
+++ b/src/Dekaf/Producer/TransactionState.cs
@@ -31,6 +31,13 @@ internal enum TransactionState
     AbortingTransaction,
 
     /// <summary>
+    /// An abortable error occurred during the current transaction. Producing and committing
+    /// are rejected; the caller must abort the transaction, after which the producer returns
+    /// to <see cref="Ready"/> and can begin a new transaction.
+    /// </summary>
+    AbortableError,
+
+    /// <summary>
     /// A fatal error occurred (e.g., ProducerFenced). No more transactions can be started.
     /// </summary>
     FatalError

--- a/src/Dekaf/Protocol/ErrorCode.cs
+++ b/src/Dekaf/Protocol/ErrorCode.cs
@@ -126,7 +126,7 @@ public enum ErrorCode : short
     UnknownSubscriptionId = 117,
     TelemetryTooLarge = 118,
     InvalidRegistration = 119,
-    NotMemberOfTenant = 120,
+    TransactionAbortable = 120,
     InvalidRecordState = 121,
     ShareSessionNotFound = 122,
     InvalidShareSessionEpoch = 123,

--- a/tests/Dekaf.Tests.Integration/TransactionErrorHandlingTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionErrorHandlingTests.cs
@@ -1,0 +1,63 @@
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Integration;
+
+/// <summary>
+/// Integration tests for KIP-1050 standardized transaction error handling: verifying that a
+/// fenced producer surfaces a <see cref="FatalTransactionException"/> and becomes unusable.
+/// </summary>
+/// <remarks>
+/// The abortable path is covered deterministically at the unit level (state-machine transitions
+/// in <c>TransactionTests</c> and classification in <c>TransactionErrorClassifierTests</c>);
+/// there is no reliable, non-flaky way to force a broker into returning an abortable error here.
+/// </remarks>
+[Category("Transaction")]
+public class TransactionErrorHandlingTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task Transaction_FencedByNewerProducer_ThrowsFatalAndProducerIsUnusable()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var txnId = $"txn-fence-{Guid.NewGuid():N}";
+
+        await using var producer1 = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId(txnId)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer1.InitTransactionsAsync();
+
+        await using var txn1 = producer1.BeginTransaction();
+
+        // Produce and await delivery so AddPartitionsToTxn + Produce complete with the current
+        // epoch. This makes the fence below observable only on EndTxn — a deterministic path.
+        await txn1.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "fence-key",
+            Value = "fence-value"
+        }, CancellationToken.None);
+
+        // A second producer with the same transactional id bumps the epoch, fencing producer1.
+        await using var producer2 = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId(txnId)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer2.InitTransactionsAsync();
+
+        // producer1's commit (EndTxn) is now rejected with a fatal, fencing error.
+        var commit = () => txn1.CommitAsync().AsTask();
+        await Assert.That(commit).Throws<FatalTransactionException>();
+
+        // The producer is in a fatal state and cannot start further transactions.
+        var begin = () => producer1.BeginTransaction();
+        await Assert.That(begin).Throws<InvalidOperationException>();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Errors/ExceptionTypesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Errors/ExceptionTypesTests.cs
@@ -224,6 +224,64 @@ public class ExceptionTypesTests
 
     #endregion
 
+    #region AbortableTransactionException Tests
+
+    [Test]
+    public async Task AbortableTransactionException_InheritsTransactionException()
+    {
+        var ex = new AbortableTransactionException();
+        await Assert.That(ex).IsAssignableTo<TransactionException>();
+        await Assert.That(ex).IsAssignableTo<KafkaException>();
+    }
+
+    [Test]
+    public async Task AbortableTransactionException_CarriesErrorCodeAndTransactionalId()
+    {
+        var ex = new AbortableTransactionException(ErrorCode.TransactionAbortable, "abort me")
+        {
+            TransactionalId = "txn-1"
+        };
+        await Assert.That(ex.ErrorCode).IsEqualTo(ErrorCode.TransactionAbortable);
+        await Assert.That(ex.TransactionalId).IsEqualTo("txn-1");
+    }
+
+    #endregion
+
+    #region FatalTransactionException Tests
+
+    [Test]
+    public async Task FatalTransactionException_InheritsTransactionException()
+    {
+        var ex = new FatalTransactionException();
+        await Assert.That(ex).IsAssignableTo<TransactionException>();
+        await Assert.That(ex).IsAssignableTo<KafkaException>();
+    }
+
+    [Test]
+    public async Task FatalTransactionException_CarriesErrorCodeAndTransactionalId()
+    {
+        var ex = new FatalTransactionException(ErrorCode.ProducerFenced, "fenced")
+        {
+            TransactionalId = "txn-1"
+        };
+        await Assert.That(ex.ErrorCode).IsEqualTo(ErrorCode.ProducerFenced);
+        await Assert.That(ex.TransactionalId).IsEqualTo("txn-1");
+    }
+
+    [Test]
+    public async Task TransactionSubtypes_AreCatchableAsTransactionException()
+    {
+        // The whole point of the KIP-1050 hierarchy: a caller catching TransactionException
+        // still receives the specific subtype so it can inspect/rethrow based on category.
+        TransactionException abortable = new AbortableTransactionException("a");
+        TransactionException fatal = new FatalTransactionException("f");
+
+        await Assert.That(abortable is AbortableTransactionException).IsTrue();
+        await Assert.That(fatal is FatalTransactionException).IsTrue();
+    }
+
+    #endregion
+
     #region BrokerVersionException Tests
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionErrorClassifierTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionErrorClassifierTests.cs
@@ -9,6 +9,10 @@ public sealed class TransactionErrorClassifierTests
     [Arguments(ErrorCode.ProducerFenced)]
     [Arguments(ErrorCode.TransactionalIdAuthorizationFailed)]
     [Arguments(ErrorCode.TransactionCoordinatorFenced)]
+    [Arguments(ErrorCode.InvalidProducerEpoch)]
+    [Arguments(ErrorCode.FencedInstanceId)]
+    [Arguments(ErrorCode.UnknownMemberId)]
+    [Arguments(ErrorCode.IllegalGeneration)]
     public async Task AlwaysFatal_ReturnsFatal_RegardlessOfTv2(ErrorCode errorCode)
     {
         var v1 = TransactionErrorClassifier.Classify(errorCode, tv2: false);
@@ -16,6 +20,18 @@ public sealed class TransactionErrorClassifierTests
 
         await Assert.That(v1).IsEqualTo(TransactionErrorClassification.Fatal);
         await Assert.That(v2).IsEqualTo(TransactionErrorClassification.Fatal);
+    }
+
+    [Test]
+    [Arguments(ErrorCode.TransactionAbortable)]
+    [Arguments(ErrorCode.InvalidTxnState)]
+    public async Task AlwaysAbortable_ReturnsAbortable_RegardlessOfTv2(ErrorCode errorCode)
+    {
+        var v1 = TransactionErrorClassifier.Classify(errorCode, tv2: false);
+        var v2 = TransactionErrorClassifier.Classify(errorCode, tv2: true);
+
+        await Assert.That(v1).IsEqualTo(TransactionErrorClassification.Abortable);
+        await Assert.That(v2).IsEqualTo(TransactionErrorClassification.Abortable);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -34,6 +34,36 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task BeginTransaction_InAbortableErrorState_Throws()
+    {
+        // A transaction that hit an abortable error must be aborted before a new one can start.
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTransactionalId("test-txn-id")
+            .Build();
+
+        ((KafkaProducer<string, string>)producer)._transactionState = TransactionState.AbortableError;
+
+        var act = () => producer.BeginTransaction();
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task BeginTransaction_InFatalErrorState_Throws()
+    {
+        // A producer in a fatal error state cannot start any further transactions.
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTransactionalId("test-txn-id")
+            .Build();
+
+        ((KafkaProducer<string, string>)producer)._transactionState = TransactionState.FatalError;
+
+        var act = () => producer.BeginTransaction();
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task InitTransactionsAsync_WithoutTransactionalId_Throws()
     {
         await using var producer = Kafka.CreateProducer<string, string>()
@@ -49,12 +79,13 @@ public sealed class TransactionTests
     {
         // Verify enum values exist and are distinct
         var values = Enum.GetValues<TransactionState>();
-        await Assert.That(values).Count().IsEqualTo(6);
+        await Assert.That(values).Count().IsEqualTo(7);
         await Assert.That(values).Contains(TransactionState.Uninitialized);
         await Assert.That(values).Contains(TransactionState.Ready);
         await Assert.That(values).Contains(TransactionState.InTransaction);
         await Assert.That(values).Contains(TransactionState.CommittingTransaction);
         await Assert.That(values).Contains(TransactionState.AbortingTransaction);
+        await Assert.That(values).Contains(TransactionState.AbortableError);
         await Assert.That(values).Contains(TransactionState.FatalError);
     }
 


### PR DESCRIPTION
Closes #829.

## Summary

Implements KIP-1050 (with KIP-890 nuances): transactional errors are categorized as **retriable**, **abortable**, or **fatal**, and the category is surfaced to callers through a typed exception hierarchy so an application knows whether to retry, abort-and-reuse the producer, or close it.

Dekaf already had an internal, tv2-aware `TransactionErrorClassifier` and a `TransactionState.FatalError`, but it was applied by only one code path and callers couldn't tell abortable from fatal. This PR makes the classifier the single source of truth for all transactional operations and exposes the category via exceptions.

## Changes

- **Exceptions** (`Errors/KafkaException.cs`): un-seal `TransactionException`; add `AbortableTransactionException` (caller must `AbortAsync()`, producer stays usable) and `FatalTransactionException` (caller must close the producer).
- **Classifier** (`Producer/TransactionErrorClassifier.cs`): add KIP-1050/KIP-890 mappings — `InvalidProducerEpoch`, `FencedInstanceId`, `UnknownMemberId`, `IllegalGeneration` → fatal; `TransactionAbortable`, `InvalidTxnState` → abortable.
- **ErrorCode** (`Protocol/ErrorCode.cs`): fix code `120` from the bogus `NotMemberOfTenant` to `TransactionAbortable`, matching the Apache Kafka wire mapping. Numeric value is unchanged, so the wire reader is unaffected; the old name was referenced nowhere.
- **Producer** (`Producer/KafkaProducer.cs`):
  - Route `InitProducerId`, `AddPartitionsToTxn`, `EndTxn`, and `SendOffsets` through the classifier via two helpers: `CreateTransactionException` and `ThrowIfNonRetriableTransactionError`.
  - New `TransactionState.AbortableError` state; abort clears it back to `Ready`.
  - Fail-fast produce guard: once a transaction is abortable/fatal, `ProduceAsync` throws immediately (one volatile read on the hot path; no allocation unless already broken).
  - `SendOffsets` now classifies its own retries instead of `RetryHelper`, whose `IsRetriable` predicate doesn't cover codes like `ConcurrentTransactions`.

## Testing

- **Unit**: classifier mappings, exception hierarchy, `BeginTransaction` guard for abortable/fatal states. Full unit suite: **3555 passed, 0 failed**.
- **Integration** (Docker): new fencing test — a second producer with the same `transactional.id` fences the first, whose `EndTxn` then throws `FatalTransactionException` and leaves the producer unusable. Existing transaction/transactionV2/edge-case suites still pass.

The abortable path is covered deterministically at the unit level (state-machine transitions + classification); there's no reliable, non-flaky way to force a broker into an abortable error, so no integration test attempts it (documented in the test file).

## Notes

- Un-sealing `TransactionException` and renaming the `NotMemberOfTenant` enum member are technically source-breaking but low-risk (subclassing only; the enum name was wrong and unused).
