### PR TITLE
perf(protocol): intern produce response topics

### DIFF
--- a/src/Dekaf/Protocol/Messages/FetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FetchResponse.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using Dekaf.Producer;
 using Dekaf.Protocol.Records;
@@ -144,12 +143,6 @@ public sealed class FetchResponseTopic
     // Pool for the partition lists to avoid per-topic-per-fetch array allocation.
     private static readonly FetchResponsePartitionListPool s_partitionListPool = new();
 
-    // Cache of topic name strings to avoid per-fetch string allocation.
-    // Topic names repeat every fetch cycle; caching them eliminates ~50-100 byte alloc per fetch per topic.
-    private static readonly ConcurrentDictionary<string, string> s_topicNameCache = new();
-    private static int s_topicNameCacheCount;
-    private const int MaxCachedTopicNames = 256;
-
     private int _pooled; // 0 = active, 1 = returned to pool
     private IReadOnlyList<FetchResponsePartition> _partitions = Array.Empty<FetchResponsePartition>();
 
@@ -205,31 +198,6 @@ public sealed class FetchResponseTopic
         return item;
     }
 
-    /// <summary>
-    /// Interns a topic name string to avoid per-fetch allocations.
-    /// Topic names are stable identifiers that repeat every fetch cycle.
-    /// </summary>
-    private static string InternTopicName(string topic)
-    {
-        if (s_topicNameCache.TryGetValue(topic, out var cached))
-            return cached;
-
-        // Avoid unbounded cache growth with dynamic topic names
-        if (Volatile.Read(ref s_topicNameCacheCount) < MaxCachedTopicNames)
-        {
-            if (s_topicNameCache.TryAdd(topic, topic))
-            {
-                Interlocked.Increment(ref s_topicNameCacheCount);
-            }
-            else if (s_topicNameCache.TryGetValue(topic, out cached))
-            {
-                return cached;
-            }
-        }
-
-        return topic;
-    }
-
     public static FetchResponseTopic Read(ref KafkaProtocolReader reader, short version)
     {
         Guid topicId = Guid.Empty;
@@ -244,7 +212,7 @@ public sealed class FetchResponseTopic
             topic = reader.ReadCompactString();
             // Intern topic names to reuse string instances across fetch cycles
             if (topic is not null)
-                topic = InternTopicName(topic);
+                topic = TopicNameInternCache.Intern(topic);
         }
 
         // Use pooled list to avoid per-topic array allocation

--- a/src/Dekaf/Protocol/Messages/ProduceResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceResponse.cs
@@ -135,7 +135,7 @@ public struct ProduceResponseTopicData
     /// </summary>
     internal void ReadInto(ref KafkaProtocolReader reader, short version)
     {
-        Name = reader.ReadCompactNonNullableString();
+        Name = TopicNameInternCache.Intern(reader.ReadCompactNonNullableString());
 
         var partitionCount = reader.ReadUnsignedVarInt() - 1;
 

--- a/src/Dekaf/Protocol/Messages/TopicNameInternCache.cs
+++ b/src/Dekaf/Protocol/Messages/TopicNameInternCache.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+
+namespace Dekaf.Protocol.Messages;
+
+internal static class TopicNameInternCache
+{
+    private const int MaxCachedTopicNames = 256;
+    private static readonly ConcurrentDictionary<string, string> s_cache = new();
+    private static int s_count;
+
+    public static string Intern(string topic)
+    {
+        if (s_cache.TryGetValue(topic, out var cached))
+            return cached;
+
+        if (Volatile.Read(ref s_count) < MaxCachedTopicNames)
+        {
+            if (s_cache.TryAdd(topic, topic))
+            {
+                Interlocked.Increment(ref s_count);
+            }
+            else if (s_cache.TryGetValue(topic, out cached))
+            {
+                return cached;
+            }
+        }
+
+        return topic;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -118,8 +118,8 @@ public class MpscFetchBufferTests
         await Assert.That(buffer.TryWrite(first)).IsTrue();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var waiter1 = Task.Run(async () => await buffer.WaitToWriteAsync(cts.Token));
-        var waiter2 = Task.Run(async () => await buffer.WaitToWriteAsync(cts.Token));
+        var waiter1 = buffer.WaitToWriteAsync(cts.Token).AsTask();
+        var waiter2 = buffer.WaitToWriteAsync(cts.Token).AsTask();
 
         await WaitUntilAsync(() => buffer.ProducerWaiterCount == 2, TimeSpan.FromSeconds(5));
 
@@ -167,7 +167,8 @@ public class MpscFetchBufferTests
         {
             Thread.Sleep(50);
             buffer.TryWrite(item);
-        }) { IsBackground = true };
+        })
+        { IsBackground = true };
         writerThread.Start();
 
         try

--- a/tests/Dekaf.Tests.Unit/Protocol/ProduceResponseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ProduceResponseTests.cs
@@ -1,0 +1,70 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public class ProduceResponseTests
+{
+    [Test]
+    public async Task Read_InternsRepeatedTopicNames()
+    {
+        var topicName = "produce-topic-" + Guid.NewGuid().ToString("N");
+
+        var first = ReadProduceResponse(topicName);
+        var second = ReadProduceResponse(topicName);
+
+        await Assert.That(second.Responses[0].Name).IsSameReferenceAs(first.Responses[0].Name);
+
+        first.Return();
+        second.Return();
+    }
+
+    [Test]
+    public async Task Read_ReusesTopicNameInternedByFetchResponse()
+    {
+        var topicName = "shared-topic-" + Guid.NewGuid().ToString("N");
+
+        var fetch = ReadFetchResponse(topicName);
+        var produce = ReadProduceResponse(topicName);
+
+        await Assert.That(produce.Responses[0].Name).IsSameReferenceAs(fetch.Responses[0].Topic);
+
+        fetch.ReturnToPool();
+        produce.Return();
+    }
+
+    private static ProduceResponse ReadProduceResponse(string topicName)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteUnsignedVarInt(2); // one topic
+        writer.WriteCompactString(topicName);
+        writer.WriteUnsignedVarInt(1); // empty partitions
+        writer.WriteUnsignedVarInt(0); // topic tagged fields
+        writer.WriteInt32(0);          // throttle time
+        writer.WriteUnsignedVarInt(0); // response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        return (ProduceResponse)ProduceResponse.Read(ref reader, ProduceResponse.LowestSupportedVersion);
+    }
+
+    private static FetchResponse ReadFetchResponse(string topicName)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);                       // throttle time
+        writer.WriteInt16((short)ErrorCode.None);   // error code
+        writer.WriteInt32(0);                       // session id
+        writer.WriteUnsignedVarInt(2);              // one topic
+        writer.WriteCompactString(topicName);
+        writer.WriteUnsignedVarInt(1);              // empty partitions
+        writer.WriteUnsignedVarInt(0);              // topic tagged fields
+        writer.WriteUnsignedVarInt(0);              // response tagged fields
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        return (FetchResponse)FetchResponse.Read(ref reader, 12);
+    }
+}


### PR DESCRIPTION
## Summary
- share the fetch response topic-name intern cache with produce responses
- intern produce response topic names during pooled read-in
- add regression coverage for repeated produce names and fetch/produce cache sharing

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Protocol/ProduceResponseTests/*"
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Protocol/FetchResponsePoolingTests/*"
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe
- [x] dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false

Closes #923
