### PR TITLE
perf(protocol): use inline leader metadata

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -559,6 +559,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     private readonly object _fetchCacheLock = new();
     private Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>>? _cachedTopicPartitions;
     private List<TopicPartition>? _cachedPartitionsList;
+    private readonly ConcurrentDictionary<string, byte> _pendingLeaderRefreshTopics = new();
 
     public KafkaConsumer(
         ConsumerOptions options,
@@ -1811,9 +1812,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                         }
                         else if (partitionResponse.ErrorCode == ErrorCode.NotLeaderOrFollower)
                         {
-                            // Invalidate metadata cache to force re-discovery of leader
-                            InvalidatePartitionCache();
-                            LogNotLeaderOrFollower(topic, partitionResponse.PartitionIndex);
+                            await HandleNotLeaderOrFollowerAsync(
+                                topic,
+                                partitionResponse,
+                                response.NodeEndpoints,
+                                cancellationToken).ConfigureAwait(false);
                         }
                         else
                         {
@@ -3275,7 +3278,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
                     if (partitionResponse.ErrorCode != ErrorCode.None)
                     {
-                        LogFetchError(topic, partitionResponse.PartitionIndex, partitionResponse.ErrorCode);
+                        if (partitionResponse.ErrorCode == ErrorCode.NotLeaderOrFollower)
+                        {
+                            await HandleNotLeaderOrFollowerAsync(
+                                topic,
+                                partitionResponse,
+                                response.NodeEndpoints,
+                                cancellationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            LogFetchError(topic, partitionResponse.PartitionIndex, partitionResponse.ErrorCode);
+                        }
                         continue;
                     }
 
@@ -3471,6 +3485,57 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             var tp = new TopicPartition(topic, partitionResponse.PartitionIndex);
             var low = partitionResponse.LogStartOffset >= 0 ? partitionResponse.LogStartOffset : 0;
             _watermarks[tp] = new WatermarkOffsets(low, partitionResponse.HighWatermark);
+        }
+    }
+
+    private ValueTask HandleNotLeaderOrFollowerAsync(
+        string topic,
+        FetchResponsePartition partitionResponse,
+        IReadOnlyList<NodeEndpoint> nodeEndpoints,
+        CancellationToken cancellationToken)
+    {
+        var currentLeader = partitionResponse.CurrentLeader;
+        var endpoint = currentLeader is null
+            ? null
+            : LeaderDiscoveryFields.FindNodeEndpoint(nodeEndpoints, currentLeader.LeaderId);
+
+        var updated = currentLeader is not null
+            && _metadataManager.TryUpdatePartitionLeader(
+                topic,
+                partitionResponse.PartitionIndex,
+                currentLeader.LeaderId,
+                currentLeader.LeaderEpoch,
+                endpoint);
+
+        InvalidatePartitionCache();
+        LogNotLeaderOrFollower(topic, partitionResponse.PartitionIndex);
+
+        if (!updated)
+            ScheduleLeaderRefresh(topic, cancellationToken);
+
+        return ValueTask.CompletedTask;
+    }
+
+    private void ScheduleLeaderRefresh(string topic, CancellationToken cancellationToken)
+    {
+        if (_pendingLeaderRefreshTopics.TryAdd(topic, 0))
+            _ = ObserveLeaderRefreshAsync(topic, cancellationToken);
+    }
+
+    private async Task ObserveLeaderRefreshAsync(string topic, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _metadataManager.RefreshMetadataAsync([topic], forceRefresh: true, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort refresh; the next fetch cycle will retry leader resolution.
+        }
+        finally
+        {
+            _pendingLeaderRefreshTopics.TryRemove(topic, out _);
         }
     }
 
@@ -4130,7 +4195,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     [LoggerMessage(Level = LogLevel.Warning, Message = "OffsetOutOfRange for {Topic}-{Partition}, resetting to {Reset}")]
     private partial void LogOffsetOutOfRangeReset(string topic, int partition, string reset);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "NotLeaderOrFollower for {Topic}-{Partition}, will refresh metadata")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "NotLeaderOrFollower for {Topic}-{Partition}, updating leader metadata")]
     private partial void LogNotLeaderOrFollower(string topic, int partition);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Prefetch error for {Topic}-{Partition}: {Error}")]

--- a/src/Dekaf/Metadata/ClusterMetadata.cs
+++ b/src/Dekaf/Metadata/ClusterMetadata.cs
@@ -245,6 +245,100 @@ public sealed class ClusterMetadata
         return snapshot.Brokers.TryGetValue(partitionInfo.LeaderId, out var broker) ? broker : null;
     }
 
+    /// <summary>
+    /// Updates a single partition leader from inline Produce/Fetch response metadata.
+    /// The update is accepted only when the leader epoch advances the cached view.
+    /// </summary>
+    internal bool TryUpdatePartitionLeader(
+        string topicName,
+        int partition,
+        int leaderId,
+        int leaderEpoch,
+        BrokerNode? leaderEndpoint)
+    {
+        if (leaderId < 0 || leaderEpoch < 0)
+            return false;
+
+        lock (_writeLock)
+        {
+            var existing = _snapshot;
+            if (!existing.Topics.TryGetValue(topicName, out var topic))
+                return false;
+
+            var currentPartition = GetPartitionInfo(existing, topicName, partition);
+            if (currentPartition is null)
+                return false;
+
+            if (currentPartition.LeaderEpoch >= 0 && leaderEpoch <= currentPartition.LeaderEpoch)
+                return false;
+
+            var brokers = new Dictionary<int, BrokerNode>(existing.Brokers);
+            if (leaderEndpoint is not null)
+            {
+                if (leaderEndpoint.NodeId != leaderId)
+                    return false;
+
+                brokers[leaderEndpoint.NodeId] = leaderEndpoint;
+            }
+            else if (!brokers.ContainsKey(leaderId))
+            {
+                return false;
+            }
+
+            var partitions = new PartitionInfo[topic.Partitions.Count];
+            var updated = false;
+            for (var i = 0; i < topic.Partitions.Count; i++)
+            {
+                var existingPartition = topic.Partitions[i];
+                if (existingPartition.PartitionIndex != partition)
+                {
+                    partitions[i] = existingPartition;
+                    continue;
+                }
+
+                partitions[i] = new PartitionInfo
+                {
+                    PartitionIndex = existingPartition.PartitionIndex,
+                    LeaderId = leaderId,
+                    LeaderEpoch = leaderEpoch,
+                    ReplicaNodes = existingPartition.ReplicaNodes,
+                    IsrNodes = existingPartition.IsrNodes,
+                    OfflineReplicas = existingPartition.OfflineReplicas,
+                    ErrorCode = existingPartition.ErrorCode
+                };
+                updated = true;
+            }
+
+            if (!updated)
+                return false;
+
+            var topics = new Dictionary<string, TopicInfo>(existing.Topics);
+            var topicsById = new Dictionary<Guid, TopicInfo>(existing.TopicsById);
+            var updatedTopic = new TopicInfo
+            {
+                Name = topic.Name,
+                TopicId = topic.TopicId,
+                ErrorCode = topic.ErrorCode,
+                IsInternal = topic.IsInternal,
+                Partitions = partitions
+            };
+
+            topics[topicName] = updatedTopic;
+            if (updatedTopic.TopicId != Guid.Empty)
+                topicsById[updatedTopic.TopicId] = updatedTopic;
+
+            _snapshot = new ClusterMetadataSnapshot(
+                existing.ClusterId,
+                existing.ControllerId,
+                DateTimeOffset.UtcNow,
+                brokers,
+                topics,
+                topicsById);
+
+            return true;
+        }
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static PartitionInfo? GetPartitionInfo(
         ClusterMetadataSnapshot snapshot,
@@ -302,7 +396,7 @@ public sealed class ClusterMetadata
                 foreach (var (id, info) in existing.TopicsById)
                     topicsById[id] = info;
 
-                AddResponseTopics(response, topics, topicsById);
+                AddResponseTopics(response, topics, topicsById, existing, brokers);
 
                 _snapshot = new ClusterMetadataSnapshot(
                     response.ClusterId,
@@ -315,24 +409,21 @@ public sealed class ClusterMetadata
         }
         else
         {
-            // Non-merge: no shared state read, build topics outside the lock
-            var topics = new Dictionary<string, TopicInfo>(response.Topics.Count);
-            var topicsById = new Dictionary<Guid, TopicInfo>();
-
-            AddResponseTopics(response, topics, topicsById);
-
-            var newSnapshot = new ClusterMetadataSnapshot(
-                response.ClusterId,
-                response.ControllerId,
-                DateTimeOffset.UtcNow,
-                brokers,
-                topics,
-                topicsById);
-
-            // Only the snapshot swap needs the lock to serialize concurrent writes
             lock (_writeLock)
             {
-                _snapshot = newSnapshot;
+                var existing = _snapshot;
+                var topics = new Dictionary<string, TopicInfo>(response.Topics.Count);
+                var topicsById = new Dictionary<Guid, TopicInfo>();
+
+                AddResponseTopics(response, topics, topicsById, existing, brokers);
+
+                _snapshot = new ClusterMetadataSnapshot(
+                    response.ClusterId,
+                    response.ControllerId,
+                    DateTimeOffset.UtcNow,
+                    brokers,
+                    topics,
+                    topicsById);
             }
         }
     }
@@ -343,7 +434,9 @@ public sealed class ClusterMetadata
     private static void AddResponseTopics(
         MetadataResponse response,
         Dictionary<string, TopicInfo> topics,
-        Dictionary<Guid, TopicInfo> topicsById)
+        Dictionary<Guid, TopicInfo> topicsById,
+        ClusterMetadataSnapshot existing,
+        Dictionary<int, BrokerNode> brokers)
     {
         foreach (var topic in response.Topics)
         {
@@ -351,6 +444,14 @@ public sealed class ClusterMetadata
             var partitions = new List<PartitionInfo>(topic.Partitions.Count);
             foreach (var p in topic.Partitions)
             {
+                var existingPartition = GetPartitionInfo(existing, topic.Name, p.PartitionIndex);
+                if (existingPartition is not null && ShouldPreserveExistingPartition(existingPartition, p))
+                {
+                    partitions.Add(existingPartition);
+                    EnsureBrokerPresent(brokers, existing, existingPartition.LeaderId);
+                    continue;
+                }
+
                 partitions.Add(new PartitionInfo
                 {
                     PartitionIndex = p.PartitionIndex,
@@ -377,6 +478,33 @@ public sealed class ClusterMetadata
             {
                 topicsById[topic.TopicId] = topicInfo;
             }
+        }
+    }
+
+    private static bool ShouldPreserveExistingPartition(PartitionInfo existing, PartitionMetadata incoming)
+    {
+        if (existing.LeaderEpoch < 0)
+            return false;
+
+        if (incoming.LeaderEpoch >= 0)
+        {
+            return incoming.LeaderEpoch < existing.LeaderEpoch
+                || (incoming.LeaderEpoch == existing.LeaderEpoch && incoming.LeaderId != existing.LeaderId);
+        }
+
+        return true;
+    }
+
+    private static void EnsureBrokerPresent(
+        Dictionary<int, BrokerNode> brokers,
+        ClusterMetadataSnapshot existing,
+        int leaderId)
+    {
+        if (leaderId >= 0
+            && !brokers.ContainsKey(leaderId)
+            && existing.Brokers.TryGetValue(leaderId, out var broker))
+        {
+            brokers[leaderId] = broker;
         }
     }
 }

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -351,6 +351,31 @@ public sealed partial class MetadataManager : IAsyncDisposable
         => _metadata.GetPartitionLeader(topicName, partition);
 
     /// <summary>
+    /// Applies inline leader information from Produce/Fetch responses when it advances the cached epoch.
+    /// </summary>
+    internal bool TryUpdatePartitionLeader(
+        string topicName,
+        int partition,
+        int leaderId,
+        int leaderEpoch,
+        NodeEndpoint? leaderEndpoint = null)
+    {
+        BrokerNode? broker = null;
+        if (leaderEndpoint is not null)
+        {
+            broker = new BrokerNode
+            {
+                NodeId = leaderEndpoint.NodeId,
+                Host = leaderEndpoint.Host,
+                Port = leaderEndpoint.Port,
+                Rack = leaderEndpoint.Rack
+            };
+        }
+
+        return _metadata.TryUpdatePartitionLeader(topicName, partition, leaderId, leaderEpoch, broker);
+    }
+
+    /// <summary>
     /// Gets the leader for a partition.
     /// </summary>
     public async ValueTask<BrokerNode?> GetPartitionLeaderAsync(

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1445,7 +1445,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     LogProduceResponseProcessed(_instanceId, _brokerId, task.Id, count, batchKeys, responseLookup?.Count ?? 0, respKeys);
                 }
 
-                ProcessResponseBatches(pending, responseLookup,
+                ProcessResponseBatches(pending, responseLookup, response.NodeEndpoints,
                     carryOver, cancellationToken, task.Id);
 
                 // Clear for reuse on next response (avoids per-response dictionary allocation)
@@ -1498,6 +1498,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private void ProcessResponseBatches(
         PendingResponse pending,
         Dictionary<(string Topic, int Partition), ProduceResponsePartitionData>? responseLookup,
+        IReadOnlyList<NodeEndpoint> nodeEndpoints,
         PartitionCarryOver carryOver,
         CancellationToken cancellationToken,
         int responseTaskId = 0)
@@ -1567,6 +1568,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             batch.RecordBatch.ProducerEpoch, batch.RecordBatch.ProducerId);
 
                         HandleRetriableBatch(batch, partitionResponse.ErrorCode,
+                            partitionResponse.CurrentLeader, nodeEndpoints,
                             carryOver, cancellationToken);
                         batches[j] = null!;
                         continue;
@@ -1795,6 +1797,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private void HandleRetriableBatch(ReadyBatch batch, ErrorCode errorCode,
         PartitionCarryOver carryOver, CancellationToken cancellationToken)
+        => HandleRetriableBatch(batch, errorCode, null, [], carryOver, cancellationToken);
+
+    private void HandleRetriableBatch(
+        ReadyBatch batch,
+        ErrorCode errorCode,
+        LeaderIdAndEpoch? currentLeader,
+        IReadOnlyList<NodeEndpoint> nodeEndpoints,
+        PartitionCarryOver carryOver,
+        CancellationToken cancellationToken)
     {
         // Check delivery deadline
         var deliveryDeadlineTicks = batch.StopwatchCreatedTicks +
@@ -1860,16 +1871,24 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
         else
         {
-            LogRetriableErrorWithBackoff(errorCode, batch.TopicPartition.Topic, batch.TopicPartition.Partition,
-                _options.RetryBackoffMs);
+            if (TryApplyInlineLeader(batch.TopicPartition, errorCode, currentLeader, nodeEndpoints))
+            {
+                LogRetriableErrorWithoutBackoff(errorCode, batch.TopicPartition.Topic, batch.TopicPartition.Partition);
+                batch.RetryNotBefore = 0;
+            }
+            else
+            {
+                LogRetriableErrorWithBackoff(errorCode, batch.TopicPartition.Topic, batch.TopicPartition.Partition,
+                    _options.RetryBackoffMs);
 
-            // Fire-and-forget metadata refresh for leader changes.
-            // Observe exceptions to prevent UnobservedTaskException on GC.
-            _ = ObserveMetadataRefreshAsync(batch.TopicPartition.Topic, cancellationToken);
+                // Fire-and-forget metadata refresh for leader changes.
+                // Observe exceptions to prevent UnobservedTaskException on GC.
+                _ = ObserveMetadataRefreshAsync(batch.TopicPartition.Topic, cancellationToken);
 
-            // Set backoff via RetryNotBefore instead of Task.Delay
-            batch.RetryNotBefore = Stopwatch.GetTimestamp() +
-                _options.RetryBackoffTicks;
+                // Set backoff via RetryNotBefore instead of Task.Delay
+                batch.RetryNotBefore = Stopwatch.GetTimestamp() +
+                    _options.RetryBackoffTicks;
+            }
         }
 
         Diagnostics.DekafMetrics.Retries.Add(1,
@@ -1882,6 +1901,27 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         batch.IsRetry = true;
         batch.AppendDiag('H'); // HandleRetriableBatch → carry-over
         carryOver.AddAfterRetries(batch);
+    }
+
+    private bool TryApplyInlineLeader(
+        TopicPartition topicPartition,
+        ErrorCode errorCode,
+        LeaderIdAndEpoch? currentLeader,
+        IReadOnlyList<NodeEndpoint> nodeEndpoints)
+    {
+        if (errorCode is not (ErrorCode.NotLeaderOrFollower or ErrorCode.FencedLeaderEpoch)
+            || currentLeader is null)
+        {
+            return false;
+        }
+
+        var endpoint = LeaderDiscoveryFields.FindNodeEndpoint(nodeEndpoints, currentLeader.LeaderId);
+        return _metadataManager.TryUpdatePartitionLeader(
+            topicPartition.Topic,
+            topicPartition.Partition,
+            currentLeader.LeaderId,
+            currentLeader.LeaderEpoch,
+            endpoint);
     }
 
     /// <summary>
@@ -3105,6 +3145,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "[BrokerSender] Retriable error {ErrorCode} for {Topic}-{Partition}, retrying after {BackoffMs}ms")]
     private partial void LogRetriableErrorWithBackoff(ErrorCode errorCode, string topic, int partition, int backoffMs);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "[BrokerSender] Retriable error {ErrorCode} for {Topic}-{Partition}, inline leader update accepted; retrying without backoff")]
+    private partial void LogRetriableErrorWithoutBackoff(ErrorCode errorCode, string topic, int partition);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "BrokerSender[{BrokerId}] send loop iteration: {CarryOverCount} carry-over, {PendingResponseCount} pending responses")]
     private partial void LogSendLoopIteration(int brokerId, int carryOverCount, int pendingResponseCount);

--- a/src/Dekaf/Protocol/Messages/FetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FetchResponse.cs
@@ -41,6 +41,11 @@ public sealed class FetchResponse : IKafkaResponse
     public int SessionId { get; internal set; }
 
     /// <summary>
+    /// Endpoints for current leaders reported in KIP-951 response tagged fields.
+    /// </summary>
+    public NodeEndpoint[] NodeEndpoints { get; internal set; } = [];
+
+    /// <summary>
     /// Responses per topic.
     /// </summary>
     public IReadOnlyList<FetchResponseTopic> Responses
@@ -100,14 +105,40 @@ public sealed class FetchResponse : IKafkaResponse
         var responses = s_topicListPool.Rent();
         reader.ReadCompactArrayInto(responses, static (ref KafkaProtocolReader r, short v) => FetchResponseTopic.Read(ref r, v), version);
 
-        reader.SkipTaggedFields();
+        var nodeEndpoints = ReadResponseTaggedFields(ref reader, version);
 
         var response = Rent();
         response.ThrottleTimeMs = throttleTimeMs;
         response.ErrorCode = errorCode;
         response.SessionId = sessionId;
         response.Responses = responses;
+        response.NodeEndpoints = nodeEndpoints;
         return response;
+    }
+
+    private static NodeEndpoint[] ReadResponseTaggedFields(ref KafkaProtocolReader reader, short version)
+    {
+        NodeEndpoint[]? nodeEndpoints = null;
+        var numFields = reader.ReadUnsignedVarInt();
+        for (var i = 0; i < numFields; i++)
+        {
+            var tag = reader.ReadUnsignedVarInt();
+            var size = reader.ReadUnsignedVarInt();
+            var start = reader.Consumed;
+
+            if (tag == 0 && version >= 16)
+            {
+                nodeEndpoints = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => NodeEndpoint.Read(ref r));
+            }
+            else
+            {
+                reader.Skip(size);
+            }
+
+            LeaderDiscoveryFields.SkipRemaining(ref reader, start, size);
+        }
+
+        return nodeEndpoints ?? [];
     }
 
     private sealed class FetchResponsePool() : ObjectPool<FetchResponse>(maxPoolSize: 16)
@@ -119,6 +150,7 @@ public sealed class FetchResponse : IKafkaResponse
             item.ThrottleTimeMs = 0;
             item.ErrorCode = ErrorCode.None;
             item.SessionId = 0;
+            item.NodeEndpoints = [];
             item._responses = Array.Empty<FetchResponseTopic>();
             item.PooledMemoryOwner = null;
         }
@@ -439,7 +471,7 @@ public sealed class FetchResponsePartition
             }
         }
 
-        reader.SkipTaggedFields();
+        ReadPartitionTaggedFields(ref reader, version, out divergingEpoch, out currentLeader, out snapshotId);
 
         var result = Rent();
         result.PartitionIndex = partitionIndex;
@@ -454,6 +486,51 @@ public sealed class FetchResponsePartition
         result.PreferredReadReplica = preferredReadReplica;
         result.Records = records;
         return result;
+    }
+
+    private static void ReadPartitionTaggedFields(
+        ref KafkaProtocolReader reader,
+        short version,
+        out EpochEndOffset? divergingEpoch,
+        out LeaderIdAndEpoch? currentLeader,
+        out SnapshotId? snapshotId)
+    {
+        divergingEpoch = null;
+        currentLeader = null;
+        snapshotId = null;
+
+        var numFields = reader.ReadUnsignedVarInt();
+        for (var i = 0; i < numFields; i++)
+        {
+            var tag = reader.ReadUnsignedVarInt();
+            var size = reader.ReadUnsignedVarInt();
+            var start = reader.Consumed;
+
+            if (version >= 12)
+            {
+                switch (tag)
+                {
+                    case 0:
+                        divergingEpoch = LeaderDiscoveryFields.ReadEpochEndOffset(ref reader, size);
+                        break;
+                    case 1:
+                        currentLeader = LeaderDiscoveryFields.ReadLeaderIdAndEpoch(ref reader, size);
+                        break;
+                    case 2:
+                        snapshotId = LeaderDiscoveryFields.ReadSnapshotId(ref reader, size);
+                        break;
+                    default:
+                        reader.Skip(size);
+                        break;
+                }
+            }
+            else
+            {
+                reader.Skip(size);
+            }
+
+            LeaderDiscoveryFields.SkipRemaining(ref reader, start, size);
+        }
     }
 
     private sealed class FetchResponsePartitionPool() : ObjectPool<FetchResponsePartition>(maxPoolSize: 64)

--- a/src/Dekaf/Protocol/Messages/LeaderDiscoveryFields.cs
+++ b/src/Dekaf/Protocol/Messages/LeaderDiscoveryFields.cs
@@ -1,0 +1,117 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// Broker endpoint information carried by KIP-951 response tagged fields.
+/// </summary>
+public sealed class NodeEndpoint
+{
+    public int NodeId { get; init; }
+
+    public required string Host { get; init; }
+
+    public int Port { get; init; }
+
+    public string? Rack { get; init; }
+
+    public static NodeEndpoint Read(ref KafkaProtocolReader reader)
+    {
+        var nodeId = reader.ReadInt32();
+        var host = reader.ReadCompactNonNullableString();
+        var port = reader.ReadInt32();
+        var rack = reader.ReadCompactString();
+
+        reader.SkipTaggedFields();
+
+        return new NodeEndpoint
+        {
+            NodeId = nodeId,
+            Host = host,
+            Port = port,
+            Rack = rack
+        };
+    }
+}
+
+internal static class LeaderDiscoveryFields
+{
+    public static LeaderIdAndEpoch ReadLeaderIdAndEpoch(ref KafkaProtocolReader reader, int size)
+    {
+        EnsureMinSize(size, 8);
+
+        var start = reader.Consumed;
+        var leader = new LeaderIdAndEpoch
+        {
+            LeaderId = reader.ReadInt32(),
+            LeaderEpoch = reader.ReadInt32()
+        };
+
+        SkipRemaining(ref reader, start, size);
+        return leader;
+    }
+
+    public static EpochEndOffset ReadEpochEndOffset(ref KafkaProtocolReader reader, int size)
+    {
+        EnsureMinSize(size, 12);
+
+        var start = reader.Consumed;
+        var epochEndOffset = new EpochEndOffset
+        {
+            Epoch = reader.ReadInt32(),
+            EndOffset = reader.ReadInt64()
+        };
+
+        SkipRemaining(ref reader, start, size);
+        return epochEndOffset;
+    }
+
+    public static SnapshotId ReadSnapshotId(ref KafkaProtocolReader reader, int size)
+    {
+        EnsureMinSize(size, 12);
+
+        var start = reader.Consumed;
+        var snapshotId = new SnapshotId
+        {
+            EndOffset = reader.ReadInt64(),
+            Epoch = reader.ReadInt32()
+        };
+
+        SkipRemaining(ref reader, start, size);
+        return snapshotId;
+    }
+
+    public static NodeEndpoint? FindNodeEndpoint(IReadOnlyList<NodeEndpoint> nodeEndpoints, int nodeId)
+    {
+        for (var i = 0; i < nodeEndpoints.Count; i++)
+        {
+            if (nodeEndpoints[i].NodeId == nodeId)
+                return nodeEndpoints[i];
+        }
+
+        return null;
+    }
+
+    public static void SkipRemaining(ref KafkaProtocolReader reader, long start, int size)
+    {
+        var consumed = reader.Consumed - start;
+        if (consumed < size)
+        {
+            reader.Skip((int)(size - consumed));
+            return;
+        }
+
+        if (consumed > size)
+        {
+            throw new MalformedProtocolDataException(
+                $"Tagged field parser consumed {consumed} bytes but field size is {size}");
+        }
+    }
+
+    private static void EnsureMinSize(int size, int minSize)
+    {
+        if (size < minSize)
+        {
+            throw new MalformedProtocolDataException(
+                $"Tagged field size {size} is smaller than required {minSize} bytes");
+        }
+    }
+}

--- a/src/Dekaf/Protocol/Messages/ProduceResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceResponse.cs
@@ -34,6 +34,11 @@ public sealed class ProduceResponse : IKafkaResponse
     /// </summary>
     public int ThrottleTimeMs { get; internal set; }
 
+    /// <summary>
+    /// Endpoints for current leaders reported in KIP-951 response tagged fields.
+    /// </summary>
+    public NodeEndpoint[] NodeEndpoints { get; internal set; } = [];
+
     public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
     {
         var topicCount = reader.ReadUnsignedVarInt() - 1;
@@ -51,10 +56,34 @@ public sealed class ProduceResponse : IKafkaResponse
 
         response.TopicCount = Math.Max(topicCount, 0);
         response.ThrottleTimeMs = reader.ReadInt32();
-
-        reader.SkipTaggedFields();
+        response.NodeEndpoints = ReadResponseTaggedFields(ref reader, version);
 
         return response;
+    }
+
+    private static NodeEndpoint[] ReadResponseTaggedFields(ref KafkaProtocolReader reader, short version)
+    {
+        NodeEndpoint[]? nodeEndpoints = null;
+        var numFields = reader.ReadUnsignedVarInt();
+        for (var i = 0; i < numFields; i++)
+        {
+            var tag = reader.ReadUnsignedVarInt();
+            var size = reader.ReadUnsignedVarInt();
+            var start = reader.Consumed;
+
+            if (tag == 0 && version >= 10)
+            {
+                nodeEndpoints = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => NodeEndpoint.Read(ref r));
+            }
+            else
+            {
+                reader.Skip(size);
+            }
+
+            LeaderDiscoveryFields.SkipRemaining(ref reader, start, size);
+        }
+
+        return nodeEndpoints ?? [];
     }
 
     /// <summary>
@@ -90,6 +119,7 @@ public sealed class ProduceResponse : IKafkaResponse
         {
             item.TopicCount = 0;
             item.ThrottleTimeMs = 0;
+            item.NodeEndpoints = [];
         }
     }
 }
@@ -198,6 +228,11 @@ public readonly struct ProduceResponsePartitionData
     /// </summary>
     public string? ErrorMessage { get; init; }
 
+    /// <summary>
+    /// Current leader reported by KIP-951 for retriable leader errors.
+    /// </summary>
+    public LeaderIdAndEpoch? CurrentLeader { get; init; }
+
     public static ProduceResponsePartitionData Read(ref KafkaProtocolReader reader, short version)
     {
         var index = reader.ReadInt32();
@@ -208,8 +243,7 @@ public readonly struct ProduceResponsePartitionData
 
         var recordErrors = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => BatchIndexAndErrorMessage.Read(ref r, v), version);
         var errorMessage = reader.ReadCompactString();
-
-        reader.SkipTaggedFields();
+        var currentLeader = ReadPartitionTaggedFields(ref reader, version);
 
         return new ProduceResponsePartitionData
         {
@@ -219,8 +253,34 @@ public readonly struct ProduceResponsePartitionData
             LogAppendTimeMs = logAppendTimeMs,
             LogStartOffset = logStartOffset,
             RecordErrors = recordErrors,
-            ErrorMessage = errorMessage
+            ErrorMessage = errorMessage,
+            CurrentLeader = currentLeader
         };
+    }
+
+    private static LeaderIdAndEpoch? ReadPartitionTaggedFields(ref KafkaProtocolReader reader, short version)
+    {
+        LeaderIdAndEpoch? currentLeader = null;
+        var numFields = reader.ReadUnsignedVarInt();
+        for (var i = 0; i < numFields; i++)
+        {
+            var tag = reader.ReadUnsignedVarInt();
+            var size = reader.ReadUnsignedVarInt();
+            var start = reader.Consumed;
+
+            if (tag == 0 && version >= 10)
+            {
+                currentLeader = LeaderDiscoveryFields.ReadLeaderIdAndEpoch(ref reader, size);
+            }
+            else
+            {
+                reader.Skip(size);
+            }
+
+            LeaderDiscoveryFields.SkipRemaining(ref reader, start, size);
+        }
+
+        return currentLeader;
     }
 }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -1,0 +1,149 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerLeaderDiscoveryTests
+{
+    private const string Topic = "test-topic";
+
+    [Test]
+    public async Task HandleNotLeaderOrFollower_WithInlineLeader_UpdatesMetadataWithoutRefresh()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+
+        SeedMetadata(metadataManager);
+
+        var partitionResponse = new FetchResponsePartition
+        {
+            PartitionIndex = 0,
+            ErrorCode = ErrorCode.NotLeaderOrFollower,
+            CurrentLeader = new LeaderIdAndEpoch
+            {
+                LeaderId = 2,
+                LeaderEpoch = 6
+            }
+        };
+
+        await InvokeHandleNotLeaderOrFollowerAsync(
+            consumer,
+            partitionResponse,
+            [new NodeEndpoint { NodeId = 2, Host = "broker-2", Port = 9094 }]);
+
+        var leader = metadataManager.Metadata.GetPartitionLeader(Topic, 0);
+
+        await Assert.That(leader).IsNotNull();
+        await Assert.That(leader!.NodeId).IsEqualTo(2);
+        await Assert.That(leader.Host).IsEqualTo("broker-2");
+        _ = pool.DidNotReceive().GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleNotLeaderOrFollower_WithoutInlineLeader_DeduplicatesRefreshPerTopic()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connectionRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseConnection = new TaskCompletionSource<IKafkaConnection>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                connectionRequested.TrySetResult();
+                return new ValueTask<IKafkaConnection>(releaseConnection.Task);
+            });
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+
+        var partitionResponse = new FetchResponsePartition
+        {
+            PartitionIndex = 0,
+            ErrorCode = ErrorCode.NotLeaderOrFollower
+        };
+
+        await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
+        await connectionRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
+        await Task.Delay(50);
+
+        _ = pool.Received(1).GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>());
+
+        releaseConnection.SetException(new InvalidOperationException("stop refresh"));
+        await Task.Delay(50);
+    }
+
+    private static MetadataManager CreateMetadataManager(IConnectionPool pool)
+        => new(pool, ["localhost:9092"]);
+
+    private static KafkaConsumer<string, string> CreateConsumer(
+        IConnectionPool pool,
+        MetadataManager metadataManager)
+        => new(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "test-consumer"
+            },
+            Serializers.String,
+            Serializers.String,
+            pool,
+            metadataManager);
+
+    private static void SeedMetadata(MetadataManager metadataManager)
+    {
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            ClusterId = "test-cluster",
+            ControllerId = 1,
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9093 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = Topic,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 1,
+                            LeaderEpoch = 5,
+                            ReplicaNodes = [1],
+                            IsrNodes = [1]
+                        }
+                    ]
+                }
+            ]
+        });
+    }
+
+    private static async ValueTask InvokeHandleNotLeaderOrFollowerAsync(
+        KafkaConsumer<string, string> consumer,
+        FetchResponsePartition partitionResponse,
+        IReadOnlyList<NodeEndpoint> nodeEndpoints)
+    {
+        var method = typeof(KafkaConsumer<string, string>)
+            .GetMethod("HandleNotLeaderOrFollowerAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("HandleNotLeaderOrFollowerAsync method not found");
+
+        var result = method.Invoke(consumer, [Topic, partitionResponse, nodeEndpoints, CancellationToken.None]);
+        if (result is not ValueTask valueTask)
+            throw new InvalidOperationException("HandleNotLeaderOrFollowerAsync did not return ValueTask");
+
+        await valueTask.ConfigureAwait(false);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Metadata/ClusterMetadataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/ClusterMetadataTests.cs
@@ -281,6 +281,97 @@ public sealed class ClusterMetadataTests
     }
 
     [Test]
+    public async Task TryUpdatePartitionLeader_NewerEpoch_UpdatesLeaderAndEndpoint()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var updated = metadata.TryUpdatePartitionLeader(
+            "test-topic",
+            partition: 0,
+            leaderId: 4,
+            leaderEpoch: 6,
+            new BrokerNode { NodeId = 4, Host = "broker4", Port = 9094, Rack = "rack-b" });
+
+        var leader = metadata.GetPartitionLeader("test-topic", 0);
+        var partition = metadata.GetPartitionInfo("test-topic", 0);
+
+        await Assert.That(updated).IsTrue();
+        await Assert.That(leader).IsNotNull();
+        await Assert.That(leader!.NodeId).IsEqualTo(4);
+        await Assert.That(leader.Host).IsEqualTo("broker4");
+        await Assert.That(leader.Port).IsEqualTo(9094);
+        await Assert.That(leader.Rack).IsEqualTo("rack-b");
+        await Assert.That(partition!.LeaderEpoch).IsEqualTo(6);
+    }
+
+    [Test]
+    public async Task TryUpdatePartitionLeader_StaleEpoch_DoesNotUpdateLeader()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+
+        var updated = metadata.TryUpdatePartitionLeader(
+            "test-topic",
+            partition: 0,
+            leaderId: 2,
+            leaderEpoch: 4,
+            new BrokerNode { NodeId = 2, Host = "broker2", Port = 9092 });
+
+        var leader = metadata.GetPartitionLeader("test-topic", 0);
+        var partition = metadata.GetPartitionInfo("test-topic", 0);
+
+        await Assert.That(updated).IsFalse();
+        await Assert.That(leader!.NodeId).IsEqualTo(1);
+        await Assert.That(partition!.LeaderEpoch).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task Update_StaleLeaderEpoch_DoesNotOverwriteInlineLeader()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+        metadata.TryUpdatePartitionLeader(
+            "test-topic",
+            partition: 0,
+            leaderId: 4,
+            leaderEpoch: 6,
+            new BrokerNode { NodeId = 4, Host = "broker4", Port = 9094 });
+
+        metadata.Update(CreateMetadataResponse());
+
+        var leader = metadata.GetPartitionLeader("test-topic", 0);
+        var partition = metadata.GetPartitionInfo("test-topic", 0);
+
+        await Assert.That(leader).IsNotNull();
+        await Assert.That(leader!.NodeId).IsEqualTo(4);
+        await Assert.That(leader.Host).IsEqualTo("broker4");
+        await Assert.That(partition!.LeaderEpoch).IsEqualTo(6);
+    }
+
+    [Test]
+    public async Task Update_UnknownLeaderEpoch_DoesNotOverwriteInlineLeader()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(CreateMetadataResponse());
+        metadata.TryUpdatePartitionLeader(
+            "test-topic",
+            partition: 0,
+            leaderId: 4,
+            leaderEpoch: 6,
+            new BrokerNode { NodeId = 4, Host = "broker4", Port = 9094 });
+
+        metadata.Update(CreateMetadataResponse(partition0LeaderId: 1, partition0LeaderEpoch: -1));
+
+        var leader = metadata.GetPartitionLeader("test-topic", 0);
+        var partition = metadata.GetPartitionInfo("test-topic", 0);
+
+        await Assert.That(leader).IsNotNull();
+        await Assert.That(leader!.NodeId).IsEqualTo(4);
+        await Assert.That(partition!.LeaderEpoch).IsEqualTo(6);
+    }
+
+    [Test]
     public async Task GetPartitionInfo_HighPartitionIndex_ReturnsPartition()
     {
         var metadata = new ClusterMetadata();
@@ -394,9 +485,9 @@ public sealed class ClusterMetadataTests
                     Name = "test-topic",
                     Partitions =
                     [
-                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] },
-                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 1, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] },
-                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 2, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] },
+                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = 1, LeaderEpoch = 6, ReplicaNodes = [1], IsrNodes = [1] },
+                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 1, LeaderId = 1, LeaderEpoch = 6, ReplicaNodes = [1], IsrNodes = [1] },
+                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 2, LeaderId = 1, LeaderEpoch = 6, ReplicaNodes = [1], IsrNodes = [1] },
                     ]
                 }
             ]
@@ -591,7 +682,9 @@ public sealed class ClusterMetadataTests
     private static MetadataResponse CreateMetadataResponse(
         string? clusterId = "test-cluster",
         int controllerId = 1,
-        Guid topicId = default)
+        Guid topicId = default,
+        int partition0LeaderId = 1,
+        int partition0LeaderEpoch = 5)
     {
         return new MetadataResponse
         {
@@ -616,8 +709,8 @@ public sealed class ClusterMetadataTests
                         {
                             ErrorCode = ErrorCode.None,
                             PartitionIndex = 0,
-                            LeaderId = 1,
-                            LeaderEpoch = 5,
+                            LeaderId = partition0LeaderId,
+                            LeaderEpoch = partition0LeaderEpoch,
                             ReplicaNodes = [1, 2, 3],
                             IsrNodes = [1, 2, 3]
                         },

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -24,16 +24,16 @@ public sealed class BrokerSenderMuteOrderingTests
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 0, int retryBackoffMaxMs = 0,
         int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000) => new()
-    {
-        BootstrapServers = ["localhost:9092"],
-        MaxInFlightRequestsPerConnection = maxInFlight,
-        Acks = acks,
-        DeliveryTimeoutMs = deliveryTimeoutMs,
-        RetryBackoffMs = retryBackoffMs,
-        RetryBackoffMaxMs = retryBackoffMaxMs,
-        RequestTimeoutMs = requestTimeoutMs,
-        LingerMs = 0
-    };
+        {
+            BootstrapServers = ["localhost:9092"],
+            MaxInFlightRequestsPerConnection = maxInFlight,
+            Acks = acks,
+            DeliveryTimeoutMs = deliveryTimeoutMs,
+            RetryBackoffMs = retryBackoffMs,
+            RetryBackoffMaxMs = retryBackoffMaxMs,
+            RequestTimeoutMs = requestTimeoutMs,
+            LingerMs = 0
+        };
 
     private static (IConnectionPool pool, IKafkaConnection connection) CreateMockConnection(
         Queue<TaskCompletionSource<ProduceResponse>> responseQueue,
@@ -129,6 +129,42 @@ public sealed class BrokerSenderMuteOrderingTests
             ]
         };
 
+    private static ProduceResponse CreateInlineLeaderErrorResponse(
+        string topic,
+        int partition,
+        int leaderId,
+        int leaderEpoch) =>
+        new()
+        {
+            TopicCount = 1,
+            NodeEndpoints =
+            [
+                new NodeEndpoint { NodeId = leaderId, Host = $"broker-{leaderId}", Port = 9092 + leaderId }
+            ],
+            Responses =
+            [
+                new ProduceResponseTopicData
+                {
+                    Name = topic,
+                    PartitionCount = 1,
+                    PartitionResponses =
+                    [
+                        new ProduceResponsePartitionData
+                        {
+                            Index = partition,
+                            ErrorCode = ErrorCode.NotLeaderOrFollower,
+                            BaseOffset = -1,
+                            CurrentLeader = new LeaderIdAndEpoch
+                            {
+                                LeaderId = leaderId,
+                                LeaderEpoch = leaderEpoch
+                            }
+                        }
+                    ]
+                }
+            ]
+        };
+
     private static ProduceResponse CreateMultiPartitionResponse(
         string topic, params (int partition, ErrorCode errorCode, long baseOffset)[] partitions) =>
         new()
@@ -155,10 +191,12 @@ public sealed class BrokerSenderMuteOrderingTests
         IConnectionPool pool,
         ProducerOptions options,
         RecordAccumulator accumulator,
-        Action<TopicPartition, long, DateTimeOffset, int, Exception?> onAcknowledgement) =>
+        Action<TopicPartition, long, DateTimeOffset, int, Exception?> onAcknowledgement,
+        MetadataManager? metadataManager = null,
+        Action<ReadyBatch>? rerouteBatch = null) =>
         new(
             brokerId: 1, pool,
-            new MetadataManager(pool, options.BootstrapServers),
+            metadataManager ?? new MetadataManager(pool, options.BootstrapServers),
             accumulator, options,
             new CompressionCodecRegistry(),
             inflightTracker: new PartitionInflightTracker(),
@@ -168,9 +206,82 @@ public sealed class BrokerSenderMuteOrderingTests
             ensurePartitionInTransaction: null,
             bumpEpoch: null,
             getCurrentEpoch: null,
-            rerouteBatch: null,
+            rerouteBatch: rerouteBatch,
             onAcknowledgement: onAcknowledgement,
             logger: null);
+
+    [Test]
+    [Timeout(60_000)]
+    public async Task RetriableError_WithInlineLeader_ReroutesWithoutRetryBackoff(CancellationToken ct)
+    {
+        var tcs = new TaskCompletionSource<ProduceResponse>();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
+        responseQueue.Enqueue(tcs);
+
+        var requestSent = new TaskCompletionSource();
+        var (pool, _) = CreateMockConnection(responseQueue, onSend: () => requestSent.TrySetResult());
+        var options = CreateOptions(retryBackoffMs: 10_000, retryBackoffMaxMs: 10_000);
+        var accumulator = new RecordAccumulator(options);
+        var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var rerouted = new TaskCompletionSource<ReadyBatch>();
+
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9093 }],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "test-topic",
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 1,
+                            LeaderEpoch = 5,
+                            ReplicaNodes = [1],
+                            IsrNodes = [1]
+                        }
+                    ]
+                }
+            ]
+        });
+
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: (_, _, _, _, _) => { },
+            metadataManager,
+            rerouteBatch: batch => rerouted.TrySetResult(batch));
+
+        try
+        {
+            var batch = CreateTestBatch(vtPool, "test-topic", 0);
+            sender.Enqueue(batch);
+
+            await requestSent.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
+            tcs.SetResult(CreateInlineLeaderErrorResponse("test-topic", 0, leaderId: 2, leaderEpoch: 6));
+
+            var reroutedBatch = await rerouted.Task.WaitAsync(TimeSpan.FromSeconds(3), ct);
+            var leader = metadataManager.Metadata.GetPartitionLeader("test-topic", 0);
+
+            await Assert.That(reroutedBatch).IsSameReferenceAs(batch);
+            await Assert.That(leader).IsNotNull();
+            await Assert.That(leader!.NodeId).IsEqualTo(2);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
 
     /// <summary>
     /// Core muting test: a retriable error on partition 0 should mute it, blocking

--- a/tests/Dekaf.Tests.Unit/Protocol/LeaderDiscoveryResponseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/LeaderDiscoveryResponseTests.cs
@@ -1,0 +1,136 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class LeaderDiscoveryResponseTests
+{
+    [Test]
+    public async Task ProduceResponse_Read_WithCurrentLeaderTaggedField_ParsesLeaderAndEndpoint()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteUnsignedVarInt(1 + 1); // Responses
+        writer.WriteCompactString("topic-a");
+        writer.WriteUnsignedVarInt(1 + 1); // PartitionResponses
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.NotLeaderOrFollower);
+        writer.WriteInt64(-1);
+        writer.WriteInt64(-1);
+        writer.WriteInt64(-1);
+        writer.WriteUnsignedVarInt(0 + 1); // RecordErrors
+        writer.WriteUnsignedVarInt(0);     // ErrorMessage
+
+        var leaderField = new ArrayBufferWriter<byte>();
+        var leaderWriter = new KafkaProtocolWriter(leaderField);
+        leaderWriter.WriteInt32(2);
+        leaderWriter.WriteInt32(9);
+        leaderWriter.WriteUnsignedVarInt(0);
+
+        writer.WriteUnsignedVarInt(1);
+        WriteTaggedField(ref writer, tag: 0, leaderField);
+        writer.WriteUnsignedVarInt(0); // topic tagged fields
+        writer.WriteInt32(0);          // throttle time
+
+        var endpointsField = new ArrayBufferWriter<byte>();
+        var endpointsWriter = new KafkaProtocolWriter(endpointsField);
+        endpointsWriter.WriteUnsignedVarInt(1 + 1);
+        WriteNodeEndpoint(ref endpointsWriter, nodeId: 2, host: "broker-2", port: 9094, rack: "rack-b");
+
+        writer.WriteUnsignedVarInt(1);
+        WriteTaggedField(ref writer, tag: 0, endpointsField);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (ProduceResponse)ProduceResponse.Read(ref reader, version: 11);
+
+        var partition = response.Responses[0].PartitionResponses[0];
+        await Assert.That(partition.CurrentLeader).IsNotNull();
+        await Assert.That(partition.CurrentLeader!.LeaderId).IsEqualTo(2);
+        await Assert.That(partition.CurrentLeader.LeaderEpoch).IsEqualTo(9);
+        await Assert.That(response.NodeEndpoints).Count().IsEqualTo(1);
+        await Assert.That(response.NodeEndpoints[0].NodeId).IsEqualTo(2);
+        await Assert.That(response.NodeEndpoints[0].Host).IsEqualTo("broker-2");
+        await Assert.That(response.NodeEndpoints[0].Port).IsEqualTo(9094);
+        await Assert.That(response.NodeEndpoints[0].Rack).IsEqualTo("rack-b");
+
+        response.Return();
+    }
+
+    [Test]
+    public async Task FetchResponse_Read_WithCurrentLeaderTaggedField_ParsesLeaderAndEndpoint()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt32(0);
+        writer.WriteUnsignedVarInt(1 + 1); // Responses
+        writer.WriteUuid(Guid.NewGuid());
+        writer.WriteUnsignedVarInt(1 + 1); // Partitions
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.NotLeaderOrFollower);
+        writer.WriteInt64(10);
+        writer.WriteInt64(9);
+        writer.WriteInt64(0);
+        writer.WriteUnsignedVarInt(0 + 1); // AbortedTransactions
+        writer.WriteInt32(-1);
+        writer.WriteUnsignedVarInt(0); // Records
+
+        var leaderField = new ArrayBufferWriter<byte>();
+        var leaderWriter = new KafkaProtocolWriter(leaderField);
+        leaderWriter.WriteInt32(3);
+        leaderWriter.WriteInt32(11);
+        leaderWriter.WriteUnsignedVarInt(0);
+
+        writer.WriteUnsignedVarInt(1);
+        WriteTaggedField(ref writer, tag: 1, leaderField);
+        writer.WriteUnsignedVarInt(0); // topic tagged fields
+
+        var endpointsField = new ArrayBufferWriter<byte>();
+        var endpointsWriter = new KafkaProtocolWriter(endpointsField);
+        endpointsWriter.WriteUnsignedVarInt(1 + 1);
+        WriteNodeEndpoint(ref endpointsWriter, nodeId: 3, host: "broker-3", port: 9095, rack: null);
+
+        writer.WriteUnsignedVarInt(1);
+        WriteTaggedField(ref writer, tag: 0, endpointsField);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (FetchResponse)FetchResponse.Read(ref reader, version: 16);
+
+        var partition = response.Responses[0].Partitions[0];
+        await Assert.That(partition.CurrentLeader).IsNotNull();
+        await Assert.That(partition.CurrentLeader!.LeaderId).IsEqualTo(3);
+        await Assert.That(partition.CurrentLeader.LeaderEpoch).IsEqualTo(11);
+        await Assert.That(response.NodeEndpoints).Count().IsEqualTo(1);
+        await Assert.That(response.NodeEndpoints[0].NodeId).IsEqualTo(3);
+        await Assert.That(response.NodeEndpoints[0].Host).IsEqualTo("broker-3");
+        await Assert.That(response.NodeEndpoints[0].Port).IsEqualTo(9095);
+        await Assert.That(response.NodeEndpoints[0].Rack).IsNull();
+
+        response.ReturnToPool();
+    }
+
+    private static void WriteTaggedField(ref KafkaProtocolWriter writer, int tag, ArrayBufferWriter<byte> field)
+    {
+        writer.WriteUnsignedVarInt(tag);
+        writer.WriteUnsignedVarInt(field.WrittenCount);
+        writer.WriteRawBytes(field.WrittenSpan);
+    }
+
+    private static void WriteNodeEndpoint(
+        ref KafkaProtocolWriter writer,
+        int nodeId,
+        string host,
+        int port,
+        string? rack)
+    {
+        writer.WriteInt32(nodeId);
+        writer.WriteCompactString(host);
+        writer.WriteInt32(port);
+        writer.WriteCompactString(rack);
+        writer.WriteUnsignedVarInt(0);
+    }
+}


### PR DESCRIPTION
Closes #823

## Summary
- Parse KIP-951 `CurrentLeader` and `NodeEndpoints` tagged fields from Produce and Fetch responses.
- Apply newer inline leader epochs directly to cached metadata and preserve them from stale metadata refreshes.
- Retry producer batches without backoff when an inline leader update is accepted; consumers apply inline leaders with metadata refresh fallback.

## Tests
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --disable-logo --no-ansi --timeout 8m` (3590 passed)
- Focused `ClusterMetadataTests`, `LeaderDiscoveryResponseTests`, `BrokerSenderMuteOrderingTests`, `FetchResponsePoolingTests`, `ProduceResponseTests`