### PR TITLE
fix(protocol): bound record header count

### DIFF
--- a/src/Dekaf/Protocol/Records/Record.cs
+++ b/src/Dekaf/Protocol/Records/Record.cs
@@ -115,6 +115,10 @@ public readonly record struct Record
     public static Record Read(ref KafkaProtocolReader reader)
     {
         var length = reader.ReadVarInt();
+        if (length < 0)
+            throw new MalformedProtocolDataException($"Invalid record length {length}");
+
+        var bodyStart = reader.Consumed;
         var attributes = (byte)reader.ReadInt8();
         var timestampDelta = reader.ReadVarLong();
         var offsetDelta = reader.ReadVarInt();
@@ -128,6 +132,8 @@ public readonly record struct Record
         var value = isValueNull ? ReadOnlyMemory<byte>.Empty : reader.ReadMemorySlice(valueLength);
 
         var headerCount = reader.ReadVarInt();
+        ValidateHeaderCount(headerCount, length, reader.Consumed - bodyStart, reader.Remaining);
+
         Header[]? headers = null;
 
         if (headerCount > 0)
@@ -155,6 +161,20 @@ public readonly record struct Record
             Headers = headers,
             HeaderCount = headerCount
         };
+    }
+
+    private static void ValidateHeaderCount(int headerCount, int recordBodyLength, long bodyBytesRead, long readerRemaining)
+    {
+        var remainingInRecord = recordBodyLength - bodyBytesRead;
+        if (remainingInRecord < 0 || headerCount < 0)
+            throw new MalformedProtocolDataException($"Invalid record header count {headerCount}");
+
+        // A header needs at least one byte for key length and one byte for value length.
+        // Bound the declared record body by the actual readable bytes so corrupt frames
+        // cannot force a giant ArrayPool rent before the first header read fails.
+        var readableRecordBytes = Math.Min(remainingInRecord, readerRemaining);
+        if (headerCount > readableRecordBytes / 2)
+            throw new MalformedProtocolDataException($"Invalid record header count {headerCount}");
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -993,6 +993,36 @@ public class RecordBatchTests
         await Assert.That(parsedBatch.Records[0].Value.ToArray()).IsEquivalentTo("value"u8.ToArray());
     }
 
+    [Test]
+    public async Task Record_Read_HeaderCountExceedsRemainingRecordBody_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var body = new ArrayBufferWriter<byte>();
+        var bodyWriter = new KafkaProtocolWriter(body);
+        bodyWriter.WriteInt8(0); // attributes
+        bodyWriter.WriteVarLong(0); // timestamp delta
+        bodyWriter.WriteVarInt(0); // offset delta
+        bodyWriter.WriteVarInt(-1); // null key
+        bodyWriter.WriteVarInt(-1); // null value
+        bodyWriter.WriteVarInt(1024); // impossible: no bytes remain for headers
+
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteVarInt(bodyWriter.BytesWritten);
+        writer.WriteRawBytes(body.WrittenSpan);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        try
+        {
+            Record.Read(ref reader);
+            throw new InvalidOperationException("Expected MalformedProtocolDataException was not thrown");
+        }
+        catch (MalformedProtocolDataException ex)
+        {
+            await Assert.That(ex.Message).Contains("header count");
+        }
+    }
+
     #endregion
 
     #region Header Copy Correctness Tests


### PR DESCRIPTION
## Summary
- Reject negative record lengths and invalid record header counts while parsing
- Bound declared header count by remaining record body bytes and actual readable bytes before renting Header[]
- Add regression coverage for corrupt records that declare impossible header counts

## Tests
- dotnet build tests\Dekaf.Tests.Unit --configuration Release
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordBatchTests/Record_Read_HeaderCountExceedsRemainingRecordBody_ThrowsMalformedProtocolData"
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordBatchTests/*"
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe
- dotnet build tests\Dekaf.Tests.Integration --configuration Release -maxcpucount:1 -nodeReuse:false

Note: an earlier parallel validation attempt timed out the unit run and caused an MSBuild child-node cancellation in the integration build; rerunning sequentially passed.

Closes #925