### PR TITLE
Make consumer mutators return void

### DIFF
--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -42,6 +42,17 @@ var consumer = await Kafka.CreateConsumer<string, string>()
     .BuildAsync();
 ```
 
+Consumer mutation methods are commands and return `void`. Keep live consumer operations as separate statements:
+
+```csharp
+// Before
+consumer.Subscribe("my-topic").Pause(new TopicPartition("my-topic", 0));
+
+// After
+consumer.Subscribe("my-topic");
+consumer.Pause(new TopicPartition("my-topic", 0));
+```
+
 ## Consuming Messages
 
 The primary way to consume is with `await foreach`:

--- a/docs/docs/consumer/manual-assignment.md
+++ b/docs/docs/consumer/manual-assignment.md
@@ -112,6 +112,18 @@ consumer.IncrementalUnassign(new[]
 });
 ```
 
+Assignment and seek methods mutate a live consumer and return `void`, so write them as sequential commands:
+
+```csharp
+// Before
+consumer.Assign(new TopicPartition("my-topic", 0))
+    .SeekToBeginning(new TopicPartition("my-topic", 0));
+
+// After
+consumer.Assign(new TopicPartition("my-topic", 0));
+consumer.SeekToBeginning(new TopicPartition("my-topic", 0));
+```
+
 ## Seeking
 
 With manual assignment, you can freely seek to any offset:

--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -176,6 +176,18 @@ consumer.SeekToBeginning(new TopicPartition("my-topic", 0));
 consumer.SeekToEnd(new TopicPartition("my-topic", 0));
 ```
 
+Seek and pause/resume operations mutate current consumer state and return `void`. Keep them as separate statements:
+
+```csharp
+// Before
+consumer.Seek(new TopicPartitionOffset("my-topic", 0, 100))
+    .Pause(new TopicPartition("my-topic", 0));
+
+// After
+consumer.Seek(new TopicPartitionOffset("my-topic", 0, 100));
+consumer.Pause(new TopicPartition("my-topic", 0));
+```
+
 ### Seek by Timestamp
 
 Find offsets for a specific time:

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -34,27 +34,27 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <summary>
     /// Subscribes to topics.
     /// </summary>
-    IKafkaConsumer<TKey, TValue> Subscribe(params string[] topics);
+    void Subscribe(params string[] topics);
 
     /// <summary>
     /// Subscribes to topics matching a pattern.
     /// </summary>
-    IKafkaConsumer<TKey, TValue> Subscribe(Func<string, bool> topicFilter);
+    void Subscribe(Func<string, bool> topicFilter);
 
     /// <summary>
     /// Unsubscribes from all topics.
     /// </summary>
-    IKafkaConsumer<TKey, TValue> Unsubscribe();
+    void Unsubscribe();
 
     /// <summary>
     /// Manually assigns partitions.
     /// </summary>
-    IKafkaConsumer<TKey, TValue> Assign(params TopicPartition[] partitions);
+    void Assign(params TopicPartition[] partitions);
 
     /// <summary>
     /// Unassigns all partitions.
     /// </summary>
-    IKafkaConsumer<TKey, TValue> Unassign();
+    void Unassign();
 
     /// <summary>
     /// Incrementally adds partitions to the current assignment.
@@ -62,8 +62,7 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Unlike <see cref="Assign"/>, does not replace the entire assignment.
     /// </summary>
     /// <param name="partitions">The partitions to add with optional starting offsets.</param>
-    /// <returns>This consumer for method chaining.</returns>
-    IKafkaConsumer<TKey, TValue> IncrementalAssign(IEnumerable<TopicPartitionOffset> partitions);
+    void IncrementalAssign(IEnumerable<TopicPartitionOffset> partitions);
 
     /// <summary>
     /// Incrementally removes partitions from the current assignment.
@@ -71,8 +70,7 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Unlike <see cref="Unassign"/>, only removes the specified partitions.
     /// </summary>
     /// <param name="partitions">The partitions to remove.</param>
-    /// <returns>This consumer for method chaining.</returns>
-    IKafkaConsumer<TKey, TValue> IncrementalUnassign(IEnumerable<TopicPartition> partitions);
+    void IncrementalUnassign(IEnumerable<TopicPartition> partitions);
 
     /// <summary>
     /// Consumes messages as an async enumerable.
@@ -127,27 +125,27 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <summary>
     /// Seeks to a specific offset.
     /// </summary>
-    IKafkaConsumer<TKey, TValue> Seek(TopicPartitionOffset offset);
+    void Seek(TopicPartitionOffset offset);
 
     /// <summary>
     /// Seeks to the beginning of partitions.
     /// </summary>
-    IKafkaConsumer<TKey, TValue> SeekToBeginning(params TopicPartition[] partitions);
+    void SeekToBeginning(params TopicPartition[] partitions);
 
     /// <summary>
     /// Seeks to the end of partitions.
     /// </summary>
-    IKafkaConsumer<TKey, TValue> SeekToEnd(params TopicPartition[] partitions);
+    void SeekToEnd(params TopicPartition[] partitions);
 
     /// <summary>
     /// Pauses consumption from partitions.
     /// </summary>
-    IKafkaConsumer<TKey, TValue> Pause(params TopicPartition[] partitions);
+    void Pause(params TopicPartition[] partitions);
 
     /// <summary>
     /// Resumes consumption from partitions.
     /// </summary>
-    IKafkaConsumer<TKey, TValue> Resume(params TopicPartition[] partitions);
+    void Resume(params TopicPartition[] partitions);
 
     /// <summary>
     /// Gets the paused partitions.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -795,7 +795,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         }
     }
 
-    public IKafkaConsumer<TKey, TValue> Subscribe(params string[] topics)
+    public void Subscribe(params string[] topics)
     {
         _topicFilter = null;
         _subscription.Clear();
@@ -824,10 +824,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         ClearFetchBuffer();
 
         InvalidateFetchRequestCache();
-        return this;
     }
 
-    public IKafkaConsumer<TKey, TValue> Subscribe(Func<string, bool> topicFilter)
+    public void Subscribe(Func<string, bool> topicFilter)
     {
         ArgumentNullException.ThrowIfNull(topicFilter);
 
@@ -851,10 +850,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         _lastFilterRefreshTicks = 0; // Force immediate refresh on next EnsureAssignment
         InvalidatePartitionCache();
         InvalidateFetchRequestCache();
-        return this;
     }
 
-    public IKafkaConsumer<TKey, TValue> Unsubscribe()
+    public void Unsubscribe()
     {
         _topicFilter = null;
         _subscription.Clear();
@@ -875,10 +873,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
         InvalidatePartitionCache();
         InvalidateFetchRequestCache();
-        return this;
     }
 
-    public IKafkaConsumer<TKey, TValue> Assign(params TopicPartition[] partitions)
+    public void Assign(params TopicPartition[] partitions)
     {
         _subscription.Clear();
         PublishSubscriptionSnapshot();
@@ -906,10 +903,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
         InvalidatePartitionCache();
         InvalidateFetchRequestCache();
-        return this;
     }
 
-    public IKafkaConsumer<TKey, TValue> Unassign()
+    public void Unassign()
     {
         SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
         try
@@ -927,10 +923,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
         InvalidatePartitionCache();
         InvalidateFetchRequestCache();
-        return this;
     }
 
-    public IKafkaConsumer<TKey, TValue> IncrementalAssign(IEnumerable<TopicPartitionOffset> partitions)
+    public void IncrementalAssign(IEnumerable<TopicPartitionOffset> partitions)
     {
         // Clear subscription since we're doing manual assignment
         _subscription.Clear();
@@ -961,10 +956,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         }
         InvalidatePartitionCache();
         InvalidateFetchRequestCache();
-        return this;
     }
 
-    public IKafkaConsumer<TKey, TValue> IncrementalUnassign(IEnumerable<TopicPartition> partitions)
+    public void IncrementalUnassign(IEnumerable<TopicPartition> partitions)
     {
         // Materialize once: the enumerable is iterated three times (assignment removal,
         // state cleanup, fetch buffer clear) and a forward-only sequence would silently
@@ -995,7 +989,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             PublishPausedSnapshot();
         InvalidatePartitionCache();
         InvalidateFetchRequestCache();
-        return this;
     }
 
     public async IAsyncEnumerable<ConsumeResult<TKey, TValue>> ConsumeAsync(
@@ -2321,7 +2314,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         Diagnostics.DekafMetrics.BytesReceived.Add(fetch.TotalBytesConsumed, metricTags);
     }
 
-    public IKafkaConsumer<TKey, TValue> Seek(TopicPartitionOffset offset)
+    public void Seek(TopicPartitionOffset offset)
     {
         LogSeek(offset.Topic, offset.Partition, offset.Offset);
         var tp = new TopicPartition(offset.Topic, offset.Partition);
@@ -2332,10 +2325,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         // Reset EOF state for this partition so it can fire again
         _eofEmitted.TryRemove(tp, out _);
         ClearFetchBuffer();
-        return this;
     }
 
-    public IKafkaConsumer<TKey, TValue> SeekToBeginning(params TopicPartition[] partitions)
+    public void SeekToBeginning(params TopicPartition[] partitions)
     {
         // Update positions (thread-safe with ConcurrentDictionary)
         foreach (var partition in partitions)
@@ -2350,10 +2342,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             _eofEmitted.TryRemove(partition, out _);
         }
         ClearFetchBuffer();
-        return this;
     }
 
-    public IKafkaConsumer<TKey, TValue> SeekToEnd(params TopicPartition[] partitions)
+    public void SeekToEnd(params TopicPartition[] partitions)
     {
         // Update positions (thread-safe with ConcurrentDictionary)
         foreach (var partition in partitions)
@@ -2368,7 +2359,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             _eofEmitted.TryRemove(partition, out _);
         }
         ClearFetchBuffer();
-        return this;
     }
 
     /// <summary>
@@ -2492,7 +2482,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         }
     }
 
-    public IKafkaConsumer<TKey, TValue> Pause(params TopicPartition[] partitions)
+    public void Pause(params TopicPartition[] partitions)
     {
         foreach (var partition in partitions)
         {
@@ -2501,10 +2491,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         PublishPausedSnapshot();
         InvalidatePartitionCache();
         InvalidateFetchRequestCache();
-        return this;
     }
 
-    public IKafkaConsumer<TKey, TValue> Resume(params TopicPartition[] partitions)
+    public void Resume(params TopicPartition[] partitions)
     {
         foreach (var partition in partitions)
         {
@@ -2513,7 +2502,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         PublishPausedSnapshot();
         InvalidatePartitionCache();
         InvalidateFetchRequestCache();
-        return this;
     }
 
     private void CancelActiveConsumeOperations()

--- a/tests/Dekaf.Tests.Unit/Consumer/IncrementalAssignmentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/IncrementalAssignmentTests.cs
@@ -350,7 +350,7 @@ public class IncrementalAssignmentTests
     }
 
     [Test]
-    public async Task IncrementalAssign_MethodChaining()
+    public async Task IncrementalAssign_AllowsSequentialCalls()
     {
         // Arrange
         await using var consumer = new KafkaConsumer<string, string>(
@@ -358,19 +358,17 @@ public class IncrementalAssignmentTests
             Serializers.String,
             Serializers.String);
 
-        // Act - verify method chaining returns the consumer
-        var result = consumer
-            .IncrementalAssign(new[] { new TopicPartitionOffset("topic1", 0, 0) })
-            .IncrementalAssign(new[] { new TopicPartitionOffset("topic1", 1, 0) })
-            .IncrementalAssign(new[] { new TopicPartitionOffset("topic2", 0, 0) });
+        // Act
+        consumer.IncrementalAssign(new[] { new TopicPartitionOffset("topic1", 0, 0) });
+        consumer.IncrementalAssign(new[] { new TopicPartitionOffset("topic1", 1, 0) });
+        consumer.IncrementalAssign(new[] { new TopicPartitionOffset("topic2", 0, 0) });
 
         // Assert
-        await Assert.That(result).IsEqualTo(consumer);
         await Assert.That(consumer.Assignment).Count().IsEqualTo(3);
     }
 
     [Test]
-    public async Task IncrementalUnassign_MethodChaining()
+    public async Task IncrementalUnassign_AllowsSequentialCalls()
     {
         // Arrange
         await using var consumer = new KafkaConsumer<string, string>(
@@ -383,13 +381,11 @@ public class IncrementalAssignmentTests
             new TopicPartition("topic1", 1),
             new TopicPartition("topic2", 0));
 
-        // Act - verify method chaining returns the consumer
-        var result = consumer
-            .IncrementalUnassign(new[] { new TopicPartition("topic1", 0) })
-            .IncrementalUnassign(new[] { new TopicPartition("topic1", 1) });
+        // Act
+        consumer.IncrementalUnassign(new[] { new TopicPartition("topic1", 0) });
+        consumer.IncrementalUnassign(new[] { new TopicPartition("topic1", 1) });
 
         // Assert
-        await Assert.That(result).IsEqualTo(consumer);
         await Assert.That(consumer.Assignment).Count().IsEqualTo(1);
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/PatternSubscriptionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PatternSubscriptionTests.cs
@@ -82,7 +82,7 @@ public sealed class PatternSubscriptionTests
     }
 
     [Test]
-    public async Task Subscribe_WithFilter_StoresPatternSubscription()
+    public async Task Subscribe_WithFilter_LeavesExplicitSubscriptionAndAssignmentEmpty()
     {
         await using var consumer = Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers("localhost:9092")

--- a/tests/Dekaf.Tests.Unit/Consumer/PatternSubscriptionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PatternSubscriptionTests.cs
@@ -82,13 +82,15 @@ public sealed class PatternSubscriptionTests
     }
 
     [Test]
-    public async Task Subscribe_WithFilter_ReturnsSelf()
+    public async Task Subscribe_WithFilter_StoresPatternSubscription()
     {
         await using var consumer = Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers("localhost:9092")
             .Build();
 
-        var result = consumer.Subscribe(topic => topic.Contains("test"));
-        await Assert.That(result).IsEqualTo(consumer);
+        consumer.Subscribe(topic => topic.Contains("test", StringComparison.Ordinal));
+
+        await Assert.That(consumer.Subscription.Count).IsEqualTo(0);
+        await Assert.That(consumer.Assignment.Count).IsEqualTo(0);
     }
 }


### PR DESCRIPTION
Closes #1012

## Summary
- change live consumer mutators from fluent self-return to void
- update consumer implementation and unit tests that expected chaining
- document sequential command style with before/after snippets in consumer docs

## Validation
- dotnet build Dekaf.sln --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false
- dotnet run --project tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --disable-logo --no-progress