### PR TITLE
feat(telemetry): add client lifecycle loop

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -23,6 +23,7 @@ public sealed class AdminClient : IAdminClient
     private readonly MetadataManager _metadataManager;
     private readonly ClientTelemetryManager _telemetryManager;
     private readonly ILogger<AdminClient>? _logger;
+    private int _telemetryStartAttempted;
     private int _disposed;
 
     public AdminClient(AdminClientOptions options, ILoggerFactory? loggerFactory = null, MetadataOptions? metadataOptions = null)
@@ -1966,7 +1967,28 @@ public sealed class AdminClient : IAdminClient
             await _metadataManager.InitializeAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        await _telemetryManager.StartAsync(cancellationToken).ConfigureAwait(false);
+        if (Volatile.Read(ref _telemetryStartAttempted) == 0)
+        {
+            await StartTelemetryOnceAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask StartTelemetryOnceAsync(CancellationToken cancellationToken)
+    {
+        if (Interlocked.CompareExchange(ref _telemetryStartAttempted, 1, 0) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await _telemetryManager.StartAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            Volatile.Write(ref _telemetryStartAttempted, 0);
+            throw;
+        }
     }
 
     private ValueTask WithRetryAsync(Func<ValueTask> operation, CancellationToken cancellationToken)

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -8,6 +8,7 @@ using Dekaf.Retry;
 using Dekaf.Protocol.Messages;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
+using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Admin;
@@ -20,6 +21,7 @@ public sealed class AdminClient : IAdminClient
     private readonly AdminClientOptions _options;
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
+    private readonly ClientTelemetryManager _telemetryManager;
     private readonly ILogger<AdminClient>? _logger;
     private int _disposed;
 
@@ -50,6 +52,11 @@ public sealed class AdminClient : IAdminClient
             options.BootstrapServers,
             options: metadataOptions,
             logger: loggerFactory?.CreateLogger<MetadataManager>());
+
+        _telemetryManager = new ClientTelemetryManager(
+            _connectionPool,
+            _metadataManager,
+            loggerFactory?.CreateLogger<ClientTelemetryManager>());
     }
 
     public ClusterMetadata Metadata => _metadataManager.Metadata;
@@ -1958,6 +1965,8 @@ public sealed class AdminClient : IAdminClient
         {
             await _metadataManager.InitializeAsync(cancellationToken).ConfigureAwait(false);
         }
+
+        await _telemetryManager.StartAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private ValueTask WithRetryAsync(Func<ValueTask> operation, CancellationToken cancellationToken)
@@ -2062,6 +2071,9 @@ public sealed class AdminClient : IAdminClient
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
+        var telemetryStopMs = Math.Max(1, Math.Min(_options.RequestTimeoutMs, 5000));
+        await _telemetryManager.StopAsync(TimeSpan.FromMilliseconds(telemetryStopMs)).ConfigureAwait(false);
+        await _telemetryManager.DisposeAsync().ConfigureAwait(false);
         await _metadataManager.DisposeAsync().ConfigureAwait(false);
         await _connectionPool.DisposeAsync().ConfigureAwait(false);
     }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -14,6 +14,7 @@ using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
 using Dekaf.Retry;
 using Dekaf.Serialization;
+using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Consumer;
@@ -450,6 +451,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     private readonly IDeserializer<TValue> _valueDeserializer;
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
+    private readonly ClientTelemetryManager _telemetryManager;
     private readonly ConsumerCoordinator? _coordinator;
     private readonly CompressionCodecRegistry _compressionCodecs;
     private readonly ILogger _logger;
@@ -665,6 +667,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
         _connectionPool = infrastructure.Pool;
         _metadataManager = infrastructure.Metadata;
+        _telemetryManager = new ClientTelemetryManager(
+            _connectionPool,
+            _metadataManager,
+            loggerFactory?.CreateLogger<ClientTelemetryManager>());
 
         _compressionCodecs = CompressionCodecRegistry.Default;
 
@@ -2647,6 +2653,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                 return;
 
             await _metadataManager.InitializeAsync(cancellationToken).ConfigureAwait(false);
+            await _telemetryManager.StartAsync(cancellationToken).ConfigureAwait(false);
             _initialized = true;
         }
         finally
@@ -4056,6 +4063,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             prefetched.Dispose();
         }
 
+        await _telemetryManager.StopAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+
         LogConsumerClosed();
     }
 
@@ -4283,6 +4292,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         if (_coordinator is not null)
             await _coordinator.DisposeAsync().ConfigureAwait(false);
 
+        await _telemetryManager.DisposeAsync().ConfigureAwait(false);
         await _metadataManager.DisposeAsync().ConfigureAwait(false);
         await _connectionPool.DisposeAsync().ConfigureAwait(false);
 

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -13,6 +13,7 @@ using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
 using Dekaf.Retry;
 using Dekaf.Serialization;
+using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Producer;
@@ -43,6 +44,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly bool _usesCustomPartitioner;
     private readonly ConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
+    private readonly ClientTelemetryManager _telemetryManager;
     private readonly RecordAccumulator _accumulator;
     internal RecordAccumulator RecordAccumulator => _accumulator;
     private readonly CompressionCodecRegistry _compressionCodecs;
@@ -249,6 +251,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             options.BootstrapServers,
             options: metadataOptions,
             logger: loggerFactory?.CreateLogger<MetadataManager>());
+
+        _telemetryManager = new ClientTelemetryManager(
+            _connectionPool,
+            _metadataManager,
+            loggerFactory?.CreateLogger<ClientTelemetryManager>());
 
         // Re-ratchet shared pool sizes after metadata refresh discovers the real broker count.
         // Bootstrap servers are seed nodes — the actual cluster may have more brokers.
@@ -2378,6 +2385,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 await InitIdempotentProducerAsync(cancellationToken).ConfigureAwait(false);
             }
 
+            await _telemetryManager.StartAsync(cancellationToken).ConfigureAwait(false);
+
             _initialized = true;
         }
         finally
@@ -3201,6 +3210,15 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // Dispose ValueTaskSource pool — prevents resource leaks (usually fast).
         await DisposeWithBudgetAsync(
             _valueTaskSourcePool.DisposeAsync(), Math.Max(200, RemainingMs() / 10), "valueTaskSourcePool");
+
+        var telemetryStopMs = Math.Max(200, Math.Min(5000, RemainingMs()));
+        await DisposeWithBudgetAsync(
+            _telemetryManager.StopAsync(TimeSpan.FromMilliseconds(telemetryStopMs)),
+            telemetryStopMs,
+            "telemetry");
+
+        await DisposeWithBudgetAsync(
+            _telemetryManager.DisposeAsync(), Math.Max(100, RemainingMs() / 10), "telemetryManager");
 
         // Dispose metadata manager and connection pool in parallel.
         // Connection pool disposal waits up to ConnectionTimeout (30s default) per connection,

--- a/src/Dekaf/Telemetry/ClientTelemetryManager.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryManager.cs
@@ -1,0 +1,451 @@
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Dekaf.Telemetry;
+
+internal sealed record ClientTelemetrySubscription(
+    Guid ClientInstanceId,
+    int SubscriptionId,
+    sbyte CompressionType,
+    int PushIntervalMs,
+    int TelemetryMaxBytes,
+    bool DeltaTemporality,
+    IReadOnlyList<string> RequestedMetrics);
+
+internal interface IClientTelemetryPayloadProvider
+{
+    ReadOnlyMemory<byte> Collect(ClientTelemetrySubscription subscription, bool terminating);
+}
+
+internal sealed class EmptyClientTelemetryPayloadProvider : IClientTelemetryPayloadProvider
+{
+    public static EmptyClientTelemetryPayloadProvider Instance { get; } = new();
+
+    public ReadOnlyMemory<byte> Collect(ClientTelemetrySubscription subscription, bool terminating) =>
+        ReadOnlyMemory<byte>.Empty;
+}
+
+internal sealed partial class ClientTelemetryManager : IAsyncDisposable
+{
+    private static readonly TimeSpan DefaultStopTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly IConnectionPool _connectionPool;
+    private readonly MetadataManager _metadataManager;
+    private readonly IClientTelemetryPayloadProvider _payloadProvider;
+    private readonly ILogger<ClientTelemetryManager> _logger;
+    private readonly SemaphoreSlim _startLock = new(1, 1);
+
+    private CancellationTokenSource? _loopCts;
+    private Task? _loopTask;
+    private ClientTelemetrySubscription? _subscription;
+    private int _started;
+    private int _stopped;
+    private int _disabled;
+    private int _disposed;
+
+    public ClientTelemetryManager(
+        IConnectionPool connectionPool,
+        MetadataManager metadataManager,
+        ILogger<ClientTelemetryManager>? logger = null,
+        IClientTelemetryPayloadProvider? payloadProvider = null)
+    {
+        _connectionPool = connectionPool;
+        _metadataManager = metadataManager;
+        _logger = logger ?? NullLogger<ClientTelemetryManager>.Instance;
+        _payloadProvider = payloadProvider ?? EmptyClientTelemetryPayloadProvider.Instance;
+    }
+
+    internal Guid ClientInstanceId => _subscription?.ClientInstanceId ?? Guid.Empty;
+    internal int SubscriptionId => _subscription?.SubscriptionId ?? -1;
+    internal bool IsDisabled => Volatile.Read(ref _disabled) != 0;
+    internal bool IsStarted => Volatile.Read(ref _started) != 0;
+
+    public async ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (Volatile.Read(ref _disposed) != 0 ||
+            Volatile.Read(ref _stopped) != 0 ||
+            Volatile.Read(ref _started) != 0 ||
+            Volatile.Read(ref _disabled) != 0)
+        {
+            return;
+        }
+
+        await _startLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (Volatile.Read(ref _disposed) != 0 ||
+                Volatile.Read(ref _stopped) != 0 ||
+                Volatile.Read(ref _started) != 0 ||
+                Volatile.Read(ref _disabled) != 0)
+            {
+                return;
+            }
+
+            var subscription = await TryFetchSubscriptionAsync(Guid.Empty, cancellationToken).ConfigureAwait(false);
+            if (subscription is null)
+            {
+                return;
+            }
+
+            _subscription = subscription;
+            var loopCts = new CancellationTokenSource();
+            _loopCts = loopCts;
+            Volatile.Write(ref _started, 1);
+            _loopTask = Task.Run(() => RunLoopAsync(loopCts.Token), CancellationToken.None);
+        }
+        finally
+        {
+            _startLock.Release();
+        }
+    }
+
+    public async ValueTask StopAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        if (Interlocked.Exchange(ref _stopped, 1) != 0)
+        {
+            return;
+        }
+
+        if (timeout <= TimeSpan.Zero)
+        {
+            timeout = DefaultStopTimeout;
+        }
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
+        var stopToken = linkedCts.Token;
+
+        _loopCts?.Cancel();
+
+        var loopTask = _loopTask;
+        if (loopTask is not null)
+        {
+            try
+            {
+                await loopTask.WaitAsync(stopToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutdown is bounded by stopToken.
+            }
+            catch (Exception ex)
+            {
+                LogTelemetryLoopFailed(ex);
+            }
+        }
+
+        if (!stopToken.IsCancellationRequested &&
+            Volatile.Read(ref _disabled) == 0 &&
+            _subscription is { } subscription)
+        {
+            try
+            {
+                _ = await PushTelemetryAsync(subscription, terminating: true, stopToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutdown is bounded by stopToken.
+            }
+            catch (Exception ex)
+            {
+                LogTerminatingPushFailed(ex);
+            }
+        }
+
+        _loopCts?.Dispose();
+        _loopCts = null;
+        _loopTask = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        await StopAsync(DefaultStopTimeout).ConfigureAwait(false);
+        _startLock.Dispose();
+    }
+
+    private async Task RunLoopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested && Volatile.Read(ref _disabled) == 0)
+            {
+                var subscription = _subscription;
+                if (subscription is null)
+                {
+                    return;
+                }
+
+                await Task.Delay(
+                    TimeSpan.FromMilliseconds(Math.Max(1, subscription.PushIntervalMs)),
+                    cancellationToken).ConfigureAwait(false);
+
+                var errorCode = await PushTelemetryAsync(
+                    subscription,
+                    terminating: false,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (errorCode == ErrorCode.UnknownSubscriptionId)
+                {
+                    var refreshed = await TryFetchSubscriptionAsync(
+                        subscription.ClientInstanceId,
+                        cancellationToken).ConfigureAwait(false);
+
+                    if (refreshed is not null)
+                    {
+                        _subscription = refreshed;
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Expected during shutdown.
+        }
+        catch (Exception ex)
+        {
+            LogTelemetryLoopFailed(ex);
+        }
+    }
+
+    private async ValueTask<ClientTelemetrySubscription?> TryFetchSubscriptionAsync(
+        Guid clientInstanceId,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetNegotiatedVersion(
+                ApiKey.GetTelemetrySubscriptions,
+                GetTelemetrySubscriptionsRequest.LowestSupportedVersion,
+                GetTelemetrySubscriptionsRequest.HighestSupportedVersion,
+                out var apiVersion) ||
+            !TryGetNegotiatedVersion(
+                ApiKey.PushTelemetry,
+                PushTelemetryRequest.LowestSupportedVersion,
+                PushTelemetryRequest.HighestSupportedVersion,
+                out _))
+        {
+            Disable();
+            return null;
+        }
+
+        try
+        {
+            var connection = await GetTelemetryConnectionAsync(cancellationToken).ConfigureAwait(false);
+            if (connection is null)
+            {
+                return null;
+            }
+
+            var response = await connection.SendAsync<GetTelemetrySubscriptionsRequest, GetTelemetrySubscriptionsResponse>(
+                new GetTelemetrySubscriptionsRequest { ClientInstanceId = clientInstanceId },
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            if (response.ErrorCode == ErrorCode.UnsupportedVersion)
+            {
+                Disable();
+                return null;
+            }
+
+            if (response.ErrorCode != ErrorCode.None)
+            {
+                LogSubscriptionRejected(response.ErrorCode);
+                return null;
+            }
+
+            if (!TrySelectCompression(response.AcceptedCompressionTypes, out var compressionType))
+            {
+                Disable();
+                return null;
+            }
+
+            var assignedClientInstanceId = response.ClientInstanceId != Guid.Empty
+                ? response.ClientInstanceId
+                : clientInstanceId;
+
+            if (assignedClientInstanceId == Guid.Empty)
+            {
+                LogSubscriptionRejected(ErrorCode.InvalidRequest);
+                return null;
+            }
+
+            return new ClientTelemetrySubscription(
+                assignedClientInstanceId,
+                response.SubscriptionId,
+                compressionType,
+                response.PushIntervalMs,
+                response.TelemetryMaxBytes,
+                response.DeltaTemporality,
+                response.RequestedMetrics);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogSubscriptionFailed(ex);
+            return null;
+        }
+    }
+
+    private async ValueTask<ErrorCode> PushTelemetryAsync(
+        ClientTelemetrySubscription subscription,
+        bool terminating,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetNegotiatedVersion(
+                ApiKey.PushTelemetry,
+                PushTelemetryRequest.LowestSupportedVersion,
+                PushTelemetryRequest.HighestSupportedVersion,
+                out var apiVersion))
+        {
+            Disable();
+            return ErrorCode.UnsupportedVersion;
+        }
+
+        try
+        {
+            var connection = await GetTelemetryConnectionAsync(cancellationToken).ConfigureAwait(false);
+            if (connection is null)
+            {
+                return ErrorCode.BrokerNotAvailable;
+            }
+
+            var metrics = _payloadProvider.Collect(subscription, terminating);
+            if (subscription.TelemetryMaxBytes > 0 && metrics.Length > subscription.TelemetryMaxBytes)
+            {
+                LogTelemetryPayloadTooLarge(metrics.Length, subscription.TelemetryMaxBytes);
+                metrics = ReadOnlyMemory<byte>.Empty;
+            }
+
+            var response = await connection.SendAsync<PushTelemetryRequest, PushTelemetryResponse>(
+                new PushTelemetryRequest
+                {
+                    ClientInstanceId = subscription.ClientInstanceId,
+                    SubscriptionId = subscription.SubscriptionId,
+                    Terminating = terminating,
+                    CompressionType = subscription.CompressionType,
+                    Metrics = metrics
+                },
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            if (response.ErrorCode == ErrorCode.UnsupportedVersion)
+            {
+                Disable();
+            }
+            else if (response.ErrorCode != ErrorCode.None &&
+                     response.ErrorCode != ErrorCode.UnknownSubscriptionId)
+            {
+                LogPushRejected(response.ErrorCode);
+            }
+
+            return response.ErrorCode;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogPushFailed(ex, terminating);
+            return ErrorCode.NetworkException;
+        }
+    }
+
+    private async ValueTask<IKafkaConnection?> GetTelemetryConnectionAsync(CancellationToken cancellationToken)
+    {
+        var brokerId = SelectBrokerId();
+        return brokerId is null
+            ? null
+            : await _connectionPool.GetConnectionAsync(brokerId.Value, cancellationToken).ConfigureAwait(false);
+    }
+
+    private int? SelectBrokerId()
+    {
+        var controllerId = _metadataManager.Metadata.ControllerId;
+        if (controllerId >= 0 && _metadataManager.Metadata.GetBroker(controllerId) is not null)
+        {
+            return controllerId;
+        }
+
+        var brokers = _metadataManager.Metadata.GetBrokers();
+        return brokers.Count == 0 ? null : brokers[0].NodeId;
+    }
+
+    private bool TryGetNegotiatedVersion(ApiKey apiKey, short lowestSupportedVersion, short highestSupportedVersion, out short apiVersion)
+    {
+        apiVersion = lowestSupportedVersion;
+        if (!_metadataManager.HasApiKey(apiKey))
+        {
+            return false;
+        }
+
+        var negotiated = _metadataManager.GetNegotiatedApiVersion(apiKey, lowestSupportedVersion, highestSupportedVersion);
+        if (negotiated < lowestSupportedVersion || negotiated > highestSupportedVersion)
+        {
+            return false;
+        }
+
+        apiVersion = negotiated;
+        return true;
+    }
+
+    private static bool TrySelectCompression(IReadOnlyList<sbyte> acceptedCompressionTypes, out sbyte compressionType)
+    {
+        const sbyte noCompression = 0;
+        compressionType = noCompression;
+
+        if (acceptedCompressionTypes.Count == 0)
+        {
+            return true;
+        }
+
+        for (var i = 0; i < acceptedCompressionTypes.Count; i++)
+        {
+            if (acceptedCompressionTypes[i] == noCompression)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void Disable()
+    {
+        if (Interlocked.Exchange(ref _disabled, 1) == 0)
+        {
+            _loopCts?.Cancel();
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Client telemetry subscription failed")]
+    private partial void LogSubscriptionFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Client telemetry subscription rejected with {ErrorCode}")]
+    private partial void LogSubscriptionRejected(ErrorCode errorCode);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Client telemetry push failed (terminating={Terminating})")]
+    private partial void LogPushFailed(Exception exception, bool terminating);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Client telemetry push rejected with {ErrorCode}")]
+    private partial void LogPushRejected(ErrorCode errorCode);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Client telemetry terminating push failed")]
+    private partial void LogTerminatingPushFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Client telemetry loop failed")]
+    private partial void LogTelemetryLoopFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Client telemetry payload too large ({PayloadSize} > {MaxSize}); sending empty payload")]
+    private partial void LogTelemetryPayloadTooLarge(int payloadSize, int maxSize);
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientTelemetryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientTelemetryTests.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using Dekaf.Admin;
+using Dekaf.Metadata;
+using Dekaf.Protocol.Messages;
+using Dekaf.Telemetry;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public sealed class AdminClientTelemetryTests
+{
+    private static readonly MethodInfo EnsureInitializedMethod = typeof(AdminClient)
+        .GetMethod("EnsureInitializedAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static readonly FieldInfo MetadataManagerField = typeof(AdminClient)
+        .GetField("_metadataManager", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static readonly FieldInfo TelemetryManagerField = typeof(AdminClient)
+        .GetField("_telemetryManager", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static readonly FieldInfo TelemetryDisabledField = typeof(ClientTelemetryManager)
+        .GetField("_disabled", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    [Test]
+    public async Task EnsureInitializedAsync_AttemptsTelemetryStartOnlyOnceAfterFailure()
+    {
+        await using var client = new AdminClient(new AdminClientOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            RequestTimeoutMs = 100
+        });
+
+        var metadataManager = (MetadataManager)MetadataManagerField.GetValue(client)!;
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers = [],
+            ClusterId = "test-cluster",
+            ControllerId = -1,
+            Topics = []
+        });
+
+        var telemetryManager = (ClientTelemetryManager)TelemetryManagerField.GetValue(client)!;
+
+        await InvokeEnsureInitializedAsync(client);
+        await Assert.That(telemetryManager.IsDisabled).IsTrue();
+
+        TelemetryDisabledField.SetValue(telemetryManager, 0);
+
+        await InvokeEnsureInitializedAsync(client);
+        await Assert.That(telemetryManager.IsDisabled).IsFalse();
+    }
+
+    private static async ValueTask InvokeEnsureInitializedAsync(AdminClient client)
+    {
+        var result = (ValueTask)EnsureInitializedMethod.Invoke(client, [CancellationToken.None])!;
+        await result.ConfigureAwait(false);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
@@ -1,0 +1,297 @@
+using System.Collections.Concurrent;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Telemetry;
+
+namespace Dekaf.Tests.Unit.Telemetry;
+
+public sealed class ClientTelemetryManagerTests
+{
+    [Test]
+    public async Task StartAsync_FetchesSubscriptionAndStoresIds()
+    {
+        await using var context = new TelemetryTestContext();
+        var clientInstanceId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        context.Connection.Enqueue(Subscription(clientInstanceId, subscriptionId: 42, pushIntervalMs: 60000));
+
+        await context.Manager.StartAsync();
+
+        var requests = context.Connection.RequestsOfType<GetTelemetrySubscriptionsRequest>();
+        await Assert.That(requests.Count).IsEqualTo(1);
+        await Assert.That(requests[0].ClientInstanceId).IsEqualTo(Guid.Empty);
+        await Assert.That(context.Manager.ClientInstanceId).IsEqualTo(clientInstanceId);
+        await Assert.That(context.Manager.SubscriptionId).IsEqualTo(42);
+        await Assert.That(context.Manager.IsStarted).IsTrue();
+    }
+
+    [Test]
+    public async Task BackgroundLoop_PushesTelemetryOnBrokerInterval()
+    {
+        await using var context = new TelemetryTestContext();
+        var clientInstanceId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        context.Connection.Enqueue(Subscription(clientInstanceId, subscriptionId: 7, pushIntervalMs: 10));
+        context.Connection.Enqueue(new PushTelemetryResponse { ErrorCode = ErrorCode.None });
+
+        await context.Manager.StartAsync();
+
+        var pushes = await context.Connection.WaitForRequestsAsync<PushTelemetryRequest>(
+            count: 1,
+            timeout: TimeSpan.FromSeconds(2));
+
+        await Assert.That(pushes[0].ClientInstanceId).IsEqualTo(clientInstanceId);
+        await Assert.That(pushes[0].SubscriptionId).IsEqualTo(7);
+        await Assert.That(pushes[0].Terminating).IsFalse();
+    }
+
+    [Test]
+    public async Task BackgroundLoop_RefetchesSubscriptionOnUnknownSubscriptionId()
+    {
+        await using var context = new TelemetryTestContext();
+        var clientInstanceId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        context.Connection.Enqueue(Subscription(clientInstanceId, subscriptionId: 1, pushIntervalMs: 10));
+        context.Connection.Enqueue(new PushTelemetryResponse { ErrorCode = ErrorCode.UnknownSubscriptionId });
+        context.Connection.Enqueue(Subscription(clientInstanceId, subscriptionId: 2, pushIntervalMs: 10));
+        context.Connection.Enqueue(new PushTelemetryResponse { ErrorCode = ErrorCode.None });
+
+        await context.Manager.StartAsync();
+
+        var pushes = await context.Connection.WaitForRequestsAsync<PushTelemetryRequest>(
+            count: 2,
+            timeout: TimeSpan.FromSeconds(2));
+        var subscriptions = context.Connection.RequestsOfType<GetTelemetrySubscriptionsRequest>();
+
+        await Assert.That(subscriptions.Count).IsEqualTo(2);
+        await Assert.That(subscriptions[1].ClientInstanceId).IsEqualTo(clientInstanceId);
+        await Assert.That(pushes[0].SubscriptionId).IsEqualTo(1);
+        await Assert.That(pushes[1].SubscriptionId).IsEqualTo(2);
+        await Assert.That(context.Manager.SubscriptionId).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task StopAsync_SendsTerminatingPush()
+    {
+        await using var context = new TelemetryTestContext();
+        var clientInstanceId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+        context.Connection.Enqueue(Subscription(clientInstanceId, subscriptionId: 99, pushIntervalMs: 60000));
+        context.Connection.Enqueue(new PushTelemetryResponse { ErrorCode = ErrorCode.None });
+
+        await context.Manager.StartAsync();
+        await context.Manager.StopAsync(TimeSpan.FromSeconds(2));
+
+        var pushes = context.Connection.RequestsOfType<PushTelemetryRequest>();
+        await Assert.That(pushes.Count).IsEqualTo(1);
+        await Assert.That(pushes[0].ClientInstanceId).IsEqualTo(clientInstanceId);
+        await Assert.That(pushes[0].SubscriptionId).IsEqualTo(99);
+        await Assert.That(pushes[0].Terminating).IsTrue();
+    }
+
+    [Test]
+    public async Task UnsupportedVersion_DisablesBrokerPushTelemetry()
+    {
+        await using var context = new TelemetryTestContext();
+        context.Connection.Enqueue(new GetTelemetrySubscriptionsResponse
+        {
+            ErrorCode = ErrorCode.UnsupportedVersion
+        });
+
+        await context.Manager.StartAsync();
+
+        await Assert.That(context.Manager.IsDisabled).IsTrue();
+        await Assert.That(context.Manager.IsStarted).IsFalse();
+        await Assert.That(context.Connection.RequestsOfType<PushTelemetryRequest>().Count).IsEqualTo(0);
+    }
+
+    private static GetTelemetrySubscriptionsResponse Subscription(
+        Guid clientInstanceId,
+        int subscriptionId,
+        int pushIntervalMs) => new()
+    {
+        ErrorCode = ErrorCode.None,
+        ClientInstanceId = clientInstanceId,
+        SubscriptionId = subscriptionId,
+        AcceptedCompressionTypes = [0],
+        PushIntervalMs = pushIntervalMs,
+        TelemetryMaxBytes = 1024,
+        DeltaTemporality = true,
+        RequestedMetrics = ["kafka."]
+    };
+
+    private sealed class TelemetryTestContext : IAsyncDisposable
+    {
+        private readonly MetadataManager _metadataManager;
+        private readonly TestConnectionPool _pool;
+
+        public TelemetryTestContext()
+        {
+            _pool = new TestConnectionPool();
+            _metadataManager = new MetadataManager(_pool, ["localhost:9092"]);
+            _metadataManager.SetApiVersion(ApiKey.GetTelemetrySubscriptions, 0, 0);
+            _metadataManager.SetApiVersion(ApiKey.PushTelemetry, 0, 0);
+            _metadataManager.Metadata.Update(new MetadataResponse
+            {
+                Brokers =
+                [
+                    new BrokerMetadata
+                    {
+                        NodeId = 0,
+                        Host = "localhost",
+                        Port = 9092
+                    }
+                ],
+                ClusterId = "test-cluster",
+                ControllerId = 0,
+                Topics = []
+            });
+
+            Manager = new ClientTelemetryManager(_pool, _metadataManager);
+        }
+
+        public ClientTelemetryManager Manager { get; }
+        public TestKafkaConnection Connection => _pool.Connection;
+
+        public async ValueTask DisposeAsync()
+        {
+            await Manager.DisposeAsync().ConfigureAwait(false);
+            await _metadataManager.DisposeAsync().ConfigureAwait(false);
+            await _pool.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private sealed class TestConnectionPool : IConnectionPool
+    {
+        public TestKafkaConnection Connection { get; } = new();
+
+        public ValueTask<IKafkaConnection> GetConnectionAsync(int brokerId, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IKafkaConnection>(Connection);
+
+        public ValueTask<IKafkaConnection> GetConnectionByIndexAsync(int brokerId, int index, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IKafkaConnection>(Connection);
+
+        public ValueTask<IKafkaConnection> GetConnectionAsync(string host, int port, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IKafkaConnection>(Connection);
+
+        public void RegisterBroker(int brokerId, string host, int port)
+        {
+        }
+
+        public ValueTask<int> ScaleConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(newCount);
+
+        public ValueTask<IKafkaConnection?> ShrinkConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IKafkaConnection?>(null);
+
+        public ValueTask RemoveConnectionAsync(int brokerId) => ValueTask.CompletedTask;
+
+        public ValueTask CloseAllAsync() => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class TestKafkaConnection : IKafkaConnection
+    {
+        private readonly ConcurrentQueue<object> _responses = new();
+        private readonly ConcurrentQueue<object> _requests = new();
+        private readonly SemaphoreSlim _requestSignal = new(0);
+
+        public int BrokerId => 0;
+        public string Host => "localhost";
+        public int Port => 9092;
+        public bool IsConnected => true;
+
+        public void Enqueue<TResponse>(TResponse response)
+            where TResponse : IKafkaResponse =>
+            _responses.Enqueue(response);
+
+        public IReadOnlyList<T> RequestsOfType<T>() =>
+            _requests.ToArray().OfType<T>().ToArray();
+
+        public async Task<IReadOnlyList<T>> WaitForRequestsAsync<T>(int count, TimeSpan timeout)
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            while (true)
+            {
+                var requests = RequestsOfType<T>();
+                if (requests.Count >= count)
+                {
+                    return requests;
+                }
+
+                try
+                {
+                    await _requestSignal.WaitAsync(cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw new TimeoutException($"Timed out waiting for {count} {typeof(T).Name} request(s).");
+                }
+            }
+        }
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            _requests.Enqueue(request);
+            _requestSignal.Release();
+
+            if (!_responses.TryDequeue(out var response))
+            {
+                if (typeof(TResponse) == typeof(PushTelemetryResponse))
+                {
+                    response = new PushTelemetryResponse { ErrorCode = ErrorCode.None };
+                }
+                else
+                {
+                    throw new InvalidOperationException($"No queued response for {typeof(TRequest).Name}.");
+                }
+            }
+
+            return ValueTask.FromResult((TResponse)response);
+        }
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            ValueTask.CompletedTask;
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            Task.FromResult(default(TResponse)!);
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            ValueTask.CompletedTask;
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            Task.FromResult(default(TResponse)!);
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync()
+        {
+            _requestSignal.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add internal client telemetry lifecycle manager for GetTelemetrySubscriptions and PushTelemetry.
- Start telemetry after metadata initialization for producer, consumer, and admin clients.
- Push on broker interval, refetch on UNKNOWN_SUBSCRIPTION_ID, disable silently on UNSUPPORTED_VERSION, and send bounded terminating pushes during shutdown.

Closes #1004

## Validation
- dotnet build Dekaf.sln --configuration Release -m:1 -p:UseSharedCompilation=false
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/ClientTelemetryManagerTests/*" --disable-logo --no-progress --timeout 30s
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --disable-logo --no-progress --timeout 5m