### PR TITLE
feat(consumer): add close options

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -664,6 +664,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 $"ConsumerGroupHeartbeat: fenced member epoch: {response.ErrorMessage}")
             { GroupId = _options.GroupId },
 
+            ErrorCode.FencedInstanceId => new GroupException(response.ErrorCode,
+                $"ConsumerGroupHeartbeat: fenced instance ID '{_options.GroupInstanceId}': {response.ErrorMessage}")
+            { GroupId = _options.GroupId },
+
             ErrorCode.UnreleasedInstanceId => new GroupException(response.ErrorCode,
                 $"ConsumerGroupHeartbeat: unreleased instance ID '{_options.GroupInstanceId}': {response.ErrorMessage}")
             { GroupId = _options.GroupId },
@@ -1042,6 +1046,35 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             return;
 
         await LeaveGroupConsumerProtocolAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Closes group coordination state, optionally sending an explicit leave-group heartbeat.
+    /// </summary>
+    /// <param name="leaveGroup">Whether to explicitly leave the group.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    internal async ValueTask CloseGroupAsync(bool leaveGroup, CancellationToken cancellationToken = default)
+    {
+        if (leaveGroup)
+        {
+            await LeaveGroupAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        if (Volatile.Read(ref _disposed) != 0)
+            return;
+
+        await StopHeartbeatAsync().ConfigureAwait(false);
+
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ResetMemberState();
+        }
+        finally
+        {
+            _lock.Release();
+        }
     }
 
     /// <summary>

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -4,6 +4,24 @@ using Dekaf.Serialization;
 namespace Dekaf.Consumer;
 
 /// <summary>
+/// Controls consumer shutdown behavior.
+/// </summary>
+public sealed class ConsumerCloseOptions
+{
+    /// <summary>
+    /// Whether to explicitly leave the consumer group on close.
+    /// Set to <see langword="false" /> for static membership handoff scenarios where the broker
+    /// should preserve the member slot until the session timeout expires.
+    /// </summary>
+    public bool LeaveGroup { get; init; } = true;
+
+    /// <summary>
+    /// Maximum time to wait for pending commits and leave-group during close.
+    /// </summary>
+    public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(30);
+}
+
+/// <summary>
 /// Interface for Kafka consumer.
 /// </summary>
 /// <typeparam name="TKey">Key type.</typeparam>
@@ -155,8 +173,9 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     IReadOnlySet<TopicPartition> Paused { get; }
 
     /// <summary>
-    /// Gracefully closes the consumer: stops background tasks (heartbeat, auto-commit, prefetch),
-    /// commits pending offsets, leaves the consumer group, and releases resources.
+    /// Gracefully closes the consumer with default close options: stops background tasks
+    /// (heartbeat, auto-commit, prefetch), commits pending offsets, leaves the consumer group,
+    /// and releases resources.
     /// </summary>
     /// <remarks>
     /// <para><b>Optional:</b> Calling <c>CloseAsync</c> explicitly is not required.
@@ -173,6 +192,19 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task representing the asynchronous close operation.</returns>
     ValueTask CloseAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gracefully closes the consumer with caller-specified close options.
+    /// </summary>
+    /// <remarks>
+    /// Set <see cref="ConsumerCloseOptions.LeaveGroup" /> to <see langword="false" /> when using
+    /// static membership and the member slot should be preserved for a quick restart with the same
+    /// group instance ID.
+    /// </remarks>
+    /// <param name="options">Close behavior options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous close operation.</returns>
+    ValueTask CloseAsync(ConsumerCloseOptions options, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Look up the offsets for the given partitions by timestamp.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4037,20 +4037,33 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     }
 
     /// <inheritdoc />
-    public async ValueTask CloseAsync(CancellationToken cancellationToken = default)
+    public ValueTask CloseAsync(CancellationToken cancellationToken = default) =>
+        CloseAsync(new ConsumerCloseOptions(), cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask CloseAsync(ConsumerCloseOptions options, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.Timeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(options.Timeout.TotalMilliseconds, int.MaxValue);
+
         // Idempotent - return early if already closed/disposed
         if (Interlocked.Exchange(ref _closed, 1) != 0 || Volatile.Read(ref _consumerDisposed) != 0)
             return;
 
-        await CloseAsyncCore(cancellationToken).ConfigureAwait(false);
+        using var timeoutCts = new CancellationTokenSource(options.Timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutCts.Token);
+
+        await CloseAsyncCore(options.LeaveGroup, linkedCts.Token).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Core teardown logic shared by <see cref="CloseAsync"/> and <see cref="DisposeAsync"/>.
     /// Callers must ensure this is invoked at most once via an atomic CAS on <c>_closed</c>.
     /// </summary>
-    private async ValueTask CloseAsyncCore(CancellationToken cancellationToken)
+    private async ValueTask CloseAsyncCore(bool leaveGroup, CancellationToken cancellationToken)
     {
         LogClosingConsumer();
 
@@ -4123,13 +4136,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             }
         }
 
-        // Step 5: Send LeaveGroup request to coordinator
+        // Step 6: Close group coordination, optionally sending LeaveGroup.
         if (_coordinator is not null)
         {
             try
             {
-                await _coordinator.LeaveGroupAsync(cancellationToken).ConfigureAwait(false);
-                LogLeftConsumerGroup();
+                await _coordinator.CloseGroupAsync(leaveGroup, cancellationToken).ConfigureAwait(false);
+                if (leaveGroup)
+                    LogLeftConsumerGroup();
             }
             catch (Exception ex)
             {
@@ -4137,10 +4151,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             }
         }
 
-        // Step 6: Cancel any blocked fetch operations
+        // Step 7: Cancel any blocked fetch operations
         CancelActiveConsumeOperations();
 
-        // Step 7: Clear pending fetch data and dispose to release pooled memory
+        // Step 8: Clear pending fetch data and dispose to release pooled memory
         while (_pendingFetches.TryDequeue(out var pending))
         {
             pending.Dispose();
@@ -4314,7 +4328,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             try
             {
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-                await CloseAsyncCore(cts.Token).ConfigureAwait(false);
+                await CloseAsyncCore(leaveGroup: true, cancellationToken: cts.Token).ConfigureAwait(false);
             }
             catch
             {

--- a/tests/Dekaf.Tests.Integration/StaticMembershipTests.cs
+++ b/tests/Dekaf.Tests.Integration/StaticMembershipTests.cs
@@ -109,14 +109,14 @@ public sealed class StaticMembershipTests(KafkaTestContainer kafka) : KafkaInteg
     }
 
     [Test]
-    public async Task StaticMember_RejoinWithinSessionTimeout_SkipsRebalance()
+    public async Task StaticMember_CloseWithoutLeave_DoesNotTriggerImmediateRebalance()
     {
         // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 3);
         var groupId = $"static-skip-rebalance-{Guid.NewGuid():N}";
         var instanceId = $"static-instance-{Guid.NewGuid():N}";
         var listener1 = new TrackingRebalanceListener();
-        var listener2 = new TrackingRebalanceListener();
+        var dynamicListener = new TrackingRebalanceListener();
 
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
@@ -136,7 +136,7 @@ public sealed class StaticMembershipTests(KafkaTestContainer kafka) : KafkaInteg
         }
 
         // First consumer with static membership and long session timeout
-        await using (var consumer1 = await Kafka.CreateConsumer<string, string>()
+        await using var consumer1 = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithClientId("static-consumer-1")
             .WithGroupId(groupId)
@@ -145,21 +145,18 @@ public sealed class StaticMembershipTests(KafkaTestContainer kafka) : KafkaInteg
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
             .WithOffsetCommitMode(OffsetCommitMode.Manual)
             .WithRebalanceListener(listener1)
-            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync())
-        {
-            consumer1.Subscribe(topic);
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            var result = await consumer1.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
-            await Assert.That(result).IsNotNull();
+        consumer1.Subscribe(topic);
 
-            // The first consumer should have been assigned partitions
-            await Assert.That(listener1.AssignedCallCount).IsGreaterThanOrEqualTo(1);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var result = await consumer1.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+        await Assert.That(result).IsNotNull();
 
-            await consumer1.CommitAsync();
-        }
+        // The first consumer should have been assigned partitions
+        await Assert.That(listener1.AssignedCallCount).IsGreaterThanOrEqualTo(1);
 
-        // Produce more messages for the second consumer
+        // Produce more messages so the dynamic consumer can join and consume if assigned.
         for (var p = 0; p < 3; p++)
         {
             await producer.ProduceAsync(new ProducerMessage<string, string>
@@ -171,32 +168,56 @@ public sealed class StaticMembershipTests(KafkaTestContainer kafka) : KafkaInteg
             }, CancellationToken.None);
         }
 
-        // Rejoin quickly with the same instance ID (within the 30s session timeout)
-        // Since this is a static member, the broker should recognize the instance ID
-        // and skip the rebalance protocol
-        await using var consumer2 = await Kafka.CreateConsumer<string, string>()
+        await using var dynamicConsumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
-            .WithClientId("static-consumer-2")
+            .WithClientId("dynamic-consumer")
             .WithGroupId(groupId)
-            .WithGroupInstanceId(instanceId)
             .WithSessionTimeout(TimeSpan.FromSeconds(30))
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
             .WithOffsetCommitMode(OffsetCommitMode.Manual)
-            .WithRebalanceListener(listener2)
+            .WithRebalanceListener(dynamicListener)
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
 
-        consumer2.Subscribe(topic);
+        dynamicConsumer.Subscribe(topic);
 
         using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        var result2 = await consumer2.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts2.Token);
-        await Assert.That(result2).IsNotNull();
+        try
+        {
+            await dynamicConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), cts2.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // No message on assigned partitions is fine; the poll still drives group join.
+        }
 
-        // The second consumer should have been assigned (at least 1 assignment call),
-        // but the key property of static membership is that there was no revoke/rebalance
-        // triggered for other members. With a single member, we verify assignment succeeds
-        // and the revoked count stays at zero for the new consumer.
-        await Assert.That(listener2.AssignedCallCount).IsGreaterThanOrEqualTo(1);
-        await Assert.That(listener2.RevokedCallCount).IsEqualTo(0);
+        await WaitForConditionAsync(
+            () => dynamicConsumer.Assignment.Any(tp => tp.Topic == topic),
+            TimeSpan.FromSeconds(30));
+
+        var dynamicAssignmentBeforeClose = dynamicConsumer.Assignment
+            .Where(tp => tp.Topic == topic)
+            .Select(tp => tp.Partition)
+            .OrderBy(p => p)
+            .ToArray();
+        var dynamicRevokedBeforeClose = dynamicListener.RevokedCallCount;
+
+        await consumer1.CommitAsync();
+        await consumer1.CloseAsync(new ConsumerCloseOptions
+        {
+            LeaveGroup = false,
+            Timeout = TimeSpan.FromSeconds(10)
+        });
+
+        await Task.Delay(TimeSpan.FromSeconds(5));
+
+        var dynamicAssignmentAfterClose = dynamicConsumer.Assignment
+            .Where(tp => tp.Topic == topic)
+            .Select(tp => tp.Partition)
+            .OrderBy(p => p)
+            .ToArray();
+
+        await Assert.That(dynamicAssignmentAfterClose).IsEquivalentTo(dynamicAssignmentBeforeClose);
+        await Assert.That(dynamicListener.RevokedCallCount).IsEqualTo(dynamicRevokedBeforeClose);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCloseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCloseTests.cs
@@ -11,6 +11,15 @@ public class ConsumerCloseTests
     #region Consumer CloseAsync Idempotency Tests
 
     [Test]
+    public async Task ConsumerCloseOptions_DefaultsToLeaveGroupWithThirtySecondTimeout()
+    {
+        var options = new ConsumerCloseOptions();
+
+        await Assert.That(options.LeaveGroup).IsTrue();
+        await Assert.That(options.Timeout).IsEqualTo(TimeSpan.FromSeconds(30));
+    }
+
+    [Test]
     public async Task KafkaConsumer_CloseAsync_IsIdempotent()
     {
         // Create a minimal consumer for testing
@@ -36,6 +45,76 @@ public class ConsumerCloseTests
         // Verify consumer state reflects closed status
         var subscription = consumer.Subscription;
         await Assert.That(subscription.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task KafkaConsumer_CloseAsync_WithOptions_IsIdempotent()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-consumer"
+        };
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        await consumer.CloseAsync(new ConsumerCloseOptions
+        {
+            LeaveGroup = false,
+            Timeout = TimeSpan.FromSeconds(1)
+        });
+
+        await consumer.CloseAsync(new ConsumerCloseOptions
+        {
+            LeaveGroup = true,
+            Timeout = TimeSpan.FromSeconds(1)
+        });
+
+        var subscription = consumer.Subscription;
+        await Assert.That(subscription.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task KafkaConsumer_CloseAsync_WithNullOptions_ThrowsArgumentNullException()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-consumer"
+        };
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        await Assert.That(async () =>
+        {
+            await consumer.CloseAsync(null!);
+        }).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task KafkaConsumer_CloseAsync_WithNegativeTimeout_ThrowsArgumentOutOfRangeException()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-consumer"
+        };
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        await Assert.That(async () =>
+        {
+            await consumer.CloseAsync(new ConsumerCloseOptions { Timeout = TimeSpan.FromMilliseconds(-1) });
+        }).Throws<ArgumentOutOfRangeException>();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -480,6 +480,50 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_CloseGroup_WithLeaveGroupTrue_SendsMemberEpochNegativeOne()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        _connection.ClearReceivedCalls();
+
+        SetupConsumerGroupHeartbeat();
+
+        await coordinator.CloseGroupAsync(leaveGroup: true, cancellationToken: CancellationToken.None);
+
+        await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(r => r.MemberEpoch == -1),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_CloseGroup_WithLeaveGroupFalse_SkipsLeaveHeartbeat()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(groupInstanceId: "static-instance-1");
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        _connection.ClearReceivedCalls();
+
+        SetupConsumerGroupHeartbeat();
+
+        await coordinator.CloseGroupAsync(leaveGroup: false, cancellationToken: CancellationToken.None);
+
+        await _connection.DidNotReceive().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(r => r.MemberEpoch == -1),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+        await Assert.That(coordinator.MemberId).IsNull();
+    }
+
+    [Test]
     public async Task ConsumerProtocol_LeaveGroup_ResetsState()
     {
         SetupSuccessfulConsumerProtocolJoin();


### PR DESCRIPTION
## Summary
- add `ConsumerCloseOptions` and `CloseAsync(options, ct)` for controlled consumer shutdown
- route close through group coordination so `LeaveGroup=false` skips the `MemberEpoch=-1` heartbeat
- cover option defaults, validation, close-group leave/skip paths, and static-member no-immediate-rebalance behavior

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release
- [x] dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumerCloseTests/*"
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumerCoordinatorKip848Tests/*CloseGroup*"
- [x] tests\Dekaf.Tests.Integration\bin\Release\net10.0\Dekaf.Tests.Integration.exe --treenode-filter "/*/*/StaticMembershipTests/StaticMember_CloseWithoutLeave_DoesNotTriggerImmediateRebalance"

Closes #827
