### PR TITLE
perf(auth): avoid SCRAM HMAC allocations

### DIFF
--- a/src/Dekaf/Security/Sasl/ScramAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/ScramAuthenticator.cs
@@ -224,10 +224,9 @@ public sealed class ScramAuthenticator : ISaslAuthenticator
 
     private byte[] Hmac(byte[] key, byte[] message)
     {
-        using var hmac = _hashAlgorithm == HashAlgorithmName.SHA256
-            ? (HMAC)new HMACSHA256(key)
-            : new HMACSHA512(key);
-        return hmac.ComputeHash(message);
+        return _hashAlgorithm == HashAlgorithmName.SHA256
+            ? HMACSHA256.HashData(key, message)
+            : HMACSHA512.HashData(key, message);
     }
 
     private byte[] Hash(byte[] data)

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/ScramAuthenticatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/ScramAuthenticatorTests.cs
@@ -7,25 +7,27 @@ namespace Dekaf.Tests.Unit.Security.Sasl;
 public class ScramAuthenticatorTests
 {
     [Test]
-    public async Task Hmac_ScramSha256_MatchesOneShotHashData()
+    public async Task Hmac_ScramSha256_MatchesInstanceHmac()
     {
         var key = "test-key"u8.ToArray();
         var message = "test-message"u8.ToArray();
 
         var result = InvokeHmac(SaslMechanism.ScramSha256, key, message);
 
-        await Assert.That(result).IsEquivalentTo(HMACSHA256.HashData(key, message));
+        using var hmac = new HMACSHA256(key);
+        await Assert.That(result).IsEquivalentTo(hmac.ComputeHash(message));
     }
 
     [Test]
-    public async Task Hmac_ScramSha512_MatchesOneShotHashData()
+    public async Task Hmac_ScramSha512_MatchesInstanceHmac()
     {
         var key = "test-key"u8.ToArray();
         var message = "test-message"u8.ToArray();
 
         var result = InvokeHmac(SaslMechanism.ScramSha512, key, message);
 
-        await Assert.That(result).IsEquivalentTo(HMACSHA512.HashData(key, message));
+        using var hmac = new HMACSHA512(key);
+        await Assert.That(result).IsEquivalentTo(hmac.ComputeHash(message));
     }
 
     private static byte[] InvokeHmac(SaslMechanism mechanism, byte[] key, byte[] message)

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/ScramAuthenticatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/ScramAuthenticatorTests.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+using System.Security.Cryptography;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.Security.Sasl;
+
+public class ScramAuthenticatorTests
+{
+    [Test]
+    public async Task Hmac_ScramSha256_MatchesOneShotHashData()
+    {
+        var key = "test-key"u8.ToArray();
+        var message = "test-message"u8.ToArray();
+
+        var result = InvokeHmac(SaslMechanism.ScramSha256, key, message);
+
+        await Assert.That(result).IsEquivalentTo(HMACSHA256.HashData(key, message));
+    }
+
+    [Test]
+    public async Task Hmac_ScramSha512_MatchesOneShotHashData()
+    {
+        var key = "test-key"u8.ToArray();
+        var message = "test-message"u8.ToArray();
+
+        var result = InvokeHmac(SaslMechanism.ScramSha512, key, message);
+
+        await Assert.That(result).IsEquivalentTo(HMACSHA512.HashData(key, message));
+    }
+
+    private static byte[] InvokeHmac(SaslMechanism mechanism, byte[] key, byte[] message)
+    {
+        var authenticator = new ScramAuthenticator(mechanism, "user", "password");
+        var method = typeof(ScramAuthenticator).GetMethod(
+            "Hmac",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(byte[]), typeof(byte[])],
+            modifiers: null);
+
+        return (byte[])method!.Invoke(authenticator, [key, message])!;
+    }
+}


### PR DESCRIPTION
## Summary
- replace per-call SCRAM `HMAC` instances with one-shot `HMACSHA256.HashData` / `HMACSHA512.HashData`
- add focused SHA-256/SHA-512 coverage for the SCRAM HMAC helper output

## Test plan
- [x] `dotnet restore tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj`
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/ScramAuthenticatorTests/*"`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/SaslMechanismTests/*"`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/SaslReauthenticationConfigTests/*"`
- [x] `git diff --check HEAD~1..HEAD`

Closes #1044
