### PR TITLE
fix(networking): delay connected state until ready

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -184,6 +184,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
     private CancellationTokenSource? _receiveCts;
     private OAuthBearerTokenProvider? _ownedTokenProvider;
     private int _disposed;
+    private int _connected;
     private readonly SemaphoreSlim _connectLock = new(1, 1);
 
     // SASL re-authentication (KIP-368)
@@ -205,7 +206,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
     public int BrokerId { get; private set; } = -1;
     public string Host => _host;
     public int Port => _port;
-    public bool IsConnected => Volatile.Read(ref _disposed) == 0 && (_socket?.Connected ?? false) && _stream is not null;
+    public bool IsConnected => Volatile.Read(ref _disposed) == 0 && Volatile.Read(ref _connected) != 0 && (_socket?.Connected ?? false);
 
     /// <summary>
     /// Gets the current SASL session state, if SASL authentication was performed.
@@ -465,6 +466,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
         _receiveCts = new CancellationTokenSource();
         _receiveTask = ReceiveLoopAsync(_receiveCts.Token);
+        Volatile.Write(ref _connected, 1);
 
         LogConnected(_host, _port);
     }
@@ -2205,6 +2207,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
+        Volatile.Write(ref _connected, 0);
         var pendingRequestSlotOperationsDrained = ClosePendingRequestSlotsAsync();
         CancelPendingRequestSlotWaiters();
 

--- a/tests/Dekaf.Tests.Integration/ProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTests.cs
@@ -346,7 +346,7 @@ public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
     }
 
     [Test]
-    public async Task Producer_WithStickyPartitioner_DistributesMessages()
+    public async Task Producer_WithStickyPartitioner_SticksMessagesBeforeBatchCompletes()
     {
         // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 3);
@@ -355,10 +355,11 @@ public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithClientId("test-producer-sticky")
             .WithPartitioner(PartitionerType.Sticky)
+            .WithLinger(TimeSpan.FromSeconds(5))
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        // Act - produce messages without keys (should use sticky partitioner)
+        // Act - produce null-key messages while linger keeps the current batch open.
         var tasks = new List<ValueTask<RecordMetadata>>();
         for (var i = 0; i < 10; i++)
         {
@@ -376,11 +377,10 @@ public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
             results.Add(await task);
         }
 
-        // Assert - all messages should go to same partition (sticky)
+        // Assert - all messages choose the same sticky partition before batch completion.
         await Assert.That(results).Count().IsEqualTo(10);
         var partitions = results.Select(r => r.Partition).Distinct().ToList();
-        // With sticky partitioner and quick produces, should mostly go to same partition
-        await Assert.That(partitions.Count).IsLessThanOrEqualTo(2);
+        await Assert.That(partitions.Count).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -1,6 +1,7 @@
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using Dekaf.Networking;
 using Dekaf.Protocol.Messages;
 
@@ -160,7 +161,35 @@ public sealed class KafkaConnectionTests
 
     [Test]
     [Timeout(10_000)]
-    public async Task ConnectAsync_DoesNotAllocateRetainedRequestWriter(CancellationToken cancellationToken)
+    public async Task IsConnected_StreamAssignedBeforeConnectionReady_ReturnsFalse(CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            using var clientSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            var acceptTask = listener.AcceptSocketAsync(cancellationToken);
+            await clientSocket.ConnectAsync(IPAddress.Loopback, port, cancellationToken);
+            using var serverSocket = await acceptTask.ConfigureAwait(false);
+            await using var stream = new NetworkStream(clientSocket, ownsSocket: false);
+            await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
+
+            SetPrivateField(connection, "_socket", clientSocket);
+            SetPrivateField(connection, "_stream", stream);
+
+            await Assert.That(connection.IsConnected).IsFalse();
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task ConnectAsync_AfterPipeSetup_IsConnectedTrue(CancellationToken cancellationToken)
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();
@@ -174,11 +203,7 @@ public sealed class KafkaConnectionTests
             await connection.ConnectAsync(cancellationToken);
             using var serverClient = await acceptTask.ConfigureAwait(false);
 
-            var writerField = typeof(KafkaConnection).GetField(
-                "_writer",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-
-            await Assert.That(writerField?.GetValue(connection)).IsNull();
+            await Assert.That(connection.IsConnected).IsTrue();
         }
         finally
         {
@@ -251,5 +276,14 @@ public sealed class KafkaConnectionTests
 
         // All concurrent disposals should complete without throwing
         await Task.WhenAll(tasks);
+    }
+
+    private static void SetPrivateField<T>(KafkaConnection connection, string name, T value)
+    {
+        var field = typeof(KafkaConnection).GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+        if (field is null)
+            throw new InvalidOperationException($"Field '{name}' was not found.");
+
+        field.SetValue(connection, value);
     }
 }


### PR DESCRIPTION
## Summary
- gate `KafkaConnection.IsConnected` on an explicit ready flag set only after SASL, pipe setup, and receive loop startup complete
- clear ready flag during disposal
- replace vacuous deleted-field reflection test with coverage for the stream-before-ready window plus a connected-after-setup assertion

Fixes review feedback from #980.

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaConnectionTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe`
- `dotnet format --verify-no-changes --include src\Dekaf\Networking\KafkaConnection.cs tests\Dekaf.Tests.Unit\Networking\KafkaConnectionTests.cs`
- `git diff --check`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release`