### PR TITLE
fix(consumer): keep auto-commit loop running

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3606,16 +3606,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
     private async Task StartAutoCommitAsync(CancellationToken cancellationToken)
     {
-        if (_autoCommitTask is not null)
+        var currentTask = _autoCommitTask;
+        if (currentTask is { IsCompleted: false })
+            return;
+
+        if (currentTask is not null)
         {
-            _autoCommitCts?.Cancel();
             try
             {
-                await _autoCommitTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+                await currentTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
             }
             catch
             {
-                // Swallow — old task may not exit promptly after cancellation
+                // Swallow — old task may have completed from cancellation or fault.
             }
             _autoCommitCts?.Dispose();
         }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAutoCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAutoCommitTests.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public class ConsumerAutoCommitTests
+{
+    [Test]
+    public async Task StartAutoCommitAsync_WhenAlreadyRunning_DoesNotRestartLoop()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-consumer",
+            AutoCommitIntervalMs = 60_000
+        };
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        var consumerType = typeof(KafkaConsumer<string, string>);
+        var startAutoCommit = consumerType.GetMethod(
+            "StartAutoCommitAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var taskField = consumerType.GetField(
+            "_autoCommitTask",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var ctsField = consumerType.GetField(
+            "_autoCommitCts",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        await (Task)startAutoCommit.Invoke(consumer, [CancellationToken.None])!;
+        var firstTask = (Task?)taskField.GetValue(consumer);
+        var firstCts = (CancellationTokenSource?)ctsField.GetValue(consumer);
+
+        await (Task)startAutoCommit.Invoke(consumer, [CancellationToken.None])!;
+        var secondTask = (Task?)taskField.GetValue(consumer);
+        var secondCts = (CancellationTokenSource?)ctsField.GetValue(consumer);
+
+        await Assert.That(firstTask).IsNotNull();
+        await Assert.That(firstCts).IsNotNull();
+        await Assert.That(ReferenceEquals(secondTask, firstTask)).IsTrue();
+        await Assert.That(ReferenceEquals(secondCts, firstCts)).IsTrue();
+        await Assert.That(firstTask!.IsCompleted).IsFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- keep an active auto-commit loop running across repeated consume enumerations
- only clean up and replace a completed/faulted auto-commit task
- add a regression test proving repeated starts do not reset the loop task/CTS

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit --configuration Release
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter /*/*/ConsumerAutoCommitTests/*
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter /*/*/ConsumerCloseTests/*
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit
- [x] dotnet build tests/Dekaf.Tests.Integration --configuration Release
- [x] ./tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration --treenode-filter /*/*/OffsetCommitModeTests/OffsetCommitMode_Auto_CommitsAutomatically

Closes #892
