### PR TITLE
perf(protocol): remove metadata request LINQ

### DIFF
--- a/src/Dekaf/Protocol/Messages/MetadataRequest.cs
+++ b/src/Dekaf/Protocol/Messages/MetadataRequest.cs
@@ -93,8 +93,12 @@ public sealed class MetadataRequest : IKafkaRequest<MetadataResponse>
             return new MetadataRequest { Topics = topics };
         }
 
-        // Fallback for arbitrary enumerables - must enumerate twice or use List
-        var topicList = topicNames.Select(n => new MetadataRequestTopic { Name = n }).ToArray();
+        var topicList = new List<MetadataRequestTopic>();
+        foreach (var name in topicNames)
+        {
+            topicList.Add(new MetadataRequestTopic { Name = name });
+        }
+
         return new MetadataRequest { Topics = topicList };
     }
 }

--- a/src/Dekaf/Protocol/Messages/MetadataRequest.cs
+++ b/src/Dekaf/Protocol/Messages/MetadataRequest.cs
@@ -93,7 +93,10 @@ public sealed class MetadataRequest : IKafkaRequest<MetadataResponse>
             return new MetadataRequest { Topics = topics };
         }
 
-        var topicList = new List<MetadataRequestTopic>();
+        var topicList = topicNames.TryGetNonEnumeratedCount(out var count)
+            ? new List<MetadataRequestTopic>(count)
+            : [];
+
         foreach (var name in topicNames)
         {
             topicList.Add(new MetadataRequestTopic { Name = name });

--- a/tests/Dekaf.Tests.Unit/Protocol/MessageEncodingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/MessageEncodingTests.cs
@@ -72,6 +72,40 @@ public class MessageEncodingTests
     }
 
     [Test]
+    public async Task MetadataRequest_V9_Flexible_IteratorTopics()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = MetadataRequest.ForTopics(IteratorTopics());
+        request.Write(ref writer, version: 9);
+
+        var expected = new List<byte>();
+        // COMPACT_ARRAY length+1 = 3
+        expected.Add(0x03);
+        // Topic: COMPACT_NULLABLE_STRING "alpha" (length+1=6)
+        expected.Add(0x06);
+        expected.AddRange("alpha"u8.ToArray());
+        // Topic tagged fields
+        expected.Add(0x00);
+        // Topic: COMPACT_NULLABLE_STRING "beta" (length+1=5)
+        expected.Add(0x05);
+        expected.AddRange("beta"u8.ToArray());
+        // Topic tagged fields
+        expected.Add(0x00);
+        // AllowAutoTopicCreation (v4+)
+        expected.Add(0x01); // true
+        // IncludeClusterAuthorizedOperations (v8+)
+        expected.Add(0x00); // false
+        // IncludeTopicAuthorizedOperations (v8+)
+        expected.Add(0x00); // false
+        // Request tagged fields
+        expected.Add(0x00);
+
+        await Assert.That(buffer.WrittenSpan.ToArray()).IsEquivalentTo(expected.ToArray());
+    }
+
+    [Test]
     public async Task MetadataRequest_V9_NullTopics_FetchAll()
     {
         var buffer = new ArrayBufferWriter<byte>();
@@ -213,4 +247,10 @@ public class MessageEncodingTests
     }
 
     #endregion
+
+    private static IEnumerable<string> IteratorTopics()
+    {
+        yield return "alpha";
+        yield return "beta";
+    }
 }


### PR DESCRIPTION
## Summary
- Replace the `MetadataRequest.ForTopics(IEnumerable<string>)` LINQ fallback with explicit single-pass construction.
- Add iterator-source metadata encoding coverage to preserve exact wire bytes.

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/MessageEncodingTests/*"
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/MetadataManagerTests/*"
- [x] git diff --check

Closes #997
