### PR TITLE
perf(networking): use fixed pending table

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -161,10 +161,11 @@ public sealed partial class KafkaConnection : IKafkaConnection
     // Cap on _cancelledCorrelationIds to prevent unbounded growth when brokers
     // silently drop responses for timed-out requests.
     private const int MaxCancelledCorrelationIds = 10_000;
+    private const int PendingRequestShardCount = 16;
     private const int MinimumResponseFrameSize = 4; // Correlation ID is always first in the response header.
     private static int s_globalCorrelationId;
-    private readonly PendingRequestSlot[] _pendingRequests;
-    private readonly object _pendingRequestsLock = new();
+    private readonly PendingRequestShard[] _pendingRequestShards;
+    private readonly SemaphoreSlim _pendingRequestSlots;
     private readonly ConcurrentDictionary<int, byte> _cancelledCorrelationIds = new();
     private readonly PendingRequestPool _pendingRequestPool;
     private readonly CancellationTokenSourcePool _timeoutCtsPool;
@@ -213,28 +214,15 @@ public sealed partial class KafkaConnection : IKafkaConnection
         public short Version { get; } = version;
     }
 
-    private struct PendingRequestSlot
+    private sealed class PendingRequestShard
     {
-        public int CorrelationId;
-        public PooledPendingRequest? Request;
-        public short Version;
-        public bool IsOccupied;
-
-        public void Set(int correlationId, PooledPendingRequest request)
+        public PendingRequestShard(int capacity)
         {
-            CorrelationId = correlationId;
-            Request = request;
-            Version = request.Version;
-            IsOccupied = true;
+            Requests = new Dictionary<int, PendingRequestEntry>(capacity);
         }
 
-        public void Clear()
-        {
-            CorrelationId = 0;
-            Request = null;
-            Version = 0;
-            IsOccupied = false;
-        }
+        public object Gate { get; } = new();
+        public Dictionary<int, PendingRequestEntry> Requests { get; }
     }
 
     public KafkaConnection(
@@ -266,7 +254,8 @@ public sealed partial class KafkaConnection : IKafkaConnection
         _clientId = clientId;
         _options = options ?? new ConnectionOptions();
         var connectionSizes = PoolSizing.ForConnection(_options.MaxInFlightRequestsPerConnection);
-        _pendingRequests = new PendingRequestSlot[connectionSizes.PendingRequests];
+        _pendingRequestShards = CreatePendingRequestShards(connectionSizes.PendingRequests);
+        _pendingRequestSlots = new SemaphoreSlim(connectionSizes.PendingRequests, connectionSizes.PendingRequests);
         _pendingRequestPool = new PendingRequestPool(connectionSizes.PendingRequests);
         _timeoutCtsPool = new CancellationTokenSourcePool(connectionSizes.CancellationTokenSources);
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaConnection>.Instance;
@@ -315,6 +304,22 @@ public sealed partial class KafkaConnection : IKafkaConnection
         BrokerId = brokerId;
         _sharedPipeMemoryPool = sharedPipeMemoryPool;
     }
+
+    private static PendingRequestShard[] CreatePendingRequestShards(int capacity)
+    {
+        var shardCount = Math.Min(PendingRequestShardCount, capacity);
+        var capacityPerShard = Math.Max(1, (capacity + shardCount - 1) / shardCount);
+        var shards = new PendingRequestShard[shardCount];
+
+        for (var i = 0; i < shards.Length; i++)
+            shards[i] = new PendingRequestShard(capacityPerShard);
+
+        return shards;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private PendingRequestShard GetPendingRequestShard(int correlationId)
+        => _pendingRequestShards[(int)((uint)correlationId % (uint)_pendingRequestShards.Length)];
 
     public async ValueTask ConnectAsync(CancellationToken cancellationToken = default)
     {
@@ -476,6 +481,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
         var responseHeaderVersion = TRequest.GetResponseHeaderVersion(apiVersion);
 
+        await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
         var pending = _pendingRequestPool.Rent();
         pending.Initialize(responseHeaderVersion, cancellationToken, registerCancellation: false);
         try
@@ -484,6 +490,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         }
         catch
         {
+            ReleasePendingRequestSlot();
             _pendingRequestPool.Return(pending);
             throw;
         }
@@ -617,6 +624,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
         var responseHeaderVersion = TRequest.GetResponseHeaderVersion(apiVersion);
 
+        await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
         var pending = _pendingRequestPool.Rent();
         pending.Initialize(responseHeaderVersion, cancellationToken, registerCancellation: false);
         try
@@ -625,6 +633,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         }
         catch
         {
+            ReleasePendingRequestSlot();
             _pendingRequestPool.Return(pending);
             throw;
         }
@@ -1131,92 +1140,72 @@ public sealed partial class KafkaConnection : IKafkaConnection
         }
     }
 
+    private ValueTask ReservePendingRequestSlotAsync(CancellationToken cancellationToken)
+    {
+        if (_pendingRequestSlots.Wait(0, cancellationToken))
+            return ValueTask.CompletedTask;
+
+        return ReservePendingRequestSlotSlowAsync(cancellationToken);
+    }
+
+    private async ValueTask ReservePendingRequestSlotSlowAsync(CancellationToken cancellationToken)
+    {
+        await _pendingRequestSlots.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private void ReleasePendingRequestSlot()
+    {
+        _pendingRequestSlots.Release();
+    }
+
+    private void ReleasePendingRequestSlots(int count)
+    {
+        if (count > 0)
+            _pendingRequestSlots.Release(count);
+    }
+
     private void AddPendingRequest(int correlationId, PooledPendingRequest request)
     {
-        lock (_pendingRequestsLock)
+        var shard = GetPendingRequestShard(correlationId);
+        lock (shard.Gate)
         {
-            var start = GetPendingRequestStartIndex(correlationId);
-            for (var i = 0; i < _pendingRequests.Length; i++)
-            {
-                var index = (start + i) % _pendingRequests.Length;
-                ref var slot = ref _pendingRequests[index];
-
-                if (!slot.IsOccupied)
-                {
-                    slot.Set(correlationId, request);
-                    return;
-                }
-
-                if (slot.CorrelationId == correlationId)
-                    throw new InvalidOperationException($"Duplicate pending request correlation id {correlationId}.");
-            }
+            if (!shard.Requests.TryAdd(correlationId, new PendingRequestEntry(request, request.Version)))
+                throw new InvalidOperationException($"Duplicate pending request correlation id {correlationId}.");
         }
-
-        throw new KafkaException(
-            $"Pending request table is full on connection to broker {BrokerId}. Max capacity is {_pendingRequests.Length}.");
     }
 
     private bool TryGetPendingRequest(int correlationId, out PendingRequestEntry entry)
     {
-        lock (_pendingRequestsLock)
+        var shard = GetPendingRequestShard(correlationId);
+        lock (shard.Gate)
         {
-            if (TryFindPendingRequestSlot(correlationId, out var index))
-            {
-                var slot = _pendingRequests[index];
-                entry = new PendingRequestEntry(slot.Request!, slot.Version);
-                return true;
-            }
+            return shard.Requests.TryGetValue(correlationId, out entry);
         }
-
-        entry = default;
-        return false;
     }
 
     private bool TryRemovePendingRequest(int correlationId, out PendingRequestEntry entry)
     {
-        lock (_pendingRequestsLock)
+        bool removed;
+        var shard = GetPendingRequestShard(correlationId);
+        lock (shard.Gate)
         {
-            if (TryFindPendingRequestSlot(correlationId, out var index))
-            {
-                var slot = _pendingRequests[index];
-                entry = new PendingRequestEntry(slot.Request!, slot.Version);
-                _pendingRequests[index].Clear();
-                return true;
-            }
+            removed = shard.Requests.Remove(correlationId, out entry);
         }
 
-        entry = default;
-        return false;
+        if (removed)
+            ReleasePendingRequestSlot();
+
+        return removed;
     }
-
-    private bool TryFindPendingRequestSlot(int correlationId, out int index)
-    {
-        for (var i = 0; i < _pendingRequests.Length; i++)
-        {
-            if (_pendingRequests[i].IsOccupied && _pendingRequests[i].CorrelationId == correlationId)
-            {
-                index = i;
-                return true;
-            }
-        }
-
-        index = -1;
-        return false;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int GetPendingRequestStartIndex(int correlationId)
-        => (int)((uint)correlationId % (uint)_pendingRequests.Length);
 
     private int GetPendingRequestCount()
     {
         var count = 0;
-        lock (_pendingRequestsLock)
+        foreach (var shard in _pendingRequestShards)
         {
-            for (var i = 0; i < _pendingRequests.Length; i++)
+            lock (shard.Gate)
             {
-                if (_pendingRequests[i].IsOccupied)
-                    count++;
+                count += shard.Requests.Count;
             }
         }
 
@@ -1366,31 +1355,34 @@ public sealed partial class KafkaConnection : IKafkaConnection
         // If we remove here, the awaiter can't find the request in the table,
         // so it never returns it to the pool — causing a pool leak that forces
         // constant allocation of new PooledPendingRequest objects.
-        lock (_pendingRequestsLock)
+        foreach (var shard in _pendingRequestShards)
         {
-            for (var i = 0; i < _pendingRequests.Length; i++)
+            lock (shard.Gate)
             {
-                var slot = _pendingRequests[i];
-                if (slot.IsOccupied)
-                    slot.Request!.TrySetException(slot.Version, ex);
+                foreach (var slot in shard.Requests.Values)
+                    slot.Request.TrySetException(slot.Version, ex);
             }
         }
     }
 
     private void ReturnAllPendingRequestsToPool()
     {
-        lock (_pendingRequestsLock)
+        var releasedSlots = 0;
+        foreach (var shard in _pendingRequestShards)
         {
-            for (var i = 0; i < _pendingRequests.Length; i++)
+            lock (shard.Gate)
             {
-                var request = _pendingRequests[i].Request;
-                if (request is null)
-                    continue;
+                foreach (var slot in shard.Requests.Values)
+                {
+                    _pendingRequestPool.Return(slot.Request);
+                    releasedSlots++;
+                }
 
-                _pendingRequests[i].Clear();
-                _pendingRequestPool.Return(request);
+                shard.Requests.Clear();
             }
         }
+
+        ReleasePendingRequestSlots(releasedSlots);
     }
 
     private SslClientAuthenticationOptions BuildSslClientAuthenticationOptions()
@@ -2180,6 +2172,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         // cleaned up by a continuation since none was registered.
         ReturnAllPendingRequestsToPool();
 
+        _pendingRequestSlots.Dispose();
         _cancelledCorrelationIds.Clear();
     }
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -163,7 +163,8 @@ public sealed partial class KafkaConnection : IKafkaConnection
     private const int MaxCancelledCorrelationIds = 10_000;
     private const int MinimumResponseFrameSize = 4; // Correlation ID is always first in the response header.
     private static int s_globalCorrelationId;
-    private readonly ConcurrentDictionary<int, PendingRequestEntry> _pendingRequests = new();
+    private readonly PendingRequestSlot[] _pendingRequests;
+    private readonly object _pendingRequestsLock = new();
     private readonly ConcurrentDictionary<int, byte> _cancelledCorrelationIds = new();
     private readonly PendingRequestPool _pendingRequestPool;
     private readonly CancellationTokenSourcePool _timeoutCtsPool;
@@ -212,6 +213,30 @@ public sealed partial class KafkaConnection : IKafkaConnection
         public short Version { get; } = version;
     }
 
+    private struct PendingRequestSlot
+    {
+        public int CorrelationId;
+        public PooledPendingRequest? Request;
+        public short Version;
+        public bool IsOccupied;
+
+        public void Set(int correlationId, PooledPendingRequest request)
+        {
+            CorrelationId = correlationId;
+            Request = request;
+            Version = request.Version;
+            IsOccupied = true;
+        }
+
+        public void Clear()
+        {
+            CorrelationId = 0;
+            Request = null;
+            Version = 0;
+            IsOccupied = false;
+        }
+    }
+
     public KafkaConnection(
         string host,
         int port,
@@ -241,6 +266,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         _clientId = clientId;
         _options = options ?? new ConnectionOptions();
         var connectionSizes = PoolSizing.ForConnection(_options.MaxInFlightRequestsPerConnection);
+        _pendingRequests = new PendingRequestSlot[connectionSizes.PendingRequests];
         _pendingRequestPool = new PendingRequestPool(connectionSizes.PendingRequests);
         _timeoutCtsPool = new CancellationTokenSourcePool(connectionSizes.CancellationTokenSources);
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaConnection>.Instance;
@@ -452,7 +478,15 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
         var pending = _pendingRequestPool.Rent();
         pending.Initialize(responseHeaderVersion, cancellationToken, registerCancellation: false);
-        _pendingRequests[correlationId] = new PendingRequestEntry(pending, pending.Version);
+        try
+        {
+            AddPendingRequest(correlationId, pending);
+        }
+        catch
+        {
+            _pendingRequestPool.Return(pending);
+            throw;
+        }
 
         ThrowIfDisposedAfterAddingPendingRequest(correlationId);
 
@@ -475,7 +509,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
             // Clean up pending request on any failure (write lock cancelled, write failed,
             // or response error). AwaitAndParseResponseAsync has its own finally that also
             // tries TryRemove — the second attempt harmlessly returns false.
-            if (_pendingRequests.TryRemove(correlationId, out var removed))
+            if (TryRemovePendingRequest(correlationId, out var removed))
             {
                 _pendingRequestPool.Return(removed.Request);
             }
@@ -585,7 +619,15 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
         var pending = _pendingRequestPool.Rent();
         pending.Initialize(responseHeaderVersion, cancellationToken, registerCancellation: false);
-        _pendingRequests[correlationId] = new PendingRequestEntry(pending, pending.Version);
+        try
+        {
+            AddPendingRequest(correlationId, pending);
+        }
+        catch
+        {
+            _pendingRequestPool.Return(pending);
+            throw;
+        }
 
         ThrowIfDisposedAfterAddingPendingRequest(correlationId);
 
@@ -601,7 +643,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         catch
         {
             // On failure, ensure we clean up the pending request
-            if (_pendingRequests.TryRemove(correlationId, out var removed))
+            if (TryRemovePendingRequest(correlationId, out var removed))
             {
                 _pendingRequestPool.Return(removed.Request);
             }
@@ -716,7 +758,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         }
         finally
         {
-            if (_pendingRequests.TryRemove(correlationId, out var removed))
+            if (TryRemovePendingRequest(correlationId, out var removed))
             {
                 _pendingRequestPool.Return(removed.Request);
 
@@ -1070,7 +1112,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
     {
         LogReceivedResponse(correlationId, responseData.Length);
 
-        if (_pendingRequests.TryGetValue(correlationId, out var pending))
+        if (TryGetPendingRequest(correlationId, out var pending))
         {
             if (!pending.Request.TryComplete(pending.Version, responseData))
             {
@@ -1087,6 +1129,98 @@ public sealed partial class KafkaConnection : IKafkaConnection
             LogUnknownCorrelationId(correlationId);
             responseData.Dispose();
         }
+    }
+
+    private void AddPendingRequest(int correlationId, PooledPendingRequest request)
+    {
+        lock (_pendingRequestsLock)
+        {
+            var start = GetPendingRequestStartIndex(correlationId);
+            for (var i = 0; i < _pendingRequests.Length; i++)
+            {
+                var index = (start + i) % _pendingRequests.Length;
+                ref var slot = ref _pendingRequests[index];
+
+                if (!slot.IsOccupied)
+                {
+                    slot.Set(correlationId, request);
+                    return;
+                }
+
+                if (slot.CorrelationId == correlationId)
+                    throw new InvalidOperationException($"Duplicate pending request correlation id {correlationId}.");
+            }
+        }
+
+        throw new KafkaException(
+            $"Pending request table is full on connection to broker {BrokerId}. Max capacity is {_pendingRequests.Length}.");
+    }
+
+    private bool TryGetPendingRequest(int correlationId, out PendingRequestEntry entry)
+    {
+        lock (_pendingRequestsLock)
+        {
+            if (TryFindPendingRequestSlot(correlationId, out var index))
+            {
+                var slot = _pendingRequests[index];
+                entry = new PendingRequestEntry(slot.Request!, slot.Version);
+                return true;
+            }
+        }
+
+        entry = default;
+        return false;
+    }
+
+    private bool TryRemovePendingRequest(int correlationId, out PendingRequestEntry entry)
+    {
+        lock (_pendingRequestsLock)
+        {
+            if (TryFindPendingRequestSlot(correlationId, out var index))
+            {
+                var slot = _pendingRequests[index];
+                entry = new PendingRequestEntry(slot.Request!, slot.Version);
+                _pendingRequests[index].Clear();
+                return true;
+            }
+        }
+
+        entry = default;
+        return false;
+    }
+
+    private bool TryFindPendingRequestSlot(int correlationId, out int index)
+    {
+        for (var i = 0; i < _pendingRequests.Length; i++)
+        {
+            if (_pendingRequests[i].IsOccupied && _pendingRequests[i].CorrelationId == correlationId)
+            {
+                index = i;
+                return true;
+            }
+        }
+
+        index = -1;
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int GetPendingRequestStartIndex(int correlationId)
+        => (int)((uint)correlationId % (uint)_pendingRequests.Length);
+
+    private int GetPendingRequestCount()
+    {
+        var count = 0;
+        lock (_pendingRequestsLock)
+        {
+            for (var i = 0; i < _pendingRequests.Length; i++)
+            {
+                if (_pendingRequests[i].IsOccupied)
+                    count++;
+            }
+        }
+
+        return count;
     }
 
     private bool TryReadResponse(
@@ -1206,7 +1340,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
     {
         if (Volatile.Read(ref _disposed) != 0)
         {
-            if (_pendingRequests.TryRemove(correlationId, out var removed))
+            if (TryRemovePendingRequest(correlationId, out var removed))
             {
                 _pendingRequestPool.Return(removed.Request);
             }
@@ -1229,20 +1363,32 @@ public sealed partial class KafkaConnection : IKafkaConnection
         // AwaitAndParseResponseAsync (or the catch in SendAsync/SendPipelinedAsync)
         // will TryRemove and return the request to the pool.
         //
-        // If we remove here, the awaiter can't find the request in the dictionary,
+        // If we remove here, the awaiter can't find the request in the table,
         // so it never returns it to the pool — causing a pool leak that forces
         // constant allocation of new PooledPendingRequest objects.
-        //
-        // Iterate twice to handle the ConcurrentDictionary race: a request added
-        // by SendPipelinedAsync between the _disposed check and TryAdd may be missed
-        // by the first foreach (ConcurrentDictionary enumerators are not strict snapshots).
-        // The second pass catches late arrivals, since _disposed is already set by this
-        // point and prevents any NEW requests from being registered.
-        for (var pass = 0; pass < 2; pass++)
+        lock (_pendingRequestsLock)
         {
-            foreach (var kvp in _pendingRequests)
+            for (var i = 0; i < _pendingRequests.Length; i++)
             {
-                kvp.Value.Request.TrySetException(kvp.Value.Version, ex);
+                var slot = _pendingRequests[i];
+                if (slot.IsOccupied)
+                    slot.Request!.TrySetException(slot.Version, ex);
+            }
+        }
+    }
+
+    private void ReturnAllPendingRequestsToPool()
+    {
+        lock (_pendingRequestsLock)
+        {
+            for (var i = 0; i < _pendingRequests.Length; i++)
+            {
+                var request = _pendingRequests[i].Request;
+                if (request is null)
+                    continue;
+
+                _pendingRequests[i].Clear();
+                _pendingRequestPool.Return(request);
             }
         }
     }
@@ -1933,7 +2079,11 @@ public sealed partial class KafkaConnection : IKafkaConnection
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
-        LogConnectionDisposing(BrokerId, _pendingRequests.Count);
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            var pendingRequestCount = GetPendingRequestCount();
+            LogConnectionDisposing(BrokerId, pendingRequestCount);
+        }
 
         _receiveCts?.Cancel();
 
@@ -2028,13 +2178,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         // Sweep any remaining entries that had no awaiter (edge case: request registered
         // but cancelled before AwaitAndParseResponseAsync was entered). These won't be
         // cleaned up by a continuation since none was registered.
-        foreach (var kvp in _pendingRequests)
-        {
-            if (_pendingRequests.TryRemove(kvp.Key, out var orphaned))
-            {
-                _pendingRequestPool.Return(orphaned.Request);
-            }
-        }
+        ReturnAllPendingRequestsToPool();
 
         _cancelledCorrelationIds.Clear();
     }

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionPipelinedTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionPipelinedTests.cs
@@ -61,6 +61,18 @@ public sealed class KafkaConnectionPipelinedTests
     }
 
     [Test]
+    public async Task PendingRequests_UsesPreallocatedSlotTable()
+    {
+        var field = typeof(KafkaConnection).GetField(
+            "_pendingRequests",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        await Assert.That(field).IsNotNull();
+        await Assert.That(field!.FieldType.IsArray).IsTrue();
+        await Assert.That(field.FieldType.GetElementType()!.Name).IsEqualTo("PendingRequestSlot");
+    }
+
+    [Test]
     public async Task SendPipelinedAsync_Cancellation_Throws()
     {
         var connection = new KafkaConnection("localhost", 9092);

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionPipelinedTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionPipelinedTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using Dekaf.Internal;
 using Dekaf.Networking;
 using Dekaf.Protocol.Messages;
 
@@ -61,15 +63,28 @@ public sealed class KafkaConnectionPipelinedTests
     }
 
     [Test]
-    public async Task PendingRequests_UsesPreallocatedSlotTable()
+    public async Task PendingRequests_RemoveReleasesReservedSlot()
     {
-        var field = typeof(KafkaConnection).GetField(
-            "_pendingRequests",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var connection = new KafkaConnection("localhost", 9092);
+        var capacity = PoolSizing.ForConnection(maxInFlightRequestsPerConnection: 5).PendingRequests;
 
-        await Assert.That(field).IsNotNull();
-        await Assert.That(field!.FieldType.IsArray).IsTrue();
-        await Assert.That(field.FieldType.GetElementType()!.Name).IsEqualTo("PendingRequestSlot");
+        for (var i = 0; i < capacity; i++)
+        {
+            await ReservePendingRequestSlotAsync(connection);
+            var request = new PooledPendingRequest();
+            request.Initialize(responseHeaderVersion: 0, CancellationToken.None, registerCancellation: false);
+            AddPendingRequest(connection, i + 1, request);
+        }
+
+        var waitingForSlot = ReservePendingRequestSlotAsync(connection).AsTask();
+        await Task.Delay(50);
+        await Assert.That(waitingForSlot.IsCompleted).IsFalse();
+
+        await Assert.That(TryRemovePendingRequest(connection, correlationId: 1)).IsTrue();
+        await waitingForSlot.WaitAsync(TimeSpan.FromSeconds(1));
+        ReleasePendingRequestSlot(connection);
+
+        await connection.DisposeAsync();
     }
 
     [Test]
@@ -99,5 +114,39 @@ public sealed class KafkaConnectionPipelinedTests
             12);
 
         await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    private static async ValueTask ReservePendingRequestSlotAsync(KafkaConnection connection)
+    {
+        var method = typeof(KafkaConnection).GetMethod(
+            "ReservePendingRequestSlotAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var valueTask = (ValueTask)method.Invoke(connection, [CancellationToken.None])!;
+        await valueTask;
+    }
+
+    private static void ReleasePendingRequestSlot(KafkaConnection connection)
+    {
+        var method = typeof(KafkaConnection).GetMethod(
+            "ReleasePendingRequestSlot",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        method.Invoke(connection, []);
+    }
+
+    private static void AddPendingRequest(KafkaConnection connection, int correlationId, PooledPendingRequest request)
+    {
+        var method = typeof(KafkaConnection).GetMethod(
+            "AddPendingRequest",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        method.Invoke(connection, [correlationId, request]);
+    }
+
+    private static bool TryRemovePendingRequest(KafkaConnection connection, int correlationId)
+    {
+        var method = typeof(KafkaConnection).GetMethod(
+            "TryRemovePendingRequest",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        object?[] args = [correlationId, null];
+        return (bool)method.Invoke(connection, args)!;
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PendingRequestTableBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PendingRequestTableBenchmarks.cs
@@ -1,0 +1,96 @@
+using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Isolates pending-request tracking used by KafkaConnection for one request/response round trip.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, warmupCount: 5, iterationCount: 15)]
+public class PendingRequestTableBenchmarks
+{
+    private const int Operations = 1_000;
+    private const int ShardCount = 16;
+
+    private ConcurrentDictionary<int, PendingEntry> _concurrentDictionary = null!;
+    private PendingShard[] _stripedDictionary = null!;
+    private PendingEntry[] _entries = null!;
+
+    [Params(5, 64)]
+    public int InFlight { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _concurrentDictionary = new ConcurrentDictionary<int, PendingEntry>(concurrencyLevel: 1, capacity: InFlight * 4);
+        _stripedDictionary = CreateShards(InFlight * 4);
+        _entries = new PendingEntry[Operations];
+
+        for (var i = 0; i < _entries.Length; i++)
+            _entries[i] = new PendingEntry(new object(), (short)i);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = Operations)]
+    public void ConcurrentDictionary_AddGetRemove()
+    {
+        for (var i = 0; i < Operations; i++)
+        {
+            var correlationId = i + 1;
+            _concurrentDictionary[correlationId] = _entries[i];
+            _concurrentDictionary.TryGetValue(correlationId, out _);
+            _concurrentDictionary.TryRemove(correlationId, out _);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = Operations)]
+    public void StripedDictionary_AddGetRemove()
+    {
+        for (var i = 0; i < Operations; i++)
+        {
+            var correlationId = i + 1;
+            var shard = _stripedDictionary[(int)((uint)correlationId % (uint)_stripedDictionary.Length)];
+
+            lock (shard.Gate)
+            {
+                shard.Requests.Add(correlationId, _entries[i]);
+            }
+
+            lock (shard.Gate)
+            {
+                shard.Requests.TryGetValue(correlationId, out _);
+            }
+
+            lock (shard.Gate)
+            {
+                shard.Requests.Remove(correlationId);
+            }
+        }
+    }
+
+    private static PendingShard[] CreateShards(int capacity)
+    {
+        var shardCount = Math.Min(ShardCount, capacity);
+        var capacityPerShard = Math.Max(1, (capacity + shardCount - 1) / shardCount);
+        var shards = new PendingShard[shardCount];
+
+        for (var i = 0; i < shards.Length; i++)
+            shards[i] = new PendingShard(capacityPerShard);
+
+        return shards;
+    }
+
+    private sealed class PendingShard
+    {
+        public PendingShard(int capacity)
+        {
+            Requests = new Dictionary<int, PendingEntry>(capacity);
+        }
+
+        public object Gate { get; } = new();
+        public Dictionary<int, PendingEntry> Requests { get; }
+    }
+
+    private readonly record struct PendingEntry(object Request, short Version);
+}


### PR DESCRIPTION
## Summary
- replace per-request `ConcurrentDictionary` pending-request entries with a preallocated fixed slot table
- preserve pending request pool return behavior across response, failure, and dispose paths
- add coverage that guards the allocation-free pending table shape

## Verification
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 -- --treenode-filter "/*/Dekaf.Tests.Unit.Networking/KafkaConnectionPipelinedTests/PendingRequests_UsesPreallocatedSlotTable" --detailed-stacktrace
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/Dekaf.Tests.Unit.Networking/*/*" --detailed-stacktrace
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -maxcpucount:1 -nodeReuse:false
- dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -maxcpucount:1 -nodeReuse:false
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --detailed-stacktrace

Closes #927
