### PR TITLE
fix(consumer): preserve fetch pool on resize

### DIFF
--- a/scripts/Assert-PrGreen.ps1
+++ b/scripts/Assert-PrGreen.ps1
@@ -94,7 +94,7 @@ if ($requestedChanges.Count -gt 0) {
     Deny "latest review requests changes from: $authors"
 }
 
-$actionableHeadingPattern = '(?im)^\s*#{2,4}\s*(Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Blocking|Blocker|Test coverage gap|Required|Must fix)\b'
+$actionableHeadingPattern = '(?im)^\s*#{2,4}\s+.*\b(Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|(?<!not )(?<!non-)Blocking|(?<!not )(?<!non-)Blocker|Test coverage gap|Required|Must fix)\b'
 $actionableReviews = @()
 foreach ($review in $latestReviews) {
     if ($review.state -ne 'COMMENTED') { continue }

--- a/scripts/Assert-PrGreen.ps1
+++ b/scripts/Assert-PrGreen.ps1
@@ -7,6 +7,7 @@
 #   - mergeStateStatus == CLEAN
 #   - every status check is terminal AND passing (CheckRun: status=COMPLETED and
 #     conclusion in SUCCESS/SKIPPED/NEUTRAL; StatusContext: state=SUCCESS)
+#   - no latest top-level review has actionable finding headings
 #   - no unresolved review threads
 #
 # Any other state — pending/queued/in-progress checks, an empty rollup, a failed
@@ -38,7 +39,7 @@ $repoArgs = @()
 if ($Repo) { $repoArgs = @('--repo', $Repo) }
 
 # Re-fetch fresh — survey output goes stale within seconds.
-$raw = gh pr view $Pr @repoArgs --json number,state,mergeable,mergeStateStatus,statusCheckRollup 2>$null
+$raw = gh pr view $Pr @repoArgs --json number,state,mergeable,mergeStateStatus,statusCheckRollup,latestReviews 2>$null
 if ($LASTEXITCODE -ne 0) { Deny "gh pr view failed (exit $LASTEXITCODE)" }
 try {
     $view = $raw | ConvertFrom-Json
@@ -81,6 +82,31 @@ foreach ($c in $checks) {
 }
 if ($bad.Count -gt 0) {
     Deny ("checks not green: " + ($bad -join '; '))
+}
+
+# Top-level review comments are not review threads, so GitHub does not expose a
+# resolved flag for them. Fail closed on common review-finding headings instead
+# of treating a COMMENTED review as automatically safe.
+$latestReviews = @($view.latestReviews | Where-Object { $null -ne $_ })
+$requestedChanges = @($latestReviews | Where-Object { $_.state -eq 'CHANGES_REQUESTED' })
+if ($requestedChanges.Count -gt 0) {
+    $authors = ($requestedChanges | ForEach-Object { $_.author.login }) -join ', '
+    Deny "latest review requests changes from: $authors"
+}
+
+$actionableHeadingPattern = '(?im)^\s*#{2,4}\s*(Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Blocking|Blocker|Test coverage gap|Required|Must fix)\b'
+$actionableReviews = @()
+foreach ($review in $latestReviews) {
+    if ($review.state -ne 'COMMENTED') { continue }
+    $body = [string]$review.body
+    if (-not $body) { continue }
+    if ($body -match $actionableHeadingPattern) {
+        $heading = $Matches[0].Trim()
+        $actionableReviews += "$($review.author.login): $heading"
+    }
+}
+if ($actionableReviews.Count -gt 0) {
+    Deny ("latest top-level review comment has actionable finding(s): " + ($actionableReviews -join '; '))
 }
 
 # Unresolved review threads block merge even when a review's state is COMMENTED.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -35,7 +35,7 @@ internal sealed class PendingFetchData : IDisposable
     private const int DefaultMaxPoolSize = 128;
     private static int s_maxPoolSize = DefaultMaxPoolSize;
     private static LockFreeStack<PendingFetchData> s_pool = new(DefaultMaxPoolSize);
-    private static readonly object s_resizeLock = new();
+    private static readonly Lock s_resizeLock = new();
 
     internal static int MaxPoolSizeValue => Volatile.Read(ref s_maxPoolSize);
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -52,6 +52,12 @@ internal sealed class PendingFetchData : IDisposable
                 if (currentPool.Capacity < newSize)
                 {
                     var newPool = new LockFreeStack<PendingFetchData>(newSize);
+                    // Drain existing pool into the new one. A thread holding a stale
+                    // reference to currentPool may return an item after this drain but
+                    // before the Volatile.Write below. That item is not migrated and can
+                    // be GC'd. This is acceptable because resize runs only when consumer
+                    // assignment raises the high-water mark, not per message; a one-time
+                    // loss is recovered on demand via the miss path.
                     while (currentPool.TryPop(out var item))
                         newPool.TryPush(item);
                     Volatile.Write(ref s_pool, newPool);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -35,21 +35,27 @@ internal sealed class PendingFetchData : IDisposable
     private const int DefaultMaxPoolSize = 128;
     private static int s_maxPoolSize = DefaultMaxPoolSize;
     private static LockFreeStack<PendingFetchData> s_pool = new(DefaultMaxPoolSize);
+    private static readonly object s_resizeLock = new();
 
     internal static int MaxPoolSizeValue => Volatile.Read(ref s_maxPoolSize);
 
     internal static void RatchetPoolSize(int newSize)
     {
-        while (true)
-        {
-            var current = Volatile.Read(ref s_maxPoolSize);
-            if (newSize <= current)
-                return;
+        InterlockedHelper.RatchetUp(ref s_maxPoolSize, newSize);
 
-            if (Interlocked.CompareExchange(ref s_maxPoolSize, newSize, current) == current)
+        var currentPool = Volatile.Read(ref s_pool);
+        if (currentPool.Capacity < newSize)
+        {
+            lock (s_resizeLock)
             {
-                Volatile.Write(ref s_pool, new LockFreeStack<PendingFetchData>(newSize));
-                return;
+                currentPool = Volatile.Read(ref s_pool);
+                if (currentPool.Capacity < newSize)
+                {
+                    var newPool = new LockFreeStack<PendingFetchData>(newSize);
+                    while (currentPool.TryPop(out var item))
+                        newPool.TryPush(item);
+                    Volatile.Write(ref s_pool, newPool);
+                }
             }
         }
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Dekaf.Consumer;
+using Dekaf.Internal;
 using Dekaf.Protocol.Records;
 
 namespace Dekaf.Tests.Unit.Consumer;
@@ -8,6 +9,10 @@ public class PendingFetchDataTests
 {
     private static readonly FieldInfo ActivityNameField = typeof(PendingFetchData)
         .GetField("_activityName", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly FieldInfo MaxPoolSizeField = typeof(PendingFetchData)
+        .GetField("s_maxPoolSize", BindingFlags.Static | BindingFlags.NonPublic)!;
+    private static readonly FieldInfo PoolField = typeof(PendingFetchData)
+        .GetField("s_pool", BindingFlags.Static | BindingFlags.NonPublic)!;
 
     [Test]
     public async Task Constructor_WithActivityName_UsesCachedValue()
@@ -111,6 +116,42 @@ public class PendingFetchDataTests
 
         PendingFetchData.RatchetPoolSize(before + 100);
         await Assert.That(PendingFetchData.MaxPoolSizeValue).IsGreaterThanOrEqualTo(before + 100);
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task RatchetPoolSize_PreservesPooledInstances()
+    {
+        var originalMaxPoolSize = MaxPoolSizeField.GetValue(null);
+        var originalPool = PoolField.GetValue(null);
+        PendingFetchData? second = null;
+
+        try
+        {
+            MaxPoolSizeField.SetValue(null, 1);
+            PoolField.SetValue(null, new LockFreeStack<PendingFetchData>(1));
+
+            var first = PendingFetchData.Create(
+                "topic-1",
+                partitionIndex: 0,
+                batches: Array.Empty<RecordBatch>());
+            first.Dispose();
+
+            PendingFetchData.RatchetPoolSize(2);
+
+            second = PendingFetchData.Create(
+                "topic-2",
+                partitionIndex: 1,
+                batches: Array.Empty<RecordBatch>());
+
+            await Assert.That(second).IsSameReferenceAs(first);
+        }
+        finally
+        {
+            second?.Dispose();
+            MaxPoolSizeField.SetValue(null, originalMaxPoolSize);
+            PoolField.SetValue(null, originalPool);
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- preserve pooled `PendingFetchData` instances when `RatchetPoolSize` grows the static pool
- mirror the existing `BatchArena` drain-and-swap resize pattern
- add regression coverage that a disposed pooled instance survives a resize
- harden `Assert-PrGreen.ps1` so latest top-level `COMMENTED` reviews with actionable finding headings block merge

Refs #1031 follow-up review.

## Validation
- `dotnet restore tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj`
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/PendingFetchDataTests/*" --no-ansi --output Detailed` (9 passed)
- PowerShell parsed `scripts\Assert-PrGreen.ps1`
- `Assert-PrGreen.ps1 -Pr 1036` denied while checks were pending
- regex validation matched #1031's `### Correctness` top-level review heading

Note: full unit run with `--fail-fast` hit an unrelated networking timeout in `SendFireAndForgetAsync_WritesFrameToStream` and cascaded cancellation before completion.