### PR TITLE
perf(metadata): index partition lookup

### DIFF
--- a/src/Dekaf/Metadata/ClusterMetadata.cs
+++ b/src/Dekaf/Metadata/ClusterMetadata.cs
@@ -31,6 +31,12 @@ internal sealed class ClusterMetadataSnapshot
     /// </summary>
     public IReadOnlyDictionary<int, IReadOnlyList<TopicPartition>> PartitionsByBroker { get; }
 
+    /// <summary>
+    /// Topic name → partition metadata array indexed by PartitionIndex.
+    /// Built at snapshot creation time so partition-leader lookup is O(1).
+    /// </summary>
+    public IReadOnlyDictionary<string, PartitionInfo?[]> PartitionsByTopicIndex { get; }
+
     public ClusterMetadataSnapshot(
         string? clusterId,
         int controllerId,
@@ -46,6 +52,7 @@ internal sealed class ClusterMetadataSnapshot
         Topics = topics;
         TopicsById = topicsById;
         PartitionsByBroker = BuildPartitionsByBroker(topics);
+        PartitionsByTopicIndex = BuildPartitionsByTopicIndex(topics);
     }
 
     private static Dictionary<int, IReadOnlyList<TopicPartition>> BuildPartitionsByBroker(
@@ -66,6 +73,38 @@ internal sealed class ClusterMetadataSnapshot
         var result = new Dictionary<int, IReadOnlyList<TopicPartition>>(builder.Count);
         foreach (var (key, list) in builder)
             result[key] = list.ToArray();
+        return result;
+    }
+
+    private static Dictionary<string, PartitionInfo?[]> BuildPartitionsByTopicIndex(
+        Dictionary<string, TopicInfo> topics)
+    {
+        var result = new Dictionary<string, PartitionInfo?[]>(topics.Count);
+        foreach (var topic in topics.Values)
+        {
+            var maxPartitionIndex = -1;
+            foreach (var partition in topic.Partitions)
+            {
+                if (partition.PartitionIndex > maxPartitionIndex)
+                    maxPartitionIndex = partition.PartitionIndex;
+            }
+
+            if (maxPartitionIndex < 0)
+            {
+                result[topic.Name] = [];
+                continue;
+            }
+
+            var partitionsByIndex = new PartitionInfo?[maxPartitionIndex + 1];
+            foreach (var partition in topic.Partitions)
+            {
+                if ((uint)partition.PartitionIndex < (uint)partitionsByIndex.Length)
+                    partitionsByIndex[partition.PartitionIndex] = partition;
+            }
+
+            result[topic.Name] = partitionsByIndex;
+        }
+
         return result;
     }
 }
@@ -146,6 +185,15 @@ public sealed class ClusterMetadata
     }
 
     /// <summary>
+    /// Gets partition metadata by topic and partition index.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal PartitionInfo? GetPartitionInfo(string topicName, int partition)
+    {
+        return GetPartitionInfo(_snapshot, topicName, partition);
+    }
+
+    /// <summary>
     /// Gets all known topics.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -189,25 +237,26 @@ public sealed class ClusterMetadata
     public BrokerNode? GetPartitionLeader(string topicName, int partition)
     {
         var snapshot = _snapshot;
-
-        if (!snapshot.Topics.TryGetValue(topicName, out var topic))
-            return null;
-
-        // Manual loop to avoid closure allocation from FirstOrDefault lambda
-        PartitionInfo? partitionInfo = null;
-        foreach (var p in topic.Partitions)
-        {
-            if (p.PartitionIndex == partition)
-            {
-                partitionInfo = p;
-                break;
-            }
-        }
+        var partitionInfo = GetPartitionInfo(snapshot, topicName, partition);
 
         if (partitionInfo is null)
             return null;
 
         return snapshot.Brokers.TryGetValue(partitionInfo.LeaderId, out var broker) ? broker : null;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static PartitionInfo? GetPartitionInfo(
+        ClusterMetadataSnapshot snapshot,
+        string topicName,
+        int partition)
+    {
+        if (!snapshot.PartitionsByTopicIndex.TryGetValue(topicName, out var partitionsByIndex))
+            return null;
+
+        return (uint)partition < (uint)partitionsByIndex.Length
+            ? partitionsByIndex[partition]
+            : null;
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Metadata/ClusterMetadataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/ClusterMetadataTests.cs
@@ -280,6 +280,44 @@ public sealed class ClusterMetadataTests
         await Assert.That(leader).IsNull();
     }
 
+    [Test]
+    public async Task GetPartitionInfo_HighPartitionIndex_ReturnsPartition()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateLargePartitionMetadataResponse(partitionCount: 1024));
+
+        var partition = metadata.GetPartitionInfo("large-topic", 1023);
+
+        await Assert.That(partition).IsNotNull();
+        await Assert.That(partition!.PartitionIndex).IsEqualTo(1023);
+        await Assert.That(partition.LeaderId).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task GetPartitionLeader_HighPartitionIndex_ReturnsBroker()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateLargePartitionMetadataResponse(partitionCount: 1024));
+
+        var leader = metadata.GetPartitionLeader("large-topic", 1023);
+
+        await Assert.That(leader).IsNotNull();
+        await Assert.That(leader!.NodeId).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task GetPartitionInfo_UpdateRefreshesIndex()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateLargePartitionMetadataResponse(partitionCount: 1024));
+        await Assert.That(metadata.GetPartitionInfo("large-topic", 1023)).IsNotNull();
+
+        metadata.Update(CreateLargePartitionMetadataResponse(partitionCount: 8));
+
+        await Assert.That(metadata.GetPartitionInfo("large-topic", 1023)).IsNull();
+        await Assert.That(metadata.GetPartitionInfo("large-topic", 7)).IsNotNull();
+    }
+
     #endregion
 
     #region GetPartitionsForBroker
@@ -636,6 +674,42 @@ public sealed class ClusterMetadataTests
                     [
                         new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] }
                     ]
+                }
+            ]
+        };
+    }
+
+    private static MetadataResponse CreateLargePartitionMetadataResponse(int partitionCount)
+    {
+        var partitions = new List<PartitionMetadata>(partitionCount);
+        for (var i = 0; i < partitionCount; i++)
+        {
+            partitions.Add(new PartitionMetadata
+            {
+                ErrorCode = ErrorCode.None,
+                PartitionIndex = i,
+                LeaderId = i % 2 == 0 ? 1 : 2,
+                ReplicaNodes = [1, 2],
+                IsrNodes = [1, 2]
+            });
+        }
+
+        return new MetadataResponse
+        {
+            ClusterId = "test-cluster",
+            ControllerId = 1,
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker1", Port = 9092 },
+                new BrokerMetadata { NodeId = 2, Host = "broker2", Port = 9092 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "large-topic",
+                    Partitions = partitions
                 }
             ]
         };


### PR DESCRIPTION
## Summary
- build partition metadata arrays indexed by partition id in each cluster metadata snapshot
- route partition leader lookup through the snapshot index instead of scanning topic partitions
- cover high-partition lookup and index refresh behavior

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release
- [x] dotnet run --project tests\Dekaf.Tests.Unit --configuration Release --no-build -- --no-ansi --disable-logo --no-progress --maximum-failed-tests 1 --timeout 2m --minimum-expected-tests 34 --treenode-filter "/*/*/ClusterMetadataTests/*"
- [x] dotnet run --project tests\Dekaf.Tests.Unit --configuration Release --no-build -- --no-ansi --disable-logo --no-progress --maximum-failed-tests 1 --timeout 2m --minimum-expected-tests 1 --treenode-filter "/*/*/MetadataManagerTests/*"
- [x] dotnet format --verify-no-changes --include src\Dekaf\Metadata\ClusterMetadata.cs tests\Dekaf.Tests.Unit\Metadata\ClusterMetadataTests.cs --verbosity minimal
- [x] dotnet build tests\Dekaf.Tests.Integration --configuration Release

Closes #933
