### PR TITLE
perf(compression): avoid payload copies

### DIFF
--- a/src/Dekaf.Compression.Snappy/SnappyCompressionCodec.cs
+++ b/src/Dekaf.Compression.Snappy/SnappyCompressionCodec.cs
@@ -26,7 +26,7 @@ public sealed class SnappyCompressionCodec : ICompressionCodec
 
     private readonly int _blockSize;
 
-    // Thread-local reusable buffer for compression output (avoids ~77KB allocation per Compress call)
+    // Thread-local fallback for multi-segment block compression.
     [ThreadStatic]
     private static ArrayBufferWriter<byte>? t_compressedBuffer;
 
@@ -59,28 +59,32 @@ public sealed class SnappyCompressionCodec : ICompressionCodec
         var position = source.Start;
         var remaining = source.Length;
 
-        // Reuse thread-local buffer to capture compressed output (needed to get size for header)
-        var compressedBuffer = t_compressedBuffer ??= new ArrayBufferWriter<byte>();
-
         while (remaining > 0)
         {
             var blockLength = (int)Math.Min(remaining, _blockSize);
             var blockSequence = source.Slice(position, blockLength);
 
-            // Compress the block using ReadOnlySequence/IBufferWriter overload
-            compressedBuffer.ResetWrittenCount();
-            Snappier.Snappy.Compress(blockSequence, compressedBuffer);
-            var compressedLength = compressedBuffer.WrittenCount;
+            if (blockSequence.IsSingleSegment)
+            {
+                var maxCompressedLength = Snappier.Snappy.GetMaxCompressedLength(blockLength);
+                var blockSpan = destination.GetSpan(4 + maxCompressedLength);
+                var compressedLength = Snappier.Snappy.Compress(blockSequence.FirstSpan, blockSpan[4..]);
 
-            // Write block header: [compressed size (4 bytes BE)]
-            var blockHeaderSpan = destination.GetSpan(4);
-            BinaryPrimitives.WriteInt32BigEndian(blockHeaderSpan, compressedLength);
-            destination.Advance(4);
+                BinaryPrimitives.WriteInt32BigEndian(blockSpan, compressedLength);
+                destination.Advance(4 + compressedLength);
+            }
+            else
+            {
+                var compressedBuffer = t_compressedBuffer ??= new ArrayBufferWriter<byte>();
+                compressedBuffer.ResetWrittenCount();
+                Snappier.Snappy.Compress(blockSequence, compressedBuffer);
+                var compressedLength = compressedBuffer.WrittenCount;
 
-            // Write compressed data
-            var compressedSpan = destination.GetSpan(compressedLength);
-            compressedBuffer.WrittenSpan.CopyTo(compressedSpan);
-            destination.Advance(compressedLength);
+                var blockSpan = destination.GetSpan(4 + compressedLength);
+                BinaryPrimitives.WriteInt32BigEndian(blockSpan, compressedLength);
+                compressedBuffer.WrittenSpan.CopyTo(blockSpan[4..]);
+                destination.Advance(4 + compressedLength);
+            }
 
             position = source.GetPosition(blockLength, position);
             remaining -= blockLength;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5381,7 +5381,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         }
 
         // Return pre-compressed buffer and RecordBatch to pool.
-        // ReturnPreCompressedBuffer() releases the ArrayPool buffer, then ReturnToPool()
+        // ReturnPreCompressedBuffer() releases the producer-pool buffer, then ReturnToPool()
         // clears all references and returns the RecordBatch object for reuse.
         if (_recordBatch is not null)
         {

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -179,117 +179,22 @@ internal sealed class PooledReusableBufferWriter : IBufferWriter<byte>, IDisposa
 }
 
 /// <summary>
-/// Lightweight IBufferWriter backed by ArrayPool&lt;byte&gt;.Shared for decompression.
-/// After decompression, <see cref="DetachBuffer"/> transfers ownership of the underlying
-/// pooled array to the caller, eliminating a second memcpy that would otherwise be needed
-/// when using a shared scratch buffer (PooledReusableBufferWriter).
+/// Lightweight <see cref="IBufferWriter{T}"/> backed by a supplied array pool.
+/// <see cref="DetachBuffer"/> transfers ownership of the underlying pooled array to
+/// the caller, eliminating a second memcpy from reusable scratch storage.
 /// </summary>
-/// <remarks>
-/// Not reusable — each instance is created per decompression operation (per-batch cost, acceptable).
-/// The array is rented from ArrayPool&lt;byte&gt;.Shared so it can be returned by
-/// <see cref="LazyRecordList.Dispose"/> which also uses ArrayPool&lt;byte&gt;.Shared.
-/// </remarks>
-internal sealed class DecompressDirectBufferWriter : IBufferWriter<byte>, IDisposable
+internal sealed class DetachableBufferWriter : IBufferWriter<byte>, IDisposable
 {
+    private const int MinimumInitialCapacity = 256;
+
+    private readonly ArrayPool<byte> _pool;
     private byte[] _buffer;
     private int _written;
 
-    public DecompressDirectBufferWriter(int initialCapacity)
+    public DetachableBufferWriter(ArrayPool<byte> pool, int initialCapacity)
     {
-        _buffer = ArrayPool<byte>.Shared.Rent(Math.Max(256, initialCapacity));
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Advance(int count)
-    {
-        if ((uint)count > (uint)(_buffer.Length - _written))
-            throw new InvalidOperationException("Advance called with count exceeding available space.");
-        _written += count;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Memory<byte> GetMemory(int sizeHint = 0)
-    {
-        EnsureCapacity(sizeHint);
-        return _buffer.AsMemory(_written);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Span<byte> GetSpan(int sizeHint = 0)
-    {
-        EnsureCapacity(sizeHint);
-        return _buffer.AsSpan(_written);
-    }
-
-    /// <summary>
-    /// Transfers ownership of the internal pooled array to the caller.
-    /// The caller must return it to ArrayPool&lt;byte&gt;.Shared when done.
-    /// </summary>
-    public byte[] DetachBuffer(out int length)
-    {
-        length = _written;
-        var buf = _buffer;
-        _buffer = [];
-        _written = 0;
-        return buf;
-    }
-
-    /// <summary>
-    /// Returns the rented buffer if ownership was not transferred via <see cref="DetachBuffer"/>.
-    /// </summary>
-    public void Dispose()
-    {
-        var buf = _buffer;
-        _buffer = [];
-        _written = 0;
-        if (buf.Length > 0)
-            ArrayPool<byte>.Shared.Return(buf, clearArray: false);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void EnsureCapacity(int sizeHint)
-    {
-        if (sizeHint < 1)
-            sizeHint = 1;
-
-        if (_buffer.Length - _written < sizeHint)
-        {
-            Grow(sizeHint);
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private void Grow(int sizeHint)
-    {
-        var doubled = Math.Min((long)_buffer.Length * 2, Array.MaxLength);
-        var required = Math.Min((long)_written + sizeHint, Array.MaxLength);
-        var newSize = (int)Math.Max(doubled, required);
-
-        if (newSize <= _buffer.Length)
-            throw new InvalidOperationException("Cannot grow buffer: maximum size reached.");
-
-        var newBuffer = ArrayPool<byte>.Shared.Rent(newSize);
-        _buffer.AsSpan(0, _written).CopyTo(newBuffer);
-        ArrayPool<byte>.Shared.Return(_buffer, clearArray: false);
-        _buffer = newBuffer;
-    }
-}
-
-/// <summary>
-/// Lightweight <see cref="IBufferWriter{T}"/> backed by <see cref="ProducerDataPool"/>.
-/// <see cref="DetachBuffer"/> transfers the compressed payload buffer to the caller,
-/// avoiding an extra copy from a reusable scratch buffer into producer-owned storage.
-/// </summary>
-internal sealed class ProducerDataBufferWriter : IBufferWriter<byte>, IDisposable
-{
-    private const int InitialCapacityLimit = 4096;
-
-    private byte[] _buffer;
-    private int _written;
-
-    public ProducerDataBufferWriter(int initialCapacity)
-    {
-        _buffer = ProducerDataPool.BytePool.Rent(Math.Clamp(initialCapacity, 256, InitialCapacityLimit));
+        _pool = pool;
+        _buffer = pool.Rent(Math.Max(MinimumInitialCapacity, initialCapacity));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -329,7 +234,7 @@ internal sealed class ProducerDataBufferWriter : IBufferWriter<byte>, IDisposabl
         _buffer = [];
         _written = 0;
         if (buf.Length > 0)
-            ProducerDataPool.BytePool.Return(buf, clearArray: false);
+            _pool.Return(buf, clearArray: false);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -354,9 +259,9 @@ internal sealed class ProducerDataBufferWriter : IBufferWriter<byte>, IDisposabl
         if (newSize <= _buffer.Length)
             throw new InvalidOperationException("Cannot grow buffer: maximum size reached.");
 
-        var newBuffer = ProducerDataPool.BytePool.Rent(newSize);
+        var newBuffer = _pool.Rent(newSize);
         _buffer.AsSpan(0, _written).CopyTo(newBuffer);
-        ProducerDataPool.BytePool.Return(_buffer, clearArray: false);
+        _pool.Return(_buffer, clearArray: false);
         _buffer = newBuffer;
     }
 }
@@ -567,7 +472,7 @@ public sealed class RecordBatch : IDisposable
             // Compress directly into a detachable producer-pool buffer.
             var registry = codecs ?? CompressionCodecRegistry.Default;
             var codec = registry.GetCodec(compression);
-            using var compressedBuffer = new ProducerDataBufferWriter(recordsBuffer.WrittenCount);
+            using var compressedBuffer = new DetachableBufferWriter(ProducerDataPool.BytePool, recordsBuffer.WrittenCount);
             codec.Compress(new ReadOnlySequence<byte>(recordsBuffer.WrittenMemory), compressedBuffer);
 
             PreCompressedRecords = compressedBuffer.DetachBuffer(out var compressedLength);
@@ -1037,7 +942,7 @@ public sealed class RecordBatch : IDisposable
             var registry = codecs ?? CompressionCodecRegistry.Default;
             var codec = registry.GetCodec(compression);
             var estimatedSize = recordsLength * 4; // Estimate 4x expansion
-            using var decompressWriter = new DecompressDirectBufferWriter(estimatedSize);
+            using var decompressWriter = new DetachableBufferWriter(ArrayPool<byte>.Shared, estimatedSize);
             codec.Decompress(new ReadOnlySequence<byte>(rawRecordData), decompressWriter);
 
             // Transfer ownership of the pooled array — Dispose is a no-op after DetachBuffer.

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -276,6 +276,92 @@ internal sealed class DecompressDirectBufferWriter : IBufferWriter<byte>, IDispo
 }
 
 /// <summary>
+/// Lightweight <see cref="IBufferWriter{T}"/> backed by <see cref="ProducerDataPool"/>.
+/// <see cref="DetachBuffer"/> transfers the compressed payload buffer to the caller,
+/// avoiding an extra copy from a reusable scratch buffer into producer-owned storage.
+/// </summary>
+internal sealed class ProducerDataBufferWriter : IBufferWriter<byte>, IDisposable
+{
+    private const int InitialCapacityLimit = 4096;
+
+    private byte[] _buffer;
+    private int _written;
+
+    public ProducerDataBufferWriter(int initialCapacity)
+    {
+        _buffer = ProducerDataPool.BytePool.Rent(Math.Clamp(initialCapacity, 256, InitialCapacityLimit));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Advance(int count)
+    {
+        if ((uint)count > (uint)(_buffer.Length - _written))
+            throw new InvalidOperationException("Advance called with count exceeding available space.");
+        _written += count;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return _buffer.AsMemory(_written);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Span<byte> GetSpan(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return _buffer.AsSpan(_written);
+    }
+
+    public byte[] DetachBuffer(out int length)
+    {
+        length = _written;
+        var buf = _buffer;
+        _buffer = [];
+        _written = 0;
+        return buf;
+    }
+
+    public void Dispose()
+    {
+        var buf = _buffer;
+        _buffer = [];
+        _written = 0;
+        if (buf.Length > 0)
+            ProducerDataPool.BytePool.Return(buf, clearArray: false);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void EnsureCapacity(int sizeHint)
+    {
+        if (sizeHint < 1)
+            sizeHint = 1;
+
+        if (_buffer.Length - _written < sizeHint)
+        {
+            Grow(sizeHint);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Grow(int sizeHint)
+    {
+        var doubled = Math.Min((long)_buffer.Length * 2, Array.MaxLength);
+        var required = Math.Min((long)_written + sizeHint, Array.MaxLength);
+        var newSize = (int)Math.Max(doubled, required);
+
+        if (newSize <= _buffer.Length)
+            throw new InvalidOperationException("Cannot grow buffer: maximum size reached.");
+
+        var newBuffer = ProducerDataPool.BytePool.Rent(newSize);
+        _buffer.AsSpan(0, _written).CopyTo(newBuffer);
+        ProducerDataPool.BytePool.Return(_buffer, clearArray: false);
+        _buffer = newBuffer;
+    }
+}
+
+/// <summary>
 /// Kafka RecordBatch v2 format (magic byte 2).
 /// This is the modern record format used since Kafka 0.11.
 /// Supports lazy record parsing - records are only parsed when enumerated.
@@ -436,7 +522,7 @@ public sealed class RecordBatch : IDisposable
 
     /// <summary>
     /// Pre-compressed records data. When set, <see cref="Write"/> skips compression
-    /// and uses this data directly. The array is rented from <see cref="ArrayPool{T}"/>
+    /// and uses this data directly. The array is rented from <see cref="ProducerDataPool"/>
     /// and must be returned by the caller after Write() completes.
     /// Set by <see cref="PreCompress"/> before send so <see cref="Write"/> can emit
     /// the compressed payload directly.
@@ -478,21 +564,13 @@ public sealed class RecordBatch : IDisposable
 
             WriteRecords(records, ref recordsWriter);
 
-            // Compress to pooled scratch buffer
+            // Compress directly into a detachable producer-pool buffer.
             var registry = codecs ?? CompressionCodecRegistry.Default;
             var codec = registry.GetCodec(compression);
-            var compressedBuffer = GetCompressedBuffer(cache);
+            using var compressedBuffer = new ProducerDataBufferWriter(recordsBuffer.WrittenCount);
             codec.Compress(new ReadOnlySequence<byte>(recordsBuffer.WrittenMemory), compressedBuffer);
 
-            // Copy to a pooled array for storage (scratch buffer will be reused).
-            // Uses ProducerDataPool (not ArrayPool<byte>.Shared) because PreCompress and
-            // ReturnPreCompressedBuffer may run on different producer threads; cross-thread
-            // ArrayPool<byte>.Shared use causes TLS accumulation.
-            var compressedLength = compressedBuffer.WrittenCount;
-            var pooledArray = Producer.ProducerDataPool.BytePool.Rent(compressedLength);
-            compressedBuffer.WrittenSpan.CopyTo(pooledArray);
-
-            PreCompressedRecords = pooledArray;
+            PreCompressedRecords = compressedBuffer.DetachBuffer(out var compressedLength);
             PreCompressedLength = compressedLength;
             PreCompressedType = compression;
         }

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -1,4 +1,6 @@
 using System.Buffers;
+using System.Runtime.InteropServices;
+using Dekaf.Compression;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
@@ -569,6 +571,39 @@ public class RecordBatchTests
     }
 
     [Test]
+    public async Task PreCompress_StoresCodecOutputBufferWithoutCopy()
+    {
+        var codec = new CapturingCompressionCodec(CompressionType.Gzip);
+        var registry = new CompressionCodecRegistry();
+        registry.Register(codec);
+
+        using var batch = new RecordBatch
+        {
+            BaseOffset = 0,
+            BaseTimestamp = 0,
+            MaxTimestamp = 0,
+            Records =
+            [
+                new Record
+                {
+                    OffsetDelta = 0,
+                    TimestampDelta = 0,
+                    Key = "key"u8.ToArray(),
+                    Value = new byte[512]
+                }
+            ]
+        };
+
+        batch.PreCompress(CompressionType.Gzip, registry);
+
+        await Assert.That(codec.OutputArray).IsNotNull();
+        await Assert.That(batch.PreCompressedRecords).IsSameReferenceAs(codec.OutputArray!);
+        await Assert.That(batch.PreCompressedLength).IsEqualTo(codec.BytesWritten);
+        await Assert.That(batch.PreCompressedRecords.AsSpan(0, batch.PreCompressedLength).ToArray())
+            .IsEquivalentTo(CapturingCompressionCodec.Payload);
+    }
+
+    [Test]
     public async Task Write_WithPreCompressedData_ProducesSameOutputAsInlineCompression()
     {
         var records = new Record[]
@@ -631,6 +666,33 @@ public class RecordBatchTests
     }
 
     #endregion
+
+    private sealed class CapturingCompressionCodec(CompressionType type) : ICompressionCodec
+    {
+        public static readonly byte[] Payload = [0x44, 0x45, 0x4b, 0x41, 0x46];
+
+        public CompressionType Type { get; } = type;
+        public byte[]? OutputArray { get; private set; }
+        public int BytesWritten { get; private set; }
+
+        public void Compress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+        {
+            var memory = destination.GetMemory(Payload.Length);
+            if (!MemoryMarshal.TryGetArray<byte>(memory, out var segment) || segment.Array is null)
+                throw new InvalidOperationException("Expected array-backed compression destination.");
+
+            OutputArray = segment.Array;
+            Payload.CopyTo(memory.Span);
+            BytesWritten = Payload.Length;
+            destination.Advance(Payload.Length);
+        }
+
+        public void Decompress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+        {
+            foreach (var segment in source)
+                destination.Write(segment.Span);
+        }
+    }
 
     #region Pool Reuse on Consumer Read Path Tests
 

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -604,6 +604,36 @@ public class RecordBatchTests
     }
 
     [Test]
+    public async Task PreCompress_UsesSerializedRecordSizeAsInitialOutputCapacity()
+    {
+        var codec = new CapturingCompressionCodec(CompressionType.Gzip);
+        var registry = new CompressionCodecRegistry();
+        registry.Register(codec);
+
+        using var batch = new RecordBatch
+        {
+            BaseOffset = 0,
+            BaseTimestamp = 0,
+            MaxTimestamp = 0,
+            Records =
+            [
+                new Record
+                {
+                    OffsetDelta = 0,
+                    TimestampDelta = 0,
+                    Key = "key"u8.ToArray(),
+                    Value = new byte[64 * 1024]
+                }
+            ]
+        };
+
+        batch.PreCompress(CompressionType.Gzip, registry);
+
+        await Assert.That(codec.SourceLength).IsGreaterThan(4096);
+        await Assert.That(codec.InitialArrayLength).IsGreaterThanOrEqualTo(codec.SourceLength);
+    }
+
+    [Test]
     public async Task Write_WithPreCompressedData_ProducesSameOutputAsInlineCompression()
     {
         var records = new Record[]
@@ -674,14 +704,18 @@ public class RecordBatchTests
         public CompressionType Type { get; } = type;
         public byte[]? OutputArray { get; private set; }
         public int BytesWritten { get; private set; }
+        public int InitialArrayLength { get; private set; }
+        public int SourceLength { get; private set; }
 
         public void Compress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
         {
+            SourceLength = checked((int)source.Length);
             var memory = destination.GetMemory(Payload.Length);
             if (!MemoryMarshal.TryGetArray<byte>(memory, out var segment) || segment.Array is null)
                 throw new InvalidOperationException("Expected array-backed compression destination.");
 
             OutputArray = segment.Array;
+            InitialArrayLength = segment.Array.Length;
             Payload.CopyTo(memory.Span);
             BytesWritten = Payload.Length;
             destination.Advance(Payload.Length);


### PR DESCRIPTION
## Summary
- write single-segment Snappy xerial blocks directly into the destination buffer, keeping the scratch writer only for multi-segment blocks
- make RecordBatch pre-compression use a detachable ProducerDataPool-backed buffer so the compressed payload is not copied from scratch storage into send storage
- disambiguate two admin test constructor calls that became ambiguous on latest main after logger overloads landed

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/RecordBatchTests/*" --maximum-parallel-tests 1`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/SnappyCompressionCodecTests/*"`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/Compression*/*"`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/RecordAccumulatorReadyTests/*" --maximum-parallel-tests 1`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/AdminClientConsumerGroupDescribeTests/*" --maximum-parallel-tests 1`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/AdminDescribeTopicPartitionsTests/*" --maximum-parallel-tests 1`
- [x] `git diff --check HEAD~2..HEAD`
- [ ] Full serialized unit run was attempted but timed out after 5 minutes before producing a result

Closes #931
