### PR TITLE
perf(producer): avoid sender factory alloc

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2187,7 +2187,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// </summary>
     private BrokerSender GetOrCreateBrokerSender(int brokerId)
     {
-        var sender = _brokerSenders.GetOrAdd(brokerId, CreateBrokerSender);
+        var sender = GetExistingOrCreateBrokerSender(brokerId);
 
         if (sender.IsAlive)
             return sender;
@@ -2209,7 +2209,21 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         // Another thread replaced it concurrently — dispose ours, use theirs
         _ = replacement.DisposeAsync();
-        return _brokerSenders.GetOrAdd(brokerId, CreateBrokerSender);
+        return GetExistingOrCreateBrokerSender(brokerId);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private BrokerSender GetExistingOrCreateBrokerSender(int brokerId)
+    {
+        if (_brokerSenders.TryGetValue(brokerId, out var sender))
+        {
+            return sender;
+        }
+
+        return _brokerSenders.GetOrAdd(
+            brokerId,
+            static (id, producer) => producer.CreateBrokerSender(id),
+            this);
     }
 
     private BrokerSender CreateBrokerSender(int brokerId)


### PR DESCRIPTION
## Summary
- avoid the per-call instance method-group allocation in `GetOrCreateBrokerSender`
- add a `TryGetValue` fast path for the common existing-sender case
- use the stateful `ConcurrentDictionary.GetOrAdd` factory only on sender misses

Refs #935 (first checklist item)

## Validation
- `dotnet restore tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj`
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaProducerFastPathTests/*" --minimum-expected-tests 1 --maximum-parallel-tests 1 --log-level Information`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/BrokerSenderTests/*" --minimum-expected-tests 1 --maximum-parallel-tests 1 --log-level Information`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/BrokerSenderSendLoopTests/*" --minimum-expected-tests 1 --maximum-parallel-tests 1 --log-level Information`
- `git diff --check -- src\Dekaf\Producer\KafkaProducer.cs`