### PR TITLE
perf(networking): cut cancellation churn

### DIFF
--- a/src/Dekaf/Networking/IKafkaConnection.cs
+++ b/src/Dekaf/Networking/IKafkaConnection.cs
@@ -80,8 +80,8 @@ public interface IKafkaConnection : IAsyncDisposable
 
     /// <summary>
     /// Sends a pipelined request where the caller's cancellation token already carries a timeout
-    /// for the write phase. Skips the per-write CancellationTokenSource allocation — a hot-path
-    /// optimization for BrokerSender. The response phase still uses the standard timeout.
+    /// for the write and response phases. Skips per-request timeout CTS/linking on the hot path —
+    /// a hot-path optimization for BrokerSender.
     /// </summary>
     /// <remarks>
     /// The caller's token MUST be exclusively a timeout token (e.g., from a CancellationTokenSource

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -460,7 +460,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         var responseHeaderVersion = TRequest.GetResponseHeaderVersion(apiVersion);
 
         var pending = _pendingRequestPool.Rent();
-        pending.Initialize(responseHeaderVersion, cancellationToken);
+        pending.Initialize(responseHeaderVersion, cancellationToken, registerCancellation: false);
         _pendingRequests[correlationId] = new PendingRequestEntry(pending, pending.Version);
 
         ThrowIfDisposedAfterAddingPendingRequest(correlationId);
@@ -477,7 +477,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
             // Response phase: await response with timeout and parse
             return await AwaitAndParseResponseAsync<TRequest, TResponse>(
-                pending, correlationId, apiVersion, cancellationToken).ConfigureAwait(false);
+                pending, correlationId, apiVersion, callerOwnsTimeout: false, cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -559,7 +559,6 @@ public sealed partial class KafkaConnection : IKafkaConnection
     /// Pipelined overload that skips the per-write CancellationTokenSource rent and
     /// CancellationTokenRegistration allocation. The caller's token must already carry a
     /// timeout (e.g. BrokerSender's sendTimeoutCts).
-    /// The response phase still uses the standard timeout via AwaitAndParseResponseAsync.
     /// </summary>
     /// <remarks>
     /// The caller's token MUST be exclusively a timeout token (e.g., from a CancellationTokenSource
@@ -594,7 +593,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         var responseHeaderVersion = TRequest.GetResponseHeaderVersion(apiVersion);
 
         var pending = _pendingRequestPool.Rent();
-        pending.Initialize(responseHeaderVersion, cancellationToken);
+        pending.Initialize(responseHeaderVersion, cancellationToken, registerCancellation: false);
         _pendingRequests[correlationId] = new PendingRequestEntry(pending, pending.Version);
 
         ThrowIfDisposedAfterAddingPendingRequest(correlationId);
@@ -606,7 +605,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
             // Response phase: await response with timeout, then parse
             return await AwaitAndParseResponseAsync<TRequest, TResponse>(
-                pending, correlationId, apiVersion, cancellationToken).ConfigureAwait(false);
+                pending, correlationId, apiVersion, callerOwnsTimeout, cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -628,6 +627,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         PooledPendingRequest pending,
         int correlationId,
         short apiVersion,
+        bool callerOwnsTimeout,
         CancellationToken cancellationToken)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
@@ -637,25 +637,44 @@ public sealed partial class KafkaConnection : IKafkaConnection
         {
             LogWaitingForResponse(correlationId);
 
-            using var timeoutCts = _timeoutCtsPool.Rent();
-            timeoutCts.CancelAfter(_options.RequestTimeout);
-            using var reg = cancellationToken.CanBeCanceled
-                ? cancellationToken.Register(static s => ((CancellationTokenSource)s!).Cancel(), timeoutCts)
-                : default;
-            pending.RegisterCancellation(timeoutCts.Token);
-
             PooledResponseBuffer pooledBuffer;
-            try
+            if (callerOwnsTimeout && cancellationToken.CanBeCanceled)
             {
-                pooledBuffer = await pending.AsValueTask().ConfigureAwait(false);
+                pending.RegisterCancellation(cancellationToken);
+                try
+                {
+                    pooledBuffer = await pending.AsValueTask().ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw CreateResponseTimeoutException(TRequest.ApiKey, correlationId);
+                }
+                finally
+                {
+                    pending.DisposeRegistration();
+                }
             }
-            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            else
             {
-                throw new TimeoutException($"Request {TRequest.ApiKey} (correlation {correlationId}) timed out after {_options.RequestTimeout.TotalSeconds}s waiting for response from {_host}:{_port}");
-            }
-            finally
-            {
-                pending.DisposeRegistration();
+                using var timeoutCts = _timeoutCtsPool.Rent();
+                timeoutCts.CancelAfter(_options.RequestTimeout);
+                using var reg = cancellationToken.CanBeCanceled
+                    ? cancellationToken.Register(static s => ((CancellationTokenSource)s!).Cancel(), timeoutCts)
+                    : default;
+                pending.RegisterCancellation(timeoutCts.Token);
+
+                try
+                {
+                    pooledBuffer = await pending.AsValueTask().ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    throw CreateResponseTimeoutException(TRequest.ApiKey, correlationId);
+                }
+                finally
+                {
+                    pending.DisposeRegistration();
+                }
             }
 
             responseReceived = true;
@@ -723,6 +742,9 @@ public sealed partial class KafkaConnection : IKafkaConnection
             }
         }
     }
+
+    private TimeoutException CreateResponseTimeoutException(ApiKey apiKey, int correlationId) =>
+        new($"Request {apiKey} (correlation {correlationId}) timed out after {_options.RequestTimeout.TotalSeconds}s waiting for response from {_host}:{_port}");
 
     /// <summary>
     /// Returns the thread-local request buffer for SASL handshake serialization only.
@@ -2578,13 +2600,13 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
     /// <summary>
     /// Initializes the request for a new operation.
     /// </summary>
-    public void Initialize(short responseHeaderVersion, CancellationToken cancellationToken)
+    public void Initialize(short responseHeaderVersion, CancellationToken cancellationToken, bool registerCancellation = true)
     {
         _responseHeaderVersion = responseHeaderVersion;
         _state = CreateState(_core.Version, StatePending);
 
         // Register for cancellation if the token can be cancelled
-        if (cancellationToken.CanBeCanceled)
+        if (registerCancellation && cancellationToken.CanBeCanceled)
         {
             _cancellationRegistration = cancellationToken.Register(
                 static state => ((PooledPendingRequest)state!).OnCancelled(),
@@ -2598,17 +2620,15 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
     /// </summary>
     public void RegisterCancellation(CancellationToken cancellationToken)
     {
-        if (cancellationToken.CanBeCanceled)
-        {
-            var newRegistration = cancellationToken.Register(
+        var newRegistration = cancellationToken.CanBeCanceled
+            ? cancellationToken.Register(
                 static state => ((PooledPendingRequest)state!).OnCancelled(),
-                this);
+                this)
+            : default;
 
-            // Dispose old registration and replace with new one
-            var oldRegistration = _cancellationRegistration;
-            _cancellationRegistration = newRegistration;
-            oldRegistration.Dispose();
-        }
+        var oldRegistration = _cancellationRegistration;
+        _cancellationRegistration = newRegistration;
+        oldRegistration.Dispose();
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using Dekaf.Networking;
 using Dekaf.Protocol.Messages;
 
@@ -116,6 +118,39 @@ public sealed class KafkaConnectionTests
         Func<Task> act = () => connection.ConnectAsync().AsTask();
 
         await Assert.That(act).Throws<ObjectDisposedException>();
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task SendPipelinedWithCallerTimeoutAsync_ResponseCancellation_ThrowsTimeoutException(CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            await using var connection = new KafkaConnection(
+                IPAddress.Loopback.ToString(),
+                port,
+                options: new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(30) });
+
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+            using var callerTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+            var act = async () => await connection.SendPipelinedWithCallerTimeoutAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                apiVersion: 3,
+                callerTimeout.Token);
+
+            await Assert.That(act).Throws<TimeoutException>();
+        }
+        finally
+        {
+            listener.Stop();
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
@@ -154,6 +154,29 @@ public class PooledPendingRequestTests
     }
 
     [Test]
+    public async Task Initialize_CanSkipCancellationRegistration()
+    {
+        var pool = new PendingRequestPool();
+        var request = pool.Rent();
+        var cts = new CancellationTokenSource();
+
+        request.Initialize(responseHeaderVersion: 0, cts.Token, registerCancellation: false);
+
+        cts.Cancel();
+
+        var testData = new byte[] { 0, 0, 0, 1, 42 };
+        var buffer = new PooledResponseBuffer(testData, testData.Length, isPooled: false);
+        var completed = request.TryComplete(buffer);
+
+        await Assert.That(completed).IsTrue();
+
+        var result = await request.AsValueTask().ConfigureAwait(false);
+        await Assert.That(result.Data.Span[0]).IsEqualTo((byte)42);
+
+        pool.Return(request);
+    }
+
+    [Test]
     public async Task Pool_ReusesInstances()
     {
         var pool = new PendingRequestPool();
@@ -381,6 +404,29 @@ public class PooledPendingRequestTests
         {
             await request.AsValueTask().ConfigureAwait(false);
         });
+
+        pool.Return(request);
+    }
+
+    [Test]
+    public async Task RegisterCancellation_WithNonCancelableToken_ReplacesExistingRegistration()
+    {
+        var pool = new PendingRequestPool();
+        var request = pool.Rent();
+        var cts = new CancellationTokenSource();
+        request.Initialize(responseHeaderVersion: 0, cts.Token);
+
+        request.RegisterCancellation(CancellationToken.None);
+        cts.Cancel();
+
+        var testData = new byte[] { 0, 0, 0, 1, 99 };
+        var buffer = new PooledResponseBuffer(testData, testData.Length, isPooled: false);
+        var completed = request.TryComplete(buffer);
+
+        await Assert.That(completed).IsTrue();
+
+        var result = await request.AsValueTask().ConfigureAwait(false);
+        await Assert.That(result.Data.Span[0]).IsEqualTo((byte)99);
 
         pool.Return(request);
     }


### PR DESCRIPTION
## Summary
- skip the initial pending-request cancellation registration when the response path immediately owns cancellation
- use the caller-owned timeout token directly for pipelined response waits
- cover skipped/replaced registrations and caller-timeout response cancellation

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/PooledPendingRequestTests/*
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/KafkaConnectionTests/*
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/KafkaConnectionPipelinedTests/*
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe
- [x] dotnet build tests\Dekaf.Tests.Integration --configuration Release
- [x] dotnet format --verify-no-changes --include src\Dekaf\Networking\KafkaConnection.cs src\Dekaf\Networking\IKafkaConnection.cs tests\Dekaf.Tests.Unit\Networking\PooledPendingRequestTests.cs tests\Dekaf.Tests.Unit\Networking\KafkaConnectionTests.cs
- [x] git diff --check

Closes #926
