### PR TITLE
perf(producer): scale header array pool

### DIFF
--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -152,6 +152,13 @@ internal static class PoolSizing
         public required int ProducerDataArraysPerBucket { get; init; }
 
         /// <summary>
+        /// <c>maxArraysPerBucket</c> for per-message <c>Header[]</c> arrays.
+        /// Header arrays have the same in-flight lifetime as producer data arrays:
+        /// rent on append, return after batch response cleanup.
+        /// </summary>
+        public required int HeaderArraysPerBucket { get; init; }
+
+        /// <summary>
         /// <c>maxArraysPerBucket</c> for the shared <c>PipeMemoryPool</c> in ConnectionPool.
         /// Scales by total connections (brokers x connections-per-broker) since all
         /// connections share the same pool instance.
@@ -207,6 +214,10 @@ internal static class PoolSizing
         var peakInFlightBatches = totalMaxConnections * maxInFlightRequestsPerConnection;
         var producerDataArrays = Math.Clamp(estimatedMessagesPerBatch * peakInFlightBatches, 64, 4096);
 
+        // Header[] arrays are rented once per header-bearing message and held until
+        // the owning batch completes, so they need the same working-set depth.
+        var headerArrays = producerDataArrays;
+
         // PipeMemoryPool: 32 arrays per connection (covers pipelined segments),
         // scaled by total connections, capped at 256.
         var pipeMemoryArrays = Math.Clamp(totalConnections * 32, 32, 256);
@@ -226,6 +237,7 @@ internal static class PoolSizing
         return new SharedPoolSizes
         {
             ProducerDataArraysPerBucket = producerDataArrays,
+            HeaderArraysPerBucket = headerArrays,
             PipeMemoryArraysPerBucket = pipeMemoryArrays,
             SerializationArraysPerBucket = serializationArrays,
             ProduceResponsePoolSize = responsePoolSize,

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -203,6 +203,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             batchSize: options.BatchSize,
             maxConnectionsPerBroker: options.MaxConnectionsPerBroker);
         ProducerDataPool.RatchetBucketCapacity(sharedPoolSizes.ProducerDataArraysPerBucket);
+        ProducerContainerPools.RatchetHeaderBucketCapacity(sharedPoolSizes.HeaderArraysPerBucket);
         DekafPools.RatchetSerializationBucketCapacity(sharedPoolSizes.SerializationArraysPerBucket);
         ProduceResponse.RatchetPoolSize(sharedPoolSizes.ProduceResponsePoolSize);
 
@@ -260,6 +261,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         {
             var sizes = PoolSizing.ForSharedPools(brokerCount, connectionsPerBroker, maxInFlight, batchSize, maxConns);
             ProducerDataPool.RatchetBucketCapacity(sizes.ProducerDataArraysPerBucket);
+            ProducerContainerPools.RatchetHeaderBucketCapacity(sizes.HeaderArraysPerBucket);
             DekafPools.RatchetSerializationBucketCapacity(sizes.SerializationArraysPerBucket);
             ProduceResponse.RatchetPoolSize(sizes.ProduceResponsePoolSize);
             _connectionPool.RatchetPipeMemoryBucketCapacity(sizes.PipeMemoryArraysPerBucket);

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -249,18 +249,23 @@ internal static class ProducerDataPool
 /// the fallback path must use <c>ArrayPool</c>. Using <c>ArrayPool&lt;T&gt;.Create()</c> for the
 /// fallback ensures cross-thread rent/return does not cause TLS accumulation.
 /// <para/>
-/// Each pool uses <c>maxArraysPerBucket: 16</c> — sufficient for concurrent access from
-/// producer threads and BrokerSender threads, while bounding total retention.
-/// <c>maxArrayLength</c> values are set to accommodate both the initial capacity and
-/// one round of doubling via <c>GrowArray</c>. Arrays that grow beyond this (extremely
-/// rare — requires more records per batch than <c>_initialRecordCapacity × 2</c>) fall
-/// through to unpooled allocations, which is acceptable.
+/// Most pools use <c>maxArraysPerBucket: 16</c> — sufficient for concurrent access from
+/// producer threads and BrokerSender threads while bounding total retention. The per-message
+/// <c>Header[]</c> pool is ratcheted separately because header arrays stay in-flight for
+/// the whole batch round trip, and header-heavy workloads can have thousands outstanding.
+/// <c>maxArrayLength</c> values are set to accommodate both the initial capacity and one
+/// round of doubling via <c>GrowArray</c>. Arrays that grow beyond this (extremely rare —
+/// requires more records per batch than <c>_initialRecordCapacity × 2</c>) fall through to
+/// unpooled allocations, which is acceptable.
 /// </summary>
 internal static class ProducerContainerPools
 {
     // Max initial record capacity is 16384 (from ComputeInitialRecordCapacity).
     // GrowArray doubles, so allow up to 32768 to cover one growth step.
     private const int MaxRecordArrayLength = 32768;
+    private static readonly RatchetableArrayPool<Header> s_headers = new(
+        maxArrayLength: 1024,
+        initialArraysPerBucket: 16);
 
     /// <summary>Pool for Record[] container arrays used by PartitionBatch/ReadyBatch.</summary>
     internal static readonly ArrayPool<Record> Records = ArrayPool<Record>.Create(
@@ -280,8 +285,13 @@ internal static class ProducerContainerPools
         maxArrayLength: 1024, maxArraysPerBucket: 16);
 
     /// <summary>Pool for Header[] arrays (per-message headers).</summary>
-    internal static readonly ArrayPool<Header> Headers = ArrayPool<Header>.Create(
-        maxArrayLength: 1024, maxArraysPerBucket: 16);
+    internal static ArrayPool<Header> Headers => s_headers.Pool;
+
+    internal static int CurrentHeaderArraysPerBucket => s_headers.CurrentArraysPerBucket;
+
+    /// <inheritdoc cref="RatchetableArrayPool{T}.RatchetBucketCapacity"/>
+    internal static void RatchetHeaderBucketCapacity(int arraysPerBucket) =>
+        s_headers.RatchetBucketCapacity(arraysPerBucket);
 
     /// <summary>Pool for callback arrays (Send with callback pattern).</summary>
     internal static readonly ArrayPool<Action<RecordMetadata, Exception?>?> Callbacks =

--- a/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
@@ -203,6 +203,7 @@ public class PoolSizingTests
         // producerDataArrays = clamp(512 * 50, 64, 4096) = 4096 (capped)
         await Assert.That(sizes.ProducerDataArraysPerBucket).IsGreaterThanOrEqualTo(64);
         await Assert.That(sizes.ProducerDataArraysPerBucket).IsLessThanOrEqualTo(4096);
+        await Assert.That(sizes.HeaderArraysPerBucket).IsEqualTo(sizes.ProducerDataArraysPerBucket);
         // 1 broker * 1 conn * 32 = 32
         await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(32);
         // SerializationBuffers: 1 * 10 * 8 = 80
@@ -234,6 +235,7 @@ public class PoolSizingTests
         // producerDataArrays = clamp(64 * 5, 64, 4096) = 320
         await Assert.That(sizes.ProducerDataArraysPerBucket).IsGreaterThanOrEqualTo(64);
         await Assert.That(sizes.ProducerDataArraysPerBucket).IsLessThanOrEqualTo(512);
+        await Assert.That(sizes.HeaderArraysPerBucket).IsLessThanOrEqualTo(512);
     }
 
     [Test]
@@ -268,6 +270,7 @@ public class PoolSizingTests
         var sizes = PoolSizing.ForSharedPools(brokerCount: 20, connectionsPerBroker: 10);
 
         await Assert.That(sizes.ProducerDataArraysPerBucket).IsLessThanOrEqualTo(4096);
+        await Assert.That(sizes.HeaderArraysPerBucket).IsLessThanOrEqualTo(4096);
         // 16 * 10 * 32 = 5120, capped at 256
         await Assert.That(sizes.PipeMemoryArraysPerBucket).IsLessThanOrEqualTo(256);
         // SerializationBuffers capped at 256
@@ -293,6 +296,39 @@ public class PoolSizingTests
 
         await Assert.That(largeConns.SerializationArraysPerBucket)
             .IsGreaterThan(smallConns.SerializationArraysPerBucket);
+    }
+
+    [Test]
+    public async Task ForSharedPools_HeaderArrays_ScalesWithInFlightMessages()
+    {
+        var smallConns = PoolSizing.ForSharedPools(
+            brokerCount: 1,
+            batchSize: 16 * 1024,
+            maxConnectionsPerBroker: 1);
+        var largeConns = PoolSizing.ForSharedPools(
+            brokerCount: 1,
+            batchSize: 16 * 1024,
+            maxConnectionsPerBroker: 10);
+
+        await Assert.That(largeConns.HeaderArraysPerBucket)
+            .IsGreaterThan(smallConns.HeaderArraysPerBucket);
+    }
+
+    [Test]
+    [NotInParallel("ProducerContainerPools")]
+    public async Task HeaderPool_RatchetBucketCapacity_GrowsMonotonically()
+    {
+        var target = ProducerContainerPools.CurrentHeaderArraysPerBucket + 16;
+
+        ProducerContainerPools.RatchetHeaderBucketCapacity(target);
+
+        await Assert.That(ProducerContainerPools.CurrentHeaderArraysPerBucket)
+            .IsGreaterThanOrEqualTo(target);
+
+        ProducerContainerPools.RatchetHeaderBucketCapacity(target - 1);
+
+        await Assert.That(ProducerContainerPools.CurrentHeaderArraysPerBucket)
+            .IsGreaterThanOrEqualTo(target);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -719,21 +719,30 @@ public class PooledValueTaskSourceTests
         Action complete)
     {
         var awaiter = valueTask.GetAwaiter();
-        using var releaseContinuation = new ManualResetEventSlim();
+        var releaseContinuation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var continuationFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         awaiter.UnsafeOnCompleted(() =>
         {
-            releaseContinuation.Wait();
-            continuationFinished.SetResult();
+            try
+            {
+                releaseContinuation.Task.GetAwaiter().GetResult();
+                continuationFinished.SetResult();
+            }
+            catch (Exception ex)
+            {
+                continuationFinished.SetException(ex);
+            }
         });
 
         Exception? completionException = null;
-        using var completionReturned = new ManualResetEventSlim();
+        var completionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completionReturned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var completionThread = new Thread(() =>
         {
             try
             {
+                completionStarted.SetResult();
                 complete();
             }
             catch (Exception ex)
@@ -742,7 +751,7 @@ public class PooledValueTaskSourceTests
             }
             finally
             {
-                completionReturned.Set();
+                completionReturned.SetResult();
             }
         })
         {
@@ -751,16 +760,19 @@ public class PooledValueTaskSourceTests
         };
 
         completionThread.Start();
-        var completedBeforeRelease = completionReturned.Wait(TimeSpan.FromSeconds(2));
+        if (!completionStarted.Task.Wait(TimeSpan.FromSeconds(5)))
+            throw new TimeoutException("Completion probe thread did not start.");
 
-        releaseContinuation.Set();
+        var completedBeforeRelease = completionReturned.Task.Wait(TimeSpan.FromSeconds(2));
 
-        if (!completionReturned.Wait(TimeSpan.FromSeconds(5)))
+        releaseContinuation.SetResult();
+
+        if (!completionReturned.Task.Wait(TimeSpan.FromSeconds(30)))
             throw new TimeoutException("Completion did not return after releasing continuation.");
 
         if (completionException is not null)
             ExceptionDispatchInfo.Capture(completionException).Throw();
-        await continuationFinished.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await continuationFinished.Task.WaitAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
 
         await Assert.That(completedBeforeRelease).IsTrue();
         return awaiter.GetResult();


### PR DESCRIPTION
## Summary
- size the per-message `Header[]` pool from the shared producer working-set estimate
- make the header pool ratchetable like the producer data pool
- ratchet it at producer startup and after broker discovery

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Internal/PoolSizingTests/*"`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Producer/*/*"`
- [x] `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `git diff --check origin/main...HEAD`

Closes #912
