### PR TITLE
perf(consumer): remove pending fetch allocs

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -30,16 +30,28 @@ namespace Dekaf.Consumer;
 internal sealed class PendingFetchData : IDisposable
 {
     // Pool for reusing PendingFetchData instances to eliminate per-partition-per-fetch allocation.
-    // Typically 1-6 instances per fetch cycle. Soft limit avoids ConcurrentStack.Count overhead.
-    private static readonly ConcurrentStack<PendingFetchData> s_pool = new();
-    private static int s_poolCount;
+    // LockFreeStack avoids the ConcurrentStack node allocation on every return to the pool.
     private const int DefaultMaxPoolSize = 128;
     private static int s_maxPoolSize = DefaultMaxPoolSize;
+    private static LockFreeStack<PendingFetchData> s_pool = new(DefaultMaxPoolSize);
 
     internal static int MaxPoolSizeValue => Volatile.Read(ref s_maxPoolSize);
 
-    internal static void RatchetPoolSize(int newSize) =>
-        InterlockedHelper.RatchetUp(ref s_maxPoolSize, newSize);
+    internal static void RatchetPoolSize(int newSize)
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref s_maxPoolSize);
+            if (newSize <= current)
+                return;
+
+            if (Interlocked.CompareExchange(ref s_maxPoolSize, newSize, current) == current)
+            {
+                Volatile.Write(ref s_pool, new LockFreeStack<PendingFetchData>(newSize));
+                return;
+            }
+        }
+    }
 
     private IReadOnlyList<RecordBatch> _batches = null!;
     private Dictionary<long, Queue<long>>? _abortedProducers;
@@ -53,9 +65,20 @@ internal sealed class PendingFetchData : IDisposable
     public int PartitionIndex { get; private set; }
 
     /// <summary>
-    /// Cached activity name to avoid per-record string interpolation in consume loop.
+    /// Cached activity name for tracing. Lazily created so no-listener consume paths avoid
+    /// the per-fetch string allocation.
     /// </summary>
-    internal string ActivityName { get; private set; } = null!;
+    private string? _activityName;
+
+    internal string ActivityName
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            var activityName = _activityName;
+            return activityName ?? CreateActivityName();
+        }
+    }
 
     /// <summary>
     /// Cached TopicPartition to avoid per-message allocation in consume loop.
@@ -97,7 +120,7 @@ internal sealed class PendingFetchData : IDisposable
         var instance = Rent();
         instance.Topic = topic;
         instance.PartitionIndex = partitionIndex;
-        instance.ActivityName = activityName ?? $"{topic} receive";
+        instance._activityName = activityName;
         instance.TopicPartition = new TopicPartition(topic, partitionIndex);
         instance._batches = batches;
         instance._memoryOwner = memoryOwner;
@@ -123,13 +146,20 @@ internal sealed class PendingFetchData : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static PendingFetchData Rent()
     {
-        if (s_pool.TryPop(out var instance))
+        if (Volatile.Read(ref s_pool).TryPop(out var instance))
         {
-            Interlocked.Decrement(ref s_poolCount);
             Volatile.Write(ref instance._disposed, 0);
             return instance;
         }
         return new PendingFetchData();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private string CreateActivityName()
+    {
+        var activityName = string.Concat(Topic, " receive");
+        _activityName = activityName;
+        return activityName;
     }
 
     /// <summary>
@@ -345,10 +375,12 @@ internal sealed class PendingFetchData : IDisposable
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
-        // Dispose all batches to mark them as disposed
-        foreach (var batch in _batches)
+        // Dispose all batches to mark them as disposed.
+        // Indexing avoids boxing/enumerator allocation from the IReadOnlyList<T> interface.
+        var batches = _batches;
+        for (var i = 0; i < batches.Count; i++)
         {
-            batch.Dispose();
+            batches[i].Dispose();
         }
 
         // Return the batch list to the pool for reuse
@@ -383,17 +415,10 @@ internal sealed class PendingFetchData : IDisposable
         PartitionIndex = 0;
         TopicPartition = default;
         Topic = null!;
-        ActivityName = null!;
+        _activityName = null;
         _abortedProducers?.Clear();
 
-        // Soft limit: the check-then-act is intentionally non-atomic.
-        // Under high concurrency, the pool may briefly exceed the max by a few items.
-        // This is acceptable — avoiding a CAS loop keeps the return path lock-free.
-        if (Volatile.Read(ref s_poolCount) < Volatile.Read(ref s_maxPoolSize))
-        {
-            s_pool.Push(this);
-            Interlocked.Increment(ref s_poolCount);
-        }
+        Volatile.Read(ref s_pool).TryPush(this);
     }
 }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Protocol.Records;
 
@@ -5,6 +6,9 @@ namespace Dekaf.Tests.Unit.Consumer;
 
 public class PendingFetchDataTests
 {
+    private static readonly FieldInfo ActivityNameField = typeof(PendingFetchData)
+        .GetField("_activityName", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
     [Test]
     public async Task Constructor_WithActivityName_UsesCachedValue()
     {
@@ -23,7 +27,7 @@ public class PendingFetchDataTests
     }
 
     [Test]
-    public async Task Constructor_WithoutActivityName_GeneratesActivityName()
+    public async Task Constructor_WithoutActivityName_DefersActivityNameAllocation()
     {
         // Arrange
         const string topic = "my-topic";
@@ -33,8 +37,24 @@ public class PendingFetchDataTests
             partitionIndex: 0,
             batches: Array.Empty<RecordBatch>());
 
-        // Assert - falls back to string interpolation
+        // Assert - no tracing listener has requested the activity name yet.
+        await Assert.That(ActivityNameField.GetValue(pending)).IsNull();
+    }
+
+    [Test]
+    public async Task ActivityName_WithoutProvidedName_GeneratesOnDemand()
+    {
+        // Arrange
+        const string topic = "my-topic";
+
+        using var pending = PendingFetchData.Create(
+            topic,
+            partitionIndex: 0,
+            batches: Array.Empty<RecordBatch>());
+
+        // Assert - falls back to lazy activity name creation
         await Assert.That(pending.ActivityName).IsEqualTo("my-topic receive");
+        await Assert.That(ActivityNameField.GetValue(pending)).IsSameReferenceAs(pending.ActivityName);
     }
 
     [Test]
@@ -97,7 +117,7 @@ public class PendingFetchDataTests
     public async Task RatchetPoolSize_DoesNotDecrease()
     {
         // Ratchet to a known high value first to avoid ordering dependency with other tests
-        PendingFetchData.RatchetPoolSize(50_000);
+        PendingFetchData.RatchetPoolSize(PendingFetchData.MaxPoolSizeValue + 100);
         var current = PendingFetchData.MaxPoolSizeValue;
 
         // Try to ratchet down — should be no-op

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerHotPathBenchmarks.cs
@@ -1,0 +1,145 @@
+using System.Collections;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Consumer hot-path allocation benchmarks over already-parsed fetch records.
+/// The setup mirrors the consume loop after protocol parsing so serializer payload
+/// allocation is measured separately from batch/record traversal overhead.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 3, iterationCount: 10)]
+public class ConsumerHotPathBenchmarks
+{
+    private const int MessageCount = 1_000;
+
+    private readonly SingleRecordBatchList _batchList = new();
+    private Record[] _records = null!;
+    private string _topic = null!;
+    private long _timestampMs;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _topic = "consumer-hot-path";
+        _timestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        _records = new Record[MessageCount];
+
+        for (var i = 0; i < MessageCount; i++)
+        {
+            var key = Encoding.UTF8.GetBytes($"key-{i}");
+            var value = Encoding.UTF8.GetBytes($"value-{i}");
+
+            _records[i] = new Record
+            {
+                OffsetDelta = i,
+                TimestampDelta = i,
+                Key = key,
+                Value = value,
+                IsKeyNull = false,
+                IsValueNull = false,
+                Headers = null,
+                HeaderCount = 0,
+            };
+        }
+
+        using var pending = CreatePendingFetchData();
+        var batch = new ConsumeRawBatch(pending);
+        foreach (var _ in batch)
+        {
+        }
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = MessageCount, Description = "Raw batch enumerate")]
+    public int ConsumeRawBatch_Enumerate()
+    {
+        using var pending = CreatePendingFetchData();
+        var batch = new ConsumeRawBatch(pending);
+        var bytes = 0;
+
+        foreach (var record in batch)
+        {
+            bytes += record.Value.Length;
+        }
+
+        return bytes;
+    }
+
+    [Benchmark(OperationsPerInvoke = MessageCount, Description = "Typed batch raw bytes enumerate")]
+    public int ConsumeBatch_RawBytes_Enumerate()
+    {
+        using var pending = CreatePendingFetchData();
+        var batch = new ConsumeBatch<Ignore, ReadOnlyMemory<byte>>(
+            pending,
+            Serializers.Ignore,
+            Serializers.RawBytes);
+        var bytes = 0;
+
+        foreach (var result in batch)
+        {
+            bytes += result.Value.Length;
+        }
+
+        return bytes;
+    }
+
+    [Benchmark(OperationsPerInvoke = MessageCount, Description = "Typed batch string deserialize")]
+    public int ConsumeBatch_String_Deserialize()
+    {
+        using var pending = CreatePendingFetchData();
+        var batch = new ConsumeBatch<string, string>(
+            pending,
+            Serializers.String,
+            Serializers.String);
+        var chars = 0;
+
+        foreach (var result in batch)
+        {
+            chars += result.Value.Length;
+        }
+
+        return chars;
+    }
+
+    private PendingFetchData CreatePendingFetchData()
+    {
+        var recordBatch = RecordBatch.RentFromPool();
+        recordBatch.BaseOffset = 0;
+        recordBatch.BaseTimestamp = _timestampMs;
+        recordBatch.MaxTimestamp = _timestampMs + MessageCount - 1;
+        recordBatch.LastOffsetDelta = MessageCount - 1;
+        recordBatch.Attributes = RecordBatchAttributes.None;
+        recordBatch.Records = _records;
+
+        _batchList.Batch = recordBatch;
+        var pending = PendingFetchData.Create(_topic, partitionIndex: 0, _batchList);
+        pending.EagerParseAll();
+        return pending;
+    }
+
+    private sealed class SingleRecordBatchList : IReadOnlyList<RecordBatch>
+    {
+        public RecordBatch Batch { get; set; } = null!;
+
+        public int Count => 1;
+
+        public RecordBatch this[int index] => index == 0
+            ? Batch
+            : throw new ArgumentOutOfRangeException(nameof(index));
+
+        public IEnumerator<RecordBatch> GetEnumerator()
+        {
+            yield return Batch;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the `PendingFetchData` `ConcurrentStack` pool with the existing array-backed `LockFreeStack`
- avoid fallback activity-name string creation until tracing actually requests it
- dispose pending fetch batches by index to avoid `IReadOnlyList<T>` enumerator allocation
- add `ConsumerHotPathBenchmarks` to track raw, raw-bytes typed, and string deserialization allocation

Closes #757

## Benchmark
`dotnet run --project tools\Dekaf.Benchmarks\Dekaf.Benchmarks.csproj --configuration Release --no-build -- --filter "*ConsumerHotPathBenchmarks*"`

| Method | Mean | Allocated |
| --- | ---: | ---: |
| Raw batch enumerate | 2.739 ns | 0 B |
| Typed batch raw bytes enumerate | 31.620 ns | 0 B |
| Typed batch string deserialize | 61.955 ns | 80 B |

## Validation
- `dotnet restore tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj`
- `dotnet restore tools\Dekaf.Benchmarks\Dekaf.Benchmarks.csproj`
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `dotnet build tools\Dekaf.Benchmarks\Dekaf.Benchmarks.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PendingFetchDataTests/*" --minimum-expected-tests 1 --maximum-parallel-tests 1 --log-level Information`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumeBatchTests/*" --minimum-expected-tests 1 --maximum-parallel-tests 1 --log-level Information`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumeRawBatchTests/*" --minimum-expected-tests 1 --maximum-parallel-tests 1 --log-level Information`
- `git diff --cached --check`