### PR TITLE
perf(producer): queue linger partitions

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3263,7 +3263,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         while (true)
         {
             var waitForRotation = false;
-            var requeueForLinger = false;
 
             {
                 using var guard = new SpinLockGuard(ref pd.Lock);
@@ -3288,15 +3287,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     if (batchCreatedTicks < newOldestTicks)
                         newOldestTicks = batchCreatedTicks;
 
-                    requeueForLinger = !sealAll;
+                    if (!sealAll)
+                        QueueLingerPartition(pd, topicPartition);
                     break;
                 }
-            }
-
-            if (requeueForLinger)
-            {
-                QueueLingerPartition(pd, topicPartition);
-                break;
             }
 
             if (!waitForRotation)

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2067,6 +2067,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         if (TryAppendToBatch(currentBatch, timestamp, key, value, headers, headerCount,
                             completionSource, callback, recordSize))
                         {
+                            if (completionSource is not null)
+                                QueueLingerPartition(pd, topicPartition);
                             batchToReturn = rentedBatch;
                             rentedBatch = null;
                             appendSucceeded = true;
@@ -2378,6 +2380,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         if (TryAppendFromSpansToBatch(currentBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
                             headers, headerCount, completionSource, callback, recordSize))
                         {
+                            if (completionSource is not null)
+                                QueueLingerPartition(pd, topicPartition);
                             batchToReturn = rentedBatch;
                             rentedBatch = null;
                             appendSucceeded = true;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -798,9 +798,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private long _oldestBatchCreatedTicks = long.MaxValue;
 
     // Track whether there are pending awaited produces (ProduceAsync with completion sources).
-    // These need immediate flushing via ShouldFlush() regardless of LingerMs, so we can't
-    // skip enumeration when this counter is non-zero.
+    // These need micro-linger checks regardless of LingerMs, so ExpireLingerAsync drains the
+    // active linger queue when this counter is non-zero.
     private int _pendingAwaitedProduceCount;
+
+    // Push-based notification queue for partitions with an unsealed CurrentBatch.
+    // Linger drains this instead of scanning _partitionDeques every 1ms, making awaited-produce
+    // checks O(active unsealed partitions) instead of O(all partitions ever touched).
+    private readonly ConcurrentQueue<TopicPartition> _lingerPartitions = new();
 
     // Push-based notification queue for partitions with sealed batches ready to send.
     // Populated by append rotation, SealBatchesAsync, and Reenqueue when a batch
@@ -966,6 +971,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         /// <summary>Current unsealed batch accepting new records. Null if no active batch.</summary>
         public PartitionBatch? CurrentBatch;
+
+        /// <summary>1 when this partition has an entry in the linger notification queue.</summary>
+        public int LingerQueued;
 
         /// <summary>
         /// True while a thread has detached CurrentBatch and is completing it outside Lock.
@@ -1907,6 +1915,38 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return deque;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void TrackCurrentBatchForLinger(PartitionDeque pd, TopicPartition topicPartition, PartitionBatch batch)
+    {
+        TrackOldestBatchCreated(batch.CreatedAtStopwatchTimestamp);
+        QueueLingerPartition(pd, topicPartition);
+    }
+
+    private void TrackOldestBatchCreated(long createdTicks)
+    {
+        var current = Volatile.Read(ref _oldestBatchCreatedTicks);
+        while (createdTicks < current)
+        {
+            var original = Interlocked.CompareExchange(ref _oldestBatchCreatedTicks, createdTicks, current);
+            if (original == current)
+                break;
+            current = original;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void QueueLingerPartition(PartitionDeque pd, TopicPartition topicPartition)
+    {
+        if (Interlocked.Exchange(ref pd.LingerQueued, 1) == 0)
+            _lingerPartitions.Enqueue(topicPartition);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void MarkLingerPartitionDequeued(PartitionDeque pd)
+    {
+        Volatile.Write(ref pd.LingerQueued, 0);
+    }
+
     /// <summary>
     /// Async append method for all produce paths (fire-and-forget and awaitable).
     /// Hot path: if <see cref="TryReserveMemory"/> succeeds, completes synchronously with no async state machine.
@@ -2048,6 +2088,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         rentedBatch = null;
                         pd.CurrentBatch = newBatch;
                         Interlocked.Increment(ref _unsealedBatchCount);
+                        TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
 
                         if (TryAppendToBatch(newBatch, timestamp, key, value, headers, headerCount,
                             completionSource, callback, recordSize))
@@ -2059,6 +2100,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         else
                         {
                             pd.CurrentBatch = null;
+                            MarkLingerPartitionDequeued(pd);
                             Interlocked.Decrement(ref _unsealedBatchCount);
                             ClearRotationInProgressUnderLock(pd);
                             ownsRotation = false;
@@ -2357,6 +2399,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         rentedBatch = null;
                         pd.CurrentBatch = newBatch;
                         Interlocked.Increment(ref _unsealedBatchCount);
+                        TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
 
                         if (TryAppendFromSpansToBatch(newBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
                             headers, headerCount, completionSource, callback, recordSize))
@@ -2368,6 +2411,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         else
                         {
                             pd.CurrentBatch = null;
+                            MarkLingerPartitionDequeued(pd);
                             Interlocked.Decrement(ref _unsealedBatchCount);
                             ClearRotationInProgressUnderLock(pd);
                             ownsRotation = false;
@@ -2603,6 +2647,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private PartitionBatch DetachCurrentBatchForSealUnderLock(PartitionDeque pd, PartitionBatch currentBatch)
     {
         pd.CurrentBatch = null;
+        MarkLingerPartitionDequeued(pd);
         pd.RotationInProgress = true;
         Interlocked.Decrement(ref _unsealedBatchCount);
         return currentBatch;
@@ -3041,20 +3086,21 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             {
                 Interlocked.Decrement(ref _unsealedBatchCount);
                 pd.CurrentBatch = null;
+                MarkLingerPartitionDequeued(pd);
             }
         }
     }
 
     /// <remarks>
     /// Optimized with multiple fast paths:
-    /// 1. Empty dictionary check - avoids enumeration overhead
-    /// 2. Oldest batch age check - skips enumeration if no batch can possibly be ready
-    /// With LingerMs=5ms and 1ms timer, this reduces enumeration from 5x to 1x per batch lifetime.
+    /// 1. No-unsealed-batch check avoids linger work entirely.
+    /// 2. Oldest batch age check skips active queue draining if no fire-and-forget batch can be ready.
+    /// 3. Active linger queue avoids scanning all historical partition deques under awaited load.
     /// Also uses synchronous TryWrite when possible to avoid async overhead.
     /// </remarks>
     public ValueTask ExpireLingerAsync(CancellationToken cancellationToken)
     {
-        // Fast path 1: no unsealed batches to check - avoid enumeration and async overhead entirely
+        // Fast path 1: no unsealed batches to check - avoid queue draining and async overhead entirely
         if (!HasUnsealedBatches())
         {
             // Reset oldest batch tracking since there are no batches
@@ -3063,10 +3109,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
 
         // Fast path 2: if the oldest batch hasn't reached linger time yet AND there are no
-        // pending awaited produces, skip enumeration. Awaited produces (ProduceAsync) use a
-        // micro-linger (min(1ms, LingerMs/10)) so they need more frequent enumeration checks.
-        // This is the key optimization: with LingerMs=5 and 1ms timer, we'd enumerate 5x per batch.
-        // By tracking the oldest batch, we skip 4 out of 5 enumerations for fire-and-forget workloads.
+        // pending awaited produces, skip active queue checks. Awaited produces (ProduceAsync)
+        // use a micro-linger (min(1ms, LingerMs/10)) so they need more frequent checks.
         if (Volatile.Read(ref _pendingAwaitedProduceCount) == 0)
         {
             var oldestTicks = Volatile.Read(ref _oldestBatchCreatedTicks);
@@ -3075,7 +3119,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 var millisSinceOldest = (long)Stopwatch.GetElapsedTime(oldestTicks).TotalMilliseconds;
                 if (millisSinceOldest < _options.LingerMs)
                 {
-                    // No batch is old enough to flush yet - skip the O(n) enumeration
+                    // No batch is old enough to flush yet.
                     return ValueTask.CompletedTask;
                 }
             }
@@ -3124,7 +3168,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     /// <param name="sealAll">
     /// true = flush mode: seals ALL batches (Keys.ToArray snapshot, blocking lock).
-    /// false = linger mode: seals only expired batches (foreach enumeration, non-blocking lock).
+    /// false = linger mode: seals expired batches from the active linger notification queue.
     /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     private async ValueTask SealBatchesAsync(bool sealAll, CancellationToken cancellationToken)
@@ -3148,89 +3192,36 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             var newOldestTicks = long.MaxValue;
             var anySealed = false;
 
-            foreach (var kvp in _partitionDeques)
+            if (sealAll)
             {
-                var pd = kvp.Value;
-                ReadyBatch? sealedBatch = null;
-                PartitionBatch? batchToComplete = null;
-                var spinner = new SpinWait();
-
-                while (true)
+                foreach (var kvp in _partitionDeques)
                 {
-                    var waitForRotation = false;
-
-                    {
-                        using var guard = new SpinLockGuard(ref pd.Lock);
-
-                        if (pd.RotationInProgress)
-                        {
-                            waitForRotation = true;
-                        }
-                        else if (pd.CurrentBatch is null)
-                        {
-                            break;
-                        }
-                        else if (sealAll || pd.CurrentBatch.ShouldFlush(now, _options.LingerMs))
-                        {
-                            ProducerDebugCounters.RecordBatchFlushedFromDictionary();
-                            batchToComplete = DetachCurrentBatchForSealUnderLock(pd, pd.CurrentBatch);
-                            break;
-                        }
-                        else
-                        {
-                            // Batch not ready for flush - track its creation time for oldest batch calculation
-                            var batchCreatedTicks = pd.CurrentBatch.CreatedAtStopwatchTimestamp;
-                            if (batchCreatedTicks < newOldestTicks)
-                                newOldestTicks = batchCreatedTicks;
-                            break;
-                        }
-                    }
-
-                    if (waitForRotation)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        spinner.SpinOnce();
-                    }
-                }
-
-                if (batchToComplete is not null)
-                {
-                    try
-                    {
-                        sealedBatch = CompleteDetachedBatch(batchToComplete);
-                    }
-                    catch
-                    {
-                        ClearRotationInProgress(pd);
-                        throw;
-                    }
-
-                    {
-                        using var guard = new SpinLockGuard(ref pd.Lock);
-                        if (sealedBatch is not null)
-                            EnqueueCompletedBatchUnderLock(pd, sealedBatch);
-                        ClearRotationInProgressUnderLock(pd);
-                    }
-
-                    if (sealedBatch is not null)
-                    {
-                        PublishSealedBatch(sealedBatch, signalWakeup: false);
+                    if (TrySealCurrentBatch(kvp.Key, kvp.Value, now, sealAll: true, cancellationToken, ref newOldestTicks))
                         anySealed = true;
-                    }
+                }
+            }
+            else
+            {
+                var count = _lingerPartitions.Count;
+                for (var i = 0; i < count; i++)
+                {
+                    if (!_lingerPartitions.TryDequeue(out var topicPartition))
+                        break;
+
+                    if (!_partitionDeques.TryGetValue(topicPartition, out var pd))
+                        continue;
+
+                    MarkLingerPartitionDequeued(pd);
+                    if (TrySealCurrentBatch(topicPartition, pd, now, sealAll: false, cancellationToken, ref newOldestTicks))
+                        anySealed = true;
                 }
             }
 
             if (!sealAll)
             {
-                // Update the oldest batch tracking for next check using CAS to prevent race condition.
-                var current = Volatile.Read(ref _oldestBatchCreatedTicks);
-                while (newOldestTicks < current)
-                {
-                    var original = Interlocked.CompareExchange(ref _oldestBatchCreatedTicks, newOldestTicks, current);
-                    if (original == current)
-                        break;
-                    current = original;
-                }
+                // This is a best-effort hint. If a concurrent append creates a batch after our
+                // queue snapshot, the next tick falls through and observes its queue entry.
+                Volatile.Write(ref _oldestBatchCreatedTicks, newOldestTicks);
             }
             else
             {
@@ -3249,6 +3240,97 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     private ValueTask ExpireLingerAsyncCore(CancellationToken cancellationToken)
         => SealBatchesAsync(sealAll: false, cancellationToken);
+
+    private bool TrySealCurrentBatch(
+        TopicPartition topicPartition,
+        PartitionDeque pd,
+        long now,
+        bool sealAll,
+        CancellationToken cancellationToken,
+        ref long newOldestTicks)
+    {
+        ReadyBatch? sealedBatch = null;
+        PartitionBatch? batchToComplete = null;
+        var spinner = new SpinWait();
+
+        while (true)
+        {
+            var waitForRotation = false;
+            var requeueForLinger = false;
+
+            {
+                using var guard = new SpinLockGuard(ref pd.Lock);
+
+                if (pd.RotationInProgress)
+                {
+                    waitForRotation = true;
+                }
+                else if (pd.CurrentBatch is null)
+                {
+                    break;
+                }
+                else if (sealAll || pd.CurrentBatch.ShouldFlush(now, _options.LingerMs))
+                {
+                    ProducerDebugCounters.RecordBatchFlushedFromDictionary();
+                    batchToComplete = DetachCurrentBatchForSealUnderLock(pd, pd.CurrentBatch);
+                    break;
+                }
+                else
+                {
+                    var batchCreatedTicks = pd.CurrentBatch.CreatedAtStopwatchTimestamp;
+                    if (batchCreatedTicks < newOldestTicks)
+                        newOldestTicks = batchCreatedTicks;
+
+                    requeueForLinger = !sealAll;
+                    break;
+                }
+            }
+
+            if (requeueForLinger)
+            {
+                QueueLingerPartition(pd, topicPartition);
+                break;
+            }
+
+            if (!waitForRotation)
+                break;
+
+            if (!sealAll)
+            {
+                QueueLingerPartition(pd, topicPartition);
+                break;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            spinner.SpinOnce();
+        }
+
+        if (batchToComplete is null)
+            return false;
+
+        try
+        {
+            sealedBatch = CompleteDetachedBatch(batchToComplete);
+        }
+        catch
+        {
+            ClearRotationInProgress(pd);
+            throw;
+        }
+
+        {
+            using var guard = new SpinLockGuard(ref pd.Lock);
+            if (sealedBatch is not null)
+                EnqueueCompletedBatchUnderLock(pd, sealedBatch);
+            ClearRotationInProgressUnderLock(pd);
+        }
+
+        if (sealedBatch is null)
+            return false;
+
+        PublishSealedBatch(sealedBatch, signalWakeup: false);
+        return true;
+    }
 
     /// <summary>
     /// Tracks a batch entering the pipeline: increments counter and adds to reference-tracking dictionary.
@@ -3754,6 +3836,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     }
                     _batchPool.Return(current);
                     pd.CurrentBatch = null;
+                    MarkLingerPartitionDequeued(pd);
                     Interlocked.Decrement(ref _unsealedBatchCount);
                 }
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3219,9 +3219,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
             if (!sealAll)
             {
-                // This is a best-effort hint. If a concurrent append creates a batch after our
-                // queue snapshot, the next tick falls through and observes its queue entry.
-                Volatile.Write(ref _oldestBatchCreatedTicks, newOldestTicks);
+                // This is a best-effort lower-bound hint. Linger mode drains a queue snapshot,
+                // so a concurrent append or queued partition outside this snapshot may be older
+                // than newOldestTicks. Only lower the hint; raising it can delay an already
+                // expired batch until a newer batch reaches linger.
+                if (newOldestTicks != long.MaxValue)
+                    TrackOldestBatchCreated(newOldestTicks);
             }
             else
             {

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -641,7 +641,7 @@ public class RecordAccumulatorReadyTests
             await Assert.That(appended).IsTrue();
 
             var createdTicks = GetPrivateField<long>(accumulator, "_oldestBatchCreatedTicks");
-            var olderHint = Math.Max(0, createdTicks - Stopwatch.Frequency);
+            var olderHint = Math.Max(0, createdTicks - Stopwatch.Frequency * 20);
             SetPrivateField(accumulator, "_oldestBatchCreatedTicks", olderHint);
             var lingerQueue = GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_lingerPartitions");
 

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -643,11 +643,13 @@ public class RecordAccumulatorReadyTests
             var createdTicks = GetPrivateField<long>(accumulator, "_oldestBatchCreatedTicks");
             var olderHint = Math.Max(0, createdTicks - Stopwatch.Frequency);
             SetPrivateField(accumulator, "_oldestBatchCreatedTicks", olderHint);
+            var lingerQueue = GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_lingerPartitions");
 
             await accumulator.ExpireLingerAsync(CancellationToken.None);
 
             await Assert.That(GetPrivateField<long>(accumulator, "_oldestBatchCreatedTicks"))
                 .IsEqualTo(olderHint);
+            await Assert.That(lingerQueue.Count).IsEqualTo(1);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -587,6 +587,38 @@ public class RecordAccumulatorReadyTests
     }
 
     [Test]
+    public async Task ExpireLingerAsync_DoesNotRaiseOldestBatchHint()
+    {
+        var options = CreateTestOptions(batchSize: 100_000, lingerMs: 10_000);
+        var accumulator = new RecordAccumulator(options);
+
+        try
+        {
+            var pooledKey = new PooledMemory(null, 0, isNull: true);
+            var pooledValue = new PooledMemory(null, 0, isNull: true);
+
+            var appended = await accumulator.AppendAsync(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                pooledKey, pooledValue, null, 0, null, null, CancellationToken.None);
+
+            await Assert.That(appended).IsTrue();
+
+            var createdTicks = GetPrivateField<long>(accumulator, "_oldestBatchCreatedTicks");
+            var olderHint = Math.Max(0, createdTicks - Stopwatch.Frequency);
+            SetPrivateField(accumulator, "_oldestBatchCreatedTicks", olderHint);
+
+            await accumulator.ExpireLingerAsync(CancellationToken.None);
+
+            await Assert.That(GetPrivateField<long>(accumulator, "_oldestBatchCreatedTicks"))
+                .IsEqualTo(olderHint);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task Drain_MaxRequestSizeExceeded_ReenqueuesSkippedPartitions()
     {
         // Regression test: when DrainBatchesForOneNode hits maxRequestSize and breaks,
@@ -1007,5 +1039,11 @@ public class RecordAccumulatorReadyTests
     {
         var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
         return (T)field!.GetValue(instance)!;
+    }
+
+    private static void SetPrivateField<T>(object instance, string fieldName, T value)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(instance, value);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -587,6 +587,43 @@ public class RecordAccumulatorReadyTests
     }
 
     [Test]
+    public async Task LingerPartitionsQueue_AwaitedAppendRequeuesWhenFlagCleared()
+    {
+        var options = CreateTestOptions(batchSize: 100_000, lingerMs: 10_000);
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            var pooledKey = new PooledMemory(null, 0, isNull: true);
+            var pooledValue = new PooledMemory(null, 0, isNull: true);
+
+            var firstCompletion = pool.Rent();
+            accumulator.TryAppendWithCompletion("test-topic", 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                pooledKey, pooledValue, null, 0, firstCompletion);
+
+            var lingerQueue = GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_lingerPartitions");
+            await Assert.That(lingerQueue.TryDequeue(out _)).IsTrue();
+
+            var partitionDeque = GetPartitionDeque(accumulator, "test-topic", 0);
+            SetInstanceField(partitionDeque, "LingerQueued", 0);
+
+            var secondCompletion = pool.Rent();
+            accumulator.TryAppendWithCompletion("test-topic", 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                pooledKey, pooledValue, null, 0, secondCompletion);
+
+            await Assert.That(lingerQueue.Count).IsEqualTo(1);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task ExpireLingerAsync_DoesNotRaiseOldestBatchHint()
     {
         var options = CreateTestOptions(batchSize: 100_000, lingerMs: 10_000);
@@ -1044,6 +1081,21 @@ public class RecordAccumulatorReadyTests
     private static void SetPrivateField<T>(object instance, string fieldName, T value)
     {
         var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(instance, value);
+    }
+
+    private static object GetPartitionDeque(RecordAccumulator accumulator, string topic, int partition)
+    {
+        var method = typeof(RecordAccumulator).GetMethod(
+            "GetOrCreateDeque",
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            [typeof(string), typeof(int)]);
+        return method!.Invoke(accumulator, [topic, partition])!;
+    }
+
+    private static void SetInstanceField<T>(object instance, string fieldName, T value)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
         field!.SetValue(instance, value);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -1,5 +1,7 @@
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Reflection;
 using Dekaf.Compression;
 using Dekaf.Metadata;
 using Dekaf.Producer;
@@ -532,8 +534,12 @@ public class RecordAccumulatorReadyTests
                 DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                 pooledKey, pooledValue, null, 0, completion);
 
+            var lingerQueue = GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_lingerPartitions");
+            await Assert.That(lingerQueue.Count).IsEqualTo(1);
+
             // Seal via linger expiry (doesn't wait for delivery like FlushAsync does)
             await accumulator.ExpireLingerAsync(CancellationToken.None);
+            await Assert.That(lingerQueue.IsEmpty).IsTrue();
 
             // Act: Ready() should find the sealed batch
             var readyNodes = new HashSet<int>();
@@ -547,6 +553,36 @@ public class RecordAccumulatorReadyTests
             await accumulator.DisposeAsync();
             await pool.DisposeAsync();
             await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task LingerPartitionsQueue_SameCurrentBatch_QueuesOnce()
+    {
+        var options = CreateTestOptions(batchSize: 100_000, lingerMs: 10_000);
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            var pooledKey = new PooledMemory(null, 0, isNull: true);
+            var pooledValue = new PooledMemory(null, 0, isNull: true);
+
+            for (var i = 0; i < 10; i++)
+            {
+                var completion = pool.Rent();
+                accumulator.TryAppendWithCompletion("test-topic", 0,
+                    DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    pooledKey, pooledValue, null, 0, completion);
+            }
+
+            var lingerQueue = GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_lingerPartitions");
+            await Assert.That(lingerQueue.Count).IsEqualTo(1);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
         }
     }
 
@@ -965,5 +1001,11 @@ public class RecordAccumulatorReadyTests
 
         manager.Metadata.Update(response);
         return manager;
+    }
+
+    private static T GetPrivateField<T>(object instance, string fieldName)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        return (T)field!.GetValue(instance)!;
     }
 }


### PR DESCRIPTION
## Summary
- add an active linger partition queue for current unsealed batches
- drain queued active partitions during linger instead of scanning every partition deque every 1ms
- keep full dictionary scan for FlushAsync, and preserve oldest-batch skip for fire-and-forget workloads
- add unit coverage for linger queue sealing and same-batch queue dedupe

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -m:1 -p:UseSharedCompilation=false`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --disable-logo --no-ansi --treenode-filter "/*/*/RecordAccumulatorReadyTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --disable-logo --no-ansi --treenode-filter "/*/*/RecordAccumulatorTests/*"`
- focused producer class sweep: `ShouldFlushTests`, `BufferMemoryTests`, `KafkaProducerFastPathTests`, `ProducerCancellationTests`, `MemoryReleasedAtomicityTests`, `RecordAccumulatorBudgetTests`, `AppendWorkerAffinityTests`
- `git diff --check`

Note: a full unit run was attempted and hit the local 10-minute command timeout before completion; focused high-risk producer suites above passed.

Closes #913
