### PR TITLE
perf(schemaregistry): skip cached deserializer async

### DIFF
--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
@@ -64,11 +64,7 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
         // Optionally validate the schema exists (with timeout to prevent indefinite hang)
         if (!_config.SkipSchemaValidation)
         {
-            var schema = _schemaRegistry.GetSchemaAsync(schemaId)
-                .WaitAsync(SchemaRegistryTimeout)
-                .ConfigureAwait(false)
-                .GetAwaiter()
-                .GetResult();
+            var schema = GetSchemaSync(schemaId);
             if (schema.SchemaType != SchemaType.Protobuf)
                 throw new InvalidOperationException($"Schema {schemaId} is not a Protobuf schema (type: {schema.SchemaType})");
         }
@@ -111,6 +107,19 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
         }
 
         throw new InvalidOperationException("Varint is truncated");
+    }
+
+    private Schema GetSchemaSync(int schemaId)
+    {
+        if (_schemaRegistry is ISchemaRegistryCache cache
+            && cache.TryGetCachedSchema(schemaId, out var cached))
+            return cached;
+
+        return _schemaRegistry.GetSchemaAsync(schemaId)
+            .WaitAsync(SchemaRegistryTimeout)
+            .ConfigureAwait(false)
+            .GetAwaiter()
+            .GetResult();
     }
 
     /// <inheritdoc />

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
@@ -64,7 +64,7 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
         // Optionally validate the schema exists (with timeout to prevent indefinite hang)
         if (!_config.SkipSchemaValidation)
         {
-            var schema = GetSchemaSync(schemaId);
+            var schema = _schemaRegistry.GetSchemaSync(schemaId, SchemaRegistryTimeout);
             if (schema.SchemaType != SchemaType.Protobuf)
                 throw new InvalidOperationException($"Schema {schemaId} is not a Protobuf schema (type: {schema.SchemaType})");
         }
@@ -108,20 +108,6 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
 
         throw new InvalidOperationException("Varint is truncated");
     }
-
-    private Schema GetSchemaSync(int schemaId)
-    {
-        if (_schemaRegistry is ISchemaRegistryCache cache
-            && cache.TryGetCachedSchema(schemaId, out var cached))
-            return cached;
-
-        return _schemaRegistry.GetSchemaAsync(schemaId)
-            .WaitAsync(SchemaRegistryTimeout)
-            .ConfigureAwait(false)
-            .GetAwaiter()
-            .GetResult();
-    }
-
     /// <inheritdoc />
     public ValueTask DisposeAsync()
     {

--- a/src/Dekaf.SchemaRegistry/Dekaf.SchemaRegistry.csproj
+++ b/src/Dekaf.SchemaRegistry/Dekaf.SchemaRegistry.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Dekaf.Tests.Unit" />
+    <InternalsVisibleTo Include="Dekaf.SchemaRegistry.Protobuf" />
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
   </ItemGroup>
 

--- a/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
@@ -78,6 +78,20 @@ public interface ISchemaRegistryClient : IDisposable
 }
 
 /// <summary>
+/// Optional Schema Registry client cache access used by hot deserialization paths.
+/// </summary>
+public interface ISchemaRegistryCache
+{
+    /// <summary>
+    /// Attempts to get a schema by global ID from the local cache without allocating.
+    /// </summary>
+    /// <param name="id">The schema ID.</param>
+    /// <param name="schema">The cached schema, when found.</param>
+    /// <returns>True when the schema is already cached.</returns>
+    bool TryGetCachedSchema(int id, out Schema schema);
+}
+
+/// <summary>
 /// Represents a schema.
 /// </summary>
 public sealed class Schema

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -219,18 +219,24 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
 
         var schemaId = BinaryPrimitives.ReadInt32BigEndian(span.Slice(1, 4));
 
-        // Optionally fetch schema for validation (schema is cached)
-        // For JSON, we typically just deserialize without validation
-        // but we still verify the schema exists
-        // Add timeout to prevent indefinite blocking
-        _ = _schemaRegistry.GetSchemaAsync(schemaId)
+        // Verify the schema exists. Cache hits avoid Task allocation and sync-over-async.
+        _ = GetSchemaSync(schemaId);
+
+        // Extract JSON payload and deserialize
+        return JsonSerializer.Deserialize<T>(span.Slice(5), _jsonOptions)!;
+    }
+
+    private Schema GetSchemaSync(int schemaId)
+    {
+        if (_schemaRegistry is ISchemaRegistryCache cache
+            && cache.TryGetCachedSchema(schemaId, out var cached))
+            return cached;
+
+        return _schemaRegistry.GetSchemaAsync(schemaId)
             .WaitAsync(SchemaRegistryTimeout)
             .ConfigureAwait(false)
             .GetAwaiter()
             .GetResult();
-
-        // Extract JSON payload and deserialize
-        return JsonSerializer.Deserialize<T>(span.Slice(5), _jsonOptions)!;
     }
 
     public ValueTask DisposeAsync()

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -220,23 +220,10 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
         var schemaId = BinaryPrimitives.ReadInt32BigEndian(span.Slice(1, 4));
 
         // Verify the schema exists. Cache hits avoid Task allocation and sync-over-async.
-        _ = GetSchemaSync(schemaId);
+        _ = _schemaRegistry.GetSchemaSync(schemaId, SchemaRegistryTimeout);
 
         // Extract JSON payload and deserialize
         return JsonSerializer.Deserialize<T>(span.Slice(5), _jsonOptions)!;
-    }
-
-    private Schema GetSchemaSync(int schemaId)
-    {
-        if (_schemaRegistry is ISchemaRegistryCache cache
-            && cache.TryGetCachedSchema(schemaId, out var cached))
-            return cached;
-
-        return _schemaRegistry.GetSchemaAsync(schemaId)
-            .WaitAsync(SchemaRegistryTimeout)
-            .ConfigureAwait(false)
-            .GetAwaiter()
-            .GetResult();
     }
 
     public ValueTask DisposeAsync()

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryCacheExtensions.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryCacheExtensions.cs
@@ -1,0 +1,17 @@
+namespace Dekaf.SchemaRegistry;
+
+internal static class SchemaRegistryCacheExtensions
+{
+    internal static Schema GetSchemaSync(this ISchemaRegistryClient schemaRegistry, int schemaId, TimeSpan timeout)
+    {
+        if (schemaRegistry is ISchemaRegistryCache cache
+            && cache.TryGetCachedSchema(schemaId, out var cached))
+            return cached;
+
+        return schemaRegistry.GetSchemaAsync(schemaId)
+            .WaitAsync(timeout)
+            .ConfigureAwait(false)
+            .GetAwaiter()
+            .GetResult();
+    }
+}

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -11,7 +11,7 @@ namespace Dekaf.SchemaRegistry;
 /// <summary>
 /// HTTP client for Confluent Schema Registry.
 /// </summary>
-public sealed class SchemaRegistryClient : ISchemaRegistryClient
+public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistryCache
 {
     private static readonly TimeSpan PooledConnectionLifetime = TimeSpan.FromMinutes(2);
 
@@ -125,6 +125,9 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient
         CacheSchema(id, subject: null, schema);
         return schema;
     }
+
+    public bool TryGetCachedSchema(int id, out Schema schema)
+        => _schemaByIdCache.TryGetValue(id, out schema!);
 
     public async Task<RegisteredSchema> GetSchemaBySubjectAsync(string subject, string version = "latest", CancellationToken cancellationToken = default)
     {

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryExtensions.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryExtensions.cs
@@ -140,4 +140,26 @@ public static class SchemaRegistryExtensions
 
         return builder.WithValueDeserializer(deserializer);
     }
+
+    /// <summary>
+    /// Configures the consumer to use a custom Schema Registry deserializer for values
+    /// using a ReadOnlyMemory payload.
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="builder">The consumer builder.</param>
+    /// <param name="schemaRegistry">The Schema Registry client.</param>
+    /// <param name="deserialize">Function to deserialize bytes to value using the schema without copying the payload.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static ConsumerBuilder<TKey, TValue> UseSchemaRegistryMemory<TKey, TValue>(
+        this ConsumerBuilder<TKey, TValue> builder,
+        ISchemaRegistryClient schemaRegistry,
+        Func<ReadOnlyMemory<byte>, Schema, TValue> deserialize)
+    {
+        var deserializer = SchemaRegistryDeserializer.Create(
+            schemaRegistry,
+            deserialize);
+
+        return builder.WithValueDeserializer(deserializer);
+    }
 }

--- a/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
@@ -193,7 +193,7 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
     private static readonly TimeSpan SchemaRegistryTimeout = TimeSpan.FromSeconds(30);
 
     private readonly ISchemaRegistryClient _schemaRegistry;
-    private readonly Func<byte[], Schema, T> _deserialize;
+    private readonly Func<ReadOnlyMemory<byte>, Schema, T> _deserialize;
     private readonly bool _ownsClient;
 
     /// <summary>
@@ -206,6 +206,23 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
         ISchemaRegistryClient schemaRegistry,
         Func<byte[], Schema, T> deserialize,
         bool ownsClient = false)
+        : this(
+            schemaRegistry,
+            (ReadOnlyMemory<byte> payload, Schema schema) => deserialize(payload.ToArray(), schema),
+            ownsClient)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new Schema Registry deserializer.
+    /// </summary>
+    /// <param name="schemaRegistry">The Schema Registry client.</param>
+    /// <param name="deserialize">Function to deserialize bytes to value using the schema.</param>
+    /// <param name="ownsClient">Whether this deserializer owns the client and should dispose it.</param>
+    internal SchemaRegistryDeserializer(
+        ISchemaRegistryClient schemaRegistry,
+        Func<ReadOnlyMemory<byte>, Schema, T> deserialize,
+        bool ownsClient)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _deserialize = deserialize ?? throw new ArgumentNullException(nameof(deserialize));
@@ -224,17 +241,23 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
 
         var schemaId = BinaryPrimitives.ReadInt32BigEndian(span.Slice(1, 4));
 
-        // Get schema from registry (cached, with timeout to prevent indefinite hang)
-        var schema = _schemaRegistry.GetSchemaAsync(schemaId)
+        var schema = GetSchemaSync(schemaId);
+        var payload = data.Slice(5);
+
+        return _deserialize(payload, schema);
+    }
+
+    private Schema GetSchemaSync(int schemaId)
+    {
+        if (_schemaRegistry is ISchemaRegistryCache cache
+            && cache.TryGetCachedSchema(schemaId, out var cached))
+            return cached;
+
+        return _schemaRegistry.GetSchemaAsync(schemaId)
             .WaitAsync(SchemaRegistryTimeout)
             .ConfigureAwait(false)
             .GetAwaiter()
             .GetResult();
-
-        // Extract payload
-        var payload = span.Slice(5).ToArray();
-
-        return _deserialize(payload, schema);
     }
 
     public ValueTask DisposeAsync()
@@ -243,6 +266,26 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
             _schemaRegistry.Dispose();
         return ValueTask.CompletedTask;
     }
+}
+
+/// <summary>
+/// Factory methods for Schema Registry deserializers.
+/// </summary>
+public static class SchemaRegistryDeserializer
+{
+    /// <summary>
+    /// Creates a Schema Registry deserializer that receives the payload as ReadOnlyMemory without copying it.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize.</typeparam>
+    /// <param name="schemaRegistry">The Schema Registry client.</param>
+    /// <param name="deserialize">Function to deserialize bytes to value using the schema.</param>
+    /// <param name="ownsClient">Whether this deserializer owns the client and should dispose it.</param>
+    /// <returns>The deserializer.</returns>
+    public static SchemaRegistryDeserializer<T> Create<T>(
+        ISchemaRegistryClient schemaRegistry,
+        Func<ReadOnlyMemory<byte>, Schema, T> deserialize,
+        bool ownsClient = false)
+        => new(schemaRegistry, deserialize, ownsClient);
 }
 
 /// <summary>

--- a/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
@@ -241,23 +241,10 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
 
         var schemaId = BinaryPrimitives.ReadInt32BigEndian(span.Slice(1, 4));
 
-        var schema = GetSchemaSync(schemaId);
+        var schema = _schemaRegistry.GetSchemaSync(schemaId, SchemaRegistryTimeout);
         var payload = data.Slice(5);
 
         return _deserialize(payload, schema);
-    }
-
-    private Schema GetSchemaSync(int schemaId)
-    {
-        if (_schemaRegistry is ISchemaRegistryCache cache
-            && cache.TryGetCachedSchema(schemaId, out var cached))
-            return cached;
-
-        return _schemaRegistry.GetSchemaAsync(schemaId)
-            .WaitAsync(SchemaRegistryTimeout)
-            .ConfigureAwait(false)
-            .GetAwaiter()
-            .GetResult();
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/MockSchemaRegistryClient.cs
@@ -6,12 +6,15 @@ namespace Dekaf.Tests.Unit.SchemaRegistry;
 /// <summary>
 /// Mock implementation of ISchemaRegistryClient for unit testing.
 /// </summary>
-internal sealed class MockSchemaRegistryClient : ISchemaRegistryClient
+internal sealed class MockSchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistryCache
 {
     private readonly Dictionary<int, Schema> _schemasById = new();
     private readonly Dictionary<string, List<(int Version, int Id, Schema Schema)>> _schemasBySubject = new();
     private int _nextId = 1;
     private bool _disposed;
+
+    public int GetSchemaCallCount { get; private set; }
+    public int TryGetCachedSchemaCallCount { get; private set; }
 
     /// <summary>
     /// Normalizes a JSON schema string by parsing and re-serializing.
@@ -58,11 +61,19 @@ internal sealed class MockSchemaRegistryClient : ISchemaRegistryClient
     public Task<Schema> GetSchemaAsync(int id, CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
+        GetSchemaCallCount++;
 
         if (_schemasById.TryGetValue(id, out var schema))
             return Task.FromResult(schema);
 
         throw new SchemaRegistryException(40403, $"Schema {id} not found");
+    }
+
+    public bool TryGetCachedSchema(int id, out Schema schema)
+    {
+        ThrowIfDisposed();
+        TryGetCachedSchemaCallCount++;
+        return _schemasById.TryGetValue(id, out schema!);
     }
 
     public Task<RegisteredSchema> GetSchemaBySubjectAsync(string subject, string version = "latest", CancellationToken cancellationToken = default)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistryDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistryDeserializerTests.cs
@@ -49,6 +49,38 @@ public class ProtobufSchemaRegistryDeserializerTests
     }
 
     [Test]
+    public async Task Deserialize_UsesCachedSchema_WhenValidationEnabled()
+    {
+        // Arrange
+        var schemaRegistry = new MockSchemaRegistryClient();
+        var schemaId = await schemaRegistry.RegisterSchemaAsync("test-topic-value", new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = "syntax = \"proto3\";"
+        });
+
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(schemaRegistry);
+
+        var originalMessage = new TestMessage { Id = 42, Name = "Hello", Value = 3.14 };
+        var protoBytes = originalMessage.ToByteArray();
+        var wireBytes = new byte[1 + 4 + 2 + protoBytes.Length];
+
+        wireBytes[0] = 0x00;
+        BinaryPrimitives.WriteInt32BigEndian(wireBytes.AsSpan(1, 4), schemaId);
+        wireBytes[5] = 1;
+        wireBytes[6] = 0;
+        protoBytes.CopyTo(wireBytes.AsSpan(7));
+
+        // Act
+        var result = deserializer.Deserialize(wireBytes, CreateContext());
+
+        // Assert
+        await Assert.That(result.Id).IsEqualTo(42);
+        await Assert.That(schemaRegistry.TryGetCachedSchemaCallCount).IsEqualTo(1);
+        await Assert.That(schemaRegistry.GetSchemaCallCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Deserialize_ThrowsOnInvalidMagicByte()
     {
         // Arrange

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
@@ -1,5 +1,9 @@
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
 using Dekaf.SchemaRegistry;
 using Dekaf.Serialization;
 
@@ -138,6 +142,63 @@ public sealed class SchemaRegistryCacheTests
         using var handler = SchemaRegistryClient.CreateHttpHandler();
 
         await Assert.That(handler.PooledConnectionLifetime).IsEqualTo(TimeSpan.FromMinutes(2));
+    }
+
+    [Test]
+    public async Task Deserializer_UsesCachedSchema_AndPassesPayloadWithoutCopy()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schema = new Schema { SchemaType = SchemaType.Json, SchemaString = """{ "type": "string" }""" };
+        var schemaId = await registry.RegisterSchemaAsync("topic-value", schema);
+        var payloadBytes = "hello"u8.ToArray();
+        var wireBytes = new byte[5 + payloadBytes.Length];
+        wireBytes[0] = 0;
+        BinaryPrimitives.WriteInt32BigEndian(wireBytes.AsSpan(1, 4), schemaId);
+        payloadBytes.CopyTo(wireBytes.AsSpan(5));
+
+        ArraySegment<byte> payloadSegment = default;
+        await using var deserializer = SchemaRegistryDeserializer.Create(
+            registry,
+            (ReadOnlyMemory<byte> payload, Schema _) =>
+            {
+                MemoryMarshal.TryGetArray(payload, out var segment);
+                payloadSegment = segment;
+                return Encoding.UTF8.GetString(payload.Span);
+            });
+
+        var result = deserializer.Deserialize(
+            wireBytes,
+            new SerializationContext { Topic = "topic", Component = SerializationComponent.Value });
+
+        await Assert.That(result).IsEqualTo("hello");
+        await Assert.That(payloadSegment.Array).IsSameReferenceAs(wireBytes);
+        await Assert.That(payloadSegment.Offset).IsEqualTo(5);
+        await Assert.That(payloadSegment.Count).IsEqualTo(payloadBytes.Length);
+        await Assert.That(registry.TryGetCachedSchemaCallCount).IsEqualTo(1);
+        await Assert.That(registry.GetSchemaCallCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task JsonDeserializer_UsesCachedSchema()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schema = new Schema { SchemaType = SchemaType.Json, SchemaString = """{ "type": "string" }""" };
+        var schemaId = await registry.RegisterSchemaAsync("topic-value", schema);
+        var payloadBytes = JsonSerializer.SerializeToUtf8Bytes("hello");
+        var wireBytes = new byte[5 + payloadBytes.Length];
+        wireBytes[0] = 0;
+        BinaryPrimitives.WriteInt32BigEndian(wireBytes.AsSpan(1, 4), schemaId);
+        payloadBytes.CopyTo(wireBytes.AsSpan(5));
+
+        await using var deserializer = new JsonSchemaRegistryDeserializer<string>(registry);
+
+        var result = deserializer.Deserialize(
+            wireBytes,
+            new SerializationContext { Topic = "topic", Component = SerializationComponent.Value });
+
+        await Assert.That(result).IsEqualTo("hello");
+        await Assert.That(registry.TryGetCachedSchemaCallCount).IsEqualTo(1);
+        await Assert.That(registry.GetSchemaCallCount).IsEqualTo(0);
     }
 
     private static Schema NewSchema(int id) => new()

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
@@ -61,6 +61,40 @@ public sealed class SchemaRegistryCacheTests
         public void Dispose() { }
     }
 
+    private sealed class NonCachingSchemaRegistryClient(Schema schema) : ISchemaRegistryClient
+    {
+        public int GetSchemaCallCount { get; private set; }
+
+        public Task<int> GetOrRegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<int> RegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<Schema> GetSchemaAsync(int id, CancellationToken cancellationToken = default)
+        {
+            GetSchemaCallCount++;
+            return Task.FromResult(schema);
+        }
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(string subject, string version = "latest", CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<IReadOnlyList<string>> GetAllSubjectsAsync(CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<IReadOnlyList<int>> GetVersionsAsync(string subject, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<bool> IsCompatibleAsync(string subject, Schema schema, string version = "latest", CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<IReadOnlyList<int>> DeleteSubjectAsync(string subject, bool permanent = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public void Dispose() { }
+    }
+
     [Test]
     public async Task Serializer_CachesSchemaId_AcrossMultipleSubjects()
     {
@@ -176,6 +210,29 @@ public sealed class SchemaRegistryCacheTests
         await Assert.That(payloadSegment.Count).IsEqualTo(payloadBytes.Length);
         await Assert.That(registry.TryGetCachedSchemaCallCount).IsEqualTo(1);
         await Assert.That(registry.GetSchemaCallCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Deserializer_FallsBackToGetSchema_WhenClientDoesNotExposeCache()
+    {
+        var schema = new Schema { SchemaType = SchemaType.Json, SchemaString = """{ "type": "string" }""" };
+        var registry = new NonCachingSchemaRegistryClient(schema);
+        var payloadBytes = "hello"u8.ToArray();
+        var wireBytes = new byte[5 + payloadBytes.Length];
+        wireBytes[0] = 0;
+        BinaryPrimitives.WriteInt32BigEndian(wireBytes.AsSpan(1, 4), 123);
+        payloadBytes.CopyTo(wireBytes.AsSpan(5));
+
+        await using var deserializer = SchemaRegistryDeserializer.Create(
+            registry,
+            static (ReadOnlyMemory<byte> payload, Schema _) => Encoding.UTF8.GetString(payload.Span));
+
+        var result = deserializer.Deserialize(
+            wireBytes,
+            new SerializationContext { Topic = "topic", Component = SerializationComponent.Value });
+
+        await Assert.That(result).IsEqualTo("hello");
+        await Assert.That(registry.GetSchemaCallCount).IsEqualTo(1);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add optional schema registry cache access for cached schema ID fast paths
- use cache fast path in custom, JSON, and Protobuf deserializers
- add ReadOnlyMemory-based custom deserializer factory and builder hook to avoid payload ToArray copies
- cover cache-hit behavior for custom, JSON, and Protobuf deserializers

Closes #906

## Test plan
- dotnet build tests\\Dekaf.Tests.Unit --configuration Release
- .\\tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe --treenode-filter /*/*/SchemaRegistryCacheTests/*
- .\\tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe --treenode-filter /*/*/ProtobufSchemaRegistryDeserializerTests/*
- .\\tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe
- dotnet build tests\\Dekaf.Tests.Integration --configuration Release