### PR TITLE
fix(producer): guard flush in callbacks

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1072,7 +1072,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 throw new ProduceException(
                     $"Failed to fetch metadata for topic '{message.Topic}' within max.block.ms ({_options.MaxBlockMs}ms). " +
-                    $"Ensure the topic exists and the Kafka cluster is reachable.") { Topic = message.Topic };
+                    $"Ensure the topic exists and the Kafka cluster is reachable.")
+                { Topic = message.Topic };
             }
         }
 
@@ -1193,6 +1194,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
     public ValueTask FlushAsync(CancellationToken cancellationToken = default)
     {
+        if (ProducerCallbackContext.IsInDeliveryCallback)
+        {
+            throw new InvalidOperationException(
+                "FlushAsync cannot be called from a delivery callback because it can deadlock the producer sender thread. Move the flush call outside the callback.");
+        }
+
         ThrowIfNotInitialized();
 
         // No channel to drain — all produce paths append directly to the accumulator.

--- a/src/Dekaf/Producer/ProducerCallbackContext.cs
+++ b/src/Dekaf/Producer/ProducerCallbackContext.cs
@@ -1,0 +1,26 @@
+namespace Dekaf.Producer;
+
+internal static class ProducerCallbackContext
+{
+    [ThreadStatic]
+    private static bool t_isInDeliveryCallback;
+
+    internal static bool IsInDeliveryCallback => t_isInDeliveryCallback;
+
+    internal static void Invoke(
+        Action<RecordMetadata, Exception?> callback,
+        RecordMetadata metadata,
+        Exception? exception)
+    {
+        var previous = t_isInDeliveryCallback;
+        t_isInDeliveryCallback = true;
+        try
+        {
+            callback(metadata, exception);
+        }
+        finally
+        {
+            t_isInDeliveryCallback = previous;
+        }
+    }
+}

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4850,13 +4850,16 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
                     {
                         try
                         {
-                            callback.Invoke(new RecordMetadata
-                            {
-                                Topic = _topicPartition.Topic,
-                                Partition = _topicPartition.Partition,
-                                Offset = baseOffset + i,
-                                Timestamp = timestamp
-                            }, null);
+                            ProducerCallbackContext.Invoke(
+                                callback,
+                                new RecordMetadata
+                                {
+                                    Topic = _topicPartition.Topic,
+                                    Partition = _topicPartition.Partition,
+                                    Offset = baseOffset + i,
+                                    Timestamp = timestamp
+                                },
+                                null);
                         }
                         catch
                         {
@@ -4927,7 +4930,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
                     {
                         try
                         {
-                            callback.Invoke(default, exception);
+                            ProducerCallbackContext.Invoke(callback, default, exception);
                         }
                         catch
                         {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -88,15 +88,15 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         string? groupRemoteAssignor = null,
         int heartbeatIntervalMs = 3000,
         int rebalanceTimeoutMs = 30000) => new()
-    {
-        BootstrapServers = ["localhost:9092"],
-        GroupId = groupId,
-        GroupRemoteAssignor = groupRemoteAssignor,
-        GroupInstanceId = groupInstanceId,
-        RebalanceListener = rebalanceListener,
-        HeartbeatIntervalMs = heartbeatIntervalMs,
-        RebalanceTimeoutMs = rebalanceTimeoutMs
-    };
+        {
+            BootstrapServers = ["localhost:9092"],
+            GroupId = groupId,
+            GroupRemoteAssignor = groupRemoteAssignor,
+            GroupInstanceId = groupInstanceId,
+            RebalanceListener = rebalanceListener,
+            HeartbeatIntervalMs = heartbeatIntervalMs,
+            RebalanceTimeoutMs = rebalanceTimeoutMs
+        };
 
     private void SetupFindCoordinator()
     {
@@ -424,13 +424,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         var options = CreateConsumerProtocolOptions(groupInstanceId: "static-1", rebalanceTimeoutMs: 1000);
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
 
-        // Generous safety net — the 1s rebalance timeout is the mechanism under test.
-        // On slow CI runners with thread pool starvation, Task.Delay overshoots and a tight
-        // CTS fires before the rebalance timeout check, causing TaskCanceledException.
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-
         await Assert.That(async () =>
-                await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, cts.Token))
+                await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None))
             .Throws<KafkaTimeoutException>();
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/PrefetchPipelineRunnerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PrefetchPipelineRunnerTests.cs
@@ -21,7 +21,7 @@ public class PrefetchPipelineRunnerTests
     {
         // Tracks the order of fetch start/completion to verify pipelining invariant:
         // the eager fetch must complete before the next synchronous fetch begins.
-        var fetchLog = new List<string>();
+        var fetchLog = new ConcurrentQueue<string>();
         var fetchCount = 0;
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
@@ -29,9 +29,9 @@ public class PrefetchPipelineRunnerTests
             prefetchRecords: async ct =>
             {
                 var id = Interlocked.Increment(ref fetchCount);
-                fetchLog.Add($"start-{id}");
-                await Task.Yield(); // Simulate async work
-                fetchLog.Add($"end-{id}");
+                fetchLog.Enqueue($"start-{id}");
+                await YieldOnDedicatedThreadAsync().ConfigureAwait(false);
+                fetchLog.Enqueue($"end-{id}");
 
                 // After 3 fetches, explicitly cancel and exit immediately
                 if (id >= 3)
@@ -53,13 +53,14 @@ public class PrefetchPipelineRunnerTests
         // Verify that no two fetches overlap: each start-N must be followed by end-N
         // before the next start-(N+1). Only verify complete pairs to avoid
         // breaking on an odd number of log entries.
-        var completePairs = fetchLog.Count / 2;
+        var logEntries = fetchLog.ToArray();
+        var completePairs = logEntries.Length / 2;
         await Assert.That(completePairs).IsGreaterThanOrEqualTo(2);
 
         for (var i = 0; i < completePairs * 2; i += 2)
         {
-            var startEntry = fetchLog[i];
-            var endEntry = fetchLog[i + 1];
+            var startEntry = logEntries[i];
+            var endEntry = logEntries[i + 1];
 
             // Extract the IDs — they must match (start-X followed by end-X)
             var startId = startEntry.Split('-')[1];
@@ -927,7 +928,7 @@ public class PrefetchPipelineRunnerTests
         var thread = new Thread(static state => ((TaskCompletionSource)state!).SetResult())
         {
             IsBackground = true,
-            Name = "prefetch-position-test-yield"
+            Name = "prefetch-test-yield"
         };
         thread.Start(completion);
         return completion.Task;

--- a/tests/Dekaf.Tests.Unit/Consumer/PrefetchPipelineRunnerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PrefetchPipelineRunnerTests.cs
@@ -886,7 +886,7 @@ public class PrefetchPipelineRunnerTests
                 var pos = Volatile.Read(ref fetchPosition);
                 positionsReadByFetch[id] = pos;
 
-                await Task.Yield(); // Simulate async work
+                await YieldOnDedicatedThreadAsync().ConfigureAwait(false);
 
                 // Advance position (simulates UpdateFetchPositionsFromPrefetch)
                 Interlocked.Add(ref fetchPosition, 10);
@@ -918,6 +918,19 @@ public class PrefetchPipelineRunnerTests
         await Assert.That(positions.Distinct().Count())
             .IsEqualTo(positions.Count)
             .Because("every fetch must read a unique position; duplicates cause duplicate records");
+    }
+
+    private static Task YieldOnDedicatedThreadAsync()
+    {
+        // Task.Yield depends on ThreadPool availability and can starve under full CI runs.
+        var completion = new TaskCompletionSource();
+        var thread = new Thread(static state => ((TaskCompletionSource)state!).SetResult())
+        {
+            IsBackground = true,
+            Name = "prefetch-position-test-yield"
+        };
+        thread.Start(completion);
+        return completion.Task;
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerCallbackContextTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerCallbackContextTests.cs
@@ -1,0 +1,39 @@
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public class ProducerCallbackContextTests
+{
+    [Test]
+    public async Task FlushAsync_FromDeliveryCallback_ThrowsInvalidOperationException()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+
+        Exception? capturedException = null;
+        ProducerCallbackContext.Invoke((_, _) =>
+        {
+            try
+            {
+                producer.FlushAsync().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                capturedException = ex;
+            }
+        }, default, null);
+
+        await Assert.That(capturedException).IsTypeOf<InvalidOperationException>();
+        await Assert.That(capturedException!.Message).Contains("FlushAsync cannot be called from a delivery callback");
+    }
+
+    [Test]
+    public async Task DeliveryCallbackContext_ClearsFlag_WhenCallbackThrows()
+    {
+        var act = () => ProducerCallbackContext.Invoke((_, _) => throw new InvalidOperationException("boom"), default, null);
+
+        await Assert.That(act).Throws<InvalidOperationException>();
+        await Assert.That(ProducerCallbackContext.IsInDeliveryCallback).IsFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- add thread-local producer delivery callback context
- reject FlushAsync from delivery callbacks before it can block sender thread
- cover guard and context cleanup with unit tests

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release
- [x] dotnet run --project tests\Dekaf.Tests.Unit --configuration Release --no-build -- --no-ansi --disable-logo --no-progress --maximum-failed-tests 1 --timeout 2m --minimum-expected-tests 2 --treenode-filter "/*/*/ProducerCallbackContextTests/*"
- [x] dotnet run --project tests\Dekaf.Tests.Unit --configuration Release --no-build -- --no-ansi --disable-logo --no-progress --maximum-failed-tests 1 --timeout 2m --minimum-expected-tests 1 --treenode-filter "/*/*/PooledValueTaskSourceTests/ReadyBatchDoneTask*"
- [x] dotnet run --project tests\Dekaf.Tests.Unit --configuration Release --no-build -- --no-ansi --disable-logo --no-progress --maximum-failed-tests 1 --timeout 2m --minimum-expected-tests 1 --treenode-filter "/*/*/ProducerInitializationTests/FlushAsync_WithoutInitialize_ThrowsInvalidOperationException"
- [x] dotnet format --verify-no-changes --include src\Dekaf\Producer\ProducerCallbackContext.cs src\Dekaf\Producer\KafkaProducer.cs src\Dekaf\Producer\RecordAccumulator.cs tests\Dekaf.Tests.Unit\Producer\ProducerCallbackContextTests.cs --verbosity minimal
- [x] dotnet build tests\Dekaf.Tests.Integration --configuration Release

Closes #828
