### PR TITLE
feat(di): bind clients from configuration

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -31,6 +31,82 @@ builder.Services.AddDekaf(dekaf =>
 });
 ```
 
+## Configuration Binding
+
+`Dekaf.Extensions.DependencyInjection` can bind consumer settings from an `IConfiguration` section. Keys use `ConsumerOptions` property names:
+
+```json
+{
+  "Kafka": {
+    "Consumers": {
+      "Orders": {
+        "BootstrapServers": [
+          "broker1:9092",
+          "broker2:9092"
+        ],
+        "ClientId": "orders-consumer",
+        "GroupId": "orders",
+        "AutoOffsetReset": "Earliest",
+        "OffsetCommitMode": "Manual",
+        "FetchMinBytes": 1024,
+        "FetchMaxBytes": 52428800,
+        "FetchMaxWaitMs": 200,
+        "MaxPollRecords": 500,
+        "UseTls": true
+      }
+    }
+  }
+}
+```
+
+```csharp
+builder.Services.AddDekaf(dekaf =>
+{
+    dekaf.AddConsumer<string, Order>(
+        builder.Configuration.GetSection("Kafka:Consumers:Orders"),
+        consumer => consumer
+            .WithValueDeserializer(new JsonDeserializer<Order>())
+            .SubscribeTo("orders"));
+});
+```
+
+Configuration is applied before the optional fluent callback, so fluent calls can override values from `appsettings.json`.
+
+| Fluent API | Config key | Notes |
+|------------|------------|-------|
+| `WithBootstrapServers(...)` | `BootstrapServers` | Comma-separated string or JSON array |
+| `WithClientId(...)` | `ClientId` | String |
+| `WithGroupId(...)` | `GroupId` | String |
+| `WithGroupInstanceId(...)` | `GroupInstanceId` | String |
+| `WithGroupRemoteAssignor(...)` | `GroupRemoteAssignor` | Common values: `uniform`, `range` |
+| `WithOffsetCommitMode(...)` | `OffsetCommitMode` | `Auto` or `Manual` |
+| `WithAutoCommitInterval(...)` | `AutoCommitIntervalMs` | Milliseconds |
+| `WithAutoOffsetReset(...)` | `AutoOffsetReset` | `Latest`, `Earliest`, `None` |
+| `WithFetchMinBytes(...)` | `FetchMinBytes` | Bytes |
+| `WithFetchMaxBytes(...)` | `FetchMaxBytes` | Bytes |
+| `WithMaxPartitionFetchBytes(...)` | `MaxPartitionFetchBytes` | Bytes |
+| `WithFetchMaxWait(...)` | `FetchMaxWaitMs` | Milliseconds |
+| `WithFetchSessions(...)` | `EnableFetchSessions` | Boolean |
+| `WithMaxPollRecords(...)` | `MaxPollRecords` | Integer |
+| `WithSessionTimeout(...)` | `SessionTimeoutMs` | Milliseconds |
+| `WithHeartbeatInterval(...)` | `HeartbeatIntervalMs` | Milliseconds |
+| `WithIsolationLevel(...)` | `IsolationLevel` | `ReadUncommitted` or `ReadCommitted` |
+| `WithPartitionEof(...)` | `EnablePartitionEof` | Boolean |
+| `WithQueuedMinMessages(...)` | `QueuedMinMessages` | Integer |
+| `WithQueuedMaxMessagesKbytes(...)` | `QueuedMaxMessagesKbytes` | KiB; omit to keep auto-tuning |
+| `WithPrefetchPipelineDepth(...)` | `PrefetchPipelineDepth` | Integer |
+| `WithConnectionsPerBroker(...)` | `ConnectionsPerBroker` | Integer |
+| `WithAdaptiveConnections(...)` | `EnableAdaptiveConnections`, `MaxConnectionsPerBroker` | Set `EnableAdaptiveConnections` to `false` to disable |
+| `WithAdaptiveFetchSizing(...)` | `EnableAdaptiveFetchSizing`, `AdaptiveFetchSizingOptions` | Bind nested adaptive sizing fields |
+| `UseTls(...)` | `UseTls`, `TlsConfig` | `TlsConfig` can bind certificate path fields |
+| `WithSaslPlain(...)` / `WithSaslScramSha512(...)` | `SaslMechanism`, `SaslUsername`, `SaslPassword` | `SaslMechanism` values match the enum names |
+| `WithGssapi(...)` | `SaslMechanism`, `GssapiConfig` | Use `SaslMechanism: Gssapi` |
+| `WithOAuthBearer(...)` | `SaslMechanism`, `OAuthBearerConfig` | Use `SaslMechanism: OAuthBearer` |
+| `WithMetadataRecoveryStrategy(...)` | `MetadataRecoveryStrategy` | `None` or `Rebootstrap` |
+| `WithMetadataRecoveryRebootstrapTrigger(...)` | `MetadataRecoveryRebootstrapTriggerMs` | Milliseconds |
+
+Topics, deserializers, rebalance listeners, interceptors, and retry policies are objects or runtime choices, so configure those in the fluent callback.
+
 ## Connection Settings
 
 ### WithBootstrapServers
@@ -84,7 +160,6 @@ How offsets are committed (matches Kafka's `enable.auto.commit`):
 Control how often offsets are committed in Auto mode:
 
 ```csharp
-.WithAutoCommitInterval(5000)                      // Commit every 5 seconds (default)
 .WithAutoCommitInterval(TimeSpan.FromSeconds(5))  // Same, using TimeSpan
 ```
 
@@ -108,12 +183,17 @@ Maximum messages per poll:
 .WithMaxPollRecords(500)  // Default: 500
 ```
 
-### Fetch Tuning (via presets or internal settings)
+### Fetch Tuning
 
-Control how data is fetched from brokers. These are set by presets:
+Control how data is fetched from brokers:
 
-- **FetchMinBytes** - Minimum data to return (wait for more)
-- **FetchMaxWaitMs** - Maximum wait time for FetchMinBytes
+```csharp
+.WithFetchMinBytes(1024)
+.WithFetchMaxBytes(50 * 1024 * 1024)
+.WithMaxPartitionFetchBytes(4 * 1024 * 1024)
+.WithFetchMaxWait(TimeSpan.FromMilliseconds(200))
+.WithFetchSessions(enabled: true)
+```
 
 ## Session Settings
 
@@ -145,16 +225,6 @@ Get notified of partition changes:
 
 ```csharp
 .WithRebalanceListener(new MyRebalanceListener())
-```
-
-### WithPartitionAssignmentStrategy
-
-Partition assignment algorithm:
-
-```csharp
-.WithPartitionAssignmentStrategy(PartitionAssignmentStrategy.CooperativeSticky)  // Default
-.WithPartitionAssignmentStrategy(PartitionAssignmentStrategy.Range)
-.WithPartitionAssignmentStrategy(PartitionAssignmentStrategy.RoundRobin)
 ```
 
 ## Security
@@ -215,13 +285,6 @@ For transactional reads:
 .WithLoggerFactory(loggerFactory)
 ```
 
-### WithStatisticsInterval / WithStatisticsHandler
-
-```csharp
-.WithStatisticsInterval(TimeSpan.FromSeconds(30))
-.WithStatisticsHandler(stats => { /* ... */ })
-```
-
 ## All Options Reference
 
 | Method | Default | Description |
@@ -233,9 +296,20 @@ For transactional reads:
 | `WithOffsetCommitMode` | Auto | Offset management mode |
 | `WithAutoCommitInterval` | 5000ms | Auto-commit interval |
 | `WithAutoOffsetReset` | Latest | Start position |
+| `WithFetchMinBytes` | 1 | Minimum fetch bytes |
+| `WithFetchMaxBytes` | 52428800 | Maximum total fetch bytes |
+| `WithMaxPartitionFetchBytes` | 1048576 | Maximum fetch bytes per partition |
+| `WithFetchMaxWait` | 200ms | Maximum fetch wait |
+| `WithFetchSessions` | true | Enable incremental fetch sessions |
 | `WithMaxPollRecords` | 500 | Max messages per poll |
 | `WithSessionTimeout` | 45000ms | Session timeout |
+| `WithHeartbeatInterval` | 3000ms | Group heartbeat interval |
 | `SubscribeTo` | (none) | Topics to subscribe |
 | `WithRebalanceListener` | null | Rebalance callbacks |
 | `WithPartitionEof` | false | EOF notifications |
+| `WithQueuedMinMessages` | 100000 | Prefetch target count |
+| `WithQueuedMaxMessagesKbytes` | auto-tuned | Prefetch memory limit |
+| `WithPrefetchPipelineDepth` | 3 | Overlapping prefetch operations |
+| `WithConnectionsPerBroker` | 2 | TCP connections per broker |
+| `WithAdaptiveConnections` | enabled (max 4) | Auto-scale connections under load |
 | `UseTls` | false | Enable TLS |

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -29,6 +29,73 @@ builder.Services.AddDekaf(dekaf =>
 });
 ```
 
+## Configuration Binding
+
+`Dekaf.Extensions.DependencyInjection` can bind producer settings from an `IConfiguration` section. Keys use `ProducerOptions` property names:
+
+```json
+{
+  "Kafka": {
+    "Producers": {
+      "Orders": {
+        "BootstrapServers": "broker1:9092,broker2:9092",
+        "ClientId": "orders-producer",
+        "Acks": "All",
+        "LingerMs": 5,
+        "BatchSize": 65536,
+        "CompressionType": "Lz4",
+        "EnableIdempotence": true,
+        "UseTls": true,
+        "SaslMechanism": "ScramSha512",
+        "SaslUsername": "user",
+        "SaslPassword": "password"
+      }
+    }
+  }
+}
+```
+
+```csharp
+builder.Services.AddDekaf(dekaf =>
+{
+    dekaf.AddProducer<string, Order>(
+        builder.Configuration.GetSection("Kafka:Producers:Orders"),
+        producer => producer.WithValueSerializer(new JsonSerializer<Order>()));
+});
+```
+
+Configuration is applied before the optional fluent callback, so fluent calls can override values from `appsettings.json`.
+
+| Fluent API | Config key | Notes |
+|------------|------------|-------|
+| `WithBootstrapServers(...)` | `BootstrapServers` | Comma-separated string or JSON array |
+| `WithClientId(...)` | `ClientId` | String |
+| `WithAcks(...)` | `Acks` | `None`, `Leader`, `All` |
+| `WithLinger(...)` | `LingerMs` | Milliseconds |
+| `WithBatchSize(...)` | `BatchSize` | Bytes |
+| `WithBufferMemory(...)` | `BufferMemory` | Bytes; omit to keep auto-tuning |
+| `WithMaxBlock(...)` | `MaxBlockMs` | Milliseconds |
+| `WithDeliveryTimeout(...)` | `DeliveryTimeoutMs` | Milliseconds |
+| `WithRequestTimeout(...)` | `RequestTimeoutMs` | Milliseconds |
+| `WithIdempotence(...)` | `EnableIdempotence` | Boolean |
+| `WithConnectionsPerBroker(...)` | `ConnectionsPerBroker` | Integer |
+| `WithAdaptiveConnections(...)` | `EnableAdaptiveConnections`, `MaxConnectionsPerBroker` | Set `EnableAdaptiveConnections` to `false` to disable |
+| `WithTransactionalId(...)` | `TransactionalId` | String |
+| `WithTransactionTimeout(...)` | `TransactionTimeoutMs` | Milliseconds |
+| `UseCompression(...)` | `CompressionType` | `None`, `Gzip`, `Snappy`, `Lz4`, `Zstd` |
+| `WithCompressionLevel(...)` | `CompressionLevel` | Codec-specific integer |
+| `WithPartitioner(...)` | `Partitioner` | `Default`, `Sticky`, `RoundRobin` |
+| `UseTls(...)` | `UseTls`, `TlsConfig` | `TlsConfig` can bind certificate path fields |
+| `WithSaslPlain(...)` / `WithSaslScramSha512(...)` | `SaslMechanism`, `SaslUsername`, `SaslPassword` | `SaslMechanism` values match the enum names |
+| `WithGssapi(...)` | `SaslMechanism`, `GssapiConfig` | Use `SaslMechanism: Gssapi` |
+| `WithOAuthBearer(...)` | `SaslMechanism`, `OAuthBearerConfig` | Use `SaslMechanism: OAuthBearer` |
+| `WithSocketSendBufferBytes(...)` | `SocketSendBufferBytes` | Bytes |
+| `WithSocketReceiveBufferBytes(...)` | `SocketReceiveBufferBytes` | Bytes |
+| `WithMetadataRecoveryStrategy(...)` | `MetadataRecoveryStrategy` | `None` or `Rebootstrap` |
+| `WithMetadataRecoveryRebootstrapTrigger(...)` | `MetadataRecoveryRebootstrapTriggerMs` | Milliseconds |
+
+Serializers, custom partitioners, interceptors, and retry policies are objects, so configure those in the fluent callback.
+
 ## Connection Settings
 
 ### WithBootstrapServers
@@ -66,24 +133,23 @@ Controls when the broker considers a message delivered:
 .WithAcks(Acks.None)    // Don't wait (fastest, may lose messages)
 ```
 
-### EnableIdempotence
+### WithIdempotence
 
 Prevents duplicate messages during retries:
 
 ```csharp
-.EnableIdempotence()
+.WithIdempotence(true)
 ```
 
 Automatically sets `Acks.All` and enables sequence numbers.
 
 ## Batching Settings
 
-### WithLingerMs / WithLinger
+### WithLinger
 
 Time to wait before sending a batch:
 
 ```csharp
-.WithLingerMs(5)                    // Wait up to 5ms
 .WithLinger(TimeSpan.FromMilliseconds(5))  // Same, using TimeSpan
 ```
 
@@ -238,18 +304,6 @@ Enable logging:
 .WithLoggerFactory(loggerFactory)
 ```
 
-### WithStatisticsInterval / WithStatisticsHandler
-
-Enable periodic statistics:
-
-```csharp
-.WithStatisticsInterval(TimeSpan.FromSeconds(30))
-.WithStatisticsHandler(stats =>
-{
-    Console.WriteLine($"Messages sent: {stats.TotalMessagesSent}");
-})
-```
-
 ## All Options Reference
 
 | Method | Default | Description |
@@ -257,18 +311,23 @@ Enable periodic statistics:
 | `WithBootstrapServers` | (required) | Broker addresses |
 | `WithClientId` | "dekaf-producer" | Client identifier |
 | `WithAcks` | All | Acknowledgment mode |
-| `WithLingerMs` | 5 | Batch wait time (ms) |
-| `WithBatchSize` | 16384 | Max batch size (bytes) |
-| `EnableIdempotence` | false | Prevent duplicates |
+| `WithLinger` | 0ms | Batch wait time |
+| `WithBatchSize` | 1048576 | Max batch size in bytes |
+| `WithIdempotence` | true | Prevent duplicates |
 | `WithTransactionalId` | null | Transaction ID |
+| `WithTransactionTimeout` | 60000ms | Transaction timeout |
 | `UseCompression` | None | Compression codec |
+| `WithCompressionLevel` | null | Codec-specific compression level |
 | `WithPartitioner` | Default | Partition strategy |
 | `WithConnectionsPerBroker` | 1 | TCP connections per broker |
 | `WithAdaptiveConnections` | enabled (max 10) | Auto-scale connections under load |
-| `WithoutAdaptiveConnections` | — | Disable adaptive scaling |
-| `WithBufferMemory` | 2GB | Max buffer for unsent messages |
-| `WithSocketSendBufferBytes` | (OS default) | TCP send buffer size |
-| `WithSocketReceiveBufferBytes` | (OS default) | TCP receive buffer size |
+| `WithoutAdaptiveConnections` | - | Disable adaptive scaling |
+| `WithBufferMemory` | auto-tuned | Max buffer for unsent messages |
+| `WithMaxBlock` | 60000ms | Max time produce calls wait for metadata or buffer space |
+| `WithDeliveryTimeout` | 120000ms | Max time for delivery success or failure |
+| `WithRequestTimeout` | 30000ms | Per-request timeout |
+| `WithSocketSendBufferBytes` | OS default | TCP send buffer size |
+| `WithSocketReceiveBufferBytes` | OS default | TCP receive buffer size |
 | `UseTls` | false | Enable TLS |
-| `WithKeySerializer` | (auto) | Key serializer |
-| `WithValueSerializer` | (auto) | Value serializer |
+| `WithKeySerializer` | inferred | Key serializer |
+| `WithValueSerializer` | inferred | Value serializer |

--- a/docs/docs/dependency-injection.md
+++ b/docs/docs/dependency-injection.md
@@ -198,13 +198,30 @@ builder.Services.AddHostedService<OrderConsumerService>();
 ```json
 {
   "Kafka": {
-    "BootstrapServers": "localhost:9092",
-    "Producer": {
-      "ClientId": "my-service-producer"
+    "Producers": {
+      "Orders": {
+        "BootstrapServers": "broker1:9092,broker2:9092",
+        "ClientId": "orders-producer",
+        "Acks": "All",
+        "LingerMs": 5,
+        "CompressionType": "Lz4"
+      }
     },
-    "Consumer": {
-      "ClientId": "my-service-consumer",
-      "GroupId": "my-service"
+    "Consumers": {
+      "Orders": {
+        "BootstrapServers": [
+          "broker1:9092",
+          "broker2:9092"
+        ],
+        "ClientId": "orders-consumer",
+        "GroupId": "orders",
+        "AutoOffsetReset": "Earliest",
+        "FetchMinBytes": 1024
+      }
+    },
+    "Admin": {
+      "BootstrapServers": "broker1:9092,broker2:9092",
+      "ClientId": "orders-admin"
     }
   }
 }
@@ -213,18 +230,23 @@ builder.Services.AddHostedService<OrderConsumerService>();
 ```csharp
 builder.Services.AddDekaf(dekaf =>
 {
-    var config = builder.Configuration.GetSection("Kafka");
+    var kafka = builder.Configuration.GetSection("Kafka");
 
-    dekaf.AddProducer<string, string>(producer => producer
-        .WithBootstrapServers(config["BootstrapServers"]!)
-        .WithClientId(config["Producer:ClientId"]!));
+    dekaf.AddProducer<string, Order>(
+        kafka.GetSection("Producers:Orders"),
+        producer => producer.WithValueSerializer(new JsonSerializer<Order>()));
 
-    dekaf.AddConsumer<string, string>(consumer => consumer
-        .WithBootstrapServers(config["BootstrapServers"]!)
-        .WithClientId(config["Consumer:ClientId"]!)
-        .WithGroupId(config["Consumer:GroupId"]!));
+    dekaf.AddConsumer<string, Order>(
+        kafka.GetSection("Consumers:Orders"),
+        consumer => consumer
+            .WithValueDeserializer(new JsonDeserializer<Order>())
+            .SubscribeTo("orders"));
+
+    dekaf.AddAdminClient(kafka.GetSection("Admin"));
 });
 ```
+
+The section keys match `ProducerOptions`, `ConsumerOptions`, and `AdminClientOptions` property names. Configuration is applied first; the optional fluent callback runs after binding, so it can override values or attach objects that cannot be represented in JSON, such as serializers, deserializers, interceptors, retry policies, and rebalance listeners.
 
 ## Lifetime Management
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -186,11 +186,49 @@ catch (OperationCanceledException) { }
 Console.WriteLine("Done!");
 ```
 
+## Configuration-First Services
+
+For ASP.NET Core or worker services, add `Dekaf.Extensions.DependencyInjection` and bind clients from `appsettings.json`:
+
+```json
+{
+  "Kafka": {
+    "Producers": {
+      "Orders": {
+        "BootstrapServers": "localhost:9092",
+        "ClientId": "orders-producer",
+        "LingerMs": 5
+      }
+    },
+    "Consumers": {
+      "Orders": {
+        "BootstrapServers": "localhost:9092",
+        "GroupId": "orders",
+        "AutoOffsetReset": "Earliest"
+      }
+    }
+  }
+}
+```
+
+```csharp
+builder.Services.AddDekaf(dekaf =>
+{
+    dekaf.AddProducer<string, string>(
+        builder.Configuration.GetSection("Kafka:Producers:Orders"));
+
+    dekaf.AddConsumer<string, string>(
+        builder.Configuration.GetSection("Kafka:Consumers:Orders"),
+        consumer => consumer.SubscribeTo("orders"));
+});
+```
+
 ## Next Steps
 
 That's the basics. From here:
 
 - **[Producer Guide](./producer/basics)** - Batching, compression, delivery guarantees
 - **[Consumer Guide](./consumer/basics)** - Offset management, consumer groups, rebalancing
+- **[Dependency Injection](./dependency-injection)** - Register clients in hosted services
 - **[Configuration Presets](./configuration/presets)** - Pre-tuned configs for common scenarios
 - **[Performance Tips](./performance)** - Squeezing out more throughput

--- a/src/Dekaf.Extensions.DependencyInjection/Dekaf.Extensions.DependencyInjection.csproj
+++ b/src/Dekaf.Extensions.DependencyInjection/Dekaf.Extensions.DependencyInjection.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,8 +1,13 @@
 using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Consumer.DeadLetter;
+using Dekaf.Metadata;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
 using Dekaf.Producer;
-using Dekaf.Serialization;
+using Dekaf.Security;
+using Dekaf.Security.Sasl;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -148,6 +153,25 @@ public sealed class DekafBuilder
     }
 
     /// <summary>
+    /// Adds a producer configured from an <see cref="IConfiguration"/> section.
+    /// Fluent configuration runs after binding, so it can override config values and add services such as serializers.
+    /// </summary>
+    /// <param name="configuration">Configuration section using <see cref="ProducerOptions"/> property names.</param>
+    /// <param name="configure">Optional additional producer configuration.</param>
+    public DekafBuilder AddProducer<TKey, TValue>(
+        IConfiguration configuration,
+        Action<ProducerBuilder<TKey, TValue>>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return AddProducer<TKey, TValue>(producer =>
+        {
+            DekafConfigurationBinding.ApplyProducer(configuration, producer);
+            configure?.Invoke(producer);
+        });
+    }
+
+    /// <summary>
     /// Adds a consumer to the service collection.
     /// </summary>
     /// <param name="configure">Configures the full consumer builder surface.</param>
@@ -212,6 +236,29 @@ public sealed class DekafBuilder
     }
 
     /// <summary>
+    /// Adds a consumer configured from an <see cref="IConfiguration"/> section.
+    /// Fluent configuration runs after binding, so it can override config values and add services such as deserializers.
+    /// </summary>
+    /// <param name="configuration">Configuration section using <see cref="ConsumerOptions"/> property names.</param>
+    /// <param name="configure">Optional additional consumer configuration.</param>
+    /// <param name="configureDeadLetterQueue">Optional dead letter queue configuration for hosted consumer services.</param>
+    public DekafBuilder AddConsumer<TKey, TValue>(
+        IConfiguration configuration,
+        Action<ConsumerBuilder<TKey, TValue>>? configure = null,
+        Action<DeadLetterQueueBuilder>? configureDeadLetterQueue = null)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return AddConsumer<TKey, TValue>(
+            consumer =>
+            {
+                DekafConfigurationBinding.ApplyConsumer(configuration, consumer);
+                configure?.Invoke(consumer);
+            },
+            configureDeadLetterQueue);
+    }
+
+    /// <summary>
     /// Adds an admin client to the service collection.
     /// </summary>
     public DekafBuilder AddAdminClient(Action<AdminClientServiceBuilder> configure)
@@ -226,6 +273,25 @@ public sealed class DekafBuilder
         });
 
         return this;
+    }
+
+    /// <summary>
+    /// Adds an admin client configured from an <see cref="IConfiguration"/> section.
+    /// Fluent configuration runs after binding, so it can override config values.
+    /// </summary>
+    /// <param name="configuration">Configuration section using <see cref="AdminClientOptions"/> property names.</param>
+    /// <param name="configure">Optional additional admin client configuration.</param>
+    public DekafBuilder AddAdminClient(
+        IConfiguration configuration,
+        Action<AdminClientServiceBuilder>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return AddAdminClient(admin =>
+        {
+            admin.ApplyConfiguration(configuration);
+            configure?.Invoke(admin);
+        });
     }
 }
 
@@ -254,6 +320,12 @@ public sealed class AdminClientServiceBuilder
         return this;
     }
 
+    internal AdminClientServiceBuilder ApplyConfiguration(IConfiguration configuration)
+    {
+        DekafConfigurationBinding.ApplyAdmin(configuration, _builder);
+        return this;
+    }
+
     internal IAdminClient Build(Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory)
     {
         if (loggerFactory is not null)
@@ -261,5 +333,303 @@ public sealed class AdminClientServiceBuilder
             _builder.WithLoggerFactory(loggerFactory);
         }
         return _builder.Build();
+    }
+}
+
+internal static class DekafConfigurationBinding
+{
+    public static void ApplyProducer<TKey, TValue>(
+        IConfiguration configuration,
+        ProducerBuilder<TKey, TValue> builder)
+    {
+        if (TryGetBootstrapServers(configuration, out var bootstrapServers))
+            builder.WithBootstrapServers(bootstrapServers);
+        if (TryGetValue<string>(configuration, nameof(ProducerOptions.ClientId), out var clientId))
+            builder.WithClientId(clientId);
+        if (TryGetValue<Acks>(configuration, nameof(ProducerOptions.Acks), out var acks))
+            builder.WithAcks(acks);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.LingerMs), out var lingerMs))
+            builder.WithLinger(TimeSpan.FromMilliseconds(lingerMs));
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.BatchSize), out var batchSize))
+            builder.WithBatchSize(batchSize);
+        if (TryGetValue<ulong>(configuration, nameof(ProducerOptions.BufferMemory), out var bufferMemory))
+            builder.WithBufferMemory(bufferMemory);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.MaxInFlightRequestsPerConnection), out var maxInFlight))
+            builder.WithMaxInFlightRequestsPerConnection(maxInFlight);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.Retries), out var retries))
+            builder.WithRetries(retries);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.RetryBackoffMs), out var retryBackoffMs))
+            builder.WithRetryBackoff(TimeSpan.FromMilliseconds(retryBackoffMs));
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.RetryBackoffMaxMs), out var retryBackoffMaxMs))
+            builder.WithRetryBackoffMax(TimeSpan.FromMilliseconds(retryBackoffMaxMs));
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.MaxBlockMs), out var maxBlockMs))
+            builder.WithMaxBlock(TimeSpan.FromMilliseconds(maxBlockMs));
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.DeliveryTimeoutMs), out var deliveryTimeoutMs))
+            builder.WithDeliveryTimeout(TimeSpan.FromMilliseconds(deliveryTimeoutMs));
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.RequestTimeoutMs), out var requestTimeoutMs))
+            builder.WithRequestTimeout(TimeSpan.FromMilliseconds(requestTimeoutMs));
+        if (TryGetValue<bool>(configuration, nameof(ProducerOptions.EnableIdempotence), out var enableIdempotence))
+            builder.WithIdempotence(enableIdempotence);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.ConnectionsPerBroker), out var connectionsPerBroker))
+            builder.WithConnectionsPerBroker(connectionsPerBroker);
+        if (TryGetValue<string>(configuration, nameof(ProducerOptions.TransactionalId), out var transactionalId))
+            builder.WithTransactionalId(transactionalId);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.TransactionTimeoutMs), out var transactionTimeoutMs))
+            builder.WithTransactionTimeout(TimeSpan.FromMilliseconds(transactionTimeoutMs));
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.CloseTimeoutMs), out var closeTimeoutMs))
+            builder.WithCloseTimeout(TimeSpan.FromMilliseconds(closeTimeoutMs));
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.MaxRequestSize), out var maxRequestSize))
+            builder.WithMaxRequestSize(maxRequestSize);
+        if (TryGetValue<CompressionType>(configuration, nameof(ProducerOptions.CompressionType), out var compressionType))
+            builder.UseCompression(compressionType);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.CompressionLevel), out var compressionLevel))
+            builder.WithCompressionLevel(compressionLevel);
+        if (TryGetValue<PartitionerType>(configuration, nameof(ProducerOptions.Partitioner), out var partitioner))
+            builder.WithPartitioner(partitioner);
+        ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
+        if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth))
+            builder.WithSaslOptions(mechanism, username, password, gssapi, oauth);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.SocketSendBufferBytes), out var sendBuffer))
+            builder.WithSocketSendBufferBytes(sendBuffer);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.SocketReceiveBufferBytes), out var receiveBuffer))
+            builder.WithSocketReceiveBufferBytes(receiveBuffer);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.ValueTaskSourcePoolSize), out var poolSize))
+            builder.WithValueTaskSourcePoolSize(poolSize);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.ArenaCapacity), out var arenaCapacity))
+            builder.WithArenaCapacity(arenaCapacity);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.InitialBatchRecordCapacity), out var initialBatchRecordCapacity))
+            builder.WithInitialBatchRecordCapacity(initialBatchRecordCapacity);
+        if (TryGetValue<MetadataRecoveryStrategy>(configuration, nameof(ProducerOptions.MetadataRecoveryStrategy), out var metadataRecoveryStrategy))
+            builder.WithMetadataRecoveryStrategy(metadataRecoveryStrategy);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.MetadataRecoveryRebootstrapTriggerMs), out var rebootstrapMs))
+            builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(rebootstrapMs));
+        ApplyAdaptiveConnections(
+            configuration,
+            nameof(ProducerOptions.EnableAdaptiveConnections),
+            nameof(ProducerOptions.MaxConnectionsPerBroker),
+            builder.WithAdaptiveConnections,
+            builder.WithoutAdaptiveConnections);
+    }
+
+    public static void ApplyConsumer<TKey, TValue>(
+        IConfiguration configuration,
+        ConsumerBuilder<TKey, TValue> builder)
+    {
+        if (TryGetBootstrapServers(configuration, out var bootstrapServers))
+            builder.WithBootstrapServers(bootstrapServers);
+        if (TryGetValue<string>(configuration, nameof(ConsumerOptions.ClientId), out var clientId))
+            builder.WithClientId(clientId);
+        if (TryGetValue<string>(configuration, nameof(ConsumerOptions.GroupId), out var groupId))
+            builder.WithGroupId(groupId);
+        if (TryGetValue<string>(configuration, nameof(ConsumerOptions.GroupInstanceId), out var groupInstanceId))
+            builder.WithGroupInstanceId(groupInstanceId);
+        if (TryGetValue<string>(configuration, nameof(ConsumerOptions.GroupRemoteAssignor), out var groupRemoteAssignor))
+            builder.WithGroupRemoteAssignor(groupRemoteAssignor);
+        if (TryGetValue<OffsetCommitMode>(configuration, nameof(ConsumerOptions.OffsetCommitMode), out var offsetCommitMode))
+            builder.WithOffsetCommitMode(offsetCommitMode);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.AutoCommitIntervalMs), out var autoCommitIntervalMs))
+            builder.WithAutoCommitInterval(TimeSpan.FromMilliseconds(autoCommitIntervalMs));
+        if (TryGetValue<AutoOffsetReset>(configuration, nameof(ConsumerOptions.AutoOffsetReset), out var autoOffsetReset))
+            builder.WithAutoOffsetReset(autoOffsetReset);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.FetchMinBytes), out var fetchMinBytes))
+            builder.WithFetchMinBytes(fetchMinBytes);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.FetchMaxBytes), out var fetchMaxBytes))
+            builder.WithFetchMaxBytes(fetchMaxBytes);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.MaxPartitionFetchBytes), out var maxPartitionFetchBytes))
+            builder.WithMaxPartitionFetchBytes(maxPartitionFetchBytes);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.FetchMaxWaitMs), out var fetchMaxWaitMs))
+            builder.WithFetchMaxWait(TimeSpan.FromMilliseconds(fetchMaxWaitMs));
+        if (TryGetValue<bool>(configuration, nameof(ConsumerOptions.EnableFetchSessions), out var enableFetchSessions))
+            builder.WithFetchSessions(enableFetchSessions);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.MaxPollRecords), out var maxPollRecords))
+            builder.WithMaxPollRecords(maxPollRecords);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.MaxPollIntervalMs), out var maxPollIntervalMs))
+            builder.WithMaxPollInterval(TimeSpan.FromMilliseconds(maxPollIntervalMs));
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.SessionTimeoutMs), out var sessionTimeoutMs))
+            builder.WithSessionTimeout(TimeSpan.FromMilliseconds(sessionTimeoutMs));
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.HeartbeatIntervalMs), out var heartbeatIntervalMs))
+            builder.WithHeartbeatInterval(TimeSpan.FromMilliseconds(heartbeatIntervalMs));
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.RebalanceTimeoutMs), out var rebalanceTimeoutMs))
+            builder.WithRebalanceTimeout(TimeSpan.FromMilliseconds(rebalanceTimeoutMs));
+        if (TryGetValue<IsolationLevel>(configuration, nameof(ConsumerOptions.IsolationLevel), out var isolationLevel))
+            builder.WithIsolationLevel(isolationLevel);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.RequestTimeoutMs), out var requestTimeoutMs))
+            builder.WithRequestTimeout(TimeSpan.FromMilliseconds(requestTimeoutMs));
+        if (TryGetValue<bool>(configuration, nameof(ConsumerOptions.CheckCrcs), out var checkCrcs))
+            builder.WithCheckCrcs(checkCrcs);
+        ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
+        if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth))
+            builder.WithSaslOptions(mechanism, username, password, gssapi, oauth);
+        if (TryGetValue<bool>(configuration, nameof(ConsumerOptions.EnablePartitionEof), out var enablePartitionEof))
+            builder.WithPartitionEof(enablePartitionEof);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.SocketSendBufferBytes), out var sendBuffer))
+            builder.WithSocketSendBufferBytes(sendBuffer);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.SocketReceiveBufferBytes), out var receiveBuffer))
+            builder.WithSocketReceiveBufferBytes(receiveBuffer);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.QueuedMinMessages), out var queuedMinMessages))
+            builder.WithQueuedMinMessages(queuedMinMessages);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.QueuedMaxMessagesKbytes), out var queuedMaxMessagesKbytes))
+            builder.WithQueuedMaxMessagesKbytes(queuedMaxMessagesKbytes);
+        if (TryGetValue<MetadataRecoveryStrategy>(configuration, nameof(ConsumerOptions.MetadataRecoveryStrategy), out var metadataRecoveryStrategy))
+            builder.WithMetadataRecoveryStrategy(metadataRecoveryStrategy);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.MetadataRecoveryRebootstrapTriggerMs), out var rebootstrapMs))
+            builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(rebootstrapMs));
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.PrefetchPipelineDepth), out var prefetchPipelineDepth))
+            builder.WithPrefetchPipelineDepth(prefetchPipelineDepth);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.ConnectionsPerBroker), out var connectionsPerBroker))
+            builder.WithConnectionsPerBroker(connectionsPerBroker);
+        ApplyAdaptiveConnections(
+            configuration,
+            nameof(ConsumerOptions.EnableAdaptiveConnections),
+            nameof(ConsumerOptions.MaxConnectionsPerBroker),
+            builder.WithAdaptiveConnections,
+            builder.WithoutAdaptiveConnections);
+        ApplyAdaptiveFetchSizing(configuration, builder);
+    }
+
+    public static void ApplyAdmin(IConfiguration configuration, AdminClientBuilder builder)
+    {
+        if (TryGetBootstrapServers(configuration, out var bootstrapServers))
+            builder.WithBootstrapServers(bootstrapServers);
+        if (TryGetValue<string>(configuration, nameof(AdminClientOptions.ClientId), out var clientId))
+            builder.WithClientId(clientId);
+        if (TryGetValue<int>(configuration, nameof(AdminClientOptions.RequestTimeoutMs), out var requestTimeoutMs))
+            builder.WithRequestTimeout(TimeSpan.FromMilliseconds(requestTimeoutMs));
+        ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
+        if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth))
+            builder.WithSaslOptions(mechanism, username, password, gssapi, oauth);
+        if (TryGetValue<MetadataRecoveryStrategy>(configuration, nameof(AdminClientOptions.MetadataRecoveryStrategy), out var metadataRecoveryStrategy))
+            builder.WithMetadataRecoveryStrategy(metadataRecoveryStrategy);
+        if (TryGetValue<int>(configuration, nameof(AdminClientOptions.MetadataRecoveryRebootstrapTriggerMs), out var rebootstrapMs))
+            builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(rebootstrapMs));
+    }
+
+    private static void ApplyTls<TBuilder>(
+        IConfiguration configuration,
+        Func<TBuilder> useTls,
+        Func<TlsConfig, TBuilder> useTlsConfig)
+    {
+        if (TryGetValue<TlsConfig>(configuration, nameof(ProducerOptions.TlsConfig), out var tlsConfig))
+        {
+            useTlsConfig(tlsConfig);
+            return;
+        }
+
+        if (TryGetValue<bool>(configuration, nameof(ProducerOptions.UseTls), out var useTlsValue) && useTlsValue)
+        {
+            useTls();
+        }
+    }
+
+    private static void ApplyAdaptiveConnections<TBuilder>(
+        IConfiguration configuration,
+        string enabledKey,
+        string maxKey,
+        Func<int, TBuilder> withAdaptiveConnections,
+        Func<TBuilder> withoutAdaptiveConnections)
+    {
+        var hasEnabled = TryGetValue<bool>(configuration, enabledKey, out var enabled);
+        var hasMax = TryGetValue<int>(configuration, maxKey, out var maxConnections);
+
+        if (hasEnabled && !enabled)
+        {
+            withoutAdaptiveConnections();
+            return;
+        }
+
+        if (hasMax)
+        {
+            withAdaptiveConnections(maxConnections);
+        }
+    }
+
+    private static void ApplyAdaptiveFetchSizing<TKey, TValue>(
+        IConfiguration configuration,
+        ConsumerBuilder<TKey, TValue> builder)
+    {
+        var hasEnabled = TryGetValue<bool>(configuration, nameof(ConsumerOptions.EnableAdaptiveFetchSizing), out var enabled);
+        var hasOptions = TryGetValue<AdaptiveFetchSizingOptions>(
+            configuration,
+            nameof(ConsumerOptions.AdaptiveFetchSizingOptions),
+            out var options);
+
+        if ((hasEnabled && enabled) || (!hasEnabled && hasOptions))
+        {
+            builder.WithAdaptiveFetchSizing(hasOptions ? options : null);
+        }
+    }
+
+    private static bool TryReadSasl(
+        IConfiguration configuration,
+        out SaslMechanism mechanism,
+        out string? username,
+        out string? password,
+        out GssapiConfig? gssapiConfig,
+        out OAuthBearerConfig? oauthConfig)
+    {
+        var hasMechanism = TryGetValue<SaslMechanism>(configuration, nameof(ProducerOptions.SaslMechanism), out mechanism);
+        var hasUsername = TryGetValue<string>(configuration, nameof(ProducerOptions.SaslUsername), out username);
+        var hasPassword = TryGetValue<string>(configuration, nameof(ProducerOptions.SaslPassword), out password);
+        var hasGssapi = TryGetValue<GssapiConfig>(configuration, nameof(ProducerOptions.GssapiConfig), out gssapiConfig);
+        var hasOAuth = TryGetValue<OAuthBearerConfig>(configuration, nameof(ProducerOptions.OAuthBearerConfig), out oauthConfig);
+
+        if (!hasMechanism)
+        {
+            mechanism = oauthConfig is not null
+                ? SaslMechanism.OAuthBearer
+                : gssapiConfig is not null
+                    ? SaslMechanism.Gssapi
+                    : hasUsername || hasPassword
+                        ? SaslMechanism.Plain
+                        : SaslMechanism.None;
+        }
+
+        return hasMechanism || hasUsername || hasPassword || hasGssapi || hasOAuth;
+    }
+
+    private static bool TryGetBootstrapServers(IConfiguration configuration, out string[] servers)
+    {
+        var section = configuration.GetSection(nameof(ProducerOptions.BootstrapServers));
+        if (!section.Exists())
+        {
+            servers = [];
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(section.Value))
+        {
+            servers = SplitBootstrapServers(section.Value);
+            return servers.Length > 0;
+        }
+
+        servers = section.Get<string[]>()?
+            .Where(server => !string.IsNullOrWhiteSpace(server))
+            .Select(server => server.Trim())
+            .ToArray() ?? [];
+
+        return servers.Length > 0;
+    }
+
+    private static string[] SplitBootstrapServers(string value) =>
+        value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static bool TryGetValue<T>(IConfiguration configuration, string key, out T value)
+    {
+        var section = configuration.GetSection(key);
+        if (!section.Exists())
+        {
+            value = default!;
+            return false;
+        }
+
+        var bound = section.Get<T>();
+        if (bound is null)
+        {
+            value = default!;
+            return false;
+        }
+
+        value = bound;
+        return true;
     }
 }

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -2127,6 +2127,7 @@ public sealed class AdminClientBuilder
 {
     private IReadOnlyList<string> _bootstrapServers = [];
     private string? _clientId;
+    private int _requestTimeoutMs = 30000;
     private bool _useTls;
     private TlsConfig? _tlsConfig;
     private SaslMechanism _saslMechanism = SaslMechanism.None;
@@ -2310,6 +2311,32 @@ public sealed class AdminClientBuilder
         return this;
     }
 
+    internal AdminClientBuilder WithRequestTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Request timeout must be positive");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+
+        _requestTimeoutMs = (int)timeout.TotalMilliseconds;
+        return this;
+    }
+
+    internal AdminClientBuilder WithSaslOptions(
+        SaslMechanism mechanism,
+        string? username,
+        string? password,
+        GssapiConfig? gssapiConfig,
+        OAuthBearerConfig? oauthConfig)
+    {
+        _saslMechanism = mechanism;
+        _saslUsername = username;
+        _saslPassword = password;
+        _gssapiConfig = gssapiConfig;
+        _oauthConfig = oauthConfig;
+        _oauthTokenProvider = null;
+        return this;
+    }
+
     public IAdminClient Build()
     {
         if (_bootstrapServers.Count == 0)
@@ -2319,6 +2346,7 @@ public sealed class AdminClientBuilder
         {
             BootstrapServers = _bootstrapServers,
             ClientId = _clientId,
+            RequestTimeoutMs = _requestTimeoutMs,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
             SaslMechanism = _saslMechanism,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -29,6 +29,15 @@ public sealed class ProducerBuilder<TKey, TValue>
     private int? _transactionTimeoutMs;
     private Protocol.Records.CompressionType _compressionType = Protocol.Records.CompressionType.None;
     private int? _compressionLevel;
+    private int _maxInFlightRequestsPerConnection = 5;
+    private int _retries = int.MaxValue;
+    private int _retryBackoffMs = 100;
+    private int _retryBackoffMaxMs = 1000;
+    private int _closeTimeoutMs = 30000;
+    private int _maxRequestSize = 1048576;
+    private int _valueTaskSourcePoolSize;
+    private int _arenaCapacity;
+    private int _initialBatchRecordCapacity;
     private PartitionerType _partitionerType = PartitionerType.Default;
     private IPartitioner? _customPartitioner;
     private bool _useTls;
@@ -608,6 +617,94 @@ public sealed class ProducerBuilder<TKey, TValue>
         return this;
     }
 
+    internal ProducerBuilder<TKey, TValue> WithMaxInFlightRequestsPerConnection(int maxInFlightRequestsPerConnection)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxInFlightRequestsPerConnection, 1);
+        _maxInFlightRequestsPerConnection = maxInFlightRequestsPerConnection;
+        return this;
+    }
+
+    internal ProducerBuilder<TKey, TValue> WithRetries(int retries)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(retries);
+        _retries = retries;
+        return this;
+    }
+
+    internal ProducerBuilder<TKey, TValue> WithRetryBackoff(TimeSpan backoff)
+    {
+        if (backoff < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(backoff), "Retry backoff cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
+
+        _retryBackoffMs = (int)backoff.TotalMilliseconds;
+        return this;
+    }
+
+    internal ProducerBuilder<TKey, TValue> WithRetryBackoffMax(TimeSpan backoff)
+    {
+        if (backoff < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(backoff), "Maximum retry backoff cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
+
+        _retryBackoffMaxMs = (int)backoff.TotalMilliseconds;
+        return this;
+    }
+
+    internal ProducerBuilder<TKey, TValue> WithCloseTimeout(TimeSpan timeout)
+    {
+        if (timeout < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Close timeout cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+
+        _closeTimeoutMs = (int)timeout.TotalMilliseconds;
+        return this;
+    }
+
+    internal ProducerBuilder<TKey, TValue> WithMaxRequestSize(int maxRequestSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxRequestSize, 1);
+        _maxRequestSize = maxRequestSize;
+        return this;
+    }
+
+    internal ProducerBuilder<TKey, TValue> WithValueTaskSourcePoolSize(int poolSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(poolSize);
+        _valueTaskSourcePoolSize = poolSize;
+        return this;
+    }
+
+    internal ProducerBuilder<TKey, TValue> WithArenaCapacity(int arenaCapacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(arenaCapacity);
+        _arenaCapacity = arenaCapacity;
+        return this;
+    }
+
+    internal ProducerBuilder<TKey, TValue> WithInitialBatchRecordCapacity(int capacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(capacity);
+        _initialBatchRecordCapacity = capacity;
+        return this;
+    }
+
+    internal ProducerBuilder<TKey, TValue> WithSaslOptions(
+        SaslMechanism mechanism,
+        string? username,
+        string? password,
+        GssapiConfig? gssapiConfig,
+        OAuthBearerConfig? oauthConfig)
+    {
+        _saslMechanism = mechanism;
+        _saslUsername = username;
+        _saslPassword = password;
+        _gssapiConfig = gssapiConfig;
+        _oauthConfig = oauthConfig;
+        _oauthTokenProvider = null;
+        return this;
+    }
+
     /// <summary>
     /// Builds and initializes the producer, ready for immediate use.
     /// This is equivalent to calling <see cref="Build"/> followed by <see cref="IKafkaProducer{TKey,TValue}.InitializeAsync"/>.
@@ -700,6 +797,10 @@ public sealed class ProducerBuilder<TKey, TValue>
             BatchSize = _batchSize,
             BufferMemory = _bufferMemory ?? DekafMemoryBudget.PreviewProducerLimit(),
             IsAutoTuned = _bufferMemory is null,
+            MaxInFlightRequestsPerConnection = _maxInFlightRequestsPerConnection,
+            Retries = _retries,
+            RetryBackoffMs = _retryBackoffMs,
+            RetryBackoffMaxMs = _retryBackoffMaxMs,
             MaxBlockMs = _maxBlockMs ?? 60000, // 60 seconds default
             DeliveryTimeoutMs = _deliveryTimeoutMs ?? 120000,
             RequestTimeoutMs = _requestTimeoutMs ?? 30000,
@@ -707,6 +808,8 @@ public sealed class ProducerBuilder<TKey, TValue>
             ConnectionsPerBroker = _connectionsPerBroker,
             TransactionalId = _transactionalId,
             TransactionTimeoutMs = _transactionTimeoutMs ?? 60000,
+            CloseTimeoutMs = _closeTimeoutMs,
+            MaxRequestSize = _maxRequestSize,
             CompressionType = _compressionType,
             CompressionLevel = _compressionLevel,
             Partitioner = _partitionerType,
@@ -723,6 +826,9 @@ public sealed class ProducerBuilder<TKey, TValue>
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             SocketSendBufferBytes = _socketSendBufferBytes,
             SocketReceiveBufferBytes = _socketReceiveBufferBytes,
+            ValueTaskSourcePoolSize = _valueTaskSourcePoolSize,
+            ArenaCapacity = _arenaCapacity,
+            InitialBatchRecordCapacity = _initialBatchRecordCapacity,
             Interceptors = _interceptors?.Count > 0 ? _interceptors.ToArray() : null,
             RetryPolicy = _retryPolicy,
             EnableAdaptiveConnections = _enableAdaptiveConnections,
@@ -809,8 +915,12 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _maxPartitionFetchBytes = 1048576;
     private int _fetchMaxWaitMs = 200;
     private int _maxPollRecords = 500;
+    private int _maxPollIntervalMs = 300000;
     private int _sessionTimeoutMs = 45000;
     private int? _heartbeatIntervalMs;
+    private int _rebalanceTimeoutMs = 60000;
+    private int _requestTimeoutMs = 30000;
+    private bool _checkCrcs;
     private bool _useTls;
     private TlsConfig? _tlsConfig;
     private List<IConsumerInterceptor<TKey, TValue>>? _interceptors;
@@ -825,6 +935,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private IRebalanceListener? _rebalanceListener;
     private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
     private bool _enablePartitionEof;
+    private int _socketSendBufferBytes;
+    private int _socketReceiveBufferBytes;
     private int _queuedMinMessages = 100000;
     private int? _queuedMaxMessagesKbytes;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
@@ -1468,6 +1580,72 @@ public sealed class ConsumerBuilder<TKey, TValue>
         return this;
     }
 
+    internal ConsumerBuilder<TKey, TValue> WithMaxPollInterval(TimeSpan interval)
+    {
+        if (interval <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(interval), "Max poll interval must be positive");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(interval.TotalMilliseconds, int.MaxValue, nameof(interval));
+
+        _maxPollIntervalMs = (int)interval.TotalMilliseconds;
+        return this;
+    }
+
+    internal ConsumerBuilder<TKey, TValue> WithRebalanceTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Rebalance timeout must be positive");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+
+        _rebalanceTimeoutMs = (int)timeout.TotalMilliseconds;
+        return this;
+    }
+
+    internal ConsumerBuilder<TKey, TValue> WithRequestTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Request timeout must be positive");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+
+        _requestTimeoutMs = (int)timeout.TotalMilliseconds;
+        return this;
+    }
+
+    internal ConsumerBuilder<TKey, TValue> WithCheckCrcs(bool checkCrcs)
+    {
+        _checkCrcs = checkCrcs;
+        return this;
+    }
+
+    internal ConsumerBuilder<TKey, TValue> WithSocketSendBufferBytes(int bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        _socketSendBufferBytes = bytes;
+        return this;
+    }
+
+    internal ConsumerBuilder<TKey, TValue> WithSocketReceiveBufferBytes(int bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        _socketReceiveBufferBytes = bytes;
+        return this;
+    }
+
+    internal ConsumerBuilder<TKey, TValue> WithSaslOptions(
+        SaslMechanism mechanism,
+        string? username,
+        string? password,
+        GssapiConfig? gssapiConfig,
+        OAuthBearerConfig? oauthConfig)
+    {
+        _saslMechanism = mechanism;
+        _saslUsername = username;
+        _saslPassword = password;
+        _gssapiConfig = gssapiConfig;
+        _oauthConfig = oauthConfig;
+        _oauthTokenProvider = null;
+        return this;
+    }
+
     /// <summary>
     /// Builds and initializes the consumer, ready for immediate use.
     /// This is equivalent to calling <see cref="Build"/> followed by <see cref="IKafkaConsumer{TKey,TValue}.InitializeAsync"/>.
@@ -1529,8 +1707,12 @@ public sealed class ConsumerBuilder<TKey, TValue>
             FetchMaxWaitMs = _fetchMaxWaitMs,
             EnableFetchSessions = _enableFetchSessions,
             MaxPollRecords = _maxPollRecords,
+            MaxPollIntervalMs = _maxPollIntervalMs,
             SessionTimeoutMs = _sessionTimeoutMs,
             HeartbeatIntervalMs = _heartbeatIntervalMs ?? 3000,
+            RebalanceTimeoutMs = _rebalanceTimeoutMs,
+            RequestTimeoutMs = _requestTimeoutMs,
+            CheckCrcs = _checkCrcs,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
             SaslMechanism = _saslMechanism,
@@ -1541,6 +1723,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
             OAuthBearerTokenProvider = _oauthTokenProvider,
             RebalanceListener = _rebalanceListener,
             EnablePartitionEof = _enablePartitionEof,
+            SocketSendBufferBytes = _socketSendBufferBytes,
+            SocketReceiveBufferBytes = _socketReceiveBufferBytes,
             QueuedMinMessages = _queuedMinMessages,
             QueuedMaxMessagesKbytes = _queuedMaxMessagesKbytes
                 ?? (int)Math.Min(DekafMemoryBudget.PreviewConsumerLimit() / 1024, int.MaxValue),

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.35.1" />
     <PackageReference Include="OpenTelemetry" Version="1.16.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.2.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -4,7 +4,12 @@ using Dekaf.Compression.Lz4;
 using Dekaf.Consumer;
 using Dekaf.Consumer.DeadLetter;
 using Dekaf.Extensions.DependencyInjection;
+using Dekaf.Metadata;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
 using Dekaf.Producer;
+using Dekaf.Security.Sasl;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -190,6 +195,262 @@ public class DependencyInjectionTests
         await Assert.That(options.TopicSuffix).IsEqualTo(".dead");
         await Assert.That(options.MaxFailures).IsEqualTo(3);
         await Assert.That(options.BootstrapServers).IsEqualTo("localhost:9092");
+    }
+
+    #endregion
+
+    #region Configuration Binding Tests
+
+    [Test]
+    public async Task AddProducer_WithConfigurationSection_BindsConfiguredOptions()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:Producers:Orders:BootstrapServers"] = "broker1:9092, broker2:9092",
+            ["Kafka:Producers:Orders:ClientId"] = "orders-producer",
+            ["Kafka:Producers:Orders:Acks"] = "Leader",
+            ["Kafka:Producers:Orders:LingerMs"] = "5",
+            ["Kafka:Producers:Orders:BatchSize"] = "65536",
+            ["Kafka:Producers:Orders:BufferMemory"] = "1048576",
+            ["Kafka:Producers:Orders:MaxInFlightRequestsPerConnection"] = "2",
+            ["Kafka:Producers:Orders:Retries"] = "7",
+            ["Kafka:Producers:Orders:RetryBackoffMs"] = "25",
+            ["Kafka:Producers:Orders:RetryBackoffMaxMs"] = "250",
+            ["Kafka:Producers:Orders:MaxBlockMs"] = "1000",
+            ["Kafka:Producers:Orders:DeliveryTimeoutMs"] = "2000",
+            ["Kafka:Producers:Orders:RequestTimeoutMs"] = "3000",
+            ["Kafka:Producers:Orders:EnableIdempotence"] = "false",
+            ["Kafka:Producers:Orders:ConnectionsPerBroker"] = "3",
+            ["Kafka:Producers:Orders:MaxConnectionsPerBroker"] = "6",
+            ["Kafka:Producers:Orders:CompressionType"] = "Gzip",
+            ["Kafka:Producers:Orders:CompressionLevel"] = "4",
+            ["Kafka:Producers:Orders:Partitioner"] = "RoundRobin",
+            ["Kafka:Producers:Orders:UseTls"] = "true",
+            ["Kafka:Producers:Orders:SaslMechanism"] = "ScramSha512",
+            ["Kafka:Producers:Orders:SaslUsername"] = "user",
+            ["Kafka:Producers:Orders:SaslPassword"] = "password",
+            ["Kafka:Producers:Orders:SocketSendBufferBytes"] = "1024",
+            ["Kafka:Producers:Orders:SocketReceiveBufferBytes"] = "2048",
+            ["Kafka:Producers:Orders:ValueTaskSourcePoolSize"] = "128",
+            ["Kafka:Producers:Orders:ArenaCapacity"] = "131072",
+            ["Kafka:Producers:Orders:InitialBatchRecordCapacity"] = "32",
+            ["Kafka:Producers:Orders:MetadataRecoveryStrategy"] = "None",
+            ["Kafka:Producers:Orders:MetadataRecoveryRebootstrapTriggerMs"] = "60000"
+        });
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>(configuration.GetSection("Kafka:Producers:Orders"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var producer = provider.GetRequiredService<IKafkaProducer<string, string>>();
+        var options = GetProducerOptions(producer);
+
+        await Assert.That(options.BootstrapServers.Count).IsEqualTo(2);
+        await Assert.That(options.BootstrapServers[0]).IsEqualTo("broker1:9092");
+        await Assert.That(options.BootstrapServers[1]).IsEqualTo("broker2:9092");
+        await Assert.That(options.ClientId).IsEqualTo("orders-producer");
+        await Assert.That(options.Acks).IsEqualTo(Acks.Leader);
+        await Assert.That(options.LingerMs).IsEqualTo(5);
+        await Assert.That(options.BatchSize).IsEqualTo(65536);
+        await Assert.That(options.BufferMemory).IsEqualTo(1048576UL);
+        await Assert.That(options.IsAutoTuned).IsFalse();
+        await Assert.That(options.MaxInFlightRequestsPerConnection).IsEqualTo(2);
+        await Assert.That(options.Retries).IsEqualTo(7);
+        await Assert.That(options.RetryBackoffMs).IsEqualTo(25);
+        await Assert.That(options.RetryBackoffMaxMs).IsEqualTo(250);
+        await Assert.That(options.MaxBlockMs).IsEqualTo(1000);
+        await Assert.That(options.DeliveryTimeoutMs).IsEqualTo(2000);
+        await Assert.That(options.RequestTimeoutMs).IsEqualTo(3000);
+        await Assert.That(options.EnableIdempotence).IsFalse();
+        await Assert.That(options.ConnectionsPerBroker).IsEqualTo(3);
+        await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(6);
+        await Assert.That(options.CompressionType).IsEqualTo(CompressionType.Gzip);
+        await Assert.That(options.CompressionLevel).IsEqualTo(4);
+        await Assert.That(options.Partitioner).IsEqualTo(PartitionerType.RoundRobin);
+        await Assert.That(options.UseTls).IsTrue();
+        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha512);
+        await Assert.That(options.SaslUsername).IsEqualTo("user");
+        await Assert.That(options.SaslPassword).IsEqualTo("password");
+        await Assert.That(options.SocketSendBufferBytes).IsEqualTo(1024);
+        await Assert.That(options.SocketReceiveBufferBytes).IsEqualTo(2048);
+        await Assert.That(options.ValueTaskSourcePoolSize).IsEqualTo(128);
+        await Assert.That(options.ArenaCapacity).IsEqualTo(131072);
+        await Assert.That(options.InitialBatchRecordCapacity).IsEqualTo(32);
+        await Assert.That(options.MetadataRecoveryStrategy).IsEqualTo(MetadataRecoveryStrategy.None);
+        await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(60000);
+    }
+
+    [Test]
+    public async Task AddProducer_WithConfigurationSection_FluentConfigurationOverridesBoundValues()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:BootstrapServers"] = "broker1:9092",
+            ["Kafka:LingerMs"] = "50",
+            ["Kafka:BatchSize"] = "65536"
+        });
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>(
+                configuration.GetSection("Kafka"),
+                producer => producer
+                    .WithLinger(TimeSpan.FromMilliseconds(2))
+                    .WithBatchSize(1024));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var producer = provider.GetRequiredService<IKafkaProducer<string, string>>();
+        var options = GetProducerOptions(producer);
+
+        await Assert.That(options.LingerMs).IsEqualTo(2);
+        await Assert.That(options.BatchSize).IsEqualTo(1024);
+        await Assert.That(options.IsAutoTuned).IsTrue();
+    }
+
+    [Test]
+    public async Task AddConsumer_WithConfigurationSection_BindsConfiguredOptions()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:Consumers:Orders:BootstrapServers:0"] = "broker1:9092",
+            ["Kafka:Consumers:Orders:BootstrapServers:1"] = "broker2:9092",
+            ["Kafka:Consumers:Orders:ClientId"] = "orders-consumer",
+            ["Kafka:Consumers:Orders:GroupId"] = "orders",
+            ["Kafka:Consumers:Orders:GroupInstanceId"] = "orders-1",
+            ["Kafka:Consumers:Orders:GroupRemoteAssignor"] = "uniform",
+            ["Kafka:Consumers:Orders:OffsetCommitMode"] = "Manual",
+            ["Kafka:Consumers:Orders:AutoCommitIntervalMs"] = "2000",
+            ["Kafka:Consumers:Orders:AutoOffsetReset"] = "Earliest",
+            ["Kafka:Consumers:Orders:FetchMinBytes"] = "1024",
+            ["Kafka:Consumers:Orders:FetchMaxBytes"] = "2097152",
+            ["Kafka:Consumers:Orders:MaxPartitionFetchBytes"] = "1048576",
+            ["Kafka:Consumers:Orders:FetchMaxWaitMs"] = "150",
+            ["Kafka:Consumers:Orders:EnableFetchSessions"] = "false",
+            ["Kafka:Consumers:Orders:MaxPollRecords"] = "250",
+            ["Kafka:Consumers:Orders:MaxPollIntervalMs"] = "120000",
+            ["Kafka:Consumers:Orders:SessionTimeoutMs"] = "30000",
+            ["Kafka:Consumers:Orders:HeartbeatIntervalMs"] = "10000",
+            ["Kafka:Consumers:Orders:RebalanceTimeoutMs"] = "45000",
+            ["Kafka:Consumers:Orders:IsolationLevel"] = "ReadCommitted",
+            ["Kafka:Consumers:Orders:RequestTimeoutMs"] = "15000",
+            ["Kafka:Consumers:Orders:CheckCrcs"] = "true",
+            ["Kafka:Consumers:Orders:UseTls"] = "true",
+            ["Kafka:Consumers:Orders:SaslMechanism"] = "Plain",
+            ["Kafka:Consumers:Orders:SaslUsername"] = "user",
+            ["Kafka:Consumers:Orders:SaslPassword"] = "password",
+            ["Kafka:Consumers:Orders:EnablePartitionEof"] = "true",
+            ["Kafka:Consumers:Orders:SocketSendBufferBytes"] = "4096",
+            ["Kafka:Consumers:Orders:SocketReceiveBufferBytes"] = "8192",
+            ["Kafka:Consumers:Orders:QueuedMinMessages"] = "1000",
+            ["Kafka:Consumers:Orders:QueuedMaxMessagesKbytes"] = "32768",
+            ["Kafka:Consumers:Orders:MetadataRecoveryStrategy"] = "None",
+            ["Kafka:Consumers:Orders:MetadataRecoveryRebootstrapTriggerMs"] = "90000",
+            ["Kafka:Consumers:Orders:PrefetchPipelineDepth"] = "4",
+            ["Kafka:Consumers:Orders:ConnectionsPerBroker"] = "2",
+            ["Kafka:Consumers:Orders:EnableAdaptiveConnections"] = "false",
+            ["Kafka:Consumers:Orders:EnableAdaptiveFetchSizing"] = "true",
+            ["Kafka:Consumers:Orders:AdaptiveFetchSizingOptions:MaxFetchMaxBytes"] = "67108864"
+        });
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddConsumer<string, string>(
+                configuration.GetSection("Kafka:Consumers:Orders"),
+                configureDeadLetterQueue: dlq => dlq.WithTopicSuffix(".dead"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var consumer = provider.GetRequiredService<IKafkaConsumer<string, string>>();
+        var options = GetConsumerOptions(consumer);
+        var deadLetterOptions = provider.GetRequiredService<DeadLetterOptions>();
+
+        await Assert.That(options.BootstrapServers.Count).IsEqualTo(2);
+        await Assert.That(options.BootstrapServers[0]).IsEqualTo("broker1:9092");
+        await Assert.That(options.BootstrapServers[1]).IsEqualTo("broker2:9092");
+        await Assert.That(options.ClientId).IsEqualTo("orders-consumer");
+        await Assert.That(options.GroupId).IsEqualTo("orders");
+        await Assert.That(options.GroupInstanceId).IsEqualTo("orders-1");
+        await Assert.That(options.GroupRemoteAssignor).IsEqualTo("uniform");
+        await Assert.That(options.OffsetCommitMode).IsEqualTo(OffsetCommitMode.Manual);
+        await Assert.That(options.AutoCommitIntervalMs).IsEqualTo(2000);
+        await Assert.That(options.AutoOffsetReset).IsEqualTo(AutoOffsetReset.Earliest);
+        await Assert.That(options.FetchMinBytes).IsEqualTo(1024);
+        await Assert.That(options.FetchMaxBytes).IsEqualTo(2097152);
+        await Assert.That(options.MaxPartitionFetchBytes).IsEqualTo(1048576);
+        await Assert.That(options.FetchMaxWaitMs).IsEqualTo(150);
+        await Assert.That(options.EnableFetchSessions).IsFalse();
+        await Assert.That(options.MaxPollRecords).IsEqualTo(250);
+        await Assert.That(options.MaxPollIntervalMs).IsEqualTo(120000);
+        await Assert.That(options.SessionTimeoutMs).IsEqualTo(30000);
+        await Assert.That(options.HeartbeatIntervalMs).IsEqualTo(10000);
+        await Assert.That(options.RebalanceTimeoutMs).IsEqualTo(45000);
+        await Assert.That(options.IsolationLevel).IsEqualTo(IsolationLevel.ReadCommitted);
+        await Assert.That(options.RequestTimeoutMs).IsEqualTo(15000);
+        await Assert.That(options.CheckCrcs).IsTrue();
+        await Assert.That(options.UseTls).IsTrue();
+        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.Plain);
+        await Assert.That(options.SaslUsername).IsEqualTo("user");
+        await Assert.That(options.SaslPassword).IsEqualTo("password");
+        await Assert.That(options.EnablePartitionEof).IsTrue();
+        await Assert.That(options.SocketSendBufferBytes).IsEqualTo(4096);
+        await Assert.That(options.SocketReceiveBufferBytes).IsEqualTo(8192);
+        await Assert.That(options.QueuedMinMessages).IsEqualTo(1000);
+        await Assert.That(options.QueuedMaxMessagesKbytes).IsEqualTo(32768);
+        await Assert.That(options.IsAutoTuned).IsFalse();
+        await Assert.That(options.MetadataRecoveryStrategy).IsEqualTo(MetadataRecoveryStrategy.None);
+        await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(90000);
+        await Assert.That(options.PrefetchPipelineDepth).IsEqualTo(4);
+        await Assert.That(options.ConnectionsPerBroker).IsEqualTo(2);
+        await Assert.That(options.EnableAdaptiveConnections).IsFalse();
+        await Assert.That(options.EnableAdaptiveFetchSizing).IsTrue();
+        await Assert.That(options.AdaptiveFetchSizingOptions).IsNotNull();
+        await Assert.That(options.AdaptiveFetchSizingOptions!.MaxFetchMaxBytes).IsEqualTo(67108864);
+        await Assert.That(deadLetterOptions.BootstrapServers).IsEqualTo("broker1:9092,broker2:9092");
+        await Assert.That(deadLetterOptions.TopicSuffix).IsEqualTo(".dead");
+    }
+
+    [Test]
+    public async Task AddAdminClient_WithConfigurationSection_BindsConfiguredOptions()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:Admin:BootstrapServers"] = "broker1:9092",
+            ["Kafka:Admin:ClientId"] = "admin-client",
+            ["Kafka:Admin:RequestTimeoutMs"] = "45000",
+            ["Kafka:Admin:UseTls"] = "true",
+            ["Kafka:Admin:SaslMechanism"] = "Plain",
+            ["Kafka:Admin:SaslUsername"] = "admin",
+            ["Kafka:Admin:SaslPassword"] = "secret",
+            ["Kafka:Admin:MetadataRecoveryStrategy"] = "None",
+            ["Kafka:Admin:MetadataRecoveryRebootstrapTriggerMs"] = "120000"
+        });
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddAdminClient(configuration.GetSection("Kafka:Admin"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var admin = provider.GetRequiredService<IAdminClient>();
+        var options = GetAdminOptions(admin);
+
+        await Assert.That(options.BootstrapServers.Count).IsEqualTo(1);
+        await Assert.That(options.BootstrapServers[0]).IsEqualTo("broker1:9092");
+        await Assert.That(options.ClientId).IsEqualTo("admin-client");
+        await Assert.That(options.RequestTimeoutMs).IsEqualTo(45000);
+        await Assert.That(options.UseTls).IsTrue();
+        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.Plain);
+        await Assert.That(options.SaslUsername).IsEqualTo("admin");
+        await Assert.That(options.SaslPassword).IsEqualTo("secret");
+        await Assert.That(options.MetadataRecoveryStrategy).IsEqualTo(MetadataRecoveryStrategy.None);
+        await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(120000);
     }
 
     #endregion
@@ -458,6 +719,32 @@ public class DependencyInjectionTests
     }
 
     #endregion
+
+    private static IConfigurationRoot BuildConfiguration(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+    private static ProducerOptions GetProducerOptions<TKey, TValue>(IKafkaProducer<TKey, TValue> producer)
+    {
+        var field = producer.GetType().GetField("_options", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Could not find _options field");
+        return (ProducerOptions)field.GetValue(producer)!;
+    }
+
+    private static ConsumerOptions GetConsumerOptions<TKey, TValue>(IKafkaConsumer<TKey, TValue> consumer)
+    {
+        var field = consumer.GetType().GetField("_options", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Could not find _options field");
+        return (ConsumerOptions)field.GetValue(consumer)!;
+    }
+
+    private static AdminClientOptions GetAdminOptions(IAdminClient admin)
+    {
+        var field = admin.GetType().GetField("_options", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Could not find _options field");
+        return (AdminClientOptions)field.GetValue(admin)!;
+    }
 
     #region Test Interceptor Implementations
 


### PR DESCRIPTION
## Summary
- add IConfiguration-backed DI overloads for producer, consumer, and admin clients
- bind config keys matching existing option property names while preserving auto-tuned defaults when keys are omitted
- document config-first DI setup and fluent-to-config key maps

## Validation
- dotnet build tests/Dekaf.Tests.Unit --configuration Release
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter '/*/*/DependencyInjectionTests/*'
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe
- npm run build --prefix docs

Closes #1016. Refs #1022.