### PR TITLE
test: stabilize prefetch timing tests

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/PrefetchPipelineRunnerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PrefetchPipelineRunnerTests.cs
@@ -589,7 +589,9 @@ public class PrefetchPipelineRunnerTests
     {
         var fetchCount = 0;
         var shouldFail = true;
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        // The delegate cancels after the successful fetch; a fixed wall-clock timeout
+        // flaked under CI starvation before that deterministic exit path ran.
+        using var cts = new CancellationTokenSource();
 
         var runner = CreateRunner(
             prefetchRecords: ct =>
@@ -707,7 +709,9 @@ public class PrefetchPipelineRunnerTests
         // (3 = depth - 1) over multiple iterations. This test verifies that at most 1
         // eager fetch starts per iteration, and the queue accumulates correctly.
         var fetchCount = 0;
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        // The delegate cancels after 6 fetches; a fixed wall-clock timeout flaked
+        // under CI starvation before the Task.Yield-based rounds completed.
+        using var cts = new CancellationTokenSource();
 
         var runner = CreateRunner(
             prefetchRecords: async ct =>


### PR DESCRIPTION
## What

Stabilizes two prefetch runner unit tests that used fixed 30s wall-clock cancellation as a safety net despite having deterministic delegate-driven exits.

## Root cause

Under CI thread-pool starvation, the fixed timeout could fire before the fetch delegate reached its intended `cts.Cancel()` path. That turned slow scheduling into either a `TaskCanceledException` timeout or an assertion that observed too few scheduled fetches.

## Fix

Remove the fixed wall-clock timeout from:
- `PrefetchPipelineRunnerTests.RunAsync_SuccessfulFetch_ResetsConsecutiveErrors`
- `PrefetchPipelineRunnerTests.RunAsync_PipelineDepth4_OneEagerFetchPerIteration`

Both tests still exit deterministically when their fetch delegate cancels. A genuine hang remains covered by the existing test runner hangdump timeout.

Note: the earlier fast-path producer test fix is already on `main` via #962, so this rebased PR now carries only the prefetch timing changes.

## Verification

- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/Dekaf.Tests.Unit.Consumer/PrefetchPipelineRunnerTests/*"`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/Dekaf.Tests.Unit.Producer/KafkaProducerFastPathTests/TryProduceSyncCore_CustomPartitionerReentry_PreservesOuterKeyAndValue"`
- `git diff --check origin/main...HEAD`