### PR TITLE
fix(compression): reuse zstd contexts

### DIFF
--- a/src/Dekaf.Compression.Zstd/ZstdCompressionCodec.cs
+++ b/src/Dekaf.Compression.Zstd/ZstdCompressionCodec.cs
@@ -10,6 +10,15 @@ namespace Dekaf.Compression.Zstd;
 /// </summary>
 public sealed class ZstdCompressionCodec : ICompressionCodec
 {
+    [ThreadStatic]
+    private static Compressor? s_compressor;
+
+    [ThreadStatic]
+    private static int s_compressorLevel;
+
+    [ThreadStatic]
+    private static Decompressor? s_decompressor;
+
     private readonly int _compressionLevel;
 
     /// <summary>
@@ -32,7 +41,7 @@ public sealed class ZstdCompressionCodec : ICompressionCodec
 
     public void Compress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
     {
-        using var compressor = new Compressor(_compressionLevel);
+        var compressor = GetCompressor(_compressionLevel);
 
         var position = source.Start;
         var remaining = source.Length;
@@ -44,10 +53,13 @@ public sealed class ZstdCompressionCodec : ICompressionCodec
             var sourceSpan = segment.Span;
 
             // Process this segment
+            var outputSizeHint = 0;
             while (sourceSpan.Length > 0)
             {
-                var maxOutputSize = Compressor.GetCompressBound(sourceSpan.Length);
-                var destSpan = destination.GetSpan(maxOutputSize);
+                outputSizeHint = outputSizeHint == 0
+                    ? Compressor.GetCompressBound(sourceSpan.Length)
+                    : outputSizeHint;
+                var destSpan = destination.GetSpan(outputSizeHint);
 
                 var status = compressor.WrapStream(sourceSpan, destSpan, out var bytesConsumed, out var bytesWritten, isFinalBlock: false);
                 destination.Advance(bytesWritten);
@@ -58,17 +70,20 @@ public sealed class ZstdCompressionCodec : ICompressionCodec
 
                 if (status == OperationStatus.DestinationTooSmall && bytesConsumed == 0)
                 {
-                    // Need larger buffer
+                    outputSizeHint = GrowDestinationSizeHint(outputSizeHint);
                     continue;
                 }
+
+                outputSizeHint = 0;
             }
 
             // On final segment, finalize the frame
             if (isFinalBlock)
             {
+                var flushSizeHint = 64;
                 while (true)
                 {
-                    var destSpan = destination.GetSpan(64);
+                    var destSpan = destination.GetSpan(flushSizeHint);
                     var status = compressor.WrapStream(ReadOnlySpan<byte>.Empty, destSpan, out _, out var bytesWritten, isFinalBlock: true);
                     destination.Advance(bytesWritten);
 
@@ -77,6 +92,9 @@ public sealed class ZstdCompressionCodec : ICompressionCodec
 
                     if (status == OperationStatus.InvalidData)
                         throw new InvalidOperationException("Zstd compression failed: invalid data");
+
+                    if (status == OperationStatus.DestinationTooSmall && bytesWritten == 0)
+                        flushSizeHint = GrowDestinationSizeHint(flushSizeHint);
                 }
             }
         }
@@ -84,7 +102,7 @@ public sealed class ZstdCompressionCodec : ICompressionCodec
 
     public void Decompress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
     {
-        using var decompressor = new Decompressor();
+        var decompressor = GetDecompressor();
 
         var position = source.Start;
 
@@ -109,6 +127,46 @@ public sealed class ZstdCompressionCodec : ICompressionCodec
                 // NeedMoreData or DestinationTooSmall: continue with next iteration
             }
         }
+    }
+
+    private static Compressor GetCompressor(int compressionLevel)
+    {
+        var compressor = s_compressor;
+        if (compressor is null || s_compressorLevel != compressionLevel)
+        {
+            compressor?.Dispose();
+            compressor = new Compressor(compressionLevel);
+            s_compressor = compressor;
+            s_compressorLevel = compressionLevel;
+            return compressor;
+        }
+
+        compressor.ResetStream();
+        return compressor;
+    }
+
+    private static Decompressor GetDecompressor()
+    {
+        var decompressor = s_decompressor;
+        if (decompressor is null)
+        {
+            decompressor = new Decompressor();
+            s_decompressor = decompressor;
+            return decompressor;
+        }
+
+        decompressor.ResetStream();
+        return decompressor;
+    }
+
+    private static int GrowDestinationSizeHint(int sizeHint)
+    {
+        if (sizeHint <= 0)
+            return 256;
+
+        return sizeHint >= int.MaxValue / 2
+            ? int.MaxValue
+            : sizeHint * 2;
     }
 }
 

--- a/tests/Dekaf.Tests.Unit/Compression/ZstdCompressionCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Compression/ZstdCompressionCodecTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Reflection;
 using System.Text;
 using Dekaf.Compression;
 using Dekaf.Compression.Zstd;
@@ -148,6 +149,63 @@ public class ZstdCompressionCodecTests
 
     #endregion
 
+    #region Context Reuse Tests
+
+    [Test]
+    public async Task ZstdCompressionCodec_Compress_ReusesThreadStaticCompressorForSameLevel()
+    {
+        var codec = new ZstdCompressionCodec();
+        var sameLevelCodec = new ZstdCompressionCodec();
+        var otherLevelCodec = new ZstdCompressionCodec(compressionLevel: 5);
+        var data = "zstd thread-static compressor cache"u8.ToArray();
+
+        Compress(codec, data);
+        var firstCompressor = GetRequiredStaticField("s_compressor");
+
+        Compress(sameLevelCodec, data);
+        var secondCompressor = GetRequiredStaticField("s_compressor");
+
+        Compress(otherLevelCodec, data);
+        var thirdCompressor = GetRequiredStaticField("s_compressor");
+
+        await Assert.That(ReferenceEquals(firstCompressor, secondCompressor)).IsTrue();
+        await Assert.That(ReferenceEquals(firstCompressor, thirdCompressor)).IsFalse();
+    }
+
+    [Test]
+    public async Task ZstdCompressionCodec_Decompress_ReusesThreadStaticDecompressor()
+    {
+        var codec = new ZstdCompressionCodec();
+        var data = "zstd thread-static decompressor cache"u8.ToArray();
+
+        var compressed = Compress(codec, data);
+
+        Decompress(codec, compressed);
+        var firstDecompressor = GetRequiredStaticField("s_decompressor");
+
+        Decompress(codec, compressed);
+        var secondDecompressor = GetRequiredStaticField("s_decompressor");
+
+        await Assert.That(ReferenceEquals(firstDecompressor, secondDecompressor)).IsTrue();
+    }
+
+    [Test]
+    public async Task ZstdCompressionCodec_GrowDestinationSizeHint_DoublesUntilIntMax()
+    {
+        var growDestinationSizeHint = typeof(ZstdCompressionCodec).GetMethod(
+            "GrowDestinationSizeHint",
+            BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new MissingMethodException(nameof(ZstdCompressionCodec), "GrowDestinationSizeHint");
+
+        var doubled = (int)growDestinationSizeHint.Invoke(null, [64])!;
+        var capped = (int)growDestinationSizeHint.Invoke(null, [int.MaxValue])!;
+
+        await Assert.That(doubled).IsEqualTo(128);
+        await Assert.That(capped).IsEqualTo(int.MaxValue);
+    }
+
+    #endregion
+
     #region Extension Methods Tests
 
     [Test]
@@ -195,6 +253,29 @@ public class ZstdCompressionCodecTests
     #endregion
 
     #region Helper Classes
+
+    private static byte[] Compress(ZstdCompressionCodec codec, byte[] data)
+    {
+        var compressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Compress(new ReadOnlySequence<byte>(data), compressedBuffer);
+        return compressedBuffer.WrittenSpan.ToArray();
+    }
+
+    private static byte[] Decompress(ZstdCompressionCodec codec, byte[] data)
+    {
+        var decompressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Decompress(new ReadOnlySequence<byte>(data), decompressedBuffer);
+        return decompressedBuffer.WrittenSpan.ToArray();
+    }
+
+    private static object GetRequiredStaticField(string name)
+    {
+        var field = typeof(ZstdCompressionCodec).GetField(name, BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new MissingFieldException(typeof(ZstdCompressionCodec).FullName, name);
+
+        return field.GetValue(null)
+            ?? throw new InvalidOperationException($"{name} was not initialized.");
+    }
 
     /// <summary>
     /// Helper class for creating multi-segment ReadOnlySequence for testing.


### PR DESCRIPTION
## Summary
- cache ZstdSharp compressor/decompressor native contexts per thread instead of creating them per batch
- recreate the cached compressor when a different compression level is used on the same thread
- grow the destination span size hint when compression makes zero progress because the destination is too small
- add regression coverage for context reuse and size-hint growth

## Test plan
- [x] TDD regression failed before implementation: `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 -- --treenode-filter "/*/Dekaf.Tests.Unit.Compression/ZstdCompressionCodecTests/ZstdCompressionCodec_*"`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 -- --treenode-filter "/*/Dekaf.Tests.Unit.Compression/*/*" --detailed-stacktrace`
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --detailed-stacktrace`
- [x] `git diff --check`

Closes #898
