### PR TITLE
fix(networking): keep pipe pool after close

### DIFF
--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -853,11 +853,6 @@ public sealed partial class ConnectionPool : IConnectionPool
             _connectionReplacementLocks.Clear();
             _groupCreationLocks.Clear();
 
-            // Dispose the shared memory pool after all connections are closed.
-            // At this point, all pipes have been completed and IMemoryOwner<byte> references
-            // returned, so the underlying ArrayPool can be collected by the GC.
-            _sharedPipeMemoryPool?.Dispose();
-
             LogAllConnectionsClosed();
         }
         finally
@@ -872,6 +867,11 @@ public sealed partial class ConnectionPool : IConnectionPool
             return;
 
         await CloseAllAsync().ConfigureAwait(false);
+
+        // Dispose the shared memory pool only when the pool itself is disposed.
+        // Public CloseAllAsync is a reset/reconnect operation; keeping the pool alive
+        // lets subsequent connections reuse it without tripping ObjectDisposedException.
+        _sharedPipeMemoryPool?.Dispose();
 
         _sharedOAuthBearerTokenProvider?.Dispose();
         _disposeLock.Dispose();

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+using System.Reflection;
 using Dekaf.Networking;
 using Dekaf.Security.Sasl;
 
@@ -105,6 +107,33 @@ public sealed class ConnectionPoolTests
         await using var pool = new ConnectionPool("test-client");
 
         await pool.CloseAllAsync();
+    }
+
+    [Test]
+    public async Task CloseAllAsync_DoesNotDisposeSharedPipeMemoryPool()
+    {
+        var pool = new ConnectionPool("test-client");
+        var sharedPool = GetSharedPipeMemoryPool(pool);
+
+        await pool.CloseAllAsync();
+
+        using (var owner = sharedPool.Rent(1))
+        {
+            await Assert.That(owner.Memory.Length).IsGreaterThanOrEqualTo(1);
+        }
+
+        await pool.DisposeAsync();
+    }
+
+    [Test]
+    public async Task DisposeAsync_DisposesSharedPipeMemoryPool()
+    {
+        var pool = new ConnectionPool("test-client");
+        var sharedPool = GetSharedPipeMemoryPool(pool);
+
+        await pool.DisposeAsync();
+
+        await Assert.That(() => sharedPool.Rent(1)).Throws<ObjectDisposedException>();
     }
 
     [Test]
@@ -340,4 +369,13 @@ public sealed class ConnectionPoolTests
         PrincipalName = "principal",
         Expiration = DateTimeOffset.UtcNow.AddHours(1)
     };
+
+    private static MemoryPool<byte> GetSharedPipeMemoryPool(ConnectionPool pool)
+    {
+        var field = typeof(ConnectionPool).GetField(
+            "_sharedPipeMemoryPool",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        return (MemoryPool<byte>)field!.GetValue(pool)!;
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -22,6 +22,9 @@ public class KafkaProducerFastPathTests
             BufferMemory = ulong.MaxValue,
             BatchSize = 4096,
             LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000,
             CustomPartitioner = partitioner
         };
 
@@ -29,6 +32,7 @@ public class KafkaProducerFastPathTests
             options,
             Serializers.String,
             Serializers.String);
+        await StopProducerBackgroundLoopsAsync(producer);
         await using var pool = new ValueTaskSourcePool<RecordMetadata>();
         var topicInfo = CreateTopicInfo();
         var innerCompletion = pool.Rent();
@@ -106,9 +110,7 @@ public class KafkaProducerFastPathTests
 
     private static ReadyBatch CompleteCurrentBatch(RecordAccumulator accumulator, TopicPartition topicPartition)
     {
-        var dequesField = typeof(RecordAccumulator).GetField("_partitionDeques",
-            BindingFlags.NonPublic | BindingFlags.Instance);
-        var deques = dequesField!.GetValue(accumulator)!;
+        var deques = GetInstanceField<object>(accumulator, "_partitionDeques");
 
         var tryGetValueMethod = deques.GetType().GetMethod("TryGetValue");
         var parameters = new object[] { topicPartition, null! };
@@ -117,10 +119,36 @@ public class KafkaProducerFastPathTests
             throw new InvalidOperationException("Partition deque was not found.");
 
         var partitionDeque = parameters[1];
-        var currentBatchField = partitionDeque!.GetType().GetField("CurrentBatch");
-        var partitionBatch = currentBatchField!.GetValue(partitionDeque);
-        var completeMethod = partitionBatch!.GetType().GetMethod("Complete");
-        return (ReadyBatch)completeMethod!.Invoke(partitionBatch, null)!;
+        var partitionBatch = GetInstanceField<object?>(partitionDeque!, "CurrentBatch");
+        if (partitionBatch is not null)
+        {
+            var completeMethod = partitionBatch.GetType().GetMethod("Complete");
+            return (ReadyBatch)completeMethod!.Invoke(partitionBatch, null)!;
+        }
+
+        var peekFirstMethod = partitionDeque.GetType().GetMethod("PeekFirst");
+        if (peekFirstMethod!.Invoke(partitionDeque, null) is ReadyBatch readyBatch)
+            return readyBatch;
+
+        throw new InvalidOperationException("Partition deque did not contain a current or sealed batch.");
+    }
+
+    private static async Task StopProducerBackgroundLoopsAsync(KafkaProducer<string, string> producer)
+    {
+        var cts = GetInstanceField<CancellationTokenSource>(producer, "_senderCts");
+        var senderTask = GetInstanceField<Task>(producer, "_senderTask");
+        var lingerTask = GetInstanceField<Task>(producer, "_lingerTask");
+
+        await cts.CancelAsync();
+        await Task.WhenAll(senderTask, lingerTask).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private static T GetInstanceField<T>(object target, string name)
+    {
+        const BindingFlags instanceFieldFlags =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        var field = target.GetType().GetField(name, instanceFieldFlags);
+        return (T)field!.GetValue(target)!;
     }
 
     private static string GetKeyString(Dekaf.Protocol.Records.Record record)


### PR DESCRIPTION
Closes #897

## Summary
- keep the shared `PipeMemoryPool` alive across public `CloseAllAsync()` so later reconnects can reuse it
- dispose the shared pool only from `ConnectionPool.DisposeAsync()`
- add regression coverage for `CloseAllAsync` versus final disposal

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Networking/ConnectionPoolTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Networking/PipeMemoryPoolTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Networking/ConnectionPoolConcurrencyTests/*"`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- `git diff --check`