### PR TITLE
fix(schemaregistry): encode protobuf indexes

### DIFF
--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufDeserializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufDeserializerConfig.cs
@@ -6,7 +6,7 @@ namespace Dekaf.SchemaRegistry.Protobuf;
 public sealed class ProtobufDeserializerConfig
 {
     /// <summary>
-    /// Whether to use the deprecated subject naming format.
+    /// Whether to read the deprecated unsigned Protobuf message-index encoding.
     /// Default is false.
     /// </summary>
     public bool UseDeprecatedFormat { get; init; }

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
@@ -71,12 +71,16 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
 
         // Read the message indexes (varints)
         var payload = span.Slice(5);
-        var (indexCount, bytesRead) = ReadVarint(payload);
+        var (indexCount, bytesRead) = ReadVarint(payload, _config.UseDeprecatedFormat);
+        if (indexCount < 0)
+            throw new InvalidOperationException("Message index array length cannot be negative");
 
         // Skip past the index array
         for (var i = 0; i < indexCount; i++)
         {
-            var (_, indexBytesRead) = ReadVarint(payload.Slice(bytesRead));
+            var (index, indexBytesRead) = ReadVarint(payload.Slice(bytesRead), _config.UseDeprecatedFormat);
+            if (index < 0)
+                throw new InvalidOperationException("Message index cannot be negative");
             bytesRead += indexBytesRead;
         }
 
@@ -88,18 +92,18 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
         return _parser.ParseFrom(protobufData);
     }
 
-    private static (int value, int bytesRead) ReadVarint(ReadOnlySpan<byte> data)
+    private static (int value, int bytesRead) ReadVarint(ReadOnlySpan<byte> data, bool useDeprecatedFormat)
     {
-        var value = 0;
+        ulong rawValue = 0;
         var shift = 0;
         var bytesRead = 0;
 
         foreach (var b in data)
         {
             bytesRead++;
-            value |= (b & 0x7F) << shift;
+            rawValue |= (ulong)(b & 0x7F) << shift;
             if ((b & 0x80) == 0)
-                return (value, bytesRead);
+                return (DecodeVarint(rawValue, useDeprecatedFormat), bytesRead);
             shift += 7;
 
             if (shift >= 35)
@@ -108,6 +112,27 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
 
         throw new InvalidOperationException("Varint is truncated");
     }
+
+    private static int DecodeVarint(ulong rawValue, bool useDeprecatedFormat)
+    {
+        if (useDeprecatedFormat)
+        {
+            if (rawValue > int.MaxValue)
+                throw new InvalidOperationException("Varint value is too large");
+
+            return (int)rawValue;
+        }
+
+        var decoded = (long)(rawValue >> 1);
+        if ((rawValue & 1) != 0)
+            decoded = ~decoded;
+
+        if (decoded is < int.MinValue or > int.MaxValue)
+            throw new InvalidOperationException("Varint value is too large");
+
+        return (int)decoded;
+    }
+
     /// <inheritdoc />
     public ValueTask DisposeAsync()
     {

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -34,7 +34,7 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
     private readonly MessageDescriptor _descriptor;
     private readonly ConcurrentDictionary<string, int> _schemaIdCache = new();
     private readonly Schema _schema;
-    private readonly int[] _messageIndexes;
+    private readonly byte[] _encodedMessageIndexes;
 
     /// <summary>
     /// Creates a new Protobuf Schema Registry serializer.
@@ -62,8 +62,10 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
             References = _config.UseSchemaReferences ? GetSchemaReferences(_descriptor) : null
         };
 
-        // Calculate the message index path
-        _messageIndexes = CalculateMessageIndexes(_descriptor);
+        // Pre-encode the immutable message index path once per serializer.
+        _encodedMessageIndexes = VarintEncoder.EncodeMessageIndexes(
+            CalculateMessageIndexes(_descriptor),
+            _config.UseDeprecatedFormat);
     }
 
     /// <inheritdoc />
@@ -79,11 +81,8 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
         // with both generated and hand-coded messages
         var protoBytes = value.ToByteArray();
 
-        // Calculate the varint-encoded message indexes size
-        var indexesSize = VarintEncoder.CalculateVarintArraySize(_messageIndexes);
-
         // Total size: magic byte + schema ID + indexes + message
-        var totalSize = 1 + 4 + indexesSize + protoBytes.Length;
+        var totalSize = 1 + 4 + _encodedMessageIndexes.Length + protoBytes.Length;
         var span = destination.GetSpan(totalSize);
 
         // Write magic byte
@@ -92,9 +91,9 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
         // Write schema ID (big-endian)
         BinaryPrimitives.WriteInt32BigEndian(span.Slice(1, 4), schemaId);
 
-        // Write message indexes as varints
         var offset = 5;
-        offset += VarintEncoder.WriteVarintArray(span.Slice(offset), _messageIndexes);
+        _encodedMessageIndexes.CopyTo(span.Slice(offset));
+        offset += _encodedMessageIndexes.Length;
 
         // Write the protobuf message
         protoBytes.AsSpan().CopyTo(span.Slice(offset));

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
@@ -34,7 +34,8 @@ public sealed class ProtobufSerializerConfig
     public bool UseLatestVersion { get; init; }
 
     /// <summary>
-    /// Whether to use the deprecated subject naming format (without -key/-value suffix for RecordName strategy).
+    /// Whether to use the deprecated unsigned Protobuf message-index encoding.
+    /// This also preserves the previous RecordName subject naming format without a -key/-value suffix.
     /// Default is false.
     /// </summary>
     public bool UseDeprecatedFormat { get; init; }

--- a/src/Dekaf.SchemaRegistry.Protobuf/VarintEncoder.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/VarintEncoder.cs
@@ -16,14 +16,7 @@ internal static class VarintEncoder
     {
         ArgumentOutOfRangeException.ThrowIfNegative(value);
 
-        var size = 1;
-        var v = (uint)value;
-        while (v >= 0x80)
-        {
-            size++;
-            v >>= 7;
-        }
-        return size;
+        return CalculateUnsignedVarintSize((uint)value);
     }
 
     /// <summary>
@@ -35,15 +28,7 @@ internal static class VarintEncoder
     {
         ArgumentOutOfRangeException.ThrowIfNegative(value);
 
-        var size = CalculateVarintSize(value);
-        var v = (uint)value;
-        for (var i = 0; i < size - 1; i++)
-        {
-            span[i] = (byte)(v | 0x80);
-            v >>= 7;
-        }
-        span[size - 1] = (byte)v;
-        return size;
+        return WriteUnsignedVarint(span, (uint)value);
     }
 
     /// <summary>
@@ -81,5 +66,93 @@ internal static class VarintEncoder
         }
 
         return written;
+    }
+
+    /// <summary>
+    /// Pre-encodes Confluent Protobuf message indexes.
+    /// </summary>
+    internal static byte[] EncodeMessageIndexes(int[] values, bool useDeprecatedFormat = false)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        if (values.Length == 0)
+            throw new ArgumentException("Message index array cannot be empty.", nameof(values));
+
+        if (values.Length == 1 && values[0] == 0)
+            return [0x00];
+
+        var bytes = new byte[CalculateMessageIndexArraySize(values, useDeprecatedFormat)];
+        WriteMessageIndexArray(bytes, values, useDeprecatedFormat);
+        return bytes;
+    }
+
+    private static int CalculateMessageIndexArraySize(int[] values, bool useDeprecatedFormat)
+    {
+        var size = CalculateMessageIndexVarintSize(values.Length, useDeprecatedFormat);
+
+        foreach (var value in values)
+        {
+            size += CalculateMessageIndexVarintSize(value, useDeprecatedFormat);
+        }
+
+        return size;
+    }
+
+    private static int WriteMessageIndexArray(Span<byte> span, int[] values, bool useDeprecatedFormat)
+    {
+        var written = WriteMessageIndexVarint(span, values.Length, useDeprecatedFormat);
+
+        foreach (var value in values)
+        {
+            written += WriteMessageIndexVarint(span.Slice(written), value, useDeprecatedFormat);
+        }
+
+        return written;
+    }
+
+    private static int CalculateMessageIndexVarintSize(int value, bool useDeprecatedFormat)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+
+        return useDeprecatedFormat
+            ? CalculateUnsignedVarintSize((uint)value)
+            : CalculateUnsignedVarintSize(EncodeZigZag(value));
+    }
+
+    private static int WriteMessageIndexVarint(Span<byte> span, int value, bool useDeprecatedFormat)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+
+        return WriteUnsignedVarint(span, useDeprecatedFormat ? (uint)value : EncodeZigZag(value));
+    }
+
+    private static int CalculateUnsignedVarintSize(uint value)
+    {
+        var size = 1;
+        while (value >= 0x80)
+        {
+            size++;
+            value >>= 7;
+        }
+
+        return size;
+    }
+
+    private static int WriteUnsignedVarint(Span<byte> span, uint value)
+    {
+        var written = 0;
+        while (value >= 0x80)
+        {
+            span[written++] = (byte)((value & 0x7F) | 0x80);
+            value >>= 7;
+        }
+
+        span[written++] = (byte)value;
+        return written;
+    }
+
+    private static uint EncodeZigZag(int value)
+    {
+        return (uint)((value << 1) ^ (value >> 31));
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistryDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistryDeserializerTests.cs
@@ -31,13 +31,12 @@ public class ProtobufSchemaRegistryDeserializerTests
 
         // Build the wire format manually
         var protoBytes = originalMessage.ToByteArray();
-        var wireBytes = new byte[1 + 4 + 2 + protoBytes.Length]; // magic + schemaId + indexes + proto
+        var wireBytes = new byte[1 + 4 + 1 + protoBytes.Length]; // magic + schemaId + indexes + proto
 
         wireBytes[0] = 0x00; // Magic byte
         BinaryPrimitives.WriteInt32BigEndian(wireBytes.AsSpan(1, 4), 123); // Schema ID
-        wireBytes[5] = 1; // Array length (1 index)
-        wireBytes[6] = 0; // Index 0
-        protoBytes.CopyTo(wireBytes.AsSpan(7));
+        wireBytes[5] = 0; // Single top-level message index [0]
+        protoBytes.CopyTo(wireBytes.AsSpan(6));
 
         // Act
         var result = deserializer.Deserialize(wireBytes, CreateContext());
@@ -63,13 +62,12 @@ public class ProtobufSchemaRegistryDeserializerTests
 
         var originalMessage = new TestMessage { Id = 42, Name = "Hello", Value = 3.14 };
         var protoBytes = originalMessage.ToByteArray();
-        var wireBytes = new byte[1 + 4 + 2 + protoBytes.Length];
+        var wireBytes = new byte[1 + 4 + 1 + protoBytes.Length];
 
         wireBytes[0] = 0x00;
         BinaryPrimitives.WriteInt32BigEndian(wireBytes.AsSpan(1, 4), schemaId);
-        wireBytes[5] = 1;
-        wireBytes[6] = 0;
-        protoBytes.CopyTo(wireBytes.AsSpan(7));
+        wireBytes[5] = 0;
+        protoBytes.CopyTo(wireBytes.AsSpan(6));
 
         // Act
         var result = deserializer.Deserialize(wireBytes, CreateContext());
@@ -146,13 +144,12 @@ public class ProtobufSchemaRegistryDeserializerTests
         // Create a valid wire format message
         var originalMessage = new TestMessage { Id = 42, Name = "Hello", Value = 3.14 };
         var protoBytes = originalMessage.ToByteArray();
-        var wireBytes = new byte[1 + 4 + 2 + protoBytes.Length];
+        var wireBytes = new byte[1 + 4 + 1 + protoBytes.Length];
 
         wireBytes[0] = 0x00;
         BinaryPrimitives.WriteInt32BigEndian(wireBytes.AsSpan(1, 4), 123);
-        wireBytes[5] = 1;
-        wireBytes[6] = 0;
-        protoBytes.CopyTo(wireBytes.AsSpan(7));
+        wireBytes[5] = 0;
+        protoBytes.CopyTo(wireBytes.AsSpan(6));
 
         // Act
         var result = deserializer.Deserialize(wireBytes, CreateContext());
@@ -160,6 +157,39 @@ public class ProtobufSchemaRegistryDeserializerTests
         // Assert - schema registry should not be called
         await schemaRegistry.DidNotReceive().GetSchemaAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
         await Assert.That(result.Id).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Deserialize_SkipsConfluentZigZagEncodedMessageIndexes()
+    {
+        // Arrange
+        var schemaRegistry = Substitute.For<ISchemaRegistryClient>();
+        schemaRegistry.GetSchemaAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new Schema
+            {
+                SchemaType = SchemaType.Protobuf,
+                SchemaString = "syntax = \"proto3\";"
+            }));
+
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(schemaRegistry);
+        var originalMessage = new TestMessage { Id = 42, Name = "Nested", Value = 6.28 };
+        var protoBytes = originalMessage.ToByteArray();
+        var wireBytes = new byte[1 + 4 + 3 + protoBytes.Length];
+
+        wireBytes[0] = 0x00;
+        BinaryPrimitives.WriteInt32BigEndian(wireBytes.AsSpan(1, 4), 123);
+        wireBytes[5] = 4; // zigzag length: 2
+        wireBytes[6] = 2; // zigzag index: 1
+        wireBytes[7] = 0; // zigzag index: 0
+        protoBytes.CopyTo(wireBytes.AsSpan(8));
+
+        // Act
+        var result = deserializer.Deserialize(wireBytes, CreateContext());
+
+        // Assert
+        await Assert.That(result.Id).IsEqualTo(42);
+        await Assert.That(result.Name).IsEqualTo("Nested");
+        await Assert.That(result.Value).IsEqualTo(6.28);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
@@ -3,6 +3,7 @@ using System.Buffers.Binary;
 using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Protobuf;
 using Dekaf.Serialization;
+using Google.Protobuf;
 using NSubstitute;
 
 namespace Dekaf.Tests.Unit.SchemaRegistry;
@@ -38,11 +39,11 @@ public class ProtobufSchemaRegistrySerializerTests
         var schemaId = BinaryPrimitives.ReadInt32BigEndian(written.AsSpan(1, 4));
         await Assert.That(schemaId).IsEqualTo(42);
 
-        // Message index array length (varint) - should be 1 for top-level message
-        await Assert.That(written[5]).IsEqualTo((byte)1);
+        // Message index array [0] is encoded as a single 0x00 byte in Confluent's Protobuf format.
+        await Assert.That(written[5]).IsEqualTo((byte)0);
 
-        // Message index (varint) - should be 0 for first message in file
-        await Assert.That(written[6]).IsEqualTo((byte)0);
+        var expectedPayload = message.ToByteArray();
+        await Assert.That(written.AsSpan(6).ToArray()).IsEquivalentTo(expectedPayload);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/VarintEncoderTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/VarintEncoderTests.cs
@@ -135,4 +135,28 @@ public class VarintEncoderTests
 
         await Assert.That(writtenSize).IsEqualTo(calculatedSize);
     }
+
+    [Test]
+    public async Task EncodeMessageIndexes_SingleTopLevelIndex_WritesConfluentShorthand()
+    {
+        var encoded = VarintEncoder.EncodeMessageIndexes([0]);
+
+        await Assert.That(encoded).IsEquivalentTo(new byte[] { 0x00 });
+    }
+
+    [Test]
+    public async Task EncodeMessageIndexes_NestedIndexes_UsesConfluentZigZagEncoding()
+    {
+        var encoded = VarintEncoder.EncodeMessageIndexes([1, 0]);
+
+        await Assert.That(encoded).IsEquivalentTo(new byte[] { 0x04, 0x02, 0x00 });
+    }
+
+    [Test]
+    public async Task EncodeMessageIndexes_DeprecatedFormat_UsesUnsignedVarints()
+    {
+        var encoded = VarintEncoder.EncodeMessageIndexes([1, 0], useDeprecatedFormat: true);
+
+        await Assert.That(encoded).IsEquivalentTo(new byte[] { 0x02, 0x01, 0x00 });
+    }
 }


### PR DESCRIPTION
## Summary
- pre-encode Protobuf message-index bytes once per serializer instead of recomputing per message
- emit Confluent's single-byte `0x00` shorthand for the common `[0]` top-level message index
- encode and decode default Protobuf message indexes with Confluent zigzag varints, retaining deprecated unsigned decoding behind `UseDeprecatedFormat`
- add serializer, deserializer, and encoder coverage for shorthand, zigzag, and deprecated unsigned framing

## References
- Confluent wire format docs: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format-schema-id-in-the-payload-prefix
- Confluent Python serializer source for shorthand/zigzag behavior: https://docs.confluent.io/platform/7.5/clients/confluent-kafka-python/html/_modules/confluent_kafka/schema_registry/protobuf.html

## Test plan
- [x] TDD regression failed before implementation: `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 -- --treenode-filter "/*/Dekaf.Tests.Unit.SchemaRegistry/*/*"`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 -- --treenode-filter "/*/Dekaf.Tests.Unit.SchemaRegistry/*/*" --detailed-stacktrace`
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --detailed-stacktrace`
- [x] `git diff --check`

Closes #899
