### PR TITLE
fix(consumer): bound prefetch buffer slots

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -691,9 +691,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                     : null);
         }
 
-        // Initialize prefetch buffer - bounded by QueuedMinMessages batches
-        var prefetchCapacity = Math.Max(options.QueuedMinMessages, 1);
-        _prefetchBuffer = new MpscFetchBuffer(prefetchCapacity * 10);
+        _prefetchBuffer = new MpscFetchBuffer(CalculatePrefetchBufferCapacity(options));
 
         // Register this instance's lag callback with the shared static gauge.
         // The callback is invoked only during metric collection (~every 5-60s), not on the hot path.
@@ -1692,6 +1690,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             fetchMaxBytes);
         var minRequired = fetchResponseSize * (pipelineDepth + 1);
         return Math.Max(configuredMax, minRequired);
+    }
+
+    internal static int CalculatePrefetchBufferCapacity(ConsumerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return PoolSizing.ForConsumerPrefetchBuffer(
+            options.QueuedMaxMessagesKbytes,
+            options.MaxPartitionFetchBytes,
+            options.FetchMaxBytes,
+            options.PrefetchPipelineDepth,
+            options.ConnectionsPerBroker);
     }
 
     internal static bool IsFatalPrefetchError(Exception ex) => ex is

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -24,19 +24,30 @@ internal sealed class MpscFetchBuffer
 
     private readonly ManualResetEventSlim _dataAvailable = new(false);
     private readonly SemaphoreSlim _spaceAvailable = new(0, int.MaxValue);
-    private volatile bool _producerWaiting;
-    private volatile bool _consumerWaiting;
+    private int _producerWaiterCount;
+    private int _consumerWaiting;
     private volatile bool _completed;
     private volatile Exception? _completionError;
 
     public MpscFetchBuffer(int capacity)
     {
+        if (capacity < 1)
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be positive.");
+
+        const int MaxPowerOfTwoCapacity = 1 << 30;
+        if (capacity > MaxPowerOfTwoCapacity)
+            throw new ArgumentOutOfRangeException(nameof(capacity), $"Capacity must be <= {MaxPowerOfTwoCapacity}.");
+
         // Round up to next power of 2 for mask-based indexing
         var size = 1;
         while (size < capacity) size <<= 1;
         _buffer = new PendingFetchData?[size];
         _mask = size - 1;
     }
+
+    internal int Capacity => _buffer.Length;
+
+    internal int ProducerWaiterCount => Volatile.Read(ref _producerWaiterCount);
 
     /// <summary>
     /// Attempts to write an item. Safe for concurrent callers (multiple prefetch tasks).
@@ -65,8 +76,9 @@ internal sealed class MpscFetchBuffer
                 spin.SpinOnce();
 
             Volatile.Write(ref _headCommitted.Value, head + 1);
+            Interlocked.MemoryBarrier();
 
-            if (_consumerWaiting)
+            if (Volatile.Read(ref _consumerWaiting) != 0)
                 _dataAvailable.Set();
 
             return true;
@@ -80,22 +92,22 @@ internal sealed class MpscFetchBuffer
     public async ValueTask WaitToWriteAsync(CancellationToken cancellationToken)
     {
         // Fast path: space already available
-        if (Volatile.Read(ref _headReserved.Value) - Volatile.Read(ref _tail.Value) < _buffer.Length)
+        if (HasSpaceAvailable())
             return;
 
         // Slow path: wait for the consumer to drain
-        _producerWaiting = true;
+        Interlocked.Increment(ref _producerWaiterCount);
         try
         {
             // Re-check after setting flag to avoid missed signal
-            if (Volatile.Read(ref _headReserved.Value) - Volatile.Read(ref _tail.Value) < _buffer.Length)
+            if (HasSpaceAvailable())
                 return;
 
             await _spaceAvailable.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
         finally
         {
-            _producerWaiting = false;
+            Interlocked.Decrement(ref _producerWaiterCount);
         }
     }
 
@@ -118,8 +130,9 @@ internal sealed class MpscFetchBuffer
         item = _buffer[tail & _mask]!;
         _buffer[tail & _mask] = null;
         Volatile.Write(ref _tail.Value, tail + 1);
+        Interlocked.MemoryBarrier();
 
-        if (_producerWaiting)
+        if (Volatile.Read(ref _producerWaiterCount) > 0)
             _spaceAvailable.Release();
 
         return true;
@@ -144,10 +157,12 @@ internal sealed class MpscFetchBuffer
 
         // Slow path: wait for signal
         _dataAvailable.Reset();
-        _consumerWaiting = true;
+        Volatile.Write(ref _consumerWaiting, 1);
 
         try
         {
+            Interlocked.MemoryBarrier();
+
             // Re-check after reset to avoid missed signal
             if (Volatile.Read(ref _headCommitted.Value) > Volatile.Read(ref _tail.Value))
                 return true;
@@ -168,7 +183,7 @@ internal sealed class MpscFetchBuffer
         }
         finally
         {
-            _consumerWaiting = false;
+            Volatile.Write(ref _consumerWaiting, 0);
         }
     }
 
@@ -189,6 +204,10 @@ internal sealed class MpscFetchBuffer
     }
 
     public bool IsCompleted => _completed;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool HasSpaceAvailable() =>
+        Volatile.Read(ref _headReserved.Value) - Volatile.Read(ref _tail.Value) < _buffer.Length;
 
     /// <summary>
     /// Cache-line-padded index to prevent false sharing between producer and consumer.

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -18,6 +18,8 @@ internal static class PoolSizing
     private const int EstimatedMessagesPerBatch = 1024;
     private const int MinValueTaskSources = 256;
     private const int MaxValueTaskSources = 65536;
+    private const int MinConsumerPrefetchBufferCapacity = 16;
+    private const int MaxConsumerPrefetchBufferCapacity = 1024;
 
     /// <summary>
     /// Approximate number of coalesced partitions per batch — used to scale
@@ -107,6 +109,34 @@ internal static class PoolSizing
             CancellationTokenSources = Math.Clamp(maxPartitionCount * 4, 64, 2048),
         };
     }
+
+    internal static int ForConsumerPrefetchBuffer(
+        int queuedMaxMessagesKbytes,
+        int maxPartitionFetchBytes,
+        int fetchMaxBytes,
+        int prefetchPipelineDepth,
+        int connectionsPerBroker)
+    {
+        var queuedMaxBytes = Math.Max(1L, (long)queuedMaxMessagesKbytes * 1024L);
+        var partitionFetchBytes = Math.Max(1L, (long)maxPartitionFetchBytes);
+        var byteBoundItems = CeilingDivide(queuedMaxBytes, partitionFetchBytes);
+
+        var responseMaxBytes = Math.Max(1L, (long)fetchMaxBytes);
+        var fetchResponseItems = CeilingDivide(responseMaxBytes, partitionFetchBytes);
+        var pipelineDepth = Math.Max((long)prefetchPipelineDepth, 1L);
+        var connectionCount = Math.Max((long)connectionsPerBroker, 1L);
+        var pipelineItems = fetchResponseItems * (pipelineDepth + 1L);
+        var pipelineFloor = pipelineDepth * connectionCount;
+        var capacity = Math.Max(Math.Max(byteBoundItems, pipelineItems), pipelineFloor);
+
+        return (int)Math.Clamp(
+            capacity,
+            MinConsumerPrefetchBufferCapacity,
+            MaxConsumerPrefetchBufferCapacity);
+    }
+
+    private static long CeilingDivide(long value, long divisor) =>
+        (value + divisor - 1L) / divisor;
 
     /// <summary>
     /// Pool sizes that scale with the number of brokers sharing a global/shared pool.

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Dekaf.Consumer;
 using Dekaf.Protocol.Records;
 
@@ -14,6 +15,18 @@ public class MpscFetchBufferTests
     private static PendingFetchData CreateDummy(string topic = "test-topic", int partition = 0)
     {
         return PendingFetchData.Create(topic, partition, Array.Empty<RecordBatch>());
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (stopwatch.Elapsed >= timeout)
+                throw new TimeoutException("Condition was not reached before the timeout.");
+
+            await Task.Delay(10);
+        }
     }
 
     #region TryWrite / TryRead basic operations
@@ -91,6 +104,37 @@ public class MpscFetchBufferTests
         item1.Dispose();
         item2.Dispose();
         item3.Dispose();
+    }
+
+    #endregion
+
+    #region WaitToWrite
+
+    [Test]
+    public async Task WaitToWriteAsync_MultipleWaiters_RemainSignaled()
+    {
+        var buffer = new MpscFetchBuffer(1);
+        var first = CreateDummy("topic", 0);
+        await Assert.That(buffer.TryWrite(first)).IsTrue();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var waiter1 = Task.Run(async () => await buffer.WaitToWriteAsync(cts.Token));
+        var waiter2 = Task.Run(async () => await buffer.WaitToWriteAsync(cts.Token));
+
+        await WaitUntilAsync(() => buffer.ProducerWaiterCount == 2, TimeSpan.FromSeconds(5));
+
+        await Assert.That(buffer.TryRead(out var readFirst)).IsTrue();
+        readFirst!.Dispose();
+
+        var firstReleased = await Task.WhenAny(waiter1, waiter2, Task.Delay(TimeSpan.FromSeconds(5), cts.Token));
+        await Assert.That(firstReleased == waiter1 || firstReleased == waiter2).IsTrue();
+
+        var second = CreateDummy("topic", 1);
+        await Assert.That(buffer.TryWrite(second)).IsTrue();
+        await Assert.That(buffer.TryRead(out var readSecond)).IsTrue();
+        readSecond!.Dispose();
+
+        await Task.WhenAll(waiter1, waiter2).WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
     }
 
     #endregion
@@ -335,6 +379,7 @@ public class MpscFetchBufferTests
     {
         // Capacity 3 should round up to 4
         var buffer = new MpscFetchBuffer(3);
+        await Assert.That(buffer.Capacity).IsEqualTo(4);
 
         var items = new List<PendingFetchData>();
         for (var i = 0; i < 4; i++)

--- a/tests/Dekaf.Tests.Unit/Consumer/PrefetchPipelineRunnerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PrefetchPipelineRunnerTests.cs
@@ -971,6 +971,66 @@ public class PrefetchPipelineRunnerTests
 
     #endregion
 
+    #region Scenario: CalculatePrefetchBufferCapacity slot sizing
+
+    [Test]
+    public async Task CalculatePrefetchBufferCapacity_DefaultOptions_UsesFetchPipelineBound()
+    {
+        var result = KafkaConsumer<string, string>.CalculatePrefetchBufferCapacity(new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"]
+        });
+
+        await Assert.That(result).IsEqualTo(200);
+    }
+
+    [Test]
+    public async Task CalculatePrefetchBufferCapacity_IgnoresQueuedMinMessagesForSlotCount()
+    {
+        var result = KafkaConsumer<string, string>.CalculatePrefetchBufferCapacity(new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            QueuedMinMessages = 100_000,
+            QueuedMaxMessagesKbytes = 65_536,
+            MaxPartitionFetchBytes = 1_048_576,
+            FetchMaxBytes = 1_048_576,
+            PrefetchPipelineDepth = 1
+        });
+
+        await Assert.That(result).IsEqualTo(64);
+    }
+
+    [Test]
+    public async Task CalculatePrefetchBufferCapacity_ClampsExtremeByteBudget()
+    {
+        var result = KafkaConsumer<string, string>.CalculatePrefetchBufferCapacity(new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            QueuedMaxMessagesKbytes = int.MaxValue,
+            MaxPartitionFetchBytes = 1
+        });
+
+        await Assert.That(result).IsEqualTo(1024);
+    }
+
+    [Test]
+    public async Task CalculatePrefetchBufferCapacity_KeepsSmallBudgetsUsable()
+    {
+        var result = KafkaConsumer<string, string>.CalculatePrefetchBufferCapacity(new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            QueuedMaxMessagesKbytes = 1,
+            MaxPartitionFetchBytes = 1_048_576,
+            FetchMaxBytes = 1,
+            PrefetchPipelineDepth = 1,
+            ConnectionsPerBroker = 1
+        });
+
+        await Assert.That(result).IsEqualTo(16);
+    }
+
+    #endregion
+
     #region Scenario: Fast-drain pipeline fill acceleration
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
@@ -177,6 +177,19 @@ public class PoolSizingTests
         await Assert.That(sizes.FetchDataPool).IsLessThanOrEqualTo(512);
     }
 
+    [Test]
+    public async Task ForConsumerPrefetchBuffer_PathologicalPipelineInputs_ClampsToMax()
+    {
+        var capacity = PoolSizing.ForConsumerPrefetchBuffer(
+            queuedMaxMessagesKbytes: 1,
+            maxPartitionFetchBytes: 1,
+            fetchMaxBytes: int.MaxValue,
+            prefetchPipelineDepth: int.MaxValue,
+            connectionsPerBroker: int.MaxValue);
+
+        await Assert.That(capacity).IsEqualTo(1024);
+    }
+
     // --- ForSharedPools tests ---
 
     [Test]


### PR DESCRIPTION
## Summary
- size the MPSC prefetch ring from fetch byte/pipeline bounds instead of QueuedMinMessages
- cap ring slots to avoid the default 1M-slot LOH allocation and extreme option overflow
- replace the single producer-waiting flag with a waiter count
- add StoreLoad barriers around wait rechecks to prevent missed producer/consumer signals
- add regression coverage for slot sizing and multiple producer waiters

Closes #904
Closes #895

## Test plan
- dotnet build tests\\Dekaf.Tests.Unit --configuration Release
- .\\tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe --treenode-filter /*/*/MpscFetchBufferTests/*
- .\\tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe --treenode-filter /*/*/PrefetchPipelineRunnerTests/*
- .\\tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe
- dotnet build tests\\Dekaf.Tests.Integration --configuration Release