### PR TITLE
Collect KIP-714 client telemetry metrics

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -618,14 +618,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         MetadataManager metadataManager,
         ILoggerFactory? loggerFactory = null)
         : this(options, keyDeserializer, valueDeserializer,
-            (connectionPool, metadataManager),
+            (connectionPool, metadataManager, new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer)),
             loggerFactory)
     {
     }
 
-    private static (IConnectionPool, MetadataManager) CreateInfrastructure(
+    private static (IConnectionPool, MetadataManager, ClientTelemetryMetricCollector) CreateInfrastructure(
         ConsumerOptions options, ILoggerFactory? loggerFactory, MetadataOptions? metadataOptions)
     {
+        var telemetryMetricCollector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer);
         var connectionPool = new ConnectionPool(
             options.ClientId,
             new ConnectionOptions
@@ -644,7 +645,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             },
             loggerFactory,
             connectionsPerBroker: options.ConnectionsPerBroker,
-            ResponseBufferPool.Create(options.FetchMaxBytes));
+            ResponseBufferPool.Create(options.FetchMaxBytes),
+            telemetryMetricCollector: telemetryMetricCollector);
 
         var metadataManager = new MetadataManager(
             connectionPool,
@@ -652,14 +654,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             options: metadataOptions,
             logger: loggerFactory?.CreateLogger<MetadataManager>());
 
-        return (connectionPool, metadataManager);
+        return (connectionPool, metadataManager, telemetryMetricCollector);
     }
 
     private KafkaConsumer(
         ConsumerOptions options,
         IDeserializer<TKey> keyDeserializer,
         IDeserializer<TValue> valueDeserializer,
-        (IConnectionPool Pool, MetadataManager Metadata) infrastructure,
+        (IConnectionPool Pool, MetadataManager Metadata, ClientTelemetryMetricCollector TelemetryMetricCollector) infrastructure,
         ILoggerFactory? loggerFactory)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(options.ConnectionsPerBroker, 1);
@@ -696,7 +698,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         _telemetryManager = new ClientTelemetryManager(
             _connectionPool,
             _metadataManager,
-            loggerFactory?.CreateLogger<ClientTelemetryManager>());
+            loggerFactory?.CreateLogger<ClientTelemetryManager>(),
+            infrastructure.TelemetryMetricCollector);
 
         _compressionCodecs = CompressionCodecRegistry.Default;
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Dekaf.Security.Sasl;
+using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Networking;
@@ -16,6 +17,7 @@ public sealed partial class ConnectionPool : IConnectionPool
     private readonly ILogger _logger;
     private readonly int _connectionsPerBroker;
     private readonly ResponseBufferPool _responseBufferPool;
+    private readonly ClientTelemetryMetricCollector? _telemetryMetricCollector;
     private readonly OAuthBearerTokenProvider? _sharedOAuthBearerTokenProvider;
 
     /// <summary>
@@ -90,7 +92,8 @@ public sealed partial class ConnectionPool : IConnectionPool
         ILoggerFactory? loggerFactory,
         int connectionsPerBroker,
         ResponseBufferPool responseBufferPool,
-        int? pipeMemoryBucketCapacity = null)
+        int? pipeMemoryBucketCapacity = null,
+        ClientTelemetryMetricCollector? telemetryMetricCollector = null)
     {
         _clientId = clientId;
         _connectionOptions = ConfigureSharedOAuthBearerProvider(
@@ -100,6 +103,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         _logger = loggerFactory?.CreateLogger<ConnectionPool>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ConnectionPool>.Instance;
         _connectionsPerBroker = Math.Max(1, connectionsPerBroker);
         _responseBufferPool = responseBufferPool;
+        _telemetryMetricCollector = telemetryMetricCollector;
         var bucketCapacity = pipeMemoryBucketCapacity ?? ScaledBucketCapacity(_connectionsPerBroker);
         _sharedPipeMemoryPool = new PipeMemoryPool(maxArraysPerBucket: bucketCapacity);
         _currentPipeMemoryBucketCapacity = bucketCapacity;
@@ -612,7 +616,8 @@ public sealed partial class ConnectionPool : IConnectionPool
             DefaultBufferMemory, _connectionsPerBroker,
             BrokerCount,
             _responseBufferPool,
-            _sharedPipeMemoryPool);
+            _sharedPipeMemoryPool,
+            _telemetryMetricCollector);
 
         await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
 
@@ -730,7 +735,8 @@ public sealed partial class ConnectionPool : IConnectionPool
             DefaultBufferMemory, _connectionsPerBroker,
             BrokerCount,
             _responseBufferPool,
-            _sharedPipeMemoryPool);
+            _sharedPipeMemoryPool,
+            _telemetryMetricCollector);
 
         await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -15,6 +15,7 @@ using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
+using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Networking;
@@ -174,6 +175,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
     private readonly ConcurrentDictionary<int, byte> _cancelledCorrelationIds = new();
     private readonly PendingRequestPool _pendingRequestPool;
     private readonly CancellationTokenSourcePool _timeoutCtsPool;
+    private readonly ClientTelemetryMetricCollector? _telemetryMetricCollector;
     private readonly SemaphoreSlim _writeLock = new(1, 1);
 
     // Partial frame assembly state for incremental response consumption.
@@ -253,7 +255,8 @@ public sealed partial class KafkaConnection : IKafkaConnection
         ulong bufferMemory,
         int connectionsPerBroker,
         int brokerCount,
-        ResponseBufferPool responseBufferPool)
+        ResponseBufferPool responseBufferPool,
+        ClientTelemetryMetricCollector? telemetryMetricCollector = null)
     {
         _host = host;
         _port = port;
@@ -269,6 +272,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         _connectionsPerBroker = connectionsPerBroker;
         _brokerCount = Math.Max(1, brokerCount);
         _responseBufferPool = responseBufferPool;
+        _telemetryMetricCollector = telemetryMetricCollector;
     }
 
     public KafkaConnection(
@@ -304,8 +308,9 @@ public sealed partial class KafkaConnection : IKafkaConnection
         int connectionsPerBroker,
         int brokerCount,
         ResponseBufferPool responseBufferPool,
-        PipeMemoryPool? sharedPipeMemoryPool = null)
-        : this(host, port, clientId, options, logger, bufferMemory, connectionsPerBroker, brokerCount, responseBufferPool)
+        PipeMemoryPool? sharedPipeMemoryPool = null,
+        ClientTelemetryMetricCollector? telemetryMetricCollector = null)
+        : this(host, port, clientId, options, logger, bufferMemory, connectionsPerBroker, brokerCount, responseBufferPool, telemetryMetricCollector)
     {
         BrokerId = brokerId;
         _sharedPipeMemoryPool = sharedPipeMemoryPool;
@@ -467,6 +472,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         _receiveCts = new CancellationTokenSource();
         _receiveTask = ReceiveLoopAsync(_receiveCts.Token);
         Volatile.Write(ref _connected, 1);
+        _telemetryMetricCollector?.RecordConnectionCreated();
 
         LogConnected(_host, _port);
     }
@@ -506,6 +512,8 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
         try
         {
+            var telemetryStartTimestamp = _telemetryMetricCollector is null ? 0 : Stopwatch.GetTimestamp();
+
             // Write phase
             LogSendingRequest(TRequest.ApiKey, correlationId, apiVersion, _host, _port);
 
@@ -515,8 +523,10 @@ public sealed partial class KafkaConnection : IKafkaConnection
             LogRequestSentWaitingForResponse(correlationId);
 
             // Response phase: await response with timeout and parse
-            return await AwaitAndParseResponseAsync<TRequest, TResponse>(
+            var response = await AwaitAndParseResponseAsync<TRequest, TResponse>(
                 pending, correlationId, apiVersion, callerOwnsTimeout: false, cancellationToken).ConfigureAwait(false);
+            _telemetryMetricCollector?.RecordRequestLatency(BrokerId, telemetryStartTimestamp);
+            return response;
         }
         catch
         {
@@ -649,12 +659,16 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
         try
         {
+            var telemetryStartTimestamp = _telemetryMetricCollector is null ? 0 : Stopwatch.GetTimestamp();
+
             await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken, callerOwnsTimeout)
                 .ConfigureAwait(false);
 
             // Response phase: await response with timeout, then parse
-            return await AwaitAndParseResponseAsync<TRequest, TResponse>(
+            var response = await AwaitAndParseResponseAsync<TRequest, TResponse>(
                 pending, correlationId, apiVersion, callerOwnsTimeout, cancellationToken).ConfigureAwait(false);
+            _telemetryMetricCollector?.RecordRequestLatency(BrokerId, telemetryStartTimestamp);
+            return response;
         }
         catch
         {

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -224,6 +224,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             _ => new DefaultPartitioner()
         };
 
+        var telemetryMetricCollector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);
+
         _connectionPool = new ConnectionPool(
             options.ClientId,
             new ConnectionOptions
@@ -244,7 +246,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             loggerFactory,
             options.ConnectionsPerBroker,
             ResponseBufferPool.Default,
-            pipeMemoryBucketCapacity: sharedPoolSizes.PipeMemoryArraysPerBucket);
+            pipeMemoryBucketCapacity: sharedPoolSizes.PipeMemoryArraysPerBucket,
+            telemetryMetricCollector: telemetryMetricCollector);
 
         _metadataManager = new MetadataManager(
             _connectionPool,
@@ -255,7 +258,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         _telemetryManager = new ClientTelemetryManager(
             _connectionPool,
             _metadataManager,
-            loggerFactory?.CreateLogger<ClientTelemetryManager>());
+            loggerFactory?.CreateLogger<ClientTelemetryManager>(),
+            telemetryMetricCollector);
 
         // Re-ratchet shared pool sizes after metadata refresh discovers the real broker count.
         // Bootstrap servers are seed nodes — the actual cluster may have more brokers.

--- a/src/Dekaf/Telemetry/ClientTelemetryManager.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryManager.cs
@@ -18,14 +18,20 @@ internal sealed record ClientTelemetrySubscription(
 
 internal interface IClientTelemetryPayloadProvider
 {
-    ReadOnlyMemory<byte> Collect(ClientTelemetrySubscription subscription, bool terminating);
+    ReadOnlyMemory<byte> Collect(
+        ClientTelemetrySubscription subscription,
+        ClientTelemetryMetricSnapshot metrics,
+        bool terminating);
 }
 
 internal sealed class EmptyClientTelemetryPayloadProvider : IClientTelemetryPayloadProvider
 {
     public static EmptyClientTelemetryPayloadProvider Instance { get; } = new();
 
-    public ReadOnlyMemory<byte> Collect(ClientTelemetrySubscription subscription, bool terminating) =>
+    public ReadOnlyMemory<byte> Collect(
+        ClientTelemetrySubscription subscription,
+        ClientTelemetryMetricSnapshot metrics,
+        bool terminating) =>
         ReadOnlyMemory<byte>.Empty;
 }
 
@@ -35,6 +41,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
 
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
+    private readonly ClientTelemetryMetricCollector? _metricCollector;
     private readonly IClientTelemetryPayloadProvider _payloadProvider;
     private readonly ILogger<ClientTelemetryManager> _logger;
     private readonly SemaphoreSlim _startLock = new(1, 1);
@@ -51,10 +58,12 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         IConnectionPool connectionPool,
         MetadataManager metadataManager,
         ILogger<ClientTelemetryManager>? logger = null,
+        ClientTelemetryMetricCollector? metricCollector = null,
         IClientTelemetryPayloadProvider? payloadProvider = null)
     {
         _connectionPool = connectionPool;
         _metadataManager = metadataManager;
+        _metricCollector = metricCollector;
         _logger = logger ?? NullLogger<ClientTelemetryManager>.Instance;
         _payloadProvider = payloadProvider ?? EmptyClientTelemetryPayloadProvider.Instance;
     }
@@ -319,11 +328,13 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
                 return ErrorCode.BrokerNotAvailable;
             }
 
-            var metrics = _payloadProvider.Collect(subscription, terminating);
-            if (subscription.TelemetryMaxBytes > 0 && metrics.Length > subscription.TelemetryMaxBytes)
+            var metricSnapshot = _metricCollector?.Collect(subscription) ??
+                ClientTelemetryMetricSnapshot.Empty(subscription.DeltaTemporality);
+            var payload = _payloadProvider.Collect(subscription, metricSnapshot, terminating);
+            if (subscription.TelemetryMaxBytes > 0 && payload.Length > subscription.TelemetryMaxBytes)
             {
-                LogTelemetryPayloadTooLarge(metrics.Length, subscription.TelemetryMaxBytes);
-                metrics = ReadOnlyMemory<byte>.Empty;
+                LogTelemetryPayloadTooLarge(payload.Length, subscription.TelemetryMaxBytes);
+                payload = ReadOnlyMemory<byte>.Empty;
             }
 
             var response = await connection.SendAsync<PushTelemetryRequest, PushTelemetryResponse>(
@@ -333,7 +344,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
                     SubscriptionId = subscription.SubscriptionId,
                     Terminating = terminating,
                     CompressionType = subscription.CompressionType,
-                    Metrics = metrics
+                    Metrics = payload
                 },
                 apiVersion,
                 cancellationToken).ConfigureAwait(false);

--- a/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
@@ -1,0 +1,266 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Dekaf.Telemetry;
+
+internal enum ClientTelemetryClientRole
+{
+    Producer,
+    Consumer
+}
+
+internal enum ClientTelemetryMetricKind
+{
+    Counter,
+    Gauge
+}
+
+internal readonly record struct ClientTelemetryMetricAttribute(string Name, string Value);
+
+internal sealed record ClientTelemetryMetric(
+    string Name,
+    ClientTelemetryMetricKind Kind,
+    double Value,
+    IReadOnlyList<ClientTelemetryMetricAttribute> Attributes);
+
+internal sealed record ClientTelemetryMetricSnapshot(
+    bool DeltaTemporality,
+    IReadOnlyList<ClientTelemetryMetric> Metrics)
+{
+    private static readonly IReadOnlyList<ClientTelemetryMetric> EmptyMetrics = [];
+
+    public static ClientTelemetryMetricSnapshot Empty(bool deltaTemporality) =>
+        new(deltaTemporality, EmptyMetrics);
+}
+
+internal static class ClientTelemetryMetricNames
+{
+    public const string ProducerConnectionCreationTotal = "org.apache.kafka.producer.connection.creation.total";
+    public const string ProducerNodeRequestLatencyAvg = "org.apache.kafka.producer.node.request.latency.avg";
+    public const string ProducerNodeRequestLatencyMax = "org.apache.kafka.producer.node.request.latency.max";
+
+    public const string ConsumerConnectionCreationTotal = "org.apache.kafka.consumer.connection.creation.total";
+    public const string ConsumerNodeRequestLatencyAvg = "org.apache.kafka.consumer.node.request.latency.avg";
+    public const string ConsumerNodeRequestLatencyMax = "org.apache.kafka.consumer.node.request.latency.max";
+}
+
+internal sealed class ClientTelemetryMetricCollector
+{
+    private static readonly IReadOnlyList<ClientTelemetryMetricAttribute> EmptyAttributes = [];
+
+    private readonly ConcurrentDictionary<int, NodeRequestLatency> _nodeRequestLatencies = new();
+    private readonly string _connectionCreationTotalName;
+    private readonly string _nodeRequestLatencyAvgName;
+    private readonly string _nodeRequestLatencyMaxName;
+
+    private long _connectionCreationTotal;
+    private long _connectionCreationDelta;
+
+    public ClientTelemetryMetricCollector(ClientTelemetryClientRole role)
+    {
+        (_connectionCreationTotalName, _nodeRequestLatencyAvgName, _nodeRequestLatencyMaxName) = role switch
+        {
+            ClientTelemetryClientRole.Producer => (
+                ClientTelemetryMetricNames.ProducerConnectionCreationTotal,
+                ClientTelemetryMetricNames.ProducerNodeRequestLatencyAvg,
+                ClientTelemetryMetricNames.ProducerNodeRequestLatencyMax),
+            ClientTelemetryClientRole.Consumer => (
+                ClientTelemetryMetricNames.ConsumerConnectionCreationTotal,
+                ClientTelemetryMetricNames.ConsumerNodeRequestLatencyAvg,
+                ClientTelemetryMetricNames.ConsumerNodeRequestLatencyMax),
+            _ => throw new ArgumentOutOfRangeException(nameof(role), role, "Unsupported telemetry client role")
+        };
+    }
+
+    public void RecordConnectionCreated()
+    {
+        Interlocked.Increment(ref _connectionCreationTotal);
+        Interlocked.Increment(ref _connectionCreationDelta);
+    }
+
+    public void RecordRequestLatency(int brokerId, long startTimestamp)
+    {
+        if (brokerId < 0)
+        {
+            return;
+        }
+
+        var elapsedTimestampTicks = Math.Max(0, Stopwatch.GetTimestamp() - startTimestamp);
+        RecordRequestLatencyTicks(brokerId, elapsedTimestampTicks);
+    }
+
+    internal void RecordRequestLatency(int brokerId, TimeSpan elapsed)
+    {
+        if (brokerId < 0)
+        {
+            return;
+        }
+
+        var elapsedTimestampTicks = Math.Max(0, (long)(elapsed.TotalSeconds * Stopwatch.Frequency));
+        RecordRequestLatencyTicks(brokerId, elapsedTimestampTicks);
+    }
+
+    public ClientTelemetryMetricSnapshot Collect(ClientTelemetrySubscription subscription)
+    {
+        var requestedMetrics = subscription.RequestedMetrics;
+        if (requestedMetrics.Count == 0)
+        {
+            return ClientTelemetryMetricSnapshot.Empty(subscription.DeltaTemporality);
+        }
+
+        var includeConnectionCreationTotal = IsRequested(_connectionCreationTotalName, requestedMetrics);
+        var includeRequestLatencyAvg = IsRequested(_nodeRequestLatencyAvgName, requestedMetrics);
+        var includeRequestLatencyMax = IsRequested(_nodeRequestLatencyMaxName, requestedMetrics);
+
+        if (!includeConnectionCreationTotal &&
+            !includeRequestLatencyAvg &&
+            !includeRequestLatencyMax)
+        {
+            return ClientTelemetryMetricSnapshot.Empty(subscription.DeltaTemporality);
+        }
+
+        var capacity = (includeConnectionCreationTotal ? 1 : 0) +
+            ((includeRequestLatencyAvg ? 1 : 0) + (includeRequestLatencyMax ? 1 : 0)) *
+            Math.Max(1, _nodeRequestLatencies.Count);
+        var metrics = new List<ClientTelemetryMetric>(capacity);
+
+        if (includeConnectionCreationTotal)
+        {
+            var value = subscription.DeltaTemporality
+                ? Interlocked.Exchange(ref _connectionCreationDelta, 0)
+                : Volatile.Read(ref _connectionCreationTotal);
+
+            if (value != 0)
+            {
+                metrics.Add(new ClientTelemetryMetric(
+                    _connectionCreationTotalName,
+                    ClientTelemetryMetricKind.Counter,
+                    value,
+                    EmptyAttributes));
+            }
+        }
+
+        if (includeRequestLatencyAvg || includeRequestLatencyMax)
+        {
+            foreach (var (nodeId, latency) in _nodeRequestLatencies)
+            {
+                var snapshot = subscription.DeltaTemporality
+                    ? latency.CollectDelta()
+                    : latency.CollectCumulative();
+
+                if (snapshot.Count == 0)
+                {
+                    continue;
+                }
+
+                var attributes = new[]
+                {
+                    new ClientTelemetryMetricAttribute("node_id", nodeId.ToString(CultureInfo.InvariantCulture))
+                };
+
+                if (includeRequestLatencyAvg)
+                {
+                    metrics.Add(new ClientTelemetryMetric(
+                        _nodeRequestLatencyAvgName,
+                        ClientTelemetryMetricKind.Gauge,
+                        StopwatchTicksToMilliseconds(snapshot.TotalTimestampTicks) / snapshot.Count,
+                        attributes));
+                }
+
+                if (includeRequestLatencyMax)
+                {
+                    metrics.Add(new ClientTelemetryMetric(
+                        _nodeRequestLatencyMaxName,
+                        ClientTelemetryMetricKind.Gauge,
+                        StopwatchTicksToMilliseconds(snapshot.MaxTimestampTicks),
+                        attributes));
+                }
+            }
+        }
+
+        return metrics.Count == 0
+            ? ClientTelemetryMetricSnapshot.Empty(subscription.DeltaTemporality)
+            : new ClientTelemetryMetricSnapshot(subscription.DeltaTemporality, metrics);
+    }
+
+    private void RecordRequestLatencyTicks(int brokerId, long elapsedTimestampTicks)
+    {
+        var latency = _nodeRequestLatencies.GetOrAdd(
+            brokerId,
+            static _ => new NodeRequestLatency());
+
+        latency.Record(elapsedTimestampTicks);
+    }
+
+    private static bool IsRequested(string metricName, IReadOnlyList<string> requestedMetrics)
+    {
+        for (var i = 0; i < requestedMetrics.Count; i++)
+        {
+            var prefix = requestedMetrics[i];
+            if (prefix.Length == 0 ||
+                metricName.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static double StopwatchTicksToMilliseconds(long stopwatchTicks) =>
+        stopwatchTicks * 1000.0 / Stopwatch.Frequency;
+
+    private readonly record struct LatencySnapshot(
+        long Count,
+        long TotalTimestampTicks,
+        long MaxTimestampTicks);
+
+    private sealed class NodeRequestLatency
+    {
+        private long _count;
+        private long _totalTimestampTicks;
+        private long _maxTimestampTicks;
+        private long _deltaCount;
+        private long _deltaTotalTimestampTicks;
+        private long _deltaMaxTimestampTicks;
+
+        public void Record(long elapsedTimestampTicks)
+        {
+            Interlocked.Increment(ref _count);
+            Interlocked.Add(ref _totalTimestampTicks, elapsedTimestampTicks);
+            AtomicMax(ref _maxTimestampTicks, elapsedTimestampTicks);
+
+            Interlocked.Increment(ref _deltaCount);
+            Interlocked.Add(ref _deltaTotalTimestampTicks, elapsedTimestampTicks);
+            AtomicMax(ref _deltaMaxTimestampTicks, elapsedTimestampTicks);
+        }
+
+        public LatencySnapshot CollectCumulative() =>
+            new(
+                Volatile.Read(ref _count),
+                Volatile.Read(ref _totalTimestampTicks),
+                Volatile.Read(ref _maxTimestampTicks));
+
+        public LatencySnapshot CollectDelta() =>
+            new(
+                Interlocked.Exchange(ref _deltaCount, 0),
+                Interlocked.Exchange(ref _deltaTotalTimestampTicks, 0),
+                Interlocked.Exchange(ref _deltaMaxTimestampTicks, 0));
+
+        private static void AtomicMax(ref long target, long value)
+        {
+            var current = Volatile.Read(ref target);
+            while (value > current)
+            {
+                var original = Interlocked.CompareExchange(ref target, value, current);
+                if (original == current)
+                {
+                    return;
+                }
+
+                current = original;
+            }
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryMetricCollectorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryMetricCollectorTests.cs
@@ -1,0 +1,108 @@
+using Dekaf.Telemetry;
+
+namespace Dekaf.Tests.Unit.Telemetry;
+
+public sealed class ClientTelemetryMetricCollectorTests
+{
+    [Test]
+    public async Task Collect_CumulativeProducerMetrics_ReturnsRequiredMetrics()
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);
+        collector.RecordConnectionCreated();
+        collector.RecordConnectionCreated();
+        collector.RecordRequestLatency(1, TimeSpan.FromMilliseconds(10));
+        collector.RecordRequestLatency(1, TimeSpan.FromMilliseconds(30));
+        collector.RecordRequestLatency(2, TimeSpan.FromMilliseconds(20));
+
+        var snapshot = collector.Collect(Subscription(
+            deltaTemporality: false,
+            "org.apache.kafka.producer."));
+
+        await Assert.That(snapshot.DeltaTemporality).IsFalse();
+        await Assert.That(snapshot.Metrics.Count).IsEqualTo(5);
+        await Assert.That(Metric(snapshot, ClientTelemetryMetricNames.ProducerConnectionCreationTotal).Value)
+            .IsEqualTo(2.0);
+        await Assert.That(Metric(snapshot, ClientTelemetryMetricNames.ProducerNodeRequestLatencyAvg, "1").Value)
+            .IsEqualTo(20.0);
+        await Assert.That(Metric(snapshot, ClientTelemetryMetricNames.ProducerNodeRequestLatencyMax, "1").Value)
+            .IsEqualTo(30.0);
+        await Assert.That(Metric(snapshot, ClientTelemetryMetricNames.ProducerNodeRequestLatencyAvg, "2").Value)
+            .IsEqualTo(20.0);
+        await Assert.That(Metric(snapshot, ClientTelemetryMetricNames.ProducerNodeRequestLatencyMax, "2").Value)
+            .IsEqualTo(20.0);
+    }
+
+    [Test]
+    public async Task Collect_FiltersByBrokerRequestedMetricPrefixes()
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer);
+        collector.RecordConnectionCreated();
+        collector.RecordRequestLatency(3, TimeSpan.FromMilliseconds(12));
+
+        var snapshot = collector.Collect(Subscription(
+            deltaTemporality: false,
+            "org.apache.kafka.consumer.node.request.latency."));
+
+        await Assert.That(snapshot.Metrics.Count).IsEqualTo(2);
+        await Assert.That(snapshot.Metrics.Any(m => m.Name == ClientTelemetryMetricNames.ConsumerConnectionCreationTotal))
+            .IsFalse();
+        await Assert.That(Metric(snapshot, ClientTelemetryMetricNames.ConsumerNodeRequestLatencyAvg, "3").Value)
+            .IsEqualTo(12.0);
+        await Assert.That(Metric(snapshot, ClientTelemetryMetricNames.ConsumerNodeRequestLatencyMax, "3").Value)
+            .IsEqualTo(12.0);
+    }
+
+    [Test]
+    public async Task Collect_DeltaTemporality_ResetsCollectedMetrics()
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);
+        collector.RecordConnectionCreated();
+        collector.RecordConnectionCreated();
+        collector.RecordRequestLatency(1, TimeSpan.FromMilliseconds(5));
+        collector.RecordRequestLatency(1, TimeSpan.FromMilliseconds(15));
+
+        var first = collector.Collect(Subscription(deltaTemporality: true, string.Empty));
+        var second = collector.Collect(Subscription(deltaTemporality: true, string.Empty));
+
+        collector.RecordConnectionCreated();
+        collector.RecordRequestLatency(1, TimeSpan.FromMilliseconds(25));
+        var third = collector.Collect(Subscription(deltaTemporality: true, string.Empty));
+
+        await Assert.That(first.DeltaTemporality).IsTrue();
+        await Assert.That(Metric(first, ClientTelemetryMetricNames.ProducerConnectionCreationTotal).Value)
+            .IsEqualTo(2.0);
+        await Assert.That(Metric(first, ClientTelemetryMetricNames.ProducerNodeRequestLatencyAvg, "1").Value)
+            .IsEqualTo(10.0);
+        await Assert.That(Metric(first, ClientTelemetryMetricNames.ProducerNodeRequestLatencyMax, "1").Value)
+            .IsEqualTo(15.0);
+
+        await Assert.That(second.Metrics.Count).IsEqualTo(0);
+
+        await Assert.That(Metric(third, ClientTelemetryMetricNames.ProducerConnectionCreationTotal).Value)
+            .IsEqualTo(1.0);
+        await Assert.That(Metric(third, ClientTelemetryMetricNames.ProducerNodeRequestLatencyAvg, "1").Value)
+            .IsEqualTo(25.0);
+        await Assert.That(Metric(third, ClientTelemetryMetricNames.ProducerNodeRequestLatencyMax, "1").Value)
+            .IsEqualTo(25.0);
+    }
+
+    private static ClientTelemetrySubscription Subscription(
+        bool deltaTemporality,
+        params string[] requestedMetrics) =>
+        new(
+            ClientInstanceId: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            SubscriptionId: 1,
+            CompressionType: 0,
+            PushIntervalMs: 60000,
+            TelemetryMaxBytes: 1024,
+            DeltaTemporality: deltaTemporality,
+            RequestedMetrics: requestedMetrics);
+
+    private static ClientTelemetryMetric Metric(
+        ClientTelemetryMetricSnapshot snapshot,
+        string name,
+        string? nodeId = null) =>
+        snapshot.Metrics.Single(m =>
+            m.Name == name &&
+            (nodeId is null || m.Attributes.Any(a => a.Name == "node_id" && a.Value == nodeId)));
+}


### PR DESCRIPTION
Closes #1005

## Summary
- add an internal KIP-714 telemetry metric collector for producer/consumer connection creation totals and per-node request latency avg/max
- wire producer and consumer connection pools into the collector with allocation-free hot-path atomic updates
- pass collected snapshots into the telemetry payload provider for future OTLP encoding
- add unit coverage for accumulation, prefix filtering, and delta reset behavior

## Validation
- dotnet build Dekaf.sln --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false
- dotnet run --project tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --disable-logo --no-progress