### PR TITLE
fix(consumer): cap prefetch memory signal

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -483,7 +483,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     // Initial count 1: at startup, memory IS available (_prefetchedBytes = 0). Starting at 0
     // causes a deadlock if the prefetch loop fills memory before the consumer reads anything —
     // the loop waits for a Release() that never comes because the consumer has no data yet.
-    private readonly SemaphoreSlim _prefetchMemoryAvailable = new(1, int.MaxValue);
+    // Max count 1: the semaphore is an edge-triggered memory-available signal, not a permit
+    // counter. Extra releases while nobody is waiting must not accumulate and later spin the
+    // prefetch loop through stale permits.
+    private readonly SemaphoreSlim _prefetchMemoryAvailable = new(1, 1);
 
     // Per-fetch reusable lists for collecting pending items during prefetch (avoids per-cycle allocation)
     // Keyed by (brokerId, connectionIndex) since PrefetchFromBrokerAsync runs concurrently
@@ -1971,11 +1974,26 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             Interlocked.Add(ref _prefetchedBytes, -bytes);
             // Signal prefetch loop that memory is now available (skip for empty responses to avoid spurious wakeups)
             if (bytes > 0)
-                _prefetchMemoryAvailable.Release();
+                SignalPrefetchMemoryAvailable();
         }
         else
         {
             Interlocked.Add(ref _prefetchedBytes, bytes);
+        }
+    }
+
+    private void SignalPrefetchMemoryAvailable()
+    {
+        if (_prefetchMemoryAvailable.CurrentCount != 0)
+            return;
+
+        try
+        {
+            _prefetchMemoryAvailable.Release();
+        }
+        catch (SemaphoreFullException)
+        {
+            // Another release won the race after CurrentCount was observed as 0.
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class KafkaConsumerPrefetchMemorySignalTests
+{
+    [Test]
+    public async Task TrackPrefetchedBytes_RepeatedRelease_DoesNotAccumulateMemorySignals()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            QueuedMinMessages = 2
+        };
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        using var pending = PendingFetchData.Create("test-topic", 0,
+        [
+            new RecordBatch
+            {
+                BatchLength = 128,
+                Records = []
+            }
+        ]);
+
+        var semaphore = GetPrefetchMemoryAvailable(consumer);
+        var trackPrefetchedBytes = GetTrackPrefetchedBytes();
+
+        for (var i = 0; i < 3; i++)
+        {
+            trackPrefetchedBytes.Invoke(consumer, [pending, false]);
+            trackPrefetchedBytes.Invoke(consumer, [pending, true]);
+        }
+
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    private static SemaphoreSlim GetPrefetchMemoryAvailable(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_prefetchMemoryAvailable", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_prefetchMemoryAvailable field not found - was it renamed?");
+
+        return (SemaphoreSlim)field.GetValue(consumer)!;
+    }
+
+    private static MethodInfo GetTrackPrefetchedBytes()
+    {
+        return typeof(KafkaConsumer<string, string>)
+            .GetMethod("TrackPrefetchedBytes", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("TrackPrefetchedBytes method not found - was it renamed?");
+    }
+}


### PR DESCRIPTION
## Summary
- cap `_prefetchMemoryAvailable` at one signal instead of accumulating stale permits
- guard memory-release signaling so extra releases while no prefetch waiter exists are dropped
- add regression coverage proving repeated prefetch release does not grow the signal count

## Test plan
- [x] TDD regression failed before implementation: `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 -- --treenode-filter "/*/Dekaf.Tests.Unit.Consumer/KafkaConsumerPrefetchMemorySignalTests/TrackPrefetchedBytes_RepeatedRelease_DoesNotAccumulateMemorySignals"`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 -- --treenode-filter "/*/Dekaf.Tests.Unit.Consumer/KafkaConsumerPrefetchMemorySignalTests/TrackPrefetchedBytes_RepeatedRelease_DoesNotAccumulateMemorySignals"`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/Dekaf.Tests.Unit.Consumer/*/*" --detailed-stacktrace`
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `git diff --check`

Closes #896
