### PR TITLE
perf(producer): scale shared pool depths

### DIFF
--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -9,6 +9,7 @@ namespace Dekaf.Internal;
 internal static class PoolSizing
 {
     private const int SharedArrayPoolDepthCeiling = 4096;
+    private const int ProduceResponsePoolSizeCeiling = 512;
 
     /// <summary>
     /// Serialization buffer arrays per connection. Each RentedBufferWriter growth step
@@ -216,10 +217,10 @@ internal static class PoolSizing
         var clampedBatchSize = Math.Clamp(batchSize, 1024, 4 * 1024 * 1024);
         var estimatedMessagesPerBatch = Math.Clamp(clampedBatchSize / 256, 8, 512);
         var peakInFlightBatches = SaturatingMultiply(totalMaxConnections, clampedMaxInFlight);
-        var producerDataArrays = (int)Math.Clamp(
+        var producerDataArrays = ClampPoolDepth(
             SaturatingMultiply(estimatedMessagesPerBatch, peakInFlightBatches),
-            64L,
-            4096L);
+            floor: 64,
+            ceiling: SharedArrayPoolDepthCeiling);
 
         // Header[] arrays are rented once per header-bearing message and held until
         // the owning batch completes, so they need the same working-set depth.
@@ -245,10 +246,10 @@ internal static class PoolSizing
 
         // ProduceResponsePool: one response per in-flight request per connection,
         // with 2x headroom for concurrent rent/return overlap.
-        var responsePoolSize = Math.Clamp(
+        var responsePoolSize = ClampPoolDepth(
             SaturatingMultiply(SaturatingMultiply(totalConnections, clampedMaxInFlight), 2L),
-            64L,
-            512L);
+            floor: 64,
+            ceiling: ProduceResponsePoolSizeCeiling);
 
         return new SharedPoolSizes
         {
@@ -256,7 +257,7 @@ internal static class PoolSizing
             HeaderArraysPerBucket = headerArrays,
             PipeMemoryArraysPerBucket = pipeMemoryArrays,
             SerializationArraysPerBucket = serializationArrays,
-            ProduceResponsePoolSize = (int)responsePoolSize,
+            ProduceResponsePoolSize = responsePoolSize,
         };
     }
 

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -8,6 +8,8 @@ namespace Dekaf.Internal;
 /// </summary>
 internal static class PoolSizing
 {
+    private const int SharedArrayPoolDepthCeiling = 4096;
+
     /// <summary>
     /// Serialization buffer arrays per connection. Each RentedBufferWriter growth step
     /// (4KB → doubling → final size) rents/returns through the pool; 8 covers the
@@ -226,14 +228,20 @@ internal static class PoolSizing
         // PipeMemoryPool: 32 arrays per peak connection (covers pipelined segments).
         // Use max connections because adaptive single-broker load concentrates all
         // traffic on one shared pool before metadata/broker spread can help.
-        var pipeMemoryArrays = ClampPoolDepth(totalMaxConnections * 32L, floor: 32);
+        // ArrayPool<T>.Create eagerly allocates per-bucket metadata based on depth,
+        // so keep even producer-driven sizing bounded for pathological options.
+        var pipeMemoryArrays = ClampPoolDepth(
+            totalMaxConnections * 32L,
+            floor: 32,
+            ceiling: SharedArrayPoolDepthCeiling);
 
         // SerializationBuffers: covers concurrent request serialization across all connections.
         // Each RentedBufferWriter growth step rents/returns arrays; with multiple connections
         // serializing concurrently, the pool needs depth proportional to peak connections.
         var serializationArrays = ClampPoolDepth(
             totalMaxConnections * SerializationArraysPerConnection,
-            floor: 16);
+            floor: 16,
+            ceiling: SharedArrayPoolDepthCeiling);
 
         // ProduceResponsePool: one response per in-flight request per connection,
         // with 2x headroom for concurrent rent/return overlap.
@@ -252,8 +260,8 @@ internal static class PoolSizing
         };
     }
 
-    private static int ClampPoolDepth(long value, int floor) =>
-        (int)Math.Clamp(value, floor, (long)int.MaxValue);
+    private static int ClampPoolDepth(long value, int floor, int ceiling) =>
+        (int)Math.Clamp(value, floor, (long)ceiling);
 
     private static long SaturatingMultiply(long left, long right)
     {

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -232,7 +232,7 @@ internal static class PoolSizing
         // ArrayPool<T>.Create eagerly allocates per-bucket metadata based on depth,
         // so keep even producer-driven sizing bounded for pathological options.
         var pipeMemoryArrays = ClampPoolDepth(
-            totalMaxConnections * 32L,
+            SaturatingMultiply(totalMaxConnections, 32L),
             floor: 32,
             ceiling: SharedArrayPoolDepthCeiling);
 
@@ -240,7 +240,7 @@ internal static class PoolSizing
         // Each RentedBufferWriter growth step rents/returns arrays; with multiple connections
         // serializing concurrently, the pool needs depth proportional to peak connections.
         var serializationArrays = ClampPoolDepth(
-            totalMaxConnections * SerializationArraysPerConnection,
+            SaturatingMultiply(totalMaxConnections, SerializationArraysPerConnection),
             floor: 16,
             ceiling: SharedArrayPoolDepthCeiling);
 

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -160,8 +160,9 @@ internal static class PoolSizing
 
         /// <summary>
         /// <c>maxArraysPerBucket</c> for the shared <c>PipeMemoryPool</c> in ConnectionPool.
-        /// Scales by total connections (brokers x connections-per-broker) since all
-        /// connections share the same pool instance.
+        /// Scales by peak total connections (brokers x max-connections-per-broker)
+        /// since all connections share the same pool instance and adaptive scaling can
+        /// concentrate load before metadata discovers more brokers.
         /// </summary>
         public required int PipeMemoryArraysPerBucket { get; init; }
 
@@ -201,8 +202,9 @@ internal static class PoolSizing
         var clampedBrokers = Math.Clamp(brokerCount, 1, 16);
         var clampedConnections = Math.Max(1, connectionsPerBroker);
         var clampedMaxConnections = Math.Max(clampedConnections, maxConnectionsPerBroker);
-        var totalConnections = clampedBrokers * clampedConnections;
-        var totalMaxConnections = clampedBrokers * clampedMaxConnections;
+        var clampedMaxInFlight = Math.Max(1, maxInFlightRequestsPerConnection);
+        var totalConnections = (long)clampedBrokers * clampedConnections;
+        var totalMaxConnections = (long)clampedBrokers * clampedMaxConnections;
 
         // ProducerDataPool: depth must cover in-flight PooledMemory arrays on the cold path.
         // When buffer pressure forces messages through AppendFromSpansAsync's cold path,
@@ -211,28 +213,34 @@ internal static class PoolSizing
         // Use maxConnectionsPerBroker (not current) since adaptive scaling can ramp up.
         var clampedBatchSize = Math.Clamp(batchSize, 1024, 4 * 1024 * 1024);
         var estimatedMessagesPerBatch = Math.Clamp(clampedBatchSize / 256, 8, 512);
-        var peakInFlightBatches = totalMaxConnections * maxInFlightRequestsPerConnection;
-        var producerDataArrays = Math.Clamp(estimatedMessagesPerBatch * peakInFlightBatches, 64, 4096);
+        var peakInFlightBatches = SaturatingMultiply(totalMaxConnections, clampedMaxInFlight);
+        var producerDataArrays = (int)Math.Clamp(
+            SaturatingMultiply(estimatedMessagesPerBatch, peakInFlightBatches),
+            64L,
+            4096L);
 
         // Header[] arrays are rented once per header-bearing message and held until
         // the owning batch completes, so they need the same working-set depth.
         var headerArrays = producerDataArrays;
 
-        // PipeMemoryPool: 32 arrays per connection (covers pipelined segments),
-        // scaled by total connections, capped at 256.
-        var pipeMemoryArrays = Math.Clamp(totalConnections * 32, 32, 256);
+        // PipeMemoryPool: 32 arrays per peak connection (covers pipelined segments).
+        // Use max connections because adaptive single-broker load concentrates all
+        // traffic on one shared pool before metadata/broker spread can help.
+        var pipeMemoryArrays = ClampPoolDepth(totalMaxConnections * 32L, floor: 32);
 
         // SerializationBuffers: covers concurrent request serialization across all connections.
         // Each RentedBufferWriter growth step rents/returns arrays; with multiple connections
         // serializing concurrently, the pool needs depth proportional to peak connections.
-        var serializationArrays = Math.Clamp(
-            totalMaxConnections * SerializationArraysPerConnection, 16, 256);
+        var serializationArrays = ClampPoolDepth(
+            totalMaxConnections * SerializationArraysPerConnection,
+            floor: 16);
 
         // ProduceResponsePool: one response per in-flight request per connection,
         // with 2x headroom for concurrent rent/return overlap.
         var responsePoolSize = Math.Clamp(
-            totalConnections * maxInFlightRequestsPerConnection * 2,
-            64, 512);
+            SaturatingMultiply(SaturatingMultiply(totalConnections, clampedMaxInFlight), 2L),
+            64L,
+            512L);
 
         return new SharedPoolSizes
         {
@@ -240,7 +248,20 @@ internal static class PoolSizing
             HeaderArraysPerBucket = headerArrays,
             PipeMemoryArraysPerBucket = pipeMemoryArrays,
             SerializationArraysPerBucket = serializationArrays,
-            ProduceResponsePoolSize = responsePoolSize,
+            ProduceResponsePoolSize = (int)responsePoolSize,
         };
+    }
+
+    private static int ClampPoolDepth(long value, int floor) =>
+        (int)Math.Clamp(value, floor, (long)int.MaxValue);
+
+    private static long SaturatingMultiply(long left, long right)
+    {
+        if (left <= 0 || right <= 0)
+            return 0;
+
+        return left > long.MaxValue / right
+            ? long.MaxValue
+            : left * right;
     }
 }

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -22,8 +22,8 @@ public sealed partial class ConnectionPool : IConnectionPool
     /// Shared memory pool for all connections. Bounds total retained memory to one set of
     /// array buckets regardless of connection count, preventing multi-GB WorkingSet growth
     /// in multi-broker scenarios with adaptive scaling. See <see cref="PipeMemoryPool"/>.
-    /// Bucket capacity is scaled by <c>_connectionsPerBroker</c> to prevent pool saturation
-    /// under high concurrent load (capped at 256 to bound memory).
+    /// Bucket capacity is either provided by broker-aware producer sizing or falls back to
+    /// scaling by <c>_connectionsPerBroker</c> for direct ConnectionPool use.
     /// </summary>
     private PipeMemoryPool? _sharedPipeMemoryPool;
     private int _currentPipeMemoryBucketCapacity;

--- a/src/Dekaf/Networking/PipeMemoryPool.cs
+++ b/src/Dekaf/Networking/PipeMemoryPool.cs
@@ -62,13 +62,13 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
     /// high-throughput pipelining.
     /// <para/>
     /// <b>Memory tradeoff:</b> <c>ArrayPool.Create()</c> applies the same bucket count to all
-    /// size classes. <c>ConfigurableArrayPool</c> pre-allocates a fixed-size reference array per
-    /// bucket (32 slots), but the actual <c>byte[]</c> arrays are only allocated when rented and
-    /// cached when returned — idle buckets hold null slots, not memory. In practice, only the
-    /// small buckets (64 KB) fill to capacity; the large buckets (4 MB) rarely cache more than
-    /// 1-2 arrays because there are far fewer concurrent large allocations. Peak per-connection
-    /// retention is bounded by connection lifetime — when the connection is disposed, all retained
-    /// arrays become GC-eligible.</param>
+    /// size classes. <c>ConfigurableArrayPool</c> pre-allocates <paramref name="maxArraysPerBucket"/>
+    /// reference slots per bucket, but the actual <c>byte[]</c> arrays are only allocated when
+    /// rented and cached when returned — idle buckets hold null slots, not memory. In practice,
+    /// only the small buckets (64 KB) fill to capacity; the large buckets (4 MB) rarely cache more
+    /// than 1-2 arrays because there are far fewer concurrent large allocations. The producer-driven
+    /// shared pool sizing path caps this value before constructing the pool so pathological
+    /// connection settings cannot create unbounded bucket metadata.</param>
     public PipeMemoryPool(int maxArrayLength = 4 * 1024 * 1024, int maxArraysPerBucket = 32)
     {
         _pool = ArrayPool<byte>.Create(maxArrayLength, maxArraysPerBucket);

--- a/src/Dekaf/Networking/PipeMemoryPool.cs
+++ b/src/Dekaf/Networking/PipeMemoryPool.cs
@@ -23,9 +23,9 @@ namespace Dekaf.Networking;
 /// to one set of array buckets (maxArraysPerBucket × bucketCount) regardless of how many
 /// connections exist. Without sharing, each connection independently retained up to
 /// <c>maxArraysPerBucket</c> arrays per size class — with 3 brokers × 10 connections/broker
-/// = 30 independent pools, each retaining up to 32 arrays in large buckets, causing
-/// multi-GB WorkingSet growth. With a shared pool, the same 32 array slots are recycled
-/// across all connections, capping total retention at ~128 MB for the 4 MB bucket.
+/// = 30 independent pools, each retaining arrays in large buckets, causing multi-GB
+/// WorkingSet growth. With a shared pool, one configured bucket depth is recycled across
+/// all connections instead of multiplying retention by connection count.
 /// <para/>
 /// Connections created outside a <see cref="ConnectionPool"/> (e.g., in tests) fall back
 /// to creating their own per-connection pool for backward compatibility.

--- a/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
@@ -271,8 +271,8 @@ public class PoolSizingTests
 
         await Assert.That(sizes.ProducerDataArraysPerBucket).IsEqualTo(4096);
         await Assert.That(sizes.HeaderArraysPerBucket).IsEqualTo(4096);
-        // 16 brokers * max 10 conns * 32 = 5120
-        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(5120);
+        // 16 brokers * max 10 conns * 32 = 5120, capped at 4096
+        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(4096);
         // 16 brokers * max 10 conns * 8 = 1280
         await Assert.That(sizes.SerializationArraysPerBucket).IsEqualTo(1280);
         // 16 * 10 * 5 * 2 = 1600, capped at 512
@@ -308,6 +308,18 @@ public class PoolSizingTests
 
         await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(1280);
         await Assert.That(sizes.SerializationArraysPerBucket).IsEqualTo(320);
+    }
+
+    [Test]
+    public async Task ForSharedPools_PathologicalMaxConnections_ClampsSharedArrayPools()
+    {
+        var sizes = PoolSizing.ForSharedPools(
+            brokerCount: 16,
+            connectionsPerBroker: 1,
+            maxConnectionsPerBroker: 100_000);
+
+        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(4096);
+        await Assert.That(sizes.SerializationArraysPerBucket).IsEqualTo(4096);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
@@ -204,10 +204,10 @@ public class PoolSizingTests
         await Assert.That(sizes.ProducerDataArraysPerBucket).IsGreaterThanOrEqualTo(64);
         await Assert.That(sizes.ProducerDataArraysPerBucket).IsLessThanOrEqualTo(4096);
         await Assert.That(sizes.HeaderArraysPerBucket).IsEqualTo(sizes.ProducerDataArraysPerBucket);
-        // 1 broker * 1 conn * 32 = 32
-        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(32);
+        // 1 broker * max 10 conns * 32 = 320
+        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(320);
         // SerializationBuffers: 1 * 10 * 8 = 80
-        await Assert.That(sizes.SerializationArraysPerBucket).IsGreaterThanOrEqualTo(16);
+        await Assert.That(sizes.SerializationArraysPerBucket).IsEqualTo(80);
         // 1 * 1 * 5 * 2 = 10, clamped to min 64
         await Assert.That(sizes.ProduceResponsePoolSize).IsEqualTo(64);
     }
@@ -247,8 +247,8 @@ public class PoolSizingTests
         var singleBroker = PoolSizing.ForSharedPools(brokerCount: 1);
         await Assert.That(sizes.ProducerDataArraysPerBucket)
             .IsGreaterThanOrEqualTo(singleBroker.ProducerDataArraysPerBucket);
-        // 3 * 1 * 32 = 96
-        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(96);
+        // 3 brokers * max 10 conns * 32 = 960
+        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(960);
         // 3 * 1 * 5 * 2 = 30, clamped to min 64
         await Assert.That(sizes.ProduceResponsePoolSize).IsEqualTo(64);
     }
@@ -258,25 +258,25 @@ public class PoolSizingTests
     {
         var sizes = PoolSizing.ForSharedPools(brokerCount: 3, connectionsPerBroker: 3);
 
-        // 3 * 3 * 32 = 288, capped at 256
-        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(256);
+        // 3 brokers * max 10 conns * 32 = 960
+        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(960);
         // 3 * 3 * 5 * 2 = 90
         await Assert.That(sizes.ProduceResponsePoolSize).IsEqualTo(90);
     }
 
     [Test]
-    public async Task ForSharedPools_ManyBrokers_ClampsToMax()
+    public async Task ForSharedPools_ManyBrokers_ScalesSharedDepthsAndClampsBoundedPools()
     {
         var sizes = PoolSizing.ForSharedPools(brokerCount: 20, connectionsPerBroker: 10);
 
-        await Assert.That(sizes.ProducerDataArraysPerBucket).IsLessThanOrEqualTo(4096);
-        await Assert.That(sizes.HeaderArraysPerBucket).IsLessThanOrEqualTo(4096);
-        // 16 * 10 * 32 = 5120, capped at 256
-        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsLessThanOrEqualTo(256);
-        // SerializationBuffers capped at 256
-        await Assert.That(sizes.SerializationArraysPerBucket).IsLessThanOrEqualTo(256);
+        await Assert.That(sizes.ProducerDataArraysPerBucket).IsEqualTo(4096);
+        await Assert.That(sizes.HeaderArraysPerBucket).IsEqualTo(4096);
+        // 16 brokers * max 10 conns * 32 = 5120
+        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(5120);
+        // 16 brokers * max 10 conns * 8 = 1280
+        await Assert.That(sizes.SerializationArraysPerBucket).IsEqualTo(1280);
         // 16 * 10 * 5 * 2 = 1600, capped at 512
-        await Assert.That(sizes.ProduceResponsePoolSize).IsLessThanOrEqualTo(512);
+        await Assert.That(sizes.ProduceResponsePoolSize).IsEqualTo(512);
     }
 
     [Test]
@@ -285,7 +285,7 @@ public class PoolSizingTests
         var sizes = PoolSizing.ForSharedPools(brokerCount: 0);
 
         await Assert.That(sizes.ProducerDataArraysPerBucket).IsGreaterThanOrEqualTo(64);
-        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(32);
+        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(320);
     }
 
     [Test]
@@ -296,6 +296,18 @@ public class PoolSizingTests
 
         await Assert.That(largeConns.SerializationArraysPerBucket)
             .IsGreaterThan(smallConns.SerializationArraysPerBucket);
+    }
+
+    [Test]
+    public async Task ForSharedPools_SingleBrokerHighMaxConnections_ExceedsLegacySharedPoolCap()
+    {
+        var sizes = PoolSizing.ForSharedPools(
+            brokerCount: 1,
+            connectionsPerBroker: 1,
+            maxConnectionsPerBroker: 40);
+
+        await Assert.That(sizes.PipeMemoryArraysPerBucket).IsEqualTo(1280);
+        await Assert.That(sizes.SerializationArraysPerBucket).IsEqualTo(320);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- scale shared PipeMemoryPool and serialization array depths from peak adaptive connections instead of legacy 256 caps
- keep producer-data/header/response pools bounded while computing shared-pool working sets in long to avoid overflow
- update shared pool docs and PoolSizing regression coverage

## Validation
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -m:1 -p:UseSharedCompilation=false
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --disable-logo --no-ansi --treenode-filter "/*/*/PoolSizingTests/*"

Closes #776