### PR TITLE
feat(consumer)!: remove Wakeup

### DIFF
--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -58,7 +58,7 @@ await foreach (var message in consumer.ConsumeAsync(cancellationToken))
 }
 ```
 
-The loop continues until the cancellation token is triggered or an error occurs.
+The loop continues until the cancellation token is triggered or an error occurs. Cancel the token to unblock an in-flight fetch and stop the consume loop.
 
 ## ConsumeResult Properties
 
@@ -158,7 +158,7 @@ await using var consumer = await Kafka.CreateConsumer<string, string>()
 
 using var cts = new CancellationTokenSource();
 
-// Handle shutdown signals
+// Handle shutdown signals by cancelling the consume token
 Console.CancelKeyPress += (_, e) =>
 {
     e.Cancel = true;

--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -194,6 +194,8 @@ When a consumer leaves gracefully (`await using` or `CloseAsync`):
 1. Consumer commits offsets and leaves group
 2. Remaining consumers get its partitions
 
+Cancel the token passed to `ConsumeAsync` before closing when you need to stop a pending fetch promptly during shutdown.
+
 ### Maximum Parallelism
 
 The maximum number of active consumers in a group equals the number of partitions:

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -155,11 +155,6 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     IReadOnlySet<TopicPartition> Paused { get; }
 
     /// <summary>
-    /// Wakes up the consumer if it's blocked on a fetch.
-    /// </summary>
-    void Wakeup();
-
-    /// <summary>
     /// Gracefully closes the consumer: stops background tasks (heartbeat, auto-commit, prefetch),
     /// commits pending offsets, leaves the consumer group, and releases resources.
     /// </summary>

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -517,7 +517,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     private readonly SemaphoreSlim _assignmentLock = new(1, 1);
 
 
-    private readonly ConcurrentDictionary<CancellationTokenSource, byte> _activeWakeupSources = new();
+    private readonly ConcurrentDictionary<CancellationTokenSource, byte> _activeConsumeCancellationSources = new();
     private CancellationTokenSource? _autoCommitCts;
     private Task? _autoCommitTask;
     private int _fetchApiVersion = -1;
@@ -1539,21 +1539,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
     private async ValueTask PrefetchRecordsAsync(CancellationToken cancellationToken)
     {
-        // Rent wakeup CTS from pool — used as the combined cancellation source
+        // Rent a CTS from the pool for the combined consume cancellation source
         // instead of allocating a LinkedCTS
-        var wakeupCts = _ctsPool.Rent();
-        _activeWakeupSources.TryAdd(wakeupCts, 0);
+        var consumeCts = _ctsPool.Rent();
+        _activeConsumeCancellationSources.TryAdd(consumeCts, 0);
 
         try
         {
-            // Forward outer cancellation and wakeup into the pooled CTS via registrations
+            // Forward outer cancellation into the pooled CTS via registration
             using var reg1 = cancellationToken.CanBeCanceled
-                ? cancellationToken.Register(static s => ((CancellationTokenSource)s!).Cancel(), wakeupCts)
+                ? cancellationToken.Register(static s => ((CancellationTokenSource)s!).Cancel(), consumeCts)
                 : default;
 
             // Close any race window: if token was cancelled between method entry and registration
             if (cancellationToken.IsCancellationRequested)
-                wakeupCts.Cancel();
+                consumeCts.Cancel();
 
             var partitionsByBroker = await GroupPartitionsByBrokerAsync(cancellationToken).ConfigureAwait(false);
             var fetchSessionSnapshot = ShouldUseFetchSessions && !_fetchSessions.IsEmpty
@@ -1609,7 +1609,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
                         fetchTasks[taskCount++] = PrefetchFromBrokerWithErrorHandlingAsync(
                             brokerId, partitions, startIndex, count, connectionIndex,
-                            wakeupCts.Token, wakeupCts.Token);
+                            consumeCts.Token, consumeCts.Token);
                     }
                 }
 
@@ -1632,7 +1632,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
                     fetchTasks[taskCount++] = PrefetchFromBrokerWithErrorHandlingAsync(
                         key.BrokerId, [], 0, 0, key.ConnectionIndex,
-                        wakeupCts.Token, wakeupCts.Token);
+                        consumeCts.Token, consumeCts.Token);
                 }
 
                 if (taskCount == 0)
@@ -1659,8 +1659,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         }
         finally
         {
-            _activeWakeupSources.TryRemove(wakeupCts, out _);
-            wakeupCts.Dispose();
+            _activeConsumeCancellationSources.TryRemove(consumeCts, out _);
+            consumeCts.Dispose();
         }
     }
 
@@ -1671,15 +1671,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         int partitionCount,
         int connectionIndex,
         CancellationToken linkedToken,
-        CancellationToken wakeupToken)
+        CancellationToken consumeCancellationToken)
     {
         try
         {
             await PrefetchFromBrokerAsync(brokerId, partitions, partitionStartIndex, partitionCount, connectionIndex, linkedToken).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (wakeupToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
         {
-            // Wakeup requested, exit silently
+            // Consume cancellation requested, exit silently
         }
         catch (Exception ex) when (IsFatalPrefetchError(ex))
         {
@@ -2082,7 +2082,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         if (release)
         {
             Interlocked.Add(ref _prefetchedBytes, -bytes);
-            // Signal prefetch loop that memory is now available (skip for empty responses to avoid spurious wakeups)
+            // Signal prefetch loop that memory is now available (skip for empty responses to avoid spurious signals)
             if (bytes > 0)
                 SignalPrefetchMemoryAvailable();
         }
@@ -2479,11 +2479,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         return this;
     }
 
-    public void Wakeup() => CancelAllActiveWakeupSources();
-
-    private void CancelAllActiveWakeupSources()
+    private void CancelActiveConsumeOperations()
     {
-        foreach (var cts in _activeWakeupSources.Keys)
+        foreach (var cts in _activeConsumeCancellationSources.Keys)
         {
             try { cts.Cancel(); }
             catch (ObjectDisposedException) { }
@@ -3047,21 +3045,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
     private async ValueTask FetchRecordsAsync(CancellationToken cancellationToken)
     {
-        // Rent wakeup CTS from pool to avoid allocation
-        var wakeupCts = _ctsPool.Rent();
-        _activeWakeupSources.TryAdd(wakeupCts, 0);
+        // Rent a CTS from the pool to avoid allocating a LinkedCTS
+        var consumeCts = _ctsPool.Rent();
+        _activeConsumeCancellationSources.TryAdd(consumeCts, 0);
 
         try
         {
-            // Forward outer cancellation into the pooled wakeup CTS via registration
+            // Forward outer cancellation into the pooled CTS via registration
             // instead of allocating a LinkedCTS (matches the prefetch path pattern)
             using var reg = cancellationToken.CanBeCanceled
-                ? cancellationToken.Register(static s => ((CancellationTokenSource)s!).Cancel(), wakeupCts)
+                ? cancellationToken.Register(static s => ((CancellationTokenSource)s!).Cancel(), consumeCts)
                 : default;
 
             // Close any race window: if token was cancelled between method entry and registration
             if (cancellationToken.IsCancellationRequested)
-                wakeupCts.Cancel();
+                consumeCts.Cancel();
 
             var partitionsByBroker = await GroupPartitionsByBrokerAsync(cancellationToken).ConfigureAwait(false);
             var fetchSessionSnapshot = ShouldUseFetchSessions && !_fetchSessions.IsEmpty
@@ -3088,7 +3086,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 {
                     scheduledFetchSessionBrokers?.Add(brokerId);
                     fetchTasks[taskCount++] = FetchFromBrokerWithErrorHandlingAsync(
-                        brokerId, partitions, wakeupCts.Token, wakeupCts.Token);
+                        brokerId, partitions, consumeCts.Token, consumeCts.Token);
                 }
 
                 foreach (var (key, handler) in fetchSessionSnapshot)
@@ -3109,7 +3107,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                         continue;
 
                     fetchTasks[taskCount++] = FetchFromBrokerWithErrorHandlingAsync(
-                        key.BrokerId, [], wakeupCts.Token, wakeupCts.Token);
+                        key.BrokerId, [], consumeCts.Token, consumeCts.Token);
                 }
 
                 if (taskCount == 0)
@@ -3149,8 +3147,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         }
         finally
         {
-            _activeWakeupSources.TryRemove(wakeupCts, out _);
-            wakeupCts.Dispose();
+            _activeConsumeCancellationSources.TryRemove(consumeCts, out _);
+            consumeCts.Dispose();
         }
     }
 
@@ -3158,15 +3156,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         int brokerId,
         List<TopicPartition> partitions,
         CancellationToken linkedToken,
-        CancellationToken wakeupToken)
+        CancellationToken consumeCancellationToken)
     {
         try
         {
             return await FetchFromBrokerAsync(brokerId, partitions, linkedToken).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (wakeupToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
         {
-            // Wakeup requested, exit silently
+            // Consume cancellation requested, exit silently
             return null;
         }
         catch (Exception ex)
@@ -4042,8 +4040,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             }
         }
 
-        // Step 6: Wake up any blocked operations
-        CancelAllActiveWakeupSources();
+        // Step 6: Cancel any blocked fetch operations
+        CancelActiveConsumeOperations();
 
         // Step 7: Clear pending fetch data and dispose to release pooled memory
         while (_pendingFetches.TryDequeue(out var pending))
@@ -4228,7 +4226,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         var closeElapsedMs = System.Diagnostics.Stopwatch.GetElapsedTime(disposeStart).TotalMilliseconds;
         LogConsumerCloseCompleted(closeElapsedMs);
 
-        CancelAllActiveWakeupSources();
+        CancelActiveConsumeOperations();
         _autoCommitCts?.Cancel();
         _prefetchCts?.Cancel();
 
@@ -4260,7 +4258,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         _prefetchCts?.Dispose();
 
         // Clear and dispose CancellationTokenSource pool
-        // Note: active wakeup sources are managed by the pool and should not be disposed here
+        // Note: active consume cancellation sources are managed by the pool and should not be disposed here
         _ctsPool.Clear();
 
         // Clear and dispose any pending fetch data to release pooled memory

--- a/src/Dekaf/Consumer/PrefetchPipelineRunner.cs
+++ b/src/Dekaf/Consumer/PrefetchPipelineRunner.cs
@@ -25,9 +25,9 @@ namespace Dekaf.Consumer;
 /// With depth 3 (the default), two eager fetches can overlap with processing, keeping
 /// the network saturated even when individual fetches stall briefly.
 /// Higher depths (up to 8) allow more overlapping fetches for improved throughput.
-/// Each in-flight fetch registers its own <c>CancellationTokenSource</c> in
-/// <c>KafkaConsumer._activeWakeupSources</c>, so <c>Wakeup()</c> correctly cancels
-/// all concurrent fetches regardless of pipeline depth.</para>
+/// Each in-flight fetch registers its own <c>CancellationTokenSource</c> so
+/// shutdown and consume cancellation can stop all concurrent fetches regardless
+/// of pipeline depth.</para>
 ///
 /// <para><b>Position safety:</b> Only one eager fetch is started per iteration to prevent
 /// reading stale <c>_fetchPositions</c>. Each fetch updates positions inside its task
@@ -282,7 +282,7 @@ internal sealed class PrefetchPipelineRunner
             }
             catch (OperationCanceledException)
             {
-                // Cancellation is not an error — expected during shutdown/wakeup
+                // Cancellation is not an error — expected during shutdown
             }
             catch (Exception inFlightEx)
             {


### PR DESCRIPTION
## Summary
- remove `Wakeup()` from `IKafkaConsumer<TKey,TValue>` and `KafkaConsumer<TKey,TValue>`
- keep internal fetch shutdown cancellation, renamed away from the public wakeup concept
- document cancellation-token shutdown for `ConsumeAsync`

## Breaking change
`IKafkaConsumer<TKey,TValue>.Wakeup()` is removed. Cancel the token passed to `ConsumeAsync` or `ConsumeOneAsync` to stop a pending fetch.

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit --configuration Release`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/Consumer*/*"`
- [x] `npm ci --prefix docs`
- [x] `npm run build --prefix docs`
- [x] `git diff --check`

Closes #1013
