### PR TITLE
perf(producer): move cancellation into source

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -485,19 +485,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         CancellationToken cancellationToken)
     {
         var startTimestamp = Stopwatch.GetTimestamp();
-        CancellationTokenRegistration registration = default;
-
-        if (cancellationToken.CanBeCanceled)
-        {
-            var state = (completion, cancellationToken);
-            registration = cancellationToken.Register(
-                static s =>
-                {
-                    var (comp, token) = ((PooledValueTaskSource<RecordMetadata>, CancellationToken))s!;
-                    comp.TrySetCanceled(token);
-                },
-                state);
-        }
+        completion.RegisterCancellation(cancellationToken);
 
         try
         {
@@ -509,13 +497,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         {
             Diagnostics.DekafMetrics.ProduceErrors.Add(1, GetMetricTags(topic));
             throw;
-        }
-        finally
-        {
-            if (cancellationToken.CanBeCanceled)
-            {
-                await registration.DisposeAsync().ConfigureAwait(false);
-            }
         }
     }
 
@@ -530,11 +511,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         CancellationToken cancellationToken)
     {
         var startTimestamp = Stopwatch.GetTimestamp();
-
-        if (cancellationToken.CanBeCanceled)
-        {
-            completion.RegisterCancellation(cancellationToken);
-        }
+        completion.RegisterCancellation(cancellationToken);
 
         try
         {

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -467,28 +467,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// GetResult() is called and the pool item is properly returned.
     /// The message delivery continues in background regardless.
     /// </summary>
-    private static async ValueTask<RecordMetadata> AwaitWithCancellation(
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ValueTask<RecordMetadata> AwaitWithCancellation(
         PooledValueTaskSource<RecordMetadata> completion,
         CancellationToken cancellationToken)
     {
-        // Capture both completion and token in a tuple for the callback
-        var state = (completion, cancellationToken);
-        var registration = cancellationToken.Register(
-            static s =>
-            {
-                var (comp, token) = ((PooledValueTaskSource<RecordMetadata>, CancellationToken))s!;
-                comp.TrySetCanceled(token);
-            },
-            state);
-
-        try
-        {
-            return await completion.Task.ConfigureAwait(false);
-        }
-        finally
-        {
-            await registration.DisposeAsync().ConfigureAwait(false);
-        }
+        completion.RegisterCancellation(cancellationToken);
+        return completion.Task;
     }
 
     /// <summary>
@@ -545,18 +530,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         CancellationToken cancellationToken)
     {
         var startTimestamp = Stopwatch.GetTimestamp();
-        CancellationTokenRegistration registration = default;
 
         if (cancellationToken.CanBeCanceled)
         {
-            var state = (completion, cancellationToken);
-            registration = cancellationToken.Register(
-                static s =>
-                {
-                    var (comp, token) = ((PooledValueTaskSource<RecordMetadata>, CancellationToken))s!;
-                    comp.TrySetCanceled(token);
-                },
-                state);
+            completion.RegisterCancellation(cancellationToken);
         }
 
         try
@@ -583,10 +560,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         finally
         {
             activity.Dispose();
-            if (cancellationToken.CanBeCanceled)
-            {
-                await registration.DisposeAsync().ConfigureAwait(false);
-            }
         }
     }
 

--- a/src/Dekaf/Producer/PooledValueTaskSource.cs
+++ b/src/Dekaf/Producer/PooledValueTaskSource.cs
@@ -22,7 +22,6 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
     private ValueTaskSourcePool<T>? _pool;
     private Action<T, Exception?>? _deliveryHandler;
     private CancellationTokenRegistration _cancellationRegistration;
-    private CancellationToken _cancellationToken;
     private int _hasCompleted; // 0 = not completed, 1 = completed
 
     /// <summary>
@@ -140,15 +139,10 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
             return;
 
         _cancellationRegistration.Dispose();
-        _cancellationToken = cancellationToken;
-        _cancellationRegistration = cancellationToken.UnsafeRegister(s_cancellationCallback, this);
+        _cancellationRegistration = cancellationToken.UnsafeRegister(
+            static (state, token) => ((PooledValueTaskSource<T>)state!).TrySetCanceled(token),
+            this);
     }
-
-    private static readonly Action<object?> s_cancellationCallback = static state =>
-    {
-        var source = (PooledValueTaskSource<T>)state!;
-        source.TrySetCanceled(source._cancellationToken);
-    };
 
     /// <summary>
     /// Gets the result of the operation. Called by the awaiter.
@@ -179,7 +173,6 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
         {
             _cancellationRegistration.Dispose();
             _cancellationRegistration = default;
-            _cancellationToken = default;
 
             // Clear handler before returning to pool
             _deliveryHandler = null;

--- a/src/Dekaf/Producer/PooledValueTaskSource.cs
+++ b/src/Dekaf/Producer/PooledValueTaskSource.cs
@@ -21,6 +21,8 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
     private ManualResetValueTaskSourceCore<T> _core = new() { RunContinuationsAsynchronously = true };
     private ValueTaskSourcePool<T>? _pool;
     private Action<T, Exception?>? _deliveryHandler;
+    private CancellationTokenRegistration _cancellationRegistration;
+    private CancellationToken _cancellationToken;
     private int _hasCompleted; // 0 = not completed, 1 = completed
 
     /// <summary>
@@ -131,6 +133,23 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void RegisterCancellation(CancellationToken cancellationToken)
+    {
+        if (!cancellationToken.CanBeCanceled)
+            return;
+
+        _cancellationRegistration.Dispose();
+        _cancellationToken = cancellationToken;
+        _cancellationRegistration = cancellationToken.UnsafeRegister(s_cancellationCallback, this);
+    }
+
+    private static readonly Action<object?> s_cancellationCallback = static state =>
+    {
+        var source = (PooledValueTaskSource<T>)state!;
+        source.TrySetCanceled(source._cancellationToken);
+    };
+
     /// <summary>
     /// Gets the result of the operation. Called by the awaiter.
     /// After this call, the source is reset and returned to the pool.
@@ -158,6 +177,10 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
         }
         finally
         {
+            _cancellationRegistration.Dispose();
+            _cancellationRegistration = default;
+            _cancellationToken = default;
+
             // Clear handler before returning to pool
             _deliveryHandler = null;
 

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
 using Dekaf.Networking;
@@ -138,19 +139,33 @@ public sealed class KafkaConnectionTests
 
             await connection.ConnectAsync(cancellationToken);
             using var serverClient = await acceptTask.ConfigureAwait(false);
-            using var callerTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+            using var callerTimeout = new CancellationTokenSource();
 
-            var act = async () => await connection.SendPipelinedWithCallerTimeoutAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            var sendTask = connection.SendPipelinedWithCallerTimeoutAsync<ApiVersionsRequest, ApiVersionsResponse>(
                 new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
                 apiVersion: 3,
                 callerTimeout.Token);
 
+            await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+            await callerTimeout.CancelAsync();
+
+            var act = async () => await sendTask;
             await Assert.That(act).Throws<TimeoutException>();
         }
         finally
         {
             listener.Stop();
         }
+    }
+
+    private static async Task ReadRequestFrameAsync(NetworkStream stream, CancellationToken cancellationToken)
+    {
+        var lengthBuffer = new byte[4];
+        await stream.ReadExactlyAsync(lengthBuffer, cancellationToken).ConfigureAwait(false);
+
+        var frameLength = BinaryPrimitives.ReadInt32BigEndian(lengthBuffer);
+        var frameBuffer = new byte[frameLength];
+        await stream.ReadExactlyAsync(frameBuffer, cancellationToken).ConfigureAwait(false);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerMetricsTests.cs
@@ -82,6 +82,27 @@ public sealed class KafkaProducerMetricsTests
         await Assert.That(durationTopic).IsEqualTo("orders");
     }
 
+    [Test]
+    public async Task AwaitWithMetrics_Cancellation_CancelsCompletion()
+    {
+        await using var producer = new KafkaProducer<string, string>(
+            new ProducerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "metrics-test"
+            },
+            Serializers.String,
+            Serializers.String);
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var completion = pool.Rent();
+        using var cts = new CancellationTokenSource();
+
+        var pending = InvokeAwaitWithMetrics(producer, completion, "orders", cts.Token);
+        cts.Cancel();
+
+        await Assert.That(async () => await pending).Throws<OperationCanceledException>();
+    }
+
     private static bool ProducerMetricsEnabled()
     {
         var method = typeof(KafkaProducer<string, string>).GetMethod(
@@ -94,7 +115,8 @@ public sealed class KafkaProducerMetricsTests
     private static async ValueTask<RecordMetadata> InvokeAwaitWithMetrics(
         KafkaProducer<string, string> producer,
         PooledValueTaskSource<RecordMetadata> completion,
-        string topic)
+        string topic,
+        CancellationToken cancellationToken = default)
     {
         var method = typeof(KafkaProducer<string, string>).GetMethod(
             "AwaitWithMetrics",
@@ -102,7 +124,7 @@ public sealed class KafkaProducerMetricsTests
 
         var result = (ValueTask<RecordMetadata>)method!.Invoke(
             producer,
-            [completion, topic, CancellationToken.None])!;
+            [completion, topic, cancellationToken])!;
         return await result;
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -122,6 +122,64 @@ public class PooledValueTaskSourceTests
     }
 
     [Test]
+    public async Task RegisterCancellation_CancelsSource()
+    {
+        var pool = new ValueTaskSourcePool<int>();
+        var source = pool.Rent();
+        using var cts = new CancellationTokenSource();
+
+        source.RegisterCancellation(cts.Token);
+        cts.Cancel();
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await source.Task.ConfigureAwait(false);
+        });
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(cts.Token);
+    }
+
+    [Test]
+    public async Task RegisterCancellation_PreCanceledToken_ReturnsToPoolAfterAwait()
+    {
+        var pool = new ValueTaskSourcePool<int>(maxPoolSize: 1);
+        var source = pool.Rent();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        source.RegisterCancellation(cts.Token);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await source.Task.ConfigureAwait(false);
+        });
+
+        await Assert.That(pool.ApproximateCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task RegisterCancellation_DisposesRegistrationBeforeReuse()
+    {
+        var pool = new ValueTaskSourcePool<int>(maxPoolSize: 1);
+        var source = pool.Rent();
+        using var cts = new CancellationTokenSource();
+
+        source.RegisterCancellation(cts.Token);
+        source.SetResult(1);
+        await source.Task.ConfigureAwait(false);
+
+        var reused = pool.Rent();
+        await Assert.That(reused).IsSameReferenceAs(source);
+
+        cts.Cancel();
+
+        reused.SetResult(2);
+        var result = await reused.Task.ConfigureAwait(false);
+
+        await Assert.That(result).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task Source_ResetsAfterAwait_CanBeReused()
     {
         // Create a pool with max size 1 to ensure reuse


### PR DESCRIPTION
## Summary
- move awaited-produce cancellation registration into PooledValueTaskSource
- use UnsafeRegister with the pooled source as callback state
- clear cancellation registration before source reset/reuse

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/PooledValueTaskSourceTests/*
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/ProducerCancellationTests/*
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe
- [x] dotnet build tests\Dekaf.Tests.Integration --configuration Release
- [x] dotnet format --verify-no-changes --include src\Dekaf\Producer\KafkaProducer.cs src\Dekaf\Producer\PooledValueTaskSource.cs tests\Dekaf.Tests.Unit\Producer\PooledValueTaskSourceTests.cs
- [x] git diff --check origin/main...HEAD

Closes #917
