### PR TITLE
Add DescribeTopicPartitions admin API

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -60,6 +60,18 @@ public sealed class AdminClient : IAdminClient
             loggerFactory?.CreateLogger<ClientTelemetryManager>());
     }
 
+    internal AdminClient(
+        AdminClientOptions options,
+        IConnectionPool connectionPool,
+        MetadataManager metadataManager,
+        ILoggerFactory? loggerFactory = null)
+    {
+        _options = options;
+        _logger = loggerFactory?.CreateLogger<AdminClient>();
+        _connectionPool = connectionPool;
+        _metadataManager = metadataManager;
+    }
+
     public ClusterMetadata Metadata => _metadataManager.Metadata;
 
     public async ValueTask CreateTopicsAsync(
@@ -296,6 +308,119 @@ public sealed class AdminClient : IAdminClient
         return result;
     }
 
+    public async ValueTask<IReadOnlyDictionary<string, TopicDescription>> DescribeTopicPartitionsAsync(
+        IEnumerable<string> topicNames,
+        DescribeTopicPartitionsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var topicList = topicNames.ToList();
+        if (topicList.Count == 0)
+        {
+            return new Dictionary<string, TopicDescription>();
+        }
+
+        var opts = options ?? new DescribeTopicPartitionsOptions();
+        ArgumentOutOfRangeException.ThrowIfLessThan(opts.ResponsePartitionLimit, 1);
+
+        var result = new Dictionary<string, TopicDescription>(StringComparer.Ordinal);
+        DescribeTopicPartitionsCursor? cursor = null;
+
+        do
+        {
+            var page = await DescribeTopicPartitionsPageAsync(
+                topicList,
+                new DescribeTopicPartitionsPageOptions
+                {
+                    ResponsePartitionLimit = opts.ResponsePartitionLimit,
+                    Cursor = cursor
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            MergeTopicPartitionPage(result, page.Topics.Values);
+            cursor = page.NextCursor;
+        } while (cursor is not null);
+
+        return result;
+    }
+
+    public async ValueTask<DescribeTopicPartitionsPage> DescribeTopicPartitionsPageAsync(
+        IEnumerable<string> topicNames,
+        DescribeTopicPartitionsPageOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var topicList = topicNames.ToList();
+        if (topicList.Count == 0)
+        {
+            return new DescribeTopicPartitionsPage
+            {
+                Topics = new Dictionary<string, TopicDescription>()
+            };
+        }
+
+        var opts = options ?? new DescribeTopicPartitionsPageOptions();
+        ArgumentOutOfRangeException.ThrowIfLessThan(opts.ResponsePartitionLimit, 1);
+
+        if (!_metadataManager.HasApiKey(Protocol.ApiKey.DescribeTopicPartitions))
+        {
+            throw new Errors.BrokerVersionException("Broker does not support DescribeTopicPartitions (API key 75).");
+        }
+
+        return await WithRetryAsync(async () =>
+        {
+            var brokers = _metadataManager.Metadata.GetBrokers();
+            if (brokers.Count == 0)
+            {
+                throw new InvalidOperationException("No brokers available");
+            }
+
+            var connection = await _connectionPool.GetConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+            var request = new DescribeTopicPartitionsRequest
+            {
+                Topics = topicList.Select(static name => new DescribeTopicPartitionsRequestTopic
+                {
+                    Name = name
+                }).ToList(),
+                ResponsePartitionLimit = opts.ResponsePartitionLimit,
+                Cursor = opts.Cursor is null
+                    ? null
+                    : new DescribeTopicPartitionsRequestCursor
+                    {
+                        TopicName = opts.Cursor.TopicName,
+                        PartitionIndex = opts.Cursor.PartitionIndex
+                    }
+            };
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.DescribeTopicPartitions,
+                DescribeTopicPartitionsRequest.LowestSupportedVersion,
+                DescribeTopicPartitionsRequest.HighestSupportedVersion);
+
+            var response = await connection.SendAsync<DescribeTopicPartitionsRequest, DescribeTopicPartitionsResponse>(
+                request,
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            var topics = response.Topics
+                .Select(ToTopicDescription)
+                .ToDictionary(static t => t.Name, StringComparer.Ordinal);
+
+            return new DescribeTopicPartitionsPage
+            {
+                ThrottleTimeMs = response.ThrottleTimeMs,
+                Topics = topics,
+                NextCursor = response.NextCursor is null
+                    ? null
+                    : new DescribeTopicPartitionsCursor
+                    {
+                        TopicName = response.NextCursor.TopicName,
+                        PartitionIndex = response.NextCursor.PartitionIndex
+                    }
+            };
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
     public async ValueTask<ClusterDescription> DescribeClusterAsync(CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
@@ -307,6 +432,51 @@ public sealed class AdminClient : IAdminClient
             Nodes = _metadataManager.Metadata.GetBrokers()
         };
     }
+
+    private static void MergeTopicPartitionPage(
+        Dictionary<string, TopicDescription> result,
+        IEnumerable<TopicDescription> pageTopics)
+    {
+        foreach (var topic in pageTopics)
+        {
+            if (!result.TryGetValue(topic.Name, out var existing))
+            {
+                result[topic.Name] = topic;
+                continue;
+            }
+
+            result[topic.Name] = new TopicDescription
+            {
+                Name = topic.Name,
+                TopicId = topic.TopicId,
+                IsInternal = topic.IsInternal,
+                ErrorCode = topic.ErrorCode,
+                TopicAuthorizedOperations = topic.TopicAuthorizedOperations,
+                Partitions = existing.Partitions.Concat(topic.Partitions).ToList()
+            };
+        }
+    }
+
+    private static TopicDescription ToTopicDescription(DescribeTopicPartitionsResponseTopic topic) => new()
+    {
+        Name = topic.Name ?? string.Empty,
+        TopicId = topic.TopicId,
+        IsInternal = topic.IsInternal,
+        ErrorCode = topic.ErrorCode,
+        TopicAuthorizedOperations = topic.TopicAuthorizedOperations,
+        Partitions = topic.Partitions.Select(static p => new PartitionInfo
+        {
+            PartitionIndex = p.PartitionIndex,
+            LeaderId = p.LeaderId,
+            LeaderEpoch = p.LeaderEpoch,
+            ReplicaNodes = p.ReplicaNodes,
+            IsrNodes = p.IsrNodes,
+            EligibleLeaderReplicas = p.EligibleLeaderReplicas,
+            LastKnownElr = p.LastKnownElr,
+            OfflineReplicas = p.OfflineReplicas,
+            ErrorCode = p.ErrorCode
+        }).ToList()
+    };
 
     public async ValueTask<IReadOnlyDictionary<string, GroupDescription>> DescribeConsumerGroupsAsync(
         IEnumerable<string> groupIds,

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -23,6 +23,7 @@ public sealed class AdminClient : IAdminClient
     private readonly MetadataManager _metadataManager;
     private readonly ClientTelemetryManager _telemetryManager;
     private readonly ILogger<AdminClient>? _logger;
+    private readonly bool _ownsResources;
     private int _telemetryStartAttempted;
     private int _disposed;
 
@@ -30,6 +31,7 @@ public sealed class AdminClient : IAdminClient
     {
         _options = options;
         _logger = loggerFactory?.CreateLogger<AdminClient>();
+        _ownsResources = true;
 
         _connectionPool = new ConnectionPool(
             options.ClientId,
@@ -64,12 +66,18 @@ public sealed class AdminClient : IAdminClient
         AdminClientOptions options,
         IConnectionPool connectionPool,
         MetadataManager metadataManager,
-        ILoggerFactory? loggerFactory = null)
+        ILoggerFactory? loggerFactory = null,
+        bool ownsResources = false)
     {
         _options = options;
         _logger = loggerFactory?.CreateLogger<AdminClient>();
         _connectionPool = connectionPool;
         _metadataManager = metadataManager;
+        _telemetryManager = new ClientTelemetryManager(
+            _connectionPool,
+            _metadataManager,
+            loggerFactory?.CreateLogger<ClientTelemetryManager>());
+        _ownsResources = ownsResources;
     }
 
     public ClusterMetadata Metadata => _metadataManager.Metadata;
@@ -313,16 +321,18 @@ public sealed class AdminClient : IAdminClient
         DescribeTopicPartitionsOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        var opts = options ?? new DescribeTopicPartitionsOptions();
+        ArgumentOutOfRangeException.ThrowIfLessThan(opts.ResponsePartitionLimit, 1);
+
         var topicList = topicNames.ToList();
         if (topicList.Count == 0)
         {
             return new Dictionary<string, TopicDescription>();
         }
 
-        var opts = options ?? new DescribeTopicPartitionsOptions();
-        ArgumentOutOfRangeException.ThrowIfLessThan(opts.ResponsePartitionLimit, 1);
-
         var result = new Dictionary<string, TopicDescription>(StringComparer.Ordinal);
+        var partitionAccumulator = new Dictionary<string, List<PartitionInfo>>(StringComparer.Ordinal);
+        var seenCursors = new HashSet<(string TopicName, int PartitionIndex)>();
         DescribeTopicPartitionsCursor? cursor = null;
 
         do
@@ -336,8 +346,12 @@ public sealed class AdminClient : IAdminClient
                 },
                 cancellationToken).ConfigureAwait(false);
 
-            MergeTopicPartitionPage(result, page.Topics.Values);
+            MergeTopicPartitionPage(result, partitionAccumulator, page.Topics.Values);
             cursor = page.NextCursor;
+            if (cursor is not null && !seenCursors.Add((cursor.TopicName, cursor.PartitionIndex)))
+            {
+                throw new InvalidOperationException("Broker returned a repeated DescribeTopicPartitions cursor.");
+            }
         } while (cursor is not null);
 
         return result;
@@ -348,7 +362,8 @@ public sealed class AdminClient : IAdminClient
         DescribeTopicPartitionsPageOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        var opts = options ?? new DescribeTopicPartitionsPageOptions();
+        ArgumentOutOfRangeException.ThrowIfLessThan(opts.ResponsePartitionLimit, 1);
 
         var topicList = topicNames.ToList();
         if (topicList.Count == 0)
@@ -359,8 +374,7 @@ public sealed class AdminClient : IAdminClient
             };
         }
 
-        var opts = options ?? new DescribeTopicPartitionsPageOptions();
-        ArgumentOutOfRangeException.ThrowIfLessThan(opts.ResponsePartitionLimit, 1);
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
         if (!_metadataManager.HasApiKey(Protocol.ApiKey.DescribeTopicPartitions))
         {
@@ -435,14 +449,19 @@ public sealed class AdminClient : IAdminClient
 
     private static void MergeTopicPartitionPage(
         Dictionary<string, TopicDescription> result,
+        Dictionary<string, List<PartitionInfo>> partitionAccumulator,
         IEnumerable<TopicDescription> pageTopics)
     {
         foreach (var topic in pageTopics)
         {
-            if (!result.TryGetValue(topic.Name, out var existing))
+            if (!partitionAccumulator.TryGetValue(topic.Name, out var partitions))
             {
-                result[topic.Name] = topic;
-                continue;
+                partitions = new List<PartitionInfo>(topic.Partitions);
+                partitionAccumulator[topic.Name] = partitions;
+            }
+            else
+            {
+                partitions.AddRange(topic.Partitions);
             }
 
             result[topic.Name] = new TopicDescription
@@ -452,7 +471,7 @@ public sealed class AdminClient : IAdminClient
                 IsInternal = topic.IsInternal,
                 ErrorCode = topic.ErrorCode,
                 TopicAuthorizedOperations = topic.TopicAuthorizedOperations,
-                Partitions = existing.Partitions.Concat(topic.Partitions).ToList()
+                Partitions = partitions
             };
         }
     }
@@ -2266,8 +2285,12 @@ public sealed class AdminClient : IAdminClient
         var telemetryStopMs = Math.Max(1, Math.Min(_options.RequestTimeoutMs, 5000));
         await _telemetryManager.StopAsync(TimeSpan.FromMilliseconds(telemetryStopMs)).ConfigureAwait(false);
         await _telemetryManager.DisposeAsync().ConfigureAwait(false);
-        await _metadataManager.DisposeAsync().ConfigureAwait(false);
-        await _connectionPool.DisposeAsync().ConfigureAwait(false);
+
+        if (_ownsResources)
+        {
+            await _metadataManager.DisposeAsync().ConfigureAwait(false);
+            await _connectionPool.DisposeAsync().ConfigureAwait(false);
+        }
     }
 }
 

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -29,6 +29,23 @@ public interface IAdminClient : IAsyncDisposable
     ValueTask<IReadOnlyDictionary<string, TopicDescription>> DescribeTopicsAsync(IEnumerable<string> topicNames, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Describes topic partitions using the paginated DescribeTopicPartitions API.
+    /// Automatically follows broker cursors until all pages are read.
+    /// </summary>
+    ValueTask<IReadOnlyDictionary<string, TopicDescription>> DescribeTopicPartitionsAsync(
+        IEnumerable<string> topicNames,
+        DescribeTopicPartitionsOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Describes a single page of topic partitions using the DescribeTopicPartitions API.
+    /// </summary>
+    ValueTask<DescribeTopicPartitionsPage> DescribeTopicPartitionsPageAsync(
+        IEnumerable<string> topicNames,
+        DescribeTopicPartitionsPageOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Describes the cluster.
     /// </summary>
     ValueTask<ClusterDescription> DescribeClusterAsync(CancellationToken cancellationToken = default);
@@ -329,6 +346,47 @@ public sealed class TopicDescription
     /// <see cref="Protocol.ErrorCode.TopicAuthorizationFailed"/>) rather than failing the whole call.
     /// </summary>
     public Protocol.ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// 32-bit bitfield representing authorized operations for this topic.
+    /// </summary>
+    public int TopicAuthorizedOperations { get; init; } = int.MinValue;
+}
+
+/// <summary>
+/// Options for auto-paginated DescribeTopicPartitions.
+/// </summary>
+public sealed class DescribeTopicPartitionsOptions
+{
+    public int ResponsePartitionLimit { get; init; } = 2000;
+}
+
+/// <summary>
+/// Options for a single DescribeTopicPartitions page.
+/// </summary>
+public sealed class DescribeTopicPartitionsPageOptions
+{
+    public int ResponsePartitionLimit { get; init; } = 2000;
+    public DescribeTopicPartitionsCursor? Cursor { get; init; }
+}
+
+/// <summary>
+/// A pagination cursor returned by DescribeTopicPartitions.
+/// </summary>
+public sealed class DescribeTopicPartitionsCursor
+{
+    public required string TopicName { get; init; }
+    public int PartitionIndex { get; init; }
+}
+
+/// <summary>
+/// A single DescribeTopicPartitions response page.
+/// </summary>
+public sealed class DescribeTopicPartitionsPage
+{
+    public int ThrottleTimeMs { get; init; }
+    public required IReadOnlyDictionary<string, TopicDescription> Topics { get; init; }
+    public DescribeTopicPartitionsCursor? NextCursor { get; init; }
 }
 
 /// <summary>

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -348,7 +348,9 @@ public sealed class TopicDescription
     public Protocol.ErrorCode ErrorCode { get; init; }
 
     /// <summary>
-    /// 32-bit bitfield representing authorized operations for this topic.
+    /// 32-bit bitfield representing authorized operations for this topic. This is populated by
+    /// DescribeTopicPartitions APIs; APIs that do not return authorized operations leave the default
+    /// <see cref="int.MinValue"/> sentinel.
     /// </summary>
     public int TopicAuthorizedOperations { get; init; } = int.MinValue;
 }

--- a/src/Dekaf/Metadata/ClusterMetadata.cs
+++ b/src/Dekaf/Metadata/ClusterMetadata.cs
@@ -549,6 +549,8 @@ public sealed class PartitionInfo
     public int LeaderEpoch { get; init; } = -1;
     public required IReadOnlyList<int> ReplicaNodes { get; init; }
     public required IReadOnlyList<int> IsrNodes { get; init; }
+    public IReadOnlyList<int>? EligibleLeaderReplicas { get; init; }
+    public IReadOnlyList<int>? LastKnownElr { get; init; }
     public IReadOnlyList<int>? OfflineReplicas { get; init; }
     public ErrorCode ErrorCode { get; init; }
 }

--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -822,6 +822,26 @@ public ref struct KafkaProtocolReader
     }
 
     /// <summary>
+    /// Reads a compact nullable array with unsigned varint length prefix (flexible format).
+    /// </summary>
+    public T[]? ReadCompactNullableArray<T>(ReadFunc<T> readItem)
+    {
+        var length = ReadUnsignedVarInt() - 1;
+        if (length < 0)
+            return null;
+
+        if (length == 0)
+            return [];
+
+        var result = new T[length];
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = readItem(ref this);
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Skips tagged fields (for flexible versions).
     /// </summary>
     public void SkipTaggedFields()
@@ -902,6 +922,27 @@ public ref struct KafkaProtocolReader
     {
         var length = ReadUnsignedVarInt() - 1;
         if (length <= 0)
+            return [];
+
+        var result = new T[length];
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = readItem(ref this, state);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Reads a compact nullable array with unsigned varint length prefix (flexible format).
+    /// State-passing overload to avoid closure allocations.
+    /// </summary>
+    public T[]? ReadCompactNullableArray<T, TState>(ReadFunc<T, TState> readItem, TState state)
+    {
+        var length = ReadUnsignedVarInt() - 1;
+        if (length < 0)
+            return null;
+
+        if (length == 0)
             return [];
 
         var result = new T[length];

--- a/src/Dekaf/Protocol/Messages/DescribeTopicPartitionsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeTopicPartitionsRequest.cs
@@ -1,0 +1,77 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DescribeTopicPartitions request (API key 75).
+/// Describes topic partitions with broker-side pagination.
+/// </summary>
+public sealed class DescribeTopicPartitionsRequest : IKafkaRequest<DescribeTopicPartitionsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.DescribeTopicPartitions;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// The topics to fetch details for.
+    /// </summary>
+    public required IReadOnlyList<DescribeTopicPartitionsRequestTopic> Topics { get; init; }
+
+    /// <summary>
+    /// The maximum number of partitions included in the response.
+    /// </summary>
+    public int ResponsePartitionLimit { get; init; } = 2000;
+
+    /// <summary>
+    /// The first topic and partition index to fetch details for, or null for the first page.
+    /// </summary>
+    public DescribeTopicPartitionsRequestCursor? Cursor { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactArray(
+            Topics,
+            static (ref KafkaProtocolWriter w, DescribeTopicPartitionsRequestTopic topic) => topic.Write(ref w));
+
+        writer.WriteInt32(ResponsePartitionLimit);
+
+        DescribeTopicPartitionsRequestCursor.WriteNullable(ref writer, Cursor);
+
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// Topic requested by DescribeTopicPartitions.
+/// </summary>
+public sealed class DescribeTopicPartitionsRequestTopic
+{
+    public required string Name { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(Name);
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// Cursor used by DescribeTopicPartitions pagination.
+/// </summary>
+public sealed class DescribeTopicPartitionsRequestCursor
+{
+    public required string TopicName { get; init; }
+    public int PartitionIndex { get; init; }
+
+    public static void WriteNullable(ref KafkaProtocolWriter writer, DescribeTopicPartitionsRequestCursor? cursor)
+    {
+        if (cursor is null)
+        {
+            writer.WriteInt8(-1);
+            return;
+        }
+
+        writer.WriteInt8(1);
+        writer.WriteCompactString(cursor.TopicName);
+        writer.WriteInt32(cursor.PartitionIndex);
+        writer.WriteEmptyTaggedFields();
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DescribeTopicPartitionsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeTopicPartitionsResponse.cs
@@ -85,8 +85,8 @@ public sealed class DescribeTopicPartitionsResponsePartition
         var leaderEpoch = reader.ReadInt32();
         var replicaNodes = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
         var isrNodes = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
-        var eligibleLeaderReplicas = ReadCompactNullableInt32Array(ref reader);
-        var lastKnownElr = ReadCompactNullableInt32Array(ref reader);
+        var eligibleLeaderReplicas = reader.ReadCompactNullableArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
+        var lastKnownElr = reader.ReadCompactNullableArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
         var offlineReplicas = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
 
         reader.SkipTaggedFields();
@@ -103,28 +103,6 @@ public sealed class DescribeTopicPartitionsResponsePartition
             LastKnownElr = lastKnownElr,
             OfflineReplicas = offlineReplicas
         };
-    }
-
-    private static IReadOnlyList<int>? ReadCompactNullableInt32Array(ref KafkaProtocolReader reader)
-    {
-        var length = reader.ReadUnsignedVarInt() - 1;
-        if (length < 0)
-        {
-            return null;
-        }
-
-        if (length == 0)
-        {
-            return [];
-        }
-
-        var result = new int[length];
-        for (var i = 0; i < length; i++)
-        {
-            result[i] = reader.ReadInt32();
-        }
-
-        return result;
     }
 }
 

--- a/src/Dekaf/Protocol/Messages/DescribeTopicPartitionsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeTopicPartitionsResponse.cs
@@ -1,0 +1,154 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DescribeTopicPartitions response (API key 75).
+/// Contains topic partition details and an optional pagination cursor.
+/// </summary>
+public sealed class DescribeTopicPartitionsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.DescribeTopicPartitions;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    public int ThrottleTimeMs { get; init; }
+    public required IReadOnlyList<DescribeTopicPartitionsResponseTopic> Topics { get; init; }
+    public DescribeTopicPartitionsResponseCursor? NextCursor { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var topics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => DescribeTopicPartitionsResponseTopic.Read(ref r));
+        var nextCursor = DescribeTopicPartitionsResponseCursor.ReadNullable(ref reader);
+
+        reader.SkipTaggedFields();
+
+        return new DescribeTopicPartitionsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            Topics = topics,
+            NextCursor = nextCursor
+        };
+    }
+}
+
+public sealed class DescribeTopicPartitionsResponseTopic
+{
+    public ErrorCode ErrorCode { get; init; }
+    public string? Name { get; init; }
+    public Guid TopicId { get; init; }
+    public bool IsInternal { get; init; }
+    public required IReadOnlyList<DescribeTopicPartitionsResponsePartition> Partitions { get; init; }
+    public int TopicAuthorizedOperations { get; init; } = int.MinValue;
+
+    public static DescribeTopicPartitionsResponseTopic Read(ref KafkaProtocolReader reader)
+    {
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var name = reader.ReadCompactString();
+        var topicId = reader.ReadUuid();
+        var isInternal = reader.ReadBoolean();
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => DescribeTopicPartitionsResponsePartition.Read(ref r));
+        var topicAuthorizedOperations = reader.ReadInt32();
+
+        reader.SkipTaggedFields();
+
+        return new DescribeTopicPartitionsResponseTopic
+        {
+            ErrorCode = errorCode,
+            Name = name,
+            TopicId = topicId,
+            IsInternal = isInternal,
+            Partitions = partitions,
+            TopicAuthorizedOperations = topicAuthorizedOperations
+        };
+    }
+}
+
+public sealed class DescribeTopicPartitionsResponsePartition
+{
+    public ErrorCode ErrorCode { get; init; }
+    public int PartitionIndex { get; init; }
+    public int LeaderId { get; init; }
+    public int LeaderEpoch { get; init; } = -1;
+    public required IReadOnlyList<int> ReplicaNodes { get; init; }
+    public required IReadOnlyList<int> IsrNodes { get; init; }
+    public IReadOnlyList<int>? EligibleLeaderReplicas { get; init; }
+    public IReadOnlyList<int>? LastKnownElr { get; init; }
+    public required IReadOnlyList<int> OfflineReplicas { get; init; }
+
+    public static DescribeTopicPartitionsResponsePartition Read(ref KafkaProtocolReader reader)
+    {
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var partitionIndex = reader.ReadInt32();
+        var leaderId = reader.ReadInt32();
+        var leaderEpoch = reader.ReadInt32();
+        var replicaNodes = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
+        var isrNodes = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
+        var eligibleLeaderReplicas = ReadCompactNullableInt32Array(ref reader);
+        var lastKnownElr = ReadCompactNullableInt32Array(ref reader);
+        var offlineReplicas = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
+
+        reader.SkipTaggedFields();
+
+        return new DescribeTopicPartitionsResponsePartition
+        {
+            ErrorCode = errorCode,
+            PartitionIndex = partitionIndex,
+            LeaderId = leaderId,
+            LeaderEpoch = leaderEpoch,
+            ReplicaNodes = replicaNodes,
+            IsrNodes = isrNodes,
+            EligibleLeaderReplicas = eligibleLeaderReplicas,
+            LastKnownElr = lastKnownElr,
+            OfflineReplicas = offlineReplicas
+        };
+    }
+
+    private static IReadOnlyList<int>? ReadCompactNullableInt32Array(ref KafkaProtocolReader reader)
+    {
+        var length = reader.ReadUnsignedVarInt() - 1;
+        if (length < 0)
+        {
+            return null;
+        }
+
+        if (length == 0)
+        {
+            return [];
+        }
+
+        var result = new int[length];
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = reader.ReadInt32();
+        }
+
+        return result;
+    }
+}
+
+public sealed class DescribeTopicPartitionsResponseCursor
+{
+    public required string TopicName { get; init; }
+    public int PartitionIndex { get; init; }
+
+    public static DescribeTopicPartitionsResponseCursor? ReadNullable(ref KafkaProtocolReader reader)
+    {
+        var marker = reader.ReadInt8();
+        if (marker < 0)
+        {
+            return null;
+        }
+
+        var topicName = reader.ReadCompactString() ?? string.Empty;
+        var partitionIndex = reader.ReadInt32();
+        reader.SkipTaggedFields();
+
+        return new DescribeTopicPartitionsResponseCursor
+        {
+            TopicName = topicName,
+            PartitionIndex = partitionIndex
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Integration/AdminClientTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminClientTests.cs
@@ -840,5 +840,38 @@ public class AdminClientTests(KafkaTestContainer kafka) : KafkaIntegrationTest(k
         await Assert.That(description.Partitions.Count).IsEqualTo(3);
     }
 
+    [Test]
+    [SupportsKafka(370)]
+    public async Task DescribeTopicPartitionsAsync_WithPagination_ReturnsAllPartitions()
+    {
+        // Arrange
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 5).ConfigureAwait(false);
+        await using var admin = CreateAdminClient();
+
+        // Act
+        var firstPage = await admin.DescribeTopicPartitionsPageAsync(
+            [topic],
+            new DescribeTopicPartitionsPageOptions { ResponsePartitionLimit = 2 })
+            .ConfigureAwait(false);
+        var descriptions = await admin.DescribeTopicPartitionsAsync(
+            [topic],
+            new DescribeTopicPartitionsOptions { ResponsePartitionLimit = 2 })
+            .ConfigureAwait(false);
+
+        // Assert
+        await Assert.That(firstPage.Topics).ContainsKey(topic);
+        await Assert.That(firstPage.Topics[topic].Partitions.Count).IsLessThanOrEqualTo(2);
+        await Assert.That(firstPage.NextCursor).IsNotNull();
+
+        await Assert.That(descriptions).ContainsKey(topic);
+        var description = descriptions[topic];
+        await Assert.That(description.Name).IsEqualTo(topic);
+        var partitionIndexes = description.Partitions.Select(static p => p.PartitionIndex).ToList();
+        await Assert.That(partitionIndexes.Count).IsEqualTo(5);
+        await Assert.That(partitionIndexes.Distinct().Count()).IsEqualTo(5);
+        await Assert.That(partitionIndexes.Min()).IsEqualTo(0);
+        await Assert.That(partitionIndexes.Max()).IsEqualTo(4);
+    }
+
     #endregion
 }

--- a/tests/Dekaf.Tests.Unit/Admin/AdminDescribeTopicPartitionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminDescribeTopicPartitionsTests.cs
@@ -1,0 +1,309 @@
+using System.Collections.Concurrent;
+using Dekaf.Admin;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public sealed class AdminDescribeTopicPartitionsTests
+{
+    [Test]
+    public async Task DescribeTopicPartitionsPageAsync_SendsCursorAndReturnsNextCursor()
+    {
+        await using var context = new AdminTestContext();
+        context.Connection.Enqueue(PageResponse(
+            "topic-a",
+            partitionIndex: 5,
+            nextCursor: new DescribeTopicPartitionsResponseCursor
+            {
+                TopicName = "topic-a",
+                PartitionIndex = 6
+            }));
+
+        var page = await context.Client.DescribeTopicPartitionsPageAsync(
+            ["topic-a"],
+            new DescribeTopicPartitionsPageOptions
+            {
+                ResponsePartitionLimit = 1,
+                Cursor = new DescribeTopicPartitionsCursor
+                {
+                    TopicName = "topic-a",
+                    PartitionIndex = 5
+                }
+            });
+
+        var request = context.Connection.SingleRequest<DescribeTopicPartitionsRequest>();
+        await Assert.That(request.ResponsePartitionLimit).IsEqualTo(1);
+        await Assert.That(request.Cursor).IsNotNull();
+        await Assert.That(request.Cursor!.TopicName).IsEqualTo("topic-a");
+        await Assert.That(request.Cursor.PartitionIndex).IsEqualTo(5);
+        await Assert.That(page.NextCursor).IsNotNull();
+        await Assert.That(page.NextCursor!.PartitionIndex).IsEqualTo(6);
+        await Assert.That(page.Topics["topic-a"].Partitions[0].PartitionIndex).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task DescribeTopicPartitionsAsync_FollowsCursorsAndMergesTopicPartitions()
+    {
+        await using var context = new AdminTestContext();
+        context.Connection.Enqueue(PageResponse(
+            "topic-a",
+            partitionIndex: 0,
+            nextCursor: new DescribeTopicPartitionsResponseCursor
+            {
+                TopicName = "topic-a",
+                PartitionIndex = 1
+            }));
+        context.Connection.Enqueue(PageResponse(
+            "topic-a",
+            partitionIndex: 1,
+            nextCursor: null));
+
+        var result = await context.Client.DescribeTopicPartitionsAsync(
+            ["topic-a"],
+            new DescribeTopicPartitionsOptions
+            {
+                ResponsePartitionLimit = 1
+            });
+
+        var requests = context.Connection.RequestsOfType<DescribeTopicPartitionsRequest>();
+        await Assert.That(requests.Count).IsEqualTo(2);
+        await Assert.That(requests[0].Cursor).IsNull();
+        await Assert.That(requests[1].Cursor).IsNotNull();
+        await Assert.That(requests[1].Cursor!.PartitionIndex).IsEqualTo(1);
+        await Assert.That(result["topic-a"].Partitions.Select(static p => p.PartitionIndex).ToArray())
+            .IsEquivalentTo([0, 1]);
+    }
+
+    [Test]
+    public async Task DescribeTopicPartitionsPageAsync_MapsElrAndAuthorizedOperations()
+    {
+        await using var context = new AdminTestContext();
+        context.Connection.Enqueue(new DescribeTopicPartitionsResponse
+        {
+            ThrottleTimeMs = 3,
+            Topics =
+            [
+                new DescribeTopicPartitionsResponseTopic
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "topic-a",
+                    TopicId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                    IsInternal = true,
+                    TopicAuthorizedOperations = 123,
+                    Partitions =
+                    [
+                        new DescribeTopicPartitionsResponsePartition
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 1,
+                            LeaderEpoch = 8,
+                            ReplicaNodes = [1, 2],
+                            IsrNodes = [1],
+                            EligibleLeaderReplicas = [2],
+                            LastKnownElr = [1],
+                            OfflineReplicas = [2]
+                        }
+                    ]
+                }
+            ],
+            NextCursor = null
+        });
+
+        var page = await context.Client.DescribeTopicPartitionsPageAsync(["topic-a"]);
+        var topic = page.Topics["topic-a"];
+        var partition = topic.Partitions[0];
+
+        await Assert.That(page.ThrottleTimeMs).IsEqualTo(3);
+        await Assert.That(topic.IsInternal).IsTrue();
+        await Assert.That(topic.TopicAuthorizedOperations).IsEqualTo(123);
+        await Assert.That(partition.EligibleLeaderReplicas).IsEquivalentTo([2]);
+        await Assert.That(partition.LastKnownElr).IsEquivalentTo([1]);
+        await Assert.That(partition.OfflineReplicas).IsEquivalentTo([2]);
+    }
+
+    private static DescribeTopicPartitionsResponse PageResponse(
+        string topicName,
+        int partitionIndex,
+        DescribeTopicPartitionsResponseCursor? nextCursor) => new()
+    {
+        ThrottleTimeMs = 0,
+        Topics =
+        [
+            new DescribeTopicPartitionsResponseTopic
+            {
+                ErrorCode = ErrorCode.None,
+                Name = topicName,
+                TopicId = Guid.Empty,
+                IsInternal = false,
+                Partitions =
+                [
+                    new DescribeTopicPartitionsResponsePartition
+                    {
+                        ErrorCode = ErrorCode.None,
+                        PartitionIndex = partitionIndex,
+                        LeaderId = 0,
+                        LeaderEpoch = -1,
+                        ReplicaNodes = [0],
+                        IsrNodes = [0],
+                        EligibleLeaderReplicas = null,
+                        LastKnownElr = null,
+                        OfflineReplicas = []
+                    }
+                ]
+            }
+        ],
+        NextCursor = nextCursor
+    };
+
+    private sealed class AdminTestContext : IAsyncDisposable
+    {
+        private readonly TestConnectionPool _pool;
+        private readonly MetadataManager _metadataManager;
+
+        public AdminTestContext()
+        {
+            _pool = new TestConnectionPool();
+            _metadataManager = new MetadataManager(_pool, ["localhost:9092"]);
+            _metadataManager.SetApiVersion(ApiKey.DescribeTopicPartitions, 0, 0);
+            _metadataManager.Metadata.Update(new MetadataResponse
+            {
+                Brokers =
+                [
+                    new BrokerMetadata
+                    {
+                        NodeId = 0,
+                        Host = "localhost",
+                        Port = 9092
+                    }
+                ],
+                ClusterId = "test-cluster",
+                ControllerId = 0,
+                Topics = []
+            });
+
+            Client = new AdminClient(
+                new AdminClientOptions
+                {
+                    BootstrapServers = ["localhost:9092"]
+                },
+                _pool,
+                _metadataManager);
+        }
+
+        public AdminClient Client { get; }
+        public TestKafkaConnection Connection => _pool.Connection;
+
+        public async ValueTask DisposeAsync()
+        {
+            await Client.DisposeAsync().ConfigureAwait(false);
+            await _metadataManager.DisposeAsync().ConfigureAwait(false);
+            await _pool.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private sealed class TestConnectionPool : IConnectionPool
+    {
+        public TestKafkaConnection Connection { get; } = new();
+
+        public ValueTask<IKafkaConnection> GetConnectionAsync(int brokerId, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IKafkaConnection>(Connection);
+
+        public ValueTask<IKafkaConnection> GetConnectionByIndexAsync(int brokerId, int index, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IKafkaConnection>(Connection);
+
+        public ValueTask<IKafkaConnection> GetConnectionAsync(string host, int port, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IKafkaConnection>(Connection);
+
+        public void RegisterBroker(int brokerId, string host, int port)
+        {
+        }
+
+        public ValueTask<int> ScaleConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(newCount);
+
+        public ValueTask<IKafkaConnection?> ShrinkConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<IKafkaConnection?>(null);
+
+        public ValueTask RemoveConnectionAsync(int brokerId) => ValueTask.CompletedTask;
+
+        public ValueTask CloseAllAsync() => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class TestKafkaConnection : IKafkaConnection
+    {
+        private readonly ConcurrentQueue<object> _responses = new();
+        private readonly ConcurrentQueue<object> _requests = new();
+
+        public int BrokerId => 0;
+        public string Host => "localhost";
+        public int Port => 9092;
+        public bool IsConnected => true;
+
+        public void Enqueue<TResponse>(TResponse response)
+            where TResponse : IKafkaResponse =>
+            _responses.Enqueue(response);
+
+        public T SingleRequest<T>() => RequestsOfType<T>().Single();
+
+        public IReadOnlyList<T> RequestsOfType<T>() =>
+            _requests.ToArray().OfType<T>().ToArray();
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            _requests.Enqueue(request);
+            if (!_responses.TryDequeue(out var response))
+            {
+                throw new InvalidOperationException($"No queued response for {typeof(TRequest).Name}.");
+            }
+
+            return ValueTask.FromResult((TResponse)response);
+        }
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            ValueTask.CompletedTask;
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            Task.FromResult(default(TResponse)!);
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            ValueTask.CompletedTask;
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            Task.FromResult(default(TResponse)!);
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminDescribeTopicPartitionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminDescribeTopicPartitionsTests.cs
@@ -1,9 +1,9 @@
-using System.Collections.Concurrent;
 using Dekaf.Admin;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Admin;
 
@@ -13,7 +13,7 @@ public sealed class AdminDescribeTopicPartitionsTests
     public async Task DescribeTopicPartitionsPageAsync_SendsCursorAndReturnsNextCursor()
     {
         await using var context = new AdminTestContext();
-        context.Connection.Enqueue(PageResponse(
+        context.Enqueue(PageResponse(
             "topic-a",
             partitionIndex: 5,
             nextCursor: new DescribeTopicPartitionsResponseCursor
@@ -34,7 +34,7 @@ public sealed class AdminDescribeTopicPartitionsTests
                 }
             });
 
-        var request = context.Connection.SingleRequest<DescribeTopicPartitionsRequest>();
+        var request = context.SingleRequest<DescribeTopicPartitionsRequest>();
         await Assert.That(request.ResponsePartitionLimit).IsEqualTo(1);
         await Assert.That(request.Cursor).IsNotNull();
         await Assert.That(request.Cursor!.TopicName).IsEqualTo("topic-a");
@@ -48,7 +48,7 @@ public sealed class AdminDescribeTopicPartitionsTests
     public async Task DescribeTopicPartitionsAsync_FollowsCursorsAndMergesTopicPartitions()
     {
         await using var context = new AdminTestContext();
-        context.Connection.Enqueue(PageResponse(
+        context.Enqueue(PageResponse(
             "topic-a",
             partitionIndex: 0,
             nextCursor: new DescribeTopicPartitionsResponseCursor
@@ -56,7 +56,7 @@ public sealed class AdminDescribeTopicPartitionsTests
                 TopicName = "topic-a",
                 PartitionIndex = 1
             }));
-        context.Connection.Enqueue(PageResponse(
+        context.Enqueue(PageResponse(
             "topic-a",
             partitionIndex: 1,
             nextCursor: null));
@@ -68,7 +68,7 @@ public sealed class AdminDescribeTopicPartitionsTests
                 ResponsePartitionLimit = 1
             });
 
-        var requests = context.Connection.RequestsOfType<DescribeTopicPartitionsRequest>();
+        var requests = context.RequestsOfType<DescribeTopicPartitionsRequest>();
         await Assert.That(requests.Count).IsEqualTo(2);
         await Assert.That(requests[0].Cursor).IsNull();
         await Assert.That(requests[1].Cursor).IsNotNull();
@@ -86,11 +86,11 @@ public sealed class AdminDescribeTopicPartitionsTests
             TopicName = "topic-a",
             PartitionIndex = 1
         };
-        context.Connection.Enqueue(PageResponse(
+        context.Enqueue(PageResponse(
             "topic-a",
             partitionIndex: 0,
             nextCursor: repeatedCursor));
-        context.Connection.Enqueue(PageResponse(
+        context.Enqueue(PageResponse(
             "topic-a",
             partitionIndex: 1,
             nextCursor: repeatedCursor));
@@ -103,7 +103,7 @@ public sealed class AdminDescribeTopicPartitionsTests
             });
 
         await Assert.That(Act).Throws<InvalidOperationException>();
-        await Assert.That(context.Connection.RequestsOfType<DescribeTopicPartitionsRequest>().Count).IsEqualTo(2);
+        await Assert.That(context.RequestsOfType<DescribeTopicPartitionsRequest>().Count).IsEqualTo(2);
     }
 
     [Test]
@@ -140,7 +140,7 @@ public sealed class AdminDescribeTopicPartitionsTests
     public async Task DescribeTopicPartitionsPageAsync_MapsElrAndAuthorizedOperations()
     {
         await using var context = new AdminTestContext();
-        context.Connection.Enqueue(new DescribeTopicPartitionsResponse
+        context.Enqueue(new DescribeTopicPartitionsResponse
         {
             ThrottleTimeMs = 3,
             Topics =
@@ -191,7 +191,7 @@ public sealed class AdminDescribeTopicPartitionsTests
 
         await context.Client.DisposeAsync();
 
-        await Assert.That(context.PoolDisposeCount).IsEqualTo(0);
+        await context.AssertPoolNotDisposedAsync();
     }
 
     private static DescribeTopicPartitionsResponse PageResponse(
@@ -230,12 +230,44 @@ public sealed class AdminDescribeTopicPartitionsTests
 
     private sealed class AdminTestContext : IAsyncDisposable
     {
-        private readonly TestConnectionPool _pool;
+        private readonly IConnectionPool _pool;
+        private readonly IKafkaConnection _connection;
         private readonly MetadataManager _metadataManager;
+        private readonly Queue<DescribeTopicPartitionsResponse> _responses = new();
+        private readonly List<object> _requests = [];
 
         public AdminTestContext()
         {
-            _pool = new TestConnectionPool();
+            _connection = Substitute.For<IKafkaConnection>();
+            _connection.BrokerId.Returns(0);
+            _connection.Host.Returns("localhost");
+            _connection.Port.Returns(9092);
+            _connection.IsConnected.Returns(true);
+            _connection
+                .SendAsync<DescribeTopicPartitionsRequest, DescribeTopicPartitionsResponse>(
+                    Arg.Any<DescribeTopicPartitionsRequest>(),
+                    Arg.Any<short>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    var request = callInfo.ArgAt<DescribeTopicPartitionsRequest>(0);
+                    _requests.Add(request);
+                    if (!_responses.TryDequeue(out var response))
+                    {
+                        throw new InvalidOperationException($"No queued response for {nameof(DescribeTopicPartitionsRequest)}.");
+                    }
+
+                    return new ValueTask<DescribeTopicPartitionsResponse>((DescribeTopicPartitionsResponse)response);
+                });
+
+            _pool = Substitute.For<IConnectionPool>();
+            _pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<IKafkaConnection>(_connection));
+            _pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<IKafkaConnection>(_connection));
+            _pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<IKafkaConnection>(_connection));
+
             _metadataManager = new MetadataManager(_pool, ["localhost:9092"]);
             _metadataManager.SetApiVersion(ApiKey.DescribeTopicPartitions, 0, 0);
             _metadataManager.Metadata.Update(new MetadataResponse
@@ -264,8 +296,14 @@ public sealed class AdminDescribeTopicPartitionsTests
         }
 
         public AdminClient Client { get; }
-        public TestKafkaConnection Connection => _pool.Connection;
-        public int PoolDisposeCount => _pool.DisposeCount;
+
+        public void Enqueue(DescribeTopicPartitionsResponse response) => _responses.Enqueue(response);
+
+        public T SingleRequest<T>() => RequestsOfType<T>().Single();
+
+        public IReadOnlyList<T> RequestsOfType<T>() => _requests.OfType<T>().ToArray();
+
+        public async ValueTask AssertPoolNotDisposedAsync() => await _pool.DidNotReceive().DisposeAsync();
 
         public async ValueTask DisposeAsync()
         {
@@ -273,112 +311,5 @@ public sealed class AdminDescribeTopicPartitionsTests
             await _metadataManager.DisposeAsync().ConfigureAwait(false);
             await _pool.DisposeAsync().ConfigureAwait(false);
         }
-    }
-
-    private sealed class TestConnectionPool : IConnectionPool
-    {
-        public TestKafkaConnection Connection { get; } = new();
-        public int DisposeCount { get; private set; }
-
-        public ValueTask<IKafkaConnection> GetConnectionAsync(int brokerId, CancellationToken cancellationToken = default) =>
-            ValueTask.FromResult<IKafkaConnection>(Connection);
-
-        public ValueTask<IKafkaConnection> GetConnectionByIndexAsync(int brokerId, int index, CancellationToken cancellationToken = default) =>
-            ValueTask.FromResult<IKafkaConnection>(Connection);
-
-        public ValueTask<IKafkaConnection> GetConnectionAsync(string host, int port, CancellationToken cancellationToken = default) =>
-            ValueTask.FromResult<IKafkaConnection>(Connection);
-
-        public void RegisterBroker(int brokerId, string host, int port)
-        {
-        }
-
-        public ValueTask<int> ScaleConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) =>
-            ValueTask.FromResult(newCount);
-
-        public ValueTask<IKafkaConnection?> ShrinkConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default) =>
-            ValueTask.FromResult<IKafkaConnection?>(null);
-
-        public ValueTask RemoveConnectionAsync(int brokerId) => ValueTask.CompletedTask;
-
-        public ValueTask CloseAllAsync() => ValueTask.CompletedTask;
-
-        public ValueTask DisposeAsync()
-        {
-            DisposeCount++;
-            return ValueTask.CompletedTask;
-        }
-    }
-
-    private sealed class TestKafkaConnection : IKafkaConnection
-    {
-        private readonly ConcurrentQueue<object> _responses = new();
-        private readonly ConcurrentQueue<object> _requests = new();
-
-        public int BrokerId => 0;
-        public string Host => "localhost";
-        public int Port => 9092;
-        public bool IsConnected => true;
-
-        public void Enqueue<TResponse>(TResponse response)
-            where TResponse : IKafkaResponse =>
-            _responses.Enqueue(response);
-
-        public T SingleRequest<T>() => RequestsOfType<T>().Single();
-
-        public IReadOnlyList<T> RequestsOfType<T>() =>
-            _requests.ToArray().OfType<T>().ToArray();
-
-        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
-            TRequest request,
-            short apiVersion,
-            CancellationToken cancellationToken = default)
-            where TRequest : IKafkaRequest<TResponse>
-            where TResponse : IKafkaResponse
-        {
-            _requests.Enqueue(request);
-            if (!_responses.TryDequeue(out var response))
-            {
-                throw new InvalidOperationException($"No queued response for {typeof(TRequest).Name}.");
-            }
-
-            return ValueTask.FromResult((TResponse)response);
-        }
-
-        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
-            TRequest request,
-            short apiVersion,
-            CancellationToken cancellationToken = default)
-            where TRequest : IKafkaRequest<TResponse>
-            where TResponse : IKafkaResponse =>
-            ValueTask.CompletedTask;
-
-        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
-            TRequest request,
-            short apiVersion,
-            CancellationToken cancellationToken = default)
-            where TRequest : IKafkaRequest<TResponse>
-            where TResponse : IKafkaResponse =>
-            Task.FromResult(default(TResponse)!);
-
-        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
-            TRequest request,
-            short apiVersion,
-            CancellationToken cancellationToken = default)
-            where TRequest : IKafkaRequest<TResponse>
-            where TResponse : IKafkaResponse =>
-            ValueTask.CompletedTask;
-
-        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
-            TRequest request,
-            short apiVersion,
-            CancellationToken cancellationToken = default)
-            where TRequest : IKafkaRequest<TResponse>
-            where TResponse : IKafkaResponse =>
-            Task.FromResult(default(TResponse)!);
-
-        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
-
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Admin/AdminDescribeTopicPartitionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminDescribeTopicPartitionsTests.cs
@@ -78,6 +78,65 @@ public sealed class AdminDescribeTopicPartitionsTests
     }
 
     [Test]
+    public async Task DescribeTopicPartitionsAsync_RepeatedCursor_ThrowsInvalidOperationException()
+    {
+        await using var context = new AdminTestContext();
+        var repeatedCursor = new DescribeTopicPartitionsResponseCursor
+        {
+            TopicName = "topic-a",
+            PartitionIndex = 1
+        };
+        context.Connection.Enqueue(PageResponse(
+            "topic-a",
+            partitionIndex: 0,
+            nextCursor: repeatedCursor));
+        context.Connection.Enqueue(PageResponse(
+            "topic-a",
+            partitionIndex: 1,
+            nextCursor: repeatedCursor));
+
+        async Task Act() => await context.Client.DescribeTopicPartitionsAsync(
+            ["topic-a"],
+            new DescribeTopicPartitionsOptions
+            {
+                ResponsePartitionLimit = 1
+            });
+
+        await Assert.That(Act).Throws<InvalidOperationException>();
+        await Assert.That(context.Connection.RequestsOfType<DescribeTopicPartitionsRequest>().Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task DescribeTopicPartitionsAsync_ValidatesResponsePartitionLimitWhenTopicsEmpty()
+    {
+        await using var context = new AdminTestContext();
+
+        async Task Act() => await context.Client.DescribeTopicPartitionsAsync(
+            [],
+            new DescribeTopicPartitionsOptions
+            {
+                ResponsePartitionLimit = 0
+            });
+
+        await Assert.That(Act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task DescribeTopicPartitionsPageAsync_ValidatesResponsePartitionLimitWhenTopicsEmpty()
+    {
+        await using var context = new AdminTestContext();
+
+        async Task Act() => await context.Client.DescribeTopicPartitionsPageAsync(
+            [],
+            new DescribeTopicPartitionsPageOptions
+            {
+                ResponsePartitionLimit = 0
+            });
+
+        await Assert.That(Act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     public async Task DescribeTopicPartitionsPageAsync_MapsElrAndAuthorizedOperations()
     {
         await using var context = new AdminTestContext();
@@ -123,6 +182,16 @@ public sealed class AdminDescribeTopicPartitionsTests
         await Assert.That(partition.EligibleLeaderReplicas).IsEquivalentTo([2]);
         await Assert.That(partition.LastKnownElr).IsEquivalentTo([1]);
         await Assert.That(partition.OfflineReplicas).IsEquivalentTo([2]);
+    }
+
+    [Test]
+    public async Task DisposeAsync_WithInjectedResources_DoesNotDisposeExternalPool()
+    {
+        await using var context = new AdminTestContext();
+
+        await context.Client.DisposeAsync();
+
+        await Assert.That(context.PoolDisposeCount).IsEqualTo(0);
     }
 
     private static DescribeTopicPartitionsResponse PageResponse(
@@ -196,6 +265,7 @@ public sealed class AdminDescribeTopicPartitionsTests
 
         public AdminClient Client { get; }
         public TestKafkaConnection Connection => _pool.Connection;
+        public int PoolDisposeCount => _pool.DisposeCount;
 
         public async ValueTask DisposeAsync()
         {
@@ -208,6 +278,7 @@ public sealed class AdminDescribeTopicPartitionsTests
     private sealed class TestConnectionPool : IConnectionPool
     {
         public TestKafkaConnection Connection { get; } = new();
+        public int DisposeCount { get; private set; }
 
         public ValueTask<IKafkaConnection> GetConnectionAsync(int brokerId, CancellationToken cancellationToken = default) =>
             ValueTask.FromResult<IKafkaConnection>(Connection);
@@ -232,7 +303,11 @@ public sealed class AdminDescribeTopicPartitionsTests
 
         public ValueTask CloseAllAsync() => ValueTask.CompletedTask;
 
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
     }
 
     private sealed class TestKafkaConnection : IKafkaConnection

--- a/tests/Dekaf.Tests.Unit/Protocol/ArrayEncodingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ArrayEncodingTests.cs
@@ -170,10 +170,22 @@ public class ArrayEncodingTests
     {
         var data = new byte[] { 0x00 };
         var reader = new KafkaProtocolReader(data);
-        var result = reader.ReadCompactArray((ref KafkaProtocolReader r) => r.ReadInt32());
+        var result = reader.ReadCompactNullableArray((ref KafkaProtocolReader r) => r.ReadInt32());
 
-        // ReadCompactArray returns empty array for 0 length
-        await Assert.That(result).IsEmpty();
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task CompactNullableArray_NonNull_RoundTrip()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactNullableArray<int>([1, 2, 3], static (ref KafkaProtocolWriter w, int v) => w.WriteInt32(v));
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var result = reader.ReadCompactNullableArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
+
+        await Assert.That(result).IsEquivalentTo([1, 2, 3]);
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Protocol/DescribeTopicPartitionsMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/DescribeTopicPartitionsMessageTests.cs
@@ -1,0 +1,152 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class DescribeTopicPartitionsMessageTests
+{
+    [Test]
+    public async Task Request_WithNullCursor_EncodesFlexibleV0()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        var request = new DescribeTopicPartitionsRequest
+        {
+            Topics =
+            [
+                new DescribeTopicPartitionsRequestTopic { Name = "topic-a" }
+            ],
+            ResponsePartitionLimit = 500,
+            Cursor = null
+        };
+
+        request.Write(ref writer, version: 0);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var topicsLength = reader.ReadUnsignedVarInt() - 1;
+        var topicName = reader.ReadCompactString();
+        reader.SkipTaggedFields();
+        var responsePartitionLimit = reader.ReadInt32();
+        var cursorMarker = reader.ReadInt8();
+        reader.SkipTaggedFields();
+
+        await Assert.That(topicsLength).IsEqualTo(1);
+        await Assert.That(topicName).IsEqualTo("topic-a");
+        await Assert.That(responsePartitionLimit).IsEqualTo(500);
+        await Assert.That(cursorMarker).IsEqualTo((sbyte)-1);
+    }
+
+    [Test]
+    public async Task Request_WithCursor_EncodesNullableStructMarkerAndCursor()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        var request = new DescribeTopicPartitionsRequest
+        {
+            Topics =
+            [
+                new DescribeTopicPartitionsRequestTopic { Name = "topic-a" },
+                new DescribeTopicPartitionsRequestTopic { Name = "topic-b" }
+            ],
+            ResponsePartitionLimit = 1,
+            Cursor = new DescribeTopicPartitionsRequestCursor
+            {
+                TopicName = "topic-a",
+                PartitionIndex = 12
+            }
+        };
+
+        request.Write(ref writer, version: 0);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var topicsLength = reader.ReadUnsignedVarInt() - 1;
+        _ = reader.ReadCompactString();
+        reader.SkipTaggedFields();
+        _ = reader.ReadCompactString();
+        reader.SkipTaggedFields();
+        var responsePartitionLimit = reader.ReadInt32();
+        var cursorMarker = reader.ReadInt8();
+        var cursorTopicName = reader.ReadCompactString();
+        var cursorPartitionIndex = reader.ReadInt32();
+        reader.SkipTaggedFields();
+        reader.SkipTaggedFields();
+
+        await Assert.That(topicsLength).IsEqualTo(2);
+        await Assert.That(responsePartitionLimit).IsEqualTo(1);
+        await Assert.That(cursorMarker).IsEqualTo((sbyte)1);
+        await Assert.That(cursorTopicName).IsEqualTo("topic-a");
+        await Assert.That(cursorPartitionIndex).IsEqualTo(12);
+    }
+
+    [Test]
+    public async Task Response_CanParseTopicPartitionsAndNextCursor()
+    {
+        var topicId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(25);
+        writer.WriteUnsignedVarInt(2); // topics: 1 element
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactString("topic-a");
+        writer.WriteUuid(topicId);
+        writer.WriteBoolean(false);
+        writer.WriteUnsignedVarInt(2); // partitions: 1 element
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt32(3); // partition_index
+        writer.WriteInt32(1); // leader_id
+        writer.WriteInt32(9); // leader_epoch
+        writer.WriteCompactArray<int>([1, 2], static (ref KafkaProtocolWriter w, int value) => w.WriteInt32(value));
+        writer.WriteCompactArray<int>([1], static (ref KafkaProtocolWriter w, int value) => w.WriteInt32(value));
+        writer.WriteCompactNullableArray<int>([2], static (ref KafkaProtocolWriter w, int value) => w.WriteInt32(value));
+        writer.WriteCompactNullableArray<int>(null, static (ref KafkaProtocolWriter w, int value) => w.WriteInt32(value));
+        writer.WriteCompactArray<int>([], static (ref KafkaProtocolWriter w, int value) => w.WriteInt32(value));
+        writer.WriteEmptyTaggedFields(); // partition tags
+        writer.WriteInt32(123); // topic_authorized_operations
+        writer.WriteEmptyTaggedFields(); // topic tags
+        writer.WriteInt8(1); // next_cursor present
+        writer.WriteCompactString("topic-a");
+        writer.WriteInt32(4);
+        writer.WriteEmptyTaggedFields(); // cursor tags
+        writer.WriteEmptyTaggedFields(); // response tags
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (DescribeTopicPartitionsResponse)DescribeTopicPartitionsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(25);
+        await Assert.That(response.Topics.Count).IsEqualTo(1);
+        await Assert.That(response.Topics[0].Name).IsEqualTo("topic-a");
+        await Assert.That(response.Topics[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(response.Topics[0].TopicAuthorizedOperations).IsEqualTo(123);
+        await Assert.That(response.Topics[0].Partitions.Count).IsEqualTo(1);
+        await Assert.That(response.Topics[0].Partitions[0].PartitionIndex).IsEqualTo(3);
+        await Assert.That(response.Topics[0].Partitions[0].LeaderEpoch).IsEqualTo(9);
+        await Assert.That(response.Topics[0].Partitions[0].ReplicaNodes).IsEquivalentTo([1, 2]);
+        await Assert.That(response.Topics[0].Partitions[0].IsrNodes).IsEquivalentTo([1]);
+        await Assert.That(response.Topics[0].Partitions[0].EligibleLeaderReplicas).IsEquivalentTo([2]);
+        await Assert.That(response.Topics[0].Partitions[0].LastKnownElr).IsNull();
+        await Assert.That(response.Topics[0].Partitions[0].OfflineReplicas).IsEmpty();
+        await Assert.That(response.NextCursor).IsNotNull();
+        await Assert.That(response.NextCursor!.TopicName).IsEqualTo("topic-a");
+        await Assert.That(response.NextCursor.PartitionIndex).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task Response_NullNextCursor_CanBeParsed()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);
+        writer.WriteUnsignedVarInt(1); // empty topics
+        writer.WriteInt8(-1); // next_cursor null
+        writer.WriteEmptyTaggedFields();
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (DescribeTopicPartitionsResponse)DescribeTopicPartitionsResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.Topics).IsEmpty();
+        await Assert.That(response.NextCursor).IsNull();
+    }
+}


### PR DESCRIPTION
## Summary
- add DescribeTopicPartitions API 75 request/response protocol messages
- expose paginated and auto-paginated admin APIs
- map ELR/offline replica fields into topic partition metadata

Closes #825.

## Validation
- `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- focused DescribeTopicPartitions unit tests passed
- focused integration `DescribeTopicPartitionsAsync_WithPagination_ReturnsAllPartitions` passed on 3 Kafka versions

Note: full unit run exceeded local tool timeout; focused tests for this change passed.