### PR TITLE
perf(schemaregistry): cache serializer subjects

### DIFF
--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -41,13 +41,12 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     private readonly AvroSerializerConfig _config;
     private readonly bool _ownsClient;
     private readonly ConcurrentDictionary<string, Lazy<Task<int>>> _schemaIdCache = new();
-    private readonly ConcurrentDictionary<SubjectCacheKey, SubjectSchemaIdCacheEntry> _subjectSchemaIdCache = new();
+    private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
     private readonly ConcurrentDictionary<AvroSchema, GenericDatumWriter<GenericRecord>> _genericWriters =
         new(AvroSchemaReferenceComparer.Instance);
     private readonly ConcurrentDictionary<AvroSchema, SpecificDefaultWriter> _specificWriters =
         new(AvroSchemaReferenceComparer.Instance);
     private readonly AvroSchema? _writerSchema;
-    private SubjectSchemaIdCacheEntry? _lastSubjectSchemaId;
 
     /// <summary>
     /// Creates a new Avro Schema Registry serializer.
@@ -143,30 +142,17 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     }
 
     private int GetSchemaIdForContext(string topic, bool isKey, T value)
-    {
-        var last = _lastSubjectSchemaId;
-        if (last is not null && last.Matches(topic, isKey))
-            return last.SchemaId;
-
-        var key = new SubjectCacheKey(topic, isKey);
-        if (_subjectSchemaIdCache.TryGetValue(key, out var cached))
-        {
-            _lastSubjectSchemaId = cached;
-            return cached.SchemaId;
-        }
-
-        var subject = GetSubjectName(topic, isKey);
-        var schemaId = GetSchemaIdCached(subject, value);
-        return CacheSubjectSchemaId(topic, isKey, schemaId);
-    }
+        => _subjectSchemaIdCache.GetOrAdd(
+            topic,
+            isKey,
+            new SubjectSchemaIdState(this, value),
+            static (state, topic, isKey) => state.Serializer.GetSubjectName(topic, isKey),
+            static (state, subject) => state.Serializer.GetSchemaIdCached(subject, state.Value));
 
     private int CacheSubjectSchemaId(string topic, bool isKey, int schemaId)
-    {
-        var entry = new SubjectSchemaIdCacheEntry(topic, isKey, schemaId);
-        _subjectSchemaIdCache[new SubjectCacheKey(topic, isKey)] = entry;
-        _lastSubjectSchemaId = entry;
-        return schemaId;
-    }
+        => _subjectSchemaIdCache.Cache(topic, isKey, schemaId);
+
+    private readonly record struct SubjectSchemaIdState(AvroSchemaRegistrySerializer<T> Serializer, T Value);
 
     private void WriteAvroValue(T value, BinaryEncoder encoder)
     {
@@ -328,14 +314,6 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         }
 
         return typeof(T).FullName ?? typeof(T).Name;
-    }
-
-    private readonly record struct SubjectCacheKey(string Topic, bool IsKey);
-
-    private sealed record SubjectSchemaIdCacheEntry(string Topic, bool IsKey, int SchemaId)
-    {
-        public bool Matches(string topic, bool isKey) =>
-            IsKey == isKey && string.Equals(Topic, topic, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -41,11 +41,13 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     private readonly AvroSerializerConfig _config;
     private readonly bool _ownsClient;
     private readonly ConcurrentDictionary<string, Lazy<Task<int>>> _schemaIdCache = new();
+    private readonly ConcurrentDictionary<SubjectCacheKey, SubjectSchemaIdCacheEntry> _subjectSchemaIdCache = new();
     private readonly ConcurrentDictionary<AvroSchema, GenericDatumWriter<GenericRecord>> _genericWriters =
         new(AvroSchemaReferenceComparer.Instance);
     private readonly ConcurrentDictionary<AvroSchema, SpecificDefaultWriter> _specificWriters =
         new(AvroSchemaReferenceComparer.Instance);
     private readonly AvroSchema? _writerSchema;
+    private SubjectSchemaIdCacheEntry? _lastSubjectSchemaId;
 
     /// <summary>
     /// Creates a new Avro Schema Registry serializer.
@@ -86,7 +88,9 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     {
         ArgumentNullException.ThrowIfNull(value);
         var subject = GetSubjectName(topic, isKey);
-        return await GetOrFetchSchemaIdAsync(subject, value, cancellationToken).ConfigureAwait(false);
+        var schemaId = await GetOrFetchSchemaIdAsync(subject, value, cancellationToken).ConfigureAwait(false);
+        CacheSubjectSchemaId(topic, isKey, schemaId);
+        return schemaId;
     }
 
     /// <summary>
@@ -104,8 +108,7 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     {
         ArgumentNullException.ThrowIfNull(value);
 
-        var subject = GetSubjectName(context.Topic, context.Component == SerializationComponent.Key);
-        var schemaId = GetSchemaIdCached(subject, value);
+        var schemaId = GetSchemaIdForContext(context.Topic, context.Component == SerializationComponent.Key, value);
 
         var codecState = AvroCodecThreadStateCache.Serialization ??= new AvroSerializationThreadState();
         var memoryStream = codecState.Stream;
@@ -137,6 +140,32 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
             memoryStream.DetachBuffer();
             ArrayPool<byte>.Shared.Return(rentedBuffer);
         }
+    }
+
+    private int GetSchemaIdForContext(string topic, bool isKey, T value)
+    {
+        var last = _lastSubjectSchemaId;
+        if (last is not null && last.Matches(topic, isKey))
+            return last.SchemaId;
+
+        var key = new SubjectCacheKey(topic, isKey);
+        if (_subjectSchemaIdCache.TryGetValue(key, out var cached))
+        {
+            _lastSubjectSchemaId = cached;
+            return cached.SchemaId;
+        }
+
+        var subject = GetSubjectName(topic, isKey);
+        var schemaId = GetSchemaIdCached(subject, value);
+        return CacheSubjectSchemaId(topic, isKey, schemaId);
+    }
+
+    private int CacheSubjectSchemaId(string topic, bool isKey, int schemaId)
+    {
+        var entry = new SubjectSchemaIdCacheEntry(topic, isKey, schemaId);
+        _subjectSchemaIdCache[new SubjectCacheKey(topic, isKey)] = entry;
+        _lastSubjectSchemaId = entry;
+        return schemaId;
     }
 
     private void WriteAvroValue(T value, BinaryEncoder encoder)
@@ -299,6 +328,14 @@ public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         }
 
         return typeof(T).FullName ?? typeof(T).Name;
+    }
+
+    private readonly record struct SubjectCacheKey(string Topic, bool IsKey);
+
+    private sealed record SubjectSchemaIdCacheEntry(string Topic, bool IsKey, int SchemaId)
+    {
+        public bool Matches(string topic, bool isKey) =>
+            IsKey == isKey && string.Equals(Topic, topic, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -33,10 +33,9 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
     private readonly bool _ownsClient;
     private readonly MessageDescriptor _descriptor;
     private readonly ConcurrentDictionary<string, int> _schemaIdCache = new();
-    private readonly ConcurrentDictionary<SubjectCacheKey, SubjectSchemaIdCacheEntry> _subjectSchemaIdCache = new();
+    private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
     private readonly Schema _schema;
     private readonly byte[] _encodedMessageIndexes;
-    private SubjectSchemaIdCacheEntry? _lastSubjectSchemaId;
 
     /// <summary>
     /// Creates a new Protobuf Schema Registry serializer.
@@ -103,25 +102,12 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
     }
 
     private int GetSchemaIdForContext(string topic, bool isKey)
-    {
-        var last = _lastSubjectSchemaId;
-        if (last is not null && last.Matches(topic, isKey))
-            return last.SchemaId;
-
-        var key = new SubjectCacheKey(topic, isKey);
-        if (_subjectSchemaIdCache.TryGetValue(key, out var cached))
-        {
-            _lastSubjectSchemaId = cached;
-            return cached.SchemaId;
-        }
-
-        var subject = GetSubjectName(topic, isKey);
-        var schemaId = GetSchemaIdSync(subject);
-        var entry = new SubjectSchemaIdCacheEntry(topic, isKey, schemaId);
-        _subjectSchemaIdCache[key] = entry;
-        _lastSubjectSchemaId = entry;
-        return schemaId;
-    }
+        => _subjectSchemaIdCache.GetOrAdd(
+            topic,
+            isKey,
+            this,
+            static (serializer, topic, isKey) => serializer.GetSubjectName(topic, isKey),
+            static (serializer, subject) => serializer.GetSchemaIdSync(subject));
 
     private int GetSchemaIdSync(string subject)
     {
@@ -168,14 +154,6 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
             SubjectNameStrategy.TopicRecordName => $"{topic}-{_descriptor.FullName}{suffix}",
             _ => topic + suffix
         };
-    }
-
-    private readonly record struct SubjectCacheKey(string Topic, bool IsKey);
-
-    private sealed record SubjectSchemaIdCacheEntry(string Topic, bool IsKey, int SchemaId)
-    {
-        public bool Matches(string topic, bool isKey) =>
-            IsKey == isKey && string.Equals(Topic, topic, StringComparison.Ordinal);
     }
 
     private static MessageDescriptor GetMessageDescriptor()

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -33,8 +33,10 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
     private readonly bool _ownsClient;
     private readonly MessageDescriptor _descriptor;
     private readonly ConcurrentDictionary<string, int> _schemaIdCache = new();
+    private readonly ConcurrentDictionary<SubjectCacheKey, SubjectSchemaIdCacheEntry> _subjectSchemaIdCache = new();
     private readonly Schema _schema;
     private readonly byte[] _encodedMessageIndexes;
+    private SubjectSchemaIdCacheEntry? _lastSubjectSchemaId;
 
     /// <summary>
     /// Creates a new Protobuf Schema Registry serializer.
@@ -74,8 +76,7 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
     {
         ArgumentNullException.ThrowIfNull(value);
 
-        var subject = GetSubjectName(context.Topic, context.Component == SerializationComponent.Key);
-        var schemaId = GetSchemaIdSync(subject);
+        var schemaId = GetSchemaIdForContext(context.Topic, context.Component == SerializationComponent.Key);
 
         // Serialize the protobuf message to bytes using ToByteArray() for compatibility
         // with both generated and hand-coded messages
@@ -99,6 +100,27 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
         protoBytes.AsSpan().CopyTo(span.Slice(offset));
 
         destination.Advance(totalSize);
+    }
+
+    private int GetSchemaIdForContext(string topic, bool isKey)
+    {
+        var last = _lastSubjectSchemaId;
+        if (last is not null && last.Matches(topic, isKey))
+            return last.SchemaId;
+
+        var key = new SubjectCacheKey(topic, isKey);
+        if (_subjectSchemaIdCache.TryGetValue(key, out var cached))
+        {
+            _lastSubjectSchemaId = cached;
+            return cached.SchemaId;
+        }
+
+        var subject = GetSubjectName(topic, isKey);
+        var schemaId = GetSchemaIdSync(subject);
+        var entry = new SubjectSchemaIdCacheEntry(topic, isKey, schemaId);
+        _subjectSchemaIdCache[key] = entry;
+        _lastSubjectSchemaId = entry;
+        return schemaId;
     }
 
     private int GetSchemaIdSync(string subject)
@@ -146,6 +168,14 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
             SubjectNameStrategy.TopicRecordName => $"{topic}-{_descriptor.FullName}{suffix}",
             _ => topic + suffix
         };
+    }
+
+    private readonly record struct SubjectCacheKey(string Topic, bool IsKey);
+
+    private sealed record SubjectSchemaIdCacheEntry(string Topic, bool IsKey, int SchemaId)
+    {
+        public bool Matches(string topic, bool isKey) =>
+            IsKey == isKey && string.Equals(Topic, topic, StringComparison.Ordinal);
     }
 
     private static MessageDescriptor GetMessageDescriptor()

--- a/src/Dekaf.SchemaRegistry/Dekaf.SchemaRegistry.csproj
+++ b/src/Dekaf.SchemaRegistry/Dekaf.SchemaRegistry.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Dekaf.Tests.Unit" />
+    <InternalsVisibleTo Include="Dekaf.SchemaRegistry.Avro" />
     <InternalsVisibleTo Include="Dekaf.SchemaRegistry.Protobuf" />
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
   </ItemGroup>

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Concurrent;
 using System.Text.Json;
 using Dekaf.Serialization;
 
@@ -35,6 +36,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
 
     private int _cachedSchemaId = -1;
     private string? _cachedSubject;
+    private readonly ConcurrentDictionary<SubjectCacheKey, SubjectSchemaIdCacheEntry> _subjectSchemaIdCache = new();
+    private SubjectSchemaIdCacheEntry? _lastSubjectSchemaId;
 
     /// <summary>
     /// Creates a new JSON Schema Registry serializer.
@@ -103,10 +106,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
     {
-        var subject = GetSubjectName(context.Topic, context.Component == SerializationComponent.Key);
-
-        // Get or register schema ID (cached after first call per subject)
-        var schemaId = GetSchemaIdSync(subject);
+        var schemaId = GetSchemaIdForContext(context.Topic, context.Component == SerializationComponent.Key);
 
         // Serialize to JSON
         var jsonBytes = JsonSerializer.SerializeToUtf8Bytes(value, _jsonOptions);
@@ -120,6 +120,27 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         jsonBytes.AsSpan().CopyTo(span.Slice(5));
 
         destination.Advance(totalSize);
+    }
+
+    private int GetSchemaIdForContext(string topic, bool isKey)
+    {
+        var last = _lastSubjectSchemaId;
+        if (last is not null && last.Matches(topic, isKey))
+            return last.SchemaId;
+
+        var key = new SubjectCacheKey(topic, isKey);
+        if (_subjectSchemaIdCache.TryGetValue(key, out var cached))
+        {
+            _lastSubjectSchemaId = cached;
+            return cached.SchemaId;
+        }
+
+        var subject = GetSubjectName(topic, isKey);
+        var schemaId = GetSchemaIdSync(subject);
+        var entry = new SubjectSchemaIdCacheEntry(topic, isKey, schemaId);
+        _subjectSchemaIdCache[key] = entry;
+        _lastSubjectSchemaId = entry;
+        return schemaId;
     }
 
     private int GetSchemaIdSync(string subject)
@@ -155,6 +176,14 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
             SubjectNameStrategy.TopicRecordName => $"{topic}-{typeof(T).FullName}{suffix}",
             _ => topic + suffix
         };
+    }
+
+    private readonly record struct SubjectCacheKey(string Topic, bool IsKey);
+
+    private sealed record SubjectSchemaIdCacheEntry(string Topic, bool IsKey, int SchemaId)
+    {
+        public bool Matches(string topic, bool isKey) =>
+            IsKey == isKey && string.Equals(Topic, topic, StringComparison.Ordinal);
     }
 
     public ValueTask DisposeAsync()

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -34,10 +34,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     private readonly Schema _schema;
     private readonly bool _ownsClient;
 
-    private int _cachedSchemaId = -1;
-    private string? _cachedSubject;
-    private readonly ConcurrentDictionary<SubjectCacheKey, SubjectSchemaIdCacheEntry> _subjectSchemaIdCache = new();
-    private SubjectSchemaIdCacheEntry? _lastSubjectSchemaId;
+    private readonly ConcurrentDictionary<string, int> _schemaIdCache = new();
+    private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
 
     /// <summary>
     /// Creates a new JSON Schema Registry serializer.
@@ -123,42 +121,26 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     }
 
     private int GetSchemaIdForContext(string topic, bool isKey)
-    {
-        var last = _lastSubjectSchemaId;
-        if (last is not null && last.Matches(topic, isKey))
-            return last.SchemaId;
-
-        var key = new SubjectCacheKey(topic, isKey);
-        if (_subjectSchemaIdCache.TryGetValue(key, out var cached))
-        {
-            _lastSubjectSchemaId = cached;
-            return cached.SchemaId;
-        }
-
-        var subject = GetSubjectName(topic, isKey);
-        var schemaId = GetSchemaIdSync(subject);
-        var entry = new SubjectSchemaIdCacheEntry(topic, isKey, schemaId);
-        _subjectSchemaIdCache[key] = entry;
-        _lastSubjectSchemaId = entry;
-        return schemaId;
-    }
+        => _subjectSchemaIdCache.GetOrAdd(
+            topic,
+            isKey,
+            this,
+            static (serializer, topic, isKey) => serializer.GetSubjectName(topic, isKey),
+            static (serializer, subject) => serializer.GetSchemaIdSync(subject));
 
     private int GetSchemaIdSync(string subject)
     {
-        if (_cachedSchemaId >= 0 && _cachedSubject == subject)
-            return _cachedSchemaId;
+        if (_schemaIdCache.TryGetValue(subject, out var cachedId))
+            return cachedId;
 
         var task = _autoRegisterSchemas
             ? _schemaRegistry.GetOrRegisterSchemaAsync(subject, _schema)
-            : _schemaRegistry.GetSchemaBySubjectAsync(subject).ContinueWith(t => t.Result.Id, TaskScheduler.Default);
+            : _schemaRegistry.GetSchemaBySubjectAsync(subject).ContinueWith(
+                static t => t.GetAwaiter().GetResult().Id, TaskScheduler.Default);
 
         // Add timeout to prevent indefinite blocking
         var id = task.WaitAsync(SchemaRegistryTimeout).ConfigureAwait(false).GetAwaiter().GetResult();
-
-        _cachedSchemaId = id;
-        _cachedSubject = subject;
-
-        return id;
+        return _schemaIdCache.GetOrAdd(subject, id);
     }
 
     private string GetSubjectName(string topic, bool isKey)
@@ -176,14 +158,6 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
             SubjectNameStrategy.TopicRecordName => $"{topic}-{typeof(T).FullName}{suffix}",
             _ => topic + suffix
         };
-    }
-
-    private readonly record struct SubjectCacheKey(string Topic, bool IsKey);
-
-    private sealed record SubjectSchemaIdCacheEntry(string Topic, bool IsKey, int SchemaId)
-    {
-        public bool Matches(string topic, bool isKey) =>
-            IsKey == isKey && string.Equals(Topic, topic, StringComparison.Ordinal);
     }
 
     public ValueTask DisposeAsync()

--- a/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
@@ -40,8 +40,7 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     private readonly bool _ownsClient;
 
     private readonly ConcurrentDictionary<string, int> _schemaIdCache = new();
-    private readonly ConcurrentDictionary<SubjectCacheKey, SubjectSchemaIdCacheEntry> _subjectSchemaIdCache = new();
-    private SubjectSchemaIdCacheEntry? _lastSubjectSchemaId;
+    private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
 
     /// <summary>
     /// Creates a new Schema Registry serializer.
@@ -117,26 +116,16 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     }
 
     private int GetSchemaIdForContext(string topic, bool isKey)
-    {
-        var last = _lastSubjectSchemaId;
-        if (last is not null && last.Matches(topic, isKey))
-            return last.SchemaId;
-
-        var key = new SubjectCacheKey(topic, isKey);
-        if (_subjectSchemaIdCache.TryGetValue(key, out var cached))
-        {
-            _lastSubjectSchemaId = cached;
-            return cached.SchemaId;
-        }
-
-        var subject = GetSubjectName(topic, isKey);
-        var schema = _getSchema(subject);
-        var schemaId = GetSchemaIdSync(subject, schema);
-        var entry = new SubjectSchemaIdCacheEntry(topic, isKey, schemaId);
-        _subjectSchemaIdCache[key] = entry;
-        _lastSubjectSchemaId = entry;
-        return schemaId;
-    }
+        => _subjectSchemaIdCache.GetOrAdd(
+            topic,
+            isKey,
+            this,
+            static (serializer, topic, isKey) => serializer.GetSubjectName(topic, isKey),
+            static (serializer, subject) =>
+            {
+                var schema = serializer._getSchema(subject);
+                return serializer.GetSchemaIdSync(subject, schema);
+            });
 
     private int GetSchemaIdSync(string subject, Schema schema)
     {
@@ -169,14 +158,6 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
             SubjectNameStrategy.TopicRecordName => $"{topic}-{typeof(T).FullName}{suffix}",
             _ => topic + suffix
         };
-    }
-
-    private readonly record struct SubjectCacheKey(string Topic, bool IsKey);
-
-    private sealed record SubjectSchemaIdCacheEntry(string Topic, bool IsKey, int SchemaId)
-    {
-        public bool Matches(string topic, bool isKey) =>
-            IsKey == isKey && string.Equals(Topic, topic, StringComparison.Ordinal);
     }
 
     public ValueTask DisposeAsync()

--- a/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
@@ -40,6 +40,8 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     private readonly bool _ownsClient;
 
     private readonly ConcurrentDictionary<string, int> _schemaIdCache = new();
+    private readonly ConcurrentDictionary<SubjectCacheKey, SubjectSchemaIdCacheEntry> _subjectSchemaIdCache = new();
+    private SubjectSchemaIdCacheEntry? _lastSubjectSchemaId;
 
     /// <summary>
     /// Creates a new Schema Registry serializer.
@@ -94,11 +96,7 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
     {
-        var subject = GetSubjectName(context.Topic, context.Component == SerializationComponent.Key);
-        var schema = _getSchema(subject);
-
-        // Get or register schema ID (cached after first call per subject)
-        var schemaId = GetSchemaIdSync(subject, schema);
+        var schemaId = GetSchemaIdForContext(context.Topic, context.Component == SerializationComponent.Key);
 
         var payloadBuffer = SchemaRegistryBuffers.PayloadBuffer ??= new ArrayBufferWriter<byte>(initialCapacity: 4096);
         payloadBuffer.ResetWrittenCount();
@@ -116,6 +114,28 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         payloadBuffer.WrittenSpan.CopyTo(span.Slice(5));
 
         destination.Advance(totalSize);
+    }
+
+    private int GetSchemaIdForContext(string topic, bool isKey)
+    {
+        var last = _lastSubjectSchemaId;
+        if (last is not null && last.Matches(topic, isKey))
+            return last.SchemaId;
+
+        var key = new SubjectCacheKey(topic, isKey);
+        if (_subjectSchemaIdCache.TryGetValue(key, out var cached))
+        {
+            _lastSubjectSchemaId = cached;
+            return cached.SchemaId;
+        }
+
+        var subject = GetSubjectName(topic, isKey);
+        var schema = _getSchema(subject);
+        var schemaId = GetSchemaIdSync(subject, schema);
+        var entry = new SubjectSchemaIdCacheEntry(topic, isKey, schemaId);
+        _subjectSchemaIdCache[key] = entry;
+        _lastSubjectSchemaId = entry;
+        return schemaId;
     }
 
     private int GetSchemaIdSync(string subject, Schema schema)
@@ -149,6 +169,14 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
             SubjectNameStrategy.TopicRecordName => $"{topic}-{typeof(T).FullName}{suffix}",
             _ => topic + suffix
         };
+    }
+
+    private readonly record struct SubjectCacheKey(string Topic, bool IsKey);
+
+    private sealed record SubjectSchemaIdCacheEntry(string Topic, bool IsKey, int SchemaId)
+    {
+        public bool Matches(string topic, bool isKey) =>
+            IsKey == isKey && string.Equals(Topic, topic, StringComparison.Ordinal);
     }
 
     public ValueTask DisposeAsync()

--- a/src/Dekaf.SchemaRegistry/SubjectSchemaIdCache.cs
+++ b/src/Dekaf.SchemaRegistry/SubjectSchemaIdCache.cs
@@ -1,0 +1,91 @@
+using System.Collections.Concurrent;
+
+namespace Dekaf.SchemaRegistry;
+
+internal sealed class SubjectSchemaIdCache
+{
+    // Match CachingStringKeyDeserializer: fixed topic sets stay cached,
+    // dynamic topic names cannot grow without bound.
+    internal const int MaxCachedEntries = 16_384;
+
+    private readonly ConcurrentDictionary<SubjectSchemaIdCacheKey, SubjectSchemaIdCacheEntry> _cache = new();
+    private int _cacheCount;
+    private SubjectSchemaIdCacheEntry? _last;
+
+    internal int CachedEntryCount => Volatile.Read(ref _cacheCount);
+
+    public int GetOrAdd<TState>(
+        string topic,
+        bool isKey,
+        TState state,
+        Func<TState, string, bool, string> getSubjectName,
+        Func<TState, string, int> getSchemaId)
+    {
+        var key = new SubjectSchemaIdCacheKey(topic, isKey);
+        var last = Volatile.Read(ref _last);
+        if (last is not null && last.Key.Equals(key))
+            return last.SchemaId;
+
+        if (_cache.TryGetValue(key, out var cached))
+        {
+            Volatile.Write(ref _last, cached);
+            return cached.SchemaId;
+        }
+
+        var subject = getSubjectName(state, topic, isKey);
+        var schemaId = getSchemaId(state, subject);
+        return Cache(key, schemaId);
+    }
+
+    public int Cache(string topic, bool isKey, int schemaId) =>
+        Cache(new SubjectSchemaIdCacheKey(topic, isKey), schemaId);
+
+    private int Cache(SubjectSchemaIdCacheKey key, int schemaId)
+    {
+        if (_cache.TryGetValue(key, out var existing))
+        {
+            Volatile.Write(ref _last, existing);
+            return existing.SchemaId;
+        }
+
+        var entry = new SubjectSchemaIdCacheEntry(key, schemaId);
+        if (!TryReserveSlot())
+        {
+            Volatile.Write(ref _last, entry);
+            return schemaId;
+        }
+
+        if (_cache.TryAdd(key, entry))
+        {
+            Volatile.Write(ref _last, entry);
+            return schemaId;
+        }
+
+        Interlocked.Decrement(ref _cacheCount);
+        if (_cache.TryGetValue(key, out existing))
+        {
+            Volatile.Write(ref _last, existing);
+            return existing.SchemaId;
+        }
+
+        Volatile.Write(ref _last, entry);
+        return schemaId;
+    }
+
+    private bool TryReserveSlot()
+    {
+        while (true)
+        {
+            var count = Volatile.Read(ref _cacheCount);
+            if (count >= MaxCachedEntries)
+                return false;
+
+            if (Interlocked.CompareExchange(ref _cacheCount, count + 1, count) == count)
+                return true;
+        }
+    }
+
+    private readonly record struct SubjectSchemaIdCacheKey(string Topic, bool IsKey);
+
+    private sealed record SubjectSchemaIdCacheEntry(SubjectSchemaIdCacheKey Key, int SchemaId);
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
@@ -21,7 +21,8 @@ public sealed class SchemaRegistryCacheTests
     private sealed class CountingSchemaRegistryClient : ISchemaRegistryClient
     {
         private readonly ConcurrentDictionary<string, int> _callCounts = new();
-        private int _nextId = 1;
+        private readonly ConcurrentDictionary<string, int> _idsBySubject = new();
+        private int _nextId;
 
         /// <summary>
         /// Returns the number of times GetOrRegisterSchemaAsync was called for a given subject.
@@ -34,10 +35,13 @@ public sealed class SchemaRegistryCacheTests
         /// </summary>
         public int TotalCallCount => _callCounts.Values.Sum();
 
+        public int GetSchemaId(string subject) =>
+            _idsBySubject[subject];
+
         public Task<int> GetOrRegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default)
         {
             _callCounts.AddOrUpdate(subject, 1, static (_, count) => count + 1);
-            var id = Interlocked.Increment(ref _nextId);
+            var id = _idsBySubject.GetOrAdd(subject, static (_, state) => Interlocked.Increment(ref state._nextId), this);
             return Task.FromResult(id);
         }
 
@@ -118,6 +122,24 @@ public sealed class SchemaRegistryCacheTests
             Topic = topic,
             Component = isKey ? SerializationComponent.Key : SerializationComponent.Value
         };
+
+    [Test]
+    public async Task SubjectSchemaIdCache_StopsAddingEntriesAtMaxCachedEntries()
+    {
+        var cache = new SubjectSchemaIdCache();
+
+        for (var i = 0; i < SubjectSchemaIdCache.MaxCachedEntries + 10; i++)
+        {
+            _ = cache.GetOrAdd(
+                $"topic-{i}",
+                isKey: false,
+                state: 0,
+                static (_, topic, isKey) => topic + (isKey ? "-key" : "-value"),
+                static (_, subject) => subject.Length);
+        }
+
+        await Assert.That(cache.CachedEntryCount).IsEqualTo(SubjectSchemaIdCache.MaxCachedEntries);
+    }
 
     [Test]
     public async Task Serializer_CachesSchemaId_AcrossMultipleSubjects()
@@ -215,6 +237,38 @@ public sealed class SchemaRegistryCacheTests
 
         await Assert.That(strategy.CallCount).IsEqualTo(1);
         await Assert.That(registry.GetCallCount("topic-value")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task JsonSerializer_UsesCorrectSchemaId_ConcurrentlyAcrossTopics()
+    {
+        var registry = new CountingSchemaRegistryClient();
+
+        await using var serializer = new JsonSchemaRegistrySerializer<string>(
+            registry,
+            """{ "type": "string" }""");
+
+        var topics = Enumerable.Range(0, 32)
+            .Select(static i => $"topic-{i}")
+            .ToArray();
+        var results = new ConcurrentBag<(string Topic, int SchemaId)>();
+
+        Parallel.For(0, 4096, i =>
+        {
+            var topic = topics[i % topics.Length];
+            var buffer = new ArrayBufferWriter<byte>();
+
+            serializer.Serialize($"msg-{i}", ref buffer, CreateContext(topic));
+
+            var schemaId = BinaryPrimitives.ReadInt32BigEndian(buffer.WrittenSpan.Slice(1, 4));
+            results.Add((topic, schemaId));
+        });
+
+        foreach (var result in results)
+        {
+            var expectedSchemaId = registry.GetSchemaId(result.Topic + "-value");
+            await Assert.That(result.SchemaId).IsEqualTo(expectedSchemaId);
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
@@ -1,11 +1,15 @@
 using System.Buffers;
-using System.Collections.Concurrent;
 using System.Buffers.Binary;
+using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using Avro.Generic;
 using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Avro;
+using Dekaf.SchemaRegistry.Protobuf;
 using Dekaf.Serialization;
+using AvroSchema = Avro.Schema;
 
 namespace Dekaf.Tests.Unit.SchemaRegistry;
 
@@ -95,6 +99,26 @@ public sealed class SchemaRegistryCacheTests
         public void Dispose() { }
     }
 
+    private sealed class CountingSubjectNameStrategy : ISubjectNameStrategy
+    {
+        private int _callCount;
+
+        public int CallCount => _callCount;
+
+        public string GetSubjectName(string topic, string? recordType, bool isKey)
+        {
+            Interlocked.Increment(ref _callCount);
+            return $"{topic}-{(isKey ? "key" : "value")}";
+        }
+    }
+
+    private static SerializationContext CreateContext(string topic = "topic", bool isKey = false) =>
+        new()
+        {
+            Topic = topic,
+            Component = isKey ? SerializationComponent.Key : SerializationComponent.Value
+        };
+
     [Test]
     public async Task Serializer_CachesSchemaId_AcrossMultipleSubjects()
     {
@@ -132,6 +156,105 @@ public sealed class SchemaRegistryCacheTests
         await Assert.That(registry.GetCallCount("topic-a-value")).IsEqualTo(1);
         await Assert.That(registry.GetCallCount("topic-b-value")).IsEqualTo(1);
         await Assert.That(registry.TotalCallCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Serializer_CachesSubjectAndSchemaId_ForSameContext()
+    {
+        var registry = new CountingSchemaRegistryClient();
+        var strategy = new CountingSubjectNameStrategy();
+        var schema = new Schema { SchemaType = SchemaType.Json, SchemaString = """{ "type": "string" }""" };
+        var schemaFactoryCalls = 0;
+
+        await using var serializer = new SchemaRegistrySerializer<string>(
+            registry,
+            serialize: static (value, writer) =>
+            {
+                var byteCount = Encoding.UTF8.GetByteCount(value);
+                Encoding.UTF8.GetBytes(value, writer.GetSpan(byteCount));
+                writer.Advance(byteCount);
+            },
+            getSchema: _ =>
+            {
+                schemaFactoryCalls++;
+                return schema;
+            },
+            customSubjectNameStrategy: strategy);
+
+        var context = CreateContext();
+
+        var buffer1 = new ArrayBufferWriter<byte>();
+        serializer.Serialize("msg-1", ref buffer1, context);
+
+        var buffer2 = new ArrayBufferWriter<byte>();
+        serializer.Serialize("msg-2", ref buffer2, context);
+
+        await Assert.That(strategy.CallCount).IsEqualTo(1);
+        await Assert.That(schemaFactoryCalls).IsEqualTo(1);
+        await Assert.That(registry.GetCallCount("topic-value")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task JsonSerializer_CachesSubjectAndSchemaId_ForSameContext()
+    {
+        var registry = new CountingSchemaRegistryClient();
+        var strategy = new CountingSubjectNameStrategy();
+
+        await using var serializer = new JsonSchemaRegistrySerializer<string>(
+            registry,
+            """{ "type": "string" }""",
+            strategy);
+
+        var context = CreateContext();
+
+        var buffer1 = new ArrayBufferWriter<byte>();
+        serializer.Serialize("msg-1", ref buffer1, context);
+
+        var buffer2 = new ArrayBufferWriter<byte>();
+        serializer.Serialize("msg-2", ref buffer2, context);
+
+        await Assert.That(strategy.CallCount).IsEqualTo(1);
+        await Assert.That(registry.GetCallCount("topic-value")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task AvroSerializer_CachesSubjectAndSchemaId_ForSameContext()
+    {
+        var registry = new CountingSchemaRegistryClient();
+        var strategy = new CountingSubjectNameStrategy();
+        var config = new AvroSerializerConfig { CustomSubjectNameStrategy = strategy };
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(registry, config);
+        var record = CreateAvroRecord();
+        var context = CreateContext();
+
+        var buffer1 = new ArrayBufferWriter<byte>();
+        serializer.Serialize(record, ref buffer1, context);
+
+        var buffer2 = new ArrayBufferWriter<byte>();
+        serializer.Serialize(record, ref buffer2, context);
+
+        await Assert.That(strategy.CallCount).IsEqualTo(1);
+        await Assert.That(registry.GetCallCount("topic-value")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ProtobufSerializer_CachesSubjectAndSchemaId_ForSameContext()
+    {
+        var registry = new CountingSchemaRegistryClient();
+        var strategy = new CountingSubjectNameStrategy();
+        var config = new ProtobufSerializerConfig { CustomSubjectNameStrategy = strategy };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(registry, config);
+        var message = new TestMessage { Id = 1, Name = "Test", Value = 3.14 };
+        var context = CreateContext();
+
+        var buffer1 = new ArrayBufferWriter<byte>();
+        serializer.Serialize(message, ref buffer1, context);
+
+        var buffer2 = new ArrayBufferWriter<byte>();
+        serializer.Serialize(message, ref buffer2, context);
+
+        await Assert.That(strategy.CallCount).IsEqualTo(1);
+        await Assert.That(registry.GetCallCount("topic-value")).IsEqualTo(1);
     }
 
     [Test]
@@ -263,4 +386,23 @@ public sealed class SchemaRegistryCacheTests
         SchemaType = SchemaType.Json,
         SchemaString = $$"""{ "type": "string", "title": "schema-{{id}}" }"""
     };
+
+    private static GenericRecord CreateAvroRecord()
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse("""
+            {
+                "type": "record",
+                "name": "SimpleRecord",
+                "namespace": "test",
+                "fields": [
+                    { "name": "id", "type": "int" },
+                    { "name": "name", "type": "string" }
+                ]
+            }
+            """);
+        var record = new GenericRecord(schema);
+        record.Add("id", 1);
+        record.Add("name", "test");
+        return record;
+    }
 }


### PR DESCRIPTION
## Summary
- cache resolved subject/schema-id entries per `(topic,isKey)` across Schema Registry serializers
- keep an immutable last-entry fast path before the per-topic dictionary for repeat sends
- add cache regression coverage for base, JSON, Avro, and Protobuf serializers

Fixes #908

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.SchemaRegistry/*/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe`
- `dotnet format --verify-no-changes --include src\Dekaf.SchemaRegistry\SchemaRegistrySerializer.cs src\Dekaf.SchemaRegistry\JsonSchemaSerializer.cs src\Dekaf.SchemaRegistry.Avro\AvroSchemaRegistrySerializer.cs src\Dekaf.SchemaRegistry.Protobuf\ProtobufSchemaRegistrySerializer.cs tests\Dekaf.Tests.Unit\SchemaRegistry\SchemaRegistryCacheTests.cs`
- `git diff --check`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release`