### PR TITLE
perf(protocol): write produce records directly

### DIFF
--- a/src/Dekaf/Protocol/KafkaProtocolWriter.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolWriter.cs
@@ -22,6 +22,11 @@ public ref struct KafkaProtocolWriter
 
     public readonly int BytesWritten => _bytesWritten;
 
+    internal readonly IBufferWriter<byte> BufferWriter => _output;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void AddBytesWritten(int byteCount) => _bytesWritten = checked(_bytesWritten + byteCount);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteInt8(sbyte value)
     {

--- a/src/Dekaf/Protocol/Messages/ProduceRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceRequest.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using Dekaf.Compression;
 using Dekaf.Protocol.Records;
 
@@ -84,25 +85,6 @@ public sealed class ProduceRequestTopicData
 /// </summary>
 public sealed class ProduceRequestPartitionData
 {
-    // Thread-local reusable buffer for record serialization
-    [ThreadStatic]
-    private static System.Buffers.ArrayBufferWriter<byte>? t_recordsBuffer;
-
-    private static System.Buffers.ArrayBufferWriter<byte> GetRecordsBuffer()
-    {
-        var buffer = t_recordsBuffer;
-        if (buffer is null)
-        {
-            buffer = new System.Buffers.ArrayBufferWriter<byte>(8192);
-            t_recordsBuffer = buffer;
-        }
-        else
-        {
-            buffer.Clear();
-        }
-        return buffer;
-    }
-
     /// <summary>
     /// Partition index.
     /// </summary>
@@ -128,15 +110,49 @@ public sealed class ProduceRequestPartitionData
     {
         writer.WriteInt32(Index);
 
-        // Serialize records to a thread-local buffer to avoid per-partition allocation
-        var recordsBuffer = GetRecordsBuffer();
-        foreach (var batch in Records)
-        {
-            batch.Write(recordsBuffer, Compression, CompressionCodecs);
-        }
+        RecordBatch[]? temporaryPreCompressed = null;
+        var temporaryPreCompressedCount = 0;
 
-        // COMPACT_RECORDS uses COMPACT_NULLABLE_BYTES encoding (length+1, 0 = null)
-        writer.WriteCompactNullableBytes(recordsBuffer.WrittenSpan, isNull: false);
+        try
+        {
+            var recordsLength = 0;
+            for (var i = 0; i < Records.Count; i++)
+            {
+                var batch = Records[i];
+                if (Compression != CompressionType.None && !batch.HasPreCompressedRecords)
+                {
+                    batch.PreCompress(Compression, CompressionCodecs);
+                    temporaryPreCompressed ??= ArrayPool<RecordBatch>.Shared.Rent(Records.Count);
+                    temporaryPreCompressed[temporaryPreCompressedCount++] = batch;
+                }
+
+                checked
+                {
+                    recordsLength += batch.GetEncodedSize(Compression);
+                }
+            }
+
+            // COMPACT_RECORDS uses COMPACT_NULLABLE_BYTES encoding (length+1, 0 = null).
+            writer.WriteUnsignedVarInt(checked(recordsLength + 1));
+            var output = writer.BufferWriter;
+            for (var i = 0; i < Records.Count; i++)
+            {
+                Records[i].Write(output, Compression, CompressionCodecs);
+            }
+            writer.AddBytesWritten(recordsLength);
+        }
+        finally
+        {
+            if (temporaryPreCompressed is not null)
+            {
+                for (var i = 0; i < temporaryPreCompressedCount; i++)
+                {
+                    temporaryPreCompressed[i].ReturnPreCompressedBuffer();
+                }
+
+                ArrayPool<RecordBatch>.Shared.Return(temporaryPreCompressed, clearArray: true);
+            }
+        }
 
         writer.WriteEmptyTaggedFields();
     }

--- a/src/Dekaf/Protocol/Records/Record.cs
+++ b/src/Dekaf/Protocol/Records/Record.cs
@@ -49,7 +49,7 @@ public readonly record struct Record
     /// When Headers is a pooled array (from Record.Read), HeaderCount &lt; Headers.Length is expected.
     /// When Headers is an exact-sized array (from producer path), HeaderCount == Headers.Length.
     /// </remarks>
-    private int EffectiveHeaderCount => Headers is null ? 0 : HeaderCount;
+    internal int EffectiveHeaderCount => Headers is null ? 0 : HeaderCount;
 
     /// <summary>
     /// Writes the record to the protocol writer.

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -453,6 +453,8 @@ public sealed class RecordBatch : IDisposable
     /// </summary>
     internal CompressionType PreCompressedType { get; private set; }
 
+    internal bool HasPreCompressedRecords => PreCompressedRecords is not null;
+
     /// <summary>
     /// Pre-compresses the records in this batch. Called at seal time on partition-affine
     /// append workers to move compression work off the single-threaded send loop.
@@ -760,6 +762,45 @@ public sealed class RecordBatch : IDisposable
             if (cache is not null)
                 ReturnSerializationCache(cache);
         }
+    }
+
+    internal int GetEncodedSize(CompressionType compression = CompressionType.None)
+    {
+        var recordsLength = GetEncodedRecordsLength(compression);
+        return checked(TotalBatchHeaderSize + recordsLength);
+    }
+
+    private int GetEncodedRecordsLength(CompressionType compression)
+    {
+        if (PreCompressedRecords is not null)
+            return PreCompressedLength;
+
+        if (compression != CompressionType.None)
+            throw new InvalidOperationException("Compressed RecordBatch size requires pre-compressed records.");
+
+        var recordsLength = 0;
+        for (var i = 0; i < Records.Count; i++)
+        {
+            var record = Records[i];
+            var bodySize = record.CachedBodySize > 0
+                ? record.CachedBodySize
+                : Record.ComputeBodySize(
+                    record.TimestampDelta,
+                    record.OffsetDelta,
+                    record.IsKeyNull,
+                    record.Key.Length,
+                    record.IsValueNull,
+                    record.Value.Length,
+                    record.Headers,
+                    record.EffectiveHeaderCount);
+
+            checked
+            {
+                recordsLength += Record.VarIntSize(bodySize) + bodySize;
+            }
+        }
+
+        return recordsLength;
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Protocol/ProduceRequestTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ProduceRequestTests.cs
@@ -1,0 +1,282 @@
+using System.Buffers;
+using Dekaf.Compression;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class ProduceRequestTests
+{
+    [Test]
+    public async Task PartitionData_Write_EncodesRecordBatchesWithoutChangingBytes()
+    {
+        var batches = new[]
+        {
+            CreateBatch(baseOffset: 0, offsetDelta: 0, value: "one"u8.ToArray()),
+            CreateBatch(baseOffset: 1, offsetDelta: 1, value: "two"u8.ToArray())
+        };
+
+        var expectedRecords = new ArrayBufferWriter<byte>();
+        foreach (var batch in batches)
+        {
+            batch.Write(expectedRecords);
+        }
+
+        var partitionData = new ProduceRequestPartitionData
+        {
+            Index = 3,
+            Records = batches
+        };
+
+        int index;
+        int recordsLength;
+        byte[] recordsBytes;
+        int taggedFields;
+        bool readerEnd;
+        int writerBytesWritten;
+        int bufferBytesWritten;
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            var writer = new KafkaProtocolWriter(buffer);
+            partitionData.Write(ref writer, ProduceRequest.HighestSupportedVersion);
+
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            index = reader.ReadInt32();
+            recordsLength = reader.ReadUnsignedVarInt() - 1;
+            recordsBytes = reader.ReadRawBytes(recordsLength);
+            taggedFields = reader.ReadUnsignedVarInt();
+            readerEnd = reader.End;
+            writerBytesWritten = writer.BytesWritten;
+            bufferBytesWritten = buffer.WrittenCount;
+        }
+
+        await Assert.That(index).IsEqualTo(3);
+        await Assert.That(recordsLength).IsEqualTo(expectedRecords.WrittenCount);
+        await Assert.That(recordsBytes).IsEquivalentTo(expectedRecords.WrittenSpan.ToArray());
+        await Assert.That(taggedFields).IsEqualTo(0);
+        await Assert.That(readerEnd).IsTrue();
+        await Assert.That(writerBytesWritten).IsEqualTo(bufferBytesWritten);
+    }
+
+    [Test]
+    public async Task PartitionData_Write_WithInlineCompression_ReturnsTemporaryPrecompressedBuffer()
+    {
+        var batch = CreateBatch(baseOffset: 0, offsetDelta: 0, value: "compressed-value"u8.ToArray());
+        var partitionData = new ProduceRequestPartitionData
+        {
+            Index = 0,
+            Records = [batch],
+            Compression = CompressionType.Gzip
+        };
+
+        int index;
+        byte[] recordsBytes;
+        int taggedFields;
+        bool readerEnd;
+        int writerBytesWritten;
+        int bufferBytesWritten;
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            var writer = new KafkaProtocolWriter(buffer);
+            partitionData.Write(ref writer, ProduceRequest.HighestSupportedVersion);
+
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            index = reader.ReadInt32();
+            var recordsLength = reader.ReadUnsignedVarInt() - 1;
+            recordsBytes = reader.ReadRawBytes(recordsLength);
+            taggedFields = reader.ReadUnsignedVarInt();
+            readerEnd = reader.End;
+            writerBytesWritten = writer.BytesWritten;
+            bufferBytesWritten = buffer.WrittenCount;
+        }
+
+        byte[] value;
+        int recordCount;
+        {
+            var recordsReader = new KafkaProtocolReader(recordsBytes);
+            using var parsedBatch = RecordBatch.Read(ref recordsReader);
+            recordCount = parsedBatch.Records.Count;
+            value = parsedBatch.Records[0].Value.ToArray();
+        }
+
+        await Assert.That(batch.PreCompressedRecords).IsNull();
+        await Assert.That(batch.PreCompressedLength).IsEqualTo(0);
+        await Assert.That(writerBytesWritten).IsEqualTo(bufferBytesWritten);
+        await Assert.That(index).IsEqualTo(0);
+        await Assert.That(recordCount).IsEqualTo(1);
+        await Assert.That(value).IsEquivalentTo("compressed-value"u8.ToArray());
+        await Assert.That(taggedFields).IsEqualTo(0);
+        await Assert.That(readerEnd).IsTrue();
+    }
+
+    [Test]
+    public async Task PartitionData_Write_UsesEffectiveHeaderCountForRecordsLength()
+    {
+        var batch = new RecordBatch
+        {
+            BaseOffset = 0,
+            BaseTimestamp = 1000,
+            MaxTimestamp = 1000,
+            ProducerId = -1,
+            ProducerEpoch = -1,
+            BaseSequence = -1,
+            Records =
+            [
+                new Record
+                {
+                    OffsetDelta = 0,
+                    TimestampDelta = 0,
+                    Key = "key"u8.ToArray(),
+                    Value = "value"u8.ToArray(),
+                    Headers = null,
+                    HeaderCount = 128
+                }
+            ]
+        };
+        var expectedRecords = new ArrayBufferWriter<byte>();
+        batch.Write(expectedRecords);
+
+        var partitionData = new ProduceRequestPartitionData
+        {
+            Index = 0,
+            Records = [batch]
+        };
+
+        int index;
+        int recordsLength;
+        byte[] recordsBytes;
+        int taggedFields;
+        bool readerEnd;
+        int writerBytesWritten;
+        int bufferBytesWritten;
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            var writer = new KafkaProtocolWriter(buffer);
+            partitionData.Write(ref writer, ProduceRequest.HighestSupportedVersion);
+
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            index = reader.ReadInt32();
+            recordsLength = reader.ReadUnsignedVarInt() - 1;
+            recordsBytes = reader.ReadRawBytes(recordsLength);
+            taggedFields = reader.ReadUnsignedVarInt();
+            readerEnd = reader.End;
+            writerBytesWritten = writer.BytesWritten;
+            bufferBytesWritten = buffer.WrittenCount;
+        }
+
+        await Assert.That(index).IsEqualTo(0);
+        await Assert.That(recordsLength).IsEqualTo(expectedRecords.WrittenCount);
+        await Assert.That(recordsBytes).IsEquivalentTo(expectedRecords.WrittenSpan.ToArray());
+        await Assert.That(taggedFields).IsEqualTo(0);
+        await Assert.That(readerEnd).IsTrue();
+        await Assert.That(writerBytesWritten).IsEqualTo(bufferBytesWritten);
+    }
+
+    [Test]
+    public async Task PartitionData_Write_WithCachedBodySize_EncodesRecordBatchesWithoutChangingBytes()
+    {
+        var batch = CreateBatchWithCachedBodySize(baseOffset: 0, offsetDelta: 0, value: "cached-value"u8.ToArray());
+        var expectedRecords = new ArrayBufferWriter<byte>();
+        batch.Write(expectedRecords);
+
+        var partitionData = new ProduceRequestPartitionData
+        {
+            Index = 0,
+            Records = [batch]
+        };
+
+        int index;
+        int recordsLength;
+        byte[] recordsBytes;
+        int taggedFields;
+        bool readerEnd;
+        int writerBytesWritten;
+        int bufferBytesWritten;
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            var writer = new KafkaProtocolWriter(buffer);
+            partitionData.Write(ref writer, ProduceRequest.HighestSupportedVersion);
+
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            index = reader.ReadInt32();
+            recordsLength = reader.ReadUnsignedVarInt() - 1;
+            recordsBytes = reader.ReadRawBytes(recordsLength);
+            taggedFields = reader.ReadUnsignedVarInt();
+            readerEnd = reader.End;
+            writerBytesWritten = writer.BytesWritten;
+            bufferBytesWritten = buffer.WrittenCount;
+        }
+
+        await Assert.That(index).IsEqualTo(0);
+        await Assert.That(recordsLength).IsEqualTo(expectedRecords.WrittenCount);
+        await Assert.That(recordsBytes).IsEquivalentTo(expectedRecords.WrittenSpan.ToArray());
+        await Assert.That(taggedFields).IsEqualTo(0);
+        await Assert.That(readerEnd).IsTrue();
+        await Assert.That(writerBytesWritten).IsEqualTo(bufferBytesWritten);
+    }
+
+    private static RecordBatch CreateBatch(long baseOffset, int offsetDelta, byte[] value)
+    {
+        return new RecordBatch
+        {
+            BaseOffset = baseOffset,
+            BaseTimestamp = 1000 + offsetDelta,
+            MaxTimestamp = 1000 + offsetDelta,
+            LastOffsetDelta = offsetDelta,
+            ProducerId = -1,
+            ProducerEpoch = -1,
+            BaseSequence = -1,
+            Records =
+            [
+                new Record
+                {
+                    OffsetDelta = offsetDelta,
+                    TimestampDelta = offsetDelta,
+                    Key = "key"u8.ToArray(),
+                    Value = value
+                }
+            ]
+        };
+    }
+
+    private static RecordBatch CreateBatchWithCachedBodySize(long baseOffset, int offsetDelta, byte[] value)
+    {
+        var key = "cached-key"u8.ToArray();
+        var headers = new[] { new Header("trace-id", "abc123"u8.ToArray()) };
+        var cachedBodySize = Record.ComputeBodySize(
+            offsetDelta,
+            offsetDelta,
+            isKeyNull: false,
+            key.Length,
+            isValueNull: false,
+            value.Length,
+            headers,
+            headers.Length);
+
+        return new RecordBatch
+        {
+            BaseOffset = baseOffset,
+            BaseTimestamp = 1000 + offsetDelta,
+            MaxTimestamp = 1000 + offsetDelta,
+            LastOffsetDelta = offsetDelta,
+            ProducerId = -1,
+            ProducerEpoch = -1,
+            BaseSequence = -1,
+            Records =
+            [
+                new Record
+                {
+                    OffsetDelta = offsetDelta,
+                    TimestampDelta = offsetDelta,
+                    Key = key,
+                    Value = value,
+                    Headers = headers,
+                    HeaderCount = headers.Length,
+                    CachedBodySize = cachedBodySize
+                }
+            ]
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- compute ProduceRequest COMPACT_RECORDS length before writing payload bytes
- remove the thread-static partition records buffer and write RecordBatch payloads to the final protocol output
- keep KafkaProtocolWriter byte accounting correct for direct payload writes and cover uncompressed/compression fallback paths

Closes #902

## Tests
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- `dotnet format --verify-no-changes --include src/Dekaf/Protocol/KafkaProtocolWriter.cs src/Dekaf/Protocol/Records/RecordBatch.cs src/Dekaf/Protocol/Messages/ProduceRequest.cs tests/Dekaf.Tests.Unit/Protocol/ProduceRequestTests.cs --verbosity minimal`
- `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
- `dotnet run --project tests/Dekaf.Tests.Unit --configuration Release --no-build -- --no-ansi --disable-logo --no-progress --maximum-failed-tests 1` (new tests passed; existing producer send-loop timeout failures: `MultiplePartitionsMuted_IndependentlyBlocked_OtherPartitionsProceed`, `InFlightWait_MutedPartitionFilter_MovesCoalescedNormalBatchToCarryOver`, `SendLoop_SequentialRequests_SecondSendsAfterFirstResponseCompletes`)
