### PR TITLE
perf(producer): defer batch compression to sender

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1151,6 +1151,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             if (head is null)
                 continue;
 
+            if (!head.IsCompressionReady)
+                CompressBatch(head);
+
             // Check retry backoff
             if (head.IsRetry && head.RetryNotBefore > 0)
             {
@@ -1295,9 +1298,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 if (batch is null)
                     continue;
 
-                // Skip batches still being compressed outside the SpinLock.
-                // CompressAndSignalBatch will enqueue a _readyPartitions
-                // notification when compression finishes.
+                // Safety check: Ready() should have compressed the head batch before
+                // marking this node ready. If another path exposes an unready batch,
+                // leave it in the deque until the next notification.
                 if (!batch.IsCompressionReady)
                     continue;
 
@@ -1974,8 +1977,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         if (sealedBatch is not null)
         {
-            CompressAndSignalBatch(sealedBatch);
-            SignalWakeup();
+            PublishSealedBatch(sealedBatch);
         }
 
         return true;
@@ -2127,8 +2129,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         if (sealedBatch is not null)
         {
-            CompressAndSignalBatch(sealedBatch);
-            SignalWakeup();
+            PublishSealedBatch(sealedBatch);
         }
 
         return true;
@@ -2205,8 +2206,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         if (sealedBatch is not null)
         {
-            CompressAndSignalBatch(sealedBatch);
-            SignalWakeup();
+            PublishSealedBatch(sealedBatch);
         }
 
         return true;
@@ -2340,8 +2340,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         if (sealedBatch is not null)
         {
-            CompressAndSignalBatch(sealedBatch);
-            SignalWakeup();
+            PublishSealedBatch(sealedBatch);
         }
 
         return true;
@@ -2414,17 +2413,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// <summary>
     /// Seals the current batch in a partition deque and returns the ready batch.
     /// Seals, tracks, and enqueues the batch into the deque under the caller's lock.
-    /// Compression and sender notification happen OUTSIDE the lock via
-    /// <see cref="CompressAndSignalBatch"/> to avoid holding the SpinLock during
-    /// potentially expensive compression (hundreds of microseconds for a full 1MB batch).
+    /// Sender notification happens OUTSIDE the lock via <see cref="PublishSealedBatch"/>.
+    /// Compression is performed later by the sender thread in <see cref="Ready"/> so
+    /// appending threads do not pay per-batch compression tail latency.
     ///
     /// Ordering is preserved because:
     /// 1. The batch is added to the deque (AddLast) under the lock, guaranteeing FIFO order
     ///    even when two threads seal batches for the same partition in rapid succession.
     /// 2. The batch is marked as not yet compression-ready (<see cref="ReadyBatch.IsCompressionReady"/>
-    ///    returns false), so the drain loop skips it until compression finishes.
-    /// 3. The sender notification (_readyPartitions.Enqueue) is deferred until after compression,
-    ///    so the sender won't actively look for this partition either.
+    ///    returns false), so the drain loop skips it until sender-thread compression finishes.
+    /// 3. The sender notification (_readyPartitions.Enqueue) is deferred until after the lock
+    ///    is released, so the sender never observes a partially-enqueued batch.
     ///
     /// MUST be called under pd.Lock.
     /// </summary>
@@ -2443,8 +2442,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             pd.AddLast(readyBatch);
             ProducerDebugCounters.RecordBatchQueuedToReady();
 
-            // Compression and _readyPartitions notification are deferred to
-            // CompressAndSignalBatch(), called by the caller AFTER releasing the lock.
+            // _readyPartitions notification is deferred to PublishSealedBatch(), called
+            // by the caller AFTER releasing the lock. Compression happens in Ready().
         }
         _batchPool.Return(currentBatch);
         pd.CurrentBatch = null;
@@ -2453,16 +2452,28 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Compresses a sealed batch (if compression is configured) and then notifies the
-    /// sender that the partition has a sendable batch. This runs OUTSIDE the partition
-    /// SpinLock — compression can take hundreds of microseconds for a full 1MB batch,
-    /// and holding a SpinLock that long causes tail latency spikes on appending threads.
+    /// Publishes a sealed batch to the sender loop. Compression, when enabled, is deferred
+    /// to <see cref="Ready"/> so the append caller only pays the queue notification cost.
+    /// </summary>
+    private void PublishSealedBatch(ReadyBatch readyBatch, bool signalWakeup = true)
+    {
+        if (_options.CompressionType == CompressionType.None)
+            readyBatch.MarkCompressionReady();
+
+        _readyPartitions.Enqueue(readyBatch.TopicPartition);
+        if (signalWakeup)
+            SignalWakeup();
+    }
+
+    /// <summary>
+    /// Compresses a sealed batch (if compression is configured). Called by the sender thread
+    /// from <see cref="Ready"/>, outside the partition SpinLock, before the batch can drain.
     ///
     /// Thread safety: the batch is already sealed and in the deque; no other thread can
     /// modify it. The drain loop skips batches where <see cref="ReadyBatch.IsCompressionReady"/>
     /// is false, so the sender won't pick it up until we finish and set the flag.
     /// </summary>
-    private void CompressAndSignalBatch(ReadyBatch readyBatch)
+    private void CompressBatch(ReadyBatch readyBatch)
     {
         if (_options.CompressionType != CompressionType.None)
         {
@@ -2476,16 +2487,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 // so subsequent batches in this partition aren't permanently blocked.
                 readyBatch.Fail(ex);
                 readyBatch.MarkCompressionReady();
-                _readyPartitions.Enqueue(readyBatch.TopicPartition);
                 return;
             }
         }
 
         // Mark compression complete so the drain loop can pick up this batch.
         readyBatch.MarkCompressionReady();
-
-        // Notify Ready() that this partition has a sendable batch.
-        _readyPartitions.Enqueue(readyBatch.TopicPartition);
     }
 
     /// <summary>
@@ -2938,7 +2945,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             var now = Stopwatch.GetTimestamp();
             var newOldestTicks = long.MaxValue;
-            bool anySealed = false;
+            var anySealed = false;
 
             foreach (var kvp in _partitionDeques)
             {
@@ -2968,7 +2975,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
                 if (sealedBatch is not null)
                 {
-                    CompressAndSignalBatch(sealedBatch);
+                    PublishSealedBatch(sealedBatch, signalWakeup: false);
                     anySealed = true;
                 }
             }
@@ -4571,7 +4578,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
 
     /// <summary>
     /// Whether compression has completed (or was not needed) for this batch.
-    /// Set after <see cref="RecordAccumulator.CompressAndSignalBatch"/> finishes.
+    /// Set after <see cref="RecordAccumulator.CompressBatch"/> finishes.
     /// The drain loop skips batches where this is false to avoid sending uncompressed data.
     /// Uses Volatile reads for lock-free checking from the sender thread.
     /// </summary>
@@ -4583,7 +4590,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     private int _compressionReady;
 
     /// <summary>
-    /// Marks compression as complete. Called by <see cref="RecordAccumulator.CompressAndSignalBatch"/>
+    /// Marks compression as complete. Called by <see cref="RecordAccumulator.CompressBatch"/>
     /// after compression finishes (or immediately if no compression is configured).
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -438,8 +438,8 @@ public sealed class RecordBatch : IDisposable
     /// Pre-compressed records data. When set, <see cref="Write"/> skips compression
     /// and uses this data directly. The array is rented from <see cref="ArrayPool{T}"/>
     /// and must be returned by the caller after Write() completes.
-    /// Set by <see cref="PreCompress"/> at batch seal time so compression happens on
-    /// partition-affine append workers instead of the single-threaded send loop.
+    /// Set by <see cref="PreCompress"/> before send so <see cref="Write"/> can emit
+    /// the compressed payload directly.
     /// </summary>
     internal byte[]? PreCompressedRecords { get; private set; }
 
@@ -456,8 +456,8 @@ public sealed class RecordBatch : IDisposable
     internal bool HasPreCompressedRecords => PreCompressedRecords is not null;
 
     /// <summary>
-    /// Pre-compresses the records in this batch. Called at seal time on partition-affine
-    /// append workers to move compression work off the single-threaded send loop.
+    /// Pre-compresses the records in this batch. Producer send paths call this before
+    /// request serialization so <see cref="Write"/> can skip re-compression.
     /// The compressed data is stored in a pooled array and used by <see cref="Write"/>
     /// to skip re-compression. This is a per-batch allocation (acceptable).
     /// </summary>
@@ -485,9 +485,9 @@ public sealed class RecordBatch : IDisposable
             codec.Compress(new ReadOnlySequence<byte>(recordsBuffer.WrittenMemory), compressedBuffer);
 
             // Copy to a pooled array for storage (scratch buffer will be reused).
-            // Uses ProducerDataPool (not ArrayPool<byte>.Shared) because PreCompress runs on
-            // the producer/accumulator thread but ReturnPreCompressedBuffer runs on the
-            // BrokerSender thread — cross-thread ArrayPool<byte>.Shared causes TLS accumulation.
+            // Uses ProducerDataPool (not ArrayPool<byte>.Shared) because PreCompress and
+            // ReturnPreCompressedBuffer may run on different producer threads; cross-thread
+            // ArrayPool<byte>.Shared use causes TLS accumulation.
             var compressedLength = compressedBuffer.WrittenCount;
             var pooledArray = Producer.ProducerDataPool.BytePool.Rent(compressedLength);
             compressedBuffer.WrittenSpan.CopyTo(pooledArray);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -1,4 +1,6 @@
+using System.Buffers;
 using System.Diagnostics;
+using Dekaf.Compression;
 using Dekaf.Metadata;
 using Dekaf.Producer;
 using Dekaf.Protocol;
@@ -14,7 +16,10 @@ namespace Dekaf.Tests.Unit.Producer;
 /// </summary>
 public class RecordAccumulatorReadyTests
 {
-    private static ProducerOptions CreateTestOptions(int batchSize = 1000, int lingerMs = 10)
+    private static ProducerOptions CreateTestOptions(
+        int batchSize = 1000,
+        int lingerMs = 10,
+        CompressionType compressionType = CompressionType.None)
     {
         return new ProducerOptions
         {
@@ -22,7 +27,8 @@ public class RecordAccumulatorReadyTests
             ClientId = "test-producer",
             BufferMemory = ulong.MaxValue,
             BatchSize = batchSize,
-            LingerMs = lingerMs
+            LingerMs = lingerMs,
+            CompressionType = compressionType
         };
     }
 
@@ -92,6 +98,49 @@ public class RecordAccumulatorReadyTests
             var (nextCheckDelayMs, unknownLeadersExist) = accumulator.Ready(metadataManager, readyNodes);
 
             // Assert: Node 1 should be ready (partition 0's leader)
+            await Assert.That(readyNodes).Contains(1);
+            await Assert.That(unknownLeadersExist).IsFalse();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Ready_CompressesSealedBatch_OutsideAppendPath()
+    {
+        var options = CreateTestOptions(batchSize: 50, compressionType: CompressionType.Gzip);
+
+        var codec = new CountingCompressionCodec(CompressionType.Gzip);
+        var compressionCodecs = new CompressionCodecRegistry();
+        compressionCodecs.Register(codec);
+
+        var accumulator = new RecordAccumulator(options, compressionCodecs);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var metadataManager = CreateMetadataManager("test-topic", 1, nodeId: 1);
+
+        try
+        {
+            var pooledKey = new PooledMemory(null, 0, isNull: true);
+            var pooledValue = new PooledMemory(null, 0, isNull: true);
+
+            for (var i = 0; i < 10; i++)
+            {
+                var completion = pool.Rent();
+                accumulator.TryAppendWithCompletion("test-topic", 0,
+                    DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    pooledKey, pooledValue, null, 0, completion);
+            }
+
+            await Assert.That(codec.CompressCount).IsEqualTo(0);
+
+            var readyNodes = new HashSet<int>();
+            var (_, unknownLeadersExist) = accumulator.Ready(metadataManager, readyNodes);
+
+            await Assert.That(codec.CompressCount).IsEqualTo(1);
             await Assert.That(readyNodes).Contains(1);
             await Assert.That(unknownLeadersExist).IsFalse();
         }
@@ -788,6 +837,28 @@ public class RecordAccumulatorReadyTests
             await accumulator.DisposeAsync();
             await pool.DisposeAsync();
             await metadataManager.DisposeAsync();
+        }
+    }
+
+    private sealed class CountingCompressionCodec(CompressionType type) : ICompressionCodec
+    {
+        private int _compressCount;
+
+        public CompressionType Type { get; } = type;
+
+        public int CompressCount => Volatile.Read(ref _compressCount);
+
+        public void Compress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+        {
+            Interlocked.Increment(ref _compressCount);
+            foreach (var segment in source)
+                destination.Write(segment.Span);
+        }
+
+        public void Decompress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+        {
+            foreach (var segment in source)
+                destination.Write(segment.Span);
         }
     }
 


### PR DESCRIPTION
## Summary
- stop compressing sealed producer batches on the append caller path
- publish sealed batches immediately and let the sender `Ready()` path pre-compress before drain
- keep uncompressed batches marked ready immediately, and add regression coverage proving compression is not invoked during append overflow

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/Dekaf.Tests.Unit.Producer/RecordAccumulatorReadyTests/*"`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/Dekaf.Tests.Unit.Producer/*/*"`
- [x] `dotnet format --verify-no-changes --include src\Dekaf\Producer\RecordAccumulator.cs src\Dekaf\Protocol\Records\RecordBatch.cs tests\Dekaf.Tests.Unit\Producer\RecordAccumulatorReadyTests.cs`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --disable-logo --no-ansi --no-progress`
- [x] `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `git diff --check`

Closes #918