### PR TITLE
fix(producer): emit metrics without tracing

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -104,6 +104,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     // Application-level retry policy (null = no retries, zero overhead on fast path)
     private readonly IRetryPolicy? _retryPolicy;
 
+    private readonly ConcurrentDictionary<string, TagList> _metricTagsCache = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, string> _activityNameCache = new(StringComparer.Ordinal);
+
     // Single thread-local cache consolidating all per-thread producer state.
     // Reduces 9 separate [ThreadStatic] lookups (each hitting GetGCThreadStaticsByIndexSlow)
     // to a single lookup per method entry point.
@@ -418,6 +421,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 return AwaitWithActivity(completion!, activity, message.Topic, cancellationToken);
             }
+            if (ProducerMetricsEnabled())
+            {
+                return AwaitWithMetrics(completion!, message.Topic, cancellationToken);
+            }
             if (cancellationToken.CanBeCanceled)
             {
                 return AwaitWithCancellation(completion!, cancellationToken);
@@ -485,10 +492,53 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     }
 
     /// <summary>
+    /// Awaits a completion source with metrics and optional cancellation support.
+    /// </summary>
+    private async ValueTask<RecordMetadata> AwaitWithMetrics(
+        PooledValueTaskSource<RecordMetadata> completion,
+        string topic,
+        CancellationToken cancellationToken)
+    {
+        var startTimestamp = Stopwatch.GetTimestamp();
+        CancellationTokenRegistration registration = default;
+
+        if (cancellationToken.CanBeCanceled)
+        {
+            var state = (completion, cancellationToken);
+            registration = cancellationToken.Register(
+                static s =>
+                {
+                    var (comp, token) = ((PooledValueTaskSource<RecordMetadata>, CancellationToken))s!;
+                    comp.TrySetCanceled(token);
+                },
+                state);
+        }
+
+        try
+        {
+            var metadata = await completion.Task.ConfigureAwait(false);
+            EmitProduceSuccessMetrics(topic, metadata, startTimestamp);
+            return metadata;
+        }
+        catch
+        {
+            Diagnostics.DekafMetrics.ProduceErrors.Add(1, GetMetricTags(topic));
+            throw;
+        }
+        finally
+        {
+            if (cancellationToken.CanBeCanceled)
+            {
+                await registration.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
     /// Awaits a completion source with Activity lifecycle and optional cancellation support.
     /// Records OTel metrics and sets span status/tags on completion.
     /// </summary>
-    private static async ValueTask<RecordMetadata> AwaitWithActivity(
+    private async ValueTask<RecordMetadata> AwaitWithActivity(
         PooledValueTaskSource<RecordMetadata> completion,
         Activity activity,
         string topic,
@@ -519,20 +569,14 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageBodySize, metadata.KeySize + metadata.ValueSize);
             activity.SetStatus(ActivityStatusCode.Ok);
 
-            var tagList = new TagList { { Diagnostics.DekafDiagnostics.MessagingDestinationName, topic } };
-            Diagnostics.DekafMetrics.MessagesSent.Add(1, tagList);
-            Diagnostics.DekafMetrics.BytesSent.Add(metadata.KeySize + metadata.ValueSize, tagList);
-            Diagnostics.DekafMetrics.OperationDuration.Record(
-                Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds, tagList);
+            EmitProduceSuccessMetrics(topic, metadata, startTimestamp);
 
             return metadata;
         }
         catch (Exception ex)
         {
             Diagnostics.DekafDiagnostics.RecordException(activity, ex);
-
-            var tagList = new TagList { { Diagnostics.DekafDiagnostics.MessagingDestinationName, topic } };
-            Diagnostics.DekafMetrics.ProduceErrors.Add(1, tagList);
+            Diagnostics.DekafMetrics.ProduceErrors.Add(1, GetMetricTags(topic));
 
             throw;
         }
@@ -545,6 +589,28 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             }
         }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool ProducerMetricsEnabled()
+        => Diagnostics.DekafMetrics.MessagesSent.Enabled
+           || Diagnostics.DekafMetrics.BytesSent.Enabled
+           || Diagnostics.DekafMetrics.OperationDuration.Enabled
+           || Diagnostics.DekafMetrics.ProduceErrors.Enabled;
+
+    private void EmitProduceSuccessMetrics(string topic, RecordMetadata metadata, long startTimestamp)
+    {
+        var tagList = GetMetricTags(topic);
+        Diagnostics.DekafMetrics.MessagesSent.Add(1, tagList);
+        Diagnostics.DekafMetrics.BytesSent.Add(metadata.KeySize + metadata.ValueSize, tagList);
+        Diagnostics.DekafMetrics.OperationDuration.Record(
+            Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds, tagList);
+    }
+
+    private TagList GetMetricTags(string topic)
+        => _metricTagsCache.GetOrAdd(topic, static t => new TagList
+        {
+            { Diagnostics.DekafDiagnostics.MessagingDestinationName, t }
+        });
 
     /// <summary>
     /// Attempts synchronous produce for awaited ProduceAsync when metadata is cached.
@@ -628,6 +694,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 return await AwaitWithActivity(fastCompletion!, activity, message.Topic, cancellationToken).ConfigureAwait(false);
             }
+            if (ProducerMetricsEnabled())
+            {
+                return await AwaitWithMetrics(fastCompletion!, message.Topic, cancellationToken).ConfigureAwait(false);
+            }
             if (cancellationToken.CanBeCanceled)
             {
                 return await AwaitWithCancellation(fastCompletion!, cancellationToken).ConfigureAwait(false);
@@ -653,6 +723,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         if (activity is not null)
         {
             return await AwaitWithActivity(completion, activity, message.Topic, cancellationToken).ConfigureAwait(false);
+        }
+        if (ProducerMetricsEnabled())
+        {
+            return await AwaitWithMetrics(completion, message.Topic, cancellationToken).ConfigureAwait(false);
         }
         if (cancellationToken.CanBeCanceled)
         {
@@ -999,7 +1073,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             return null;
 
         var activity = Diagnostics.DekafDiagnostics.Source.StartActivity(
-            $"{message.Topic} publish", ActivityKind.Producer);
+            GetPublishActivityName(message.Topic), ActivityKind.Producer);
         if (activity is not null)
         {
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingSystem, Diagnostics.DekafDiagnostics.MessagingSystemValue);
@@ -1016,6 +1090,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         return activity;
     }
+
+    private string GetPublishActivityName(string topic)
+        => _activityNameCache.GetOrAdd(topic, static t => $"{t} publish");
 
     /// <summary>
     /// Invokes OnAcknowledgement interceptors for all messages in a batch.

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerMetricsTests.cs
@@ -1,0 +1,119 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+using Dekaf.Diagnostics;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public sealed class KafkaProducerMetricsTests
+{
+    [Test]
+    [NotInParallel("MeterListener")]
+    public async Task AwaitWithMetrics_MeterOnlyListener_RecordsSuccessMetrics()
+    {
+        long messagesSent = 0;
+        long bytesSent = 0;
+        double operationDuration = -1;
+        string? messagesTopic = null;
+        string? bytesTopic = null;
+        string? durationTopic = null;
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == DekafDiagnostics.MeterName)
+                meterListener.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            if (instrument.Name == "messaging.client.sent.messages")
+            {
+                messagesSent += measurement;
+                messagesTopic = GetTag(tags, DekafDiagnostics.MessagingDestinationName);
+            }
+            else if (instrument.Name == "messaging.client.sent.bytes")
+            {
+                bytesSent += measurement;
+                bytesTopic = GetTag(tags, DekafDiagnostics.MessagingDestinationName);
+            }
+        });
+        listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
+        {
+            if (instrument.Name == "messaging.client.operation.duration")
+            {
+                operationDuration = measurement;
+                durationTopic = GetTag(tags, DekafDiagnostics.MessagingDestinationName);
+            }
+        });
+        listener.Start();
+
+        await Assert.That(ProducerMetricsEnabled()).IsTrue();
+
+        await using var producer = new KafkaProducer<string, string>(
+            new ProducerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "metrics-test"
+            },
+            Serializers.String,
+            Serializers.String);
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var completion = pool.Rent();
+        completion.TrySetResult(new RecordMetadata
+        {
+            Topic = "orders",
+            Partition = 1,
+            Offset = 42,
+            Timestamp = DateTimeOffset.UtcNow,
+            KeySize = 3,
+            ValueSize = 5
+        });
+
+        var metadata = await InvokeAwaitWithMetrics(producer, completion, "orders");
+
+        await Assert.That(metadata.Topic).IsEqualTo("orders");
+        await Assert.That(messagesSent).IsEqualTo(1);
+        await Assert.That(bytesSent).IsEqualTo(8);
+        await Assert.That(operationDuration).IsGreaterThanOrEqualTo(0);
+        await Assert.That(messagesTopic).IsEqualTo("orders");
+        await Assert.That(bytesTopic).IsEqualTo("orders");
+        await Assert.That(durationTopic).IsEqualTo("orders");
+    }
+
+    private static bool ProducerMetricsEnabled()
+    {
+        var method = typeof(KafkaProducer<string, string>).GetMethod(
+            "ProducerMetricsEnabled",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        return (bool)method!.Invoke(null, null)!;
+    }
+
+    private static async ValueTask<RecordMetadata> InvokeAwaitWithMetrics(
+        KafkaProducer<string, string> producer,
+        PooledValueTaskSource<RecordMetadata> completion,
+        string topic)
+    {
+        var method = typeof(KafkaProducer<string, string>).GetMethod(
+            "AwaitWithMetrics",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        var result = (ValueTask<RecordMetadata>)method!.Invoke(
+            producer,
+            [completion, topic, CancellationToken.None])!;
+        return await result;
+    }
+
+    private static string? GetTag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string key)
+    {
+        foreach (var tag in tags)
+        {
+            if (tag.Key == key)
+                return tag.Value?.ToString();
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Closes #894

## Summary
- route awaited produce completions through a metrics-only await path when a `MeterListener` is enabled but no tracing activity exists
- reuse cached per-topic metric tags for producer success/error metrics
- cache producer publish activity names per topic
- add a meter-only regression test for sent message/byte/duration metrics

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Producer/KafkaProducerMetricsTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Diagnostics/DekafDiagnosticsTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Producer/KafkaProducerFastPathTests/*"`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- `git diff --check`