### PR TITLE
perf(schema-registry): cache avro datum codecs

### DIFF
--- a/src/Dekaf.SchemaRegistry.Avro/AvroCodecCache.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroCodecCache.cs
@@ -1,0 +1,67 @@
+using System.Runtime.CompilerServices;
+using Avro.IO;
+using AvroSchema = Avro.Schema;
+
+namespace Dekaf.SchemaRegistry.Avro;
+
+internal readonly record struct AvroSchemaPair(AvroSchema WriterSchema, AvroSchema ReaderSchema);
+
+internal sealed class AvroSchemaReferenceComparer : IEqualityComparer<AvroSchema>
+{
+    internal static readonly AvroSchemaReferenceComparer Instance = new();
+
+    private AvroSchemaReferenceComparer() { }
+
+    public bool Equals(AvroSchema? x, AvroSchema? y) => ReferenceEquals(x, y);
+
+    public int GetHashCode(AvroSchema obj) => RuntimeHelpers.GetHashCode(obj);
+}
+
+internal sealed class AvroSchemaPairReferenceComparer : IEqualityComparer<AvroSchemaPair>
+{
+    internal static readonly AvroSchemaPairReferenceComparer Instance = new();
+
+    private AvroSchemaPairReferenceComparer() { }
+
+    public bool Equals(AvroSchemaPair x, AvroSchemaPair y) =>
+        ReferenceEquals(x.WriterSchema, y.WriterSchema) &&
+        ReferenceEquals(x.ReaderSchema, y.ReaderSchema);
+
+    public int GetHashCode(AvroSchemaPair obj) =>
+        HashCode.Combine(
+            RuntimeHelpers.GetHashCode(obj.WriterSchema),
+            RuntimeHelpers.GetHashCode(obj.ReaderSchema));
+}
+
+internal sealed class AvroSerializationThreadState
+{
+    internal AvroSerializationThreadState()
+    {
+        Stream = new PooledMemoryStream([]);
+        Encoder = new BinaryEncoder(Stream);
+    }
+
+    internal PooledMemoryStream Stream { get; }
+    internal BinaryEncoder Encoder { get; }
+}
+
+internal sealed class AvroDeserializationThreadState
+{
+    internal AvroDeserializationThreadState()
+    {
+        Stream = new PooledMemoryStream([]);
+        Decoder = new BinaryDecoder(Stream);
+    }
+
+    internal PooledMemoryStream Stream { get; }
+    internal BinaryDecoder Decoder { get; }
+}
+
+internal static class AvroCodecThreadStateCache
+{
+    [ThreadStatic]
+    internal static AvroSerializationThreadState? Serialization;
+
+    [ThreadStatic]
+    internal static AvroDeserializationThreadState? Deserialization;
+}

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -40,6 +40,10 @@ public sealed class AvroSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
     private readonly AvroDeserializerConfig _config;
     private readonly bool _ownsClient;
     private readonly ConcurrentDictionary<int, Lazy<Task<AvroSchema>>> _schemaCache = new();
+    private readonly ConcurrentDictionary<AvroSchemaPair, GenericDatumReader<GenericRecord>> _genericReaders =
+        new(AvroSchemaPairReferenceComparer.Instance);
+    private readonly ConcurrentDictionary<AvroSchemaPair, SpecificDatumReader<T>> _specificReaders =
+        new(AvroSchemaPairReferenceComparer.Instance);
     private readonly AvroSchema? _readerSchema;
 
     /// <summary>
@@ -60,6 +64,9 @@ public sealed class AvroSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
         // Parse custom reader schema if provided, otherwise derive from type
         _readerSchema = GetReaderSchema();
     }
+
+    internal int CachedGenericReaderCount => _genericReaders.Count;
+    internal int CachedSpecificReaderCount => _specificReaders.Count;
 
     /// <summary>
     /// Pre-warms the schema cache for a specific schema ID.
@@ -104,18 +111,21 @@ public sealed class AvroSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
 
         // Extract Avro payload using pooled buffer to avoid allocation
         var payload = span.Slice(5);
+        var codecState = AvroCodecThreadStateCache.Deserialization ??= new AvroDeserializationThreadState();
+        var memoryStream = codecState.Stream;
         var rentedBuffer = ArrayPool<byte>.Shared.Rent(payload.Length);
+
         try
         {
             payload.CopyTo(rentedBuffer);
 
-            using var memoryStream = new PooledMemoryStream(rentedBuffer, payload.Length);
-            var decoder = new BinaryDecoder(memoryStream);
+            memoryStream.Reset(rentedBuffer, payload.Length);
 
-            return ReadAvroValue(writerSchema, decoder);
+            return ReadAvroValue(writerSchema, codecState.Decoder);
         }
         finally
         {
+            memoryStream.DetachBuffer();
             ArrayPool<byte>.Shared.Return(rentedBuffer);
         }
     }
@@ -126,14 +136,18 @@ public sealed class AvroSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
 
         if (typeof(T) == typeof(GenericRecord))
         {
-            var reader = new GenericDatumReader<GenericRecord>(writerSchema, readerSchema);
+            var reader = _genericReaders.GetOrAdd(
+                new AvroSchemaPair(writerSchema, readerSchema),
+                static key => new GenericDatumReader<GenericRecord>(key.WriterSchema, key.ReaderSchema));
             var result = reader.Read(default!, decoder);
             return (T)(object)result;
         }
 
         if (typeof(ISpecificRecord).IsAssignableFrom(typeof(T)))
         {
-            var reader = new SpecificDatumReader<T>(writerSchema, readerSchema);
+            var reader = _specificReaders.GetOrAdd(
+                new AvroSchemaPair(writerSchema, readerSchema),
+                static key => new SpecificDatumReader<T>(key.WriterSchema, key.ReaderSchema));
             return reader.Read(default!, decoder);
         }
 
@@ -143,12 +157,7 @@ public sealed class AvroSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
 
     private AvroSchema GetWriterSchemaCached(int schemaId)
     {
-        // Use Lazy<Task<T>> pattern for thread-safe lazy initialization.
-        // GetOrAdd ensures only one Lazy instance is created per schema ID.
-        // The Lazy ensures only one thread executes the factory (fetches the schema).
-        var lazyTask = _schemaCache.GetOrAdd(
-            schemaId,
-            id => new Lazy<Task<AvroSchema>>(() => FetchWriterSchemaAsync(id)));
+        var lazyTask = GetOrAddWriterSchemaLazy(schemaId, cancellationToken: default);
 
         // If the task is already completed, this returns immediately without blocking.
         // If this is the first access, it will block waiting for the schema fetch.
@@ -169,12 +178,28 @@ public sealed class AvroSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
 
     private async Task<AvroSchema> GetOrFetchWriterSchemaAsync(int schemaId, CancellationToken cancellationToken = default)
     {
-        var lazyTask = _schemaCache.GetOrAdd(
-            schemaId,
-            id => new Lazy<Task<AvroSchema>>(() => FetchWriterSchemaAsync(id, cancellationToken)));
+        var lazyTask = GetOrAddWriterSchemaLazy(schemaId, cancellationToken);
 
         return await lazyTask.Value.ConfigureAwait(false);
     }
+
+    private Lazy<Task<AvroSchema>> GetOrAddWriterSchemaLazy(int schemaId, CancellationToken cancellationToken)
+    {
+        if (_schemaCache.TryGetValue(schemaId, out var cached))
+            return cached;
+
+        return _schemaCache.GetOrAdd(
+            schemaId,
+            static (id, state) => state.Deserializer.CreateWriterSchemaLazy(id, state.CancellationToken),
+            new WriterSchemaFetchState(this, cancellationToken));
+    }
+
+    private Lazy<Task<AvroSchema>> CreateWriterSchemaLazy(int schemaId, CancellationToken cancellationToken) =>
+        new(() => FetchWriterSchemaAsync(schemaId, cancellationToken));
+
+    private readonly record struct WriterSchemaFetchState(
+        AvroSchemaRegistryDeserializer<T> Deserializer,
+        CancellationToken CancellationToken);
 
     private async Task<AvroSchema> FetchWriterSchemaAsync(int schemaId, CancellationToken cancellationToken = default)
     {

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -41,6 +41,10 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     private readonly AvroSerializerConfig _config;
     private readonly bool _ownsClient;
     private readonly ConcurrentDictionary<string, Lazy<Task<int>>> _schemaIdCache = new();
+    private readonly ConcurrentDictionary<AvroSchema, GenericDatumWriter<GenericRecord>> _genericWriters =
+        new(AvroSchemaReferenceComparer.Instance);
+    private readonly ConcurrentDictionary<AvroSchema, SpecificDefaultWriter> _specificWriters =
+        new(AvroSchemaReferenceComparer.Instance);
     private readonly AvroSchema? _writerSchema;
 
     /// <summary>
@@ -61,6 +65,9 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         // Try to get schema from type T if it's a specific record
         _writerSchema = GetSchemaFromType();
     }
+
+    internal int CachedGenericWriterCount => _genericWriters.Count;
+    internal int CachedSpecificWriterCount => _specificWriters.Count;
 
     /// <summary>
     /// Pre-warms the schema cache for a specific topic.
@@ -100,13 +107,15 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         var subject = GetSubjectName(context.Topic, context.Component == SerializationComponent.Key);
         var schemaId = GetSchemaIdCached(subject, value);
 
-        // Use a pooled buffer for Avro serialization
-        // Initial estimate: 1KB should handle most messages, will grow if needed
+        var codecState = AvroCodecThreadStateCache.Serialization ??= new AvroSerializationThreadState();
+        var memoryStream = codecState.Stream;
         var rentedBuffer = ArrayPool<byte>.Shared.Rent(1024);
+
         try
         {
-            using var memoryStream = new PooledMemoryStream(rentedBuffer);
-            var encoder = new BinaryEncoder(memoryStream);
+            // Initial estimate: 1KB should handle most messages; the stream grows if needed.
+            memoryStream.Reset(rentedBuffer);
+            var encoder = codecState.Encoder;
 
             WriteAvroValue(value, encoder);
             encoder.Flush();
@@ -125,21 +134,26 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         }
         finally
         {
+            memoryStream.DetachBuffer();
             ArrayPool<byte>.Shared.Return(rentedBuffer);
         }
     }
 
-    private static void WriteAvroValue(T value, BinaryEncoder encoder)
+    private void WriteAvroValue(T value, BinaryEncoder encoder)
     {
         switch (value)
         {
             case ISpecificRecord specificRecord:
-                var specificWriter = new SpecificDefaultWriter(specificRecord.Schema);
+                var specificWriter = _specificWriters.GetOrAdd(
+                    specificRecord.Schema,
+                    static schema => new SpecificDefaultWriter(schema));
                 specificWriter.Write(specificRecord.Schema, specificRecord, encoder);
                 break;
 
             case GenericRecord genericRecord:
-                var genericWriter = new GenericDatumWriter<GenericRecord>(genericRecord.Schema);
+                var genericWriter = _genericWriters.GetOrAdd(
+                    genericRecord.Schema,
+                    static schema => new GenericDatumWriter<GenericRecord>(schema));
                 genericWriter.Write(genericRecord, encoder);
                 break;
 
@@ -151,12 +165,7 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
 
     private int GetSchemaIdCached(string subject, T value)
     {
-        // Use Lazy<Task<T>> pattern for thread-safe lazy initialization.
-        // GetOrAdd ensures only one Lazy instance is created per subject.
-        // The Lazy ensures only one thread executes the factory (fetches the schema).
-        var lazyTask = _schemaIdCache.GetOrAdd(
-            subject,
-            _ => new Lazy<Task<int>>(() => FetchSchemaIdAsync(subject, value)));
+        var lazyTask = GetOrAddSchemaIdLazy(subject, value, cancellationToken: default);
 
         // If the task is already completed, this returns immediately without blocking.
         // If this is the first access, it will block waiting for the schema fetch.
@@ -177,12 +186,29 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
 
     private async Task<int> GetOrFetchSchemaIdAsync(string subject, T value, CancellationToken cancellationToken = default)
     {
-        var lazyTask = _schemaIdCache.GetOrAdd(
-            subject,
-            _ => new Lazy<Task<int>>(() => FetchSchemaIdAsync(subject, value, cancellationToken)));
+        var lazyTask = GetOrAddSchemaIdLazy(subject, value, cancellationToken);
 
         return await lazyTask.Value.ConfigureAwait(false);
     }
+
+    private Lazy<Task<int>> GetOrAddSchemaIdLazy(string subject, T value, CancellationToken cancellationToken)
+    {
+        if (_schemaIdCache.TryGetValue(subject, out var cached))
+            return cached;
+
+        return _schemaIdCache.GetOrAdd(
+            subject,
+            static (key, state) => state.Serializer.CreateSchemaIdLazy(key, state.Value, state.CancellationToken),
+            new SchemaIdFetchState(this, value, cancellationToken));
+    }
+
+    private Lazy<Task<int>> CreateSchemaIdLazy(string subject, T value, CancellationToken cancellationToken) =>
+        new(() => FetchSchemaIdAsync(subject, value, cancellationToken));
+
+    private readonly record struct SchemaIdFetchState(
+        AvroSchemaRegistrySerializer<T> Serializer,
+        T Value,
+        CancellationToken CancellationToken);
 
     private async Task<int> FetchSchemaIdAsync(string subject, T value, CancellationToken cancellationToken = default)
     {

--- a/src/Dekaf.SchemaRegistry.Avro/PooledMemoryStream.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/PooledMemoryStream.cs
@@ -8,6 +8,8 @@ namespace Dekaf.SchemaRegistry.Avro;
 /// </summary>
 internal sealed class PooledMemoryStream : Stream
 {
+    private static readonly byte[] EmptyBuffer = [];
+
     private byte[] _buffer;
     private int _position;
     private int _length;
@@ -20,8 +22,8 @@ internal sealed class PooledMemoryStream : Stream
     /// <param name="initialBuffer">The initial buffer (should be rented from ArrayPool).</param>
     public PooledMemoryStream(byte[] initialBuffer)
     {
-        _buffer = initialBuffer;
-        _ownsBuffer = false; // Caller owns the initial buffer
+        _buffer = EmptyBuffer;
+        Reset(initialBuffer);
     }
 
     /// <summary>
@@ -31,9 +33,34 @@ internal sealed class PooledMemoryStream : Stream
     /// <param name="length">The number of valid bytes in the buffer.</param>
     public PooledMemoryStream(byte[] buffer, int length)
     {
+        _buffer = EmptyBuffer;
+        Reset(buffer, length);
+    }
+
+    public void Reset(byte[] buffer, int length = 0)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        if (length > buffer.Length)
+            throw new ArgumentOutOfRangeException(nameof(length), "Length cannot exceed buffer length.");
+
+        ReleaseOwnedBuffer();
+
         _buffer = buffer;
+        _position = 0;
         _length = length;
-        _ownsBuffer = false; // Caller owns the buffer
+        _ownsBuffer = false; // Caller owns the supplied buffer
+        _disposed = false;
+    }
+
+    public void DetachBuffer()
+    {
+        ReleaseOwnedBuffer();
+
+        _buffer = EmptyBuffer;
+        _position = 0;
+        _length = 0;
+        _ownsBuffer = false;
     }
 
     public override bool CanRead => !_disposed;
@@ -186,6 +213,16 @@ internal sealed class PooledMemoryStream : Stream
         _ownsBuffer = true; // We now own this buffer
     }
 
+    private void ReleaseOwnedBuffer()
+    {
+        if (!_ownsBuffer)
+            return;
+
+        // No need to clear - contains serialized Avro payloads, not sensitive data
+        ArrayPool<byte>.Shared.Return(_buffer, clearArray: false);
+        _ownsBuffer = false;
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (_disposed)
@@ -193,11 +230,10 @@ internal sealed class PooledMemoryStream : Stream
 
         if (disposing && _ownsBuffer)
         {
-            // No need to clear - contains serialized Avro payloads, not sensitive data
-            ArrayPool<byte>.Shared.Return(_buffer, clearArray: false);
-            _buffer = null!;
+            ReleaseOwnedBuffer();
         }
 
+        _buffer = EmptyBuffer;
         _disposed = true;
         base.Dispose(disposing);
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -172,6 +172,32 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_CachesGenericDatumWriter_ForSameSchema()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+
+        var schema = AvroSchema.Parse(SimpleRecordSchema) as Avro.RecordSchema;
+        var record1 = new GenericRecord(schema!);
+        record1.Add("id", 1);
+        record1.Add("name", "first");
+
+        var record2 = new GenericRecord(schema!);
+        record2.Add("id", 2);
+        record2.Add("name", "second");
+
+        var buffer1 = new ArrayBufferWriter<byte>();
+        var buffer2 = new ArrayBufferWriter<byte>();
+        var context = CreateContext();
+
+        serializer.Serialize(record1, ref buffer1, context);
+        serializer.Serialize(record2, ref buffer2, context);
+
+        await Assert.That(serializer.CachedGenericWriterCount).IsEqualTo(1);
+        await Assert.That(serializer.CachedSpecificWriterCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Serializer_UsesTopicNameStrategy_ByDefault()
     {
         // Arrange
@@ -338,5 +364,49 @@ public sealed class AvroSerializerTests
         // Verify deserialization worked correctly
         await Assert.That((int)result["id"]!).IsEqualTo(42);
         await Assert.That((string)result["name"]!).IsEqualTo("warmup-test");
+    }
+
+    [Test]
+    public async Task Deserializer_CachesGenericDatumReader_ForSameSchemaPair()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+
+        var schemaObj = new RegistrySchema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = SimpleRecordSchema
+        };
+        var schemaId = await schemaRegistry.RegisterSchemaAsync("test-topic-value", schemaObj);
+
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(schemaRegistry);
+        await deserializer.WarmupAsync(schemaId);
+
+        var avroSchema = AvroSchema.Parse(SimpleRecordSchema) as Avro.RecordSchema;
+        var record1 = new GenericRecord(avroSchema!);
+        record1.Add("id", 1);
+        record1.Add("name", "first");
+
+        var record2 = new GenericRecord(avroSchema!);
+        record2.Add("id", 2);
+        record2.Add("name", "second");
+
+        var wireFormat1 = CreateWireFormat(schemaId, SerializeAvroRecord(record1, avroSchema!));
+        var wireFormat2 = CreateWireFormat(schemaId, SerializeAvroRecord(record2, avroSchema!));
+        var context = CreateContext();
+
+        deserializer.Deserialize(wireFormat1, context);
+        deserializer.Deserialize(wireFormat2, context);
+
+        await Assert.That(deserializer.CachedGenericReaderCount).IsEqualTo(1);
+        await Assert.That(deserializer.CachedSpecificReaderCount).IsEqualTo(0);
+    }
+
+    private static byte[] CreateWireFormat(int schemaId, byte[] avroPayload)
+    {
+        var wireFormat = new byte[1 + 4 + avroPayload.Length];
+        wireFormat[0] = 0x00;
+        BinaryPrimitives.WriteInt32BigEndian(wireFormat.AsSpan(1, 4), schemaId);
+        avroPayload.CopyTo(wireFormat.AsSpan(5));
+        return wireFormat;
     }
 }


### PR DESCRIPTION
## Summary
- cache Avro datum writers/readers by reference-keyed schema pairs instead of constructing them per message
- avoid schema Lazy cache-hit closures with TryGetValue fast paths and stateful miss factories
- reuse Avro PooledMemoryStream plus BinaryEncoder/BinaryDecoder per thread

Closes #905

## Tests
- dotnet build tests/Dekaf.Tests.Unit --configuration Release
- ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter /*/*/AvroSerializerTests/*
- ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit
- dotnet build tests/Dekaf.Tests.Integration --configuration Release
- ./tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration --treenode-filter /*/*/AvroSerializerIntegrationTests/*

Note: one earlier full unit run flaked in unrelated consumer/producer tests; the failed tests passed isolated and the full rerun passed.