### PR TITLE
perf(json): reuse Utf8JsonWriter

### DIFF
--- a/src/Dekaf.Serialization.Json/JsonSerializer.cs
+++ b/src/Dekaf.Serialization.Json/JsonSerializer.cs
@@ -12,6 +12,9 @@ public sealed class JsonSerializer<T> : ISerde<T>
     [ThreadStatic]
     private static ArrayBufferWriter<byte>? t_sharedBuffer;
 
+    [ThreadStatic]
+    private static Utf8JsonWriter? t_jsonWriter;
+
     private readonly JsonSerializerOptions _options;
 
     public JsonSerializer(JsonSerializerOptions? options = null)
@@ -34,9 +37,26 @@ public sealed class JsonSerializer<T> : ISerde<T>
         var sharedBuffer = t_sharedBuffer ??= new ArrayBufferWriter<byte>();
         sharedBuffer.ResetWrittenCount();
 
-        using (var jsonWriter = new Utf8JsonWriter(sharedBuffer))
+        var jsonWriter = t_jsonWriter;
+        if (jsonWriter is null)
+        {
+            jsonWriter = new Utf8JsonWriter(sharedBuffer);
+            t_jsonWriter = jsonWriter;
+        }
+        else
+        {
+            jsonWriter.Reset(sharedBuffer);
+        }
+
+        try
         {
             System.Text.Json.JsonSerializer.Serialize(jsonWriter, value, _options);
+            jsonWriter.Flush();
+        }
+        catch
+        {
+            t_jsonWriter = null;
+            throw;
         }
 
         var written = sharedBuffer.WrittenSpan;

--- a/tests/Dekaf.Tests.Unit/Serialization/JsonSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/JsonSerializerTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Dekaf.Serialization;
 using Dekaf.Serialization.Json;
 
@@ -45,6 +46,21 @@ public class JsonSerializerTests
         await Assert.That(json).DoesNotContain("\"Age\"");
     }
 
+    [Test]
+    public async Task Serialize_RepeatedCalls_ResetsWriterAndBuffer()
+    {
+        var serializer = new JsonSerializer<TestPerson>();
+        var context = CreateContext();
+        var firstBuffer = new ArrayBufferWriter<byte>();
+        var secondBuffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(new TestPerson { Name = "Longer name", Age = 41 }, ref firstBuffer, context);
+        serializer.Serialize(new TestPerson { Name = "Al", Age = 7 }, ref secondBuffer, context);
+
+        var json = System.Text.Encoding.UTF8.GetString(secondBuffer.WrittenSpan);
+        await Assert.That(json).IsEqualTo("{\"name\":\"Al\",\"age\":7}");
+    }
+
     #endregion
 
     #region Custom Options Tests
@@ -83,6 +99,25 @@ public class JsonSerializerTests
         var act = () => serializer.Deserialize((ReadOnlyMemory<byte>)invalidJson, context);
 
         await Assert.That(act).Throws<JsonException>();
+    }
+
+    [Test]
+    public async Task Serialize_AfterSerializationException_CanSerializeAgain()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new ThrowingPayloadConverter());
+        var throwingSerializer = new JsonSerializer<ThrowingPayload>(options);
+        var serializer = new JsonSerializer<ThrowingPayload>();
+        var context = CreateContext();
+        var failedBuffer = new ArrayBufferWriter<byte>();
+        var buffer = new ArrayBufferWriter<byte>();
+
+        var act = () => throwingSerializer.Serialize(new ThrowingPayload("boom"), ref failedBuffer, context);
+        await Assert.That(act).Throws<InvalidOperationException>();
+
+        serializer.Serialize(new ThrowingPayload("ok"), ref buffer, context);
+        var json = System.Text.Encoding.UTF8.GetString(buffer.WrittenSpan);
+        await Assert.That(json).IsEqualTo("{\"value\":\"ok\"}");
     }
 
     #endregion
@@ -168,6 +203,24 @@ public class JsonSerializerTests
     {
         public string? OrderId { get; set; }
         public List<string> Items { get; set; } = [];
+    }
+
+    private sealed record ThrowingPayload(string Value);
+
+    private sealed class ThrowingPayloadConverter : JsonConverter<ThrowingPayload>
+    {
+        public override ThrowingPayload Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options) =>
+            throw new NotSupportedException();
+
+        public override void Write(Utf8JsonWriter writer, ThrowingPayload value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("value");
+            throw new InvalidOperationException("stop");
+        }
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Cache Utf8JsonWriter in thread-static storage beside the shared ArrayBufferWriter
- Reset the writer for each serialize call and drop it after serialization failures
- Add repeated-call and failure-recovery coverage

## Tests
- dotnet build tests\Dekaf.Tests.Unit --configuration Release
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/JsonSerializerTests/*"
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe
- dotnet build tests\Dekaf.Tests.Integration --configuration Release

Closes #929