### PR TITLE
perf(consumer): add fetch sessions

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -828,6 +828,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _maxConnectionsPerBroker = 4;
     private bool _enableAdaptiveFetchSizing;
     private AdaptiveFetchSizingOptions? _adaptiveFetchSizingOptions;
+    private bool _enableFetchSessions = true;
 
     public ConsumerBuilder<TKey, TValue> WithBootstrapServers(string servers)
     {
@@ -1028,6 +1029,16 @@ public sealed class ConsumerBuilder<TKey, TValue>
             throw new ArgumentOutOfRangeException(nameof(maxWait), "Fetch max wait must be positive");
         ArgumentOutOfRangeException.ThrowIfGreaterThan(maxWait.TotalMilliseconds, int.MaxValue, nameof(maxWait));
         _fetchMaxWaitMs = (int)maxWait.TotalMilliseconds;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables KIP-227 incremental fetch sessions.
+    /// Enabled by default.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithFetchSessions(bool enabled = true)
+    {
+        _enableFetchSessions = enabled;
         return this;
     }
 
@@ -1490,6 +1501,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             FetchMaxBytes = _fetchMaxBytes,
             MaxPartitionFetchBytes = _maxPartitionFetchBytes,
             FetchMaxWaitMs = _fetchMaxWaitMs,
+            EnableFetchSessions = _enableFetchSessions,
             MaxPollRecords = _maxPollRecords,
             SessionTimeoutMs = _sessionTimeoutMs,
             HeartbeatIntervalMs = _heartbeatIntervalMs ?? 3000,

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -94,6 +94,11 @@ public sealed class ConsumerOptions
     public int FetchMaxWaitMs { get; init; } = 200;
 
     /// <summary>
+    /// Enable KIP-227 incremental fetch sessions when supported by the broker.
+    /// </summary>
+    public bool EnableFetchSessions { get; init; } = true;
+
+    /// <summary>
     /// Maximum poll records.
     /// </summary>
     public int MaxPollRecords { get; init; } = 500;

--- a/src/Dekaf/Consumer/FetchSessionHandler.cs
+++ b/src/Dekaf/Consumer/FetchSessionHandler.cs
@@ -1,0 +1,253 @@
+using Dekaf.Metadata;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Consumer;
+
+internal sealed class FetchSessionHandler
+{
+    private const int LegacySessionEpoch = -1;
+    private const int InitialSessionEpoch = 0;
+    private const int FirstIncrementalEpoch = 1;
+
+    private int _sessionId;
+    private int _nextEpoch;
+    private Dictionary<TopicPartition, CachedPartitionData> _sessionPartitions = [];
+    private Dictionary<TopicPartition, CachedPartitionData> _lastDesiredPartitions = [];
+    private bool _lastBuildWasFull;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public Task WaitAsync(CancellationToken cancellationToken) => _gate.WaitAsync(cancellationToken);
+
+    public void Release() => _gate.Release();
+
+    public bool HasActiveSession => _sessionId != 0;
+
+    public FetchSessionBuildResult Build(IReadOnlyList<FetchRequestTopic> desiredTopics, ClusterMetadata? clusterMetadata)
+    {
+        var desiredPartitions = FlattenDesiredPartitions(desiredTopics);
+        _lastDesiredPartitions = desiredPartitions;
+
+        if (desiredPartitions.Count == 0 && _sessionId != 0)
+            return Close();
+
+        if (_sessionId == 0 || _nextEpoch == InitialSessionEpoch)
+        {
+            _lastBuildWasFull = true;
+            return new FetchSessionBuildResult(
+                _sessionId,
+                InitialSessionEpoch,
+                desiredTopics,
+                ForgottenTopicsData: null,
+                IsFull: true);
+        }
+
+        var changed = new List<(string Topic, Guid TopicId, FetchRequestPartition Partition)>();
+        foreach (var topic in desiredTopics)
+        {
+            var topicName = ResolveTopicName(topic, clusterMetadata);
+            foreach (var partition in topic.Partitions)
+            {
+                var tp = new TopicPartition(topicName, partition.Partition);
+                var desired = CachedPartitionData.From(partition);
+                if (!_sessionPartitions.TryGetValue(tp, out var cached) || cached != desired)
+                    changed.Add((topicName, topic.TopicId, partition));
+            }
+        }
+
+        var forgotten = BuildForgottenTopicsData(desiredPartitions, clusterMetadata);
+        _lastBuildWasFull = false;
+
+        return new FetchSessionBuildResult(
+            _sessionId,
+            _nextEpoch,
+            BuildTopics(changed),
+            forgotten.Count == 0 ? null : forgotten,
+            IsFull: false);
+    }
+
+    public bool HandleResponse(FetchResponse response)
+    {
+        if (response.ErrorCode != ErrorCode.None)
+        {
+            HandleTopLevelError(response.ErrorCode);
+            return false;
+        }
+
+        if (response.SessionId != 0)
+            _sessionId = response.SessionId;
+
+        if (_lastBuildWasFull || _sessionId != 0)
+            _sessionPartitions = new Dictionary<TopicPartition, CachedPartitionData>(_lastDesiredPartitions);
+
+        _nextEpoch = _sessionId == 0 ? InitialSessionEpoch : NextEpoch(_nextEpoch);
+        return true;
+    }
+
+    public void HandleError()
+    {
+        if (_sessionId == 0)
+        {
+            Reset();
+            return;
+        }
+
+        _nextEpoch = InitialSessionEpoch;
+    }
+
+    public void Reset()
+    {
+        _sessionId = 0;
+        _nextEpoch = InitialSessionEpoch;
+        _sessionPartitions.Clear();
+        _lastDesiredPartitions.Clear();
+        _lastBuildWasFull = false;
+    }
+
+    public FetchSessionBuildResult Close()
+    {
+        var sessionId = _sessionId;
+        Reset();
+        return new FetchSessionBuildResult(
+            sessionId,
+            LegacySessionEpoch,
+            Array.Empty<FetchRequestTopic>(),
+            ForgottenTopicsData: null,
+            IsFull: true);
+    }
+
+    private void HandleTopLevelError(ErrorCode errorCode)
+    {
+        if (errorCode == ErrorCode.FetchSessionIdNotFound)
+        {
+            Reset();
+            return;
+        }
+
+        if (errorCode is ErrorCode.InvalidFetchSessionEpoch or ErrorCode.FetchSessionTopicIdError)
+        {
+            HandleError();
+            return;
+        }
+
+        Reset();
+    }
+
+    private List<ForgottenTopic> BuildForgottenTopicsData(
+        Dictionary<TopicPartition, CachedPartitionData> desiredPartitions,
+        ClusterMetadata? clusterMetadata)
+    {
+        Dictionary<string, List<int>>? forgottenPartitions = null;
+        foreach (var tp in _sessionPartitions.Keys)
+        {
+            if (desiredPartitions.ContainsKey(tp))
+                continue;
+
+            forgottenPartitions ??= [];
+            if (!forgottenPartitions.TryGetValue(tp.Topic, out var partitions))
+            {
+                partitions = [];
+                forgottenPartitions[tp.Topic] = partitions;
+            }
+            partitions.Add(tp.Partition);
+        }
+
+        if (forgottenPartitions is null)
+            return [];
+
+        var result = new List<ForgottenTopic>(forgottenPartitions.Count);
+        foreach (var kvp in forgottenPartitions)
+        {
+            result.Add(new ForgottenTopic
+            {
+                Topic = kvp.Key,
+                TopicId = clusterMetadata?.GetTopic(kvp.Key)?.TopicId ?? Guid.Empty,
+                Partitions = [.. kvp.Value]
+            });
+        }
+
+        return result;
+    }
+
+    private static Dictionary<TopicPartition, CachedPartitionData> FlattenDesiredPartitions(
+        IReadOnlyList<FetchRequestTopic> desiredTopics)
+    {
+        var result = new Dictionary<TopicPartition, CachedPartitionData>();
+        foreach (var topic in desiredTopics)
+        {
+            var topicName = topic.Topic ?? string.Empty;
+            foreach (var partition in topic.Partitions)
+            {
+                result[new TopicPartition(topicName, partition.Partition)] = CachedPartitionData.From(partition);
+            }
+        }
+
+        return result;
+    }
+
+    private static List<FetchRequestTopic> BuildTopics(
+        List<(string Topic, Guid TopicId, FetchRequestPartition Partition)> partitions)
+    {
+        var byTopic = new Dictionary<string, (Guid TopicId, List<FetchRequestPartition> Partitions)>();
+        foreach (var (topic, topicId, partition) in partitions)
+        {
+            if (!byTopic.TryGetValue(topic, out var entry))
+            {
+                entry = (topicId, []);
+                byTopic[topic] = entry;
+            }
+            entry.Partitions.Add(partition);
+        }
+
+        var result = new List<FetchRequestTopic>(byTopic.Count);
+        foreach (var (topic, entry) in byTopic)
+        {
+            result.Add(new FetchRequestTopic
+            {
+                Topic = topic,
+                TopicId = entry.TopicId,
+                Partitions = entry.Partitions
+            });
+        }
+
+        return result;
+    }
+
+    private static string ResolveTopicName(FetchRequestTopic topic, ClusterMetadata? clusterMetadata)
+    {
+        if (!string.IsNullOrEmpty(topic.Topic))
+            return topic.Topic;
+
+        return topic.TopicId == Guid.Empty
+            ? string.Empty
+            : clusterMetadata?.GetTopic(topic.TopicId)?.Name ?? string.Empty;
+    }
+
+    private static int NextEpoch(int current)
+    {
+        if (current == int.MaxValue)
+            return FirstIncrementalEpoch;
+
+        return current < FirstIncrementalEpoch ? FirstIncrementalEpoch : current + 1;
+    }
+
+    internal readonly record struct CachedPartitionData(
+        long FetchOffset,
+        long LogStartOffset,
+        int PartitionMaxBytes,
+        int CurrentLeaderEpoch)
+    {
+        public static CachedPartitionData From(FetchRequestPartition partition) => new(
+            partition.FetchOffset,
+            partition.LogStartOffset,
+            partition.PartitionMaxBytes,
+            partition.CurrentLeaderEpoch);
+    }
+}
+
+internal readonly record struct FetchSessionBuildResult(
+    int SessionId,
+    int SessionEpoch,
+    IReadOnlyList<FetchRequestTopic> Topics,
+    IReadOnlyList<ForgottenTopic>? ForgottenTopicsData,
+    bool IsFull);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -505,6 +505,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     // for multiple brokers AND multiple connections to the same broker.
     // Stale entries from scaled-down connections are pruned lazily in PrefetchRecordsAsync.
     private readonly ConcurrentDictionary<(int BrokerId, int ConnectionIndex), List<PendingFetchData>> _prefetchPendingItemsByBroker = new();
+    private readonly ConcurrentDictionary<(int BrokerId, int ConnectionIndex), FetchSessionHandler> _fetchSessions = new();
 
     // Lock ordering (always acquire in this order to prevent deadlocks):
     //   1. _initLock          — guards one-time initialization; never held while acquiring other locks
@@ -1551,11 +1552,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 wakeupCts.Cancel();
 
             var partitionsByBroker = await GroupPartitionsByBrokerAsync(cancellationToken).ConfigureAwait(false);
+            var fetchSessionSnapshot = _options.EnableFetchSessions && !_fetchSessions.IsEmpty
+                ? _fetchSessions.ToArray()
+                : Array.Empty<KeyValuePair<(int BrokerId, int ConnectionIndex), FetchSessionHandler>>();
+            var currentConnections = _connectionScaler?.CurrentConnectionCount ?? _options.ConnectionsPerBroker;
+            var fetchConnectionCount = ConsumerConnectionScaler.GetFetchConnectionCount(currentConnections);
 
             // If all partitions are paused, delay to prevent tight spin loop
             // that would starve timeout/cancellation mechanisms of CPU time
             var brokerCount = partitionsByBroker.Count;
-            if (brokerCount == 0)
+            if (brokerCount == 0 && fetchSessionSnapshot.Length == 0)
             {
                 await Task.Delay(AllPartitionsPausedDelayMs, cancellationToken).ConfigureAwait(false);
                 return;
@@ -1564,8 +1570,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             // Fetch from all brokers in parallel for maximum throughput.
             // When multiple fetch connections are available, split each broker's partitions
             // across connections to issue concurrent fetches to the same broker.
-            var currentConnections = _connectionScaler?.CurrentConnectionCount ?? _options.ConnectionsPerBroker;
-            var fetchConnectionCount = ConsumerConnectionScaler.GetFetchConnectionCount(currentConnections);
 
             // Lazily prune stale entries from scaled-down connections.
             // O(k) over a small dictionary (brokers × connections), once per fetch cycle — not hot path.
@@ -1576,11 +1580,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             }
 
             // Upper bound: each broker can produce up to fetchConnectionCount tasks
-            var maxTasks = brokerCount * fetchConnectionCount;
+            var maxTasks = (brokerCount * fetchConnectionCount) + fetchSessionSnapshot.Length;
             var fetchTasks = ArrayPool<Task>.Shared.Rent(maxTasks);
             try
             {
                 var taskCount = 0;
+                HashSet<(int BrokerId, int ConnectionIndex)>? scheduledFetchSessions = fetchSessionSnapshot.Length == 0 ? null : [];
 
                 // Stack-allocate group ranges — bounded by MaxFetchConnectionsPerBroker
                 Span<(int StartIndex, int Count)> groups = stackalloc (int, int)[Math.Min(fetchConnectionCount, ConsumerConnectionScaler.MaxFetchConnectionsPerBroker)];
@@ -1596,11 +1601,40 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                         // Deterministic: group g always maps to connection g, ensuring stable
                         // (brokerId, connectionIndex) keys across cycles for pendingItems lists
                         var connectionIndex = g % fetchConnectionCount;
+                        scheduledFetchSessions?.Add((brokerId, connectionIndex));
 
                         fetchTasks[taskCount++] = PrefetchFromBrokerWithErrorHandlingAsync(
                             brokerId, partitions, startIndex, count, connectionIndex,
                             wakeupCts.Token, wakeupCts.Token);
                     }
+                }
+
+                foreach (var (key, handler) in fetchSessionSnapshot)
+                {
+                    if (!handler.HasActiveSession)
+                    {
+                        _fetchSessions.TryRemove(key, out _);
+                        continue;
+                    }
+
+                    if (key.ConnectionIndex >= fetchConnectionCount)
+                    {
+                        _fetchSessions.TryRemove(key, out _);
+                        continue;
+                    }
+
+                    if (scheduledFetchSessions is not null && scheduledFetchSessions.Contains(key))
+                        continue;
+
+                    fetchTasks[taskCount++] = PrefetchFromBrokerWithErrorHandlingAsync(
+                        key.BrokerId, [], 0, 0, key.ConnectionIndex,
+                        wakeupCts.Token, wakeupCts.Token);
+                }
+
+                if (taskCount == 0)
+                {
+                    await Task.Delay(AllPartitionsPausedDelayMs, cancellationToken).ConfigureAwait(false);
+                    return;
                 }
 
                 // Timing wraps the entire parallel fetch cycle (all brokers via Task.WhenAll)
@@ -1734,167 +1768,201 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         // Resolve any special offset values — pass index range to avoid GetRange allocation
         await ResolveSpecialOffsetsAsync(partitions, partitionStartIndex, partitionCount, cancellationToken).ConfigureAwait(false);
 
-        // Build fetch request — pass index range to avoid GetRange allocation
-        var topicData = BuildFetchRequestTopics(partitions, partitionStartIndex, partitionCount);
-
-        var request = FetchRequest.Rent();
-        request.MaxWaitMs = _options.FetchMaxWaitMs;
-        request.MinBytes = _options.FetchMinBytes;
-        request.MaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes;
-        request.IsolationLevel = _options.IsolationLevel;
-        request.Topics = topicData;
-
-        var fetchStarted = System.Diagnostics.Stopwatch.GetTimestamp();
-
-        FetchResponse response;
-        try
+        FetchSessionHandler? fetchSessionHandler = null;
+        if (_options.EnableFetchSessions && apiVersion >= 7)
         {
-            response = await connection.SendAsync<FetchRequest, FetchResponse>(
-                request,
-                (short)apiVersion,
-                cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            request.ReturnToPool();
+            fetchSessionHandler = _fetchSessions.GetOrAdd((brokerId, connectionIndex), static _ => new FetchSessionHandler());
+            await fetchSessionHandler.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        // Record fetch round-trip duration (~3ns no-op when no listener)
-        Diagnostics.DekafMetrics.FetchDuration.Record(
-            System.Diagnostics.Stopwatch.GetElapsedTime(fetchStarted).TotalSeconds,
-            new System.Diagnostics.TagList { { Diagnostics.DekafDiagnostics.MessagingKafkaBrokerId, brokerId } });
-
-        // Take ownership of pooled memory from the response (if zero-copy was used)
-        var memoryOwner = response.PooledMemoryOwner;
-        response.PooledMemoryOwner = null; // Clear to prevent double-dispose
-
-        // Collect pending fetch data items - we need to assign memory owner to the last one
-        // since FIFO processing means the last one will be disposed last
-        // Reuse list per (broker, connection) across prefetch cycles to avoid per-cycle allocation
-        // Each (broker, connection) pair gets its own list since PrefetchFromBrokerAsync runs
-        // concurrently for different brokers AND different connections to the same broker
-        var pendingItems = _prefetchPendingItemsByBroker.GetOrAdd((brokerId, connectionIndex), static _ => []);
-        pendingItems.Clear();
-
-        // Write to prefetch channel
         try
         {
-            foreach (var topicResponse in response.Responses)
+            // Build fetch request — pass index range to avoid GetRange allocation
+            var topicData = BuildFetchRequestTopics(partitions, partitionStartIndex, partitionCount);
+            FetchSessionBuildResult? fetchSessionBuild = fetchSessionHandler?.Build(topicData, _metadataManager.Metadata);
+
+            var request = FetchRequest.Rent();
+            request.MaxWaitMs = _options.FetchMaxWaitMs;
+            request.MinBytes = _options.FetchMinBytes;
+            request.MaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes;
+            request.IsolationLevel = _options.IsolationLevel;
+            request.Topics = fetchSessionBuild?.Topics ?? topicData;
+            request.ForgottenTopicsData = fetchSessionBuild?.ForgottenTopicsData;
+            request.SessionId = fetchSessionBuild?.SessionId ?? 0;
+            request.SessionEpoch = fetchSessionBuild?.SessionEpoch ?? -1;
+
+            var fetchStarted = System.Diagnostics.Stopwatch.GetTimestamp();
+
+            FetchResponse response;
+            try
             {
-                var topic = ResolveTopicName(topicResponse);
-                var activityName = _activityNameCache.GetOrAdd(topic, static t => $"{t} receive");
+                response = await connection.SendAsync<FetchRequest, FetchResponse>(
+                    request,
+                    (short)apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                fetchSessionHandler?.HandleError();
+                throw;
+            }
+            finally
+            {
+                request.ReturnToPool();
+            }
 
-                foreach (var partitionResponse in topicResponse.Partitions)
+            // Record fetch round-trip duration (~3ns no-op when no listener)
+            Diagnostics.DekafMetrics.FetchDuration.Record(
+                System.Diagnostics.Stopwatch.GetElapsedTime(fetchStarted).TotalSeconds,
+                new System.Diagnostics.TagList { { Diagnostics.DekafDiagnostics.MessagingKafkaBrokerId, brokerId } });
+
+            // Take ownership of pooled memory from the response (if zero-copy was used)
+            var memoryOwner = response.PooledMemoryOwner;
+            response.PooledMemoryOwner = null; // Clear to prevent double-dispose
+
+            if (response.ErrorCode != ErrorCode.None)
+            {
+                fetchSessionHandler?.HandleResponse(response);
+                LogFetchSessionError(brokerId, response.ErrorCode);
+                response.ReturnToPool();
+                memoryOwner?.Dispose();
+                return;
+            }
+
+            fetchSessionHandler?.HandleResponse(response);
+
+            // Collect pending fetch data items - we need to assign memory owner to the last one
+            // since FIFO processing means the last one will be disposed last
+            // Reuse list per (broker, connection) across prefetch cycles to avoid per-cycle allocation
+            // Each (broker, connection) pair gets its own list since PrefetchFromBrokerAsync runs
+            // concurrently for different brokers AND different connections to the same broker
+            var pendingItems = _prefetchPendingItemsByBroker.GetOrAdd((brokerId, connectionIndex), static _ => []);
+            pendingItems.Clear();
+
+            // Write to prefetch channel
+            try
+            {
+                foreach (var topicResponse in response.Responses)
                 {
-                    var tp = new TopicPartition(topic, partitionResponse.PartitionIndex);
+                    var topic = ResolveTopicName(topicResponse);
+                    var activityName = _activityNameCache.GetOrAdd(topic, static t => $"{t} receive");
 
-                    // Update watermark cache from fetch response (even on errors, watermarks may be valid)
-                    UpdateWatermarksFromFetchResponse(topic, partitionResponse);
-
-                    if (partitionResponse.ErrorCode != ErrorCode.None)
+                    foreach (var partitionResponse in topicResponse.Partitions)
                     {
-                        if (partitionResponse.ErrorCode == ErrorCode.OffsetOutOfRange)
+                        var tp = new TopicPartition(topic, partitionResponse.PartitionIndex);
+
+                        // Update watermark cache from fetch response (even on errors, watermarks may be valid)
+                        UpdateWatermarksFromFetchResponse(topic, partitionResponse);
+
+                        if (partitionResponse.ErrorCode != ErrorCode.None)
                         {
-                            // CRITICAL: Reset fetch position based on auto.offset.reset policy
-                            // Without this, we would retry with the same invalid offset forever
-                            var (resetTimestamp, resetName) = _options.AutoOffsetReset switch
+                            if (partitionResponse.ErrorCode == ErrorCode.OffsetOutOfRange)
                             {
-                                AutoOffsetReset.Latest => (-1L, "latest"),
-                                AutoOffsetReset.Earliest => (-2L, "earliest"),
-                                AutoOffsetReset.None => throw new KafkaException(
-                                    ErrorCode.OffsetOutOfRange,
-                                    $"OffsetOutOfRange for {topic}-{partitionResponse.PartitionIndex} and auto.offset.reset is 'none'"),
-                                _ => throw new InvalidOperationException($"Unknown AutoOffsetReset value: {_options.AutoOffsetReset}")
-                            };
-                            _fetchPositions[tp] = resetTimestamp;
-                            _positions[tp] = resetTimestamp;
-                            LogOffsetOutOfRangeReset(topic, partitionResponse.PartitionIndex, resetName);
+                                // CRITICAL: Reset fetch position based on auto.offset.reset policy
+                                // Without this, we would retry with the same invalid offset forever
+                                var (resetTimestamp, resetName) = _options.AutoOffsetReset switch
+                                {
+                                    AutoOffsetReset.Latest => (-1L, "latest"),
+                                    AutoOffsetReset.Earliest => (-2L, "earliest"),
+                                    AutoOffsetReset.None => throw new KafkaException(
+                                        ErrorCode.OffsetOutOfRange,
+                                        $"OffsetOutOfRange for {topic}-{partitionResponse.PartitionIndex} and auto.offset.reset is 'none'"),
+                                    _ => throw new InvalidOperationException($"Unknown AutoOffsetReset value: {_options.AutoOffsetReset}")
+                                };
+                                _fetchPositions[tp] = resetTimestamp;
+                                _positions[tp] = resetTimestamp;
+                                LogOffsetOutOfRangeReset(topic, partitionResponse.PartitionIndex, resetName);
+                            }
+                            else if (partitionResponse.ErrorCode == ErrorCode.NotLeaderOrFollower)
+                            {
+                                await HandleNotLeaderOrFollowerAsync(
+                                    topic,
+                                    partitionResponse,
+                                    response.NodeEndpoints,
+                                    cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                LogPrefetchError(topic, partitionResponse.PartitionIndex, partitionResponse.ErrorCode);
+                            }
+                            continue;
                         }
-                        else if (partitionResponse.ErrorCode == ErrorCode.NotLeaderOrFollower)
+
+                        // Update high watermark from response (thread-safe with ConcurrentDictionary)
+                        _highWatermarks[tp] = partitionResponse.HighWatermark;
+
+                        // Cache Records reference to avoid repeated Volatile.Read from the pool guard
+                        var records = partitionResponse.Records;
+
+                        if (records is { Count: > 0 })
                         {
-                            await HandleNotLeaderOrFollowerAsync(
+                            // We have new records - reset EOF state for this partition
+                            _eofEmitted.TryRemove(tp, out _);
+
+                            var pending = PendingFetchData.Create(
                                 topic,
-                                partitionResponse,
-                                response.NodeEndpoints,
-                                cancellationToken).ConfigureAwait(false);
+                                partitionResponse.PartitionIndex,
+                                records,
+                                partitionResponse.AbortedTransactions,
+                                activityName: activityName);
+
+                            // Track memory before adding to channel
+                            TrackPrefetchedBytes(pending, release: false);
+
+                            // Update fetch positions for next prefetch
+                            UpdateFetchPositionsFromPrefetch(pending);
+
+                            // Collect for later - we'll assign memory owner to the last one
+                            pendingItems.Add(pending);
                         }
-                        else
+                        else if (_options.EnablePartitionEof)
                         {
-                            LogPrefetchError(topic, partitionResponse.PartitionIndex, partitionResponse.ErrorCode);
-                        }
-                        continue;
-                    }
+                            // No records returned - check if we're at EOF
+                            var fetchPosition = _fetchPositions.GetValueOrDefault(tp, 0);
 
-                    // Update high watermark from response (thread-safe with ConcurrentDictionary)
-                    _highWatermarks[tp] = partitionResponse.HighWatermark;
-
-                    // Cache Records reference to avoid repeated Volatile.Read from the pool guard
-                    var records = partitionResponse.Records;
-
-                    if (records is { Count: > 0 })
-                    {
-                        // We have new records - reset EOF state for this partition
-                        _eofEmitted.TryRemove(tp, out _);
-
-                        var pending = PendingFetchData.Create(
-                            topic,
-                            partitionResponse.PartitionIndex,
-                            records,
-                            partitionResponse.AbortedTransactions,
-                            activityName: activityName);
-
-                        // Track memory before adding to channel
-                        TrackPrefetchedBytes(pending, release: false);
-
-                        // Update fetch positions for next prefetch
-                        UpdateFetchPositionsFromPrefetch(pending);
-
-                        // Collect for later - we'll assign memory owner to the last one
-                        pendingItems.Add(pending);
-                    }
-                    else if (_options.EnablePartitionEof)
-                    {
-                        // No records returned - check if we're at EOF
-                        var fetchPosition = _fetchPositions.GetValueOrDefault(tp, 0);
-
-                        // EOF condition: position >= high watermark and we haven't emitted EOF yet
-                        if (fetchPosition >= partitionResponse.HighWatermark && _eofEmitted.TryAdd(tp, 0))
-                        {
-                            // Queue EOF event and mark as emitted
-                            _pendingEofEvents.Enqueue((tp, fetchPosition));
+                            // EOF condition: position >= high watermark and we haven't emitted EOF yet
+                            if (fetchPosition >= partitionResponse.HighWatermark && _eofEmitted.TryAdd(tp, 0))
+                            {
+                                // Queue EOF event and mark as emitted
+                                _pendingEofEvents.Enqueue((tp, fetchPosition));
+                            }
                         }
                     }
                 }
             }
+            finally
+            {
+                // Return the response and its nested objects to their pools.
+                // Data has been transferred to PendingFetchData; the response wrappers are no longer needed.
+                response.ReturnToPool();
+            }
+
+            // Write all pending items to the channel, with shared memory owner
+            if (pendingItems.Count > 0)
+            {
+                if (memoryOwner is not null)
+                {
+                    AssignSharedMemoryOwner(pendingItems, memoryOwner);
+                    memoryOwner = null; // Transferred
+                }
+
+                for (var i = 0; i < pendingItems.Count; i++)
+                {
+                    while (!_prefetchBuffer.TryWrite(pendingItems[i]))
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await _prefetchBuffer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+
+            // If no pending items were created but we have a memory owner, dispose it
+            memoryOwner?.Dispose();
         }
         finally
         {
-            // Return the response and its nested objects to their pools.
-            // Data has been transferred to PendingFetchData; the response wrappers are no longer needed.
-            response.ReturnToPool();
+            fetchSessionHandler?.Release();
         }
-
-        // Write all pending items to the channel, with shared memory owner
-        if (pendingItems.Count > 0)
-        {
-            if (memoryOwner is not null)
-            {
-                AssignSharedMemoryOwner(pendingItems, memoryOwner);
-                memoryOwner = null; // Transferred
-            }
-
-            for (var i = 0; i < pendingItems.Count; i++)
-            {
-                while (!_prefetchBuffer.TryWrite(pendingItems[i]))
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await _prefetchBuffer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
-                }
-            }
-        }
-
-        // If no pending items were created but we have a memory owner, dispose it
-        memoryOwner?.Dispose();
     }
 
     /// <summary>
@@ -2992,11 +3060,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 wakeupCts.Cancel();
 
             var partitionsByBroker = await GroupPartitionsByBrokerAsync(cancellationToken).ConfigureAwait(false);
+            var fetchSessionSnapshot = _options.EnableFetchSessions && !_fetchSessions.IsEmpty
+                ? _fetchSessions.ToArray()
+                : Array.Empty<KeyValuePair<(int BrokerId, int ConnectionIndex), FetchSessionHandler>>();
 
             // If all partitions are paused, delay to prevent tight spin loop
             // that would starve timeout/cancellation mechanisms of CPU time
             var brokerCount = partitionsByBroker.Count;
-            if (brokerCount == 0)
+            if (brokerCount == 0 && fetchSessionSnapshot.Length == 0)
             {
                 await Task.Delay(AllPartitionsPausedDelayMs, cancellationToken).ConfigureAwait(false);
                 return;
@@ -3004,14 +3075,43 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
             // Fetch from all brokers in parallel for maximum throughput
             // Use pooled array to avoid allocation per fetch cycle
-            var fetchTasks = ArrayPool<Task<List<PendingFetchData>?>>.Shared.Rent(brokerCount);
+            var fetchTasks = ArrayPool<Task<List<PendingFetchData>?>>.Shared.Rent(brokerCount + fetchSessionSnapshot.Length);
             try
             {
-                var i = 0;
+                var taskCount = 0;
+                HashSet<int>? scheduledFetchSessionBrokers = fetchSessionSnapshot.Length == 0 ? null : [];
                 foreach (var (brokerId, partitions) in partitionsByBroker)
                 {
-                    fetchTasks[i++] = FetchFromBrokerWithErrorHandlingAsync(
+                    scheduledFetchSessionBrokers?.Add(brokerId);
+                    fetchTasks[taskCount++] = FetchFromBrokerWithErrorHandlingAsync(
                         brokerId, partitions, wakeupCts.Token, wakeupCts.Token);
+                }
+
+                foreach (var (key, handler) in fetchSessionSnapshot)
+                {
+                    if (!handler.HasActiveSession)
+                    {
+                        _fetchSessions.TryRemove(key, out _);
+                        continue;
+                    }
+
+                    if (key.ConnectionIndex != 0)
+                    {
+                        _fetchSessions.TryRemove(key, out _);
+                        continue;
+                    }
+
+                    if (scheduledFetchSessionBrokers is not null && scheduledFetchSessionBrokers.Contains(key.BrokerId))
+                        continue;
+
+                    fetchTasks[taskCount++] = FetchFromBrokerWithErrorHandlingAsync(
+                        key.BrokerId, [], wakeupCts.Token, wakeupCts.Token);
+                }
+
+                if (taskCount == 0)
+                {
+                    await Task.Delay(AllPartitionsPausedDelayMs, cancellationToken).ConfigureAwait(false);
+                    return;
                 }
 
                 // Timing wraps the entire parallel fetch cycle (all brokers via Task.WhenAll)
@@ -3021,12 +3121,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 _adaptiveFetchSizer?.RecordFetchStart();
 
                 // ReadOnlySpan overload: same zero-copy benefit as above
-                await Task.WhenAll(new ReadOnlySpan<Task<List<PendingFetchData>?>>(fetchTasks, 0, brokerCount)).ConfigureAwait(false);
+                await Task.WhenAll(new ReadOnlySpan<Task<List<PendingFetchData>?>>(fetchTasks, 0, taskCount)).ConfigureAwait(false);
 
                 _adaptiveFetchSizer?.RecordFetchEnd();
 
                 // Enqueue results from all brokers (now on main thread, safe for Queue)
-                for (var j = 0; j < brokerCount; j++)
+                for (var j = 0; j < taskCount; j++)
                 {
                     var pendingItems = fetchTasks[j].Result;
                     if (pendingItems is not null)
@@ -3226,13 +3326,23 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
         // Build fetch request - use imperative code to avoid LINQ allocations
         var topicData = BuildFetchRequestTopics(partitions, 0, partitions.Count);
+        FetchSessionHandler? fetchSessionHandler = null;
+        FetchSessionBuildResult? fetchSessionBuild = null;
+        if (_options.EnableFetchSessions && apiVersion >= 7)
+        {
+            fetchSessionHandler = _fetchSessions.GetOrAdd((brokerId, 0), static _ => new FetchSessionHandler());
+            fetchSessionBuild = fetchSessionHandler.Build(topicData, _metadataManager.Metadata);
+        }
 
         var request = FetchRequest.Rent();
         request.MaxWaitMs = _options.FetchMaxWaitMs;
         request.MinBytes = _options.FetchMinBytes;
         request.MaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes;
         request.IsolationLevel = _options.IsolationLevel;
-        request.Topics = topicData;
+        request.Topics = fetchSessionBuild?.Topics ?? topicData;
+        request.ForgottenTopicsData = fetchSessionBuild?.ForgottenTopicsData;
+        request.SessionId = fetchSessionBuild?.SessionId ?? 0;
+        request.SessionEpoch = fetchSessionBuild?.SessionEpoch ?? -1;
 
         var fetchStarted = System.Diagnostics.Stopwatch.GetTimestamp();
 
@@ -3243,6 +3353,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 request,
                 (short)apiVersion,
                 cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            fetchSessionHandler?.HandleError();
+            throw;
         }
         finally
         {
@@ -3257,6 +3372,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         // Take ownership of pooled memory from the response (if zero-copy was used)
         var memoryOwner = response.PooledMemoryOwner;
         response.PooledMemoryOwner = null; // Clear to prevent double-dispose
+
+        if (response.ErrorCode != ErrorCode.None)
+        {
+            fetchSessionHandler?.HandleResponse(response);
+            LogFetchSessionError(brokerId, response.ErrorCode);
+            response.ReturnToPool();
+            memoryOwner?.Dispose();
+            return null;
+        }
+
+        fetchSessionHandler?.HandleResponse(response);
 
         // Collect pending fetch data items - we need to assign memory owner to the last one
         List<PendingFetchData>? pendingItems = null;
@@ -4206,6 +4332,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to fetch from broker {BrokerId}")]
     private partial void LogFetchFromBrokerError(Exception exception, int brokerId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Fetch session error from broker {BrokerId}: {Error}")]
+    private partial void LogFetchSessionError(int brokerId, ErrorCode error);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Fetch error for {Topic}-{Partition}: {Error}")]
     private partial void LogFetchError(string topic, int partition, ErrorCode error);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -548,6 +548,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     // Interceptors - stored as typed array for zero-allocation iteration
     private readonly IConsumerInterceptor<TKey, TValue>[]? _interceptors;
 
+    // Incremental fetch responses can omit unchanged empty partitions; EOF mode needs those
+    // empty partition responses to emit partition EOF events.
+    private bool ShouldUseFetchSessions => _options.EnableFetchSessions && !_options.EnablePartitionEof;
+
     // Cached partition grouping by broker to avoid allocations on every fetch
     // Invalidated whenever _assignment or _paused changes
     // Access to _cachedPartitionsByBroker must be synchronized via _partitionCacheLock
@@ -1552,7 +1556,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 wakeupCts.Cancel();
 
             var partitionsByBroker = await GroupPartitionsByBrokerAsync(cancellationToken).ConfigureAwait(false);
-            var fetchSessionSnapshot = _options.EnableFetchSessions && !_fetchSessions.IsEmpty
+            var fetchSessionSnapshot = ShouldUseFetchSessions && !_fetchSessions.IsEmpty
                 ? _fetchSessions.ToArray()
                 : Array.Empty<KeyValuePair<(int BrokerId, int ConnectionIndex), FetchSessionHandler>>();
             var currentConnections = _connectionScaler?.CurrentConnectionCount ?? _options.ConnectionsPerBroker;
@@ -1769,7 +1773,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         await ResolveSpecialOffsetsAsync(partitions, partitionStartIndex, partitionCount, cancellationToken).ConfigureAwait(false);
 
         FetchSessionHandler? fetchSessionHandler = null;
-        if (_options.EnableFetchSessions && apiVersion >= 7)
+        if (ShouldUseFetchSessions && apiVersion >= 7)
         {
             fetchSessionHandler = _fetchSessions.GetOrAdd((brokerId, connectionIndex), static _ => new FetchSessionHandler());
             await fetchSessionHandler.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -3060,7 +3064,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 wakeupCts.Cancel();
 
             var partitionsByBroker = await GroupPartitionsByBrokerAsync(cancellationToken).ConfigureAwait(false);
-            var fetchSessionSnapshot = _options.EnableFetchSessions && !_fetchSessions.IsEmpty
+            var fetchSessionSnapshot = ShouldUseFetchSessions && !_fetchSessions.IsEmpty
                 ? _fetchSessions.ToArray()
                 : Array.Empty<KeyValuePair<(int BrokerId, int ConnectionIndex), FetchSessionHandler>>();
 
@@ -3328,7 +3332,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         var topicData = BuildFetchRequestTopics(partitions, 0, partitions.Count);
         FetchSessionHandler? fetchSessionHandler = null;
         FetchSessionBuildResult? fetchSessionBuild = null;
-        if (_options.EnableFetchSessions && apiVersion >= 7)
+        if (ShouldUseFetchSessions && apiVersion >= 7)
         {
             fetchSessionHandler = _fetchSessions.GetOrAdd((brokerId, 0), static _ => new FetchSessionHandler());
             fetchSessionBuild = fetchSessionHandler.Build(topicData, _metadataManager.Metadata);
@@ -4066,43 +4070,50 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
         ThrowIfNotInitialized();
 
-        // Group partitions by broker leader for efficient batch requests
-        var partitionsByBroker = new Dictionary<int, List<TopicPartitionTimestamp>>();
-        foreach (var tpt in timestampsToSearch)
+        var timestamps = timestampsToSearch as IReadOnlyList<TopicPartitionTimestamp>
+            ?? [.. timestampsToSearch];
+
+        return await RetryHelper.WithRetryAsync<IReadOnlyDictionary<TopicPartition, long>>(async () =>
         {
-            var leader = await _metadataManager.GetPartitionLeaderAsync(tpt.Topic, tpt.Partition, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (leader is null)
+            // Group partitions by broker leader for efficient batch requests.
+            // Retrying the whole operation re-groups after metadata refreshes.
+            var partitionsByBroker = new Dictionary<int, List<TopicPartitionTimestamp>>();
+            foreach (var tpt in timestamps)
             {
-                LogNoLeaderFound(tpt.Topic, tpt.Partition);
-                continue;
+                var leader = await _metadataManager.GetPartitionLeaderAsync(tpt.Topic, tpt.Partition, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (leader is null)
+                {
+                    LogNoLeaderFound(tpt.Topic, tpt.Partition);
+                    continue;
+                }
+
+                if (!partitionsByBroker.TryGetValue(leader.NodeId, out var list))
+                {
+                    list = [];
+                    partitionsByBroker[leader.NodeId] = list;
+                }
+
+                list.Add(tpt);
             }
 
-            if (!partitionsByBroker.TryGetValue(leader.NodeId, out var list))
+            var results = new Dictionary<TopicPartition, long>();
+
+            // Send ListOffsets requests to each broker
+            foreach (var (brokerId, partitions) in partitionsByBroker)
             {
-                list = [];
-                partitionsByBroker[leader.NodeId] = list;
+                var brokerResults = await GetOffsetsForTimesFromBrokerAsync(brokerId, partitions, cancellationToken)
+                    .ConfigureAwait(false);
+
+                foreach (var kvp in brokerResults)
+                {
+                    results[kvp.Key] = kvp.Value;
+                }
             }
 
-            list.Add(tpt);
-        }
-
-        var results = new Dictionary<TopicPartition, long>();
-
-        // Send ListOffsets requests to each broker
-        foreach (var (brokerId, partitions) in partitionsByBroker)
-        {
-            var brokerResults = await GetOffsetsForTimesFromBrokerAsync(brokerId, partitions, cancellationToken)
-                .ConfigureAwait(false);
-
-            foreach (var kvp in brokerResults)
-            {
-                results[kvp.Key] = kvp.Value;
-            }
-        }
-
-        return results;
+            return results;
+        }, _metadataManager, cancellationToken).ConfigureAwait(false);
     }
 
     private async ValueTask<Dictionary<TopicPartition, long>> GetOffsetsForTimesFromBrokerAsync(
@@ -4171,8 +4182,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 if (partitionResponse.ErrorCode != ErrorCode.None)
                 {
                     LogListOffsetsError(topicName, partitionResponse.PartitionIndex, partitionResponse.ErrorCode);
-                    results[tp] = -1;
-                    continue;
+                    throw new Errors.ConsumeException(partitionResponse.ErrorCode,
+                        $"ListOffsets failed for {topicName}-{partitionResponse.PartitionIndex}: {partitionResponse.ErrorCode}");
                 }
 
                 results[tp] = partitionResponse.Offset;

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -149,6 +149,33 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task WithFetchSessions_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+        var result = builder.WithFetchSessions(false);
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithFetchSessions_DisablesOption()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithFetchSessions(false)
+            .Build();
+
+        var options = GetConsumerOptions(consumer);
+        await Assert.That(options.EnableFetchSessions).IsFalse();
+    }
+
+    private static ConsumerOptions GetConsumerOptions<TKey, TValue>(IKafkaConsumer<TKey, TValue> consumer)
+    {
+        var field = consumer.GetType().GetField("_options", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Could not find _options field");
+        return (ConsumerOptions)field.GetValue(consumer)!;
+    }
+
+    [Test]
     public async Task WithSessionTimeout_Milliseconds_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateConsumer<string, string>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
@@ -82,6 +82,13 @@ public class ConsumerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task EnableFetchSessions_DefaultsTo_True()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.EnableFetchSessions).IsTrue();
+    }
+
+    [Test]
     public async Task MaxPollRecords_DefaultsTo_500()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/Consumer/FetchSessionHandlerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/FetchSessionHandlerTests.cs
@@ -1,0 +1,173 @@
+using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class FetchSessionHandlerTests
+{
+    [Test]
+    public async Task Build_FirstRequest_UsesInitialEpochAndFullPartitionSet()
+    {
+        var handler = new FetchSessionHandler();
+        var topics = Topics(("topic-a", 0, 100, 1024));
+
+        var build = handler.Build(topics, clusterMetadata: null);
+
+        await Assert.That(build.SessionId).IsEqualTo(0);
+        await Assert.That(build.SessionEpoch).IsEqualTo(0);
+        await Assert.That(build.IsFull).IsTrue();
+        await Assert.That(build.Topics[0].Partitions).Count().IsEqualTo(1);
+        await Assert.That(build.ForgottenTopicsData).IsNull();
+    }
+
+    [Test]
+    public async Task Build_AfterSuccessfulInitialResponse_SendsOnlyChangedPartitions()
+    {
+        var handler = new FetchSessionHandler();
+        var initial = Topics(("topic-a", 0, 100, 1024), ("topic-a", 1, 200, 1024));
+
+        handler.Build(initial, clusterMetadata: null);
+        handler.HandleResponse(Response(sessionId: 42));
+
+        var unchanged = handler.Build(initial, clusterMetadata: null);
+        await Assert.That(unchanged.SessionId).IsEqualTo(42);
+        await Assert.That(unchanged.SessionEpoch).IsEqualTo(1);
+        await Assert.That(unchanged.IsFull).IsFalse();
+        await Assert.That(unchanged.Topics).IsEmpty();
+
+        var changed = handler.Build(Topics(("topic-a", 0, 101, 1024), ("topic-a", 1, 200, 1024)), clusterMetadata: null);
+        await Assert.That(changed.Topics).Count().IsEqualTo(1);
+        await Assert.That(changed.Topics[0].Partitions).Count().IsEqualTo(1);
+        await Assert.That(changed.Topics[0].Partitions[0].Partition).IsEqualTo(0);
+        await Assert.That(changed.Topics[0].Partitions[0].FetchOffset).IsEqualTo(101);
+    }
+
+    [Test]
+    public async Task Build_IncrementalDetectsForgottenPartitions()
+    {
+        var topicId = Guid.NewGuid();
+        var metadata = Metadata("topic-a", topicId);
+        var handler = new FetchSessionHandler();
+
+        handler.Build(Topics(("topic-a", 0, 100, 1024), ("topic-a", 1, 200, 1024)), metadata);
+        handler.HandleResponse(Response(sessionId: 42));
+
+        var build = handler.Build(Topics(("topic-a", 1, 200, 1024)), metadata);
+
+        await Assert.That(build.ForgottenTopicsData).IsNotNull();
+        await Assert.That(build.ForgottenTopicsData![0].Topic).IsEqualTo("topic-a");
+        await Assert.That(build.ForgottenTopicsData[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(build.ForgottenTopicsData[0].Partitions).IsEquivalentTo([0]);
+    }
+
+    [Test]
+    public async Task Build_NoDesiredPartitions_ClosesActiveSession()
+    {
+        var handler = new FetchSessionHandler();
+
+        handler.Build(Topics(("topic-a", 0, 100, 1024)), clusterMetadata: null);
+        handler.HandleResponse(Response(sessionId: 42));
+
+        var build = handler.Build([], clusterMetadata: null);
+
+        await Assert.That(build.SessionId).IsEqualTo(42);
+        await Assert.That(build.SessionEpoch).IsEqualTo(-1);
+        await Assert.That(build.Topics).IsEmpty();
+        await Assert.That(handler.HasActiveSession).IsFalse();
+    }
+
+    [Test]
+    public async Task HandleResponse_FetchSessionIdNotFound_ResetsToInitial()
+    {
+        var handler = new FetchSessionHandler();
+        var topics = Topics(("topic-a", 0, 100, 1024));
+
+        handler.Build(topics, clusterMetadata: null);
+        handler.HandleResponse(Response(sessionId: 42));
+        handler.HandleResponse(Response(sessionId: 0, ErrorCode.FetchSessionIdNotFound));
+
+        var build = handler.Build(topics, clusterMetadata: null);
+
+        await Assert.That(build.SessionId).IsEqualTo(0);
+        await Assert.That(build.SessionEpoch).IsEqualTo(0);
+        await Assert.That(build.IsFull).IsTrue();
+    }
+
+    [Test]
+    public async Task HandleResponse_InvalidEpoch_ClosesExistingAndAttemptsNewSession()
+    {
+        var handler = new FetchSessionHandler();
+        var topics = Topics(("topic-a", 0, 100, 1024));
+
+        handler.Build(topics, clusterMetadata: null);
+        handler.HandleResponse(Response(sessionId: 42));
+        handler.HandleResponse(Response(sessionId: 42, ErrorCode.InvalidFetchSessionEpoch));
+
+        var build = handler.Build(topics, clusterMetadata: null);
+
+        await Assert.That(build.SessionId).IsEqualTo(42);
+        await Assert.That(build.SessionEpoch).IsEqualTo(0);
+        await Assert.That(build.IsFull).IsTrue();
+    }
+
+    private static FetchResponse Response(int sessionId, ErrorCode errorCode = ErrorCode.None) => new()
+    {
+        SessionId = sessionId,
+        ErrorCode = errorCode,
+        Responses = []
+    };
+
+    private static List<FetchRequestTopic> Topics(params (string Topic, int Partition, long Offset, int MaxBytes)[] partitions)
+    {
+        var grouped = new Dictionary<string, List<FetchRequestPartition>>();
+        foreach (var (topic, partition, offset, maxBytes) in partitions)
+        {
+            if (!grouped.TryGetValue(topic, out var list))
+            {
+                list = [];
+                grouped[topic] = list;
+            }
+
+            list.Add(new FetchRequestPartition
+            {
+                Partition = partition,
+                FetchOffset = offset,
+                PartitionMaxBytes = maxBytes
+            });
+        }
+
+        var result = new List<FetchRequestTopic>(grouped.Count);
+        foreach (var (topic, topicPartitions) in grouped)
+        {
+            result.Add(new FetchRequestTopic
+            {
+                Topic = topic,
+                Partitions = topicPartitions
+            });
+        }
+
+        return result;
+    }
+
+    private static ClusterMetadata Metadata(string topic, Guid topicId)
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    Name = topic,
+                    TopicId = topicId,
+                    ErrorCode = ErrorCode.None,
+                    Partitions = [new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] }]
+                }
+            ]
+        });
+        return metadata;
+    }
+}


### PR DESCRIPTION
## Summary
- add a per-broker/connection `FetchSessionHandler` for KIP-227 session ids, epochs, changed partitions, forgotten partitions, and top-level session errors
- wire prefetch and direct fetch requests to send incremental fetch sessions when supported, with `WithFetchSessions(false)` fallback
- close/flush active sessions when a broker/connection no longer has desired partitions, and populate forgotten topic ids from metadata

Closes #817

## Tests
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/FetchSessionHandlerTests/*"`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PrefetchPipelineRunnerTests/*"`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumerBuilderValidationTests/*"`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumerOptionsDefaultsTests/*"`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/BuildFetchResultTests/*"`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumerLeaderDiscoveryTests/*"`
- `git diff --check`