### PR TITLE
feat(di)!: expose core builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,15 +312,19 @@ using Dekaf.Extensions.DependencyInjection;
 services.AddDekaf(dekaf =>
 {
     dekaf.AddProducer<string, string>(producer => producer
-        .WithBootstrapServers(configuration["Kafka:BootstrapServers"]!));
+        .WithBootstrapServers(configuration["Kafka:BootstrapServers"]!)
+        .WithLinger(TimeSpan.FromMilliseconds(5))
+        .ForReliability());
 
     dekaf.AddConsumer<string, string>(consumer => consumer
         .WithBootstrapServers(configuration["Kafka:BootstrapServers"]!)
-        .WithGroupId("my-service"));
+        .WithGroupId("my-service")
+        .WithFetchMinBytes(1024));
 });
 ```
 
 Then inject `IKafkaProducer<string, string>` or `IKafkaConsumer<string, string>` wherever you need them.
+The DI callbacks use the same `ProducerBuilder` and `ConsumerBuilder` types as `Kafka.CreateProducer()` and `Kafka.CreateConsumer()`, so advanced options, SASL/TLS, retry policies, presets, interceptors, and compression extension methods are available there too.
 
 ### Global Interceptors
 
@@ -334,11 +338,13 @@ services.AddDekaf(dekaf =>
     dekaf.AddGlobalConsumerInterceptor(typeof(MetricsInterceptor<,>));
 
     dekaf.AddProducer<string, string>(producer => producer
-        .WithBootstrapServers("localhost:9092"));
+        .WithBootstrapServers("localhost:9092")
+        .WithLinger(TimeSpan.FromMilliseconds(5)));
 
     dekaf.AddConsumer<string, string>(consumer => consumer
         .WithBootstrapServers("localhost:9092")
-        .WithGroupId("my-service"));
+        .WithGroupId("my-service")
+        .WithPrefetchPipelineDepth(4));
 });
 ```
 

--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -6,6 +6,31 @@ sidebar_position: 3
 
 Complete reference for all consumer configuration options.
 
+These methods are available anywhere a `ConsumerBuilder<TKey,TValue>` is used, including dependency injection registration:
+
+```csharp
+// Before: DI examples only showed connection and group settings.
+builder.Services.AddDekaf(dekaf =>
+{
+    dekaf.AddConsumer<string, string>(consumer => consumer
+        .WithBootstrapServers("localhost:9092")
+        .WithGroupId("orders"));
+});
+
+// After: DI uses the full consumer builder.
+builder.Services.AddDekaf(dekaf =>
+{
+    dekaf.AddConsumer<string, string>(consumer => consumer
+        .WithBootstrapServers("localhost:9092")
+        .WithGroupId("orders")
+        .WithFetchMinBytes(1024)
+        .WithFetchMaxBytes(50 * 1024 * 1024)
+        .WithPrefetchPipelineDepth(4)
+        .WithSaslScramSha512("user", "password")
+        .SubscribeTo("orders"));
+});
+```
+
 ## Connection Settings
 
 ### WithBootstrapServers

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -6,6 +6,29 @@ sidebar_position: 2
 
 Complete reference for all producer configuration options.
 
+These methods are available anywhere a `ProducerBuilder<TKey,TValue>` is used, including dependency injection registration:
+
+```csharp
+// Before: DI examples only showed the small common subset.
+builder.Services.AddDekaf(dekaf =>
+{
+    dekaf.AddProducer<string, string>(producer => producer
+        .WithBootstrapServers("localhost:9092"));
+});
+
+// After: DI uses the full producer builder.
+builder.Services.AddDekaf(dekaf =>
+{
+    dekaf.AddProducer<string, string>(producer => producer
+        .WithBootstrapServers("localhost:9092")
+        .WithLinger(TimeSpan.FromMilliseconds(5))
+        .WithBatchSize(64 * 1024)
+        .WithBufferMemory(256 * 1024 * 1024)
+        .WithSaslScramSha512("user", "password")
+        .ForHighThroughput());
+});
+```
+
 ## Connection Settings
 
 ### WithBootstrapServers

--- a/docs/docs/dependency-injection.md
+++ b/docs/docs/dependency-injection.md
@@ -25,11 +25,60 @@ builder.Services.AddDekaf(dekaf =>
 {
     dekaf.AddProducer<string, string>(producer => producer
         .WithBootstrapServers(builder.Configuration["Kafka:BootstrapServers"]!)
+        .WithLinger(TimeSpan.FromMilliseconds(5))
+        .WithBatchSize(64 * 1024)
         .ForReliability());
 
     dekaf.AddConsumer<string, string>(consumer => consumer
         .WithBootstrapServers(builder.Configuration["Kafka:BootstrapServers"]!)
-        .WithGroupId("my-service"));
+        .WithGroupId("my-service")
+        .WithFetchMinBytes(1024));
+});
+```
+
+## Full Builder Surface
+
+The DI callback receives the same `ProducerBuilder<TKey,TValue>` and `ConsumerBuilder<TKey,TValue>` used by the non-DI API. Any option available during manual construction is available during registration too.
+
+Before:
+
+```csharp
+builder.Services.AddDekaf(dekaf =>
+{
+    dekaf.AddProducer<string, string>(producer => producer
+        .WithBootstrapServers("localhost:9092")
+        .WithAcks(Acks.All));
+});
+```
+
+After:
+
+```csharp
+var retryPolicy = new FixedDelayRetryPolicy
+{
+    Delay = TimeSpan.FromMilliseconds(100),
+    MaxAttempts = 3
+};
+
+builder.Services.AddDekaf(dekaf =>
+{
+    dekaf.AddProducer<string, string>(producer => producer
+        .WithBootstrapServers("localhost:9092")
+        .WithLinger(TimeSpan.FromMilliseconds(5))
+        .WithBatchSize(64 * 1024)
+        .WithBufferMemory(256 * 1024 * 1024)
+        .WithSaslScramSha512("user", "password")
+        .WithRetryPolicy(retryPolicy)
+        .ForHighThroughput());
+
+    dekaf.AddConsumer<string, string>(consumer => consumer
+        .WithBootstrapServers("localhost:9092")
+        .WithGroupId("orders")
+        .WithFetchMinBytes(1024)
+        .WithFetchMaxBytes(50 * 1024 * 1024)
+        .WithPrefetchPipelineDepth(4)
+        .WithRetryPolicy(retryPolicy)
+        .SubscribeTo("orders"));
 });
 ```
 
@@ -63,10 +112,12 @@ builder.Services.AddDekaf(dekaf =>
 {
     dekaf.AddProducer<string, string>(producer => producer
         .WithBootstrapServers(config["Kafka:BootstrapServers"]!)
+        .WithLinger(TimeSpan.FromMilliseconds(5))
         .ForReliability());
 
     dekaf.AddProducer<string, byte[]>(producer => producer
         .WithBootstrapServers(config["Kafka:BootstrapServers"]!)
+        .WithBatchSize(128 * 1024)
         .ForHighThroughput());
 });
 ```

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -104,9 +104,10 @@ public sealed class DekafBuilder
     /// <summary>
     /// Adds a producer to the service collection.
     /// </summary>
-    public DekafBuilder AddProducer<TKey, TValue>(Action<ProducerServiceBuilder<TKey, TValue>> configure)
+    /// <param name="configure">Configures the full producer builder surface.</param>
+    public DekafBuilder AddProducer<TKey, TValue>(Action<ProducerBuilder<TKey, TValue>> configure)
     {
-        var builder = new ProducerServiceBuilder<TKey, TValue>();
+        var builder = new ProducerBuilder<TKey, TValue>();
         configure(builder);
 
         var globalTypes = _globalProducerInterceptorTypes;
@@ -115,10 +116,9 @@ public sealed class DekafBuilder
         {
             var loggerFactory = sp.GetService<ILoggerFactory>();
 
-            List<IProducerInterceptor<TKey, TValue>>? globalInterceptors = null;
             if (globalTypes.Count > 0)
             {
-                globalInterceptors = new List<IProducerInterceptor<TKey, TValue>>(globalTypes.Count);
+                var globalInterceptors = new List<IProducerInterceptor<TKey, TValue>>(globalTypes.Count);
                 foreach (var type in globalTypes)
                 {
                     var closedType = type.IsGenericTypeDefinition
@@ -128,9 +128,16 @@ public sealed class DekafBuilder
                         ActivatorUtilities.CreateInstance(sp, closedType);
                     globalInterceptors.Add(interceptor);
                 }
+
+                builder.AddInterceptorsFirst(globalInterceptors);
             }
 
-            return builder.Build(loggerFactory, globalInterceptors);
+            if (loggerFactory is not null)
+            {
+                builder.WithLoggerFactory(loggerFactory);
+            }
+
+            return builder.Build();
         });
 
         // Register as IInitializableKafkaClient (resolves the same singleton instance)
@@ -143,9 +150,13 @@ public sealed class DekafBuilder
     /// <summary>
     /// Adds a consumer to the service collection.
     /// </summary>
-    public DekafBuilder AddConsumer<TKey, TValue>(Action<ConsumerServiceBuilder<TKey, TValue>> configure)
+    /// <param name="configure">Configures the full consumer builder surface.</param>
+    /// <param name="configureDeadLetterQueue">Optional dead letter queue configuration for hosted consumer services.</param>
+    public DekafBuilder AddConsumer<TKey, TValue>(
+        Action<ConsumerBuilder<TKey, TValue>> configure,
+        Action<DeadLetterQueueBuilder>? configureDeadLetterQueue = null)
     {
-        var builder = new ConsumerServiceBuilder<TKey, TValue>();
+        var builder = new ConsumerBuilder<TKey, TValue>();
         configure(builder);
 
         var globalTypes = _globalConsumerInterceptorTypes;
@@ -154,10 +165,9 @@ public sealed class DekafBuilder
         {
             var loggerFactory = sp.GetService<ILoggerFactory>();
 
-            List<IConsumerInterceptor<TKey, TValue>>? globalInterceptors = null;
             if (globalTypes.Count > 0)
             {
-                globalInterceptors = new List<IConsumerInterceptor<TKey, TValue>>(globalTypes.Count);
+                var globalInterceptors = new List<IConsumerInterceptor<TKey, TValue>>(globalTypes.Count);
                 foreach (var type in globalTypes)
                 {
                     var closedType = type.IsGenericTypeDefinition
@@ -167,19 +177,34 @@ public sealed class DekafBuilder
                         ActivatorUtilities.CreateInstance(sp, closedType);
                     globalInterceptors.Add(interceptor);
                 }
+
+                builder.AddInterceptorsFirst(globalInterceptors);
             }
 
-            return builder.Build(loggerFactory, globalInterceptors);
+            if (loggerFactory is not null)
+            {
+                builder.WithLoggerFactory(loggerFactory);
+            }
+
+            return builder.Build();
         });
 
         // Register as IInitializableKafkaClient (resolves the same singleton instance)
         _services.AddSingleton<IInitializableKafkaClient>(sp =>
             sp.GetRequiredService<IKafkaConsumer<TKey, TValue>>());
 
-        // Register DLQ options if configured
-        var dlqOptions = builder.BuildDeadLetterOptions();
-        if (dlqOptions is not null)
+        if (configureDeadLetterQueue is not null)
         {
+            var dlqBuilder = new DeadLetterQueueBuilder();
+            configureDeadLetterQueue(dlqBuilder);
+
+            var bootstrapServers = builder.BootstrapServersString;
+            if (bootstrapServers is not null)
+            {
+                dlqBuilder.WithDefaultBootstrapServers(bootstrapServers);
+            }
+
+            var dlqOptions = dlqBuilder.Build();
             _services.AddSingleton(dlqOptions);
         }
 
@@ -201,258 +226,6 @@ public sealed class DekafBuilder
         });
 
         return this;
-    }
-}
-
-/// <summary>
-/// Builder for configuring a producer service.
-/// </summary>
-public sealed class ProducerServiceBuilder<TKey, TValue>
-{
-    private readonly ProducerBuilder<TKey, TValue> _builder = new();
-    private readonly List<IProducerInterceptor<TKey, TValue>> _perInstanceInterceptors = [];
-
-    public ProducerServiceBuilder<TKey, TValue> WithBootstrapServers(string servers)
-    {
-        _builder.WithBootstrapServers(servers);
-        return this;
-    }
-
-    public ProducerServiceBuilder<TKey, TValue> WithClientId(string clientId)
-    {
-        _builder.WithClientId(clientId);
-        return this;
-    }
-
-    public ProducerServiceBuilder<TKey, TValue> WithAcks(Acks acks)
-    {
-        _builder.WithAcks(acks);
-        return this;
-    }
-
-    public ProducerServiceBuilder<TKey, TValue> WithTransactionalId(string transactionalId)
-    {
-        _builder.WithTransactionalId(transactionalId);
-        return this;
-    }
-
-    public ProducerServiceBuilder<TKey, TValue> UseZstdCompression()
-    {
-        _builder.UseCompression(Protocol.Records.CompressionType.Zstd);
-        return this;
-    }
-
-    public ProducerServiceBuilder<TKey, TValue> UseGzipCompression()
-    {
-        _builder.UseGzipCompression();
-        return this;
-    }
-
-    public ProducerServiceBuilder<TKey, TValue> UseLz4Compression()
-    {
-        _builder.UseCompression(Protocol.Records.CompressionType.Lz4);
-        return this;
-    }
-
-    public ProducerServiceBuilder<TKey, TValue> WithKeySerializer(ISerializer<TKey> serializer)
-    {
-        _builder.WithKeySerializer(serializer);
-        return this;
-    }
-
-    public ProducerServiceBuilder<TKey, TValue> WithValueSerializer(ISerializer<TValue> serializer)
-    {
-        _builder.WithValueSerializer(serializer);
-        return this;
-    }
-
-    public ProducerServiceBuilder<TKey, TValue> UseTls()
-    {
-        _builder.UseTls();
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a per-instance producer interceptor. Per-instance interceptors execute after global interceptors.
-    /// </summary>
-    /// <param name="interceptor">The interceptor to add.</param>
-    /// <returns>The builder instance for method chaining.</returns>
-    public ProducerServiceBuilder<TKey, TValue> AddInterceptor(IProducerInterceptor<TKey, TValue> interceptor)
-    {
-        ArgumentNullException.ThrowIfNull(interceptor);
-        _perInstanceInterceptors.Add(interceptor);
-        return this;
-    }
-
-    internal IKafkaProducer<TKey, TValue> Build(
-        ILoggerFactory? loggerFactory,
-        List<IProducerInterceptor<TKey, TValue>>? globalInterceptors = null)
-    {
-        if (loggerFactory is not null)
-        {
-            _builder.WithLoggerFactory(loggerFactory);
-        }
-
-        // Add global interceptors first (execute first)
-        if (globalInterceptors is not null)
-        {
-            foreach (var interceptor in globalInterceptors)
-            {
-                _builder.AddInterceptor(interceptor);
-            }
-        }
-
-        // Add per-instance interceptors second (execute after globals)
-        foreach (var interceptor in _perInstanceInterceptors)
-        {
-            _builder.AddInterceptor(interceptor);
-        }
-
-        return _builder.Build();
-    }
-}
-
-/// <summary>
-/// Builder for configuring a consumer service.
-/// </summary>
-public sealed class ConsumerServiceBuilder<TKey, TValue>
-{
-    private readonly ConsumerBuilder<TKey, TValue> _builder = new();
-    private readonly List<IConsumerInterceptor<TKey, TValue>> _perInstanceInterceptors = [];
-    private string? _bootstrapServers;
-
-    public ConsumerServiceBuilder<TKey, TValue> WithBootstrapServers(string servers)
-    {
-        _bootstrapServers = servers;
-        _builder.WithBootstrapServers(servers);
-        return this;
-    }
-
-    public ConsumerServiceBuilder<TKey, TValue> WithClientId(string clientId)
-    {
-        _builder.WithClientId(clientId);
-        return this;
-    }
-
-    public ConsumerServiceBuilder<TKey, TValue> WithGroupId(string groupId)
-    {
-        _builder.WithGroupId(groupId);
-        return this;
-    }
-
-    public ConsumerServiceBuilder<TKey, TValue> WithGroupInstanceId(string groupInstanceId)
-    {
-        _builder.WithGroupInstanceId(groupInstanceId);
-        return this;
-    }
-
-    public ConsumerServiceBuilder<TKey, TValue> WithOffsetCommitMode(OffsetCommitMode mode)
-    {
-        _builder.WithOffsetCommitMode(mode);
-        return this;
-    }
-
-    public ConsumerServiceBuilder<TKey, TValue> WithAutoOffsetReset(AutoOffsetReset autoOffsetReset)
-    {
-        _builder.WithAutoOffsetReset(autoOffsetReset);
-        return this;
-    }
-
-    public ConsumerServiceBuilder<TKey, TValue> WithKeyDeserializer(IDeserializer<TKey> deserializer)
-    {
-        _builder.WithKeyDeserializer(deserializer);
-        return this;
-    }
-
-    public ConsumerServiceBuilder<TKey, TValue> WithValueDeserializer(IDeserializer<TValue> deserializer)
-    {
-        _builder.WithValueDeserializer(deserializer);
-        return this;
-    }
-
-    public ConsumerServiceBuilder<TKey, TValue> WithRebalanceListener(IRebalanceListener listener)
-    {
-        _builder.WithRebalanceListener(listener);
-        return this;
-    }
-
-    public ConsumerServiceBuilder<TKey, TValue> UseTls()
-    {
-        _builder.UseTls();
-        return this;
-    }
-
-    private DeadLetterQueueBuilder? _dlqBuilder;
-
-    /// <summary>
-    /// Configures dead letter queue routing for the consumer service.
-    /// </summary>
-    /// <param name="configure">An action to configure the dead letter queue builder.</param>
-    /// <returns>The builder instance for method chaining.</returns>
-    public ConsumerServiceBuilder<TKey, TValue> WithDeadLetterQueue(Action<DeadLetterQueueBuilder> configure)
-    {
-        _dlqBuilder = new DeadLetterQueueBuilder();
-        configure(_dlqBuilder);
-        return this;
-    }
-
-    /// <summary>
-    /// Builds the dead letter options if a DLQ was configured.
-    /// </summary>
-    /// <returns>The configured <see cref="DeadLetterOptions"/> or null if DLQ was not configured.</returns>
-    internal DeadLetterOptions? BuildDeadLetterOptions()
-    {
-        if (_dlqBuilder is null)
-        {
-            return null;
-        }
-
-        // Inherit consumer's bootstrap servers if not explicitly set on DLQ
-        if (_bootstrapServers is not null)
-        {
-            _dlqBuilder.WithDefaultBootstrapServers(_bootstrapServers);
-        }
-
-        return _dlqBuilder.Build();
-    }
-
-    /// <summary>
-    /// Adds a per-instance consumer interceptor. Per-instance interceptors execute after global interceptors.
-    /// </summary>
-    /// <param name="interceptor">The interceptor to add.</param>
-    /// <returns>The builder instance for method chaining.</returns>
-    public ConsumerServiceBuilder<TKey, TValue> AddInterceptor(IConsumerInterceptor<TKey, TValue> interceptor)
-    {
-        ArgumentNullException.ThrowIfNull(interceptor);
-        _perInstanceInterceptors.Add(interceptor);
-        return this;
-    }
-
-    internal IKafkaConsumer<TKey, TValue> Build(
-        ILoggerFactory? loggerFactory,
-        List<IConsumerInterceptor<TKey, TValue>>? globalInterceptors = null)
-    {
-        if (loggerFactory is not null)
-        {
-            _builder.WithLoggerFactory(loggerFactory);
-        }
-
-        // Add global interceptors first (execute first)
-        if (globalInterceptors is not null)
-        {
-            foreach (var interceptor in globalInterceptors)
-            {
-                _builder.AddInterceptor(interceptor);
-            }
-        }
-
-        // Add per-instance interceptors second (execute after globals)
-        foreach (var interceptor in _perInstanceInterceptors)
-        {
-            _builder.AddInterceptor(interceptor);
-        }
-
-        return _builder.Build();
     }
 }
 

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -552,6 +552,17 @@ public sealed class ProducerBuilder<TKey, TValue>
         return this;
     }
 
+    internal void AddInterceptorsFirst(IReadOnlyList<IProducerInterceptor<TKey, TValue>> interceptors)
+    {
+        if (interceptors.Count == 0)
+        {
+            return;
+        }
+
+        _interceptors ??= [];
+        _interceptors.InsertRange(0, interceptors);
+    }
+
     /// <summary>
     /// Sets the delivery timeout - the upper bound on the time to report success or failure
     /// after a call to <c>ProduceAsync</c>. This limits the total time a message can spend
@@ -1419,6 +1430,21 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _interceptors ??= [];
         _interceptors.Add(interceptor);
         return this;
+    }
+
+    internal string? BootstrapServersString => _bootstrapServers.Count == 0
+        ? null
+        : string.Join(",", _bootstrapServers);
+
+    internal void AddInterceptorsFirst(IReadOnlyList<IConsumerInterceptor<TKey, TValue>> interceptors)
+    {
+        if (interceptors.Count == 0)
+        {
+            return;
+        }
+
+        _interceptors ??= [];
+        _interceptors.InsertRange(0, interceptors);
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -1,10 +1,12 @@
+using Dekaf;
 using Dekaf.Admin;
+using Dekaf.Compression.Lz4;
 using Dekaf.Consumer;
+using Dekaf.Consumer.DeadLetter;
 using Dekaf.Extensions.DependencyInjection;
 using Dekaf.Producer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Extensions;
 
@@ -117,122 +119,77 @@ public class DependencyInjectionTests
 
     #endregion
 
-    #region ProducerServiceBuilder Chaining Tests
+    #region Full Builder Surface Tests
 
     [Test]
-    public async Task ProducerServiceBuilder_WithBootstrapServers_ReturnsSelf()
+    public async Task AddProducer_CallbackExposesCoreProducerBuilder()
     {
-        var builder = new ProducerServiceBuilder<string, string>();
-        var result = builder.WithBootstrapServers("localhost:9092");
-        await Assert.That(result).IsSameReferenceAs(builder);
+        var services = new ServiceCollection();
+        ProducerBuilder<string, string>? capturedBuilder = null;
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>(p =>
+            {
+                capturedBuilder = p;
+                p.WithBootstrapServers("localhost:9092")
+                    .WithLinger(TimeSpan.FromMilliseconds(5))
+                    .WithBatchSize(64 * 1024)
+                    .WithSaslScramSha512("user", "password")
+                    .UseLz4Compression();
+            });
+        });
+
+        await Assert.That(capturedBuilder).IsNotNull();
+        await Assert.That(capturedBuilder).IsTypeOf<ProducerBuilder<string, string>>();
     }
 
     [Test]
-    public async Task ProducerServiceBuilder_WithClientId_ReturnsSelf()
+    public async Task AddConsumer_CallbackExposesCoreConsumerBuilder()
     {
-        var builder = new ProducerServiceBuilder<string, string>();
-        var result = builder.WithClientId("client");
-        await Assert.That(result).IsSameReferenceAs(builder);
+        var services = new ServiceCollection();
+        ConsumerBuilder<string, string>? capturedBuilder = null;
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddConsumer<string, string>(c =>
+            {
+                capturedBuilder = c;
+                c.WithBootstrapServers("localhost:9092")
+                    .WithGroupId("test-group")
+                    .WithGroupRemoteAssignor("uniform")
+                    .WithFetchMinBytes(1024)
+                    .WithAdaptiveConnections(maxConnections: 6)
+                    .SubscribeTo("orders");
+            });
+        });
+
+        await Assert.That(capturedBuilder).IsNotNull();
+        await Assert.That(capturedBuilder).IsTypeOf<ConsumerBuilder<string, string>>();
     }
 
     [Test]
-    public async Task ProducerServiceBuilder_WithAcks_ReturnsSelf()
+    public async Task AddConsumer_WithDeadLetterQueue_RegistersOptions()
     {
-        var builder = new ProducerServiceBuilder<string, string>();
-        var result = builder.WithAcks(Acks.All);
-        await Assert.That(result).IsSameReferenceAs(builder);
-    }
+        var services = new ServiceCollection();
 
-    [Test]
-    public async Task ProducerServiceBuilder_UseZstdCompression_ReturnsSelf()
-    {
-        var builder = new ProducerServiceBuilder<string, string>();
-        var result = builder.UseZstdCompression();
-        await Assert.That(result).IsSameReferenceAs(builder);
-    }
+        services.AddDekaf(builder =>
+        {
+            builder.AddConsumer<string, string>(
+                c => c
+                    .WithBootstrapServers("localhost:9092")
+                    .WithGroupId("test-group"),
+                dlq => dlq
+                    .WithTopicSuffix(".dead")
+                    .WithMaxFailures(3));
+        });
 
-    [Test]
-    public async Task ProducerServiceBuilder_UseGzipCompression_ReturnsSelf()
-    {
-        var builder = new ProducerServiceBuilder<string, string>();
-        var result = builder.UseGzipCompression();
-        await Assert.That(result).IsSameReferenceAs(builder);
-    }
+        var serviceProvider = services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<DeadLetterOptions>();
 
-    [Test]
-    public async Task ProducerServiceBuilder_UseLz4Compression_ReturnsSelf()
-    {
-        var builder = new ProducerServiceBuilder<string, string>();
-        var result = builder.UseLz4Compression();
-        await Assert.That(result).IsSameReferenceAs(builder);
-    }
-
-    [Test]
-    public async Task ProducerServiceBuilder_UseTls_ReturnsSelf()
-    {
-        var builder = new ProducerServiceBuilder<string, string>();
-        var result = builder.UseTls();
-        await Assert.That(result).IsSameReferenceAs(builder);
-    }
-
-    #endregion
-
-    #region ConsumerServiceBuilder Chaining Tests
-
-    [Test]
-    public async Task ConsumerServiceBuilder_WithBootstrapServers_ReturnsSelf()
-    {
-        var builder = new ConsumerServiceBuilder<string, string>();
-        var result = builder.WithBootstrapServers("localhost:9092");
-        await Assert.That(result).IsSameReferenceAs(builder);
-    }
-
-    [Test]
-    public async Task ConsumerServiceBuilder_WithClientId_ReturnsSelf()
-    {
-        var builder = new ConsumerServiceBuilder<string, string>();
-        var result = builder.WithClientId("client");
-        await Assert.That(result).IsSameReferenceAs(builder);
-    }
-
-    [Test]
-    public async Task ConsumerServiceBuilder_WithGroupId_ReturnsSelf()
-    {
-        var builder = new ConsumerServiceBuilder<string, string>();
-        var result = builder.WithGroupId("group");
-        await Assert.That(result).IsSameReferenceAs(builder);
-    }
-
-    [Test]
-    public async Task ConsumerServiceBuilder_WithGroupInstanceId_ReturnsSelf()
-    {
-        var builder = new ConsumerServiceBuilder<string, string>();
-        var result = builder.WithGroupInstanceId("instance");
-        await Assert.That(result).IsSameReferenceAs(builder);
-    }
-
-    [Test]
-    public async Task ConsumerServiceBuilder_WithOffsetCommitMode_ReturnsSelf()
-    {
-        var builder = new ConsumerServiceBuilder<string, string>();
-        var result = builder.WithOffsetCommitMode(OffsetCommitMode.Manual);
-        await Assert.That(result).IsSameReferenceAs(builder);
-    }
-
-    [Test]
-    public async Task ConsumerServiceBuilder_WithAutoOffsetReset_ReturnsSelf()
-    {
-        var builder = new ConsumerServiceBuilder<string, string>();
-        var result = builder.WithAutoOffsetReset(AutoOffsetReset.Earliest);
-        await Assert.That(result).IsSameReferenceAs(builder);
-    }
-
-    [Test]
-    public async Task ConsumerServiceBuilder_UseTls_ReturnsSelf()
-    {
-        var builder = new ConsumerServiceBuilder<string, string>();
-        var result = builder.UseTls();
-        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(options.TopicSuffix).IsEqualTo(".dead");
+        await Assert.That(options.MaxFailures).IsEqualTo(3);
+        await Assert.That(options.BootstrapServers).IsEqualTo("localhost:9092");
     }
 
     #endregion
@@ -498,32 +455,6 @@ public class DependencyInjectionTests
 
         var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IKafkaConsumer<string, string>));
         await Assert.That(descriptor).IsNotNull();
-    }
-
-    #endregion
-
-    #region ProducerServiceBuilder.AddInterceptor Chaining Tests
-
-    [Test]
-    public async Task ProducerServiceBuilder_AddInterceptor_ReturnsSelf()
-    {
-        var builder = new ProducerServiceBuilder<string, string>();
-        var interceptor = Substitute.For<IProducerInterceptor<string, string>>();
-        var result = builder.AddInterceptor(interceptor);
-        await Assert.That(result).IsSameReferenceAs(builder);
-    }
-
-    #endregion
-
-    #region ConsumerServiceBuilder.AddInterceptor Chaining Tests
-
-    [Test]
-    public async Task ConsumerServiceBuilder_AddInterceptor_ReturnsSelf()
-    {
-        var builder = new ConsumerServiceBuilder<string, string>();
-        var interceptor = Substitute.For<IConsumerInterceptor<string, string>>();
-        var result = builder.AddInterceptor(interceptor);
-        await Assert.That(result).IsSameReferenceAs(builder);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- pass the real `ProducerBuilder<TKey,TValue>` and `ConsumerBuilder<TKey,TValue>` into DI registration callbacks
- preserve DI global interceptor ordering with internal prepend hooks and keep DLQ config via an optional consumer callback
- update DI/config docs and README with full-surface before/after examples

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter '/*/*/DependencyInjectionTests/*'`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter '/*/*/GlobalInterceptorOrderingTests/*'`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter '/*/Dekaf.Tests.Unit.Extensions/*/*'`
- [x] `npm ci --prefix docs`
- [x] `npm run build --prefix docs`

## Breaking change
`AddProducer` and `AddConsumer` callbacks now receive the core builder types directly. Configure consumer DLQ options with the optional second `AddConsumer` callback.

Closes #1014
Refs #1022
