### PR TITLE
perf(protocol): parallelize x86 crc32c

### DIFF
--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -1193,8 +1193,12 @@ internal static class Crc32C
 {
     private const int TableSize = 256;
     private const int SliceCount = 8;
+    private const int X86ParallelChunkSize = 512;
+    private const int X86ParallelBlockSize = X86ParallelChunkSize * 3;
 
     private static readonly uint[] Table = GenerateTable();
+    private static readonly uint[] X86ShiftChunk = CreateShiftOperator(X86ParallelChunkSize);
+    private static readonly uint[] X86ShiftTwoChunks = CreateShiftOperator(X86ParallelChunkSize * 2);
 
     private static uint[] GenerateTable()
     {
@@ -1245,7 +1249,60 @@ internal static class Crc32C
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static uint ComputeHardwareX86(ReadOnlySpan<byte> data)
     {
+        if (Sse42.X64.IsSupported && data.Length >= X86ParallelBlockSize)
+        {
+            return ComputeHardwareX86Optimized(data);
+        }
+
+        return ComputeHardwareX86Scalar(data);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static uint ComputeHardwareX86Scalar(ReadOnlySpan<byte> data)
+        => UpdateHardwareX86(data, 0xFFFFFFFFu) ^ 0xFFFFFFFFu;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal static uint ComputeHardwareX86Optimized(ReadOnlySpan<byte> data)
+    {
+        if (!Sse42.X64.IsSupported || data.Length < X86ParallelBlockSize)
+        {
+            return ComputeHardwareX86Scalar(data);
+        }
+
         var crc = 0xFFFFFFFFu;
+        var offset = 0;
+
+        while (offset + X86ParallelBlockSize <= data.Length)
+        {
+            var crc0 = crc;
+            var crc1 = 0u;
+            var crc2 = 0u;
+
+            for (var i = 0; i < X86ParallelChunkSize; i += 8)
+            {
+                crc0 = (uint)Sse42.X64.Crc32(
+                    crc0,
+                    BinaryPrimitives.ReadUInt64LittleEndian(data.Slice(offset + i, 8)));
+                crc1 = (uint)Sse42.X64.Crc32(
+                    crc1,
+                    BinaryPrimitives.ReadUInt64LittleEndian(data.Slice(offset + X86ParallelChunkSize + i, 8)));
+                crc2 = (uint)Sse42.X64.Crc32(
+                    crc2,
+                    BinaryPrimitives.ReadUInt64LittleEndian(data.Slice(offset + (X86ParallelChunkSize * 2) + i, 8)));
+            }
+
+            // crc1/crc2 start from zero, so combine the three independent chains by
+            // shifting each raw CRC state as though its following chunks were zero bytes.
+            crc = ShiftCrc32C(crc0, X86ShiftTwoChunks) ^ ShiftCrc32C(crc1, X86ShiftChunk) ^ crc2;
+            offset += X86ParallelBlockSize;
+        }
+
+        return UpdateHardwareX86(data[offset..], crc) ^ 0xFFFFFFFFu;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint UpdateHardwareX86(ReadOnlySpan<byte> data, uint crc)
+    {
         var i = 0;
 
         // Process 8 bytes at a time using 64-bit CRC instruction
@@ -1275,7 +1332,7 @@ internal static class Crc32C
             i++;
         }
 
-        return crc ^ 0xFFFFFFFFu;
+        return crc;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1344,5 +1401,113 @@ internal static class Crc32C
         }
 
         return crc ^ 0xFFFFFFFFu;
+    }
+
+    private static uint[] CreateShiftOperator(int byteCount)
+    {
+        var shift = new uint[32];
+
+        for (var bit = 0; bit < 32; bit++)
+        {
+            shift[bit] = ShiftCrc32C(1u << bit, byteCount);
+        }
+
+        return shift;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint ShiftCrc32C(uint crc, uint[] shiftOperator)
+    {
+        var shifted = 0u;
+        var bit = 0;
+
+        while (crc != 0)
+        {
+            if ((crc & 1) != 0)
+            {
+                shifted ^= shiftOperator[bit];
+            }
+
+            crc >>= 1;
+            bit++;
+        }
+
+        return shifted;
+    }
+
+    private static uint ShiftCrc32C(uint crc, int byteCount)
+    {
+        if (byteCount <= 0)
+        {
+            return crc;
+        }
+
+        Span<uint> odd = stackalloc uint[32];
+        Span<uint> even = stackalloc uint[32];
+
+        odd[0] = 0x82F63B78u;
+        var row = 1u;
+        for (var i = 1; i < 32; i++)
+        {
+            odd[i] = row;
+            row <<= 1;
+        }
+
+        SquareMatrix(even, odd);
+        SquareMatrix(odd, even);
+
+        var length = byteCount;
+        do
+        {
+            SquareMatrix(even, odd);
+            if ((length & 1) != 0)
+            {
+                crc = MatrixTimes(even, crc);
+            }
+
+            length >>= 1;
+            if (length == 0)
+            {
+                break;
+            }
+
+            SquareMatrix(odd, even);
+            if ((length & 1) != 0)
+            {
+                crc = MatrixTimes(odd, crc);
+            }
+
+            length >>= 1;
+        }
+        while (length != 0);
+
+        return crc;
+    }
+
+    private static void SquareMatrix(Span<uint> square, ReadOnlySpan<uint> matrix)
+    {
+        for (var i = 0; i < 32; i++)
+        {
+            square[i] = MatrixTimes(matrix, matrix[i]);
+        }
+    }
+
+    private static uint MatrixTimes(ReadOnlySpan<uint> matrix, uint vector)
+    {
+        var sum = 0u;
+        var index = 0;
+
+        while (vector != 0)
+        {
+            if ((vector & 1) != 0)
+            {
+                sum ^= matrix[index];
+            }
+
+            vector >>= 1;
+            index++;
+        }
+
+        return sum;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Protocol/Crc32CTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/Crc32CTests.cs
@@ -21,7 +21,7 @@ public class Crc32CTests
     [Test]
     public async Task Compute_MixedLengths_MatchesBitwiseReference()
     {
-        for (var length = 0; length <= 512; length++)
+        foreach (var length in MixedLengths())
         {
             var data = CreateDeterministicBytes(length);
             var expected = ComputeBitwise(data);
@@ -33,7 +33,7 @@ public class Crc32CTests
     [Test]
     public async Task ComputeSoftware_MixedLengths_MatchesBitwiseReference()
     {
-        for (var length = 0; length <= 512; length++)
+        foreach (var length in MixedLengths())
         {
             var data = CreateDeterministicBytes(length);
             var expected = ComputeBitwise(data);
@@ -48,12 +48,42 @@ public class Crc32CTests
         if (!Sse42.IsSupported)
             return;
 
-        for (var length = 0; length <= 512; length++)
+        foreach (var length in MixedLengths())
         {
             var data = CreateDeterministicBytes(length);
             var expected = ComputeBitwise(data);
 
             await Assert.That(Crc32C.ComputeHardwareX86(data)).IsEqualTo(expected);
+        }
+    }
+
+    [Test]
+    public async Task ComputeHardwareX86Scalar_WhenSupported_MatchesBitwiseReference()
+    {
+        if (!Sse42.IsSupported)
+            return;
+
+        foreach (var length in MixedLengths())
+        {
+            var data = CreateDeterministicBytes(length);
+            var expected = ComputeBitwise(data);
+
+            await Assert.That(Crc32C.ComputeHardwareX86Scalar(data)).IsEqualTo(expected);
+        }
+    }
+
+    [Test]
+    public async Task ComputeHardwareX86Optimized_WhenSupported_MatchesBitwiseReference()
+    {
+        if (!Sse42.X64.IsSupported)
+            return;
+
+        foreach (var length in MixedLengths())
+        {
+            var data = CreateDeterministicBytes(length);
+            var expected = ComputeBitwise(data);
+
+            await Assert.That(Crc32C.ComputeHardwareX86Optimized(data)).IsEqualTo(expected);
         }
     }
 
@@ -82,6 +112,19 @@ public class Crc32CTests
         }
 
         return data;
+    }
+
+    private static IEnumerable<int> MixedLengths()
+    {
+        for (var length = 0; length <= 512; length++)
+        {
+            yield return length;
+        }
+
+        foreach (var length in new[] { 513, 777, 1024, 1535, 1536, 1537, 2048, 4096, 8191, 8192, 16384, 65536 })
+        {
+            yield return length;
+        }
     }
 
     private static uint ComputeBitwise(ReadOnlySpan<byte> data)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/Crc32CBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/Crc32CBenchmarks.cs
@@ -1,0 +1,44 @@
+using System.Runtime.Intrinsics.X86;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Benchmarks CRC32C implementations across representative record-batch payload sizes.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 3, iterationCount: 10)]
+public class Crc32CBenchmarks
+{
+    private byte[] _data = null!;
+
+    [Params(128, 512, 1024, 1536, 4096, 16384, 65536)]
+    public int Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _data = new byte[Size];
+        for (var i = 0; i < _data.Length; i++)
+        {
+            _data[i] = (byte)((i * 251) + (Size * 17));
+        }
+    }
+
+    [Benchmark(Baseline = true, Description = "CRC32C auto")]
+    public uint Auto()
+        => Crc32C.Compute(_data);
+
+    [Benchmark(Description = "CRC32C x86 scalar")]
+    public uint X86Scalar()
+        => Sse42.IsSupported ? Crc32C.ComputeHardwareX86Scalar(_data) : 0;
+
+    [Benchmark(Description = "CRC32C x86 optimized")]
+    public uint X86Optimized()
+        => Sse42.X64.IsSupported ? Crc32C.ComputeHardwareX86Optimized(_data) : 0;
+
+    [Benchmark(Description = "CRC32C software")]
+    public uint Software()
+        => Crc32C.ComputeSoftware(_data);
+}


### PR DESCRIPTION
## Summary
- add a 3-way SSE4.2 x86 CRC32C path for large buffers while keeping the scalar x86 path for small payloads
- precompute fixed CRC shift operators so the hot checksum path has no per-call allocations
- add larger CRC32C vectors plus BenchmarkDotNet coverage for auto/scalar/optimized/software paths

## Verification
- dotnet build tests\Dekaf.Tests.Unit --configuration Release
- dotnet build tools\Dekaf.Benchmarks --configuration Release
- dotnet run --project tests\Dekaf.Tests.Unit --configuration Release --no-build -- --no-ansi --disable-logo --no-progress --maximum-failed-tests 1 --timeout 5m
- dotnet format --verify-no-changes --include src\Dekaf\Protocol\Records\RecordBatch.cs tests\Dekaf.Tests.Unit\Protocol\Crc32CTests.cs tools\Dekaf.Benchmarks\Benchmarks\Unit\Crc32CBenchmarks.cs --verbosity minimal
- dotnet build tests\Dekaf.Tests.Integration --configuration Release

Note: attempted `dotnet run --project tools\Dekaf.Benchmarks --configuration Release --no-build -- --filter "*Crc32CBenchmarks*" --job Dry`; it timed out locally after 4 minutes, so I verified benchmark compilation via the benchmark project build instead.

Closes #951