### PR TITLE
fix(schema-registry): bound schema cache

### DIFF
--- a/src/Dekaf.SchemaRegistry/Dekaf.SchemaRegistry.csproj
+++ b/src/Dekaf.SchemaRegistry/Dekaf.SchemaRegistry.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Dekaf.Tests.Unit" />
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
   </ItemGroup>
 

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -13,18 +13,23 @@ namespace Dekaf.SchemaRegistry;
 /// </summary>
 public sealed class SchemaRegistryClient : ISchemaRegistryClient
 {
+    private static readonly TimeSpan PooledConnectionLifetime = TimeSpan.FromMinutes(2);
+
     private readonly HttpClient _httpClient;
     private readonly SchemaRegistryConfig _config;
     private readonly ConcurrentDictionary<int, Schema> _schemaByIdCache = new();
     private readonly ConcurrentDictionary<(string Subject, Schema Schema), int> _idBySchemaCache = new();
+    private readonly object _cacheLock = new();
     private readonly JsonSerializerOptions _jsonOptions;
+    private readonly int _maxCachedSchemas;
     private bool _disposed;
 
     public SchemaRegistryClient(SchemaRegistryConfig config)
     {
         _config = config ?? throw new ArgumentNullException(nameof(config));
+        _maxCachedSchemas = Math.Max(0, config.MaxCachedSchemas);
 
-        _httpClient = new HttpClient
+        _httpClient = new HttpClient(CreateHttpHandler(), disposeHandler: true)
         {
             BaseAddress = new Uri(config.Url.TrimEnd('/') + "/"),
             Timeout = TimeSpan.FromMilliseconds(config.RequestTimeoutMs)
@@ -46,6 +51,14 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
     }
+
+    internal int CachedSchemaByIdCount => _schemaByIdCache.Count;
+    internal int CachedSchemaIdCount => _idBySchemaCache.Count;
+
+    internal static SocketsHttpHandler CreateHttpHandler() => new()
+    {
+        PooledConnectionLifetime = PooledConnectionLifetime
+    };
 
     public async Task<int> RegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default)
     {
@@ -78,9 +91,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient
 
         var id = result!.Id;
 
-        // Cache both directions
-        _schemaByIdCache.TryAdd(id, schema);
-        _idBySchemaCache.TryAdd(cacheKey, id);
+        CacheSchema(id, subject, schema);
 
         return id;
     }
@@ -111,7 +122,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient
             }).ToList()
         };
 
-        _schemaByIdCache.TryAdd(id, schema);
+        CacheSchema(id, subject: null, schema);
         return schema;
     }
 
@@ -138,8 +149,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient
             }).ToList()
         };
 
-        // Cache the schema
-        _schemaByIdCache.TryAdd(result.Id, schema);
+        CacheSchema(result.Id, subject: null, schema);
 
         return new RegisteredSchema
         {
@@ -188,11 +198,30 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient
 
         var id = result!.Id;
 
-        // Cache both directions
-        _schemaByIdCache.TryAdd(id, schema);
-        _idBySchemaCache.TryAdd(cacheKey, id);
+        CacheSchema(id, subject, schema);
 
         return id;
+    }
+
+    internal void CacheSchema(int id, string? subject, Schema schema)
+    {
+        if (_maxCachedSchemas == 0)
+            return;
+
+        lock (_cacheLock)
+        {
+            if (_schemaByIdCache.Count >= _maxCachedSchemas || _idBySchemaCache.Count >= _maxCachedSchemas)
+            {
+                _schemaByIdCache.Clear();
+                _idBySchemaCache.Clear();
+            }
+
+            _schemaByIdCache.TryAdd(id, schema);
+            if (subject is not null)
+            {
+                _idBySchemaCache.TryAdd((subject, schema), id);
+            }
+        }
     }
 
     public async Task<IReadOnlyList<string>> GetAllSubjectsAsync(CancellationToken cancellationToken = default)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
@@ -95,4 +95,54 @@ public sealed class SchemaRegistryCacheTests
         await Assert.That(registry.GetCallCount("topic-b-value")).IsEqualTo(1);
         await Assert.That(registry.TotalCallCount).IsEqualTo(2);
     }
+
+    [Test]
+    public async Task Client_CacheSchema_ClearsWhenMaxCachedSchemasReached()
+    {
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://localhost:8081",
+            MaxCachedSchemas = 2
+        });
+
+        client.CacheSchema(1, "subject-1", NewSchema(1));
+        client.CacheSchema(2, "subject-2", NewSchema(2));
+
+        await Assert.That(client.CachedSchemaByIdCount).IsEqualTo(2);
+        await Assert.That(client.CachedSchemaIdCount).IsEqualTo(2);
+
+        client.CacheSchema(3, "subject-3", NewSchema(3));
+
+        await Assert.That(client.CachedSchemaByIdCount).IsEqualTo(1);
+        await Assert.That(client.CachedSchemaIdCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Client_CacheSchema_MaxCachedSchemasZero_DisablesCaching()
+    {
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://localhost:8081",
+            MaxCachedSchemas = 0
+        });
+
+        client.CacheSchema(1, "subject-1", NewSchema(1));
+
+        await Assert.That(client.CachedSchemaByIdCount).IsEqualTo(0);
+        await Assert.That(client.CachedSchemaIdCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Client_CreateHttpHandler_SetsPooledConnectionLifetime()
+    {
+        using var handler = SchemaRegistryClient.CreateHttpHandler();
+
+        await Assert.That(handler.PooledConnectionLifetime).IsEqualTo(TimeSpan.FromMinutes(2));
+    }
+
+    private static Schema NewSchema(int id) => new()
+    {
+        SchemaType = SchemaType.Json,
+        SchemaString = $$"""{ "type": "string", "title": "schema-{{id}}" }"""
+    };
 }


### PR DESCRIPTION
## Summary
- enforce SchemaRegistryClient MaxCachedSchemas with clear-on-cap cache writes
- use SocketsHttpHandler with a 2 minute pooled connection lifetime for DNS refresh
- cover cache cap/disabled mode and handler lifetime

Closes #932

## Tests
- dotnet build tests/Dekaf.Tests.Unit --configuration Release
- ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter /*/*/SchemaRegistryCacheTests/*
- ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter /*/*/SchemaRegistry*/*
- ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit