### PR TITLE
perf(networking): share oauth token provider

### DIFF
--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Dekaf.Security.Sasl;
 using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Networking;
@@ -15,6 +16,7 @@ public sealed partial class ConnectionPool : IConnectionPool
     private readonly ILogger _logger;
     private readonly int _connectionsPerBroker;
     private readonly ResponseBufferPool _responseBufferPool;
+    private readonly OAuthBearerTokenProvider? _sharedOAuthBearerTokenProvider;
 
     /// <summary>
     /// Shared memory pool for all connections. Bounds total retained memory to one set of
@@ -91,7 +93,9 @@ public sealed partial class ConnectionPool : IConnectionPool
         int? pipeMemoryBucketCapacity = null)
     {
         _clientId = clientId;
-        _connectionOptions = connectionOptions ?? new ConnectionOptions();
+        _connectionOptions = ConfigureSharedOAuthBearerProvider(
+            connectionOptions ?? new ConnectionOptions(),
+            out _sharedOAuthBearerTokenProvider);
         _loggerFactory = loggerFactory;
         _logger = loggerFactory?.CreateLogger<ConnectionPool>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ConnectionPool>.Instance;
         _connectionsPerBroker = Math.Max(1, connectionsPerBroker);
@@ -112,7 +116,9 @@ public sealed partial class ConnectionPool : IConnectionPool
         Func<int, string, int, int, CancellationToken, ValueTask<IKafkaConnection>> connectionFactory)
     {
         _clientId = clientId;
-        _connectionOptions = connectionOptions ?? new ConnectionOptions();
+        _connectionOptions = ConfigureSharedOAuthBearerProvider(
+            connectionOptions ?? new ConnectionOptions(),
+            out _sharedOAuthBearerTokenProvider);
         _loggerFactory = null;
         _logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<ConnectionPool>.Instance;
         _connectionsPerBroker = Math.Max(1, connectionsPerBroker);
@@ -129,6 +135,46 @@ public sealed partial class ConnectionPool : IConnectionPool
     /// </summary>
     private static int ScaledBucketCapacity(int connectionsPerBroker)
         => Math.Min(connectionsPerBroker * 32, 256);
+
+    internal ConnectionOptions EffectiveConnectionOptions => _connectionOptions;
+
+    internal bool HasSharedOAuthBearerTokenProvider => _sharedOAuthBearerTokenProvider is not null;
+
+    private static ConnectionOptions ConfigureSharedOAuthBearerProvider(
+        ConnectionOptions options,
+        out OAuthBearerTokenProvider? sharedProvider)
+    {
+        if (options.OAuthBearerConfig is null ||
+            options.OAuthBearerTokenProvider is not null ||
+            options.OAuthBearerToken is not null)
+        {
+            sharedProvider = null;
+            return options;
+        }
+
+        sharedProvider = new OAuthBearerTokenProvider(options.OAuthBearerConfig);
+
+        return new ConnectionOptions
+        {
+            UseTls = options.UseTls,
+            TlsConfig = options.TlsConfig,
+            RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
+            SaslMechanism = options.SaslMechanism,
+            SaslUsername = options.SaslUsername,
+            SaslPassword = options.SaslPassword,
+            GssapiConfig = options.GssapiConfig,
+            OAuthBearerTokenProvider = sharedProvider.GetTokenAsync,
+            OAuthBearerToken = options.OAuthBearerToken,
+            SaslReauthenticationConfig = options.SaslReauthenticationConfig,
+            SendBufferSize = options.SendBufferSize,
+            ReceiveBufferSize = options.ReceiveBufferSize,
+            MinimumSegmentSize = options.MinimumSegmentSize,
+            MinimumReadSize = options.MinimumReadSize,
+            ConnectionTimeout = options.ConnectionTimeout,
+            RequestTimeout = options.RequestTimeout,
+            MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection
+        };
+    }
 
     /// <summary>
     /// Increases the shared PipeMemoryPool bucket capacity if <paramref name="bucketCapacity"/>
@@ -827,6 +873,7 @@ public sealed partial class ConnectionPool : IConnectionPool
 
         await CloseAllAsync().ConfigureAwait(false);
 
+        _sharedOAuthBearerTokenProvider?.Dispose();
         _disposeLock.Dispose();
         _scaleLock.Dispose();
     }

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Networking;
+using Dekaf.Security.Sasl;
 
 namespace Dekaf.Tests.Unit.Networking;
 
@@ -187,6 +188,78 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task Constructor_OAuthBearerConfig_CreatesSharedTokenProvider()
+    {
+        var config = CreateOAuthBearerConfig();
+        var options = new ConnectionOptions
+        {
+            SaslMechanism = SaslMechanism.OAuthBearer,
+            OAuthBearerConfig = config
+        };
+
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: options,
+            loggerFactory: null,
+            connectionsPerBroker: 3);
+
+        await Assert.That(pool.HasSharedOAuthBearerTokenProvider).IsTrue();
+        await Assert.That(pool.EffectiveConnectionOptions).IsNotSameReferenceAs(options);
+        await Assert.That((object?)pool.EffectiveConnectionOptions.OAuthBearerTokenProvider).IsNotNull();
+        await Assert.That(pool.EffectiveConnectionOptions.OAuthBearerConfig).IsNull();
+        await Assert.That(pool.EffectiveConnectionOptions.SaslMechanism).IsEqualTo(SaslMechanism.OAuthBearer);
+    }
+
+    [Test]
+    public async Task Constructor_OAuthBearerTokenProvider_PreservesCustomProvider()
+    {
+        var config = CreateOAuthBearerConfig();
+        Func<CancellationToken, ValueTask<OAuthBearerToken>> tokenProvider =
+            _ => new ValueTask<OAuthBearerToken>(CreateOAuthBearerToken());
+        var options = new ConnectionOptions
+        {
+            SaslMechanism = SaslMechanism.OAuthBearer,
+            OAuthBearerConfig = config,
+            OAuthBearerTokenProvider = tokenProvider
+        };
+
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: options,
+            loggerFactory: null,
+            connectionsPerBroker: 3);
+
+        await Assert.That(pool.HasSharedOAuthBearerTokenProvider).IsFalse();
+        await Assert.That(pool.EffectiveConnectionOptions).IsSameReferenceAs(options);
+        await Assert.That((object?)pool.EffectiveConnectionOptions.OAuthBearerTokenProvider).IsSameReferenceAs(tokenProvider);
+        await Assert.That(pool.EffectiveConnectionOptions.OAuthBearerConfig).IsSameReferenceAs(config);
+    }
+
+    [Test]
+    public async Task Constructor_OAuthBearerToken_PreservesStaticToken()
+    {
+        var config = CreateOAuthBearerConfig();
+        var token = CreateOAuthBearerToken();
+        var options = new ConnectionOptions
+        {
+            SaslMechanism = SaslMechanism.OAuthBearer,
+            OAuthBearerConfig = config,
+            OAuthBearerToken = token
+        };
+
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: options,
+            loggerFactory: null,
+            connectionsPerBroker: 3);
+
+        await Assert.That(pool.HasSharedOAuthBearerTokenProvider).IsFalse();
+        await Assert.That(pool.EffectiveConnectionOptions).IsSameReferenceAs(options);
+        await Assert.That(pool.EffectiveConnectionOptions.OAuthBearerToken).IsSameReferenceAs(token);
+        await Assert.That(pool.EffectiveConnectionOptions.OAuthBearerConfig).IsSameReferenceAs(config);
+    }
+
+    [Test]
     public async Task DisposeAsync_ConcurrentCalls_DoesNotThrow()
     {
         var pool = new ConnectionPool("test-client");
@@ -253,4 +326,18 @@ public sealed class ConnectionPoolTests
 
         await Assert.That(result).IsNull();
     }
+
+    private static OAuthBearerConfig CreateOAuthBearerConfig() => new()
+    {
+        TokenEndpointUrl = "https://auth.example.invalid/token",
+        ClientId = "client",
+        ClientSecret = "secret"
+    };
+
+    private static OAuthBearerToken CreateOAuthBearerToken() => new()
+    {
+        TokenValue = "token",
+        PrincipalName = "principal",
+        Expiration = DateTimeOffset.UtcNow.AddHours(1)
+    };
 }


### PR DESCRIPTION
## Summary
- build one shared OAuthBearerTokenProvider per ConnectionPool when OAuthBearerConfig is supplied
- pass the shared GetTokenAsync delegate through effective connection options so connections do not allocate per-connection HttpClients/token caches
- preserve static-token and custom-token-provider precedence

## Verification
- dotnet build tests\Dekaf.Tests.Unit --configuration Release
- dotnet run --project tests\Dekaf.Tests.Unit --configuration Release --no-build -- --no-ansi --disable-logo --no-progress --maximum-failed-tests 1 --timeout 5m
- dotnet format --verify-no-changes --include src\Dekaf\Networking\ConnectionPool.cs tests\Dekaf.Tests.Unit\Networking\ConnectionPoolTests.cs --verbosity minimal
- dotnet build tests\Dekaf.Tests.Integration --configuration Release

Closes #928