### PR TITLE
perf(compression): decompress into destination

### DIFF
--- a/src/Dekaf.Compression.Brotli/BrotliCompressionCodec.cs
+++ b/src/Dekaf.Compression.Brotli/BrotliCompressionCodec.cs
@@ -70,21 +70,7 @@ public sealed class BrotliCompressionCodec : ICompressionCodec
         using var inputStream = new ReadOnlySequenceStream(source);
         using var brotliStream = new BrotliStream(inputStream, CompressionMode.Decompress);
 
-        var buffer = ArrayPool<byte>.Shared.Rent(8192);
-        try
-        {
-            int bytesRead;
-            while ((bytesRead = brotliStream.Read(buffer)) > 0)
-            {
-                var span = destination.GetSpan(bytesRead);
-                buffer.AsSpan(0, bytesRead).CopyTo(span);
-                destination.Advance(bytesRead);
-            }
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
+        CompressionStreamCopy.CopyToBufferWriter(brotliStream, destination);
     }
 }
 

--- a/src/Dekaf.Compression.Lz4/Lz4CompressionCodec.cs
+++ b/src/Dekaf.Compression.Lz4/Lz4CompressionCodec.cs
@@ -52,21 +52,7 @@ public sealed class Lz4CompressionCodec : ICompressionCodec
         using var inputStream = new ReadOnlySequenceStream(source);
         using var lz4Stream = LZ4Stream.Decode(inputStream, leaveOpen: true);
 
-        var buffer = ArrayPool<byte>.Shared.Rent(8192);
-        try
-        {
-            int bytesRead;
-            while ((bytesRead = lz4Stream.Read(buffer)) > 0)
-            {
-                var span = destination.GetSpan(bytesRead);
-                buffer.AsSpan(0, bytesRead).CopyTo(span);
-                destination.Advance(bytesRead);
-            }
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
+        CompressionStreamCopy.CopyToBufferWriter(lz4Stream, destination);
     }
 }
 

--- a/src/Dekaf/Compression/BuiltInCodecs.cs
+++ b/src/Dekaf/Compression/BuiltInCodecs.cs
@@ -89,20 +89,24 @@ public sealed class GzipCompressionCodec : ICompressionCodec
         using var inputStream = new ReadOnlySequenceStream(source);
         using var gzipStream = new GZipStream(inputStream, CompressionMode.Decompress);
 
-        var buffer = ArrayPool<byte>.Shared.Rent(8192);
-        try
+        CompressionStreamCopy.CopyToBufferWriter(gzipStream, destination);
+    }
+}
+
+internal static class CompressionStreamCopy
+{
+    private const int BufferSize = 8192;
+
+    internal static void CopyToBufferWriter(Stream source, IBufferWriter<byte> destination)
+    {
+        while (true)
         {
-            int bytesRead;
-            while ((bytesRead = gzipStream.Read(buffer)) > 0)
-            {
-                var span = destination.GetSpan(bytesRead);
-                buffer.AsSpan(0, bytesRead).CopyTo(span);
-                destination.Advance(bytesRead);
-            }
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
+            var span = destination.GetSpan(BufferSize);
+            var bytesRead = source.Read(span);
+            if (bytesRead == 0)
+                break;
+
+            destination.Advance(bytesRead);
         }
     }
 }


### PR DESCRIPTION
## Summary
- decompress gzip, LZ4, and Brotli streams directly into the destination `IBufferWriter<byte>`
- remove the per-decompression rented 8KB scratch buffer and copy step
- share the direct stream-to-buffer-writer loop across compression codecs

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/GzipCompressionCodecTests/*"
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/Lz4CompressionCodecTests/*"
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/BrotliCompressionCodecTests/*"
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe
- [x] dotnet build tests\Dekaf.Tests.Integration --configuration Release

Closes #930
