### PR TITLE
fix(networking): validate response frame size

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -162,6 +162,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
     // Cap on _cancelledCorrelationIds to prevent unbounded growth when brokers
     // silently drop responses for timed-out requests.
     private const int MaxCancelledCorrelationIds = 10_000;
+    private const int MinimumResponseFrameSize = 4; // Correlation ID is always first in the response header.
     private static int s_globalCorrelationId;
     private readonly ConcurrentDictionary<int, PooledPendingRequest> _pendingRequests = new();
     private readonly ConcurrentDictionary<int, byte> _cancelledCorrelationIds = new();
@@ -1125,8 +1126,10 @@ public sealed partial class KafkaConnection : IKafkaConnection
         Span<byte> sizeBuffer = stackalloc byte[4];
         buffer.Slice(0, 4).CopyTo(sizeBuffer);
         var size = BinaryPrimitives.ReadInt32BigEndian(sizeBuffer);
+        ValidateResponseFrameSize(size, _responseBufferPool.MaxArrayLength);
 
-        if (buffer.Length < 4 + size)
+        var frameLength = 4L + size;
+        if (buffer.Length < frameLength)
             return false;
 
         // Extract response data (including header)
@@ -1142,7 +1145,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         responseBuffer.CopyTo(responseArray);
         responseData = new PooledResponseBuffer(responseArray, size, isPooled, pool: _responseBufferPool);
 
-        buffer = buffer.Slice(4 + size);
+        buffer = buffer.Slice(frameLength);
         return true;
     }
 
@@ -1162,8 +1165,10 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
         // Read size prefix directly from span
         var size = BinaryPrimitives.ReadInt32BigEndian(span);
+        ValidateResponseFrameSize(size, _responseBufferPool.MaxArrayLength);
 
-        if (span.Length < 4 + size)
+        var frameLength = 4L + size;
+        if (span.Length < frameLength)
             return false;
 
         // Read correlation ID directly from span (offset 4 = past size prefix)
@@ -1175,8 +1180,18 @@ public sealed partial class KafkaConnection : IKafkaConnection
         span.Slice(4, size).CopyTo(responseArray);
         responseData = new PooledResponseBuffer(responseArray, size, isPooled, pool: _responseBufferPool);
 
-        buffer = buffer.Slice(4 + size);
+        buffer = buffer.Slice(frameLength);
         return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ValidateResponseFrameSize(int frameSize, int maxFrameSize)
+    {
+        if (frameSize < MinimumResponseFrameSize || frameSize > maxFrameSize)
+        {
+            throw new KafkaException(
+                $"Invalid response frame size {frameSize}. Expected between {MinimumResponseFrameSize} and {maxFrameSize} bytes.");
+        }
     }
 
     /// <summary>
@@ -1187,6 +1202,8 @@ public sealed partial class KafkaConnection : IKafkaConnection
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private (byte[] Array, bool IsPooled) RentResponseArray(int size)
     {
+        ValidateResponseFrameSize(size, _responseBufferPool.MaxArrayLength);
+
         if (size <= _responseBufferPool.MaxArrayLength)
         {
             return (_responseBufferPool.Pool.Rent(size), true);
@@ -2170,9 +2187,11 @@ public sealed partial class KafkaConnection : IKafkaConnection
         Span<byte> sizeSpan = stackalloc byte[4];
         buffer.Slice(0, 4).CopyTo(sizeSpan);
         var frameSize = BinaryPrimitives.ReadInt32BigEndian(sizeSpan);
+        ValidateResponseFrameSize(frameSize, responseBufferPool.MaxArrayLength);
 
         // If the full frame is available, don't start partial — let TryReadResponse handle it
-        if (buffer.Length >= 4 + frameSize)
+        var frameLength = 4L + frameSize;
+        if (buffer.Length >= frameLength)
             return false;
 
         // Read correlation ID (first 4 bytes of payload, at offset 4)

--- a/tests/Dekaf.Tests.Unit/Networking/IncrementalFrameConsumptionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/IncrementalFrameConsumptionTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
+using Dekaf.Errors;
 using Dekaf.Networking;
 
 namespace Dekaf.Tests.Unit.Networking;
@@ -56,6 +57,72 @@ public sealed class IncrementalFrameConsumptionTests
             ref buffer, ref context, ResponseBufferPool.Default);
 
         await Assert.That(started).IsFalse();
+    }
+
+    [Test]
+    public async Task TryStartPartialFrame_InvalidNegativeSize_ThrowsKafkaException()
+    {
+        var frame = new byte[8];
+        BinaryPrimitives.WriteInt32BigEndian(frame, -1);
+        var buffer = new ReadOnlySequence<byte>(frame);
+
+        var context = new KafkaConnection.PartialFrameContext();
+        KafkaException? thrown = null;
+        try
+        {
+            KafkaConnection.TryStartPartialFrame(
+                ref buffer, ref context, ResponseBufferPool.Default);
+        }
+        catch (KafkaException ex)
+        {
+            thrown = ex;
+        }
+
+        await Assert.That(thrown).IsNotNull();
+        await Assert.That(thrown!.Message).Contains("Invalid response frame size -1");
+        await Assert.That(context.IsActive).IsFalse();
+        await Assert.That(buffer.Length).IsEqualTo(frame.Length);
+    }
+
+    [Test]
+    public async Task TryStartPartialFrame_SizeAbovePoolLimit_ThrowsKafkaException()
+    {
+        var pool = new ResponseBufferPool(maxArrayLength: 16);
+        var frame = BuildPartialFrame(correlationId: 1, totalPayloadSize: 17, availablePayload: 4);
+        var buffer = new ReadOnlySequence<byte>(frame);
+
+        var context = new KafkaConnection.PartialFrameContext();
+        KafkaException? thrown = null;
+        try
+        {
+            KafkaConnection.TryStartPartialFrame(ref buffer, ref context, pool);
+        }
+        catch (KafkaException ex)
+        {
+            thrown = ex;
+        }
+
+        await Assert.That(thrown).IsNotNull();
+        await Assert.That(thrown!.Message).Contains("Invalid response frame size 17");
+        await Assert.That(context.IsActive).IsFalse();
+        await Assert.That(buffer.Length).IsEqualTo(frame.Length);
+    }
+
+    [Test]
+    public async Task ValidateResponseFrameSize_RejectsInvalidSizes()
+    {
+        foreach (var size in new[] { int.MinValue, -1, 0, 3, 17, int.MaxValue })
+        {
+            await Assert.That(() => KafkaConnection.ValidateResponseFrameSize(size, maxFrameSize: 16))
+                .Throws<KafkaException>();
+        }
+    }
+
+    [Test]
+    public void ValidateResponseFrameSize_AllowsMinimumAndMaximumSizes()
+    {
+        KafkaConnection.ValidateResponseFrameSize(frameSize: 4, maxFrameSize: 16);
+        KafkaConnection.ValidateResponseFrameSize(frameSize: 16, maxFrameSize: 16);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- validate response frame sizes before length arithmetic or slicing
- reject frames smaller than the response correlation ID or larger than the response buffer cap
- add regression coverage for corrupt negative and oversized partial frames

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit --configuration Release
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter /*/*/IncrementalFrameConsumptionTests/*
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter /*/*/KafkaConnectionTests/*
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --maximum-parallel-tests 1

Note: default-parallel full unit suite hit an unrelated timing failure in KafkaConsumerServiceTests.StopAsync_DrainTimeoutElapsed_CompletesAndCommits; that test passed in isolation and the full suite passed serially.

Closes #893
