### PR TITLE
fix(producer): queue completions asynchronously

### DIFF
--- a/src/Dekaf/Producer/PooledValueTaskSource.cs
+++ b/src/Dekaf/Producer/PooledValueTaskSource.cs
@@ -18,7 +18,7 @@ namespace Dekaf.Producer;
 /// <typeparam name="T">The result type.</typeparam>
 public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
 {
-    private ManualResetValueTaskSourceCore<T> _core;
+    private ManualResetValueTaskSourceCore<T> _core = new() { RunContinuationsAsynchronously = true };
     private ValueTaskSourcePool<T>? _pool;
     private Action<T, Exception?>? _deliveryHandler;
     private int _hasCompleted; // 0 = not completed, 1 = completed

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4601,7 +4601,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
 
     // Batch-level completion tracking using resettable ManualResetValueTaskSourceCore
     // Never faults - uses SetResult(true) for success, SetResult(false) for failure
-    private ManualResetValueTaskSourceCore<bool> _doneCore;
+    private ManualResetValueTaskSourceCore<bool> _doneCore = new() { RunContinuationsAsynchronously = true };
 
     private int _cleanedUp; // 0 = not cleaned, 1 = cleaned (prevents double-cleanup in Cleanup())
     private int _completed; // 0 = not completed, 1 = completed (prevents double-signal of _doneCore)

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks.Sources;
 using Dekaf.Producer;
+using Dekaf.Protocol.Records;
 
 namespace Dekaf.Tests.Unit.Producer;
 
@@ -670,5 +671,88 @@ public class PooledValueTaskSourceTests
 
         await Assert.That(receivedValue).IsEqualTo(default(int));
         await Assert.That(receivedException).IsSameReferenceAs(expectedException);
+    }
+
+    [Test]
+    public async Task RunContinuationsAsynchronously_SurvivesResetAndReuse()
+    {
+        var pool = new ValueTaskSourcePool<int>(maxPoolSize: 1);
+        var source = pool.Rent();
+
+        source.SetResult(1);
+        await source.Task.ConfigureAwait(false);
+
+        var reused = pool.Rent();
+        await Assert.That(reused).IsSameReferenceAs(source);
+
+        var result = await CompleteWithoutRunningContinuationInlineAsync(
+            reused.Task,
+            () => reused.SetResult(2)).ConfigureAwait(false);
+
+        await Assert.That(result).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ReadyBatchDoneTask_RunContinuationsAsynchronously_SurvivesResetAndReuse()
+    {
+        var batch = new ReadyBatch();
+
+        InitializeBatch(batch);
+        var firstTask = batch.DoneTask;
+        batch.CompleteDelivery();
+        await firstTask.ConfigureAwait(false);
+        batch.Reset();
+
+        InitializeBatch(batch);
+        var result = await CompleteWithoutRunningContinuationInlineAsync(
+            batch.DoneTask,
+            batch.CompleteDelivery).ConfigureAwait(false);
+
+        await Assert.That(result).IsTrue();
+
+        batch.Reset();
+    }
+
+    private static async Task<T> CompleteWithoutRunningContinuationInlineAsync<T>(
+        ValueTask<T> valueTask,
+        Action complete)
+    {
+        var awaiter = valueTask.GetAwaiter();
+        using var releaseContinuation = new ManualResetEventSlim();
+        var continuationFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        awaiter.UnsafeOnCompleted(() =>
+        {
+            releaseContinuation.Wait();
+            continuationFinished.SetResult();
+        });
+
+        var completionTask = Task.Run(complete);
+        var completedBeforeRelease = await Task.WhenAny(
+                completionTask,
+                Task.Delay(TimeSpan.FromSeconds(2)))
+            .ConfigureAwait(false) == completionTask;
+
+        releaseContinuation.Set();
+
+        await completionTask.ConfigureAwait(false);
+        await continuationFinished.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        await Assert.That(completedBeforeRelease).IsTrue();
+        return awaiter.GetResult();
+    }
+
+    private static void InitializeBatch(ReadyBatch batch)
+    {
+        batch.Initialize(
+            new TopicPartition("test-topic", 0),
+            new RecordBatch { Records = Array.Empty<Record>() },
+            completionSourcesArray: null,
+            completionSourcesCount: 0,
+            pooledDataArrays: null,
+            pooledDataArraysCount: 0,
+            pooledHeaderArrays: null,
+            pooledHeaderArraysCount: 0,
+            dataSize: 0);
     }
 }


### PR DESCRIPTION
## Summary
- Configure producer PooledValueTaskSource continuations to run asynchronously.
- Configure ReadyBatch.DoneTask continuations to run asynchronously.
- Add regression tests that block continuations and verify completion threads still return.

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/PooledValueTaskSourceTests/*
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/Producer*/*
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe

Closes #901
