### PR TITLE
fix(consumer): stabilize leader refresh token

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -564,7 +564,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     private readonly object _fetchCacheLock = new();
     private Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>>? _cachedTopicPartitions;
     private List<TopicPartition>? _cachedPartitionsList;
-    private readonly ConcurrentDictionary<string, byte> _pendingLeaderRefreshTopics = new();
+    private readonly object _leaderRefreshTasksLock = new();
+    private readonly ConcurrentDictionary<string, Task> _pendingLeaderRefreshTasks = new();
 
     public KafkaConsumer(
         ConsumerOptions options,
@@ -3649,8 +3650,39 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
             return;
 
-        if (_pendingLeaderRefreshTopics.TryAdd(topic, 0))
-            _ = ObserveLeaderRefreshAsync(topic, _leaderRefreshCts.Token);
+        lock (_leaderRefreshTasksLock)
+        {
+            if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
+                return;
+
+            if (_pendingLeaderRefreshTasks.ContainsKey(topic))
+                return;
+
+            CancellationToken cancellationToken;
+            try
+            {
+                cancellationToken = _leaderRefreshCts.Token;
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+
+            var refreshTask = ObserveLeaderRefreshAsync(topic, cancellationToken);
+            _pendingLeaderRefreshTasks[topic] = refreshTask;
+
+            if (refreshTask.IsCompleted)
+            {
+                _pendingLeaderRefreshTasks.TryRemove(topic, out _);
+                return;
+            }
+
+            _ = refreshTask.ContinueWith(static (task, state) =>
+            {
+                var (consumer, topicName) = ((KafkaConsumer<TKey, TValue> Consumer, string Topic))state!;
+                consumer._pendingLeaderRefreshTasks.TryRemove(topicName, out _);
+            }, (this, topic), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
     }
 
     private async Task ObserveLeaderRefreshAsync(string topic, CancellationToken cancellationToken)
@@ -3664,9 +3696,28 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         {
             // Best-effort refresh; the next fetch cycle will retry leader resolution.
         }
-        finally
+    }
+
+    private async ValueTask WaitForLeaderRefreshTasksAsync(CancellationToken cancellationToken = default)
+    {
+        Task[] refreshTasks;
+        lock (_leaderRefreshTasksLock)
         {
-            _pendingLeaderRefreshTopics.TryRemove(topic, out _);
+            if (_pendingLeaderRefreshTasks.IsEmpty)
+                return;
+
+            refreshTasks = [.. _pendingLeaderRefreshTasks.Values];
+        }
+
+        try
+        {
+            await Task.WhenAll(refreshTasks)
+                .WaitAsync(TimeSpan.FromSeconds(5), cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            // Ignore — best-effort refresh may not exit promptly after cancellation.
         }
     }
 
@@ -3970,13 +4021,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             await _coordinator.StopHeartbeatAsync().ConfigureAwait(false);
         }
 
-        // Step 2: Stop auto-commit task
+        // Step 2: Stop leader-refresh tasks before metadata dependencies are disposed
+        _leaderRefreshCts.Cancel();
+        await WaitForLeaderRefreshTasksAsync(cancellationToken).ConfigureAwait(false);
+
+        // Step 3: Stop auto-commit task
         // Use WaitAsync with both a hard timeout and the caller's cancellation token so that
         // DisposeAsync's 30s CTS actually bounds this step. Without this, a mid-flight
         // CommitAsync (which waits up to RequestTimeoutMs=30s for network I/O) would cause
         // CloseAsync to hang for the full network timeout, chaining across multiple consumers
         // during sequential `await using` disposal and exceeding test timeouts.
-        _leaderRefreshCts.Cancel();
         _autoCommitCts?.Cancel();
         if (_autoCommitTask is not null)
         {
@@ -3990,8 +4044,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             }
         }
 
-        // Step 3: Stop prefetch task
-        // Same rationale as Step 2: a mid-flight FetchAsync network operation could hang for
+        // Step 4: Stop prefetch task
+        // Same rationale as Step 3: a mid-flight FetchAsync network operation could hang for
         // up to RequestTimeoutMs without the WaitAsync timeout bounding it.
         _prefetchCts?.Cancel();
         if (_prefetchTask is not null)
@@ -4006,7 +4060,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             }
         }
 
-        // Step 4: Commit pending offsets (if auto-commit enabled and we have a coordinator)
+        // Step 5: Commit pending offsets (if auto-commit enabled and we have a coordinator)
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null && !_positions.IsEmpty)
         {
             for (var attempt = 0; attempt < 3; attempt++)
@@ -4234,6 +4288,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         _leaderRefreshCts.Cancel();
         _autoCommitCts?.Cancel();
         _prefetchCts?.Cancel();
+
+        await WaitForLeaderRefreshTasksAsync().ConfigureAwait(false);
 
         if (_autoCommitTask is not null)
         {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1883,8 +1883,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                                 await HandleNotLeaderOrFollowerAsync(
                                     topic,
                                     partitionResponse,
-                                    response.NodeEndpoints,
-                                    cancellationToken).ConfigureAwait(false);
+                                    response.NodeEndpoints).ConfigureAwait(false);
                             }
                             else
                             {
@@ -3412,8 +3411,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                             await HandleNotLeaderOrFollowerAsync(
                                 topic,
                                 partitionResponse,
-                                response.NodeEndpoints,
-                                cancellationToken).ConfigureAwait(false);
+                                response.NodeEndpoints).ConfigureAwait(false);
                         }
                         else
                         {
@@ -3620,8 +3618,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     private ValueTask HandleNotLeaderOrFollowerAsync(
         string topic,
         FetchResponsePartition partitionResponse,
-        IReadOnlyList<NodeEndpoint> nodeEndpoints,
-        CancellationToken cancellationToken)
+        IReadOnlyList<NodeEndpoint> nodeEndpoints)
     {
         var currentLeader = partitionResponse.CurrentLeader;
         var endpoint = currentLeader is null
@@ -3725,7 +3722,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         }
         catch
         {
-            // Ignore — best-effort refresh may not exit promptly after cancellation.
+            // Leader refresh is best-effort. Shutdown cancels the refresh token before this wait;
+            // if it still outlives the bound, teardown continues and the refresh task observes
+            // any late dependency-disposal exception internally.
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -516,8 +516,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     private readonly SemaphoreSlim _initLock = new(1, 1);
     private readonly SemaphoreSlim _assignmentLock = new(1, 1);
 
-
     private readonly ConcurrentDictionary<CancellationTokenSource, byte> _activeConsumeCancellationSources = new();
+    private readonly CancellationTokenSource _leaderRefreshCts = new();
     private CancellationTokenSource? _autoCommitCts;
     private Task? _autoCommitTask;
     private int _fetchApiVersion = -1;
@@ -3638,16 +3638,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         InvalidatePartitionCache();
         LogNotLeaderOrFollower(topic, partitionResponse.PartitionIndex);
 
-        if (!updated)
-            ScheduleLeaderRefresh(topic, cancellationToken);
+        if (!updated && !cancellationToken.IsCancellationRequested)
+            ScheduleLeaderRefresh(topic);
 
         return ValueTask.CompletedTask;
     }
 
-    private void ScheduleLeaderRefresh(string topic, CancellationToken cancellationToken)
+    private void ScheduleLeaderRefresh(string topic)
     {
+        if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
+            return;
+
         if (_pendingLeaderRefreshTopics.TryAdd(topic, 0))
-            _ = ObserveLeaderRefreshAsync(topic, cancellationToken);
+            _ = ObserveLeaderRefreshAsync(topic, _leaderRefreshCts.Token);
     }
 
     private async Task ObserveLeaderRefreshAsync(string topic, CancellationToken cancellationToken)
@@ -3973,6 +3976,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         // CommitAsync (which waits up to RequestTimeoutMs=30s for network I/O) would cause
         // CloseAsync to hang for the full network timeout, chaining across multiple consumers
         // during sequential `await using` disposal and exceeding test timeouts.
+        _leaderRefreshCts.Cancel();
         _autoCommitCts?.Cancel();
         if (_autoCommitTask is not null)
         {
@@ -4227,6 +4231,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         LogConsumerCloseCompleted(closeElapsedMs);
 
         CancelActiveConsumeOperations();
+        _leaderRefreshCts.Cancel();
         _autoCommitCts?.Cancel();
         _prefetchCts?.Cancel();
 
@@ -4256,6 +4261,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
         _autoCommitCts?.Dispose();
         _prefetchCts?.Dispose();
+        _leaderRefreshCts.Dispose();
 
         // Clear and dispose CancellationTokenSource pool
         // Note: active consume cancellation sources are managed by the pool and should not be disposed here

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3639,7 +3639,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         InvalidatePartitionCache();
         LogNotLeaderOrFollower(topic, partitionResponse.PartitionIndex);
 
-        if (!updated && !cancellationToken.IsCancellationRequested)
+        if (!updated)
             ScheduleLeaderRefresh(topic);
 
         return ValueTask.CompletedTask;
@@ -3650,6 +3650,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
             return;
 
+        TaskCompletionSource refreshCompletion;
+        CancellationToken cancellationToken;
+
         lock (_leaderRefreshTasksLock)
         {
             if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
@@ -3658,7 +3661,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             if (_pendingLeaderRefreshTasks.ContainsKey(topic))
                 return;
 
-            CancellationToken cancellationToken;
             try
             {
                 cancellationToken = _leaderRefreshCts.Token;
@@ -3668,24 +3670,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 return;
             }
 
-            var refreshTask = ObserveLeaderRefreshAsync(topic, cancellationToken);
-            _pendingLeaderRefreshTasks[topic] = refreshTask;
-
-            if (refreshTask.IsCompleted)
-            {
-                _pendingLeaderRefreshTasks.TryRemove(topic, out _);
-                return;
-            }
-
-            _ = refreshTask.ContinueWith(static (task, state) =>
-            {
-                var (consumer, topicName) = ((KafkaConsumer<TKey, TValue> Consumer, string Topic))state!;
-                consumer._pendingLeaderRefreshTasks.TryRemove(topicName, out _);
-            }, (this, topic), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            refreshCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _pendingLeaderRefreshTasks[topic] = refreshCompletion.Task;
         }
+
+        _ = ExecuteLeaderRefreshAsync(topic, refreshCompletion, cancellationToken);
     }
 
-    private async Task ObserveLeaderRefreshAsync(string topic, CancellationToken cancellationToken)
+    private async Task ExecuteLeaderRefreshAsync(
+        string topic,
+        TaskCompletionSource refreshCompletion,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -3695,6 +3690,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         catch
         {
             // Best-effort refresh; the next fetch cycle will retry leader resolution.
+        }
+        finally
+        {
+            if (_pendingLeaderRefreshTasks.TryGetValue(topic, out var task)
+                && ReferenceEquals(task, refreshCompletion.Task))
+            {
+                _pendingLeaderRefreshTasks.TryRemove(topic, out _);
+            }
+
+            refreshCompletion.TrySetResult();
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3693,10 +3693,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         }
         finally
         {
-            if (_pendingLeaderRefreshTasks.TryGetValue(topic, out var task)
-                && ReferenceEquals(task, refreshCompletion.Task))
+            lock (_leaderRefreshTasksLock)
             {
-                _pendingLeaderRefreshTasks.TryRemove(topic, out _);
+                if (_pendingLeaderRefreshTasks.TryGetValue(topic, out var task)
+                    && ReferenceEquals(task, refreshCompletion.Task))
+                {
+                    _pendingLeaderRefreshTasks.TryRemove(topic, out _);
+                }
             }
 
             refreshCompletion.TrySetResult();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -74,16 +74,15 @@ public sealed class ConsumerLeaderDiscoveryTests
         await connectionRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
-        await Task.Delay(50);
 
         _ = pool.Received(1).GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>());
 
         releaseConnection.SetException(new InvalidOperationException("stop refresh"));
-        await Task.Delay(50);
+        await WaitForLeaderRefreshToDrainAsync(consumer);
     }
 
     [Test]
-    public async Task HandleNotLeaderOrFollower_WithoutInlineLeader_RefreshOutlivesFetchCycleCancellation()
+    public async Task HandleNotLeaderOrFollower_WithoutInlineLeader_UsesDedicatedRefreshToken()
     {
         var pool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
@@ -106,19 +105,15 @@ public sealed class ConsumerLeaderDiscoveryTests
         await using var metadataManager = CreateMetadataManager(pool);
         SetMetadataApiVersion(metadataManager);
         await using var consumer = CreateConsumer(pool, metadataManager);
-        using var fetchCycleCts = new CancellationTokenSource();
-
         var partitionResponse = new FetchResponsePartition
         {
             PartitionIndex = 0,
             ErrorCode = ErrorCode.NotLeaderOrFollower
         };
 
-        await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, [], fetchCycleCts.Token);
+        await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
 
         var refreshToken = await refreshTokenCaptured.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        fetchCycleCts.Cancel();
-
         await Assert.That(refreshToken.IsCancellationRequested).IsFalse();
 
         refreshResponse.SetResult(CreateMetadataResponse());
@@ -126,7 +121,7 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
-    public async Task HandleNotLeaderOrFollower_WithoutInlineLeader_SchedulesRefreshWhenFetchCycleAlreadyCanceled()
+    public async Task HandleNotLeaderOrFollower_WithoutInlineLeader_SchedulesRefreshWithoutFetchCycleToken()
     {
         var pool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
@@ -149,16 +144,13 @@ public sealed class ConsumerLeaderDiscoveryTests
         await using var metadataManager = CreateMetadataManager(pool);
         SetMetadataApiVersion(metadataManager);
         await using var consumer = CreateConsumer(pool, metadataManager);
-        using var fetchCycleCts = new CancellationTokenSource();
-
         var partitionResponse = new FetchResponsePartition
         {
             PartitionIndex = 0,
             ErrorCode = ErrorCode.NotLeaderOrFollower
         };
 
-        fetchCycleCts.Cancel();
-        await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, [], fetchCycleCts.Token);
+        await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
 
         var refreshToken = await refreshTokenCaptured.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
@@ -308,30 +300,22 @@ public sealed class ConsumerLeaderDiscoveryTests
             ?? throw new InvalidOperationException("_pendingLeaderRefreshTasks field not found");
 
         var pending = (ConcurrentDictionary<string, Task>)field.GetValue(consumer)!;
-        var stopAt = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-
-        while (DateTime.UtcNow < stopAt)
+        if (pending.TryGetValue(Topic, out var task))
         {
-            if (!pending.ContainsKey(Topic))
-                return;
-
-            await Task.Delay(20).ConfigureAwait(false);
+            await task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
         }
-
-        throw new TimeoutException("Leader refresh did not drain.");
     }
 
     private static async ValueTask InvokeHandleNotLeaderOrFollowerAsync(
         KafkaConsumer<string, string> consumer,
         FetchResponsePartition partitionResponse,
-        IReadOnlyList<NodeEndpoint> nodeEndpoints,
-        CancellationToken cancellationToken = default)
+        IReadOnlyList<NodeEndpoint> nodeEndpoints)
     {
         var method = typeof(KafkaConsumer<string, string>)
             .GetMethod("HandleNotLeaderOrFollowerAsync", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("HandleNotLeaderOrFollowerAsync method not found");
 
-        var result = method.Invoke(consumer, [Topic, partitionResponse, nodeEndpoints, cancellationToken]);
+        var result = method.Invoke(consumer, [Topic, partitionResponse, nodeEndpoints]);
         if (result is not ValueTask valueTask)
             throw new InvalidOperationException("HandleNotLeaderOrFollowerAsync did not return ValueTask");
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Metadata;
@@ -81,6 +82,49 @@ public sealed class ConsumerLeaderDiscoveryTests
         await Task.Delay(50);
     }
 
+    [Test]
+    public async Task HandleNotLeaderOrFollower_WithoutInlineLeader_RefreshOutlivesFetchCycleCancellation()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var refreshTokenCaptured = new TaskCompletionSource<CancellationToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var refreshResponse = new TaskCompletionSource<MetadataResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(connection));
+
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                refreshTokenCaptured.TrySetResult((CancellationToken)callInfo[2]!);
+                return new ValueTask<MetadataResponse>(refreshResponse.Task);
+            });
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        SetMetadataApiVersion(metadataManager);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        using var fetchCycleCts = new CancellationTokenSource();
+
+        var partitionResponse = new FetchResponsePartition
+        {
+            PartitionIndex = 0,
+            ErrorCode = ErrorCode.NotLeaderOrFollower
+        };
+
+        await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, [], fetchCycleCts.Token);
+
+        var refreshToken = await refreshTokenCaptured.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        fetchCycleCts.Cancel();
+
+        await Assert.That(refreshToken.IsCancellationRequested).IsFalse();
+
+        refreshResponse.SetResult(CreateMetadataResponse());
+        await WaitForLeaderRefreshToDrainAsync(consumer);
+    }
+
     private static MetadataManager CreateMetadataManager(IConnectionPool pool)
         => new(pool, ["localhost:9092"]);
 
@@ -100,7 +144,11 @@ public sealed class ConsumerLeaderDiscoveryTests
 
     private static void SeedMetadata(MetadataManager metadataManager)
     {
-        metadataManager.Metadata.Update(new MetadataResponse
+        metadataManager.Metadata.Update(CreateMetadataResponse());
+    }
+
+    private static MetadataResponse CreateMetadataResponse()
+        => new()
         {
             ClusterId = "test-cluster",
             ControllerId = 1,
@@ -128,19 +176,48 @@ public sealed class ConsumerLeaderDiscoveryTests
                     ]
                 }
             ]
-        });
+        };
+
+    private static void SetMetadataApiVersion(MetadataManager metadataManager)
+    {
+        var field = typeof(MetadataManager)
+            .GetField("_metadataApiVersion", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_metadataApiVersion field not found");
+
+        field.SetValue(metadataManager, MetadataRequest.HighestSupportedVersion);
+    }
+
+    private static async Task WaitForLeaderRefreshToDrainAsync(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_pendingLeaderRefreshTopics", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_pendingLeaderRefreshTopics field not found");
+
+        var pending = (ConcurrentDictionary<string, byte>)field.GetValue(consumer)!;
+        var stopAt = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+
+        while (DateTime.UtcNow < stopAt)
+        {
+            if (!pending.ContainsKey(Topic))
+                return;
+
+            await Task.Delay(20).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException("Leader refresh did not drain.");
     }
 
     private static async ValueTask InvokeHandleNotLeaderOrFollowerAsync(
         KafkaConsumer<string, string> consumer,
         FetchResponsePartition partitionResponse,
-        IReadOnlyList<NodeEndpoint> nodeEndpoints)
+        IReadOnlyList<NodeEndpoint> nodeEndpoints,
+        CancellationToken cancellationToken = default)
     {
         var method = typeof(KafkaConsumer<string, string>)
             .GetMethod("HandleNotLeaderOrFollowerAsync", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("HandleNotLeaderOrFollowerAsync method not found");
 
-        var result = method.Invoke(consumer, [Topic, partitionResponse, nodeEndpoints, CancellationToken.None]);
+        var result = method.Invoke(consumer, [Topic, partitionResponse, nodeEndpoints, cancellationToken]);
         if (result is not ValueTask valueTask)
             throw new InvalidOperationException("HandleNotLeaderOrFollowerAsync did not return ValueTask");
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -126,11 +126,55 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
+    public async Task HandleNotLeaderOrFollower_WithoutInlineLeader_SchedulesRefreshWhenFetchCycleAlreadyCanceled()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var refreshTokenCaptured = new TaskCompletionSource<CancellationToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var refreshResponse = new TaskCompletionSource<MetadataResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(connection));
+
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                refreshTokenCaptured.TrySetResult((CancellationToken)callInfo[2]!);
+                return new ValueTask<MetadataResponse>(refreshResponse.Task);
+            });
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        SetMetadataApiVersion(metadataManager);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        using var fetchCycleCts = new CancellationTokenSource();
+
+        var partitionResponse = new FetchResponsePartition
+        {
+            PartitionIndex = 0,
+            ErrorCode = ErrorCode.NotLeaderOrFollower
+        };
+
+        fetchCycleCts.Cancel();
+        await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, [], fetchCycleCts.Token);
+
+        var refreshToken = await refreshTokenCaptured.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(refreshToken.IsCancellationRequested).IsFalse();
+
+        refreshResponse.SetResult(CreateMetadataResponse());
+        await WaitForLeaderRefreshToDrainAsync(consumer);
+    }
+
+    [Test]
     public async Task DisposeAsync_WithInFlightLeaderRefresh_WaitsBeforeDisposingDependencies()
     {
         var pool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
         var refreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var refreshCancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var refreshResponse = new TaskCompletionSource<MetadataResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
         var poolDisposeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -148,8 +192,12 @@ public sealed class ConsumerLeaderDiscoveryTests
                 Arg.Any<MetadataRequest>(),
                 Arg.Any<short>(),
                 Arg.Any<CancellationToken>())
-            .Returns(_ =>
+            .Returns(callInfo =>
             {
+                var cancellationToken = (CancellationToken)callInfo[2]!;
+                cancellationToken.Register(static state =>
+                    ((TaskCompletionSource)state!).TrySetResult(), refreshCancellationObserved);
+
                 refreshStarted.TrySetResult();
                 return new ValueTask<MetadataResponse>(refreshResponse.Task);
             });
@@ -171,7 +219,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             disposeTask = consumer.DisposeAsync().AsTask();
-            await Task.Delay(100);
+            await refreshCancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             await Assert.That(poolDisposeStarted.Task.IsCompleted).IsFalse();
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -125,6 +125,72 @@ public sealed class ConsumerLeaderDiscoveryTests
         await WaitForLeaderRefreshToDrainAsync(consumer);
     }
 
+    [Test]
+    public async Task DisposeAsync_WithInFlightLeaderRefresh_WaitsBeforeDisposingDependencies()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var refreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var refreshResponse = new TaskCompletionSource<MetadataResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var poolDisposeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(connection));
+
+        pool.DisposeAsync()
+            .Returns(_ =>
+            {
+                poolDisposeStarted.TrySetResult();
+                return ValueTask.CompletedTask;
+            });
+
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                refreshStarted.TrySetResult();
+                return new ValueTask<MetadataResponse>(refreshResponse.Task);
+            });
+
+        var metadataManager = CreateMetadataManager(pool);
+        SetMetadataApiVersion(metadataManager);
+        var consumer = CreateConsumer(pool, metadataManager);
+        Task? disposeTask = null;
+
+        try
+        {
+            var partitionResponse = new FetchResponsePartition
+            {
+                PartitionIndex = 0,
+                ErrorCode = ErrorCode.NotLeaderOrFollower
+            };
+
+            await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
+            await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            disposeTask = consumer.DisposeAsync().AsTask();
+            await Task.Delay(100);
+
+            await Assert.That(poolDisposeStarted.Task.IsCompleted).IsFalse();
+
+            refreshResponse.SetResult(CreateMetadataResponse());
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(poolDisposeStarted.Task.IsCompleted).IsTrue();
+        }
+        finally
+        {
+            refreshResponse.TrySetCanceled();
+
+            if (disposeTask is not null)
+                await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+            else
+                await consumer.DisposeAsync();
+        }
+    }
+
     private static MetadataManager CreateMetadataManager(IConnectionPool pool)
         => new(pool, ["localhost:9092"]);
 
@@ -190,10 +256,10 @@ public sealed class ConsumerLeaderDiscoveryTests
     private static async Task WaitForLeaderRefreshToDrainAsync(KafkaConsumer<string, string> consumer)
     {
         var field = typeof(KafkaConsumer<string, string>)
-            .GetField("_pendingLeaderRefreshTopics", BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("_pendingLeaderRefreshTopics field not found");
+            .GetField("_pendingLeaderRefreshTasks", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_pendingLeaderRefreshTasks field not found");
 
-        var pending = (ConcurrentDictionary<string, byte>)field.GetValue(consumer)!;
+        var pending = (ConcurrentDictionary<string, Task>)field.GetValue(consumer)!;
         var stopAt = DateTime.UtcNow + TimeSpan.FromSeconds(5);
 
         while (DateTime.UtcNow < stopAt)


### PR DESCRIPTION
## Summary
- use a consumer-scoped cancellation token for fire-and-forget leader metadata refreshes
- cancel the leader refresh token during close/dispose instead of tying it to a pooled fetch-cycle wakeup token
- add regression coverage that cancels the fetch-cycle token after scheduling refresh

## Test plan
- dotnet build tests\Dekaf.Tests.Unit --configuration Release
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumerLeaderDiscoveryTests/*" --minimum-expected-tests 3
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/LeaderDiscoveryResponseTests/*" --minimum-expected-tests 2

Follow-up to #987.