### PR TITLE
perf(protocol): cache utf8 header keys

### DIFF
--- a/src/Dekaf/Internal/Utf8StringInternCache.cs
+++ b/src/Dekaf/Internal/Utf8StringInternCache.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using System.IO.Hashing;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Dekaf.Internal;
+
+/// <summary>
+/// Bounded UTF-8 byte-keyed string intern cache.
+/// Avoids allocating a string when repeated protocol names are already cached.
+/// </summary>
+internal sealed class Utf8StringInternCache
+{
+    private readonly ConcurrentDictionary<ulong, CacheEntry> _cache = new();
+    private readonly int _maxCachedEntries;
+    private readonly int _maxCachedBytes;
+    private readonly Func<string, string>? _canonicalize;
+    private int _count;
+
+    internal Utf8StringInternCache(int maxCachedEntries, int maxCachedBytes, Func<string, string>? canonicalize = null)
+    {
+        _maxCachedEntries = maxCachedEntries;
+        _maxCachedBytes = maxCachedBytes;
+        _canonicalize = canonicalize;
+    }
+
+    internal string Intern(ReadOnlyMemory<byte> utf8Bytes)
+    {
+        if (utf8Bytes.Length == 0)
+            return string.Empty;
+
+        var span = utf8Bytes.Span;
+        if (utf8Bytes.Length > _maxCachedBytes)
+            return Decode(span);
+
+        var hash = XxHash64.HashToUInt64(span);
+        if (_cache.TryGetValue(hash, out var entry) && entry.Matches(span))
+            return entry.Value;
+
+        var value = Decode(span);
+        if (Volatile.Read(ref _count) >= _maxCachedEntries)
+            return value;
+
+        var newEntry = new CacheEntry(span.ToArray(), value);
+        if (_cache.TryAdd(hash, newEntry))
+        {
+            Interlocked.Increment(ref _count);
+        }
+        else if (_cache.TryGetValue(hash, out entry) && entry.Matches(span))
+        {
+            return entry.Value;
+        }
+
+        return value;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private string Decode(ReadOnlySpan<byte> utf8Bytes)
+    {
+        var value = Encoding.UTF8.GetString(utf8Bytes);
+        return _canonicalize is null ? value : _canonicalize(value);
+    }
+
+    private readonly struct CacheEntry(byte[] utf8Bytes, string value)
+    {
+        private readonly byte[] _utf8Bytes = utf8Bytes;
+        internal string Value { get; } = value;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool Matches(ReadOnlySpan<byte> utf8Bytes) => utf8Bytes.SequenceEqual(_utf8Bytes);
+    }
+}

--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -604,6 +604,19 @@ public ref struct KafkaProtocolReader
     }
 
     /// <summary>
+    /// Reads compact string bytes without decoding them.
+    /// Length is encoded as length + 1 (0 means null).
+    /// </summary>
+    public ReadOnlyMemory<byte>? ReadCompactStringBytes()
+    {
+        var length = ReadUnsignedVarInt() - 1;
+        if (length < 0)
+            return null;
+
+        return ReadMemorySlice(length);
+    }
+
+    /// <summary>
     /// Reads string content of the specified length without additional allocation for single-segment data.
     /// </summary>
     public string ReadStringContent(int length)

--- a/src/Dekaf/Protocol/Messages/FetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FetchResponse.cs
@@ -209,10 +209,10 @@ public sealed class FetchResponseTopic
         }
         else
         {
-            topic = reader.ReadCompactString();
+            var topicBytes = reader.ReadCompactStringBytes();
             // Intern topic names to reuse string instances across fetch cycles
-            if (topic is not null)
-                topic = TopicNameInternCache.Intern(topic);
+            if (topicBytes is not null)
+                topic = TopicNameInternCache.Intern(topicBytes.Value);
         }
 
         // Use pooled list to avoid per-topic array allocation

--- a/src/Dekaf/Protocol/Messages/TopicNameInternCache.cs
+++ b/src/Dekaf/Protocol/Messages/TopicNameInternCache.cs
@@ -1,11 +1,14 @@
 using System.Collections.Concurrent;
+using Dekaf.Internal;
 
 namespace Dekaf.Protocol.Messages;
 
 internal static class TopicNameInternCache
 {
     private const int MaxCachedTopicNames = 256;
+    private const int MaxCachedTopicNameBytes = 512;
     private static readonly ConcurrentDictionary<string, string> s_cache = new();
+    private static readonly Utf8StringInternCache s_utf8Cache = new(MaxCachedTopicNames, MaxCachedTopicNameBytes, Intern);
     private static int s_count;
 
     public static string Intern(string topic)
@@ -26,5 +29,10 @@ internal static class TopicNameInternCache
         }
 
         return topic;
+    }
+
+    public static string Intern(ReadOnlyMemory<byte> utf8Topic)
+    {
+        return s_utf8Cache.Intern(utf8Topic);
     }
 }

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -1,6 +1,7 @@
 using System.Collections;
-using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Text;
+using Dekaf.Internal;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
 
@@ -237,9 +238,9 @@ public readonly record struct Header
     /// Kafka headers typically reuse the same small set of keys across all messages,
     /// so caching them avoids repeated string allocations. Capped to prevent unbounded growth.
     /// </summary>
-    private static readonly ConcurrentDictionary<string, string> s_keyCache = new();
-    private static int s_keyCacheCount;
     private const int MaxCachedKeys = 128;
+    private const int MaxCachedKeyBytes = 256;
+    private static readonly Utf8StringInternCache s_keyCache = new(MaxCachedKeys, MaxCachedKeyBytes);
 
     /// <summary>
     /// Creates a new header with a byte array value.
@@ -295,12 +296,10 @@ public readonly record struct Header
     /// <summary>
     /// Writes the header to the protocol writer.
     /// </summary>
+    [SkipLocalsInit]
     internal void Write(ref KafkaProtocolWriter writer)
     {
-        // Write key with VarInt length prefix - use the writer's string encoding support
-        var keyByteCount = Encoding.UTF8.GetByteCount(Key);
-        writer.WriteVarInt(keyByteCount);
-        writer.WriteStringContent(Key);
+        WriteKey(ref writer, Key);
 
         if (IsValueNull)
         {
@@ -313,30 +312,41 @@ public readonly record struct Header
         }
     }
 
+    private static void WriteKey(ref KafkaProtocolWriter writer, string key)
+    {
+        if (key.Length <= 128)
+        {
+            Span<byte> buffer = stackalloc byte[512];
+            var actualBytes = Encoding.UTF8.GetBytes(key, buffer);
+            writer.WriteVarInt(actualBytes);
+            if (actualBytes > 0)
+            {
+                var outputSpan = writer.BufferWriter.GetSpan(actualBytes);
+                buffer[..actualBytes].CopyTo(outputSpan);
+                writer.BufferWriter.Advance(actualBytes);
+                writer.AddBytesWritten(actualBytes);
+            }
+            return;
+        }
+
+        var keyByteCount = Encoding.UTF8.GetByteCount(key);
+        writer.WriteVarInt(keyByteCount);
+        if (keyByteCount == 0)
+            return;
+
+        var span = writer.BufferWriter.GetSpan(keyByteCount);
+        Encoding.UTF8.GetBytes(key, span);
+        writer.BufferWriter.Advance(keyByteCount);
+        writer.AddBytesWritten(keyByteCount);
+    }
+
     /// <summary>
     /// Reads a header from the protocol reader.
     /// </summary>
     internal static Header Read(ref KafkaProtocolReader reader)
     {
         var keyLength = reader.ReadVarInt();
-        var key = reader.ReadStringContent(keyLength);
-
-        // Intern the key string: Kafka headers typically reuse the same keys
-        // across all messages, so caching avoids per-message string allocation.
-        // Use TryGetValue first (lock-free read) for the common case where the key is already cached.
-        if (s_keyCache.TryGetValue(key, out var cached))
-        {
-            key = cached;
-        }
-        else if (Volatile.Read(ref s_keyCacheCount) < MaxCachedKeys)
-        {
-            // Only attempt to add if under the cap. The volatile read avoids
-            // ConcurrentDictionary.Count which acquires all bucket locks.
-            if (s_keyCache.TryAdd(key, key))
-            {
-                Interlocked.Increment(ref s_keyCacheCount);
-            }
-        }
+        var key = s_keyCache.Intern(reader.ReadMemorySlice(keyLength));
 
         var valueLength = reader.ReadVarInt();
         var isValueNull = valueLength < 0;

--- a/tests/Dekaf.Tests.Unit/Protocol/ProduceResponseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ProduceResponseTests.cs
@@ -34,6 +34,20 @@ public class ProduceResponseTests
         produce.Return();
     }
 
+    [Test]
+    public async Task FetchResponseRead_InternsRepeatedTopicNames()
+    {
+        var topicName = "fetch-topic-" + Guid.NewGuid().ToString("N");
+
+        var first = ReadFetchResponse(topicName);
+        var second = ReadFetchResponse(topicName);
+
+        await Assert.That(second.Responses[0].Topic).IsSameReferenceAs(first.Responses[0].Topic);
+
+        first.ReturnToPool();
+        second.ReturnToPool();
+    }
+
     private static ProduceResponse ReadProduceResponse(string topicName)
     {
         var buffer = new ArrayBufferWriter<byte>();

--- a/tests/Dekaf.Tests.Unit/Serialization/HeaderRecordStructTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/HeaderRecordStructTests.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+using Dekaf.Protocol;
 using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Serialization;
@@ -119,5 +121,36 @@ public class HeaderRecordStructTests
         var header1 = new Header("key1", data);
         var header2 = new Header("key2", data);
         await Assert.That(header1).IsNotEqualTo(header2);
+    }
+
+    [Test]
+    public async Task Write_LongUtf8Key_RoundTrips()
+    {
+        var key = new string('x', 140) + "-é";
+        var parsed = RoundTrip(new Header(key, "value"u8.ToArray()));
+
+        await Assert.That(parsed.Key).IsEqualTo(key);
+        await Assert.That(parsed.GetValueAsString()).IsEqualTo("value");
+    }
+
+    [Test]
+    public async Task Read_RepeatedKeyBytes_ReusesCachedString()
+    {
+        var key = "trace-id-" + Guid.NewGuid().ToString("N");
+
+        var first = RoundTrip(new Header(key, "one"u8.ToArray()));
+        var second = RoundTrip(new Header(key, "two"u8.ToArray()));
+
+        await Assert.That(second.Key).IsSameReferenceAs(first.Key);
+    }
+
+    private static Header RoundTrip(Header header)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        header.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        return Header.Read(ref reader);
     }
 }


### PR DESCRIPTION
## Summary
- add a bounded UTF-8 byte-keyed intern cache for protocol strings
- read header keys and fetch topic names from raw bytes before decoding, so repeated keys/topics avoid transient string allocation on cache hit
- encode header keys once during write instead of `GetByteCount` plus a second encode pass

## Verification
- `dotnet build tests\Dekaf.Tests.Unit --configuration Release -maxcpucount:1 -nodeReuse:false`
- focused: `HeaderRecordStructTests`, `ProduceResponseTests`
- full unit suite: 3575 passed
- `dotnet build tests\Dekaf.Tests.Integration --configuration Release -maxcpucount:1 -nodeReuse:false`
- `dotnet format --verify-no-changes --include src\Dekaf\Internal\Utf8StringInternCache.cs src\Dekaf\Serialization\Headers.cs src\Dekaf\Protocol\KafkaProtocolReader.cs src\Dekaf\Protocol\Messages\FetchResponse.cs src\Dekaf\Protocol\Messages\TopicNameInternCache.cs tests\Dekaf.Tests.Unit\Serialization\HeaderRecordStructTests.cs tests\Dekaf.Tests.Unit\Protocol\ProduceResponseTests.cs`
- `git diff --check origin/main...HEAD`

Closes #922