### PR TITLE
perf(producer): drain tracked ready partitions

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -827,6 +827,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // thread. Entries survive after Drain re-enqueues partitions and are only cleared by the next
     // Ready() call. Breaking this ordering could cause duplicate re-enqueues.
     private readonly Dictionary<int, List<TopicPartition>> _readyPartitionsPerNode = new();
+    private readonly HashSet<TopicPartition> _readyPartitionDedup = new();
     private readonly Stack<List<TopicPartition>> _partitionListPool = new();
 
     // Coordination lock between FlushAsyncCore and ExpireLingerAsyncCore.
@@ -1119,6 +1120,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             _partitionListPool.Push(list);
         }
         _readyPartitionsPerNode.Clear();
+        _readyPartitionDedup.Clear();
 
         // Snapshot the current queue length to avoid infinite loop: partitions that need
         // re-enqueue (backoff, unknown leader) are added back during the loop, but we only
@@ -1202,7 +1204,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     : new List<TopicPartition>();
                 _readyPartitionsPerNode[leader.NodeId] = nodePartitions;
             }
-            nodePartitions.Add(tp);
+            if (_readyPartitionDedup.Add(tp))
+                nodePartitions.Add(tp);
         }
 
         // With push-based notifications, the sender wakes on SignalWakeup() from batch
@@ -1254,16 +1257,20 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int maxRequestSize,
         List<ReadyBatch> ready)
     {
-        var partitions = metadataManager.GetPartitionsForNode(nodeId);
+        var usingTrackedPartitions = _readyPartitionsPerNode.TryGetValue(nodeId, out var readyPartitionsForNode)
+            && readyPartitionsForNode.Count > 0;
+        IReadOnlyList<TopicPartition> partitions = usingTrackedPartitions
+            ? readyPartitionsForNode!
+            : metadataManager.GetPartitionsForNode(nodeId);
         if (partitions.Count == 0)
         {
             // Leader migrated between Ready() and Drain(). Re-enqueue only the specific
             // partitions that Ready() consumed for this node — O(k) where k is the number
             // of ready partitions for this node, not O(n) over all partition deques (#577).
-            if (_readyPartitionsPerNode.TryGetValue(nodeId, out var trackedPartitions))
+            if (_readyPartitionsPerNode.TryGetValue(nodeId, out var migratedPartitions))
             {
-                for (var j = 0; j < trackedPartitions.Count; j++)
-                    _readyPartitions.Enqueue(trackedPartitions[j]);
+                for (var j = 0; j < migratedPartitions.Count; j++)
+                    _readyPartitions.Enqueue(migratedPartitions[j]);
             }
             SignalWakeup();
             return;
@@ -1276,6 +1283,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var count = partitions.Count;
         var now = Stopwatch.GetTimestamp();
         var lastDrainIndex = startIndex;
+        var reenqueueLeaderChanges = false;
 
         for (var i = 0; i < count; i++)
         {
@@ -1283,6 +1291,19 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             var tp = partitions[idx];
 
             lastDrainIndex = (startIndex + i + 1) % count;
+
+            if (usingTrackedPartitions)
+            {
+                var currentLeader = metadataManager.TryGetCachedPartitionLeader(tp.Topic, tp.Partition);
+                if (currentLeader is null || currentLeader.NodeId != nodeId)
+                {
+                    // Ready() consumed this partition for nodeId, but leadership changed before
+                    // Drain(). Re-enqueue it so the next Ready() resolves the current leader.
+                    _readyPartitions.Enqueue(tp);
+                    reenqueueLeaderChanges = true;
+                    continue;
+                }
+            }
 
             if (_mutedPartitions.ContainsKey(tp))
                 continue;
@@ -1338,6 +1359,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
 
         _drainIndex[nodeId] = lastDrainIndex;
+        if (reenqueueLeaderChanges)
+            SignalWakeup();
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -783,6 +783,63 @@ public class RecordAccumulatorReadyTests
     }
 
     [Test]
+    public async Task Drain_PartialLeaderMigration_ReenqueuesTrackedPartition()
+    {
+        // Node 1 still owns another partition after migration, so the old full-node scan
+        // would not take the empty-node re-enqueue path and would orphan partition 0.
+        var options = CreateTestOptions(batchSize: 50);
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        var metadataManager = CreateMultiBrokerMetadataManager("test-topic",
+            [(0, 1), (1, 1), (2, 2)]);
+
+        try
+        {
+            var pooledKey = new PooledMemory(null, 0, isNull: true);
+            var pooledValue = new PooledMemory(null, 0, isNull: true);
+
+            for (var i = 0; i < 10; i++)
+            {
+                var completion = pool.Rent();
+                accumulator.TryAppendWithCompletion("test-topic", 0,
+                    DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    pooledKey, pooledValue, null, 0, completion);
+            }
+
+            var readyNodes = new HashSet<int>();
+            accumulator.Ready(metadataManager, readyNodes);
+            await Assert.That(readyNodes).Contains(1);
+
+            var migratedManager = CreateMultiBrokerMetadataManager("test-topic",
+                [(0, 2), (1, 1), (2, 2)]);
+
+            var drainResult = new Dictionary<int, List<ReadyBatch>>();
+            var batchListPool = new Stack<List<ReadyBatch>>();
+            accumulator.Drain(migratedManager, readyNodes, int.MaxValue, drainResult, batchListPool);
+
+            await Assert.That(drainResult.ContainsKey(1)).IsFalse();
+
+            var readyNodes2 = new HashSet<int>();
+            accumulator.Ready(migratedManager, readyNodes2);
+            await Assert.That(readyNodes2).Contains(2);
+
+            var drainResult2 = new Dictionary<int, List<ReadyBatch>>();
+            accumulator.Drain(migratedManager, readyNodes2, int.MaxValue, drainResult2, batchListPool);
+            await Assert.That(drainResult2).ContainsKey(2);
+            await Assert.That(drainResult2[2].Count).IsEqualTo(1);
+
+            await migratedManager.DisposeAsync();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task Drain_LeaderMigration_MultipleCycles_NoPartitionLoss()
     {
         // Verifies that repeated leader migration cycles don't lose partition notifications.


### PR DESCRIPTION
## Summary
- drain broker batches from the partitions consumed by Ready() instead of scanning every partition led by the node
- de-duplicate ready partition tracking so duplicate notifications still drain one batch per partition per cycle
- re-enqueue tracked partitions whose leader changes between Ready() and Drain(), including partial leader migration cases

Closes #914

## Verification
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --disable-logo --no-ansi --no-progress --treenode-filter "/*/Dekaf.Tests.Unit.Producer/RecordAccumulatorReadyTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --disable-logo --no-ansi --no-progress --treenode-filter "/*/Dekaf.Tests.Unit.Producer/*/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --disable-logo --no-ansi --no-progress
- dotnet format --verify-no-changes --include src\Dekaf\Producer\RecordAccumulator.cs tests\Dekaf.Tests.Unit\Producer\RecordAccumulatorReadyTests.cs
- dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false
- git diff --check
