### PR TITLE
fix(producer): rotate sticky batch partition

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -261,7 +261,14 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         };
 
         _compressionCodecs = CreateCompressionCodecRegistry(options);
-        _accumulator = new RecordAccumulator(options, _compressionCodecs, loggerFactory?.CreateLogger<RecordAccumulator>());
+        Action<string, int>? batchCompletionCallback = _partitioner is IBatchCompletionAwarePartitioner batchCompletionAware
+            ? batchCompletionAware.OnBatchComplete
+            : null;
+        _accumulator = new RecordAccumulator(
+            options,
+            _compressionCodecs,
+            loggerFactory?.CreateLogger<RecordAccumulator>(),
+            batchCompletionCallback);
 
         // Inflight tracker enables coordinated retry with multiple in-flight batches per partition.
         // The broker uses sequence numbers to guarantee ordering, so multiple batches can be
@@ -828,6 +835,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             // Determine partition
             var partition = message.Partition
                 ?? _partitioner.Partition(message.Topic, key.Span, keyIsNull, topicInfo.PartitionCount);
+            var batchCompletionPartitionCount = message.Partition is null && keyIsNull
+                ? topicInfo.PartitionCount
+                : 0;
 
             // Get timestamp - use fast cached timestamp when no override provided
             var timestampMs = message.Timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs();
@@ -849,7 +859,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 value,
                 pooledHeaderArray,
                 headerCount,
-                completion))
+                completion,
+                batchCompletionPartitionCount))
             {
                 // Clean up serialized data — the async slow path will re-serialize
                 CleanupPooledResources(key, value, pooledHeaderArray);
@@ -1084,6 +1095,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // Determine partition
         var partition = message.Partition
             ?? _partitioner.Partition(message.Topic, key.Span, keyIsNull, topicInfo.PartitionCount);
+        var batchCompletionPartitionCount = message.Partition is null && keyIsNull
+            ? topicInfo.PartitionCount
+            : 0;
 
         // Get timestamp
         var timestamp = message.Timestamp ?? DateTimeOffset.UtcNow;
@@ -1108,7 +1122,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             pooledHeaderArray,
             headerCount,
             completion,
-            cancellationToken);
+            cancellationToken,
+            batchCompletionPartitionCount);
     }
 
     public ValueTask<RecordMetadata> ProduceAsync(
@@ -2394,6 +2409,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var keySpan = keyIsNull ? ReadOnlySpan<byte>.Empty : cache.KeySerializationBuffer.AsSpan(0, keyLength);
         var resolvedPartition = partition
             ?? _partitioner.Partition(topic, keySpan, keyIsNull, topicInfo.PartitionCount);
+        var batchCompletionPartitionCount = partition is null && keyIsNull
+            ? topicInfo.PartitionCount
+            : 0;
 
         var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs();
 
@@ -2412,7 +2430,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             keySpan, keyIsNull,
             valueIsNull ? ReadOnlySpan<byte>.Empty : cache.ValueSerializationBuffer.AsSpan(0, valueLength),
             valueIsNull,
-            pooledHeaderArray, headerCount, callback, CancellationToken.None);
+            pooledHeaderArray, headerCount, callback, CancellationToken.None, batchCompletionPartitionCount);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -14,6 +14,11 @@ public interface IPartitioner
     int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount);
 }
 
+internal interface IBatchCompletionAwarePartitioner
+{
+    void OnBatchComplete(string topic, int partitionCount);
+}
+
 /// <summary>
 /// Default partitioner - uses murmur2 hash of key, or round-robin for null keys.
 /// </summary>
@@ -40,7 +45,7 @@ public sealed class DefaultPartitioner : IPartitioner
 /// Sticky partitioner - sticks to a partition for null keys until batch is full.
 /// Uses ConcurrentDictionary for lock-free read access in the hot path.
 /// </summary>
-public sealed class StickyPartitioner : IPartitioner
+public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwarePartitioner
 {
     private readonly ConcurrentDictionary<string, int> _stickyPartitions = new();
     private uint _counter;

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -39,6 +39,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     // Append parameters — stored on Initialize, consumed by drain
     private string _topic = null!;
     private int _partition;
+    private int _partitionCount;
     private long _timestamp;
     private PooledMemory _key;
     private PooledMemory _value;
@@ -71,6 +72,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     // Expose stored parameters for DrainPendingAppends
     internal string Topic => _topic;
     internal int Partition => _partition;
+    internal int PartitionCount => _partitionCount;
     internal long Timestamp => _timestamp;
     internal PooledMemory Key => _key;
     internal PooledMemory Value => _value;
@@ -98,6 +100,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     internal void Initialize(
         string topic,
         int partition,
+        int partitionCount,
         long timestamp,
         PooledMemory key,
         PooledMemory value,
@@ -114,6 +117,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     {
         _topic = topic;
         _partition = partition;
+        _partitionCount = partitionCount;
         _timestamp = timestamp;
         _key = key;
         _value = value;
@@ -243,6 +247,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     {
         // Clear references to avoid rooting objects across pool rentals
         _topic = null!;
+        _partitionCount = 0;
         _key = default;
         _value = default;
         _headers = null;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -380,6 +380,7 @@ internal readonly struct AppendWorkItem
 {
     public readonly string Topic;
     public readonly int Partition;
+    public readonly int PartitionCount;
     public readonly long Timestamp;
     public readonly PooledMemory Key;
     public readonly PooledMemory Value;
@@ -391,6 +392,7 @@ internal readonly struct AppendWorkItem
     public AppendWorkItem(
         string topic,
         int partition,
+        int partitionCount,
         long timestamp,
         PooledMemory key,
         PooledMemory value,
@@ -401,6 +403,7 @@ internal readonly struct AppendWorkItem
     {
         Topic = topic;
         Partition = partition;
+        PartitionCount = partitionCount;
         Timestamp = timestamp;
         Key = key;
         Value = value;
@@ -897,6 +900,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly SemaphoreSlim _flushLingerLock = new(1, 1);
 
     private readonly ILogger _logger;
+    private readonly Action<string, int>? _onBatchComplete;
 
     private int _disposed;
     private int _closed;
@@ -1548,7 +1552,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         var result = AppendAfterReservation(
                             op.Topic, op.Partition, op.Timestamp,
                             op.Key, op.Value, op.Headers, op.HeaderCount,
-                            op.CompletionSource, op.Callback, op.RecordSize);
+                            op.CompletionSource, op.Callback, op.RecordSize, op.PartitionCount);
 
                         op.CompleteResult(result);
                     }
@@ -1617,11 +1621,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         _wakeupSignal.RegisterShutdownToken(cancellationToken);
     }
 
-    public RecordAccumulator(ProducerOptions options, CompressionCodecRegistry? compressionCodecs = null, ILogger? logger = null)
+    public RecordAccumulator(
+        ProducerOptions options,
+        CompressionCodecRegistry? compressionCodecs = null,
+        ILogger? logger = null,
+        Action<string, int>? onBatchComplete = null)
     {
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
         _options = options;
         _compressionCodecs = compressionCodecs;
+        _onBatchComplete = onBatchComplete;
 
         // Scale pool sizes with BufferMemory/BatchSize to prevent pool exhaustion.
         // Small batches (e.g., 16KB) create high batch churn (~6,250/sec at 100K msg/sec)
@@ -1798,7 +1807,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     workItem.HeaderCount,
                     workItem.Completion,
                     null,
-                    workItem.CancellationToken).ConfigureAwait(false))
+                    workItem.CancellationToken,
+                    partitionCount: workItem.PartitionCount).ConfigureAwait(false))
                 {
                     CleanupWorkItemResources(in workItem);
                     workItem.Completion.TrySetException(new ObjectDisposedException(nameof(RecordAccumulator)));
@@ -1850,11 +1860,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Header[]? headers,
         int headerCount,
         PooledValueTaskSource<RecordMetadata> completion,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        int partitionCount = 0)
     {
         EnsureAppendWorkersStarted();
         var workerIndex = (int)((uint)partition % (uint)_appendWorkerCount);
-        var workItem = new AppendWorkItem(topic, partition, timestamp, key, value,
+        var workItem = new AppendWorkItem(topic, partition, partitionCount, timestamp, key, value,
             headers, headerCount, completion, cancellationToken);
 
         if (!_appendWorkerChannels[workerIndex].Writer.TryWrite(workItem))
@@ -1868,9 +1879,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// Rents a new PartitionBatch from the pool and configures it with current transaction state.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private PartitionBatch RentBatch(TopicPartition topicPartition)
+    private PartitionBatch RentBatch(TopicPartition topicPartition, int partitionCount)
     {
-        var batch = _batchPool.Rent(topicPartition);
+        var batch = _batchPool.Rent(topicPartition, partitionCount);
         batch.SetTransactionState(ProducerId, ProducerEpoch, IsTransactional);
         return batch;
     }
@@ -1945,7 +1956,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int headerCount,
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        int partitionCount = 0)
     {
         if (Volatile.Read(ref _disposed) != 0)
             return new ValueTask<bool>(false);
@@ -1955,11 +1967,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // Hot path: non-blocking CAS reservation — no async state machine allocated
         if (TryReserveMemory(recordSize))
             return new ValueTask<bool>(AppendAfterReservation(topic, partition, timestamp, key, value,
-                headers, headerCount, completionSource, callback, recordSize));
+                headers, headerCount, completionSource, callback, recordSize, partitionCount));
 
         // Cold path: buffer full — enqueue pooled PendingAppend (zero async state machine allocation)
         return AppendSlowPathPooled(topic, partition, timestamp, key, value,
-            headers, headerCount, completionSource, callback, recordSize, cancellationToken);
+            headers, headerCount, completionSource, callback, recordSize, cancellationToken, partitionCount);
     }
 
     private bool AppendAfterReservation(
@@ -1972,7 +1984,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int headerCount,
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
-        int recordSize)
+        int recordSize,
+        int partitionCount)
     {
         if (completionSource is not null)
             Interlocked.Increment(ref _pendingAwaitedProduceCount);
@@ -2003,7 +2016,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 sealedBatch = SealCurrentBatchUnderLock(pd, currentBatch);
             }
 
-            var newBatch = RentBatch(new TopicPartition(topic, partition));
+            var newBatch = RentBatch(new TopicPartition(topic, partition), partitionCount);
             pd.CurrentBatch = newBatch;
             Interlocked.Increment(ref _unsealedBatchCount);
 
@@ -2049,7 +2062,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
         int recordSize,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        int partitionCount = 0)
     {
         if (Volatile.Read(ref _disposed) != 0)
         {
@@ -2070,7 +2084,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var (startTicks, deadline) = BeginReservationWait(recordSize);
 
         var op = _pendingAppendPool.Rent();
-        op.Initialize(topic, partition, timestamp, key, value, headers, headerCount,
+        op.Initialize(topic, partition, partitionCount, timestamp, key, value, headers, headerCount,
             completionSource, callback, recordSize, startTicks, deadline,
             this, _pendingAppendPool, cancellationToken);
 
@@ -2109,7 +2123,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         PooledMemory value,
         Header[]? headers,
         int headerCount,
-        PooledValueTaskSource<RecordMetadata> completionSource)
+        PooledValueTaskSource<RecordMetadata> completionSource,
+        int partitionCount = 0)
     {
         if (Volatile.Read(ref _disposed) != 0)
             return false;
@@ -2152,7 +2167,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             }
 
             // Create new batch
-            var newBatch = RentBatch(new TopicPartition(topic, partition));
+            var newBatch = RentBatch(new TopicPartition(topic, partition), partitionCount);
             pd.CurrentBatch = newBatch;
             Interlocked.Increment(ref _unsealedBatchCount);
 
@@ -2228,7 +2243,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Header[]? headers,
         int headerCount,
         Action<RecordMetadata, Exception?>? callback,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        int partitionCount = 0)
     {
         if (Volatile.Read(ref _disposed) != 0)
             return new ValueTask<bool>(false);
@@ -2240,7 +2256,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // Hot path: non-blocking CAS reservation — no async state machine allocated
         if (TryReserveMemory(recordSize))
             return new ValueTask<bool>(AppendFromSpansAfterReservation(topic, partition, timestamp,
-                keyData, keyIsNull, valueData, valueIsNull, headers, headerCount, callback, recordSize));
+                keyData, keyIsNull, valueData, valueIsNull, headers, headerCount, callback, recordSize, partitionCount));
 
         // Cold path: buffer full. Copy spans to PooledMemory BEFORE the await boundary
         // (ReadOnlySpan<byte> cannot survive across async suspension points).
@@ -2248,7 +2264,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var valuePooled = valueIsNull ? PooledMemory.Null : CopySpanToPooledMemory(valueData);
 
         return AppendFromSpansSlowPathPooled(topic, partition, timestamp, keyPooled, valuePooled,
-            headers, headerCount, callback, recordSize, cancellationToken);
+            headers, headerCount, callback, recordSize, partitionCount, cancellationToken);
     }
 
     /// <summary>
@@ -2265,7 +2281,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Header[]? headers,
         int headerCount,
         Action<RecordMetadata, Exception?>? callback,
-        int recordSize)
+        int recordSize,
+        int partitionCount)
     {
         var pd = GetOrCreateDeque(topic, partition);
         ReadyBatch? sealedBatch = null;
@@ -2289,7 +2306,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 sealedBatch = SealCurrentBatchUnderLock(pd, currentBatch);
             }
 
-            var newBatch = RentBatch(new TopicPartition(topic, partition));
+            var newBatch = RentBatch(new TopicPartition(topic, partition), partitionCount);
             pd.CurrentBatch = newBatch;
             Interlocked.Increment(ref _unsealedBatchCount);
 
@@ -2329,10 +2346,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int headerCount,
         Action<RecordMetadata, Exception?>? callback,
         int recordSize,
+        int partitionCount,
         CancellationToken cancellationToken)
     {
         return AppendSlowPathPooled(topic, partition, timestamp, keyPooled, valuePooled,
-            headers, headerCount, null, callback, recordSize, cancellationToken);
+            headers, headerCount, null, callback, recordSize, cancellationToken, partitionCount);
     }
 
     /// <summary>
@@ -2402,6 +2420,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             if (readyBatch.CompletionSourcesCount > 0)
                 Interlocked.Add(ref _pendingAwaitedProduceCount, -readyBatch.CompletionSourcesCount);
             ProducerDebugCounters.RecordBatchCompleted(readyBatch.CompletionSourcesCount);
+            if (currentBatch.PartitionCount > 1)
+                _onBatchComplete?.Invoke(readyBatch.TopicPartition.Topic, currentBatch.PartitionCount);
 
             OnBatchEntersPipeline(readyBatch);
             pd.AddLast(readyBatch);
@@ -3640,10 +3660,10 @@ internal sealed class PartitionBatchPool : ObjectPool<PartitionBatch>
     /// <summary>
     /// Gets a batch from the pool or creates a new one, configured for the given partition.
     /// </summary>
-    public PartitionBatch Rent(TopicPartition topicPartition)
+    public PartitionBatch Rent(TopicPartition topicPartition, int partitionCount)
     {
         var batch = Rent();
-        batch.Reset(topicPartition);
+        batch.Reset(topicPartition, partitionCount);
         return batch;
     }
 }
@@ -3659,6 +3679,7 @@ internal sealed class PartitionBatchPool : ObjectPool<PartitionBatch>
 internal sealed class PartitionBatch
 {
     private TopicPartition _topicPartition;
+    private int _partitionCount;
     private ProducerOptions _options;
     private readonly int _initialRecordCapacity;
     private ReadyBatchPool? _readyBatchPool; // Pool for renting ReadyBatch objects
@@ -3788,9 +3809,10 @@ internal sealed class PartitionBatch
     /// and those messages would be lost when Reset() is later called. By only resetting this flag
     /// at rent time, we ensure that any stale references fail the _isCompleted check in TryAppend().
     /// </remarks>
-    internal void Reset(TopicPartition topicPartition)
+    internal void Reset(TopicPartition topicPartition, int partitionCount)
     {
         _topicPartition = topicPartition;
+        _partitionCount = partitionCount;
         _createdStopwatchTimestamp = Stopwatch.GetTimestamp();
         _recordCount = 0;
         _completionSourceCount = 0;
@@ -3863,6 +3885,7 @@ internal sealed class PartitionBatch
     public BatchArena? Arena => Volatile.Read(ref _isCompleted) == 0 ? _arena : null;
 
     public TopicPartition TopicPartition => _topicPartition;
+    public int PartitionCount => _partitionCount;
     public int RecordCount => _recordCount;
     public int EstimatedSize => _estimatedSize;
 

--- a/tests/Dekaf.Tests.Integration/ProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTests.cs
@@ -384,6 +384,38 @@ public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
     }
 
     [Test]
+    public async Task Producer_WithStickyPartitioner_RotatesAcrossCompletedBatches()
+    {
+        // Arrange
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 3);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer-sticky-rotates")
+            .WithPartitioner(PartitionerType.Sticky)
+            .WithBatchSize(256)
+            .WithLinger(TimeSpan.Zero)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        // Act - each awaited null-key message completes its batch before the next partition choice.
+        var partitions = new HashSet<int>();
+        for (var i = 0; i < 9; i++)
+        {
+            var metadata = await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = null,
+                Value = new string('x', 128)
+            }, CancellationToken.None);
+            partitions.Add(metadata.Partition);
+        }
+
+        // Assert - sticky partition advances as batches complete, so traffic spreads over time.
+        await Assert.That(partitions.Count).IsGreaterThan(1);
+    }
+
+    [Test]
     public async Task Producer_WithRoundRobinPartitioner_DistributesMessages()
     {
         // Arrange

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -24,6 +24,54 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task SealCurrentBatch_NotifiesBatchCompletionCallback()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 30,
+            LingerMs = 10
+        };
+        var callbackCount = 0;
+        string? callbackTopic = null;
+        var callbackPartitionCount = 0;
+
+        await using var accumulator = new RecordAccumulator(
+            options,
+            onBatchComplete: (topic, partitionCount) =>
+            {
+                callbackCount++;
+                callbackTopic = topic;
+                callbackPartitionCount = partitionCount;
+            });
+
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        for (var i = 0; i < 2; i++)
+        {
+            var appended = await accumulator.AppendAsync(
+                "test-topic",
+                partition: 0,
+                timestamp + i,
+                PooledMemory.Null,
+                PooledMemory.Null,
+                headers: null,
+                headerCount: 0,
+                completionSource: null,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 3);
+
+            await Assert.That(appended).IsTrue();
+        }
+
+        await Assert.That(callbackCount).IsEqualTo(1);
+        await Assert.That(callbackTopic).IsEqualTo("test-topic");
+        await Assert.That(callbackPartitionCount).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task PartitionBatch_Complete_CalledTwice_ReturnsIdempotent()
     {
         // This test verifies that calling Complete() multiple times on the same PartitionBatch


### PR DESCRIPTION
## Summary
- Notify the sticky partitioner when null-key batches seal so later batches can rotate partitions.
- Carry partition-count metadata through append worker and slow-path appends.
- Add unit and integration coverage for sticky batch rotation over time.

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/RecordAccumulatorTests/SealCurrentBatch_NotifiesBatchCompletionCallback
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/Producer*/*
- [x] dotnet build tests\Dekaf.Tests.Integration --configuration Release
- [x] .\tests\Dekaf.Tests.Integration\bin\Release\net10.0\Dekaf.Tests.Integration.exe --treenode-filter /*/*/ProducerTests/Producer_WithStickyPartitioner_RotatesAcrossCompletedBatches
- [x] .\tests\Dekaf.Tests.Integration\bin\Release\net10.0\Dekaf.Tests.Integration.exe --treenode-filter /*/*/ProducerTests/Producer_WithStickyPartitioner_DistributesMessages
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe

Closes #891
