### PR TITLE
perf(protocol): skip string stack init

### DIFF
--- a/src/Dekaf/Protocol/KafkaProtocolWriter.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolWriter.cs
@@ -214,6 +214,7 @@ public ref struct KafkaProtocolWriter
     /// <summary>
     /// Writes a string with 2-byte length prefix (legacy format).
     /// </summary>
+    [SkipLocalsInit]
     public void WriteString(string? value)
     {
         if (value is null)
@@ -262,6 +263,7 @@ public ref struct KafkaProtocolWriter
     /// Writes a string's UTF-8 bytes without any length prefix.
     /// Use when length is written separately (e.g., with VarInt).
     /// </summary>
+    [SkipLocalsInit]
     public void WriteStringContent(string value)
     {
         // Fast path for short strings
@@ -317,6 +319,7 @@ public ref struct KafkaProtocolWriter
     /// Writes a compact string with unsigned varint length prefix (flexible format).
     /// Length is encoded as length + 1 (0 means null).
     /// </summary>
+    [SkipLocalsInit]
     public void WriteCompactString(string? value)
     {
         if (value is null)

--- a/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolWriterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolWriterTests.cs
@@ -1,4 +1,6 @@
 using System.Buffers;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using Dekaf.Protocol;
 
 namespace Dekaf.Tests.Unit.Protocol;
@@ -124,6 +126,32 @@ public class KafkaProtocolWriterTests
         var result = buffer.WrittenSpan.ToArray();
         // Length + 1 = 5, encoded as varint
         await Assert.That(result).IsEquivalentTo(new byte[] { 0x05, (byte)'t', (byte)'e', (byte)'s', (byte)'t' });
+    }
+
+    [Test]
+    public async Task StackallocStringWriters_SkipLocalsInit()
+    {
+        var methods = new[]
+        {
+            typeof(KafkaProtocolWriter).GetMethod(
+                nameof(KafkaProtocolWriter.WriteString),
+                BindingFlags.Instance | BindingFlags.Public,
+                [typeof(string)]),
+            typeof(KafkaProtocolWriter).GetMethod(
+                nameof(KafkaProtocolWriter.WriteStringContent),
+                BindingFlags.Instance | BindingFlags.Public,
+                [typeof(string)]),
+            typeof(KafkaProtocolWriter).GetMethod(
+                nameof(KafkaProtocolWriter.WriteCompactString),
+                BindingFlags.Instance | BindingFlags.Public,
+                [typeof(string)])
+        };
+
+        foreach (var method in methods)
+        {
+            await Assert.That(method).IsNotNull();
+            await Assert.That(method!.IsDefined(typeof(SkipLocalsInitAttribute), inherit: false)).IsTrue();
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add `[SkipLocalsInit]` to short-string stackalloc protocol writer methods
- add regression coverage so the hot string writers keep the attribute

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Protocol/KafkaProtocolWriterTests/*"`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Protocol/*/*"`
- [x] `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `git diff --check`

Closes #911
