### PR TITLE
perf(consumer): lazy-copy consumed headers

### DIFF
--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -107,12 +107,6 @@ namespace Dekaf.Consumer
                 long offset = pending.CurrentBaseOffset + record.OffsetDelta;
                 long timestampMs = pending.CurrentBaseTimestamp + record.TimestampDelta;
 
-                IReadOnlyList<Header>? headers = null;
-                if (record.Headers is not null && record.HeaderCount > 0)
-                {
-                    headers = record.Headers[..record.HeaderCount];
-                }
-
                 TimestampType timestampType = pending.CurrentTimestampType;
 
                 int messageBytes = (record.IsKeyNull ? 0 : record.Key.Length) +
@@ -126,7 +120,9 @@ namespace Dekaf.Consumer
                     isKeyNull: record.IsKeyNull,
                     valueData: record.Value,
                     isValueNull: record.IsValueNull,
-                    headers: headers,
+                    pooledHeaders: record.Headers,
+                    pooledHeaderCount: record.HeaderCount,
+                    headerOwner: pending,
                     timestampMs: timestampMs,
                     timestampType: timestampType,
                     leaderEpoch: null,

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -246,6 +246,11 @@ public readonly struct ConsumeResult<TKey, TValue>
     // DateTimeOffset.FromUnixTimeMilliseconds() construction in the consume loop.
     // The DateTimeOffset is computed on demand via the Timestamp property.
     private readonly long _timestampMs;
+    private readonly IReadOnlyList<Header>? _headers;
+    private readonly Header[]? _pooledHeaders;
+    private readonly int _pooledHeaderCount;
+    private readonly PendingFetchData? _headerOwner;
+    private readonly int _headerGeneration;
 
     /// <summary>
     /// Creates a new ConsumeResult with eager deserialization.
@@ -266,11 +271,94 @@ public readonly struct ConsumeResult<TKey, TValue>
         IDeserializer<TKey>? keyDeserializer,
         IDeserializer<TValue>? valueDeserializer,
         bool isPartitionEof = false)
+        : this(
+            topic,
+            partition,
+            offset,
+            keyData,
+            isKeyNull,
+            valueData,
+            isValueNull,
+            headers,
+            pooledHeaders: null,
+            pooledHeaderCount: 0,
+            headerOwner: null,
+            headerGeneration: 0,
+            timestampMs,
+            timestampType,
+            leaderEpoch,
+            keyDeserializer,
+            valueDeserializer,
+            isPartitionEof)
+    {
+    }
+
+    internal ConsumeResult(
+        string topic,
+        int partition,
+        long offset,
+        ReadOnlyMemory<byte> keyData,
+        bool isKeyNull,
+        ReadOnlyMemory<byte> valueData,
+        bool isValueNull,
+        Header[]? pooledHeaders,
+        int pooledHeaderCount,
+        PendingFetchData headerOwner,
+        long timestampMs,
+        TimestampType timestampType,
+        int? leaderEpoch,
+        IDeserializer<TKey>? keyDeserializer,
+        IDeserializer<TValue>? valueDeserializer)
+        : this(
+            topic,
+            partition,
+            offset,
+            keyData,
+            isKeyNull,
+            valueData,
+            isValueNull,
+            headers: null,
+            pooledHeaders,
+            pooledHeaderCount,
+            headerOwner,
+            headerOwner.HeaderGeneration,
+            timestampMs,
+            timestampType,
+            leaderEpoch,
+            keyDeserializer,
+            valueDeserializer,
+            isPartitionEof: false)
+    {
+    }
+
+    private ConsumeResult(
+        string topic,
+        int partition,
+        long offset,
+        ReadOnlyMemory<byte> keyData,
+        bool isKeyNull,
+        ReadOnlyMemory<byte> valueData,
+        bool isValueNull,
+        IReadOnlyList<Header>? headers,
+        Header[]? pooledHeaders,
+        int pooledHeaderCount,
+        PendingFetchData? headerOwner,
+        int headerGeneration,
+        long timestampMs,
+        TimestampType timestampType,
+        int? leaderEpoch,
+        IDeserializer<TKey>? keyDeserializer,
+        IDeserializer<TValue>? valueDeserializer,
+        bool isPartitionEof)
     {
         Topic = topic;
         Partition = partition;
         Offset = offset;
-        Headers = headers;
+        _headers = headers;
+        _pooledHeaders = pooledHeaders;
+        _pooledHeaderCount = pooledHeaderCount;
+        _headerOwner = headerOwner;
+        _headerGeneration = headerGeneration;
         _timestampMs = timestampMs;
         TimestampType = timestampType;
         LeaderEpoch = leaderEpoch;
@@ -369,8 +457,15 @@ public readonly struct ConsumeResult<TKey, TValue>
 
     /// <summary>
     /// The message headers. Returns null if no headers.
+    /// Header arrays from consumed record batches are copied lazily on first access; if a
+    /// result is retained beyond the consume loop, access this property before the owning
+    /// fetch batch is disposed to keep a safe snapshot.
     /// </summary>
-    public IReadOnlyList<Header>? Headers { get; }
+    public IReadOnlyList<Header>? Headers => _headers ?? LazyConsumeHeaders.Create(
+        _pooledHeaders,
+        _pooledHeaderCount,
+        _headerOwner,
+        _headerGeneration);
 
     /// <summary>
     /// The message timestamp as a DateTimeOffset.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -47,6 +47,7 @@ internal sealed class PendingFetchData : IDisposable
     private int _batchIndex = -1;
     private int _recordIndex = -1;
     private int _disposed;
+    private int _headerGeneration;
 
     public string Topic { get; private set; } = null!;
     public int PartitionIndex { get; private set; }
@@ -141,6 +142,11 @@ internal sealed class PendingFetchData : IDisposable
     }
 
     public RecordBatch CurrentBatch => _batches[_batchIndex];
+
+    internal int HeaderGeneration => Volatile.Read(ref _headerGeneration);
+
+    internal bool IsHeaderGenerationActive(int generation) =>
+        Volatile.Read(ref _disposed) == 0 && Volatile.Read(ref _headerGeneration) == generation;
 
     /// <summary>
     /// Gets the current record via direct array access, bypassing the LazyRecordList
@@ -362,6 +368,12 @@ internal sealed class PendingFetchData : IDisposable
         _currentRecordsArray = null;
         _currentRecords = null;
         _currentRecordsCount = 0;
+        unchecked
+        {
+            _headerGeneration++;
+            if (_headerGeneration == 0)
+                _headerGeneration = 1;
+        }
         CurrentBaseOffset = 0;
         CurrentBaseTimestamp = 0;
         CurrentTimestampType = default;
@@ -1081,21 +1093,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                             var offset = pending.CurrentBaseOffset + record.OffsetDelta;
                             var timestampMs = pending.CurrentBaseTimestamp + record.TimestampDelta;
 
-                            // Create a standalone header array snapshot. Previous attempts used
-                            // pooled HeaderSlice instances to avoid per-message allocation, but
-                            // this created a use-after-free hazard: callers who store ConsumeResult
-                            // objects in a collection and access headers after the await foreach
-                            // loop exits would find zeroed-out headers because the pool reclaims
-                            // slices when the enumerator is disposed. A small per-message Header[]
-                            // copy (typically 1-3 headers = ~48-144 bytes) is the correct trade-off
-                            // for correctness. The Header struct itself is cheap to copy (string ref
-                            // + ReadOnlyMemory<byte> ref + bool).
-                            IReadOnlyList<Header>? headers = null;
-                            if (record.Headers is not null && record.HeaderCount > 0)
-                            {
-                                headers = record.Headers[..record.HeaderCount];
-                            }
-
                             // Use batch-level cached timestamp type (computed once per batch
                             // transition in CacheCurrentBatchState, not per message)
                             var timestampType = pending.CurrentTimestampType;
@@ -1109,6 +1106,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                             System.Diagnostics.Activity? activity = null;
                             if (hasTraceListeners)
                             {
+                                var headers = LazyConsumeHeaders.Create(
+                                    record.Headers,
+                                    record.HeaderCount,
+                                    pending,
+                                    pending.HeaderGeneration);
                                 activity = StartConsumeActivity(pending, headers, offset, messageBytes);
                                 if (activity is not null)
                                     previousActivity = activity;
@@ -1123,7 +1125,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                                 isKeyNull: record.IsKeyNull,
                                 valueData: record.Value,
                                 isValueNull: record.IsValueNull,
-                                headers: headers,
+                                pooledHeaders: record.Headers,
+                                pooledHeaderCount: record.HeaderCount,
+                                headerOwner: pending,
                                 timestampMs: timestampMs,
                                 timestampType: timestampType,
                                 leaderEpoch: null,

--- a/src/Dekaf/Consumer/LazyConsumeHeaders.cs
+++ b/src/Dekaf/Consumer/LazyConsumeHeaders.cs
@@ -13,6 +13,7 @@ internal sealed class LazyConsumeHeaders : IReadOnlyList<Header>
     private readonly PendingFetchData _owner;
     private readonly int _generation;
     private Header[]? _snapshot;
+    private const string StaleHeadersMessage = "Consumer headers were not materialized before the owning fetch batch was disposed.";
 
     private LazyConsumeHeaders(Header[] pooledHeaders, int count, PendingFetchData owner, int generation)
     {
@@ -32,7 +33,7 @@ internal sealed class LazyConsumeHeaders : IReadOnlyList<Header>
             return null;
 
         if (owner is null)
-            throw new ObjectDisposedException(nameof(Headers), "Consumer headers were not materialized before the owning fetch batch was disposed.");
+            throw new ObjectDisposedException(nameof(Headers), StaleHeadersMessage);
 
         return new LazyConsumeHeaders(pooledHeaders, count, owner, generation);
     }
@@ -79,6 +80,6 @@ internal sealed class LazyConsumeHeaders : IReadOnlyList<Header>
     private void ThrowIfStale()
     {
         if (!_owner.IsHeaderGenerationActive(_generation))
-            throw new ObjectDisposedException(nameof(Headers), "Consumer headers were not materialized before the owning fetch batch was disposed.");
+            throw new ObjectDisposedException(nameof(Headers), StaleHeadersMessage);
     }
 }

--- a/src/Dekaf/Consumer/LazyConsumeHeaders.cs
+++ b/src/Dekaf/Consumer/LazyConsumeHeaders.cs
@@ -1,0 +1,84 @@
+using System.Collections;
+using Dekaf.Serialization;
+
+namespace Dekaf.Consumer;
+
+/// <summary>
+/// Exposes pooled record headers without copying until the caller reads header values.
+/// </summary>
+internal sealed class LazyConsumeHeaders : IReadOnlyList<Header>
+{
+    private readonly Header[] _pooledHeaders;
+    private readonly int _count;
+    private readonly PendingFetchData _owner;
+    private readonly int _generation;
+    private Header[]? _snapshot;
+
+    private LazyConsumeHeaders(Header[] pooledHeaders, int count, PendingFetchData owner, int generation)
+    {
+        _pooledHeaders = pooledHeaders;
+        _count = count;
+        _owner = owner;
+        _generation = generation;
+    }
+
+    internal static IReadOnlyList<Header>? Create(
+        Header[]? pooledHeaders,
+        int count,
+        PendingFetchData? owner,
+        int generation)
+    {
+        if (pooledHeaders is null || count == 0)
+            return null;
+
+        if (owner is null)
+            throw new ObjectDisposedException(nameof(Headers), "Consumer headers were not materialized before the owning fetch batch was disposed.");
+
+        return new LazyConsumeHeaders(pooledHeaders, count, owner, generation);
+    }
+
+    public int Count => _count;
+
+    public Header this[int index]
+    {
+        get
+        {
+            if ((uint)index >= (uint)_count)
+                throw new ArgumentOutOfRangeException(nameof(index));
+
+            return GetSnapshot()[index];
+        }
+    }
+
+    public IEnumerator<Header> GetEnumerator() => ((IEnumerable<Header>)GetSnapshot()).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private Header[] GetSnapshot()
+    {
+        var snapshot = Volatile.Read(ref _snapshot);
+        if (snapshot is not null)
+            return snapshot;
+
+        return MaterializeSnapshot();
+    }
+
+    private Header[] MaterializeSnapshot()
+    {
+        ThrowIfStale();
+
+        var snapshot = new Header[_count];
+        _pooledHeaders.AsSpan(0, _count).CopyTo(snapshot);
+
+        ThrowIfStale();
+
+        var published = Interlocked.CompareExchange(ref _snapshot, snapshot, null);
+        return published ?? snapshot;
+    }
+
+    private void ThrowIfStale()
+    {
+        if (!_owner.IsHeaderGenerationActive(_generation))
+            throw new ObjectDisposedException(nameof(Headers), "Consumer headers were not materialized before the owning fetch batch was disposed.");
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeResultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeResultTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Consumer;
@@ -129,6 +130,127 @@ public class ConsumeResultTests
             valueDeserializer: null);
 
         await Assert.That(result.TimestampMs).IsEqualTo(timestampMs);
+    }
+
+    [Test]
+    public async Task LazyConsumeHeaders_CountDoesNotMaterialize()
+    {
+        var pooledHeaders = new[]
+        {
+            new Header("trace-id", "abc"u8.ToArray())
+        };
+        var pending = CreatePendingFetchData(pooledHeaders);
+        pending.EagerParseAll();
+        pending.MoveNext();
+
+        var headers = LazyConsumeHeaders.Create(pooledHeaders, 1, pending, pending.HeaderGeneration);
+
+        await Assert.That(headers).IsNotNull();
+        await Assert.That(headers!.Count).IsEqualTo(1);
+
+        pending.Dispose();
+    }
+
+    [Test]
+    public async Task LazyConsumeHeaders_FirstAccessCopiesSnapshot()
+    {
+        var pooledHeaders = new[]
+        {
+            new Header("trace-id", "abc"u8.ToArray())
+        };
+        var pending = CreatePendingFetchData(pooledHeaders);
+        pending.EagerParseAll();
+        pending.MoveNext();
+
+        var headers = LazyConsumeHeaders.Create(pooledHeaders, 1, pending, pending.HeaderGeneration)!;
+        var header = headers[0];
+
+        pooledHeaders[0] = new Header("changed", "def"u8.ToArray());
+
+        await Assert.That(header.Key).IsEqualTo("trace-id");
+        await Assert.That(headers[0].Key).IsEqualTo("trace-id");
+
+        pending.Dispose();
+    }
+
+    [Test]
+    public async Task LazyConsumeHeaders_AccessAfterDisposeBeforeMaterialize_ThrowsObjectDisposedException()
+    {
+        var pooledHeaders = new[]
+        {
+            new Header("trace-id", "abc"u8.ToArray())
+        };
+        var pending = CreatePendingFetchData(pooledHeaders);
+        pending.EagerParseAll();
+        pending.MoveNext();
+
+        var headers = LazyConsumeHeaders.Create(pooledHeaders, 1, pending, pending.HeaderGeneration)!;
+        pending.Dispose();
+
+        _ = headers.Count;
+        await Assert.That(() => headers[0]).Throws<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task ConsumeResult_PooledHeaders_MaterializesOnHeadersAccess()
+    {
+        var pooledHeaders = new[]
+        {
+            new Header("trace-id", "abc"u8.ToArray())
+        };
+        var pending = CreatePendingFetchData(pooledHeaders);
+        pending.EagerParseAll();
+        pending.MoveNext();
+
+        var result = new ConsumeResult<string, string>(
+            topic: "test-topic",
+            partition: 0,
+            offset: 0,
+            keyData: default,
+            isKeyNull: true,
+            valueData: default,
+            isValueNull: true,
+            pooledHeaders: pooledHeaders,
+            pooledHeaderCount: pooledHeaders.Length,
+            headerOwner: pending,
+            timestampMs: 0,
+            timestampType: TimestampType.CreateTime,
+            leaderEpoch: null,
+            keyDeserializer: null,
+            valueDeserializer: null);
+
+        var headers = result.Headers!;
+        var first = headers[0];
+        pooledHeaders[0] = new Header("changed", "def"u8.ToArray());
+
+        await Assert.That(first.Key).IsEqualTo("trace-id");
+        await Assert.That(headers[0].Key).IsEqualTo("trace-id");
+
+        pending.Dispose();
+    }
+
+    private static PendingFetchData CreatePendingFetchData(Header[] headers)
+    {
+        var batch = new RecordBatch
+        {
+            BaseOffset = 0,
+            BaseTimestamp = 0,
+            Attributes = RecordBatchAttributes.TimestampTypeCreateTime,
+            Records =
+            [
+                new Dekaf.Protocol.Records.Record
+                {
+                    Headers = headers,
+                    HeaderCount = headers.Length,
+                    Key = ReadOnlyMemory<byte>.Empty,
+                    Value = ReadOnlyMemory<byte>.Empty,
+                    IsKeyNull = true,
+                    IsValueNull = true
+                }
+            ]
+        };
+
+        return PendingFetchData.Create("test-topic", 0, [batch]);
     }
 
 }

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
 using Dekaf.Networking;
@@ -138,19 +139,33 @@ public sealed class KafkaConnectionTests
 
             await connection.ConnectAsync(cancellationToken);
             using var serverClient = await acceptTask.ConfigureAwait(false);
-            using var callerTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+            using var callerTimeout = new CancellationTokenSource();
 
-            var act = async () => await connection.SendPipelinedWithCallerTimeoutAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            var sendTask = connection.SendPipelinedWithCallerTimeoutAsync<ApiVersionsRequest, ApiVersionsResponse>(
                 new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
                 apiVersion: 3,
                 callerTimeout.Token);
 
+            await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+            await callerTimeout.CancelAsync();
+
+            var act = async () => await sendTask;
             await Assert.That(act).Throws<TimeoutException>();
         }
         finally
         {
             listener.Stop();
         }
+    }
+
+    private static async Task ReadRequestFrameAsync(NetworkStream stream, CancellationToken cancellationToken)
+    {
+        var lengthBuffer = new byte[4];
+        await stream.ReadExactlyAsync(lengthBuffer, cancellationToken).ConfigureAwait(false);
+
+        var frameLength = BinaryPrimitives.ReadInt32BigEndian(lengthBuffer);
+        var frameBuffer = new byte[frameLength];
+        await stream.ReadExactlyAsync(frameBuffer, cancellationToken).ConfigureAwait(false);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- remove eager `record.Headers[..record.HeaderCount]` copies from consumer result construction
- store pooled header metadata in `ConsumeResult` and create a lazy `IReadOnlyList<Header>` only when `Headers` is read
- snapshot headers on first index/enumeration access and guard stale pooled arrays with `PendingFetchData` generation checks

## Behavior note
Header-bearing records no longer allocate a `Header[]` when callers never read `Headers`. If a caller retains a `ConsumeResult` beyond the owning fetch batch, `Headers` must be read before disposal so the lazy list can snapshot the pooled array; stale first access throws instead of reading returned/cleared pooled memory.

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/Dekaf.Tests.Unit.Consumer/ConsumeResultTests/*"`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/Dekaf.Tests.Unit.Consumer/*/*"`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- `rg -n "record\.Headers\[\.\.record\.HeaderCount\]|GetSubArray" src\Dekaf tests\Dekaf.Tests.Unit -g "*.cs"`
- `git diff --check origin/main...HEAD`

Closes #921