### PR TITLE
feat(protocol): add telemetry messages

### DIFF
--- a/src/Dekaf/Protocol/Messages/GetTelemetrySubscriptionsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/GetTelemetrySubscriptionsRequest.cs
@@ -9,8 +9,6 @@ public sealed class GetTelemetrySubscriptionsRequest : IKafkaRequest<GetTelemetr
     public static ApiKey ApiKey => ApiKey.GetTelemetrySubscriptions;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 0;
-    public static short GetRequestHeaderVersion(short version) => 2;
-    public static short GetResponseHeaderVersion(short version) => 1;
 
     /// <summary>
     /// The assigned client instance ID. Use Guid.Empty on the first request.

--- a/src/Dekaf/Protocol/Messages/GetTelemetrySubscriptionsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/GetTelemetrySubscriptionsRequest.cs
@@ -1,0 +1,25 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// GetTelemetrySubscriptions request (API key 71).
+/// Negotiates client telemetry subscription parameters with the broker.
+/// </summary>
+public sealed class GetTelemetrySubscriptionsRequest : IKafkaRequest<GetTelemetrySubscriptionsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.GetTelemetrySubscriptions;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+    public static short GetRequestHeaderVersion(short version) => 2;
+    public static short GetResponseHeaderVersion(short version) => 1;
+
+    /// <summary>
+    /// The assigned client instance ID. Use Guid.Empty on the first request.
+    /// </summary>
+    public Guid ClientInstanceId { get; init; } = Guid.Empty;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteUuid(ClientInstanceId);
+        writer.WriteEmptyTaggedFields();
+    }
+}

--- a/src/Dekaf/Protocol/Messages/GetTelemetrySubscriptionsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/GetTelemetrySubscriptionsResponse.cs
@@ -1,0 +1,85 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// GetTelemetrySubscriptions response (API key 71).
+/// Contains the broker-selected telemetry subscription and upload constraints.
+/// </summary>
+public sealed class GetTelemetrySubscriptionsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.GetTelemetrySubscriptions;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// Throttle time in milliseconds.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The top-level error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The assigned client instance ID, or Guid.Empty when unchanged.
+    /// </summary>
+    public Guid ClientInstanceId { get; init; }
+
+    /// <summary>
+    /// The broker-assigned subscription ID for subsequent PushTelemetry requests.
+    /// </summary>
+    public int SubscriptionId { get; init; }
+
+    /// <summary>
+    /// Compression type IDs accepted for telemetry payloads.
+    /// </summary>
+    public IReadOnlyList<sbyte> AcceptedCompressionTypes { get; init; } = [];
+
+    /// <summary>
+    /// Minimum interval in milliseconds between PushTelemetry requests.
+    /// </summary>
+    public int PushIntervalMs { get; init; }
+
+    /// <summary>
+    /// Maximum telemetry payload size in bytes.
+    /// </summary>
+    public int TelemetryMaxBytes { get; init; }
+
+    /// <summary>
+    /// True when delta temporality is requested; false for cumulative temporality.
+    /// </summary>
+    public bool DeltaTemporality { get; init; }
+
+    /// <summary>
+    /// Metric name prefixes requested by the broker.
+    /// </summary>
+    public IReadOnlyList<string> RequestedMetrics { get; init; } = [];
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var clientInstanceId = reader.ReadUuid();
+        var subscriptionId = reader.ReadInt32();
+        var acceptedCompressionTypes = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt8());
+        var pushIntervalMs = reader.ReadInt32();
+        var telemetryMaxBytes = reader.ReadInt32();
+        var deltaTemporality = reader.ReadBoolean();
+        var requestedMetrics = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadCompactNonNullableString());
+
+        reader.SkipTaggedFields();
+
+        return new GetTelemetrySubscriptionsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ClientInstanceId = clientInstanceId,
+            SubscriptionId = subscriptionId,
+            AcceptedCompressionTypes = acceptedCompressionTypes,
+            PushIntervalMs = pushIntervalMs,
+            TelemetryMaxBytes = telemetryMaxBytes,
+            DeltaTemporality = deltaTemporality,
+            RequestedMetrics = requestedMetrics
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/PushTelemetryRequest.cs
+++ b/src/Dekaf/Protocol/Messages/PushTelemetryRequest.cs
@@ -1,0 +1,49 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// PushTelemetry request (API key 72).
+/// Uploads an OpenTelemetry MetricsData payload for a broker subscription.
+/// </summary>
+public sealed class PushTelemetryRequest : IKafkaRequest<PushTelemetryResponse>
+{
+    public static ApiKey ApiKey => ApiKey.PushTelemetry;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+    public static short GetRequestHeaderVersion(short version) => 2;
+    public static short GetResponseHeaderVersion(short version) => 1;
+
+    /// <summary>
+    /// The client instance ID assigned by GetTelemetrySubscriptions.
+    /// </summary>
+    public Guid ClientInstanceId { get; init; }
+
+    /// <summary>
+    /// The subscription ID assigned by GetTelemetrySubscriptions.
+    /// </summary>
+    public int SubscriptionId { get; init; }
+
+    /// <summary>
+    /// True when this is the final telemetry push for the client lifecycle.
+    /// </summary>
+    public bool Terminating { get; init; }
+
+    /// <summary>
+    /// Compression type ID used for the metrics payload.
+    /// </summary>
+    public sbyte CompressionType { get; init; }
+
+    /// <summary>
+    /// OpenTelemetry MetricsData payload bytes.
+    /// </summary>
+    public ReadOnlyMemory<byte> Metrics { get; init; } = ReadOnlyMemory<byte>.Empty;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteUuid(ClientInstanceId);
+        writer.WriteInt32(SubscriptionId);
+        writer.WriteBoolean(Terminating);
+        writer.WriteInt8(CompressionType);
+        writer.WriteCompactBytes(Metrics.Span);
+        writer.WriteEmptyTaggedFields();
+    }
+}

--- a/src/Dekaf/Protocol/Messages/PushTelemetryRequest.cs
+++ b/src/Dekaf/Protocol/Messages/PushTelemetryRequest.cs
@@ -9,8 +9,6 @@ public sealed class PushTelemetryRequest : IKafkaRequest<PushTelemetryResponse>
     public static ApiKey ApiKey => ApiKey.PushTelemetry;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 0;
-    public static short GetRequestHeaderVersion(short version) => 2;
-    public static short GetResponseHeaderVersion(short version) => 1;
 
     /// <summary>
     /// The client instance ID assigned by GetTelemetrySubscriptions.

--- a/src/Dekaf/Protocol/Messages/PushTelemetryResponse.cs
+++ b/src/Dekaf/Protocol/Messages/PushTelemetryResponse.cs
@@ -1,0 +1,36 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// PushTelemetry response (API key 72).
+/// Contains the broker result for a telemetry upload.
+/// </summary>
+public sealed class PushTelemetryResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.PushTelemetry;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// Throttle time in milliseconds.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The top-level error code, or 0 if there was no error.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        reader.SkipTaggedFields();
+
+        return new PushTelemetryResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/TelemetryProtocolMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/TelemetryProtocolMessageTests.cs
@@ -1,0 +1,111 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class TelemetryProtocolMessageTests
+{
+    [Test]
+    public async Task GetTelemetrySubscriptionsRequest_V0_FirstRequest_WritesZeroClientInstanceId()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        var request = new GetTelemetrySubscriptionsRequest();
+
+        request.Write(ref writer, version: 0);
+
+        await Assert.That(buffer.WrittenSpan.ToArray()).IsEquivalentTo(new byte[17]);
+    }
+
+    [Test]
+    public async Task GetTelemetrySubscriptionsResponse_V0_ReadsSubscription()
+    {
+        var clientInstanceId = new Guid("00112233-4455-6677-8899-aabbccddeeff");
+        var data = new List<byte>();
+
+        data.AddRange([0x00, 0x00, 0x00, 0x05]);
+        data.AddRange([0x00, 0x00]);
+        data.AddRange(clientInstanceId.ToByteArray(bigEndian: true));
+        data.AddRange([0x00, 0x00, 0x00, 0x2A]);
+        data.Add(0x03);
+        data.Add(0x00);
+        data.Add(0x04);
+        data.AddRange([0x00, 0x00, 0xEA, 0x60]);
+        data.AddRange([0x00, 0x10, 0x00, 0x00]);
+        data.Add(0x01);
+        data.Add(0x03);
+        data.Add(0x1B);
+        data.AddRange("org.apache.kafka.producer."u8.ToArray());
+        data.Add(0x01);
+        data.Add(0x00);
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (GetTelemetrySubscriptionsResponse)GetTelemetrySubscriptionsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(5);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ClientInstanceId).IsEqualTo(clientInstanceId);
+        await Assert.That(response.SubscriptionId).IsEqualTo(42);
+        await Assert.That(response.AcceptedCompressionTypes).IsEquivalentTo([(sbyte)0, (sbyte)4]);
+        await Assert.That(response.PushIntervalMs).IsEqualTo(60_000);
+        await Assert.That(response.TelemetryMaxBytes).IsEqualTo(1_048_576);
+        await Assert.That(response.DeltaTemporality).IsTrue();
+        await Assert.That(response.RequestedMetrics).IsEquivalentTo(["org.apache.kafka.producer.", string.Empty]);
+    }
+
+    [Test]
+    public async Task PushTelemetryRequest_V0_WritesMetricsPayload()
+    {
+        var clientInstanceId = new Guid("00112233-4455-6677-8899-aabbccddeeff");
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        var request = new PushTelemetryRequest
+        {
+            ClientInstanceId = clientInstanceId,
+            SubscriptionId = 42,
+            Terminating = true,
+            CompressionType = 4,
+            Metrics = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }
+        };
+
+        request.Write(ref writer, version: 0);
+
+        var expected = new List<byte>();
+        expected.AddRange(clientInstanceId.ToByteArray(bigEndian: true));
+        expected.AddRange([0x00, 0x00, 0x00, 0x2A]);
+        expected.Add(0x01);
+        expected.Add(0x04);
+        expected.Add(0x05);
+        expected.AddRange([0xDE, 0xAD, 0xBE, 0xEF]);
+        expected.Add(0x00);
+
+        await Assert.That(buffer.WrittenSpan.ToArray()).IsEquivalentTo(expected.ToArray());
+    }
+
+    [Test]
+    public async Task PushTelemetryResponse_V0_ReadsError()
+    {
+        var data = new byte[]
+        {
+            0x00, 0x00, 0x00, 0x7B,
+            0x00, 0x75,
+            0x00
+        };
+
+        var reader = new KafkaProtocolReader(data);
+        var response = (PushTelemetryResponse)PushTelemetryResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(123);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.UnknownSubscriptionId);
+    }
+
+    [Test]
+    public async Task TelemetryRequests_UseFlexibleHeaders()
+    {
+        await Assert.That(GetTelemetrySubscriptionsRequest.GetRequestHeaderVersion(0)).IsEqualTo((short)2);
+        await Assert.That(GetTelemetrySubscriptionsRequest.GetResponseHeaderVersion(0)).IsEqualTo((short)1);
+        await Assert.That(PushTelemetryRequest.GetRequestHeaderVersion(0)).IsEqualTo((short)2);
+        await Assert.That(PushTelemetryRequest.GetResponseHeaderVersion(0)).IsEqualTo((short)1);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/TelemetryProtocolMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/TelemetryProtocolMessageTests.cs
@@ -103,9 +103,27 @@ public sealed class TelemetryProtocolMessageTests
     [Test]
     public async Task TelemetryRequests_UseFlexibleHeaders()
     {
-        await Assert.That(GetTelemetrySubscriptionsRequest.GetRequestHeaderVersion(0)).IsEqualTo((short)2);
-        await Assert.That(GetTelemetrySubscriptionsRequest.GetResponseHeaderVersion(0)).IsEqualTo((short)1);
-        await Assert.That(PushTelemetryRequest.GetRequestHeaderVersion(0)).IsEqualTo((short)2);
-        await Assert.That(PushTelemetryRequest.GetResponseHeaderVersion(0)).IsEqualTo((short)1);
+        await Assert.That(GetRequestHeaderVersion<GetTelemetrySubscriptionsRequest, GetTelemetrySubscriptionsResponse>(0))
+            .IsEqualTo((short)2);
+        await Assert.That(GetResponseHeaderVersion<GetTelemetrySubscriptionsRequest, GetTelemetrySubscriptionsResponse>(0))
+            .IsEqualTo((short)1);
+        await Assert.That(GetRequestHeaderVersion<PushTelemetryRequest, PushTelemetryResponse>(0))
+            .IsEqualTo((short)2);
+        await Assert.That(GetResponseHeaderVersion<PushTelemetryRequest, PushTelemetryResponse>(0))
+            .IsEqualTo((short)1);
+    }
+
+    private static short GetRequestHeaderVersion<TRequest, TResponse>(short version)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        return TRequest.GetRequestHeaderVersion(version);
+    }
+
+    private static short GetResponseHeaderVersion<TRequest, TResponse>(short version)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        return TRequest.GetResponseHeaderVersion(version);
     }
 }


### PR DESCRIPTION
## Summary
- Add KIP-714 GetTelemetrySubscriptions v0 request/response messages.
- Add PushTelemetry v0 request/response messages.
- Cover flexible v0 wire encoding, decoding, and header versions.

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit --configuration Release
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter '/*/*/TelemetryProtocolMessageTests/*'
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter '/*/*/MessageEncodingTests/*'
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter '/*/Dekaf.Tests.Unit.Protocol/*/*'
- [x] git diff --cached --check
- [ ] Full unit executable timed out after 300s with no failure summary; protocol suite passed.

Closes #1003
Refs #819
