### PR TITLE
perf(schemaregistry): write payloads directly

### DIFF
--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -77,12 +77,10 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
 
         var schemaId = GetSchemaIdForContext(context.Topic, context.Component == SerializationComponent.Key);
 
-        // Serialize the protobuf message to bytes using ToByteArray() for compatibility
-        // with both generated and hand-coded messages
-        var protoBytes = value.ToByteArray();
+        var protoSize = value.CalculateSize();
 
         // Total size: magic byte + schema ID + indexes + message
-        var totalSize = 1 + 4 + _encodedMessageIndexes.Length + protoBytes.Length;
+        var totalSize = 1 + 4 + _encodedMessageIndexes.Length + protoSize;
         var span = destination.GetSpan(totalSize);
 
         // Write magic byte
@@ -96,7 +94,7 @@ public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsync
         offset += _encodedMessageIndexes.Length;
 
         // Write the protobuf message
-        protoBytes.AsSpan().CopyTo(span.Slice(offset));
+        value.WriteTo(span.Slice(offset, protoSize));
 
         destination.Advance(totalSize);
     }

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -26,6 +26,9 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     private const byte MagicByte = 0x00;
     private static readonly TimeSpan SchemaRegistryTimeout = TimeSpan.FromSeconds(30);
 
+    [ThreadStatic]
+    private static Utf8JsonWriter? t_jsonWriter;
+
     private readonly ISchemaRegistryClient _schemaRegistry;
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly SubjectNameStrategy _subjectNameStrategy;
@@ -106,18 +109,46 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     {
         var schemaId = GetSchemaIdForContext(context.Topic, context.Component == SerializationComponent.Key);
 
-        // Serialize to JSON
-        var jsonBytes = JsonSerializer.SerializeToUtf8Bytes(value, _jsonOptions);
+        var payloadBuffer = SchemaRegistryBuffers.PayloadBuffer ??= new ArrayBufferWriter<byte>(initialCapacity: 4096);
+        payloadBuffer.ResetWrittenCount();
+
+        var jsonWriter = t_jsonWriter;
+        if (jsonWriter is null)
+        {
+            jsonWriter = new Utf8JsonWriter(payloadBuffer);
+            t_jsonWriter = jsonWriter;
+        }
+        else
+        {
+            jsonWriter.Reset(payloadBuffer);
+        }
+
+        try
+        {
+            JsonSerializer.Serialize(jsonWriter, value, _jsonOptions);
+            jsonWriter.Flush();
+        }
+        catch
+        {
+            t_jsonWriter = null;
+            throw;
+        }
 
         // Write wire format: [0x00] [schema ID] [JSON payload]
-        var totalSize = 1 + 4 + jsonBytes.Length;
+        var totalSize = 1 + 4 + payloadBuffer.WrittenCount;
         var span = destination.GetSpan(totalSize);
 
         span[0] = MagicByte;
         BinaryPrimitives.WriteInt32BigEndian(span.Slice(1, 4), schemaId);
-        jsonBytes.AsSpan().CopyTo(span.Slice(5));
+        payloadBuffer.WrittenSpan.CopyTo(span.Slice(5));
 
         destination.Advance(totalSize);
+
+        if (payloadBuffer.Capacity > 1024 * 1024)
+        {
+            SchemaRegistryBuffers.PayloadBuffer = null;
+            t_jsonWriter = null;
+        }
     }
 
     private int GetSchemaIdForContext(string topic, bool isKey)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -81,6 +81,20 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await _metadataManager.DisposeAsync();
     }
 
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var timeoutMs = (long)timeout.TotalMilliseconds;
+        var start = Environment.TickCount64;
+
+        while (!condition())
+        {
+            if (Environment.TickCount64 - start >= timeoutMs)
+                throw new TimeoutException("Condition was not reached before the timeout.");
+
+            await Task.Delay(10);
+        }
+    }
+
     private static ConsumerOptions CreateConsumerProtocolOptions(
         string groupId = "test-group",
         IRebalanceListener? rebalanceListener = null,
@@ -567,15 +581,17 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 100);
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
         var topics = new HashSet<string> { "test-topic" };
+        var timeout = TimeSpan.FromSeconds(30);
 
         // Initial join succeeds (epoch=5)
         await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
         await Assert.That(coordinator.GenerationId).IsEqualTo(5);
 
         // Wait for heartbeat loop to process the fencing response (deterministic signal)
-        await fencingProcessed.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        // Brief yield to let the heartbeat loop complete its state transition after the mock returns
-        await Task.Delay(50);
+        await fencingProcessed.Task.WaitAsync(timeout);
+        await WaitUntilAsync(
+            () => coordinator.State == CoordinatorState.Unjoined && coordinator.GenerationId == 0,
+            timeout);
 
         await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
         // With fix: _generationId reset to 0 by fencing handler (not stale 5)
@@ -646,15 +662,17 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         var options = CreateConsumerProtocolOptions(groupInstanceId: "static-1", heartbeatIntervalMs: 100);
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
         var topics = new HashSet<string> { "test-topic" };
+        var timeout = TimeSpan.FromSeconds(30);
 
         // Initial join succeeds (epoch=3)
         await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
         await Assert.That(coordinator.GenerationId).IsEqualTo(3);
 
         // Wait for heartbeat loop to process the fencing response (deterministic signal)
-        await fencingProcessed.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        // Brief yield to let the heartbeat loop complete its state transition after the mock returns
-        await Task.Delay(50);
+        await fencingProcessed.Task.WaitAsync(timeout);
+        await WaitUntilAsync(
+            () => coordinator.State == CoordinatorState.Unjoined && coordinator.GenerationId == -2,
+            timeout);
 
         await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
         // With fix: _generationId reset to -2 for static member (triggers MemberEpoch=-2 on rejoin)

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -117,24 +117,31 @@ public class MpscFetchBufferTests
         var first = CreateDummy("topic", 0);
         await Assert.That(buffer.TryWrite(first)).IsTrue();
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        // Generous outer budget: waiter completion depends on thread-pool scheduling of the
+        // SemaphoreSlim continuations, which can lag on a starved CI runner. All waits below
+        // bound on this single token rather than shorter fixed delays that flake under load.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var waiter1 = buffer.WaitToWriteAsync(cts.Token).AsTask();
         var waiter2 = buffer.WaitToWriteAsync(cts.Token).AsTask();
 
-        await WaitUntilAsync(() => buffer.ProducerWaiterCount == 2, TimeSpan.FromSeconds(5));
+        await WaitUntilAsync(() => buffer.ProducerWaiterCount == 2, TimeSpan.FromSeconds(10));
 
         await Assert.That(buffer.TryRead(out var readFirst)).IsTrue();
         readFirst!.Dispose();
 
-        var firstReleased = await Task.WhenAny(waiter1, waiter2, Task.Delay(TimeSpan.FromSeconds(5), cts.Token));
-        await Assert.That(firstReleased == waiter1 || firstReleased == waiter2).IsTrue();
+        var firstReleased = await Task.WhenAny(waiter1, waiter2).WaitAsync(cts.Token);
+        await Assert.That(firstReleased.IsCompletedSuccessfully).IsTrue();
+        var completedWaiterCount =
+            (waiter1.IsCompletedSuccessfully ? 1 : 0) +
+            (waiter2.IsCompletedSuccessfully ? 1 : 0);
+        await Assert.That(completedWaiterCount).IsEqualTo(1);
 
         var second = CreateDummy("topic", 1);
         await Assert.That(buffer.TryWrite(second)).IsTrue();
         await Assert.That(buffer.TryRead(out var readSecond)).IsTrue();
         readSecond!.Dispose();
 
-        await Task.WhenAll(waiter1, waiter2).WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+        await Task.WhenAll(waiter1, waiter2).WaitAsync(cts.Token);
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
@@ -346,7 +346,7 @@ public sealed class SchemaRegistryCacheTests
         var actualPayload = written.AsSpan(5).ToArray();
 
         await Assert.That(written[0]).IsEqualTo((byte)0);
-        await Assert.That(schemaId).IsEqualTo(2);
+        await Assert.That(schemaId).IsEqualTo(registry.GetSchemaId("topic-value"));
 
         var expectedPayload = JsonSerializer.SerializeToUtf8Bytes(payload, CamelCaseJsonOptions);
         await Assert.That(actualPayload).IsEquivalentTo(expectedPayload);

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
@@ -15,6 +15,11 @@ namespace Dekaf.Tests.Unit.SchemaRegistry;
 
 public sealed class SchemaRegistryCacheTests
 {
+    private static readonly JsonSerializerOptions CamelCaseJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
     /// <summary>
     /// A mock registry client that counts how many times GetOrRegisterSchemaAsync is called per subject.
     /// </summary>
@@ -140,6 +145,8 @@ public sealed class SchemaRegistryCacheTests
 
         await Assert.That(cache.CachedEntryCount).IsEqualTo(SubjectSchemaIdCache.MaxCachedEntries);
     }
+
+    private sealed record JsonPayload(int Id, string Name);
 
     [Test]
     public async Task Serializer_CachesSchemaId_AcrossMultipleSubjects()
@@ -308,6 +315,41 @@ public sealed class SchemaRegistryCacheTests
         serializer.Serialize(message, ref buffer2, context);
 
         await Assert.That(strategy.CallCount).IsEqualTo(1);
+        await Assert.That(registry.GetCallCount("topic-value")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task JsonSerializer_WritesCorrectWireFormat()
+    {
+        var registry = new CountingSchemaRegistryClient();
+        await using var serializer = new JsonSchemaRegistrySerializer<JsonPayload>(
+            registry,
+            """
+            {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer" },
+                    "name": { "type": "string" }
+                }
+            }
+            """);
+        var payload = new JsonPayload(7, "Test");
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(
+            payload,
+            ref buffer,
+            new SerializationContext { Topic = "topic", Component = SerializationComponent.Value });
+
+        var written = buffer.WrittenMemory.ToArray();
+        var schemaId = BinaryPrimitives.ReadInt32BigEndian(written.AsSpan(1, 4));
+        var actualPayload = written.AsSpan(5).ToArray();
+
+        await Assert.That(written[0]).IsEqualTo((byte)0);
+        await Assert.That(schemaId).IsEqualTo(2);
+
+        var expectedPayload = JsonSerializer.SerializeToUtf8Bytes(payload, CamelCaseJsonOptions);
+        await Assert.That(actualPayload).IsEquivalentTo(expectedPayload);
         await Assert.That(registry.GetCallCount("topic-value")).IsEqualTo(1);
     }
 


### PR DESCRIPTION
## Summary
- reuse the Schema Registry payload buffer and Utf8JsonWriter for JSON serialization instead of allocating a payload byte[] per message
- write Protobuf payloads directly into the final wire-format span using CalculateSize/WriteTo
- add JSON wire-format coverage to protect the reusable writer path

Closes #907

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.SchemaRegistry/*/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe`
- `dotnet format --verify-no-changes --include src\Dekaf.SchemaRegistry\JsonSchemaSerializer.cs src\Dekaf.SchemaRegistry.Protobuf\ProtobufSchemaRegistrySerializer.cs tests\Dekaf.Tests.Unit\SchemaRegistry\SchemaRegistryCacheTests.cs`
- `git diff --check HEAD~1..HEAD`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release`