### PR TITLE
perf(producer): append awaited records via arena

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -825,6 +825,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     {
         Header[]? pooledHeaderArray = null;
         var customPartitionerKey = PooledMemory.Null;
+        var customPartitionerValue = PooledMemory.Null;
 
         try
         {
@@ -863,12 +864,21 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             }
             else
             {
-                if (_usesCustomPartitioner && !keyIsNull && keySpan.Length > 0)
+                if (_usesCustomPartitioner)
                 {
                     // User partitioners can run arbitrary code, including reentrant ProduceAsync.
-                    // Keep key bytes independent of the thread-local serialization buffer until append copies them.
-                    customPartitionerKey = CopySpanToPooledMemory(keySpan);
-                    keySpan = customPartitionerKey.Span;
+                    // Keep serialized bytes independent of thread-local buffers until append copies them.
+                    if (!keyIsNull && keySpan.Length > 0)
+                    {
+                        customPartitionerKey = CopySpanToPooledMemory(keySpan);
+                        keySpan = customPartitionerKey.Span;
+                    }
+
+                    if (!valueIsNull && valueSpan.Length > 0)
+                    {
+                        customPartitionerValue = CopySpanToPooledMemory(valueSpan);
+                        valueSpan = customPartitionerValue.Span;
+                    }
                 }
 
                 partition = _partitioner.Partition(message.Topic, keySpan, keyIsNull, topicInfo.PartitionCount);
@@ -907,16 +917,19 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray);
                 _valueTaskSourcePool.Return(completion);
                 customPartitionerKey.Return();
+                customPartitionerValue.Return();
                 return SyncProduceResult.BufferFull;
             }
 
             customPartitionerKey.Return();
+            customPartitionerValue.Return();
             return SyncProduceResult.Success;
         }
         catch (Exception ex)
         {
             RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray);
             customPartitionerKey.Return();
+            customPartitionerValue.Return();
             if (ex is not ObjectDisposedException)
                 completion.TrySetException(ex);
             throw;

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -40,6 +40,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly ISerializer<TKey> _keySerializer;
     private readonly ISerializer<TValue> _valueSerializer;
     private readonly IPartitioner _partitioner;
+    private readonly bool _usesCustomPartitioner;
     private readonly ConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
     private readonly RecordAccumulator _accumulator;
@@ -209,6 +210,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         RecordBatch.RatchetMaxRetainedBufferSize(producerPoolSizes.MaxRetainedBufferSize);
 
+        _usesCustomPartitioner = options.CustomPartitioner is not null;
         _partitioner = options.CustomPartitioner ?? options.Partitioner switch
         {
             PartitionerType.Sticky => new StickyPartitioner(),
@@ -821,20 +823,57 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         TopicInfo topicInfo,
         PooledValueTaskSource<RecordMetadata> completion)
     {
-        var key = PooledMemory.Null;
-        var value = PooledMemory.Null;
         Header[]? pooledHeaderArray = null;
+        var customPartitionerKey = PooledMemory.Null;
 
         try
         {
+            var cache = GetOrCreateCache();
             var keyIsNull = message.Key is null;
-            key = keyIsNull ? PooledMemory.Null : SerializeKeyToPooled(message.Key!, message.Topic, message.Headers);
+            var keySpan = ReadOnlySpan<byte>.Empty;
+            if (!keyIsNull)
+            {
+                var keyWriter = new ReusableBufferWriter(ref cache.KeySerializationBuffer, DefaultKeyBufferSize);
+                cache.SerializationContext.Topic = message.Topic;
+                cache.SerializationContext.Component = SerializationComponent.Key;
+                cache.SerializationContext.Headers = message.Headers;
+                _keySerializer.Serialize(message.Key!, ref keyWriter, cache.SerializationContext);
+                keySpan = keyWriter.WrittenSpan;
+                keyWriter.UpdateBufferRef(ref cache.KeySerializationBuffer);
+            }
+
             var valueIsNull = message.Value is null;
-            value = valueIsNull ? PooledMemory.Null : SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
+            var valueSpan = ReadOnlySpan<byte>.Empty;
+            if (!valueIsNull)
+            {
+                var valueWriter = new ReusableBufferWriter(ref cache.ValueSerializationBuffer, DefaultValueBufferSize);
+                cache.SerializationContext.Topic = message.Topic;
+                cache.SerializationContext.Component = SerializationComponent.Value;
+                cache.SerializationContext.Headers = message.Headers;
+                _valueSerializer.Serialize(message.Value!, ref valueWriter, cache.SerializationContext);
+                valueSpan = valueWriter.WrittenSpan;
+                valueWriter.UpdateBufferRef(ref cache.ValueSerializationBuffer);
+            }
 
             // Determine partition
-            var partition = message.Partition
-                ?? _partitioner.Partition(message.Topic, key.Span, keyIsNull, topicInfo.PartitionCount);
+            int partition;
+            if (message.Partition is { } explicitPartition)
+            {
+                partition = explicitPartition;
+            }
+            else
+            {
+                if (_usesCustomPartitioner && !keyIsNull && keySpan.Length > 0)
+                {
+                    // User partitioners can run arbitrary code, including reentrant ProduceAsync.
+                    // Keep key bytes independent of the thread-local serialization buffer until append copies them.
+                    customPartitionerKey = CopySpanToPooledMemory(keySpan);
+                    keySpan = customPartitionerKey.Span;
+                }
+
+                partition = _partitioner.Partition(message.Topic, keySpan, keyIsNull, topicInfo.PartitionCount);
+            }
+
             var batchCompletionPartitionCount = message.Partition is null && keyIsNull
                 ? topicInfo.PartitionCount
                 : 0;
@@ -851,45 +890,36 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             // Append to accumulator synchronously (non-blocking memory reservation).
             // Returns false when buffer is full OR accumulator is disposed.
-            if (!_accumulator.TryAppendWithCompletion(
+            if (!_accumulator.TryAppendFromSpansWithCompletion(
                 message.Topic,
                 partition,
                 timestampMs,
-                key,
-                value,
+                keySpan,
+                keyIsNull,
+                valueSpan,
+                valueIsNull,
                 pooledHeaderArray,
                 headerCount,
                 completion,
                 batchCompletionPartitionCount))
             {
-                // Clean up serialized data — the async slow path will re-serialize
-                CleanupPooledResources(key, value, pooledHeaderArray);
+                // Clean up headers — the async slow path will re-serialize.
+                RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray);
                 _valueTaskSourcePool.Return(completion);
+                customPartitionerKey.Return();
                 return SyncProduceResult.BufferFull;
             }
 
+            customPartitionerKey.Return();
             return SyncProduceResult.Success;
         }
-        catch (Exception ex) when (ex is not ObjectDisposedException)
+        catch (Exception ex)
         {
-            // Cleanup resources on any exception (except ObjectDisposedException which already cleaned up)
-            CleanupPooledResources(key, value, pooledHeaderArray);
-            completion.TrySetException(ex);
+            RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray);
+            customPartitionerKey.Return();
+            if (ex is not ObjectDisposedException)
+                completion.TrySetException(ex);
             throw;
-        }
-    }
-
-    /// <summary>
-    /// Cleans up pooled resources in exception paths.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void CleanupPooledResources(PooledMemory key, PooledMemory value, Header[]? pooledHeaderArray)
-    {
-        key.Return();
-        value.Return();
-        if (pooledHeaderArray is not null)
-        {
-            ProducerContainerPools.Headers.Return(pooledHeaderArray);
         }
     }
 
@@ -1072,7 +1102,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 throw new ProduceException(
                     $"Failed to fetch metadata for topic '{message.Topic}' within max.block.ms ({_options.MaxBlockMs}ms). " +
-                    $"Ensure the topic exists and the Kafka cluster is reachable.") { Topic = message.Topic };
+                    $"Ensure the topic exists and the Kafka cluster is reachable.")
+                { Topic = message.Topic };
             }
         }
 
@@ -2739,6 +2770,17 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         return writer.ToPooledMemory();
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static PooledMemory CopySpanToPooledMemory(ReadOnlySpan<byte> data)
+    {
+        if (data.Length == 0)
+            return new PooledMemory(null, 0, isNull: false);
+
+        var pooledArray = ProducerDataPool.BytePool.Rent(data.Length);
+        data.CopyTo(pooledArray);
+        return new PooledMemory(pooledArray, data.Length);
+    }
+
     /// <summary>
     /// Gets a fast cached timestamp in milliseconds for fire-and-forget operations.
     /// Refreshes the cache approximately every millisecond to balance accuracy and performance.
@@ -3329,6 +3371,8 @@ internal ref struct ReusableBufferWriter : IBufferWriter<byte>
     }
 
     public readonly int WrittenCount => _written;
+
+    public readonly ReadOnlySpan<byte> WrittenSpan => _buffer.AsSpan(0, _written);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Advance(int count)

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -10,6 +10,7 @@ public interface IPartitioner
 {
     /// <summary>
     /// Selects a partition for a message.
+    /// The key span is valid only for the duration of this call.
     /// </summary>
     int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount);
 }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2114,6 +2114,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// Non-blocking variant of Append for the ProduceAsync fast path.
     /// Returns false when buffer is full (caller falls back to async slow path)
     /// OR when the accumulator is disposed.
+    /// Retained for pooled-memory append coverage; production ProduceAsync uses
+    /// <see cref="TryAppendFromSpansWithCompletion"/> to avoid per-message data-array rents.
     /// </summary>
     internal bool TryAppendWithCompletion(
         string topic,
@@ -2183,6 +2185,84 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 key.Return();
                 value.Return();
                 ReturnPooledHeaders(headers);
+                throw new KafkaException(ErrorCode.MessageTooLarge,
+                    $"Record of size {recordSize} exceeds maximum batch size of {_options.BatchSize}");
+            }
+        }
+
+        if (sealedBatch is not null)
+        {
+            CompressAndSignalBatch(sealedBatch);
+            SignalWakeup();
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Non-blocking span variant for the ProduceAsync fast path.
+    /// Stores the completion source in the batch while copying serialized key/value bytes
+    /// into the batch arena instead of renting per-message pooled arrays.
+    /// </summary>
+    internal bool TryAppendFromSpansWithCompletion(
+        string topic,
+        int partition,
+        long timestamp,
+        ReadOnlySpan<byte> keyData,
+        bool keyIsNull,
+        ReadOnlySpan<byte> valueData,
+        bool valueIsNull,
+        Header[]? headers,
+        int headerCount,
+        PooledValueTaskSource<RecordMetadata> completionSource,
+        int partitionCount = 0)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            return false;
+
+        var keyLength = keyIsNull ? 0 : keyData.Length;
+        var valueLength = valueIsNull ? 0 : valueData.Length;
+        var recordSize = PartitionBatch.EstimateRecordSize(keyLength, valueLength, headers, headerCount);
+
+        if (!TryReserveMemory(recordSize))
+            return false;
+
+        Interlocked.Increment(ref _pendingAwaitedProduceCount);
+
+        var pd = GetOrCreateDeque(topic, partition);
+        ReadyBatch? sealedBatch = null;
+
+        {
+            using var guard = new SpinLockGuard(ref pd.Lock);
+
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                Interlocked.Decrement(ref _pendingAwaitedProduceCount);
+                ReleaseMemory(recordSize);
+                return false;
+            }
+
+            if (pd.CurrentBatch is { } currentBatch)
+            {
+                if (TryAppendFromSpansToBatch(currentBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
+                    headers, headerCount, completionSource, null, recordSize))
+                    return true;
+
+                sealedBatch = SealCurrentBatchUnderLock(pd, currentBatch);
+            }
+
+            var newBatch = RentBatch(new TopicPartition(topic, partition), partitionCount);
+            pd.CurrentBatch = newBatch;
+            Interlocked.Increment(ref _unsealedBatchCount);
+
+            if (!TryAppendFromSpansToBatch(newBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
+                headers, headerCount, completionSource, null, recordSize))
+            {
+                pd.CurrentBatch = null;
+                Interlocked.Decrement(ref _unsealedBatchCount);
+                _batchPool.Return(newBatch);
+                Interlocked.Decrement(ref _pendingAwaitedProduceCount);
+                ReleaseMemory(recordSize);
                 throw new KafkaException(ErrorCode.MessageTooLarge,
                     $"Record of size {recordSize} exceeds maximum batch size of {_options.BatchSize}");
             }
@@ -2300,7 +2380,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             if (pd.CurrentBatch is { } currentBatch)
             {
                 if (TryAppendFromSpansToBatch(currentBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                    headers, headerCount, callback, recordSize))
+                    headers, headerCount, null, callback, recordSize))
                     return true;
 
                 sealedBatch = SealCurrentBatchUnderLock(pd, currentBatch);
@@ -2311,7 +2391,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             Interlocked.Increment(ref _unsealedBatchCount);
 
             if (!TryAppendFromSpansToBatch(newBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                headers, headerCount, callback, recordSize))
+                headers, headerCount, null, callback, recordSize))
             {
                 pd.CurrentBatch = null;
                 Interlocked.Decrement(ref _unsealedBatchCount);
@@ -2377,15 +2457,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         bool valueIsNull,
         Header[]? headers,
         int headerCount,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
         int estimatedSize)
     {
         var result = batch.TryAppendFromSpans(timestamp, keyData, keyIsNull, valueData, valueIsNull,
-            headers, headerCount, callback, estimatedSize);
+            headers, headerCount, completionSource, callback, estimatedSize);
 
         if (result.Success)
         {
-            ProducerDebugCounters.RecordMessageAppended(hasCompletionSource: false);
+            ProducerDebugCounters.RecordMessageAppended(hasCompletionSource: completionSource is not null);
             var overestimate = estimatedSize - result.ActualSizeAdded;
             if (overestimate > 0)
                 ReleaseMemory(overestimate);
@@ -4017,6 +4098,7 @@ internal sealed class PartitionBatch
         bool valueIsNull,
         Header[]? headers,
         int headerCount,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
         int estimatedRecordSize)
     {
@@ -4050,6 +4132,10 @@ internal sealed class PartitionBatch
         if (_recordCount >= _records.Length)
         {
             GrowArray(ref _records, ref _recordCount, ProducerContainerPools.Records);
+        }
+        if (completionSource is not null && _completionSourceCount >= _completionSources.Length)
+        {
+            GrowArray(ref _completionSources, ref _completionSourceCount, ProducerContainerPools.CompletionSources);
         }
         if (headers is not null && _pooledHeaderArrayCount >= _pooledHeaderArrays.Length)
         {
@@ -4133,6 +4219,12 @@ internal sealed class PartitionBatch
             HeaderCount = headerCount,
             CachedBodySize = Record.ComputeBodySize(timestampDelta, _recordCount, keyIsNull, keyLength, valueIsNull, valueLength, headers, headerCount)
         };
+
+        if (completionSource is not null)
+        {
+            _completionSources[_completionSourceCount++] = completionSource;
+            ProducerDebugCounters.RecordCompletionSourceStoredInBatch();
+        }
 
         if (callback is not null)
         {

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -1,0 +1,144 @@
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Text;
+using Dekaf.Metadata;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public class KafkaProducerFastPathTests
+{
+    private const string Topic = "test-topic";
+
+    [Test]
+    public async Task TryProduceSyncCore_CustomPartitionerReentry_PreservesOuterKey()
+    {
+        var partitioner = new ReentrantPartitioner();
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 4096,
+            LingerMs = 10,
+            CustomPartitioner = partitioner
+        };
+
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var topicInfo = CreateTopicInfo();
+        var innerCompletion = pool.Rent();
+        var outerCompletion = pool.Rent();
+        var innerTask = innerCompletion.Task;
+        var outerTask = outerCompletion.Task;
+
+        partitioner.OnFirstPartition = () =>
+        {
+            var innerResult = InvokeTryProduceSyncCore(
+                producer,
+                ProducerMessage<string, string>.Create(Topic, "inner", "inner-value"),
+                topicInfo,
+                innerCompletion);
+
+            if (innerResult.ToString() != "Success")
+                throw new InvalidOperationException($"Unexpected inner result: {innerResult}");
+        };
+
+        var outerResult = InvokeTryProduceSyncCore(
+            producer,
+            ProducerMessage<string, string>.Create(Topic, "outer", "outer-value"),
+            topicInfo,
+            outerCompletion);
+
+        await Assert.That(outerResult.ToString()).IsEqualTo("Success");
+
+        var readyBatch = CompleteCurrentBatch(producer.RecordAccumulator, new TopicPartition(Topic, 0));
+        await Assert.That(readyBatch.RecordBatch.Records.Count).IsEqualTo(2);
+        await Assert.That(GetKeyString(readyBatch.RecordBatch.Records[0])).IsEqualTo("inner");
+        await Assert.That(GetKeyString(readyBatch.RecordBatch.Records[1])).IsEqualTo("outer");
+
+        readyBatch.CompleteSend(baseOffset: 0, DateTimeOffset.UtcNow);
+        _ = await innerTask;
+        _ = await outerTask;
+    }
+
+    private static TopicInfo CreateTopicInfo() => new()
+    {
+        Name = Topic,
+        Partitions =
+        [
+            new PartitionInfo
+            {
+                PartitionIndex = 0,
+                LeaderId = 0,
+                ReplicaNodes = [0],
+                IsrNodes = [0]
+            }
+        ]
+    };
+
+    private static object InvokeTryProduceSyncCore(
+        KafkaProducer<string, string> producer,
+        ProducerMessage<string, string> message,
+        TopicInfo topicInfo,
+        PooledValueTaskSource<RecordMetadata> completion)
+    {
+        var method = typeof(KafkaProducer<string, string>).GetMethod(
+            "TryProduceSyncCore",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        try
+        {
+            return method!.Invoke(producer, [message, topicInfo, completion])!;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
+    }
+
+    private static ReadyBatch CompleteCurrentBatch(RecordAccumulator accumulator, TopicPartition topicPartition)
+    {
+        var dequesField = typeof(RecordAccumulator).GetField("_partitionDeques",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        var deques = dequesField!.GetValue(accumulator)!;
+
+        var tryGetValueMethod = deques.GetType().GetMethod("TryGetValue");
+        var parameters = new object[] { topicPartition, null! };
+        var found = (bool)tryGetValueMethod!.Invoke(deques, parameters)!;
+        if (!found)
+            throw new InvalidOperationException("Partition deque was not found.");
+
+        var partitionDeque = parameters[1];
+        var currentBatchField = partitionDeque!.GetType().GetField("CurrentBatch");
+        var partitionBatch = currentBatchField!.GetValue(partitionDeque);
+        var completeMethod = partitionBatch!.GetType().GetMethod("Complete");
+        return (ReadyBatch)completeMethod!.Invoke(partitionBatch, null)!;
+    }
+
+    private static string GetKeyString(Dekaf.Protocol.Records.Record record)
+        => Encoding.UTF8.GetString(record.Key.Span);
+
+    private sealed class ReentrantPartitioner : IPartitioner
+    {
+        private bool _hasReentered;
+
+        public Action? OnFirstPartition { get; set; }
+
+        public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+        {
+            if (!_hasReentered)
+            {
+                _hasReentered = true;
+                OnFirstPartition?.Invoke();
+            }
+
+            return 0;
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -12,7 +12,7 @@ public class KafkaProducerFastPathTests
     private const string Topic = "test-topic";
 
     [Test]
-    public async Task TryProduceSyncCore_CustomPartitionerReentry_PreservesOuterKey()
+    public async Task TryProduceSyncCore_CustomPartitionerReentry_PreservesOuterKeyAndValue()
     {
         var partitioner = new ReentrantPartitioner();
         var options = new ProducerOptions
@@ -59,7 +59,9 @@ public class KafkaProducerFastPathTests
         var readyBatch = CompleteCurrentBatch(producer.RecordAccumulator, new TopicPartition(Topic, 0));
         await Assert.That(readyBatch.RecordBatch.Records.Count).IsEqualTo(2);
         await Assert.That(GetKeyString(readyBatch.RecordBatch.Records[0])).IsEqualTo("inner");
+        await Assert.That(GetValueString(readyBatch.RecordBatch.Records[0])).IsEqualTo("inner-value");
         await Assert.That(GetKeyString(readyBatch.RecordBatch.Records[1])).IsEqualTo("outer");
+        await Assert.That(GetValueString(readyBatch.RecordBatch.Records[1])).IsEqualTo("outer-value");
 
         readyBatch.CompleteSend(baseOffset: 0, DateTimeOffset.UtcNow);
         _ = await innerTask;
@@ -123,6 +125,9 @@ public class KafkaProducerFastPathTests
 
     private static string GetKeyString(Dekaf.Protocol.Records.Record record)
         => Encoding.UTF8.GetString(record.Key.Span);
+
+    private static string GetValueString(Dekaf.Protocol.Records.Record record)
+        => Encoding.UTF8.GetString(record.Value.Span);
 
     private sealed class ReentrantPartitioner : IPartitioner
     {

--- a/tests/Dekaf.Tests.Unit/Producer/PooledBufferWriterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledBufferWriterTests.cs
@@ -7,6 +7,31 @@ namespace Dekaf.Tests.Unit.Producer;
 public class PooledBufferWriterTests
 {
     [Test]
+    public async Task ReusableBufferWriter_WrittenSpan_UsesLiveOversizedBuffer()
+    {
+        byte[]? cachedBuffer = new byte[16];
+        var writer = new ReusableBufferWriter(ref cachedBuffer, initialCapacity: 16);
+        var data = new byte[(1024 * 1024) + 1];
+        data[0] = 42;
+        data[^1] = 24;
+
+        data.CopyTo(writer.GetSpan(data.Length));
+        writer.Advance(data.Length);
+
+        var writtenSpan = writer.WrittenSpan;
+        var writtenLength = writtenSpan.Length;
+        var firstByte = writtenSpan[0];
+        var lastByte = writtenSpan[^1];
+
+        writer.UpdateBufferRef(ref cachedBuffer);
+
+        await Assert.That(cachedBuffer!.Length).IsEqualTo(16);
+        await Assert.That(writtenLength).IsEqualTo(data.Length);
+        await Assert.That(firstByte).IsEqualTo((byte)42);
+        await Assert.That(lastByte).IsEqualTo((byte)24);
+    }
+
+    [Test]
     public async Task Constructor_CreatesBufferWithInitialCapacity()
     {
         var writer = new PooledBufferWriter(initialCapacity: 128);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Reflection;
 using Dekaf.Errors;
 using Dekaf.Producer;
 using Dekaf.Protocol.Records;
@@ -130,6 +131,207 @@ public class RecordAccumulatorTests
 
             // Must return the exact same instance to prevent duplicate resource tracking
             await Assert.That(ReferenceEquals(readyBatch1, readyBatch2)).IsTrue();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task TryAppendFromSpansWithCompletion_UsesArenaAndCompletesSource()
+    {
+        var options = CreateTestOptions();
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var topicPartition = new TopicPartition("test-topic", 0);
+
+        try
+        {
+            var completion = pool.Rent();
+            var completionTask = completion.Task;
+            var key = "key"u8.ToArray();
+            var value = "value"u8.ToArray();
+
+            var result = accumulator.TryAppendFromSpansWithCompletion(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                key,
+                keyIsNull: false,
+                value,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                completion);
+
+            await Assert.That(result).IsTrue();
+
+            var readyBatch = CompleteCurrentBatch(accumulator, topicPartition);
+            var pooledDataArraysCount = GetPrivateField<int>(readyBatch, "_pooledDataArraysCount");
+            var record = readyBatch.RecordBatch.Records[0];
+
+            await Assert.That(readyBatch.CompletionSourcesCount).IsEqualTo(1);
+            await Assert.That(pooledDataArraysCount).IsEqualTo(0);
+            await Assert.That(record.Key.ToArray()).IsEquivalentTo(key);
+            await Assert.That(record.Value.ToArray()).IsEquivalentTo(value);
+
+            var timestamp = DateTimeOffset.UtcNow;
+            readyBatch.CompleteSend(baseOffset: 12, timestamp);
+            var metadata = await completionTask;
+
+            await Assert.That(metadata.Topic).IsEqualTo(topicPartition.Topic);
+            await Assert.That(metadata.Partition).IsEqualTo(topicPartition.Partition);
+            await Assert.That(metadata.Offset).IsEqualTo(12L);
+            await Assert.That(metadata.Timestamp).IsEqualTo(timestamp);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task TryAppendFromSpansWithCompletion_BufferFull_ReturnsFalseWithoutPendingCount()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = 1,
+            BatchSize = 1024,
+            LingerMs = 10
+        };
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            var completion = pool.Rent();
+
+            var result = accumulator.TryAppendFromSpansWithCompletion(
+                "test-topic",
+                0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                "value"u8,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                completion);
+
+            await Assert.That(result).IsFalse();
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+            await Assert.That(GetPrivateField<int>(accumulator, "_pendingAwaitedProduceCount")).IsEqualTo(0);
+
+            pool.Return(completion);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task TryAppendFromSpansWithCompletion_DisposedAccumulator_ReturnsFalseWithoutPendingCount()
+    {
+        var options = CreateTestOptions();
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var completion = pool.Rent();
+
+        await accumulator.DisposeAsync();
+
+        try
+        {
+            var result = accumulator.TryAppendFromSpansWithCompletion(
+                "test-topic",
+                0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                "value"u8,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                completion);
+
+            await Assert.That(result).IsFalse();
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+            await Assert.That(GetPrivateField<int>(accumulator, "_pendingAwaitedProduceCount")).IsEqualTo(0);
+
+            pool.Return(completion);
+        }
+        finally
+        {
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task TryAppendFromSpansWithCompletion_FullBatch_SealsAndAppendsToNewBatch()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = PartitionBatch.EstimateRecordSize(0, 16, null, 0) + 8,
+            LingerMs = 10
+        };
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var topicPartition = new TopicPartition("test-topic", 0);
+
+        try
+        {
+            var firstCompletion = pool.Rent();
+            var secondCompletion = pool.Rent();
+            var firstCompletionTask = firstCompletion.Task;
+            var secondCompletionTask = secondCompletion.Task;
+            var value = new byte[16];
+
+            var firstResult = accumulator.TryAppendFromSpansWithCompletion(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                value,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                firstCompletion);
+
+            var secondResult = accumulator.TryAppendFromSpansWithCompletion(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                value,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                secondCompletion);
+
+            await Assert.That(firstResult).IsTrue();
+            await Assert.That(secondResult).IsTrue();
+            await Assert.That(accumulator.TryDrainBatch(out var sealedBatch)).IsTrue();
+            await Assert.That(sealedBatch!.CompletionSourcesCount).IsEqualTo(1);
+
+            var currentBatch = CompleteCurrentBatch(accumulator, topicPartition);
+            await Assert.That(currentBatch.CompletionSourcesCount).IsEqualTo(1);
+
+            var timestamp = DateTimeOffset.UtcNow;
+            sealedBatch.CompleteSend(baseOffset: 10, timestamp);
+            currentBatch.CompleteSend(baseOffset: 11, timestamp);
+            _ = await firstCompletionTask;
+            _ = await secondCompletionTask;
         }
         finally
         {
@@ -343,8 +545,8 @@ public class RecordAccumulatorTests
             if (found)
             {
                 var partitionDeque = parameters[1];
-            var currentBatchField = partitionDeque!.GetType().GetField("CurrentBatch");
-            var partitionBatch = currentBatchField!.GetValue(partitionDeque);
+                var currentBatchField = partitionDeque!.GetType().GetField("CurrentBatch");
+                var partitionBatch = currentBatchField!.GetValue(partitionDeque);
                 var recordCountProperty = partitionBatch!.GetType().GetProperty("RecordCount");
                 var recordCount = (int)recordCountProperty!.GetValue(partitionBatch)!;
 
@@ -1884,4 +2086,29 @@ public class RecordAccumulatorTests
     }
 
     #endregion
+
+    private static ReadyBatch CompleteCurrentBatch(RecordAccumulator accumulator, TopicPartition topicPartition)
+    {
+        var dequesField = typeof(RecordAccumulator).GetField("_partitionDeques",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        var deques = dequesField!.GetValue(accumulator)!;
+
+        var tryGetValueMethod = deques.GetType().GetMethod("TryGetValue");
+        var parameters = new object[] { topicPartition, null! };
+        var found = (bool)tryGetValueMethod!.Invoke(deques, parameters)!;
+        if (!found)
+            throw new InvalidOperationException("Partition deque was not found.");
+
+        var partitionDeque = parameters[1];
+        var currentBatchField = partitionDeque!.GetType().GetField("CurrentBatch");
+        var partitionBatch = currentBatchField!.GetValue(partitionDeque);
+        var completeMethod = partitionBatch!.GetType().GetMethod("Complete");
+        return (ReadyBatch)completeMethod!.Invoke(partitionBatch, null)!;
+    }
+
+    private static T GetPrivateField<T>(object instance, string fieldName)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        return (T)field!.GetValue(instance)!;
+    }
 }


### PR DESCRIPTION
## Summary
- route ProduceAsync fast-path serialization through thread-local buffers and span append
- add a completion-tracked BatchArena append path so awaited records avoid per-message pooled key/value arrays when the arena has capacity
- cover the new path with a unit test that verifies completion source delivery and zero pooled data-array entries

Closes #900

## Tests
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- `dotnet run --project tests/Dekaf.Tests.Unit --configuration Release --no-build -- --no-ansi --disable-logo --no-progress --maximum-failed-tests 1`
- `dotnet format --verify-no-changes --include src/Dekaf/Producer/KafkaProducer.cs src/Dekaf/Producer/RecordAccumulator.cs tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs --verbosity minimal`
- `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
