### PR TITLE
Add duration-based auto offset reset

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -82,6 +82,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithOffsetCommitMode(...)` | `OffsetCommitMode` | `Auto` or `Manual` |
 | `WithAutoCommitInterval(...)` | `AutoCommitIntervalMs` | Milliseconds |
 | `WithAutoOffsetReset(...)` | `AutoOffsetReset` | `Latest`, `Earliest`, `None` |
+| `WithAutoOffsetResetByDuration(...)` | `AutoOffsetReset`, `AutoOffsetResetDuration` | Use `AutoOffsetReset: ByDuration` plus a duration, or Kafka-style `by_duration:PT24H` |
 | `WithFetchMinBytes(...)` | `FetchMinBytes` | Bytes |
 | `WithFetchMaxBytes(...)` | `FetchMaxBytes` | Bytes |
 | `WithMaxPartitionFetchBytes(...)` | `MaxPartitionFetchBytes` | Bytes |
@@ -171,6 +172,24 @@ Where to start when no committed offset exists:
 .WithAutoOffsetReset(AutoOffsetReset.Latest)    // New messages only (default)
 .WithAutoOffsetReset(AutoOffsetReset.Earliest)  // From beginning
 .WithAutoOffsetReset(AutoOffsetReset.None)      // Throw exception
+.WithAutoOffsetResetByDuration(TimeSpan.FromHours(24))
+```
+
+Configuration can use either a separate duration value:
+
+```json
+{
+  "AutoOffsetReset": "ByDuration",
+  "AutoOffsetResetDuration": "24:00:00"
+}
+```
+
+or Kafka's ISO-8601 form:
+
+```json
+{
+  "AutoOffsetReset": "by_duration:PT24H"
+}
 ```
 
 ## Fetch Settings
@@ -295,7 +314,7 @@ For transactional reads:
 | `WithGroupInstanceId` | null | Static membership ID |
 | `WithOffsetCommitMode` | Auto | Offset management mode |
 | `WithAutoCommitInterval` | 5000ms | Auto-commit interval |
-| `WithAutoOffsetReset` | Latest | Start position |
+| `WithAutoOffsetReset`, `WithAutoOffsetResetByDuration` | Latest | Start position |
 | `WithFetchMinBytes` | 1 | Minimum fetch bytes |
 | `WithFetchMaxBytes` | 52428800 | Maximum total fetch bytes |
 | `WithMaxPartitionFetchBytes` | 1048576 | Maximum fetch bytes per partition |

--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -105,6 +105,12 @@ var consumer = await Kafka.CreateConsumer<string, string>()
     .WithGroupId("my-group")
     .WithAutoOffsetReset(AutoOffsetReset.Earliest)  // Start from beginning
     .BuildAsync();
+
+var recentConsumer = await Kafka.CreateConsumer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithGroupId("recent-only")
+    .WithAutoOffsetResetByDuration(TimeSpan.FromHours(24))
+    .BuildAsync();
 ```
 
 | Value | Behavior |
@@ -112,6 +118,7 @@ var consumer = await Kafka.CreateConsumer<string, string>()
 | `Earliest` | Start from the oldest available message |
 | `Latest` | Start from new messages only (default) |
 | `None` | Throw an exception if no offset is committed |
+| `ByDuration` | Start from the first offset at or after `DateTimeOffset.UtcNow - duration` |
 
 ## Error Handling
 

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.Globalization;
 using System.Xml;
 
 namespace Dekaf.Extensions.DependencyInjection;
@@ -700,16 +701,16 @@ internal static class DekafConfigurationBinding
             throw new InvalidOperationException($"{key} must specify a duration.");
         }
 
-        if (TimeSpan.TryParse(value, out var timeSpan))
+        if (TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var timeSpan))
         {
-            ValidateAutoOffsetResetDuration(timeSpan);
+            AutoOffsetResetStrategy.ValidateDuration(timeSpan);
             return timeSpan;
         }
 
         try
         {
             var duration = XmlConvert.ToTimeSpan(value);
-            ValidateAutoOffsetResetDuration(duration);
+            AutoOffsetResetStrategy.ValidateDuration(duration);
             return duration;
         }
         catch (FormatException ex)
@@ -717,14 +718,6 @@ internal static class DekafConfigurationBinding
             throw new InvalidOperationException(
                 $"{key} must be a TimeSpan or ISO-8601 duration such as 'PT24H'.",
                 ex);
-        }
-    }
-
-    private static void ValidateAutoOffsetResetDuration(TimeSpan duration)
-    {
-        if (duration < TimeSpan.Zero)
-        {
-            throw new ArgumentOutOfRangeException(nameof(duration), duration, "Duration-based offset reset does not allow negative durations.");
         }
     }
 }

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.Xml;
 
 namespace Dekaf.Extensions.DependencyInjection;
 
@@ -429,8 +430,17 @@ internal static class DekafConfigurationBinding
             builder.WithOffsetCommitMode(offsetCommitMode);
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.AutoCommitIntervalMs), out var autoCommitIntervalMs))
             builder.WithAutoCommitInterval(TimeSpan.FromMilliseconds(autoCommitIntervalMs));
-        if (TryGetValue<AutoOffsetReset>(configuration, nameof(ConsumerOptions.AutoOffsetReset), out var autoOffsetReset))
-            builder.WithAutoOffsetReset(autoOffsetReset);
+        if (TryGetAutoOffsetReset(configuration, out var autoOffsetReset, out var autoOffsetResetDuration))
+        {
+            if (autoOffsetReset == AutoOffsetReset.ByDuration)
+            {
+                builder.WithAutoOffsetResetByDuration(autoOffsetResetDuration!.Value);
+            }
+            else
+            {
+                builder.WithAutoOffsetReset(autoOffsetReset);
+            }
+        }
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.FetchMinBytes), out var fetchMinBytes))
             builder.WithFetchMinBytes(fetchMinBytes);
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.FetchMaxBytes), out var fetchMaxBytes))
@@ -631,5 +641,90 @@ internal static class DekafConfigurationBinding
 
         value = bound;
         return true;
+    }
+
+    private static bool TryGetAutoOffsetReset(
+        IConfiguration configuration,
+        out AutoOffsetReset autoOffsetReset,
+        out TimeSpan? duration)
+    {
+        duration = null;
+
+        var section = configuration.GetSection(nameof(ConsumerOptions.AutoOffsetReset));
+        if (!section.Exists())
+        {
+            autoOffsetReset = default;
+            return false;
+        }
+
+        var rawValue = section.Value;
+        if (rawValue is not null &&
+            rawValue.StartsWith("by_duration:", StringComparison.OrdinalIgnoreCase))
+        {
+            autoOffsetReset = AutoOffsetReset.ByDuration;
+            duration = ParseDuration(
+                rawValue["by_duration:".Length..],
+                nameof(ConsumerOptions.AutoOffsetReset));
+            return true;
+        }
+
+        if (rawValue is not null &&
+            Enum.TryParse<AutoOffsetReset>(rawValue, ignoreCase: true, out var parsed))
+        {
+            autoOffsetReset = parsed;
+        }
+        else
+        {
+            autoOffsetReset = section.Get<AutoOffsetReset>();
+        }
+
+        if (autoOffsetReset == AutoOffsetReset.ByDuration)
+        {
+            var durationSection = configuration.GetSection(nameof(ConsumerOptions.AutoOffsetResetDuration));
+            if (!durationSection.Exists())
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(ConsumerOptions.AutoOffsetResetDuration)} is required when {nameof(ConsumerOptions.AutoOffsetReset)} is {nameof(AutoOffsetReset.ByDuration)}.");
+            }
+
+            duration = ParseDuration(durationSection.Value, nameof(ConsumerOptions.AutoOffsetResetDuration));
+        }
+
+        return true;
+    }
+
+    private static TimeSpan ParseDuration(string? value, string key)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"{key} must specify a duration.");
+        }
+
+        if (TimeSpan.TryParse(value, out var timeSpan))
+        {
+            ValidateAutoOffsetResetDuration(timeSpan);
+            return timeSpan;
+        }
+
+        try
+        {
+            var duration = XmlConvert.ToTimeSpan(value);
+            ValidateAutoOffsetResetDuration(duration);
+            return duration;
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException(
+                $"{key} must be a TimeSpan or ISO-8601 duration such as 'PT24H'.",
+                ex);
+        }
+    }
+
+    private static void ValidateAutoOffsetResetDuration(TimeSpan duration)
+    {
+        if (duration < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(duration), duration, "Duration-based offset reset does not allow negative durations.");
+        }
     }
 }

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -701,6 +701,13 @@ internal static class DekafConfigurationBinding
             throw new InvalidOperationException($"{key} must specify a duration.");
         }
 
+        value = value.Trim();
+        if (TryParseHoursMinutesSeconds(value, out var hoursMinutesSeconds))
+        {
+            AutoOffsetResetStrategy.ValidateDuration(hoursMinutesSeconds);
+            return hoursMinutesSeconds;
+        }
+
         if (TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var timeSpan))
         {
             AutoOffsetResetStrategy.ValidateDuration(timeSpan);
@@ -719,5 +726,30 @@ internal static class DekafConfigurationBinding
                 $"{key} must be a TimeSpan or ISO-8601 duration such as 'PT24H'.",
                 ex);
         }
+    }
+
+    private static bool TryParseHoursMinutesSeconds(string value, out TimeSpan duration)
+    {
+        duration = default;
+
+        var parts = value.Split(':');
+        if (parts.Length != 3 ||
+            parts[0].Contains('.', StringComparison.Ordinal) ||
+            parts[0].Contains(',', StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var hours) ||
+            !int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out var minutes) ||
+            !int.TryParse(parts[2], NumberStyles.None, CultureInfo.InvariantCulture, out var seconds) ||
+            (uint)minutes > 59 ||
+            (uint)seconds > 59)
+        {
+            return false;
+        }
+
+        duration = new TimeSpan(hours, minutes, seconds);
+        return true;
     }
 }

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -910,6 +910,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private OffsetCommitMode _offsetCommitMode = OffsetCommitMode.Auto;
     private int _autoCommitIntervalMs = 5000;
     private AutoOffsetReset _autoOffsetReset = AutoOffsetReset.Latest;
+    private TimeSpan? _autoOffsetResetDuration;
     private int _fetchMinBytes = 1;
     private int _fetchMaxBytes = 52428800;
     private int _maxPartitionFetchBytes = 1048576;
@@ -1049,7 +1050,23 @@ public sealed class ConsumerBuilder<TKey, TValue>
 
     public ConsumerBuilder<TKey, TValue> WithAutoOffsetReset(AutoOffsetReset autoOffsetReset)
     {
+        if (autoOffsetReset == AutoOffsetReset.ByDuration)
+        {
+            throw new ArgumentException(
+                "Use WithAutoOffsetResetByDuration(TimeSpan) to configure duration-based offset reset.",
+                nameof(autoOffsetReset));
+        }
+
         _autoOffsetReset = autoOffsetReset;
+        _autoOffsetResetDuration = null;
+        return this;
+    }
+
+    public ConsumerBuilder<TKey, TValue> WithAutoOffsetResetByDuration(TimeSpan duration)
+    {
+        AutoOffsetResetStrategy.ValidateDuration(duration);
+        _autoOffsetReset = AutoOffsetReset.ByDuration;
+        _autoOffsetResetDuration = duration;
         return this;
     }
 
@@ -1701,6 +1718,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             OffsetCommitMode = _offsetCommitMode,
             AutoCommitIntervalMs = _autoCommitIntervalMs,
             AutoOffsetReset = _autoOffsetReset,
+            AutoOffsetResetDuration = _autoOffsetResetDuration,
             FetchMinBytes = _fetchMinBytes,
             FetchMaxBytes = _fetchMaxBytes,
             MaxPartitionFetchBytes = _maxPartitionFetchBytes,

--- a/src/Dekaf/Consumer/AutoOffsetResetStrategy.cs
+++ b/src/Dekaf/Consumer/AutoOffsetResetStrategy.cs
@@ -5,7 +5,7 @@ namespace Dekaf.Consumer;
 
 internal static class AutoOffsetResetStrategy
 {
-    public static long GetListOffsetsTimestamp(ConsumerOptions options, DateTimeOffset now)
+    public static long GetListOffsetsTimestamp(ConsumerOptions options, DateTimeOffset now, TopicPartition? partition = null)
     {
         return options.AutoOffsetReset switch
         {
@@ -14,10 +14,15 @@ internal static class AutoOffsetResetStrategy
             AutoOffsetReset.ByDuration => GetByDurationTimestamp(options.AutoOffsetResetDuration, now),
             AutoOffsetReset.None => throw new KafkaException(
                 ErrorCode.OffsetOutOfRange,
-                "No committed offset and auto.offset.reset is 'none'"),
+                GetOffsetResetNoneMessage(partition)),
             _ => throw new InvalidOperationException($"Unknown AutoOffsetReset value: {options.AutoOffsetReset}")
         };
     }
+
+    private static string GetOffsetResetNoneMessage(TopicPartition? partition) =>
+        partition is { } tp
+            ? $"No committed offset for {tp.Topic}-{tp.Partition} and auto.offset.reset is 'none'"
+            : "No committed offset and auto.offset.reset is 'none'";
 
     public static long GetByDurationTimestamp(TimeSpan? duration, DateTimeOffset now)
     {

--- a/src/Dekaf/Consumer/AutoOffsetResetStrategy.cs
+++ b/src/Dekaf/Consumer/AutoOffsetResetStrategy.cs
@@ -1,0 +1,55 @@
+using Dekaf.Errors;
+using Dekaf.Protocol;
+
+namespace Dekaf.Consumer;
+
+internal static class AutoOffsetResetStrategy
+{
+    public static long GetListOffsetsTimestamp(ConsumerOptions options, DateTimeOffset now)
+    {
+        return options.AutoOffsetReset switch
+        {
+            AutoOffsetReset.Earliest => -2,
+            AutoOffsetReset.Latest => -1,
+            AutoOffsetReset.ByDuration => GetByDurationTimestamp(options.AutoOffsetResetDuration, now),
+            AutoOffsetReset.None => throw new KafkaException(
+                ErrorCode.OffsetOutOfRange,
+                "No committed offset and auto.offset.reset is 'none'"),
+            _ => throw new InvalidOperationException($"Unknown AutoOffsetReset value: {options.AutoOffsetReset}")
+        };
+    }
+
+    public static long GetByDurationTimestamp(TimeSpan? duration, DateTimeOffset now)
+    {
+        if (duration is null)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(ConsumerOptions.AutoOffsetResetDuration)} must be set when {nameof(ConsumerOptions.AutoOffsetReset)} is {nameof(AutoOffsetReset.ByDuration)}.");
+        }
+
+        ValidateDuration(duration.Value);
+        return now.Subtract(duration.Value).ToUnixTimeMilliseconds();
+    }
+
+    public static void ValidateOptions(ConsumerOptions options)
+    {
+        if (options.AutoOffsetReset == AutoOffsetReset.ByDuration)
+        {
+            if (options.AutoOffsetResetDuration is null)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(ConsumerOptions.AutoOffsetResetDuration)} must be set when {nameof(ConsumerOptions.AutoOffsetReset)} is {nameof(AutoOffsetReset.ByDuration)}.");
+            }
+
+            ValidateDuration(options.AutoOffsetResetDuration.Value);
+        }
+    }
+
+    public static void ValidateDuration(TimeSpan duration)
+    {
+        if (duration < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(duration), duration, "Duration-based offset reset does not allow negative durations.");
+        }
+    }
+}

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -74,6 +74,11 @@ public sealed class ConsumerOptions
     public AutoOffsetReset AutoOffsetReset { get; init; } = AutoOffsetReset.Latest;
 
     /// <summary>
+    /// Duration used when <see cref="AutoOffsetReset"/> is <see cref="AutoOffsetReset.ByDuration"/>.
+    /// </summary>
+    public TimeSpan? AutoOffsetResetDuration { get; init; }
+
+    /// <summary>
     /// Fetch minimum bytes.
     /// </summary>
     public int FetchMinBytes { get; init; } = 1;
@@ -370,7 +375,12 @@ public enum AutoOffsetReset
     /// <summary>
     /// Throw exception if no offset is found.
     /// </summary>
-    None
+    None,
+
+    /// <summary>
+    /// Start from the first offset at or after the current UTC time minus a configured duration.
+    /// </summary>
+    ByDuration
 }
 
 /// <summary>

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1891,7 +1891,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                             {
                                 // CRITICAL: Reset fetch position based on auto.offset.reset policy
                                 // Without this, we would retry with the same invalid offset forever
-                                var resetTimestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow);
+                                var resetTimestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow, tp);
                                 if (resetTimestamp == -1 || resetTimestamp == -2)
                                 {
                                     _fetchPositions[tp] = resetTimestamp;
@@ -1899,7 +1899,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                                 }
                                 else
                                 {
-                                    var resetOffset = await ResolveOffsetAsync(tp, resetTimestamp, cancellationToken).ConfigureAwait(false);
+                                    var resetOffset = await ResolveAutoResetOffsetAsync(tp, resetTimestamp, cancellationToken).ConfigureAwait(false);
                                     _fetchPositions[tp] = resetOffset;
                                     _positions[tp] = resetOffset;
                                 }
@@ -2909,68 +2909,29 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
     private async ValueTask<long> GetResetOffsetAsync(TopicPartition partition, CancellationToken cancellationToken)
     {
-        var timestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow);
-
-        var connection = await GetPartitionLeaderConnectionAsync(partition, cancellationToken).ConfigureAwait(false);
-        if (connection is null)
-            return 0;
-
-        var listOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
-            ApiKey.ListOffsets,
-            ListOffsetsRequest.LowestSupportedVersion,
-            ListOffsetsRequest.HighestSupportedVersion);
-
-        var request = new ListOffsetsRequest
-        {
-            ReplicaId = -1,
-            IsolationLevel = _options.IsolationLevel,
-            Topics =
-            [
-                new ListOffsetsRequestTopic
-                {
-                    Name = partition.Topic,
-                    Partitions =
-                    [
-                        new ListOffsetsRequestPartition
-                        {
-                            PartitionIndex = partition.Partition,
-                            Timestamp = timestamp,
-                            CurrentLeaderEpoch = -1
-                        }
-                    ]
-                }
-            ]
-        };
-
-        var response = await connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
-            request,
-            listOffsetsVersion,
-            cancellationToken).ConfigureAwait(false);
-
-        ListOffsetsResponsePartition? partitionResponse = null;
-        foreach (var topic in response.Topics)
-        {
-            if (topic.Name == partition.Topic)
-            {
-                foreach (var p in topic.Partitions)
-                {
-                    if (p.PartitionIndex == partition.Partition)
-                    {
-                        partitionResponse = p;
-                        break;
-                    }
-                }
-                break;
-            }
-        }
-
-        return partitionResponse?.Offset ?? 0;
+        var timestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow, partition);
+        return await ResolveAutoResetOffsetAsync(partition, timestamp, cancellationToken).ConfigureAwait(false);
     }
 
     private string GetAutoOffsetResetName() =>
         _options.AutoOffsetReset == AutoOffsetReset.ByDuration
             ? $"by_duration:{_options.AutoOffsetResetDuration}"
             : _options.AutoOffsetReset.ToString().ToLowerInvariant();
+
+    private async ValueTask<long> ResolveAutoResetOffsetAsync(
+        TopicPartition partition,
+        long timestamp,
+        CancellationToken cancellationToken)
+    {
+        var offset = await ResolveOffsetAsync(partition, timestamp, cancellationToken).ConfigureAwait(false);
+        if (timestamp >= 0 && offset == TopicPartitionTimestamp.Latest)
+        {
+            return await ResolveOffsetAsync(partition, TopicPartitionTimestamp.Latest, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return offset;
+    }
 
     private async ValueTask ResolveSpecialOffsetsAsync(
         List<TopicPartition> partitions, int startIndex, int count, CancellationToken cancellationToken)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -662,6 +662,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(options.ConnectionsPerBroker, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(options.ConnectionsPerBroker, options.MaxConnectionsPerBroker);
+        AutoOffsetResetStrategy.ValidateOptions(options);
 
         _options = options;
         _currentQueuedMaxBytes = (long)((ulong)options.QueuedMaxMessagesKbytes * 1024UL);
@@ -1890,18 +1891,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                             {
                                 // CRITICAL: Reset fetch position based on auto.offset.reset policy
                                 // Without this, we would retry with the same invalid offset forever
-                                var (resetTimestamp, resetName) = _options.AutoOffsetReset switch
+                                var resetTimestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow);
+                                if (resetTimestamp == -1 || resetTimestamp == -2)
                                 {
-                                    AutoOffsetReset.Latest => (-1L, "latest"),
-                                    AutoOffsetReset.Earliest => (-2L, "earliest"),
-                                    AutoOffsetReset.None => throw new KafkaException(
-                                        ErrorCode.OffsetOutOfRange,
-                                        $"OffsetOutOfRange for {topic}-{partitionResponse.PartitionIndex} and auto.offset.reset is 'none'"),
-                                    _ => throw new InvalidOperationException($"Unknown AutoOffsetReset value: {_options.AutoOffsetReset}")
-                                };
-                                _fetchPositions[tp] = resetTimestamp;
-                                _positions[tp] = resetTimestamp;
-                                LogOffsetOutOfRangeReset(topic, partitionResponse.PartitionIndex, resetName);
+                                    _fetchPositions[tp] = resetTimestamp;
+                                    _positions[tp] = resetTimestamp;
+                                }
+                                else
+                                {
+                                    var resetOffset = await ResolveOffsetAsync(tp, resetTimestamp, cancellationToken).ConfigureAwait(false);
+                                    _fetchPositions[tp] = resetOffset;
+                                    _positions[tp] = resetOffset;
+                                }
+
+                                LogOffsetOutOfRangeReset(topic, partitionResponse.PartitionIndex, GetAutoOffsetResetName());
                             }
                             else if (partitionResponse.ErrorCode == ErrorCode.NotLeaderOrFollower)
                             {
@@ -2906,13 +2909,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
     private async ValueTask<long> GetResetOffsetAsync(TopicPartition partition, CancellationToken cancellationToken)
     {
-        // Get the offset based on auto offset reset policy
-        var timestamp = _options.AutoOffsetReset switch
-        {
-            AutoOffsetReset.Earliest => -2, // Earliest
-            AutoOffsetReset.Latest => -1,   // Latest
-            _ => -2 // Default to earliest
-        };
+        var timestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow);
 
         var connection = await GetPartitionLeaderConnectionAsync(partition, cancellationToken).ConfigureAwait(false);
         if (connection is null)
@@ -2969,6 +2966,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
         return partitionResponse?.Offset ?? 0;
     }
+
+    private string GetAutoOffsetResetName() =>
+        _options.AutoOffsetReset == AutoOffsetReset.ByDuration
+            ? $"by_duration:{_options.AutoOffsetResetDuration}"
+            : _options.AutoOffsetReset.ToString().ToLowerInvariant();
 
     private async ValueTask ResolveSpecialOffsetsAsync(
         List<TopicPartition> partitions, int startIndex, int count, CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -1298,6 +1298,81 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
     }
 
     [Test]
+    public async Task Consumer_AutoOffsetResetByDuration_AfterNewestMessage_StartsFromEnd()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "old-key",
+            Value = "old-value",
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-10)
+        }, CancellationToken.None);
+        await producer.FlushAsync(CancellationToken.None);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-consumer")
+            .WithAutoOffsetResetByDuration(TimeSpan.Zero)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var consumeTask = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token).AsTask();
+
+        await Task.Delay(2000, cts.Token);
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "new-key",
+            Value = "new-value"
+        }, CancellationToken.None);
+        await producer.FlushAsync(CancellationToken.None);
+
+        var result = await consumeTask;
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Key).IsEqualTo("new-key");
+        await Assert.That(result.Value.Value).IsEqualTo("new-value");
+    }
+
+    [Test]
+    public async Task Consumer_AutoOffsetResetNone_NoCommittedOffset_ThrowsException()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-consumer")
+            .WithAutoOffsetReset(AutoOffsetReset.None)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await Assert.That(async () =>
+        {
+            await foreach (var _ in consumer.ConsumeAsync(cts.Token))
+            {
+                // Should throw before yielding
+            }
+        }).Throws<KafkaException>()
+            .WithMessageContaining($"{topic}-0");
+    }
+
+    [Test]
     public async Task Consumer_OffsetOutOfRange_WithNone_ThrowsException()
     {
         // This tests that when AutoOffsetReset.None is configured and OffsetOutOfRange occurs,

--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -1206,6 +1206,98 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
     }
 
     [Test]
+    public async Task Consumer_AutoOffsetResetByDuration_StartsFromMatchingTimestamp()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "old-key",
+            Value = "old-value",
+            Timestamp = DateTimeOffset.UtcNow.AddHours(-2)
+        }, CancellationToken.None);
+        await producer.FlushAsync(CancellationToken.None);
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "recent-key",
+            Value = "recent-value",
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-1)
+        }, CancellationToken.None);
+        await producer.FlushAsync(CancellationToken.None);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-consumer")
+            .WithAutoOffsetResetByDuration(TimeSpan.FromMinutes(30))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Key).IsEqualTo("recent-key");
+        await Assert.That(result.Value.Value).IsEqualTo("recent-value");
+    }
+
+    [Test]
+    public async Task Consumer_AutoOffsetResetByDuration_OlderThanLogStart_StartsFromBeginning()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "first-key",
+            Value = "first-value",
+            Timestamp = DateTimeOffset.UtcNow.AddHours(-2)
+        }, CancellationToken.None);
+        await producer.FlushAsync(CancellationToken.None);
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "second-key",
+            Value = "second-value",
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-1)
+        }, CancellationToken.None);
+        await producer.FlushAsync(CancellationToken.None);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-consumer")
+            .WithAutoOffsetResetByDuration(TimeSpan.FromDays(7))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Key).IsEqualTo("first-key");
+        await Assert.That(result.Value.Value).IsEqualTo("first-value");
+    }
+
+    [Test]
     public async Task Consumer_OffsetOutOfRange_WithNone_ThrowsException()
     {
         // This tests that when AutoOffsetReset.None is configured and OffsetOutOfRange occurs,

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -141,6 +141,43 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task WithAutoOffsetResetByDuration_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+        var result = builder.WithAutoOffsetResetByDuration(TimeSpan.FromHours(24));
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithAutoOffsetResetByDuration_SetsOptions()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithAutoOffsetResetByDuration(TimeSpan.FromHours(24))
+            .Build();
+
+        var options = GetConsumerOptions(consumer);
+        await Assert.That(options.AutoOffsetReset).IsEqualTo(AutoOffsetReset.ByDuration);
+        await Assert.That(options.AutoOffsetResetDuration).IsEqualTo(TimeSpan.FromHours(24));
+    }
+
+    [Test]
+    public async Task WithAutoOffsetReset_ByDuration_ThrowsArgumentException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+        await Assert.That(() => builder.WithAutoOffsetReset(AutoOffsetReset.ByDuration))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task WithAutoOffsetResetByDuration_NegativeDuration_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+        await Assert.That(() => builder.WithAutoOffsetResetByDuration(TimeSpan.FromSeconds(-1)))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     public async Task WithMaxPollRecords_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateConsumer<string, string>();

--- a/tests/Dekaf.Tests.Unit/Consumer/AutoOffsetResetStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/AutoOffsetResetStrategyTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Consumer;
+using Dekaf.Errors;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
@@ -32,5 +33,22 @@ public class AutoOffsetResetStrategyTests
     {
         await Assert.That(() => AutoOffsetResetStrategy.ValidateDuration(TimeSpan.FromSeconds(-1)))
             .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task GetListOffsetsTimestamp_NoneIncludesPartitionInExceptionMessage()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            AutoOffsetReset = AutoOffsetReset.None
+        };
+
+        await Assert.That(() => AutoOffsetResetStrategy.GetListOffsetsTimestamp(
+                options,
+                DateTimeOffset.Parse("2026-07-02T12:00:00Z"),
+                new TopicPartition("orders", 5)))
+            .Throws<KafkaException>()
+            .WithMessageContaining("orders-5");
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/AutoOffsetResetStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/AutoOffsetResetStrategyTests.cs
@@ -1,0 +1,36 @@
+using Dekaf.Consumer;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public class AutoOffsetResetStrategyTests
+{
+    [Test]
+    public async Task GetByDurationTimestamp_SubtractsDurationFromNow()
+    {
+        var now = DateTimeOffset.Parse("2026-07-02T12:00:00Z");
+
+        var timestamp = AutoOffsetResetStrategy.GetByDurationTimestamp(TimeSpan.FromHours(2), now);
+
+        await Assert.That(timestamp).IsEqualTo(now.AddHours(-2).ToUnixTimeMilliseconds());
+    }
+
+    [Test]
+    public async Task ValidateOptions_ByDurationWithoutDuration_ThrowsInvalidOperationException()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            AutoOffsetReset = AutoOffsetReset.ByDuration
+        };
+
+        await Assert.That(() => AutoOffsetResetStrategy.ValidateOptions(options))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ValidateDuration_NegativeDuration_ThrowsArgumentOutOfRangeException()
+    {
+        await Assert.That(() => AutoOffsetResetStrategy.ValidateDuration(TimeSpan.FromSeconds(-1)))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
@@ -54,6 +54,13 @@ public class ConsumerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task AutoOffsetResetDuration_DefaultsTo_Null()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.AutoOffsetResetDuration).IsNull();
+    }
+
+    [Test]
     public async Task FetchMinBytes_DefaultsTo_1()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -416,6 +416,29 @@ public class DependencyInjectionTests
     }
 
     [Test]
+    public async Task AddConsumer_WithByDurationAutoOffsetReset_BindsIsoDuration()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:Consumers:Orders:BootstrapServers:0"] = "broker1:9092",
+            ["Kafka:Consumers:Orders:AutoOffsetReset"] = "by_duration:PT24H"
+        });
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddConsumer<string, string>(configuration.GetSection("Kafka:Consumers:Orders"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var consumer = provider.GetRequiredService<IKafkaConsumer<string, string>>();
+        var options = GetConsumerOptions(consumer);
+
+        await Assert.That(options.AutoOffsetReset).IsEqualTo(AutoOffsetReset.ByDuration);
+        await Assert.That(options.AutoOffsetResetDuration).IsEqualTo(TimeSpan.FromHours(24));
+    }
+
+    [Test]
     public async Task AddAdminClient_WithConfigurationSection_BindsConfiguredOptions()
     {
         var services = new ServiceCollection();

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -439,6 +439,49 @@ public class DependencyInjectionTests
     }
 
     [Test]
+    public async Task AddConsumer_WithByDurationAutoOffsetReset_BindsSplitDuration()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:Consumers:Orders:BootstrapServers:0"] = "broker1:9092",
+            ["Kafka:Consumers:Orders:AutoOffsetReset"] = "ByDuration",
+            ["Kafka:Consumers:Orders:AutoOffsetResetDuration"] = "24:00:00"
+        });
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddConsumer<string, string>(configuration.GetSection("Kafka:Consumers:Orders"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var consumer = provider.GetRequiredService<IKafkaConsumer<string, string>>();
+        var options = GetConsumerOptions(consumer);
+
+        await Assert.That(options.AutoOffsetReset).IsEqualTo(AutoOffsetReset.ByDuration);
+        await Assert.That(options.AutoOffsetResetDuration).IsEqualTo(TimeSpan.FromHours(24));
+    }
+
+    [Test]
+    public async Task AddConsumer_WithByDurationAutoOffsetResetWithoutDuration_ThrowsInvalidOperationException()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:Consumers:Orders:BootstrapServers:0"] = "broker1:9092",
+            ["Kafka:Consumers:Orders:AutoOffsetReset"] = "ByDuration"
+        });
+
+        void Act() => services.AddDekaf(builder =>
+        {
+            builder.AddConsumer<string, string>(configuration.GetSection("Kafka:Consumers:Orders"));
+        });
+
+        await Assert.That(Act).Throws<InvalidOperationException>()
+            .WithMessageContaining("AutoOffsetResetDuration is required");
+    }
+
+    [Test]
     public async Task AddAdminClient_WithConfigurationSection_BindsConfiguredOptions()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## Summary
- add `AutoOffsetReset.ByDuration` and `WithAutoOffsetResetByDuration(TimeSpan)`
- resolve initial and out-of-range offsets through ListOffsets at `UtcNow - duration`
- support config binding for `AutoOffsetReset=ByDuration` + `AutoOffsetResetDuration` and Kafka-style `by_duration:PT24H`
- update consumer docs and focused tests

Closes #826.

## Validation
- `dotnet build Dekaf.sln --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- focused unit `*ByDuration*` tests passed
- focused integration `*AutoOffsetResetByDuration*` tests passed on 3 Kafka versions