### PR TITLE
perf(producer): reserve memory with atomic add

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2762,7 +2762,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     /// <summary>
     /// Attempts to reserve buffer memory for a record without blocking.
-    /// Uses lock-free CAS loop for thread-safe reservation.
+    /// Uses atomic add with rollback so contention cannot be misreported as exhaustion.
     /// </summary>
     /// <param name="recordSize">Size in bytes to reserve</param>
     /// <returns>True if memory was reserved; false if BufferMemory limit would be exceeded</returns>
@@ -2776,40 +2776,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // Hoisted once per call — rebalancing is rare and one-cycle staleness is acceptable
         // (matches the snapshot semantics already used for _bufferedBytes).
         var max = (ulong)Volatile.Read(ref _maxBufferMemory);
+        var newValue = Interlocked.Add(ref _bufferedBytes, recordSize);
 
-        while (true)
-        {
-            var current = Volatile.Read(ref _bufferedBytes);
-            var newValue = current + recordSize;
+        if ((ulong)newValue <= max)
+            return true;
 
-            if ((ulong)newValue > max)
-                return false;
-
-            if (Interlocked.CompareExchange(ref _bufferedBytes, newValue, current) == current)
-                return true;
-
-            // CAS failed due to contention — fall through to spin path
-            break;
-        }
-
-        // Contention path: progressive backoff only when there's actual contention.
-        // Capped at the no-yield phase to stay lightweight — callers (ReserveMemoryAsync)
-        // already wrap this in their own retry loops with proper async waiting.
-        var spinner = new SpinWait();
-        while (!spinner.NextSpinWillYield)
-        {
-            spinner.SpinOnce();
-
-            var current = Volatile.Read(ref _bufferedBytes);
-            var newValue = current + recordSize;
-
-            if ((ulong)newValue > max)
-                return false;
-
-            if (Interlocked.CompareExchange(ref _bufferedBytes, newValue, current) == current)
-                return true;
-        }
-
+        Interlocked.Add(ref _bufferedBytes, -recordSize);
         return false;
     }
 

--- a/tests/Dekaf.Tests.Unit/Concurrency/RecordAccumulatorConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Concurrency/RecordAccumulatorConcurrencyTests.cs
@@ -182,7 +182,7 @@ public class RecordAccumulatorConcurrencyTests
     [Test]
     public async Task ConcurrentTryReserveAndReleaseMemory_AccountingRemainsConsistent()
     {
-        // TryReserveMemory and ReleaseMemory use CAS loops. Under contention,
+        // TryReserveMemory and ReleaseMemory use atomic updates. Under contention,
         // the final BufferedBytes must equal (reserved - released).
 
         const int taskCount = 8;

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorBudgetTests.cs
@@ -22,7 +22,7 @@ public class RecordAccumulatorBudgetTests
     public async Task SetMaxBufferMemory_Grow_AllowsAdditionalReservation()
     {
         const int OneMb = 1024 * 1024;
-        var accumulator = new RecordAccumulator(CreateOptions(OneMb));
+        await using var accumulator = new RecordAccumulator(CreateOptions(OneMb));
 
         await Assert.That(accumulator.TryReserveMemoryForTest(OneMb)).IsTrue();
         await Assert.That(accumulator.TryReserveMemoryForTest(1)).IsFalse();
@@ -37,7 +37,7 @@ public class RecordAccumulatorBudgetTests
     public async Task SetMaxBufferMemory_Shrink_BlocksFurtherReservation()
     {
         const int OneMb = 1024 * 1024;
-        var accumulator = new RecordAccumulator(CreateOptions(2 * OneMb));
+        await using var accumulator = new RecordAccumulator(CreateOptions(2 * OneMb));
 
         await Assert.That(accumulator.TryReserveMemoryForTest((3 * OneMb) / 2)).IsTrue();
 
@@ -45,5 +45,42 @@ public class RecordAccumulatorBudgetTests
 
         await Assert.That(accumulator.TryReserveMemoryForTest(1)).IsFalse();
         await Assert.That(accumulator.MaxBufferMemory).IsEqualTo((ulong)OneMb);
+    }
+
+    [Test]
+    public async Task TryReserveMemory_OverLimit_RollsBackReservation()
+    {
+        await using var accumulator = new RecordAccumulator(CreateOptions(100));
+
+        await Assert.That(accumulator.TryReserveMemoryForTest(90)).IsTrue();
+        await Assert.That(accumulator.TryReserveMemoryForTest(20)).IsFalse();
+        await Assert.That(accumulator.BufferedBytes).IsEqualTo(90);
+    }
+
+    [Test]
+    public async Task TryReserveMemory_ConcurrentReservationsBelowLimit_AllSucceed()
+    {
+        var taskCount = Math.Clamp(Environment.ProcessorCount * 2, 4, 32);
+        const int OpsPerTask = 1_000;
+        await using var accumulator = new RecordAccumulator(CreateOptions((ulong)(taskCount * OpsPerTask)));
+        using var start = new ManualResetEventSlim();
+        var failures = 0;
+
+        var tasks = Enumerable.Range(0, taskCount).Select(_ => Task.Run(() =>
+        {
+            start.Wait();
+
+            for (var i = 0; i < OpsPerTask; i++)
+            {
+                if (!accumulator.TryReserveMemoryForTest(1))
+                    Interlocked.Increment(ref failures);
+            }
+        })).ToArray();
+
+        start.Set();
+        await Task.WhenAll(tasks);
+
+        await Assert.That(failures).IsEqualTo(0);
+        await Assert.That(accumulator.BufferedBytes).IsEqualTo(taskCount * OpsPerTask);
     }
 }


### PR DESCRIPTION
## Summary
- replace the `TryReserveMemory` CAS/spin reservation path with atomic add plus rollback
- keep buffer accounting exact when a reservation exceeds `BufferMemory`
- add rollback and concurrent-reservation coverage for the reservation path

## Test plan
- dotnet build tests\Dekaf.Tests.Unit --configuration Release
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordAccumulatorBudgetTests/*" --minimum-expected-tests 4
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordAccumulatorConcurrencyTests/*" --minimum-expected-tests 5
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/BufferMemoryTests/*" --minimum-expected-tests 10

Closes #910