### PR TITLE
feat(di): add keyed client registrations

### DIFF
--- a/docs/docs/dependency-injection.md
+++ b/docs/docs/dependency-injection.md
@@ -105,7 +105,7 @@ public class OrderService
 
 ## Multiple Producers/Consumers
 
-Register multiple producers or consumers with different type parameters:
+Register multiple producers or consumers with different type parameters normally:
 
 ```csharp
 builder.Services.AddDekaf(dekaf =>
@@ -119,6 +119,84 @@ builder.Services.AddDekaf(dekaf =>
         .WithBootstrapServers(config["Kafka:BootstrapServers"]!)
         .WithBatchSize(128 * 1024)
         .ForHighThroughput());
+});
+```
+
+If two clients use the same `<TKey, TValue>` pair, register them with service keys.
+
+Before:
+
+```csharp
+builder.Services.AddDekaf(dekaf =>
+{
+    dekaf.AddProducer<string, string>(producer => producer
+        .WithBootstrapServers(config["Kafka:Orders:BootstrapServers"]!)
+        .WithClientId("orders-producer"));
+
+    dekaf.AddProducer<string, string>(producer => producer
+        .WithBootstrapServers(config["Kafka:Payments:BootstrapServers"]!)
+        .WithClientId("payments-producer"));
+});
+
+public class OrderHandler(IKafkaProducer<string, string> producer)
+{
+    // Ambiguous: both registrations use the same service type.
+}
+```
+
+After:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+builder.Services.AddDekaf(dekaf =>
+{
+    dekaf.AddProducer<string, string>("orders", producer => producer
+        .WithBootstrapServers(config["Kafka:Orders:BootstrapServers"]!)
+        .WithClientId("orders-producer"));
+
+    dekaf.AddProducer<string, string>("payments", producer => producer
+        .WithBootstrapServers(config["Kafka:Payments:BootstrapServers"]!)
+        .WithClientId("payments-producer"));
+
+    dekaf.AddConsumer<string, string>("orders", consumer => consumer
+        .WithBootstrapServers(config["Kafka:Orders:BootstrapServers"]!)
+        .WithGroupId("orders-service"));
+});
+
+public class OrderHandler(
+    [FromKeyedServices("orders")] IKafkaProducer<string, string> producer)
+{
+    // Receives the orders producer.
+}
+
+public class PaymentHandler(
+    [FromKeyedServices("payments")] IKafkaProducer<string, string> producer)
+{
+    // Receives the payments producer.
+}
+```
+
+The existing unkeyed overload remains the default-client registration. You can use one
+unkeyed producer or consumer for the common case, then add keyed clients for additional
+clusters, tenants, or workloads that share the same generic type.
+
+Keyed clients also support configuration sections:
+
+```csharp
+builder.Services.AddDekaf(dekaf =>
+{
+    dekaf.AddProducer<string, Order>(
+        "orders",
+        builder.Configuration.GetSection("Kafka:Producers:Orders"),
+        producer => producer.WithValueSerializer(new JsonSerializer<Order>()));
+
+    dekaf.AddConsumer<string, Order>(
+        "orders",
+        builder.Configuration.GetSection("Kafka:Consumers:Orders"),
+        consumer => consumer
+            .WithValueDeserializer(new JsonDeserializer<Order>())
+            .SubscribeTo("orders"));
 });
 ```
 

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -112,42 +112,53 @@ public sealed class DekafBuilder
     /// <param name="configure">Configures the full producer builder surface.</param>
     public DekafBuilder AddProducer<TKey, TValue>(Action<ProducerBuilder<TKey, TValue>> configure)
     {
+        ArgumentNullException.ThrowIfNull(configure);
+        return AddProducerCore(serviceKey: null, isKeyed: false, configure);
+    }
+
+    /// <summary>
+    /// Adds a keyed producer to the service collection.
+    /// </summary>
+    /// <param name="serviceKey">Key used to resolve the producer through keyed DI.</param>
+    /// <param name="configure">Configures the full producer builder surface.</param>
+    public DekafBuilder AddProducer<TKey, TValue>(
+        object serviceKey,
+        Action<ProducerBuilder<TKey, TValue>> configure)
+    {
+        ArgumentNullException.ThrowIfNull(serviceKey);
+        ArgumentNullException.ThrowIfNull(configure);
+        return AddProducerCore(serviceKey, isKeyed: true, configure);
+    }
+
+    private DekafBuilder AddProducerCore<TKey, TValue>(
+        object? serviceKey,
+        bool isKeyed,
+        Action<ProducerBuilder<TKey, TValue>> configure)
+    {
         var builder = new ProducerBuilder<TKey, TValue>();
         configure(builder);
 
         var globalTypes = _globalProducerInterceptorTypes;
 
-        _services.AddSingleton<IKafkaProducer<TKey, TValue>>(sp =>
+        if (isKeyed)
         {
-            var loggerFactory = sp.GetService<ILoggerFactory>();
+            _services.AddKeyedSingleton<IKafkaProducer<TKey, TValue>>(
+                serviceKey!,
+                (sp, _) => BuildProducer(sp, builder, globalTypes));
 
-            if (globalTypes.Count > 0)
-            {
-                var globalInterceptors = new List<IProducerInterceptor<TKey, TValue>>(globalTypes.Count);
-                foreach (var type in globalTypes)
-                {
-                    var closedType = type.IsGenericTypeDefinition
-                        ? type.MakeGenericType(typeof(TKey), typeof(TValue))
-                        : type;
-                    var interceptor = (IProducerInterceptor<TKey, TValue>)
-                        ActivatorUtilities.CreateInstance(sp, closedType);
-                    globalInterceptors.Add(interceptor);
-                }
+            // Register as IInitializableKafkaClient (resolves the same keyed singleton instance).
+            _services.AddSingleton<IInitializableKafkaClient>(sp =>
+                sp.GetRequiredKeyedService<IKafkaProducer<TKey, TValue>>(serviceKey!));
+        }
+        else
+        {
+            _services.AddSingleton<IKafkaProducer<TKey, TValue>>(sp =>
+                BuildProducer(sp, builder, globalTypes));
 
-                builder.AddInterceptorsFirst(globalInterceptors);
-            }
-
-            if (loggerFactory is not null)
-            {
-                builder.WithLoggerFactory(loggerFactory);
-            }
-
-            return builder.Build();
-        });
-
-        // Register as IInitializableKafkaClient (resolves the same singleton instance)
-        _services.AddSingleton<IInitializableKafkaClient>(sp =>
-            sp.GetRequiredService<IKafkaProducer<TKey, TValue>>());
+            // Register as IInitializableKafkaClient (resolves the same singleton instance).
+            _services.AddSingleton<IInitializableKafkaClient>(sp =>
+                sp.GetRequiredService<IKafkaProducer<TKey, TValue>>());
+        }
 
         return this;
     }
@@ -172,6 +183,28 @@ public sealed class DekafBuilder
     }
 
     /// <summary>
+    /// Adds a keyed producer configured from an <see cref="IConfiguration"/> section.
+    /// Fluent configuration runs after binding, so it can override config values and add services such as serializers.
+    /// </summary>
+    /// <param name="serviceKey">Key used to resolve the producer through keyed DI.</param>
+    /// <param name="configuration">Configuration section using <see cref="ProducerOptions"/> property names.</param>
+    /// <param name="configure">Optional additional producer configuration.</param>
+    public DekafBuilder AddProducer<TKey, TValue>(
+        object serviceKey,
+        IConfiguration configuration,
+        Action<ProducerBuilder<TKey, TValue>>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceKey);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return AddProducer<TKey, TValue>(serviceKey, producer =>
+        {
+            DekafConfigurationBinding.ApplyProducer(configuration, producer);
+            configure?.Invoke(producer);
+        });
+    }
+
+    /// <summary>
     /// Adds a consumer to the service collection.
     /// </summary>
     /// <param name="configure">Configures the full consumer builder surface.</param>
@@ -180,42 +213,56 @@ public sealed class DekafBuilder
         Action<ConsumerBuilder<TKey, TValue>> configure,
         Action<DeadLetterQueueBuilder>? configureDeadLetterQueue = null)
     {
+        ArgumentNullException.ThrowIfNull(configure);
+        return AddConsumerCore(serviceKey: null, isKeyed: false, configure, configureDeadLetterQueue);
+    }
+
+    /// <summary>
+    /// Adds a keyed consumer to the service collection.
+    /// </summary>
+    /// <param name="serviceKey">Key used to resolve the consumer through keyed DI.</param>
+    /// <param name="configure">Configures the full consumer builder surface.</param>
+    /// <param name="configureDeadLetterQueue">Optional dead letter queue configuration for hosted consumer services.</param>
+    public DekafBuilder AddConsumer<TKey, TValue>(
+        object serviceKey,
+        Action<ConsumerBuilder<TKey, TValue>> configure,
+        Action<DeadLetterQueueBuilder>? configureDeadLetterQueue = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceKey);
+        ArgumentNullException.ThrowIfNull(configure);
+        return AddConsumerCore(serviceKey, isKeyed: true, configure, configureDeadLetterQueue);
+    }
+
+    private DekafBuilder AddConsumerCore<TKey, TValue>(
+        object? serviceKey,
+        bool isKeyed,
+        Action<ConsumerBuilder<TKey, TValue>> configure,
+        Action<DeadLetterQueueBuilder>? configureDeadLetterQueue)
+    {
         var builder = new ConsumerBuilder<TKey, TValue>();
         configure(builder);
 
         var globalTypes = _globalConsumerInterceptorTypes;
 
-        _services.AddSingleton<IKafkaConsumer<TKey, TValue>>(sp =>
+        if (isKeyed)
         {
-            var loggerFactory = sp.GetService<ILoggerFactory>();
+            _services.AddKeyedSingleton<IKafkaConsumer<TKey, TValue>>(
+                serviceKey!,
+                (sp, _) => BuildConsumer(sp, builder, globalTypes));
 
-            if (globalTypes.Count > 0)
-            {
-                var globalInterceptors = new List<IConsumerInterceptor<TKey, TValue>>(globalTypes.Count);
-                foreach (var type in globalTypes)
-                {
-                    var closedType = type.IsGenericTypeDefinition
-                        ? type.MakeGenericType(typeof(TKey), typeof(TValue))
-                        : type;
-                    var interceptor = (IConsumerInterceptor<TKey, TValue>)
-                        ActivatorUtilities.CreateInstance(sp, closedType);
-                    globalInterceptors.Add(interceptor);
-                }
+            // Register as IInitializableKafkaClient (resolves the same keyed singleton instance).
+            _services.AddSingleton<IInitializableKafkaClient>(sp =>
+                sp.GetRequiredKeyedService<IKafkaConsumer<TKey, TValue>>(serviceKey!));
+        }
+        else
+        {
+            _services.AddSingleton<IKafkaConsumer<TKey, TValue>>(sp =>
+                BuildConsumer(sp, builder, globalTypes));
 
-                builder.AddInterceptorsFirst(globalInterceptors);
-            }
-
-            if (loggerFactory is not null)
-            {
-                builder.WithLoggerFactory(loggerFactory);
-            }
-
-            return builder.Build();
-        });
-
-        // Register as IInitializableKafkaClient (resolves the same singleton instance)
-        _services.AddSingleton<IInitializableKafkaClient>(sp =>
-            sp.GetRequiredService<IKafkaConsumer<TKey, TValue>>());
+            // Register as IInitializableKafkaClient (resolves the same singleton instance).
+            _services.AddSingleton<IInitializableKafkaClient>(sp =>
+                sp.GetRequiredService<IKafkaConsumer<TKey, TValue>>());
+        }
 
         if (configureDeadLetterQueue is not null)
         {
@@ -259,6 +306,33 @@ public sealed class DekafBuilder
     }
 
     /// <summary>
+    /// Adds a keyed consumer configured from an <see cref="IConfiguration"/> section.
+    /// Fluent configuration runs after binding, so it can override config values and add services such as deserializers.
+    /// </summary>
+    /// <param name="serviceKey">Key used to resolve the consumer through keyed DI.</param>
+    /// <param name="configuration">Configuration section using <see cref="ConsumerOptions"/> property names.</param>
+    /// <param name="configure">Optional additional consumer configuration.</param>
+    /// <param name="configureDeadLetterQueue">Optional dead letter queue configuration for hosted consumer services.</param>
+    public DekafBuilder AddConsumer<TKey, TValue>(
+        object serviceKey,
+        IConfiguration configuration,
+        Action<ConsumerBuilder<TKey, TValue>>? configure = null,
+        Action<DeadLetterQueueBuilder>? configureDeadLetterQueue = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceKey);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return AddConsumer<TKey, TValue>(
+            serviceKey,
+            consumer =>
+            {
+                DekafConfigurationBinding.ApplyConsumer(configuration, consumer);
+                configure?.Invoke(consumer);
+            },
+            configureDeadLetterQueue);
+    }
+
+    /// <summary>
     /// Adds an admin client to the service collection.
     /// </summary>
     public DekafBuilder AddAdminClient(Action<AdminClientServiceBuilder> configure)
@@ -292,6 +366,68 @@ public sealed class DekafBuilder
             admin.ApplyConfiguration(configuration);
             configure?.Invoke(admin);
         });
+    }
+
+    private static IKafkaProducer<TKey, TValue> BuildProducer<TKey, TValue>(
+        IServiceProvider serviceProvider,
+        ProducerBuilder<TKey, TValue> builder,
+        IReadOnlyList<Type> globalTypes)
+    {
+        var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
+
+        if (globalTypes.Count > 0)
+        {
+            var globalInterceptors = new List<IProducerInterceptor<TKey, TValue>>(globalTypes.Count);
+            foreach (var type in globalTypes)
+            {
+                var closedType = type.IsGenericTypeDefinition
+                    ? type.MakeGenericType(typeof(TKey), typeof(TValue))
+                    : type;
+                var interceptor = (IProducerInterceptor<TKey, TValue>)
+                    ActivatorUtilities.CreateInstance(serviceProvider, closedType);
+                globalInterceptors.Add(interceptor);
+            }
+
+            builder.AddInterceptorsFirst(globalInterceptors);
+        }
+
+        if (loggerFactory is not null)
+        {
+            builder.WithLoggerFactory(loggerFactory);
+        }
+
+        return builder.Build();
+    }
+
+    private static IKafkaConsumer<TKey, TValue> BuildConsumer<TKey, TValue>(
+        IServiceProvider serviceProvider,
+        ConsumerBuilder<TKey, TValue> builder,
+        IReadOnlyList<Type> globalTypes)
+    {
+        var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
+
+        if (globalTypes.Count > 0)
+        {
+            var globalInterceptors = new List<IConsumerInterceptor<TKey, TValue>>(globalTypes.Count);
+            foreach (var type in globalTypes)
+            {
+                var closedType = type.IsGenericTypeDefinition
+                    ? type.MakeGenericType(typeof(TKey), typeof(TValue))
+                    : type;
+                var interceptor = (IConsumerInterceptor<TKey, TValue>)
+                    ActivatorUtilities.CreateInstance(serviceProvider, closedType);
+                globalInterceptors.Add(interceptor);
+            }
+
+            builder.AddInterceptorsFirst(globalInterceptors);
+        }
+
+        if (loggerFactory is not null)
+        {
+            builder.WithLoggerFactory(loggerFactory);
+        }
+
+        return builder.Build();
     }
 }
 

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -82,6 +82,80 @@ public class DependencyInjectionTests
         await Assert.That(intDescriptor).IsNotNull();
     }
 
+    [Test]
+    public async Task AddProducer_WithServiceKeys_RegistersDistinctKeyedProducers()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>("orders", p => p
+                .WithBootstrapServers("localhost:9092")
+                .WithClientId("orders-producer"));
+            builder.AddProducer<string, string>("payments", p => p
+                .WithBootstrapServers("localhost:9092")
+                .WithClientId("payments-producer"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var orders = provider.GetRequiredKeyedService<IKafkaProducer<string, string>>("orders");
+        var payments = provider.GetRequiredKeyedService<IKafkaProducer<string, string>>("payments");
+
+        await Assert.That(orders).IsNotSameReferenceAs(payments);
+        await Assert.That(GetProducerOptions(orders).ClientId).IsEqualTo("orders-producer");
+        await Assert.That(GetProducerOptions(payments).ClientId).IsEqualTo("payments-producer");
+        await Assert.That(provider.GetServices<IKafkaProducer<string, string>>().Count()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task AddProducer_DefaultAndKeyed_CanCoexistForSameGenericType()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>(p => p
+                .WithBootstrapServers("localhost:9092")
+                .WithClientId("default-producer"));
+            builder.AddProducer<string, string>("orders", p => p
+                .WithBootstrapServers("localhost:9092")
+                .WithClientId("orders-producer"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var defaultProducer = provider.GetRequiredService<IKafkaProducer<string, string>>();
+        var ordersProducer = provider.GetRequiredKeyedService<IKafkaProducer<string, string>>("orders");
+
+        await Assert.That(defaultProducer).IsNotSameReferenceAs(ordersProducer);
+        await Assert.That(GetProducerOptions(defaultProducer).ClientId).IsEqualTo("default-producer");
+        await Assert.That(GetProducerOptions(ordersProducer).ClientId).IsEqualTo("orders-producer");
+    }
+
+    [Test]
+    public async Task AddProducer_WithServiceKeyAndConfigurationSection_BindsOptions()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:Producers:Orders:BootstrapServers"] = "broker1:9092",
+            ["Kafka:Producers:Orders:ClientId"] = "orders-producer"
+        });
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>(
+                "orders",
+                configuration.GetSection("Kafka:Producers:Orders"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var producer = provider.GetRequiredKeyedService<IKafkaProducer<string, string>>("orders");
+        var options = GetProducerOptions(producer);
+
+        await Assert.That(options.BootstrapServers[0]).IsEqualTo("broker1:9092");
+        await Assert.That(options.ClientId).IsEqualTo("orders-producer");
+    }
+
     #endregion
 
     #region AddConsumer Tests
@@ -101,6 +175,56 @@ public class DependencyInjectionTests
         var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IKafkaConsumer<string, string>));
         await Assert.That(descriptor).IsNotNull();
         await Assert.That(descriptor!.Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+    }
+
+    [Test]
+    public async Task AddConsumer_WithServiceKeys_RegistersDistinctKeyedConsumers()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddConsumer<string, string>("orders", c => c
+                .WithBootstrapServers("localhost:9092")
+                .WithGroupId("orders-group"));
+            builder.AddConsumer<string, string>("payments", c => c
+                .WithBootstrapServers("localhost:9092")
+                .WithGroupId("payments-group"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var orders = provider.GetRequiredKeyedService<IKafkaConsumer<string, string>>("orders");
+        var payments = provider.GetRequiredKeyedService<IKafkaConsumer<string, string>>("payments");
+
+        await Assert.That(orders).IsNotSameReferenceAs(payments);
+        await Assert.That(GetConsumerOptions(orders).GroupId).IsEqualTo("orders-group");
+        await Assert.That(GetConsumerOptions(payments).GroupId).IsEqualTo("payments-group");
+        await Assert.That(provider.GetServices<IKafkaConsumer<string, string>>().Count()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task AddConsumer_WithServiceKeyAndConfigurationSection_BindsOptions()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:Consumers:Orders:BootstrapServers"] = "broker1:9092",
+            ["Kafka:Consumers:Orders:GroupId"] = "orders-group"
+        });
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddConsumer<string, string>(
+                "orders",
+                configuration.GetSection("Kafka:Consumers:Orders"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var consumer = provider.GetRequiredKeyedService<IKafkaConsumer<string, string>>("orders");
+        var options = GetConsumerOptions(consumer);
+
+        await Assert.That(options.BootstrapServers[0]).IsEqualTo("broker1:9092");
+        await Assert.That(options.GroupId).IsEqualTo("orders-group");
     }
 
     #endregion
@@ -532,6 +656,29 @@ public class DependencyInjectionTests
 
         var descriptors = services.Where(d => d.ServiceType == typeof(IInitializableKafkaClient)).ToList();
         await Assert.That(descriptors.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task AddKeyedProducerAndConsumer_RegisterAsInitializableKafkaClients()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>("orders", p => p.WithBootstrapServers("localhost:9092"));
+            builder.AddConsumer<string, string>("orders", c => c
+                .WithBootstrapServers("localhost:9092")
+                .WithGroupId("orders"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var producer = provider.GetRequiredKeyedService<IKafkaProducer<string, string>>("orders");
+        var consumer = provider.GetRequiredKeyedService<IKafkaConsumer<string, string>>("orders");
+        var initializables = provider.GetServices<IInitializableKafkaClient>().ToList();
+
+        await Assert.That(initializables.Count).IsEqualTo(2);
+        await Assert.That(initializables).Contains(producer);
+        await Assert.That(initializables).Contains(consumer);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- add keyed producer and consumer registration overloads for DI
- keep keyed clients in startup initialization by registering matching IInitializableKafkaClient factories
- document `[FromKeyedServices]` usage and keyed configuration-section overloads

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit --configuration Release
- [x] tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe --treenode-filter '/*/*/DependencyInjectionTests/*'
- [x] tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe --treenode-filter '/*/*/GlobalInterceptorOrderingTests/*'
- [x] npm ci --prefix docs (reported 41 vulnerabilities; not changed here)
- [x] npm run build --prefix docs

Closes #1015
