### PR TITLE
feat(admin): add ConsumerGroupDescribe

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -23,6 +23,7 @@ public sealed class AdminClient : IAdminClient
     private readonly MetadataManager _metadataManager;
     private readonly ClientTelemetryManager _telemetryManager;
     private readonly ILogger<AdminClient>? _logger;
+    private readonly bool _ownsResources;
     private int _telemetryStartAttempted;
     private int _disposed;
 
@@ -58,6 +59,22 @@ public sealed class AdminClient : IAdminClient
             _connectionPool,
             _metadataManager,
             loggerFactory?.CreateLogger<ClientTelemetryManager>());
+        _ownsResources = true;
+    }
+
+    internal AdminClient(
+        AdminClientOptions options,
+        IConnectionPool connectionPool,
+        MetadataManager metadataManager,
+        ILogger<AdminClient>? logger = null,
+        bool ownsResources = false)
+    {
+        _options = options;
+        _connectionPool = connectionPool;
+        _metadataManager = metadataManager;
+        _logger = logger;
+        _telemetryManager = new ClientTelemetryManager(connectionPool, metadataManager);
+        _ownsResources = ownsResources;
     }
 
     public ClusterMetadata Metadata => _metadataManager.Metadata;
@@ -331,13 +348,39 @@ public sealed class AdminClient : IAdminClient
                 groups.Add(groupId);
             }
 
-            return _metadataManager.HasApiKey(Protocol.ApiKey.ConsumerGroupDescribe)
-                ? await DescribeConsumerGroupsWithKip848Async(groupsByCoordinator, cancellationToken).ConfigureAwait(false)
-                : await DescribeConsumerGroupsWithClassicApiAsync(groupsByCoordinator, cancellationToken).ConfigureAwait(false);
+            return await DescribeConsumerGroupsWithBestAvailableApiAsync(
+                groupsByCoordinator,
+                cancellationToken).ConfigureAwait(false);
         }, cancellationToken).ConfigureAwait(false);
     }
 
-    private async ValueTask<IReadOnlyDictionary<string, GroupDescription>> DescribeConsumerGroupsWithKip848Async(
+    private async ValueTask<IReadOnlyDictionary<string, GroupDescription>> DescribeConsumerGroupsWithBestAvailableApiAsync(
+        IReadOnlyDictionary<int, List<string>> groupsByCoordinator,
+        CancellationToken cancellationToken)
+    {
+        if (!_metadataManager.HasApiKey(Protocol.ApiKey.ConsumerGroupDescribe))
+        {
+            return await DescribeConsumerGroupsWithClassicApiAsync(groupsByCoordinator, cancellationToken).ConfigureAwait(false);
+        }
+
+        var (descriptions, classicFallbackGroups) = await DescribeConsumerGroupsWithKip848Async(
+            groupsByCoordinator,
+            cancellationToken).ConfigureAwait(false);
+
+        if (classicFallbackGroups.Count > 0)
+        {
+            var classicDescriptions = await DescribeConsumerGroupsWithClassicApiAsync(
+                classicFallbackGroups,
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (var (groupId, description) in classicDescriptions)
+                descriptions[groupId] = description;
+        }
+
+        return descriptions;
+    }
+
+    private async ValueTask<(Dictionary<string, GroupDescription> Descriptions, Dictionary<int, List<string>> ClassicFallbackGroups)> DescribeConsumerGroupsWithKip848Async(
         IReadOnlyDictionary<int, List<string>> groupsByCoordinator,
         CancellationToken cancellationToken)
     {
@@ -347,6 +390,7 @@ public sealed class AdminClient : IAdminClient
             ConsumerGroupDescribeRequest.HighestSupportedVersion);
 
         var result = new Dictionary<string, GroupDescription>();
+        var classicFallbackGroups = new Dictionary<int, List<string>>();
 
         foreach (var (coordinatorId, groups) in groupsByCoordinator)
         {
@@ -365,6 +409,18 @@ public sealed class AdminClient : IAdminClient
 
             foreach (var group in response.Groups)
             {
+                if (ShouldFallbackToClassicConsumerGroupApi(group.ErrorCode))
+                {
+                    if (!classicFallbackGroups.TryGetValue(coordinatorId, out var fallbackGroups))
+                    {
+                        fallbackGroups = [];
+                        classicFallbackGroups[coordinatorId] = fallbackGroups;
+                    }
+
+                    fallbackGroups.Add(group.GroupId);
+                    continue;
+                }
+
                 if (group.ErrorCode != Protocol.ErrorCode.None)
                 {
                     throw new Errors.GroupException(group.ErrorCode,
@@ -378,6 +434,7 @@ public sealed class AdminClient : IAdminClient
                 {
                     GroupId = group.GroupId,
                     ProtocolType = "consumer",
+                    // Legacy shape: classic DescribeGroups exposes the assignor in ProtocolData.
                     ProtocolData = group.AssignorName,
                     State = group.GroupState,
                     CoordinatorId = coordinatorId,
@@ -403,8 +460,11 @@ public sealed class AdminClient : IAdminClient
             }
         }
 
-        return result;
+        return (result, classicFallbackGroups);
     }
+
+    private static bool ShouldFallbackToClassicConsumerGroupApi(Protocol.ErrorCode errorCode) =>
+        errorCode is Protocol.ErrorCode.GroupIdNotFound or Protocol.ErrorCode.UnsupportedVersion;
 
     private async ValueTask<IReadOnlyDictionary<string, GroupDescription>> DescribeConsumerGroupsWithClassicApiAsync(
         IReadOnlyDictionary<int, List<string>> groupsByCoordinator,
@@ -2185,8 +2245,12 @@ public sealed class AdminClient : IAdminClient
         var telemetryStopMs = Math.Max(1, Math.Min(_options.RequestTimeoutMs, 5000));
         await _telemetryManager.StopAsync(TimeSpan.FromMilliseconds(telemetryStopMs)).ConfigureAwait(false);
         await _telemetryManager.DisposeAsync().ConfigureAwait(false);
-        await _metadataManager.DisposeAsync().ConfigureAwait(false);
-        await _connectionPool.DisposeAsync().ConfigureAwait(false);
+
+        if (_ownsResources)
+        {
+            await _metadataManager.DisposeAsync().ConfigureAwait(false);
+            await _connectionPool.DisposeAsync().ConfigureAwait(false);
+        }
     }
 }
 

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -318,7 +318,7 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<IReadOnlyDictionary<string, GroupDescription>>(async () =>
         {
-            // Find coordinator for each group and batch groups by coordinator
+            // Find coordinator for each group and batch groups by coordinator.
             var groupsByCoordinator = new Dictionary<int, List<string>>();
             foreach (var groupId in groupIdList)
             {
@@ -331,60 +331,139 @@ public sealed class AdminClient : IAdminClient
                 groups.Add(groupId);
             }
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.DescribeGroups,
-                DescribeGroupsRequest.LowestSupportedVersion,
-                DescribeGroupsRequest.HighestSupportedVersion);
+            return _metadataManager.HasApiKey(Protocol.ApiKey.ConsumerGroupDescribe)
+                ? await DescribeConsumerGroupsWithKip848Async(groupsByCoordinator, cancellationToken).ConfigureAwait(false)
+                : await DescribeConsumerGroupsWithClassicApiAsync(groupsByCoordinator, cancellationToken).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
+    }
 
-            var result = new Dictionary<string, GroupDescription>();
+    private async ValueTask<IReadOnlyDictionary<string, GroupDescription>> DescribeConsumerGroupsWithKip848Async(
+        IReadOnlyDictionary<int, List<string>> groupsByCoordinator,
+        CancellationToken cancellationToken)
+    {
+        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            Protocol.ApiKey.ConsumerGroupDescribe,
+            ConsumerGroupDescribeRequest.LowestSupportedVersion,
+            ConsumerGroupDescribeRequest.HighestSupportedVersion);
 
-            // Send requests per coordinator
-            foreach (var (coordinatorId, groups) in groupsByCoordinator)
+        var result = new Dictionary<string, GroupDescription>();
+
+        foreach (var (coordinatorId, groups) in groupsByCoordinator)
+        {
+            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+
+            var request = new ConsumerGroupDescribeRequest
             {
-                var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+                GroupIds = groups,
+                IncludeAuthorizedOperations = true
+            };
 
-                var request = new DescribeGroupsRequest
+            var response = await connection.SendAsync<ConsumerGroupDescribeRequest, ConsumerGroupDescribeResponse>(
+                request,
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (var group in response.Groups)
+            {
+                if (group.ErrorCode != Protocol.ErrorCode.None)
                 {
-                    Groups = groups
-                };
-
-                var response = await connection.SendAsync<DescribeGroupsRequest, DescribeGroupsResponse>(
-                    request,
-                    apiVersion,
-                    cancellationToken).ConfigureAwait(false);
-
-                foreach (var group in response.Groups)
-                {
-                    if (group.ErrorCode != Protocol.ErrorCode.None)
+                    throw new Errors.GroupException(group.ErrorCode,
+                        $"DescribeConsumerGroups failed for group '{group.GroupId}': {group.ErrorCode}")
                     {
-                        throw new Errors.GroupException(group.ErrorCode,
-                            $"DescribeConsumerGroups failed for group '{group.GroupId}': {group.ErrorCode}")
-                        {
-                            GroupId = group.GroupId
-                        };
-                    }
-
-                    result[group.GroupId] = new GroupDescription
-                    {
-                        GroupId = group.GroupId,
-                        ProtocolType = group.ProtocolType,
-                        ProtocolData = group.ProtocolData,
-                        State = group.GroupState,
-                        CoordinatorId = coordinatorId,
-                        Members = group.Members.Select(m => new MemberDescription
-                        {
-                            MemberId = m.MemberId,
-                            GroupInstanceId = m.GroupInstanceId,
-                            ClientId = m.ClientId,
-                            ClientHost = m.ClientHost,
-                            Assignment = ParseMemberAssignment(m.MemberAssignment)
-                        }).ToList()
+                        GroupId = group.GroupId
                     };
                 }
-            }
 
-            return result;
-        }, cancellationToken).ConfigureAwait(false);
+                result[group.GroupId] = new GroupDescription
+                {
+                    GroupId = group.GroupId,
+                    ProtocolType = "consumer",
+                    ProtocolData = group.AssignorName,
+                    State = group.GroupState,
+                    CoordinatorId = coordinatorId,
+                    GroupEpoch = group.GroupEpoch,
+                    AssignmentEpoch = group.AssignmentEpoch,
+                    AssignorName = group.AssignorName,
+                    AuthorizedOperations = group.AuthorizedOperations,
+                    Members = group.Members.Select(m => new MemberDescription
+                    {
+                        MemberId = m.MemberId,
+                        GroupInstanceId = m.InstanceId,
+                        RackId = m.RackId,
+                        MemberEpoch = m.MemberEpoch,
+                        ClientId = m.ClientId,
+                        ClientHost = m.ClientHost,
+                        SubscribedTopicNames = m.SubscribedTopicNames,
+                        SubscribedTopicRegex = m.SubscribedTopicRegex,
+                        Assignment = FlattenAssignment(m.Assignment),
+                        TargetAssignment = FlattenAssignment(m.TargetAssignment),
+                        MemberType = m.MemberType
+                    }).ToList()
+                };
+            }
+        }
+
+        return result;
+    }
+
+    private async ValueTask<IReadOnlyDictionary<string, GroupDescription>> DescribeConsumerGroupsWithClassicApiAsync(
+        IReadOnlyDictionary<int, List<string>> groupsByCoordinator,
+        CancellationToken cancellationToken)
+    {
+        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            Protocol.ApiKey.DescribeGroups,
+            DescribeGroupsRequest.LowestSupportedVersion,
+            DescribeGroupsRequest.HighestSupportedVersion);
+
+        var result = new Dictionary<string, GroupDescription>();
+
+        foreach (var (coordinatorId, groups) in groupsByCoordinator)
+        {
+            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+
+            var request = new DescribeGroupsRequest
+            {
+                Groups = groups,
+                IncludeAuthorizedOperations = true
+            };
+
+            var response = await connection.SendAsync<DescribeGroupsRequest, DescribeGroupsResponse>(
+                request,
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (var group in response.Groups)
+            {
+                if (group.ErrorCode != Protocol.ErrorCode.None)
+                {
+                    throw new Errors.GroupException(group.ErrorCode,
+                        $"DescribeConsumerGroups failed for group '{group.GroupId}': {group.ErrorCode}")
+                    {
+                        GroupId = group.GroupId
+                    };
+                }
+
+                result[group.GroupId] = new GroupDescription
+                {
+                    GroupId = group.GroupId,
+                    ProtocolType = group.ProtocolType,
+                    ProtocolData = group.ProtocolData,
+                    State = group.GroupState,
+                    CoordinatorId = coordinatorId,
+                    AuthorizedOperations = group.AuthorizedOperations,
+                    Members = group.Members.Select(m => new MemberDescription
+                    {
+                        MemberId = m.MemberId,
+                        GroupInstanceId = m.GroupInstanceId,
+                        ClientId = m.ClientId,
+                        ClientHost = m.ClientHost,
+                        Assignment = ParseMemberAssignment(m.MemberAssignment)
+                    }).ToList()
+                };
+            }
+        }
+
+        return result;
     }
 
     public async ValueTask<IReadOnlyList<GroupListing>> ListConsumerGroupsAsync(
@@ -2086,6 +2165,16 @@ public sealed class AdminClient : IAdminClient
             // If we can't parse the assignment bytes, return null rather than failing
             return null;
         }
+    }
+
+    private static IReadOnlyList<TopicPartition>? FlattenAssignment(ConsumerGroupDescribeAssignment assignment)
+    {
+        if (assignment.TopicPartitions.Count == 0)
+            return null;
+
+        return assignment.TopicPartitions
+            .SelectMany(topic => topic.Partitions.Select(partition => new TopicPartition(topic.TopicName, partition)))
+            .ToList();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -358,12 +358,22 @@ public sealed class GroupDescription
 {
     public required string GroupId { get; init; }
     public string? ProtocolType { get; init; }
+
+    /// <summary>
+    /// Selected protocol data from the classic DescribeGroups API. For KIP-848 consumer
+    /// groups this mirrors <see cref="AssignorName"/> for compatibility.
+    /// </summary>
     public string? ProtocolData { get; init; }
     public string State { get; init; } = "Unknown";
     public required IReadOnlyList<MemberDescription> Members { get; init; }
     public int? CoordinatorId { get; init; }
     public int? GroupEpoch { get; init; }
     public int? AssignmentEpoch { get; init; }
+
+    /// <summary>
+    /// Selected assignor reported by ConsumerGroupDescribe (API 69), or null when the
+    /// group falls back to the classic DescribeGroups API.
+    /// </summary>
     public string? AssignorName { get; init; }
     public int AuthorizedOperations { get; init; } = int.MinValue;
 }

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -362,6 +362,10 @@ public sealed class GroupDescription
     public string State { get; init; } = "Unknown";
     public required IReadOnlyList<MemberDescription> Members { get; init; }
     public int? CoordinatorId { get; init; }
+    public int? GroupEpoch { get; init; }
+    public int? AssignmentEpoch { get; init; }
+    public string? AssignorName { get; init; }
+    public int AuthorizedOperations { get; init; } = int.MinValue;
 }
 
 /// <summary>
@@ -371,9 +375,15 @@ public sealed class MemberDescription
 {
     public required string MemberId { get; init; }
     public string? GroupInstanceId { get; init; }
+    public string? RackId { get; init; }
+    public int? MemberEpoch { get; init; }
     public string? ClientId { get; init; }
     public string? ClientHost { get; init; }
+    public IReadOnlyList<string>? SubscribedTopicNames { get; init; }
+    public string? SubscribedTopicRegex { get; init; }
     public IReadOnlyList<TopicPartition>? Assignment { get; init; }
+    public IReadOnlyList<TopicPartition>? TargetAssignment { get; init; }
+    public sbyte? MemberType { get; init; }
 }
 
 /// <summary>

--- a/src/Dekaf/Protocol/Messages/ConsumerGroupDescribeRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ConsumerGroupDescribeRequest.cs
@@ -1,0 +1,32 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ConsumerGroupDescribe request (API key 69).
+/// Describes KIP-848 consumer groups.
+/// </summary>
+public sealed class ConsumerGroupDescribeRequest : IKafkaRequest<ConsumerGroupDescribeResponse>
+{
+    public static ApiKey ApiKey => ApiKey.ConsumerGroupDescribe;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 1;
+
+    /// <summary>
+    /// The consumer group IDs to describe.
+    /// </summary>
+    public required IReadOnlyList<string> GroupIds { get; init; }
+
+    /// <summary>
+    /// Whether to include authorized operations.
+    /// </summary>
+    public bool IncludeAuthorizedOperations { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactArray(
+            GroupIds,
+            static (ref KafkaProtocolWriter w, string groupId) => w.WriteCompactString(groupId));
+
+        writer.WriteBoolean(IncludeAuthorizedOperations);
+        writer.WriteEmptyTaggedFields();
+    }
+}

--- a/src/Dekaf/Protocol/Messages/ConsumerGroupDescribeResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ConsumerGroupDescribeResponse.cs
@@ -1,0 +1,247 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ConsumerGroupDescribe response (API key 69).
+/// Contains KIP-848 consumer group descriptions.
+/// </summary>
+public sealed class ConsumerGroupDescribeResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.ConsumerGroupDescribe;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 1;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The described consumer groups.
+    /// </summary>
+    public required IReadOnlyList<ConsumerGroupDescribeGroup> Groups { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+
+        var groups = reader.ReadCompactArray(
+            (ref KafkaProtocolReader r) => ConsumerGroupDescribeGroup.Read(ref r, version));
+
+        reader.SkipTaggedFields();
+
+        return new ConsumerGroupDescribeResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            Groups = groups
+        };
+    }
+}
+
+/// <summary>
+/// Described KIP-848 consumer group.
+/// </summary>
+public sealed class ConsumerGroupDescribeGroup
+{
+    public ErrorCode ErrorCode { get; init; }
+    public string? ErrorMessage { get; init; }
+    public required string GroupId { get; init; }
+    public required string GroupState { get; init; }
+    public int GroupEpoch { get; init; }
+    public int AssignmentEpoch { get; init; }
+    public required string AssignorName { get; init; }
+    public required IReadOnlyList<ConsumerGroupDescribeMember> Members { get; init; }
+    public int AuthorizedOperations { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteInt16((short)ErrorCode);
+        writer.WriteCompactNullableString(ErrorMessage);
+        writer.WriteCompactString(GroupId);
+        writer.WriteCompactString(GroupState);
+        writer.WriteInt32(GroupEpoch);
+        writer.WriteInt32(AssignmentEpoch);
+        writer.WriteCompactString(AssignorName);
+
+        writer.WriteCompactArray(
+            Members,
+            (ref KafkaProtocolWriter w, ConsumerGroupDescribeMember member) => member.Write(ref w, version));
+
+        writer.WriteInt32(AuthorizedOperations);
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ConsumerGroupDescribeGroup Read(ref KafkaProtocolReader reader, short version)
+    {
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+        var groupId = reader.ReadCompactString() ?? string.Empty;
+        var groupState = reader.ReadCompactString() ?? string.Empty;
+        var groupEpoch = reader.ReadInt32();
+        var assignmentEpoch = reader.ReadInt32();
+        var assignorName = reader.ReadCompactString() ?? string.Empty;
+
+        var members = reader.ReadCompactArray(
+            (ref KafkaProtocolReader r) => ConsumerGroupDescribeMember.Read(ref r, version));
+
+        var authorizedOperations = reader.ReadInt32();
+        reader.SkipTaggedFields();
+
+        return new ConsumerGroupDescribeGroup
+        {
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            GroupId = groupId,
+            GroupState = groupState,
+            GroupEpoch = groupEpoch,
+            AssignmentEpoch = assignmentEpoch,
+            AssignorName = assignorName,
+            Members = members,
+            AuthorizedOperations = authorizedOperations
+        };
+    }
+}
+
+/// <summary>
+/// Member in a KIP-848 consumer group description.
+/// </summary>
+public sealed class ConsumerGroupDescribeMember
+{
+    public required string MemberId { get; init; }
+    public string? InstanceId { get; init; }
+    public string? RackId { get; init; }
+    public int MemberEpoch { get; init; }
+    public required string ClientId { get; init; }
+    public required string ClientHost { get; init; }
+    public required IReadOnlyList<string> SubscribedTopicNames { get; init; }
+    public string? SubscribedTopicRegex { get; init; }
+    public required ConsumerGroupDescribeAssignment Assignment { get; init; }
+    public required ConsumerGroupDescribeAssignment TargetAssignment { get; init; }
+    public sbyte? MemberType { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactString(MemberId);
+        writer.WriteCompactNullableString(InstanceId);
+        writer.WriteCompactNullableString(RackId);
+        writer.WriteInt32(MemberEpoch);
+        writer.WriteCompactString(ClientId);
+        writer.WriteCompactString(ClientHost);
+
+        writer.WriteCompactArray(
+            SubscribedTopicNames,
+            static (ref KafkaProtocolWriter w, string topicName) => w.WriteCompactString(topicName));
+
+        writer.WriteCompactNullableString(SubscribedTopicRegex);
+        Assignment.Write(ref writer);
+        TargetAssignment.Write(ref writer);
+
+        if (version >= 1)
+        {
+            writer.WriteInt8(MemberType ?? (sbyte)-1);
+        }
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ConsumerGroupDescribeMember Read(ref KafkaProtocolReader reader, short version)
+    {
+        var memberId = reader.ReadCompactString() ?? string.Empty;
+        var instanceId = reader.ReadCompactString();
+        var rackId = reader.ReadCompactString();
+        var memberEpoch = reader.ReadInt32();
+        var clientId = reader.ReadCompactString() ?? string.Empty;
+        var clientHost = reader.ReadCompactString() ?? string.Empty;
+
+        var subscribedTopicNames = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty);
+
+        var subscribedTopicRegex = reader.ReadCompactString();
+        var assignment = ConsumerGroupDescribeAssignment.Read(ref reader);
+        var targetAssignment = ConsumerGroupDescribeAssignment.Read(ref reader);
+        sbyte? memberType = version >= 1 ? reader.ReadInt8() : null;
+
+        reader.SkipTaggedFields();
+
+        return new ConsumerGroupDescribeMember
+        {
+            MemberId = memberId,
+            InstanceId = instanceId,
+            RackId = rackId,
+            MemberEpoch = memberEpoch,
+            ClientId = clientId,
+            ClientHost = clientHost,
+            SubscribedTopicNames = subscribedTopicNames,
+            SubscribedTopicRegex = subscribedTopicRegex,
+            Assignment = assignment,
+            TargetAssignment = targetAssignment,
+            MemberType = memberType
+        };
+    }
+}
+
+/// <summary>
+/// Assignment information in a ConsumerGroupDescribe response.
+/// </summary>
+public sealed class ConsumerGroupDescribeAssignment
+{
+    public required IReadOnlyList<ConsumerGroupDescribeTopicPartitions> TopicPartitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactArray(
+            TopicPartitions,
+            static (ref KafkaProtocolWriter w, ConsumerGroupDescribeTopicPartitions topicPartitions) => topicPartitions.Write(ref w));
+
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ConsumerGroupDescribeAssignment Read(ref KafkaProtocolReader reader)
+    {
+        var topicPartitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ConsumerGroupDescribeTopicPartitions.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new ConsumerGroupDescribeAssignment
+        {
+            TopicPartitions = topicPartitions
+        };
+    }
+}
+
+/// <summary>
+/// Topic partitions in a ConsumerGroupDescribe assignment.
+/// </summary>
+public sealed class ConsumerGroupDescribeTopicPartitions
+{
+    public required Guid TopicId { get; init; }
+    public required string TopicName { get; init; }
+    public required IReadOnlyList<int> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteUuid(TopicId);
+        writer.WriteCompactString(TopicName);
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, int partition) => w.WriteInt32(partition));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static ConsumerGroupDescribeTopicPartitions Read(ref KafkaProtocolReader reader)
+    {
+        var topicId = reader.ReadUuid();
+        var topicName = reader.ReadCompactString() ?? string.Empty;
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32());
+
+        reader.SkipTaggedFields();
+
+        return new ConsumerGroupDescribeTopicPartitions
+        {
+            TopicId = topicId,
+            TopicName = topicName,
+            Partitions = partitions
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Integration/RealWorld/AdminWorkflowTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/AdminWorkflowTests.cs
@@ -264,10 +264,10 @@ public sealed class AdminWorkflowTests(KafkaTestContainer kafka) : KafkaIntegrat
             var group = descriptions[groupId];
             await Assert.That(group.GroupId).IsEqualTo(groupId);
             await Assert.That(group.State).IsNotNull();
-            // Note: DescribeGroups (API key 15) does not return member details for
-            // KIP-848 consumer groups. Full member info requires ConsumerGroupDescribe
-            // (API key 69) which is not yet implemented.
-            await Assert.That(group.Members).IsNotNull();
+            await Assert.That(group.ProtocolType).IsEqualTo("consumer");
+            await Assert.That(group.GroupEpoch).IsNotNull();
+            await Assert.That(group.AssignmentEpoch).IsNotNull();
+            await Assert.That(group.Members.Count).IsGreaterThan(0);
         }
         catch (Exception ex) when (
             ex is TimeoutException ||
@@ -692,11 +692,13 @@ public sealed class AdminWorkflowTests(KafkaTestContainer kafka) : KafkaIntegrat
             var descriptions = await admin.DescribeConsumerGroupsAsync([groupId]).ConfigureAwait(false);
             var group = descriptions[groupId];
 
-            // DescribeGroups (API key 15) does not return member/assignment details for
-            // KIP-848 consumer groups. Verify group metadata is present; full member/assignment
-            // verification requires ConsumerGroupDescribe (API key 69).
+            // ConsumerGroupDescribe (API key 69) returns KIP-848 group metadata
+            // and member descriptions for active consumer groups.
             await Assert.That(group.GroupId).IsEqualTo(groupId);
             await Assert.That(group.State).IsNotNull();
+            await Assert.That(group.GroupEpoch).IsNotNull();
+            await Assert.That(group.AssignmentEpoch).IsNotNull();
+            await Assert.That(group.Members.Count).IsGreaterThan(0);
         }
         catch (Exception ex) when (
             ex is TimeoutException ||
@@ -765,9 +767,8 @@ public sealed class AdminWorkflowTests(KafkaTestContainer kafka) : KafkaIntegrat
             await Assert.That(descriptions).ContainsKey(groupId2);
             await Assert.That(descriptions[groupId1].GroupId).IsEqualTo(groupId1);
             await Assert.That(descriptions[groupId2].GroupId).IsEqualTo(groupId2);
-            // DescribeGroups (API key 15) does not return member details for KIP-848 groups
-            await Assert.That(descriptions[groupId1].Members).IsNotNull();
-            await Assert.That(descriptions[groupId2].Members).IsNotNull();
+            await Assert.That(descriptions[groupId1].GroupEpoch).IsNotNull();
+            await Assert.That(descriptions[groupId2].GroupEpoch).IsNotNull();
         }
         catch (Exception ex) when (
             ex is TimeoutException ||

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientConsumerGroupDescribeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientConsumerGroupDescribeTests.cs
@@ -1,0 +1,151 @@
+using Dekaf.Admin;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public sealed class AdminClientConsumerGroupDescribeTests
+{
+    [Test]
+    public async Task DescribeConsumerGroupsAsync_FallsBackPerGroupWhenApi69ReportsClassicGroup()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection();
+
+        connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<FindCoordinatorRequest>();
+                return ValueTask.FromResult(new FindCoordinatorResponse
+                {
+                    Coordinators =
+                    [
+                        new Coordinator
+                        {
+                            Key = request.Key,
+                            NodeId = 1,
+                            Host = "localhost",
+                            Port = 9092,
+                            ErrorCode = ErrorCode.None
+                        }
+                    ]
+                });
+            });
+
+        connection.SendAsync<ConsumerGroupDescribeRequest, ConsumerGroupDescribeResponse>(
+                Arg.Any<ConsumerGroupDescribeRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<ConsumerGroupDescribeRequest>();
+                return ValueTask.FromResult(new ConsumerGroupDescribeResponse
+                {
+                    Groups = request.GroupIds.Select(groupId => groupId == "classic-group"
+                        ? new ConsumerGroupDescribeGroup
+                        {
+                            ErrorCode = ErrorCode.GroupIdNotFound,
+                            ErrorMessage = "Group is not a consumer protocol group.",
+                            GroupId = groupId,
+                            GroupState = "",
+                            GroupEpoch = -1,
+                            AssignmentEpoch = -1,
+                            AssignorName = "",
+                            Members = []
+                        }
+                        : new ConsumerGroupDescribeGroup
+                        {
+                            ErrorCode = ErrorCode.None,
+                            GroupId = groupId,
+                            GroupState = "Stable",
+                            GroupEpoch = 3,
+                            AssignmentEpoch = 4,
+                            AssignorName = "range",
+                            AuthorizedOperations = 123,
+                            Members = []
+                        }).ToList()
+                });
+            });
+
+        connection.SendAsync<DescribeGroupsRequest, DescribeGroupsResponse>(
+                Arg.Any<DescribeGroupsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<DescribeGroupsRequest>();
+                return ValueTask.FromResult(new DescribeGroupsResponse
+                {
+                    Groups = request.Groups.Select(groupId => new DescribeGroupsResponseGroup
+                    {
+                        ErrorCode = ErrorCode.None,
+                        GroupId = groupId,
+                        GroupState = "Stable",
+                        ProtocolType = "consumer",
+                        ProtocolData = "cooperative-sticky",
+                        AuthorizedOperations = 456,
+                        Members = []
+                    }).ToList()
+                });
+            });
+
+        var descriptions = await admin.DescribeConsumerGroupsAsync(["consumer-group", "classic-group"]);
+
+        await Assert.That(descriptions).ContainsKey("consumer-group");
+        await Assert.That(descriptions).ContainsKey("classic-group");
+        await Assert.That(descriptions["consumer-group"].GroupEpoch).IsEqualTo(3);
+        await Assert.That(descriptions["consumer-group"].AssignorName).IsEqualTo("range");
+        await Assert.That(descriptions["classic-group"].GroupEpoch).IsNull();
+        await Assert.That(descriptions["classic-group"].ProtocolData).IsEqualTo("cooperative-sticky");
+
+        await connection.Received(1).SendAsync<DescribeGroupsRequest, DescribeGroupsResponse>(
+            Arg.Is<DescribeGroupsRequest>(r => r.Groups.Count == 1 && r.Groups[0] == "classic-group"),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static (AdminClient Admin, IKafkaConnection Connection) CreateAdminWithMockConnection()
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.BrokerId.Returns(1);
+        connection.Host.Returns("localhost");
+        connection.Port.Returns(9092);
+        connection.IsConnected.Returns(true);
+
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata
+                {
+                    NodeId = 1,
+                    Host = "localhost",
+                    Port = 9092
+                }
+            ],
+            ClusterId = "test-cluster",
+            ControllerId = 1,
+            Topics = []
+        });
+        metadataManager.SetApiVersion(ApiKey.FindCoordinator, 4, 5);
+        metadataManager.SetApiVersion(ApiKey.ConsumerGroupDescribe, 0, 1);
+        metadataManager.SetApiVersion(ApiKey.DescribeGroups, 5, 5);
+
+        var admin = new AdminClient(
+            new AdminClientOptions { BootstrapServers = ["localhost:9092"] },
+            pool,
+            metadataManager);
+
+        return (admin, connection);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ConsumerGroupDescribeMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ConsumerGroupDescribeMessageTests.cs
@@ -1,0 +1,336 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class ConsumerGroupDescribeMessageTests
+{
+    [Test]
+    public async Task Request_Metadata_MatchesApi69()
+    {
+        await Assert.That(ConsumerGroupDescribeRequest.ApiKey).IsEqualTo(ApiKey.ConsumerGroupDescribe);
+        await Assert.That(ConsumerGroupDescribeRequest.LowestSupportedVersion).IsEqualTo((short)0);
+        await Assert.That(ConsumerGroupDescribeRequest.HighestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    [Test]
+    public async Task Request_Write_V0_EncodesFlexibleSchema()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new ConsumerGroupDescribeRequest
+        {
+            GroupIds = ["group-a", "group-b"],
+            IncludeAuthorizedOperations = true
+        };
+
+        request.Write(ref writer, version: 0);
+
+        IReadOnlyList<string> groupIds;
+        bool includeAuthorizedOperations;
+        long remaining;
+        {
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            groupIds = reader.ReadCompactArray(
+                static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty);
+            includeAuthorizedOperations = reader.ReadBoolean();
+            reader.SkipTaggedFields();
+            remaining = reader.Remaining;
+        }
+
+        await Assert.That(groupIds).IsEquivalentTo(["group-a", "group-b"]);
+        await Assert.That(includeAuthorizedOperations).IsTrue();
+        await Assert.That(remaining).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_Metadata_MatchesApi69()
+    {
+        await Assert.That(ConsumerGroupDescribeResponse.ApiKey).IsEqualTo(ApiKey.ConsumerGroupDescribe);
+        await Assert.That(ConsumerGroupDescribeResponse.LowestSupportedVersion).IsEqualTo((short)0);
+        await Assert.That(ConsumerGroupDescribeResponse.HighestSupportedVersion).IsEqualTo((short)1);
+    }
+
+    [Test]
+    public async Task Response_Read_V0_ParsesMemberWithoutMemberType()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        WriteResponse(ref writer, version: 0);
+
+        ConsumerGroupDescribeResponse response;
+        long remaining;
+        {
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            response = (ConsumerGroupDescribeResponse)ConsumerGroupDescribeResponse.Read(ref reader, version: 0);
+            remaining = reader.Remaining;
+        }
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(25);
+        await Assert.That(response.Groups.Count).IsEqualTo(1);
+
+        var group = response.Groups[0];
+        await Assert.That(group.GroupId).IsEqualTo("consumer-group");
+        await Assert.That(group.GroupState).IsEqualTo("Stable");
+        await Assert.That(group.GroupEpoch).IsEqualTo(12);
+        await Assert.That(group.AssignmentEpoch).IsEqualTo(9);
+        await Assert.That(group.AssignorName).IsEqualTo("uniform");
+        await Assert.That(group.AuthorizedOperations).IsEqualTo(0x1F);
+
+        var member = group.Members[0];
+        await Assert.That(member.MemberId).IsEqualTo("member-1");
+        await Assert.That(member.InstanceId).IsEqualTo("instance-1");
+        await Assert.That(member.RackId).IsEqualTo("rack-a");
+        await Assert.That(member.MemberEpoch).IsEqualTo(7);
+        await Assert.That(member.ClientId).IsEqualTo("client-1");
+        await Assert.That(member.ClientHost).IsEqualTo("/127.0.0.1");
+        await Assert.That(member.SubscribedTopicNames).IsEquivalentTo(["topic-a", "topic-b"]);
+        await Assert.That(member.SubscribedTopicRegex).IsEqualTo("orders-.*");
+        await Assert.That(member.MemberType).IsNull();
+
+        await Assert.That(member.Assignment.TopicPartitions[0].TopicName).IsEqualTo("topic-a");
+        await Assert.That(member.Assignment.TopicPartitions[0].Partitions).IsEquivalentTo([0, 1]);
+        await Assert.That(member.TargetAssignment.TopicPartitions[0].TopicName).IsEqualTo("topic-b");
+        await Assert.That(member.TargetAssignment.TopicPartitions[0].Partitions).IsEquivalentTo([2]);
+        await Assert.That(remaining).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_Read_V1_ParsesMemberType()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        WriteResponse(ref writer, version: 1);
+
+        ConsumerGroupDescribeResponse response;
+        long remaining;
+        {
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            response = (ConsumerGroupDescribeResponse)ConsumerGroupDescribeResponse.Read(ref reader, version: 1);
+            remaining = reader.Remaining;
+        }
+
+        await Assert.That(response.Groups[0].Members[0].MemberType).IsEqualTo((sbyte)1);
+        await Assert.That(remaining).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_Read_ErrorGroup_ParsesError()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt16((short)ErrorCode.GroupIdNotFound);
+        writer.WriteCompactNullableString("missing");
+        writer.WriteCompactString("missing-group");
+        writer.WriteCompactString(string.Empty);
+        writer.WriteInt32(0);
+        writer.WriteInt32(0);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteUnsignedVarInt(0 + 1);
+        writer.WriteInt32(int.MinValue);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+
+        ConsumerGroupDescribeResponse response;
+        {
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            response = (ConsumerGroupDescribeResponse)ConsumerGroupDescribeResponse.Read(ref reader, version: 0);
+        }
+
+        await Assert.That(response.Groups[0].ErrorCode).IsEqualTo(ErrorCode.GroupIdNotFound);
+        await Assert.That(response.Groups[0].ErrorMessage).IsEqualTo("missing");
+        await Assert.That(response.Groups[0].AuthorizedOperations).IsEqualTo(int.MinValue);
+    }
+
+    [Test]
+    public async Task Member_WriteAndRead_V1_RoundTripsAllFields()
+    {
+        var topicId = Guid.NewGuid();
+        var targetTopicId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ConsumerGroupDescribeMember
+        {
+            MemberId = "member-1",
+            InstanceId = "instance-1",
+            RackId = "rack-a",
+            MemberEpoch = 7,
+            ClientId = "client-1",
+            ClientHost = "/127.0.0.1",
+            SubscribedTopicNames = ["topic-a", "topic-b"],
+            SubscribedTopicRegex = "orders-.*",
+            Assignment = Assignment(topicId, "topic-a", [0, 1]),
+            TargetAssignment = Assignment(targetTopicId, "topic-b", [2]),
+            MemberType = 1
+        };
+
+        original.Write(ref writer, version: 1);
+
+        ConsumerGroupDescribeMember deserialized;
+        long remaining;
+        {
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            deserialized = ConsumerGroupDescribeMember.Read(ref reader, version: 1);
+            remaining = reader.Remaining;
+        }
+
+        await Assert.That(deserialized.MemberId).IsEqualTo(original.MemberId);
+        await Assert.That(deserialized.InstanceId).IsEqualTo(original.InstanceId);
+        await Assert.That(deserialized.RackId).IsEqualTo(original.RackId);
+        await Assert.That(deserialized.MemberEpoch).IsEqualTo(original.MemberEpoch);
+        await Assert.That(deserialized.ClientId).IsEqualTo(original.ClientId);
+        await Assert.That(deserialized.ClientHost).IsEqualTo(original.ClientHost);
+        await Assert.That(deserialized.SubscribedTopicNames).IsEquivalentTo(original.SubscribedTopicNames);
+        await Assert.That(deserialized.SubscribedTopicRegex).IsEqualTo(original.SubscribedTopicRegex);
+        await Assert.That(deserialized.Assignment.TopicPartitions[0].TopicId).IsEqualTo(topicId);
+        await Assert.That(deserialized.TargetAssignment.TopicPartitions[0].TopicId).IsEqualTo(targetTopicId);
+        await Assert.That(deserialized.MemberType).IsEqualTo((sbyte)1);
+        await Assert.That(remaining).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Member_WriteAndRead_V0_DoesNotWriteMemberType()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ConsumerGroupDescribeMember
+        {
+            MemberId = "member-1",
+            MemberEpoch = 1,
+            ClientId = "client-1",
+            ClientHost = "/127.0.0.1",
+            SubscribedTopicNames = [],
+            Assignment = EmptyAssignment(),
+            TargetAssignment = EmptyAssignment(),
+            MemberType = 1
+        };
+
+        original.Write(ref writer, version: 0);
+
+        ConsumerGroupDescribeMember deserialized;
+        long remaining;
+        {
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            deserialized = ConsumerGroupDescribeMember.Read(ref reader, version: 0);
+            remaining = reader.Remaining;
+        }
+
+        await Assert.That(deserialized.MemberType).IsNull();
+        await Assert.That(remaining).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Member_WriteAndRead_V1_NullMemberTypeDefaultsToUnknown()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new ConsumerGroupDescribeMember
+        {
+            MemberId = "member-1",
+            MemberEpoch = 1,
+            ClientId = "client-1",
+            ClientHost = "/127.0.0.1",
+            SubscribedTopicNames = [],
+            Assignment = EmptyAssignment(),
+            TargetAssignment = EmptyAssignment()
+        };
+
+        original.Write(ref writer, version: 1);
+
+        ConsumerGroupDescribeMember deserialized;
+        {
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            deserialized = ConsumerGroupDescribeMember.Read(ref reader, version: 1);
+        }
+
+        await Assert.That(deserialized.MemberType).IsEqualTo((sbyte)-1);
+    }
+
+    private static void WriteResponse(ref KafkaProtocolWriter writer, short version)
+    {
+        var topicId = Guid.NewGuid();
+        var targetTopicId = Guid.NewGuid();
+
+        writer.WriteInt32(25);
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactNullableString(null);
+        writer.WriteCompactString("consumer-group");
+        writer.WriteCompactString("Stable");
+        writer.WriteInt32(12);
+        writer.WriteInt32(9);
+        writer.WriteCompactString("uniform");
+        writer.WriteUnsignedVarInt(1 + 1);
+
+        writer.WriteCompactString("member-1");
+        writer.WriteCompactNullableString("instance-1");
+        writer.WriteCompactNullableString("rack-a");
+        writer.WriteInt32(7);
+        writer.WriteCompactString("client-1");
+        writer.WriteCompactString("/127.0.0.1");
+        writer.WriteUnsignedVarInt(2 + 1);
+        writer.WriteCompactString("topic-a");
+        writer.WriteCompactString("topic-b");
+        writer.WriteCompactNullableString("orders-.*");
+        WriteAssignment(ref writer, topicId, "topic-a", [0, 1]);
+        WriteAssignment(ref writer, targetTopicId, "topic-b", [2]);
+        if (version >= 1)
+        {
+            writer.WriteInt8(1);
+        }
+        writer.WriteEmptyTaggedFields();
+
+        writer.WriteInt32(0x1F);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+    }
+
+    private static ConsumerGroupDescribeAssignment Assignment(
+        Guid topicId,
+        string topicName,
+        IReadOnlyList<int> partitions) =>
+        new()
+        {
+            TopicPartitions =
+            [
+                new ConsumerGroupDescribeTopicPartitions
+                {
+                    TopicId = topicId,
+                    TopicName = topicName,
+                    Partitions = partitions
+                }
+            ]
+        };
+
+    private static ConsumerGroupDescribeAssignment EmptyAssignment() =>
+        new()
+        {
+            TopicPartitions = []
+        };
+
+    private static void WriteAssignment(
+        ref KafkaProtocolWriter writer,
+        Guid topicId,
+        string topicName,
+        IReadOnlyList<int> partitions)
+    {
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteUuid(topicId);
+        writer.WriteCompactString(topicName);
+        writer.WriteCompactArray(
+            partitions,
+            static (ref KafkaProtocolWriter w, int partition) => w.WriteInt32(partition));
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+    }
+}


### PR DESCRIPTION
## Summary
- add ConsumerGroupDescribe API 69 request/response messages for versions 0-1
- route admin consumer group descriptions through API 69 when broker supports it, with classic DescribeGroups fallback
- expose KIP-848 group/member metadata on admin descriptions and update admin integration coverage

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit --configuration Release
- [x] tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe --treenode-filter '/*/*/*/(Request_Metadata_MatchesApi69|Request_Write_V0_EncodesFlexibleSchema|Response_Metadata_MatchesApi69|Response_Read_V0_ParsesMemberWithoutMemberType|Response_Read_V1_ParsesMemberType|Response_Read_ErrorGroup_ParsesError|Member_WriteAndRead_V1_RoundTripsAllFields|Member_WriteAndRead_V0_DoesNotWriteMemberType|Member_WriteAndRead_V1_NullMemberTypeDefaultsToUnknown)'
- [x] dotnet build tests/Dekaf.Tests.Integration --configuration Release
- [x] tests\\Dekaf.Tests.Integration\\bin\\Release\\net10.0\\Dekaf.Tests.Integration.exe --treenode-filter '/*/*/*/(AdminClient_DescribeConsumerGroups_ReturnsGroupDetails|AdminClient_DescribeConsumerGroups_MultipleGroups_ReturnsSeparateDescriptions)' --timeout 10m
- [ ] Full unit suite: one unrelated intermittent failure in RunAsync_AssignmentLoss_DrainsInFlightAndStopsFetching (expected fetchCount >= 3, got 2); isolated rerun of that test passed.

Closes #824
