### PR TITLE
perf(protocol): write records from spans

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5079,7 +5079,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
 }
 
 /// <summary>
-/// Zero-allocation wrapper around a pooled Record array that implements IReadOnlyList.
+/// Wrapper around a pooled Record array that implements IReadOnlyList.
 /// Used to present only the valid portion of a pooled array without copying.
 /// </summary>
 internal readonly struct RecordListWrapper : IReadOnlyList<Record>
@@ -5104,6 +5104,9 @@ internal readonly struct RecordListWrapper : IReadOnlyList<Record>
     }
 
     public int Count => _count;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ReadOnlySpan<Record> AsSpan() => _array.AsSpan(0, _count);
 
     public Enumerator GetEnumerator() => new(_array, _count);
 

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -474,11 +474,9 @@ public sealed class RecordBatch : IDisposable
             // Serialize records to pooled scratch buffer
             var recordsBuffer = GetRecordsBuffer(cache);
             var recordsWriter = new KafkaProtocolWriter(recordsBuffer);
+            var records = Records;
 
-            for (var i = 0; i < Records.Count; i++)
-            {
-                Records[i].Write(ref recordsWriter);
-            }
+            WriteRecords(records, ref recordsWriter);
 
             // Compress to pooled scratch buffer
             var registry = codecs ?? CompressionCodecRegistry.Default;
@@ -652,6 +650,7 @@ public sealed class RecordBatch : IDisposable
     public void Write(IBufferWriter<byte> output, CompressionType compression = CompressionType.None, CompressionCodecRegistry? codecs = null)
     {
         var writer = new KafkaProtocolWriter(output);
+        var records = Records;
 
         // Determine the effective compression and records data to write.
         // If pre-compressed at seal time, use that data directly (skip CPU-bound compression
@@ -678,10 +677,7 @@ public sealed class RecordBatch : IDisposable
                 var recordsBuffer = GetRecordsBuffer(cache);
                 var recordsWriter = new KafkaProtocolWriter(recordsBuffer);
 
-                for (var i = 0; i < Records.Count; i++)
-                {
-                    Records[i].Write(ref recordsWriter);
-                }
+                WriteRecords(records, ref recordsWriter);
 
                 // Apply compression if needed
                 if (compression != CompressionType.None)
@@ -743,7 +739,7 @@ public sealed class RecordBatch : IDisposable
             offset += 2;
             BinaryPrimitives.WriteInt32BigEndian(contentSpan[offset..], BaseSequence);
             offset += 4;
-            BinaryPrimitives.WriteInt32BigEndian(contentSpan[offset..], Records.Count);
+            BinaryPrimitives.WriteInt32BigEndian(contentSpan[offset..], records.Count);
             offset += 4;
             compressedRecords.CopyTo(contentSpan[offset..]);
 
@@ -778,29 +774,113 @@ public sealed class RecordBatch : IDisposable
         if (compression != CompressionType.None)
             throw new InvalidOperationException("Compressed RecordBatch size requires pre-compressed records.");
 
-        var recordsLength = 0;
-        for (var i = 0; i < Records.Count; i++)
-        {
-            var record = Records[i];
-            var bodySize = record.CachedBodySize > 0
-                ? record.CachedBodySize
-                : Record.ComputeBodySize(
-                    record.TimestampDelta,
-                    record.OffsetDelta,
-                    record.IsKeyNull,
-                    record.Key.Length,
-                    record.IsValueNull,
-                    record.Value.Length,
-                    record.Headers,
-                    record.EffectiveHeaderCount);
+        return GetEncodedRecordsLength(Records);
+    }
 
+    private static void WriteRecords(IReadOnlyList<Record> records, ref KafkaProtocolWriter writer)
+    {
+        switch (records)
+        {
+            case Record[] array:
+                WriteRecordSpan(array, ref writer);
+                return;
+            case RecordListWrapper wrapper:
+                WriteRecordSpan(wrapper.AsSpan(), ref writer);
+                return;
+            case LazyRecordList lazyRecords:
+                lazyRecords.EnsureAllParsed();
+                var parsedRecords = lazyRecords.GetParsedArray();
+                if (parsedRecords is not null)
+                    WriteRecordSpan(parsedRecords.AsSpan(0, lazyRecords.Count), ref writer);
+                return;
+            default:
+                WriteRecordList(records, ref writer);
+                return;
+        }
+    }
+
+    private static void WriteRecordSpan(ReadOnlySpan<Record> records, ref KafkaProtocolWriter writer)
+    {
+        foreach (ref readonly var record in records)
+        {
+            record.Write(ref writer);
+        }
+    }
+
+    private static void WriteRecordList(IReadOnlyList<Record> records, ref KafkaProtocolWriter writer)
+    {
+        var count = records.Count;
+        for (var i = 0; i < count; i++)
+        {
+            var record = records[i];
+            record.Write(ref writer);
+        }
+    }
+
+    private static int GetEncodedRecordsLength(IReadOnlyList<Record> records)
+    {
+        return records switch
+        {
+            Record[] array => GetEncodedRecordSpanLength(array),
+            RecordListWrapper wrapper => GetEncodedRecordSpanLength(wrapper.AsSpan()),
+            LazyRecordList lazyRecords => GetEncodedLazyRecordListLength(lazyRecords),
+            _ => GetEncodedRecordListLength(records)
+        };
+    }
+
+    private static int GetEncodedLazyRecordListLength(LazyRecordList lazyRecords)
+    {
+        lazyRecords.EnsureAllParsed();
+        var parsedRecords = lazyRecords.GetParsedArray();
+        return parsedRecords is null ? 0 : GetEncodedRecordSpanLength(parsedRecords.AsSpan(0, lazyRecords.Count));
+    }
+
+    private static int GetEncodedRecordSpanLength(ReadOnlySpan<Record> records)
+    {
+        var recordsLength = 0;
+        foreach (ref readonly var record in records)
+        {
             checked
             {
-                recordsLength += Record.VarIntSize(bodySize) + bodySize;
+                recordsLength += GetEncodedRecordLength(in record);
             }
         }
 
         return recordsLength;
+    }
+
+    private static int GetEncodedRecordListLength(IReadOnlyList<Record> records)
+    {
+        var recordsLength = 0;
+        var count = records.Count;
+        for (var i = 0; i < count; i++)
+        {
+            var record = records[i];
+            checked
+            {
+                recordsLength += GetEncodedRecordLength(in record);
+            }
+        }
+
+        return recordsLength;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int GetEncodedRecordLength(in Record record)
+    {
+        var bodySize = record.CachedBodySize > 0
+            ? record.CachedBodySize
+            : Record.ComputeBodySize(
+                record.TimestampDelta,
+                record.OffsetDelta,
+                record.IsKeyNull,
+                record.Key.Length,
+                record.IsValueNull,
+                record.Value.Length,
+                record.Headers,
+                record.EffectiveHeaderCount);
+
+        return checked(Record.VarIntSize(bodySize) + bodySize);
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1309,6 +1309,23 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task RecordListWrapper_AsSpan_ExposesValidRecordsOnly()
+    {
+        var records = new Record[4];
+        records[0] = new Record { OffsetDelta = 10 };
+        records[1] = new Record { OffsetDelta = 20 };
+        records[2] = new Record { OffsetDelta = 30 };
+        records[3] = new Record { OffsetDelta = 40 };
+
+        var wrapper = new RecordListWrapper(records, 2);
+        var snapshot = ReadWrapperSpan(wrapper);
+
+        await Assert.That(snapshot.Length).IsEqualTo(2);
+        await Assert.That(snapshot.FirstOffset).IsEqualTo(10);
+        await Assert.That(snapshot.SecondOffset).IsEqualTo(20);
+    }
+
+    [Test]
     public async Task RecordListWrapper_IndexBasedIteration_MatchesEnumerator()
     {
         var records = new Record[10];
@@ -1335,6 +1352,12 @@ public class RecordAccumulatorTests
     }
 
     #endregion
+
+    private static (int Length, int FirstOffset, int SecondOffset) ReadWrapperSpan(RecordListWrapper wrapper)
+    {
+        var span = wrapper.AsSpan();
+        return (span.Length, span[0].OffsetDelta, span[1].OffsetDelta);
+    }
 
     #region ReadyBatch.Reset Safety Net
 


### PR DESCRIPTION
## Summary
- expose `RecordListWrapper.AsSpan()` for the valid pooled record window
- route `RecordBatch` serialization and encoded-size paths through span-aware helpers
- add coverage for the wrapper span boundary

## Verification
- `dotnet build tests\Dekaf.Tests.Unit --configuration Release`
- `dotnet run --project tests\Dekaf.Tests.Unit --configuration Release --no-build -- --disable-logo --no-ansi --no-progress` (3566 passed)
- `dotnet build tests\Dekaf.Tests.Integration --configuration Release`
- `dotnet format --verify-no-changes --include src\Dekaf\Protocol\Records\RecordBatch.cs src\Dekaf\Producer\RecordAccumulator.cs tests\Dekaf.Tests.Unit\Producer\RecordAccumulatorTests.cs`
- `git diff --check origin/main...HEAD`

Closes #924