### PR TITLE
perf(protocol): avoid boxed enumerators

### DIFF
--- a/src/Dekaf/Protocol/Messages/FetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FetchResponse.cs
@@ -74,9 +74,9 @@ public sealed class FetchResponse : IKafkaResponse
         if (Interlocked.CompareExchange(ref _pooled, 1, 0) != 0)
             return;
 
-        foreach (var topic in _responses)
+        for (var i = 0; i < _responses.Count; i++)
         {
-            topic.ReturnToPool();
+            _responses[i].ReturnToPool();
         }
 
         // Return the topic list to the pool if it's a pooled list
@@ -209,9 +209,9 @@ public sealed class FetchResponseTopic
         if (Interlocked.CompareExchange(ref _pooled, 1, 0) != 0)
             return;
 
-        foreach (var partition in _partitions)
+        for (var i = 0; i < _partitions.Count; i++)
         {
-            partition.ReturnToPool();
+            _partitions[i].ReturnToPool();
         }
 
         // Return the partition list to the pool if it's a pooled list


### PR DESCRIPTION
## Summary
- Replace fetch response pool cleanup `foreach` loops over `IReadOnlyList<T>` with indexed loops to avoid boxed enumerators.
- Confirm `ProduceRequest` record-batch paths already use indexed loops on current main.

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/FetchResponsePoolingTests/*"
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ProduceRequestTests/*"
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordBatchTests/*"
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/LeaderDiscoveryResponseTests/*"
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/LazyRecordListTests/*"
- [x] git diff --check

Full unfiltered unit executable was also attempted but exceeded the 185s local timeout without a failure summary.

Closes #993
