### PR TITLE
perf(producer): fast-path awaited topic produce

### DIFF
--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -50,6 +50,8 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <remarks>
     /// <para>See <see cref="ProduceAsync(ProducerMessage{TKey, TValue}, CancellationToken)"/> for
     /// important information about <see cref="ValueTask{TResult}"/> usage rules.</para>
+    /// <para>Implementations may optimize this overload to avoid allocating a
+    /// <see cref="ProducerMessage{TKey, TValue}"/> object on the hot path.</para>
     /// </remarks>
     ValueTask<RecordMetadata> ProduceAsync(
         string topic,

--- a/src/Dekaf/Producer/IProducerFastPath.cs
+++ b/src/Dekaf/Producer/IProducerFastPath.cs
@@ -1,0 +1,15 @@
+using Dekaf.Serialization;
+
+namespace Dekaf.Producer;
+
+internal interface IProducerFastPath<TKey, TValue>
+{
+    ValueTask<RecordMetadata> ProduceAsync(
+        string topic,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        int? partition,
+        DateTimeOffset? timestamp,
+        CancellationToken cancellationToken);
+}

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -22,7 +22,7 @@ namespace Dekaf.Producer;
 /// </summary>
 /// <typeparam name="TKey">Key type.</typeparam>
 /// <typeparam name="TValue">Value type.</typeparam>
-public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, TValue>, IBudgetedInstance
+public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, TValue>, IProducerFastPath<TKey, TValue>, IBudgetedInstance
 {
     /// <summary>
     /// Sentinel return value from <see cref="TryProduceSyncCore"/> indicating that the
@@ -375,35 +375,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         ProducerMessage<TKey, TValue> message,
         CancellationToken cancellationToken)
     {
-        if (Volatile.Read(ref _disposed) != 0)
-            throw new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>));
-
-        ThrowIfNotInitialized();
-
-        // KIP-1050 fail-fast: once a transaction is broken, reject new produces so the caller must
-        // abort (abortable) or close the producer (fatal) before continuing. Single volatile read
-        // on the hot path; only transactional producers ever reach the error states.
-        if (_options.TransactionalId is not null)
-        {
-            var txnState = _transactionState;
-            if (txnState == TransactionState.AbortableError)
-            {
-                throw new AbortableTransactionException(_lastTransactionError,
-                    "Cannot produce: the current transaction has an abortable error and must be aborted.")
-                {
-                    TransactionalId = _options.TransactionalId
-                };
-            }
-
-            if (txnState == TransactionState.FatalError)
-            {
-                throw new FatalTransactionException(_lastTransactionError,
-                    "Cannot produce: the producer is in a fatal error state and must be closed.")
-                {
-                    TransactionalId = _options.TransactionalId
-                };
-            }
-        }
+        ThrowIfProduceCannotStart();
 
         // Check cancellation upfront before any work
         cancellationToken.ThrowIfCancellationRequested();
@@ -437,6 +409,72 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // Slow path: Fall back to channel-based async processing.
         // This handles first-time metadata initialization or cache misses.
         return ProduceAsyncSlow(message, activity, cancellationToken);
+    }
+
+    private ValueTask<RecordMetadata> ProduceAsync(
+        string topic,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        int? partition,
+        DateTimeOffset? timestamp,
+        CancellationToken cancellationToken)
+    {
+        if (_retryPolicy is not null || _interceptors is not null || Diagnostics.DekafDiagnostics.Source.HasListeners())
+        {
+            return ProduceAsync(new ProducerMessage<TKey, TValue>
+            {
+                Topic = topic,
+                Key = key,
+                Value = value,
+                Headers = headers,
+                Partition = partition,
+                Timestamp = timestamp
+            }, cancellationToken);
+        }
+
+        return ProduceAsyncCore(topic, key, value, headers, partition, timestamp, cancellationToken);
+    }
+
+    private ValueTask<RecordMetadata> ProduceAsyncCore(
+        string topic,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        int? partition,
+        DateTimeOffset? timestamp,
+        CancellationToken cancellationToken)
+    {
+        ThrowIfProduceCannotStart();
+
+        // Check cancellation upfront before any work
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (TryProduceSyncForAsync(topic, key, value, headers, partition, timestamp, out var completion))
+        {
+            // POST-QUEUE: Message appended to batch, committed to being sent
+            // Message WILL be delivered, but caller can stop waiting via cancellation token.
+            if (ProducerMetricsEnabled())
+            {
+                return AwaitWithMetrics(completion!, topic, cancellationToken);
+            }
+            if (cancellationToken.CanBeCanceled)
+            {
+                return AwaitWithCancellation(completion!, cancellationToken);
+            }
+            return completion!.Task;
+        }
+
+        // Cold path: allocate the full message only when async metadata/backpressure handling needs it.
+        return ProduceAsyncSlow(new ProducerMessage<TKey, TValue>
+        {
+            Topic = topic,
+            Key = key,
+            Value = value,
+            Headers = headers,
+            Partition = partition,
+            Timestamp = timestamp
+        }, activity: null, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -572,6 +610,17 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryProduceSyncForAsync(ProducerMessage<TKey, TValue> message, out PooledValueTaskSource<RecordMetadata>? completion)
+        => TryProduceSyncForAsync(message.Topic, message.Key, message.Value, message.Headers, message.Partition, message.Timestamp, out completion);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryProduceSyncForAsync(
+        string topic,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        int? partition,
+        DateTimeOffset? timestamp,
+        out PooledValueTaskSource<RecordMetadata>? completion)
     {
         completion = null;
 
@@ -586,16 +635,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // FAST PATH: Check thread-local cached topic metadata first.
         // Avoids MetadataManager dictionary lookup for consecutive messages to the same topic.
         TopicInfo? topicInfo;
-        if (!TryGetCachedTopicInfo(message.Topic, out topicInfo))
+        if (!TryGetCachedTopicInfo(topic, out topicInfo))
         {
             // Cache miss - try MetadataManager
-            if (!_metadataManager.TryGetCachedTopicMetadata(message.Topic, out topicInfo) || topicInfo is null)
+            if (!_metadataManager.TryGetCachedTopicMetadata(topic, out topicInfo) || topicInfo is null)
             {
                 return false; // Cache miss, need async refresh
             }
 
             // Update thread-local cache for next call
-            UpdateCachedTopicInfo(message.Topic, topicInfo);
+            UpdateCachedTopicInfo(topic, topicInfo);
         }
 
         if (topicInfo!.PartitionCount == 0)
@@ -608,7 +657,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var result = SyncProduceResult.Success;
         try
         {
-            result = TryProduceSyncCore(message, topicInfo, completion);
+            result = TryProduceSyncCore(topic, key, value, headers, partition, timestamp, topicInfo, completion);
         }
         catch (Exception ex)
         {
@@ -848,6 +897,25 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         ProducerMessage<TKey, TValue> message,
         TopicInfo topicInfo,
         PooledValueTaskSource<RecordMetadata> completion)
+        => TryProduceSyncCore(
+            message.Topic,
+            message.Key,
+            message.Value,
+            message.Headers,
+            message.Partition,
+            message.Timestamp,
+            topicInfo,
+            completion);
+
+    private SyncProduceResult TryProduceSyncCore(
+        string topic,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        int? partition,
+        DateTimeOffset? timestamp,
+        TopicInfo topicInfo,
+        PooledValueTaskSource<RecordMetadata> completion)
     {
         Header[]? pooledHeaderArray = null;
         var customPartitionerKey = PooledMemory.Null;
@@ -856,37 +924,37 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         try
         {
             var cache = GetOrCreateCache();
-            var keyIsNull = message.Key is null;
+            var keyIsNull = key is null;
             var keySpan = ReadOnlySpan<byte>.Empty;
             if (!keyIsNull)
             {
                 var keyWriter = new ReusableBufferWriter(ref cache.KeySerializationBuffer, DefaultKeyBufferSize);
-                cache.SerializationContext.Topic = message.Topic;
+                cache.SerializationContext.Topic = topic;
                 cache.SerializationContext.Component = SerializationComponent.Key;
-                cache.SerializationContext.Headers = message.Headers;
-                _keySerializer.Serialize(message.Key!, ref keyWriter, cache.SerializationContext);
+                cache.SerializationContext.Headers = headers;
+                _keySerializer.Serialize(key!, ref keyWriter, cache.SerializationContext);
                 keySpan = keyWriter.WrittenSpan;
                 keyWriter.UpdateBufferRef(ref cache.KeySerializationBuffer);
             }
 
-            var valueIsNull = message.Value is null;
+            var valueIsNull = value is null;
             var valueSpan = ReadOnlySpan<byte>.Empty;
             if (!valueIsNull)
             {
                 var valueWriter = new ReusableBufferWriter(ref cache.ValueSerializationBuffer, DefaultValueBufferSize);
-                cache.SerializationContext.Topic = message.Topic;
+                cache.SerializationContext.Topic = topic;
                 cache.SerializationContext.Component = SerializationComponent.Value;
-                cache.SerializationContext.Headers = message.Headers;
-                _valueSerializer.Serialize(message.Value!, ref valueWriter, cache.SerializationContext);
+                cache.SerializationContext.Headers = headers;
+                _valueSerializer.Serialize(value!, ref valueWriter, cache.SerializationContext);
                 valueSpan = valueWriter.WrittenSpan;
                 valueWriter.UpdateBufferRef(ref cache.ValueSerializationBuffer);
             }
 
             // Determine partition
-            int partition;
-            if (message.Partition is { } explicitPartition)
+            int resolvedPartition;
+            if (partition is { } explicitPartition)
             {
-                partition = explicitPartition;
+                resolvedPartition = explicitPartition;
             }
             else
             {
@@ -907,28 +975,28 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     }
                 }
 
-                partition = _partitioner.Partition(message.Topic, keySpan, keyIsNull, topicInfo.PartitionCount);
+                resolvedPartition = _partitioner.Partition(topic, keySpan, keyIsNull, topicInfo.PartitionCount);
             }
 
-            var batchCompletionPartitionCount = message.Partition is null && keyIsNull
+            var batchCompletionPartitionCount = partition is null && keyIsNull
                 ? topicInfo.PartitionCount
                 : 0;
 
             // Get timestamp - use fast cached timestamp when no override provided
-            var timestampMs = message.Timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs();
+            var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs();
 
             // Convert headers
             var headerCount = 0;
-            if (message.Headers is not null && message.Headers.Count > 0)
+            if (headers is not null && headers.Count > 0)
             {
-                RentAndFillHeaders(message.Headers, out pooledHeaderArray, out headerCount);
+                RentAndFillHeaders(headers, out pooledHeaderArray, out headerCount);
             }
 
             // Append to accumulator synchronously (non-blocking memory reservation).
             // Returns false when buffer is full OR accumulator is disposed.
             if (!_accumulator.TryAppendFromSpansWithCompletion(
-                message.Topic,
-                partition,
+                topic,
+                resolvedPartition,
                 timestampMs,
                 keySpan,
                 keyIsNull,
@@ -1205,13 +1273,18 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         TValue value,
         CancellationToken cancellationToken = default)
     {
-        return ProduceAsync(new ProducerMessage<TKey, TValue>
-        {
-            Topic = topic,
-            Key = key,
-            Value = value
-        }, cancellationToken);
+        return ProduceAsync(topic, key, value, headers: null, partition: null, timestamp: null, cancellationToken);
     }
+
+    ValueTask<RecordMetadata> IProducerFastPath<TKey, TValue>.ProduceAsync(
+        string topic,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        int? partition,
+        DateTimeOffset? timestamp,
+        CancellationToken cancellationToken)
+        => ProduceAsync(topic, key, value, headers, partition, timestamp, cancellationToken);
 
     /// <inheritdoc />
     public async Task<RecordMetadata[]> ProduceAllAsync(
@@ -2321,6 +2394,46 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     {
         if (!_initialized)
             ThrowNotInitialized();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ThrowIfProduceCannotStart()
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>));
+
+        ThrowIfNotInitialized();
+
+        // KIP-1050 fail-fast: once a transaction is broken, reject new produces so the caller must
+        // abort (abortable) or close the producer (fatal) before continuing. Single volatile read
+        // on the hot path; only transactional producers ever reach the error states.
+        if (_options.TransactionalId is not null)
+        {
+            ThrowIfTransactionCannotProduce();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ThrowIfTransactionCannotProduce()
+    {
+        var txnState = _transactionState;
+        if (txnState == TransactionState.AbortableError)
+        {
+            throw new AbortableTransactionException(_lastTransactionError,
+                "Cannot produce: the current transaction has an abortable error and must be aborted.")
+            {
+                TransactionalId = _options.TransactionalId
+            };
+        }
+
+        if (txnState == TransactionState.FatalError)
+        {
+            throw new FatalTransactionException(_lastTransactionError,
+                "Cannot produce: the producer is in a fatal error state and must be closed.")
+            {
+                TransactionalId = _options.TransactionalId
+            };
+        }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Dekaf/Producer/ProducerExtensions.cs
+++ b/src/Dekaf/Producer/ProducerExtensions.cs
@@ -30,6 +30,9 @@ public static class ProducerExtensions
         ArgumentNullException.ThrowIfNull(producer);
         ArgumentNullException.ThrowIfNull(topic);
 
+        if (producer is IProducerFastPath<TKey, TValue> fastPath)
+            return fastPath.ProduceAsync(topic, key, value, headers, partition: null, timestamp: null, cancellationToken);
+
         return producer.ProduceAsync(new ProducerMessage<TKey, TValue>
         {
             Topic = topic,
@@ -61,6 +64,9 @@ public static class ProducerExtensions
     {
         ArgumentNullException.ThrowIfNull(producer);
         ArgumentNullException.ThrowIfNull(topic);
+
+        if (producer is IProducerFastPath<TKey, TValue> fastPath)
+            return fastPath.ProduceAsync(topic, key, value, headers: null, partition: partition, timestamp: null, cancellationToken);
 
         return producer.ProduceAsync(new ProducerMessage<TKey, TValue>
         {

--- a/src/Dekaf/Producer/TopicProducer.cs
+++ b/src/Dekaf/Producer/TopicProducer.cs
@@ -63,6 +63,9 @@ internal sealed class TopicProducer<TKey, TValue> : ITopicProducer<TKey, TValue>
         CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
+        if (_producer is IProducerFastPath<TKey, TValue> fastPath)
+            return fastPath.ProduceAsync(Topic, key, value, headers, partition: null, timestamp: null, cancellationToken);
+
         return _producer.ProduceAsync(new ProducerMessage<TKey, TValue>
         {
             Topic = Topic,
@@ -80,6 +83,9 @@ internal sealed class TopicProducer<TKey, TValue> : ITopicProducer<TKey, TValue>
         CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
+        if (_producer is IProducerFastPath<TKey, TValue> fastPath)
+            return fastPath.ProduceAsync(Topic, key, value, headers: null, partition: partition, timestamp: null, cancellationToken);
+
         return _producer.ProduceAsync(new ProducerMessage<TKey, TValue>
         {
             Topic = Topic,
@@ -96,6 +102,18 @@ internal sealed class TopicProducer<TKey, TValue> : ITopicProducer<TKey, TValue>
     {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(message);
+
+        if (_producer is IProducerFastPath<TKey, TValue> fastPath)
+        {
+            return fastPath.ProduceAsync(
+                Topic,
+                message.Key,
+                message.Value,
+                message.Headers,
+                message.Partition,
+                message.Timestamp,
+                cancellationToken);
+        }
 
         return _producer.ProduceAsync(new ProducerMessage<TKey, TValue>
         {

--- a/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
@@ -1,0 +1,100 @@
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+internal sealed class FastPathProducerSpy<TKey, TValue> : IKafkaProducer<TKey, TValue>, IProducerFastPath<TKey, TValue>
+{
+    public int FastPathCalls { get; private set; }
+    public int MessageCalls { get; private set; }
+    public string? CapturedTopic { get; private set; }
+    public TKey? CapturedKey { get; private set; }
+    public TValue? CapturedValue { get; private set; }
+    public Headers? CapturedHeaders { get; private set; }
+    public int? CapturedPartition { get; private set; }
+    public DateTimeOffset? CapturedTimestamp { get; private set; }
+    public CancellationToken CapturedCancellationToken { get; private set; }
+
+    public RecordMetadata Result { get; set; } = new()
+    {
+        Topic = "my-topic",
+        Partition = 0,
+        Offset = 42,
+        Timestamp = DateTimeOffset.UnixEpoch
+    };
+
+    public ValueTask InitializeAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+    public ValueTask<RecordMetadata> ProduceAsync(
+        ProducerMessage<TKey, TValue> message,
+        CancellationToken cancellationToken = default)
+    {
+        MessageCalls++;
+        CapturedTopic = message.Topic;
+        CapturedKey = message.Key;
+        CapturedValue = message.Value;
+        CapturedHeaders = message.Headers;
+        CapturedPartition = message.Partition;
+        CapturedTimestamp = message.Timestamp;
+        CapturedCancellationToken = cancellationToken;
+        return ValueTask.FromResult(Result);
+    }
+
+    public ValueTask<RecordMetadata> ProduceAsync(
+        string topic,
+        TKey? key,
+        TValue value,
+        CancellationToken cancellationToken = default)
+        => ((IProducerFastPath<TKey, TValue>)this).ProduceAsync(
+            topic, key, value, headers: null, partition: null, timestamp: null, cancellationToken);
+
+    ValueTask<RecordMetadata> IProducerFastPath<TKey, TValue>.ProduceAsync(
+        string topic,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        int? partition,
+        DateTimeOffset? timestamp,
+        CancellationToken cancellationToken)
+    {
+        FastPathCalls++;
+        CapturedTopic = topic;
+        CapturedKey = key;
+        CapturedValue = value;
+        CapturedHeaders = headers;
+        CapturedPartition = partition;
+        CapturedTimestamp = timestamp;
+        CapturedCancellationToken = cancellationToken;
+        return ValueTask.FromResult(Result);
+    }
+
+    public ValueTask FireAsync(ProducerMessage<TKey, TValue> message) => ValueTask.CompletedTask;
+
+    public ValueTask FireAsync(string topic, TKey? key, TValue value) => ValueTask.CompletedTask;
+
+    public ValueTask FireAsync(
+        ProducerMessage<TKey, TValue> message,
+        Action<RecordMetadata, Exception?> deliveryHandler)
+        => ValueTask.CompletedTask;
+
+    public Task<RecordMetadata[]> ProduceAllAsync(
+        IEnumerable<ProducerMessage<TKey, TValue>> messages,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(Array.Empty<RecordMetadata>());
+
+    public Task<RecordMetadata[]> ProduceAllAsync(
+        string topic,
+        IEnumerable<(TKey? Key, TValue Value)> messages,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(Array.Empty<RecordMetadata>());
+
+    public ValueTask FlushAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+    public ITransaction<TKey, TValue> BeginTransaction() => throw new NotSupportedException();
+
+    public ValueTask InitTransactionsAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+    public ITopicProducer<TKey, TValue> ForTopic(string topic) => new TopicProducer<TKey, TValue>(this, topic, ownsProducer: false);
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -3,6 +3,8 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using Dekaf.Metadata;
 using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
 using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Producer;
@@ -72,6 +74,44 @@ public class KafkaProducerFastPathTests
         _ = await outerTask;
     }
 
+    [Test]
+    public async Task ProduceAsync_TopicKeyValue_UsesHotPathWithCachedMetadata()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 4096,
+            LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000
+        };
+
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        await StopProducerBackgroundLoopsAsync(producer);
+        SeedProducerMetadata(producer);
+        SetInstanceField(producer, "_initialized", true);
+
+        var produceTask = producer.ProduceAsync(Topic, "key", "value");
+
+        var readyBatch = CompleteCurrentBatch(producer.RecordAccumulator, new TopicPartition(Topic, 0));
+        await Assert.That(readyBatch.RecordBatch.Records.Count).IsEqualTo(1);
+        await Assert.That(GetKeyString(readyBatch.RecordBatch.Records[0])).IsEqualTo("key");
+        await Assert.That(GetValueString(readyBatch.RecordBatch.Records[0])).IsEqualTo("value");
+
+        readyBatch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+        var metadata = await produceTask;
+
+        await Assert.That(metadata.Topic).IsEqualTo(Topic);
+        await Assert.That(metadata.Partition).IsEqualTo(0);
+        await Assert.That(metadata.Offset).IsEqualTo(7);
+    }
+
     private static TopicInfo CreateTopicInfo() => new()
     {
         Name = Topic,
@@ -87,6 +127,44 @@ public class KafkaProducerFastPathTests
         ]
     };
 
+    private static void SeedProducerMetadata(KafkaProducer<string, string> producer)
+    {
+        var metadataManager = GetInstanceField<MetadataManager>(producer, "_metadataManager");
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata
+                {
+                    NodeId = 0,
+                    Host = "localhost",
+                    Port = 9092
+                }
+            ],
+            ClusterId = "test-cluster",
+            ControllerId = 0,
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = Topic,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 0,
+                            ReplicaNodes = [0],
+                            IsrNodes = [0]
+                        }
+                    ]
+                }
+            ]
+        });
+    }
+
     private static object InvokeTryProduceSyncCore(
         KafkaProducer<string, string> producer,
         ProducerMessage<string, string> message,
@@ -95,7 +173,10 @@ public class KafkaProducerFastPathTests
     {
         var method = typeof(KafkaProducer<string, string>).GetMethod(
             "TryProduceSyncCore",
-            BindingFlags.NonPublic | BindingFlags.Instance);
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null,
+            [typeof(ProducerMessage<string, string>), typeof(TopicInfo), typeof(PooledValueTaskSource<RecordMetadata>)],
+            modifiers: null);
 
         try
         {
@@ -149,6 +230,14 @@ public class KafkaProducerFastPathTests
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
         var field = target.GetType().GetField(name, instanceFieldFlags);
         return (T)field!.GetValue(target)!;
+    }
+
+    private static void SetInstanceField<T>(object target, string name, T value)
+    {
+        const BindingFlags instanceFieldFlags =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        var field = target.GetType().GetField(name, instanceFieldFlags);
+        field!.SetValue(target, value);
     }
 
     private static string GetKeyString(Dekaf.Protocol.Records.Record record)

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerExtensionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerExtensionsTests.cs
@@ -36,6 +36,26 @@ public sealed class ProducerExtensionsTests
     }
 
     [Test]
+    public async Task ProduceAsync_WithHeaders_UsesFastPath_WhenProducerSupportsIt()
+    {
+        var producer = new FastPathProducerSpy<string, string>();
+        var headers = Headers.Create("h1", "v1");
+        using var cts = new CancellationTokenSource();
+
+        var result = await producer.ProduceAsync("my-topic", "key", "value", headers, cts.Token);
+
+        await Assert.That(result.Offset).IsEqualTo(42);
+        await Assert.That(producer.FastPathCalls).IsEqualTo(1);
+        await Assert.That(producer.MessageCalls).IsEqualTo(0);
+        await Assert.That(producer.CapturedTopic).IsEqualTo("my-topic");
+        await Assert.That(producer.CapturedKey).IsEqualTo("key");
+        await Assert.That(producer.CapturedValue).IsEqualTo("value");
+        await Assert.That(producer.CapturedHeaders).IsSameReferenceAs(headers);
+        await Assert.That(producer.CapturedPartition).IsNull();
+        await Assert.That(producer.CapturedCancellationToken).IsEqualTo(cts.Token);
+    }
+
+    [Test]
     public async Task ProduceAsync_WithHeaders_NullProducer_ThrowsArgumentNullException()
     {
         IKafkaProducer<string, string>? producer = null;
@@ -83,6 +103,23 @@ public sealed class ProducerExtensionsTests
                 m.Key == "key" &&
                 m.Value == "value"),
             Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ProduceAsync_WithPartition_UsesFastPath_WhenProducerSupportsIt()
+    {
+        var producer = new FastPathProducerSpy<string, string>();
+
+        var result = await producer.ProduceAsync("my-topic", partition: 3, "key", "value");
+
+        await Assert.That(result.Offset).IsEqualTo(42);
+        await Assert.That(producer.FastPathCalls).IsEqualTo(1);
+        await Assert.That(producer.MessageCalls).IsEqualTo(0);
+        await Assert.That(producer.CapturedTopic).IsEqualTo("my-topic");
+        await Assert.That(producer.CapturedKey).IsEqualTo("key");
+        await Assert.That(producer.CapturedValue).IsEqualTo("value");
+        await Assert.That(producer.CapturedHeaders).IsNull();
+        await Assert.That(producer.CapturedPartition).IsEqualTo(3);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/TopicProducerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TopicProducerTests.cs
@@ -91,6 +91,25 @@ public class TopicProducerTests
     }
 
     [Test]
+    public async Task ProduceAsync_WithHeaders_UsesInnerFastPath_WhenAvailable()
+    {
+        var innerProducer = new FastPathProducerSpy<string, string>();
+        var topicProducer = new TopicProducer<string, string>(innerProducer, "my-topic", ownsProducer: false);
+        var headers = Headers.Create("header-key", "header-value");
+
+        var result = await topicProducer.ProduceAsync("key", "value", headers, CancellationToken.None);
+
+        await Assert.That(result.Offset).IsEqualTo(42);
+        await Assert.That(innerProducer.FastPathCalls).IsEqualTo(1);
+        await Assert.That(innerProducer.MessageCalls).IsEqualTo(0);
+        await Assert.That(innerProducer.CapturedTopic).IsEqualTo("my-topic");
+        await Assert.That(innerProducer.CapturedKey).IsEqualTo("key");
+        await Assert.That(innerProducer.CapturedValue).IsEqualTo("value");
+        await Assert.That(innerProducer.CapturedHeaders).IsSameReferenceAs(headers);
+        await Assert.That(innerProducer.CapturedPartition).IsNull();
+    }
+
+    [Test]
     public async Task ProduceAsync_WithPartition_DelegatesToInnerProducer()
     {
         // Arrange
@@ -117,6 +136,24 @@ public class TopicProducerTests
                 m.Topic == "my-topic" &&
                 m.Partition == 2),
             Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ProduceAsync_WithPartition_UsesInnerFastPath_WhenAvailable()
+    {
+        var innerProducer = new FastPathProducerSpy<string, string>();
+        var topicProducer = new TopicProducer<string, string>(innerProducer, "my-topic", ownsProducer: false);
+
+        var result = await topicProducer.ProduceAsync(partition: 2, "key", "value");
+
+        await Assert.That(result.Offset).IsEqualTo(42);
+        await Assert.That(innerProducer.FastPathCalls).IsEqualTo(1);
+        await Assert.That(innerProducer.MessageCalls).IsEqualTo(0);
+        await Assert.That(innerProducer.CapturedTopic).IsEqualTo("my-topic");
+        await Assert.That(innerProducer.CapturedKey).IsEqualTo("key");
+        await Assert.That(innerProducer.CapturedValue).IsEqualTo("value");
+        await Assert.That(innerProducer.CapturedHeaders).IsNull();
+        await Assert.That(innerProducer.CapturedPartition).IsEqualTo(2);
     }
 
     [Test]
@@ -155,6 +192,35 @@ public class TopicProducerTests
                 m.Partition == 1 &&
                 m.Timestamp == timestamp),
             Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ProduceAsync_WithTopicProducerMessage_UsesInnerFastPath_WhenAvailable()
+    {
+        var innerProducer = new FastPathProducerSpy<string, string>();
+        var topicProducer = new TopicProducer<string, string>(innerProducer, "my-topic", ownsProducer: false);
+        var headers = Headers.Create("header-key", "header-value");
+        var timestamp = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var message = new TopicProducerMessage<string, string>
+        {
+            Key = "key",
+            Value = "value",
+            Headers = headers,
+            Partition = 1,
+            Timestamp = timestamp
+        };
+
+        var result = await topicProducer.ProduceAsync(message);
+
+        await Assert.That(result.Offset).IsEqualTo(42);
+        await Assert.That(innerProducer.FastPathCalls).IsEqualTo(1);
+        await Assert.That(innerProducer.MessageCalls).IsEqualTo(0);
+        await Assert.That(innerProducer.CapturedTopic).IsEqualTo("my-topic");
+        await Assert.That(innerProducer.CapturedKey).IsEqualTo("key");
+        await Assert.That(innerProducer.CapturedValue).IsEqualTo("value");
+        await Assert.That(innerProducer.CapturedHeaders).IsSameReferenceAs(headers);
+        await Assert.That(innerProducer.CapturedPartition).IsEqualTo(1);
+        await Assert.That(innerProducer.CapturedTimestamp).IsEqualTo(timestamp);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add an internal parameterized produce fast path so awaited topic/key/value calls skip ProducerMessage allocation when retry/interceptors/tracing are inactive
- route topic producer and producer extension convenience overloads through the same fast path for real KafkaProducer instances
- cover direct hot-path produce and wrapper routing with brokerless unit tests

Closes #916

## Verification
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --disable-logo --no-ansi --no-progress --treenode-filter "/*/Dekaf.Tests.Unit.Producer/KafkaProducerFastPathTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --disable-logo --no-ansi --no-progress --treenode-filter "/*/Dekaf.Tests.Unit.Producer/ProducerExtensionsTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --disable-logo --no-ansi --no-progress --treenode-filter "/*/Dekaf.Tests.Unit.Producer/TopicProducerTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --disable-logo --no-ansi --no-progress --treenode-filter "/*/Dekaf.Tests.Unit.Producer/*/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --disable-logo --no-ansi --no-progress
- dotnet format --verify-no-changes --include src\Dekaf\Producer\KafkaProducer.cs src\Dekaf\Producer\IProducerFastPath.cs src\Dekaf\Producer\IKafkaProducer.cs src\Dekaf\Producer\ProducerExtensions.cs src\Dekaf\Producer\TopicProducer.cs tests\Dekaf.Tests.Unit\Producer\KafkaProducerFastPathTests.cs tests\Dekaf.Tests.Unit\Producer\ProducerExtensionsTests.cs tests\Dekaf.Tests.Unit\Producer\TopicProducerTests.cs tests\Dekaf.Tests.Unit\Producer\FastPathProducerSpy.cs
- dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false
- git diff --check
