### PR TITLE
perf(protocol): speed varint helpers

### DIFF
--- a/src/Dekaf/Protocol/KafkaProtocolWriter.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolWriter.cs
@@ -178,7 +178,33 @@ public ref struct KafkaProtocolWriter
         _bytesWritten += pos;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void WriteVarULong(ulong value)
+    {
+        if (value < 0x80)
+        {
+            var span = _output.GetSpan(1);
+            span[0] = (byte)value;
+            _output.Advance(1);
+            _bytesWritten += 1;
+            return;
+        }
+
+        if (value < 0x4000)
+        {
+            var span = _output.GetSpan(2);
+            span[0] = (byte)(value | 0x80);
+            span[1] = (byte)(value >> 7);
+            _output.Advance(2);
+            _bytesWritten += 2;
+            return;
+        }
+
+        WriteVarULongSlow(value);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void WriteVarULongSlow(ulong value)
     {
         // Maximum 10 bytes for a 64-bit varint
         // Write directly to output span to avoid stackalloc + copy overhead

--- a/src/Dekaf/Protocol/Records/Record.cs
+++ b/src/Dekaf/Protocol/Records/Record.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Numerics;
 using Dekaf.Serialization;
 
 namespace Dekaf.Protocol.Records;
@@ -245,23 +246,11 @@ public readonly record struct Record
 
     internal static int VarUIntSize(uint value)
     {
-        var size = 1;
-        while (value >= 0x80)
-        {
-            size++;
-            value >>= 7;
-        }
-        return size;
+        return (BitOperations.Log2(value | 1u) / 7) + 1;
     }
 
     internal static int VarULongSize(ulong value)
     {
-        var size = 1;
-        while (value >= 0x80)
-        {
-            size++;
-            value >>= 7;
-        }
-        return size;
+        return (BitOperations.Log2(value | 1ul) / 7) + 1;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Protocol/VarIntEncodingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/VarIntEncodingTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using Dekaf.Protocol;
+using Dekaf.Protocol.Records;
 
 namespace Dekaf.Tests.Unit.Protocol;
 
@@ -95,6 +96,24 @@ public class VarIntEncodingTests
         await Assert.That(reader.ReadVarLong()).IsEqualTo(value);
     }
 
+    [Test]
+    [Arguments(0L, 1)]
+    [Arguments(-64L, 1)]
+    [Arguments(64L, 2)]
+    [Arguments(-8192L, 2)]
+    [Arguments(8192L, 3)]
+    [Arguments(long.MaxValue, 10)]
+    [Arguments(long.MinValue, 10)]
+    public async Task VarLong_ByteLength_Boundaries(long value, int expectedLength)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteVarLong(value);
+
+        await Assert.That(buffer.WrittenCount).IsEqualTo(expectedLength);
+    }
+
     #endregion
 
     #region UNSIGNED_VARINT Tests
@@ -171,6 +190,67 @@ public class VarIntEncodingTests
         var writer = new KafkaProtocolWriter(buffer);
         writer.WriteUnsignedVarInt(128);
         await Assert.That(buffer.WrittenCount).IsEqualTo(2);
+    }
+
+    [Test]
+    [Arguments(0, 1)]
+    [Arguments(127, 1)]
+    [Arguments(128, 2)]
+    [Arguments(16383, 2)]
+    [Arguments(16384, 3)]
+    [Arguments(2097151, 3)]
+    [Arguments(2097152, 4)]
+    [Arguments(int.MaxValue, 5)]
+    public async Task UnsignedVarInt_ByteLength_Boundaries(int value, int expectedLength)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteUnsignedVarInt(value);
+
+        await Assert.That(buffer.WrittenCount).IsEqualTo(expectedLength);
+    }
+
+    [Test]
+    [Arguments(0u, 1)]
+    [Arguments(127u, 1)]
+    [Arguments(128u, 2)]
+    [Arguments(16383u, 2)]
+    [Arguments(16384u, 3)]
+    [Arguments(2097151u, 3)]
+    [Arguments(2097152u, 4)]
+    [Arguments(268435455u, 4)]
+    [Arguments(268435456u, 5)]
+    [Arguments(uint.MaxValue, 5)]
+    public async Task VarUIntSize_Boundaries(uint value, int expectedLength)
+    {
+        await Assert.That(Record.VarUIntSize(value)).IsEqualTo(expectedLength);
+    }
+
+    [Test]
+    [Arguments(0ul, 1)]
+    [Arguments(127ul, 1)]
+    [Arguments(128ul, 2)]
+    [Arguments(16383ul, 2)]
+    [Arguments(16384ul, 3)]
+    [Arguments(2097151ul, 3)]
+    [Arguments(2097152ul, 4)]
+    [Arguments(268435455ul, 4)]
+    [Arguments(268435456ul, 5)]
+    [Arguments(34359738367ul, 5)]
+    [Arguments(34359738368ul, 6)]
+    [Arguments(4398046511103ul, 6)]
+    [Arguments(4398046511104ul, 7)]
+    [Arguments(562949953421311ul, 7)]
+    [Arguments(562949953421312ul, 8)]
+    [Arguments(72057594037927935ul, 8)]
+    [Arguments(72057594037927936ul, 9)]
+    [Arguments(9223372036854775807ul, 9)]
+    [Arguments(9223372036854775808ul, 10)]
+    [Arguments(ulong.MaxValue, 10)]
+    public async Task VarULongSize_Boundaries(ulong value, int expectedLength)
+    {
+        await Assert.That(Record.VarULongSize(value)).IsEqualTo(expectedLength);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- add one- and two-byte fast paths for VARLONG writes
- replace loop-based varuint/varulong size helpers with `BitOperations.Log2` sizing
- add boundary coverage for unsigned varint writes and varuint/varulong sizes

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit --configuration Release`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/VarIntEncodingTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaProtocolWriterTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordBatchTests/*"`
- [x] `git diff --check`

Closes #994
