### PR TITLE
perf(consumer): defer manual position writes

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1042,7 +1042,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 var hasTraceListeners = Diagnostics.DekafDiagnostics.Source.HasListeners();
                 var hasInterceptors = _interceptors is not null;
                 var rawTrackingEnabled = _rawRecordTrackingEnabled;
-                var manualCommit = _options.OffsetCommitMode == OffsetCommitMode.Manual;
 
                 while (_pendingFetches.Count > 0)
                 {
@@ -1131,13 +1130,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                                 valueDeserializer: _valueDeserializer);
 
                             pending.TrackConsumed(offset, messageBytes);
-
-                            // Manual-commit: update _positions per-message so GetPosition()/
-                            // CommitAsync() reflect the latest message mid-batch.
-                            // Auto-commit: skip per-message write (~60-100ns ConcurrentDictionary
-                            // cost); _positions is flushed once per batch in FlushConsumedPositions().
-                            if (manualCommit)
-                                _positions[pending.TopicPartition] = offset + 1;
+                            // Position dictionaries are flushed once per fetch; manual readers
+                            // flush this pending state on demand in GetPosition()/CommitAsync().
 
                             // Apply OnConsume interceptors before yielding to user
                             // Uses hoisted hasInterceptors to skip method call when no interceptors
@@ -1173,10 +1167,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                     previousActivity?.Dispose();
                     previousActivity = null;
 
-                    // Batch-level position flush. In manual-commit mode _positions was
-                    // already updated per-message; in auto-commit mode this is the first
-                    // _positions write. _fetchPositions is updated here once per partition-fetch
-                    // (in prefetch mode it is managed by UpdateFetchPositionsFromPrefetch).
+                    // Batch-level position flush. _positions and _fetchPositions are updated
+                    // once per partition-fetch (in prefetch mode it is managed by UpdateFetchPositionsFromPrefetch).
                     FlushConsumedPositions(pending);
 
                     // Record consumer metrics per-fetch instead of per-message.
@@ -1902,11 +1894,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     /// </summary>
     private void FlushConsumedPositions(PendingFetchData pending)
     {
-        if (pending.LastYieldedOffset < 0)
+        if (!TryGetConsumedPosition(pending, out var tp, out var nextOffset))
             return;
-
-        var tp = pending.TopicPartition;
-        var nextOffset = pending.LastYieldedOffset + 1;
 
         _positions[tp] = nextOffset;
 
@@ -1914,6 +1903,48 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         {
             _fetchPositions[tp] = nextOffset;
         }
+    }
+
+    private void FlushActiveConsumedPosition()
+    {
+        if (_pendingFetches.Count == 0)
+            return;
+
+        var pending = _pendingFetches.Peek();
+        if (TryGetConsumedPosition(pending, out var tp, out var nextOffset))
+            _positions[tp] = nextOffset;
+    }
+
+    private bool TryGetActiveConsumedPosition(TopicPartition partition, out long position)
+    {
+        if (_pendingFetches.Count == 0)
+        {
+            position = 0;
+            return false;
+        }
+
+        var pending = _pendingFetches.Peek();
+        if (!TryGetConsumedPosition(pending, out var tp, out position) || !tp.Equals(partition))
+        {
+            position = 0;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryGetConsumedPosition(PendingFetchData pending, out TopicPartition partition, out long nextOffset)
+    {
+        if (pending.LastYieldedOffset < 0)
+        {
+            partition = default;
+            nextOffset = 0;
+            return false;
+        }
+
+        partition = pending.TopicPartition;
+        nextOffset = pending.LastYieldedOffset + 1;
+        return true;
     }
 
     private void UpdateFetchPositionsFromPrefetch(PendingFetchData pending)
@@ -2045,6 +2076,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
     public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
     {
+        if (_options.OffsetCommitMode == OffsetCommitMode.Manual)
+            FlushActiveConsumedPosition();
+
         if (_coordinator is null)
             return;
 
@@ -2131,6 +2165,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
     public long? GetPosition(TopicPartition partition)
     {
+        if (_options.OffsetCommitMode == OffsetCommitMode.Manual
+            && TryGetActiveConsumedPosition(partition, out var activePosition))
+        {
+            _positions[partition] = activePosition;
+            return activePosition;
+        }
+
         return _positions.TryGetValue(partition, out var position) ? position : null;
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
@@ -82,6 +82,16 @@ public sealed class ConsumeAsyncRecoveryTests
         params PendingFetchData[] fetches)
         => CreateConsumerWithPendingFetches(loggerFactory, Topic, Partition, fetches);
 
+    private static ConcurrentDictionary<TopicPartition, long> GetPositions(
+        KafkaConsumer<string, string> consumer)
+    {
+        var positionsField = typeof(KafkaConsumer<string, string>)
+            .GetField("_positions", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_positions field not found - was it renamed?");
+
+        return (ConcurrentDictionary<TopicPartition, long>)positionsField.GetValue(consumer)!;
+    }
+
     /// <summary>
     /// Creates a valid RecordBatch with the specified records.
     /// </summary>
@@ -393,6 +403,64 @@ public sealed class ConsumeAsyncRecoveryTests
         await Assert.That(results[0].Offset).IsEqualTo(20L);
         await Assert.That(results[1].Offset).IsEqualTo(21L);
         await Assert.That(results[2].Offset).IsEqualTo(22L);
+    }
+
+    [Test]
+    public async Task ConsumeAsync_ManualCommit_DoesNotFlushPositionDictionaryPerRecord()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "1"),
+                CreateRecord(1, "b", "2"))
+        ]);
+
+        await using var consumer = CreateConsumerWithPendingFetches(null, fetch);
+
+        using var cts = new CancellationTokenSource();
+        var tp = new TopicPartition(Topic, Partition);
+        var positions = GetPositions(consumer);
+
+        await foreach (var result in consumer.ConsumeAsync(cts.Token))
+        {
+            await Assert.That(result.Offset).IsEqualTo(20L);
+
+            var wroteCurrentRecordPosition = positions.TryGetValue(tp, out var position) && position == 21L;
+            await Assert.That(wroteCurrentRecordPosition).IsFalse();
+
+            cts.Cancel();
+            break;
+        }
+    }
+
+    [Test]
+    public async Task CommitAsync_AfterPartialBatchConsumed_FlushesCurrentPosition()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "1"),
+                CreateRecord(1, "b", "2"))
+        ]);
+
+        await using var consumer = CreateConsumerWithPendingFetches(null, fetch);
+
+        using var cts = new CancellationTokenSource();
+        var tp = new TopicPartition(Topic, Partition);
+        var positions = GetPositions(consumer);
+
+        await foreach (var result in consumer.ConsumeAsync(cts.Token))
+        {
+            await Assert.That(result.Offset).IsEqualTo(20L);
+            await Assert.That(positions.TryGetValue(tp, out var position) && position == 21L).IsFalse();
+
+            await consumer.CommitAsync(cts.Token);
+
+            await Assert.That(positions[tp]).IsEqualTo(21L);
+
+            cts.Cancel();
+            break;
+        }
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- remove the manual-commit per-record `_positions` dictionary write from the consume hot path
- reuse `PendingFetchData.LastYieldedOffset` as the active in-batch position and flush `_positions` only at batch boundaries, `GetPosition()`, or manual `CommitAsync()`
- add regression coverage proving `_positions` is not written per yielded record while `GetPosition()` and `CommitAsync()` still expose the latest consumed offset

## Test plan
- [x] TDD regression failed before implementation: `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 -- --treenode-filter "/*/Dekaf.Tests.Unit.Consumer/ConsumeAsyncRecoveryTests/ConsumeAsync_ManualCommit_DoesNotFlushPositionDictionaryPerRecord"`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 -- --treenode-filter "/*/Dekaf.Tests.Unit.Consumer/ConsumeAsyncRecoveryTests/*"`
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/Dekaf.Tests.Unit.Consumer/*/*" --detailed-stacktrace`
- [x] `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `git diff --check`

Closes #920
