### PR TITLE
feat(api): add KafkaClient root

### DIFF
--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -21,6 +21,16 @@ await using var consumer = await Kafka.CreateConsumer<string, string>()
 
 The type parameters `<TKey, TValue>` define the expected key and value types.
 
+For services with multiple Kafka clients, create a root client once and build consumers from it. Bootstrap servers, TLS/SASL, and memory budgeting are owned by the root; group IDs and subscription settings stay on the consumer builder.
+
+```csharp
+await using var kafka = Kafka.Connect("localhost:9092");
+
+await using var consumer = await kafka.CreateConsumer<string, string>("my-consumer-group")
+    .SubscribeTo("my-topic")
+    .BuildAsync();
+```
+
 ## Subscribing to Topics
 
 Before consuming, subscribe to one or more topics:

--- a/docs/docs/dependency-injection.md
+++ b/docs/docs/dependency-injection.md
@@ -6,6 +6,8 @@ sidebar_position: 11
 
 Dekaf plays nicely with ASP.NET Core's DI container. Here's how to wire it up.
 
+DI registration owns each registered client for you. For manual wiring outside DI, prefer `Kafka.Connect(...)` when multiple clients should share a connection pool and memory budget.
+
 ## Installation
 
 ```bash

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -41,6 +41,7 @@ var producer = await Kafka.CreateProducer<string, string>()
 
 The `using Dekaf;` directive gives you access to:
 - The static `Kafka` class for creating producers and consumers
+- The `KafkaClient` root for sharing one connection pool and memory budget across related clients
 - Common types like `Headers`, `TopicPartition`, `TopicPartitionOffset`
 - Extension methods for consumers and producers
 
@@ -185,6 +186,37 @@ catch (OperationCanceledException) { }
 
 Console.WriteLine("Done!");
 ```
+
+## Sharing a Root Client
+
+When one process talks to the same Kafka cluster with multiple clients, create a root client once and build producers, consumers, and admin clients from it. The root owns the shared connection pool, metadata manager, and memory budget.
+
+Before:
+
+```csharp
+await using var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers(bootstrapServers)
+    .BuildAsync();
+
+await using var consumer = await Kafka.CreateConsumer<string, string>()
+    .WithBootstrapServers(bootstrapServers)
+    .WithGroupId("orders")
+    .BuildAsync();
+```
+
+After:
+
+```csharp
+await using var kafka = Kafka.Connect(bootstrapServers);
+
+await using var producer = await kafka.CreateProducer<string, string>()
+    .BuildAsync();
+
+await using var consumer = await kafka.CreateConsumer<string, string>("orders")
+    .BuildAsync();
+```
+
+Configure cluster-level connection settings such as TLS, SASL, socket buffers, and the root memory budget on `Kafka.Connect(...)`. Configure per-client behavior on the producer or consumer builders.
 
 ## Configuration-First Services
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -33,6 +33,7 @@ We use the same patterns you're using in your own code:
 
 - Nullable reference types (no more guessing what can be null)
 - `IAsyncEnumerable<T>` for streaming consumption
+- `KafkaClient` root objects when producers, consumers, and admin clients should share connections and memory budgeting
 - `ConfigureAwait(false)` everywhere (we're a library, we know the rules)
 - Fluent builders that guide you to valid configurations
 

--- a/docs/docs/producer/basics.md
+++ b/docs/docs/producer/basics.md
@@ -20,6 +20,15 @@ await using var producer = await Kafka.CreateProducer<string, string>()
 
 The type parameters `<TKey, TValue>` define the types for message keys and values. Dekaf includes built-in serializers for common types.
 
+If the producer is part of an app that also creates consumers or admin clients for the same cluster, use a root client so those clients share one connection pool and memory budget:
+
+```csharp
+await using var kafka = Kafka.Connect("localhost:9092");
+
+await using var producer = await kafka.CreateProducer<string, string>()
+    .BuildAsync();
+```
+
 ## Sending Messages
 
 ### With Acknowledgment (Recommended)

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using Dekaf;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Producer;
@@ -2485,6 +2486,7 @@ public sealed class AdminClientOptions
 /// </summary>
 public sealed class AdminClientBuilder
 {
+    private readonly KafkaClientInfrastructure? _clientInfrastructure;
     private IReadOnlyList<string> _bootstrapServers = [];
     private string? _clientId;
     private int _requestTimeoutMs = 30000;
@@ -2501,14 +2503,27 @@ public sealed class AdminClientBuilder
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
     private TimeSpan? _metadataMaxAge;
 
+    public AdminClientBuilder()
+    {
+    }
+
+    internal AdminClientBuilder(KafkaClientInfrastructure clientInfrastructure)
+    {
+        _clientInfrastructure = clientInfrastructure;
+        _bootstrapServers = clientInfrastructure.BootstrapServers;
+        _loggerFactory = clientInfrastructure.LoggerFactory;
+    }
+
     public AdminClientBuilder WithBootstrapServers(string servers)
     {
+        ThrowIfClientOwnedBootstrap();
         _bootstrapServers = servers.Split(',').Select(s => s.Trim()).ToArray();
         return this;
     }
 
     public AdminClientBuilder WithBootstrapServers(params string[] servers)
     {
+        ThrowIfClientOwnedBootstrap();
         _bootstrapServers = [..servers];
         return this;
     }
@@ -2723,6 +2738,18 @@ public sealed class AdminClientBuilder
             ? new MetadataOptions { MetadataRefreshInterval = _metadataMaxAge.Value }
             : null;
 
-        return new AdminClient(options, _loggerFactory, metadataOptions);
+        return _clientInfrastructure is null
+            ? new AdminClient(options, _loggerFactory, metadataOptions)
+            : new AdminClient(
+                options,
+                _clientInfrastructure.ConnectionPool,
+                _clientInfrastructure.MetadataManager,
+                _loggerFactory);
+    }
+
+    private void ThrowIfClientOwnedBootstrap()
+    {
+        if (_clientInfrastructure is not null)
+            throw new InvalidOperationException("Bootstrap servers are owned by KafkaClient. Configure them on Kafka.Connect(...).");
     }
 }

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -2536,6 +2536,7 @@ public sealed class AdminClientBuilder
 
     public AdminClientBuilder UseTls()
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = true;
         return this;
     }
@@ -2546,6 +2547,7 @@ public sealed class AdminClientBuilder
     /// <param name="config">The TLS configuration.</param>
     public AdminClientBuilder UseTls(TlsConfig config)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = true;
         _tlsConfig = config;
         return this;
@@ -2564,6 +2566,7 @@ public sealed class AdminClientBuilder
         string clientKeyPath,
         string? keyPassword = null)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = true;
         _tlsConfig = TlsConfig.CreateMutualTls(caCertPath, clientCertPath, clientKeyPath, keyPassword);
         return this;
@@ -2578,6 +2581,7 @@ public sealed class AdminClientBuilder
         X509Certificate2 clientCertificate,
         X509Certificate2? caCertificate = null)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = true;
         _tlsConfig = TlsConfig.CreateMutualTls(clientCertificate, caCertificate);
         return this;
@@ -2585,6 +2589,7 @@ public sealed class AdminClientBuilder
 
     public AdminClientBuilder WithSaslPlain(string username, string password)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.Plain;
         _saslUsername = username;
         _saslPassword = password;
@@ -2593,6 +2598,7 @@ public sealed class AdminClientBuilder
 
     public AdminClientBuilder WithSaslScramSha256(string username, string password)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = username;
         _saslPassword = password;
@@ -2601,6 +2607,7 @@ public sealed class AdminClientBuilder
 
     public AdminClientBuilder WithSaslScramSha512(string username, string password)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = username;
         _saslPassword = password;
@@ -2613,6 +2620,7 @@ public sealed class AdminClientBuilder
     /// <param name="config">The GSSAPI configuration.</param>
     public AdminClientBuilder WithGssapi(GssapiConfig config)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.Gssapi;
         _gssapiConfig = config ?? throw new ArgumentNullException(nameof(config));
         return this;
@@ -2624,6 +2632,7 @@ public sealed class AdminClientBuilder
     /// <param name="config">The OAuth configuration describing the token endpoint and client.</param>
     public AdminClientBuilder WithOAuthBearer(OAuthBearerConfig config)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthConfig = config ?? throw new ArgumentNullException(nameof(config));
         _oauthTokenProvider = null;
@@ -2636,6 +2645,7 @@ public sealed class AdminClientBuilder
     /// <param name="tokenProvider">A callback that returns an OAuth bearer token on demand.</param>
     public AdminClientBuilder WithOAuthBearer(Func<CancellationToken, ValueTask<OAuthBearerToken>> tokenProvider)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthTokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
         _oauthConfig = null;
@@ -2703,6 +2713,7 @@ public sealed class AdminClientBuilder
         GssapiConfig? gssapiConfig,
         OAuthBearerConfig? oauthConfig)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = mechanism;
         _saslUsername = username;
         _saslPassword = password;
@@ -2751,5 +2762,11 @@ public sealed class AdminClientBuilder
     {
         if (_clientInfrastructure is not null)
             throw new InvalidOperationException("Bootstrap servers are owned by KafkaClient. Configure them on Kafka.Connect(...).");
+    }
+
+    private void ThrowIfClientOwnedConnectionSettings()
+    {
+        if (_clientInfrastructure is not null)
+            throw new InvalidOperationException("Connection settings are owned by KafkaClient. Configure them on Kafka.Connect(...).");
     }
 }

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -20,6 +20,7 @@ namespace Dekaf;
 /// <typeparam name="TValue">Value type.</typeparam>
 public sealed class ProducerBuilder<TKey, TValue>
 {
+    private readonly KafkaClientInfrastructure? _clientInfrastructure;
     private IReadOnlyList<string> _bootstrapServers = [];
     private string? _clientId;
     private Acks _acks = Acks.All;
@@ -67,14 +68,29 @@ public sealed class ProducerBuilder<TKey, TValue>
     private bool _enableAdaptiveConnections = true;
     private int _maxConnectionsPerBroker = 10;
 
+    public ProducerBuilder()
+    {
+    }
+
+    internal ProducerBuilder(KafkaClientInfrastructure clientInfrastructure)
+    {
+        _clientInfrastructure = clientInfrastructure;
+        _bootstrapServers = clientInfrastructure.BootstrapServers;
+        _loggerFactory = clientInfrastructure.LoggerFactory;
+        _connectionsPerBroker = clientInfrastructure.ConnectionsPerBroker;
+        _maxConnectionsPerBroker = clientInfrastructure.MaxConnectionsPerBroker;
+    }
+
     public ProducerBuilder<TKey, TValue> WithBootstrapServers(string servers)
     {
+        ThrowIfClientOwnedBootstrap();
         _bootstrapServers = servers.Split(',').Select(s => s.Trim()).ToArray();
         return this;
     }
 
     public ProducerBuilder<TKey, TValue> WithBootstrapServers(params string[] servers)
     {
+        ThrowIfClientOwnedBootstrap();
         _bootstrapServers = [..servers];
         return this;
     }
@@ -788,6 +804,8 @@ public sealed class ProducerBuilder<TKey, TValue>
         var keySerializer = _keySerializer ?? GetDefaultSerializer<TKey>();
         var valueSerializer = _valueSerializer ?? GetDefaultSerializer<TValue>();
 
+        var memoryBudget = _clientInfrastructure?.MemoryBudget ?? DekafMemoryBudget.Global;
+
         var options = new ProducerOptions
         {
             BootstrapServers = _bootstrapServers,
@@ -795,7 +813,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             Acks = _acks,
             LingerMs = _lingerMs,
             BatchSize = _batchSize,
-            BufferMemory = _bufferMemory ?? DekafMemoryBudget.PreviewProducerLimit(),
+            BufferMemory = _bufferMemory ?? memoryBudget.PreviewProducerLimit(),
             IsAutoTuned = _bufferMemory is null,
             MaxInFlightRequestsPerConnection = _maxInFlightRequestsPerConnection,
             Retries = _retries,
@@ -839,7 +857,16 @@ public sealed class ProducerBuilder<TKey, TValue>
             ? new MetadataOptions { MetadataRefreshInterval = _metadataMaxAge.Value }
             : null;
 
-        var producer = new KafkaProducer<TKey, TValue>(options, keySerializer, valueSerializer, _loggerFactory, metadataOptions);
+        var producer = _clientInfrastructure is null
+            ? new KafkaProducer<TKey, TValue>(options, keySerializer, valueSerializer, _loggerFactory, metadataOptions)
+            : new KafkaProducer<TKey, TValue>(
+                options,
+                keySerializer,
+                valueSerializer,
+                _clientInfrastructure.ConnectionPool,
+                _clientInfrastructure.MetadataManager,
+                memoryBudget,
+                _loggerFactory);
 
         // The BufferMemory above is seeded from PreviewProducerLimit(), which assumes N producers.
         // RegisterProducer rebalances to N+1 and synchronously fires OnBudgetChanged on every
@@ -851,9 +878,9 @@ public sealed class ProducerBuilder<TKey, TValue>
         // caller. No code path today couples existing producers to the new producer's limit, so
         // this ordering is safe in practice.
         if (options.IsAutoTuned)
-            DekafMemoryBudget.RegisterProducer(producer);
+            memoryBudget.RegisterProducer(producer);
         else
-            DekafMemoryBudget.ReserveExplicit(_bufferMemory!.Value);
+            memoryBudget.ReserveExplicit(_bufferMemory!.Value);
 
         return producer;
     }
@@ -893,6 +920,12 @@ public sealed class ProducerBuilder<TKey, TValue>
 
         throw new InvalidOperationException($"No default serializer for type {typeof(T)}. Please specify a serializer.");
     }
+
+    private void ThrowIfClientOwnedBootstrap()
+    {
+        if (_clientInfrastructure is not null)
+            throw new InvalidOperationException("Bootstrap servers are owned by KafkaClient. Configure them on Kafka.Connect(...).");
+    }
 }
 
 /// <summary>
@@ -902,6 +935,7 @@ public sealed class ProducerBuilder<TKey, TValue>
 /// <typeparam name="TValue">Value type.</typeparam>
 public sealed class ConsumerBuilder<TKey, TValue>
 {
+    private readonly KafkaClientInfrastructure? _clientInfrastructure;
     private IReadOnlyList<string> _bootstrapServers = [];
     private string? _clientId;
     private string? _groupId;
@@ -954,14 +988,29 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private AdaptiveFetchSizingOptions? _adaptiveFetchSizingOptions;
     private bool _enableFetchSessions = true;
 
+    public ConsumerBuilder()
+    {
+    }
+
+    internal ConsumerBuilder(KafkaClientInfrastructure clientInfrastructure)
+    {
+        _clientInfrastructure = clientInfrastructure;
+        _bootstrapServers = clientInfrastructure.BootstrapServers;
+        _loggerFactory = clientInfrastructure.LoggerFactory;
+        _connectionsPerBroker = clientInfrastructure.ConnectionsPerBroker;
+        _maxConnectionsPerBroker = clientInfrastructure.MaxConnectionsPerBroker;
+    }
+
     public ConsumerBuilder<TKey, TValue> WithBootstrapServers(string servers)
     {
+        ThrowIfClientOwnedBootstrap();
         _bootstrapServers = servers.Split(',').Select(s => s.Trim()).ToArray();
         return this;
     }
 
     public ConsumerBuilder<TKey, TValue> WithBootstrapServers(params string[] servers)
     {
+        ThrowIfClientOwnedBootstrap();
         _bootstrapServers = [..servers];
         return this;
     }
@@ -1708,6 +1757,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
                 $"MaxConnectionsPerBroker ({_maxConnectionsPerBroker}) must be >= ConnectionsPerBroker ({_connectionsPerBroker}). " +
                 $"Adaptive scaling would be permanently disabled since the initial connection count already exceeds the maximum.");
 
+        var memoryBudget = _clientInfrastructure?.MemoryBudget ?? DekafMemoryBudget.Global;
+
         var options = new ConsumerOptions
         {
             BootstrapServers = _bootstrapServers,
@@ -1745,7 +1796,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             SocketReceiveBufferBytes = _socketReceiveBufferBytes,
             QueuedMinMessages = _queuedMinMessages,
             QueuedMaxMessagesKbytes = _queuedMaxMessagesKbytes
-                ?? (int)Math.Min(DekafMemoryBudget.PreviewConsumerLimit() / 1024, int.MaxValue),
+                ?? (int)Math.Min(memoryBudget.PreviewConsumerLimit() / 1024, int.MaxValue),
             IsAutoTuned = _queuedMaxMessagesKbytes is null,
             IsolationLevel = _isolationLevel,
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
@@ -1764,7 +1815,16 @@ public sealed class ConsumerBuilder<TKey, TValue>
             ? new MetadataOptions { MetadataRefreshInterval = _metadataMaxAge.Value }
             : null;
 
-        var consumer = new KafkaConsumer<TKey, TValue>(options, keyDeserializer, valueDeserializer, _loggerFactory, metadataOptions);
+        var consumer = _clientInfrastructure is null
+            ? new KafkaConsumer<TKey, TValue>(options, keyDeserializer, valueDeserializer, _loggerFactory, metadataOptions)
+            : new KafkaConsumer<TKey, TValue>(
+                options,
+                keyDeserializer,
+                valueDeserializer,
+                _clientInfrastructure.ConnectionPool,
+                _clientInfrastructure.MetadataManager,
+                memoryBudget,
+                _loggerFactory);
 
         // QueuedMaxMessagesKbytes above is seeded from PreviewConsumerLimit() assuming N consumers.
         // RegisterConsumer rebalances to N+1 and synchronously dispatches OnBudgetChanged on every
@@ -1772,9 +1832,9 @@ public sealed class ConsumerBuilder<TKey, TValue>
         // until Build() returns, and its final OnBudgetChanged applies the confirmed limit before
         // that happens. See the matching note in the producer builder above.
         if (options.IsAutoTuned)
-            DekafMemoryBudget.RegisterConsumer(consumer);
+            memoryBudget.RegisterConsumer(consumer);
         else
-            DekafMemoryBudget.ReserveExplicit((ulong)_queuedMaxMessagesKbytes!.Value * 1024);
+            memoryBudget.ReserveExplicit((ulong)_queuedMaxMessagesKbytes!.Value * 1024);
 
         if (_topicsToSubscribe.Count > 0)
         {
@@ -1803,6 +1863,12 @@ public sealed class ConsumerBuilder<TKey, TValue>
 
         throw new InvalidOperationException($"No default deserializer for type {typeof(T)}. Please specify a deserializer.");
     }
+
+    private void ThrowIfClientOwnedBootstrap()
+    {
+        if (_clientInfrastructure is not null)
+            throw new InvalidOperationException("Bootstrap servers are owned by KafkaClient. Configure them on Kafka.Connect(...).");
+    }
 }
 
 /// <summary>
@@ -1811,6 +1877,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
 /// </summary>
 public sealed class ShareConsumerBuilder<TKey, TValue>
 {
+    private readonly KafkaClientInfrastructure? _clientInfrastructure;
     private IReadOnlyList<string> _bootstrapServers = [];
     private string? _clientId;
     private string? _groupId;
@@ -1840,14 +1907,28 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private IRetryPolicy? _retryPolicy;
     private readonly List<string> _topicsToSubscribe = [];
 
+    public ShareConsumerBuilder()
+    {
+    }
+
+    internal ShareConsumerBuilder(KafkaClientInfrastructure clientInfrastructure)
+    {
+        _clientInfrastructure = clientInfrastructure;
+        _bootstrapServers = clientInfrastructure.BootstrapServers;
+        _loggerFactory = clientInfrastructure.LoggerFactory;
+        _connectionsPerBroker = clientInfrastructure.ConnectionsPerBroker;
+    }
+
     public ShareConsumerBuilder<TKey, TValue> WithBootstrapServers(string servers)
     {
+        ThrowIfClientOwnedBootstrap();
         _bootstrapServers = servers.Split(',').Select(s => s.Trim()).ToArray();
         return this;
     }
 
     public ShareConsumerBuilder<TKey, TValue> WithBootstrapServers(params string[] servers)
     {
+        ThrowIfClientOwnedBootstrap();
         _bootstrapServers = [..servers];
         return this;
     }
@@ -2088,7 +2169,15 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             RetryPolicy = _retryPolicy
         };
 
-        var consumer = new KafkaShareConsumer<TKey, TValue>(options, keyDeserializer, valueDeserializer, _loggerFactory);
+        var consumer = _clientInfrastructure is null
+            ? new KafkaShareConsumer<TKey, TValue>(options, keyDeserializer, valueDeserializer, _loggerFactory)
+            : new KafkaShareConsumer<TKey, TValue>(
+                options,
+                keyDeserializer,
+                valueDeserializer,
+                _clientInfrastructure.ConnectionPool,
+                _clientInfrastructure.MetadataManager,
+                _loggerFactory);
 
         if (_topicsToSubscribe.Count > 0)
         {
@@ -2116,5 +2205,11 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             return (IDeserializer<T>)(object)Serializers.Ignore;
 
         throw new InvalidOperationException($"No default deserializer for type {typeof(T)}. Please specify a deserializer.");
+    }
+
+    private void ThrowIfClientOwnedBootstrap()
+    {
+        if (_clientInfrastructure is not null)
+            throw new InvalidOperationException("Bootstrap servers are owned by KafkaClient. Configure them on Kafka.Connect(...).");
     }
 }

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -204,6 +204,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// </exception>
     public ProducerBuilder<TKey, TValue> WithConnectionsPerBroker(int connectionsPerBroker)
     {
+        ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfLessThan(connectionsPerBroker, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(connectionsPerBroker, 32);
         _connectionsPerBroker = connectionsPerBroker;
@@ -228,6 +229,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <param name="maxConnections">Maximum connections per broker. Default: 10.</param>
     public ProducerBuilder<TKey, TValue> WithAdaptiveConnections(int maxConnections = 10)
     {
+        ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfLessThan(maxConnections, 1);
         _enableAdaptiveConnections = true;
         _maxConnectionsPerBroker = maxConnections;
@@ -240,6 +242,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// </summary>
     public ProducerBuilder<TKey, TValue> WithoutAdaptiveConnections()
     {
+        ThrowIfClientOwnedConnectionSettings();
         _enableAdaptiveConnections = false;
         return this;
     }
@@ -251,6 +254,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <param name="bytes">The send buffer size in bytes. Set to 0 to use system default.</param>
     public ProducerBuilder<TKey, TValue> WithSocketSendBufferBytes(int bytes)
     {
+        ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfNegative(bytes);
         _socketSendBufferBytes = bytes;
         return this;
@@ -263,6 +267,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <param name="bytes">The receive buffer size in bytes. Set to 0 to use system default.</param>
     public ProducerBuilder<TKey, TValue> WithSocketReceiveBufferBytes(int bytes)
     {
+        ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfNegative(bytes);
         _socketReceiveBufferBytes = bytes;
         return this;
@@ -338,6 +343,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// </summary>
     public ProducerBuilder<TKey, TValue> UseTls()
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = true;
         return this;
     }
@@ -348,6 +354,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <param name="config">The TLS configuration.</param>
     public ProducerBuilder<TKey, TValue> UseTls(TlsConfig config)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = true;
         _tlsConfig = config;
         return this;
@@ -366,6 +373,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         string clientKeyPath,
         string? keyPassword = null)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = true;
         _tlsConfig = TlsConfig.CreateMutualTls(caCertPath, clientCertPath, clientKeyPath, keyPassword);
         return this;
@@ -380,6 +388,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         X509Certificate2 clientCertificate,
         X509Certificate2? caCertificate = null)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = true;
         _tlsConfig = TlsConfig.CreateMutualTls(clientCertificate, caCertificate);
         return this;
@@ -387,6 +396,7 @@ public sealed class ProducerBuilder<TKey, TValue>
 
     public ProducerBuilder<TKey, TValue> WithSaslPlain(string username, string password)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.Plain;
         _saslUsername = username;
         _saslPassword = password;
@@ -395,6 +405,7 @@ public sealed class ProducerBuilder<TKey, TValue>
 
     public ProducerBuilder<TKey, TValue> WithSaslScramSha256(string username, string password)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = username;
         _saslPassword = password;
@@ -403,6 +414,7 @@ public sealed class ProducerBuilder<TKey, TValue>
 
     public ProducerBuilder<TKey, TValue> WithSaslScramSha512(string username, string password)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = username;
         _saslPassword = password;
@@ -416,6 +428,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <returns>This builder for chaining.</returns>
     public ProducerBuilder<TKey, TValue> WithGssapi(GssapiConfig config)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.Gssapi;
         _gssapiConfig = config ?? throw new ArgumentNullException(nameof(config));
         return this;
@@ -427,6 +440,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <param name="config">The OAuth bearer configuration.</param>
     public ProducerBuilder<TKey, TValue> WithOAuthBearer(OAuthBearerConfig config)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthConfig = config ?? throw new ArgumentNullException(nameof(config));
         _oauthTokenProvider = null;
@@ -439,6 +453,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <param name="tokenProvider">A function that provides OAuth tokens on demand.</param>
     public ProducerBuilder<TKey, TValue> WithOAuthBearer(Func<CancellationToken, ValueTask<OAuthBearerToken>> tokenProvider)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthTokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
         _oauthConfig = null;
@@ -635,6 +650,7 @@ public sealed class ProducerBuilder<TKey, TValue>
 
     internal ProducerBuilder<TKey, TValue> WithMaxInFlightRequestsPerConnection(int maxInFlightRequestsPerConnection)
     {
+        ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfLessThan(maxInFlightRequestsPerConnection, 1);
         _maxInFlightRequestsPerConnection = maxInFlightRequestsPerConnection;
         return this;
@@ -712,6 +728,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         GssapiConfig? gssapiConfig,
         OAuthBearerConfig? oauthConfig)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = mechanism;
         _saslUsername = username;
         _saslPassword = password;
@@ -925,6 +942,12 @@ public sealed class ProducerBuilder<TKey, TValue>
     {
         if (_clientInfrastructure is not null)
             throw new InvalidOperationException("Bootstrap servers are owned by KafkaClient. Configure them on Kafka.Connect(...).");
+    }
+
+    private void ThrowIfClientOwnedConnectionSettings()
+    {
+        if (_clientInfrastructure is not null)
+            throw new InvalidOperationException("Connection settings are owned by KafkaClient. Configure them on Kafka.Connect(...).");
     }
 }
 
@@ -1265,6 +1288,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// </summary>
     public ConsumerBuilder<TKey, TValue> UseTls()
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = true;
         return this;
     }
@@ -1275,6 +1299,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="config">The TLS configuration.</param>
     public ConsumerBuilder<TKey, TValue> UseTls(TlsConfig config)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = true;
         _tlsConfig = config;
         return this;
@@ -1293,6 +1318,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
         string clientKeyPath,
         string? keyPassword = null)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = true;
         _tlsConfig = TlsConfig.CreateMutualTls(caCertPath, clientCertPath, clientKeyPath, keyPassword);
         return this;
@@ -1307,6 +1333,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
         X509Certificate2 clientCertificate,
         X509Certificate2? caCertificate = null)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = true;
         _tlsConfig = TlsConfig.CreateMutualTls(clientCertificate, caCertificate);
         return this;
@@ -1314,6 +1341,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
 
     public ConsumerBuilder<TKey, TValue> WithSaslPlain(string username, string password)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.Plain;
         _saslUsername = username;
         _saslPassword = password;
@@ -1322,6 +1350,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
 
     public ConsumerBuilder<TKey, TValue> WithSaslScramSha256(string username, string password)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = username;
         _saslPassword = password;
@@ -1330,6 +1359,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
 
     public ConsumerBuilder<TKey, TValue> WithSaslScramSha512(string username, string password)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = username;
         _saslPassword = password;
@@ -1343,6 +1373,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <returns>This builder for chaining.</returns>
     public ConsumerBuilder<TKey, TValue> WithGssapi(GssapiConfig config)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.Gssapi;
         _gssapiConfig = config ?? throw new ArgumentNullException(nameof(config));
         return this;
@@ -1354,6 +1385,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="config">The OAuth bearer configuration.</param>
     public ConsumerBuilder<TKey, TValue> WithOAuthBearer(OAuthBearerConfig config)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthConfig = config ?? throw new ArgumentNullException(nameof(config));
         _oauthTokenProvider = null;
@@ -1366,6 +1398,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="tokenProvider">A function that provides OAuth tokens on demand.</param>
     public ConsumerBuilder<TKey, TValue> WithOAuthBearer(Func<CancellationToken, ValueTask<OAuthBearerToken>> tokenProvider)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthTokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
         _oauthConfig = null;
@@ -1477,6 +1510,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// </exception>
     public ConsumerBuilder<TKey, TValue> WithConnectionsPerBroker(int connectionsPerBroker)
     {
+        ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfLessThan(connectionsPerBroker, 1);
         _connectionsPerBroker = connectionsPerBroker;
         return this;
@@ -1491,6 +1525,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="maxConnections">Maximum connections per broker. Default: 4.</param>
     public ConsumerBuilder<TKey, TValue> WithAdaptiveConnections(int maxConnections = 4)
     {
+        ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfLessThan(maxConnections, 1);
         _enableAdaptiveConnections = true;
         _maxConnectionsPerBroker = maxConnections;
@@ -1503,6 +1538,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// </summary>
     public ConsumerBuilder<TKey, TValue> WithoutAdaptiveConnections()
     {
+        ThrowIfClientOwnedConnectionSettings();
         _enableAdaptiveConnections = false;
         return this;
     }
@@ -1684,6 +1720,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
 
     internal ConsumerBuilder<TKey, TValue> WithSocketSendBufferBytes(int bytes)
     {
+        ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfNegative(bytes);
         _socketSendBufferBytes = bytes;
         return this;
@@ -1691,6 +1728,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
 
     internal ConsumerBuilder<TKey, TValue> WithSocketReceiveBufferBytes(int bytes)
     {
+        ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfNegative(bytes);
         _socketReceiveBufferBytes = bytes;
         return this;
@@ -1703,6 +1741,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
         GssapiConfig? gssapiConfig,
         OAuthBearerConfig? oauthConfig)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = mechanism;
         _saslUsername = username;
         _saslPassword = password;
@@ -1869,6 +1908,12 @@ public sealed class ConsumerBuilder<TKey, TValue>
         if (_clientInfrastructure is not null)
             throw new InvalidOperationException("Bootstrap servers are owned by KafkaClient. Configure them on Kafka.Connect(...).");
     }
+
+    private void ThrowIfClientOwnedConnectionSettings()
+    {
+        if (_clientInfrastructure is not null)
+            throw new InvalidOperationException("Connection settings are owned by KafkaClient. Configure them on Kafka.Connect(...).");
+    }
 }
 
 /// <summary>
@@ -2001,12 +2046,14 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
 
     public ShareConsumerBuilder<TKey, TValue> WithTls(bool useTls = true)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _useTls = useTls;
         return this;
     }
 
     public ShareConsumerBuilder<TKey, TValue> WithTlsConfig(TlsConfig tlsConfig)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _tlsConfig = tlsConfig;
         _useTls = true;
         return this;
@@ -2014,6 +2061,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
 
     public ShareConsumerBuilder<TKey, TValue> WithSaslPlain(string username, string password)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.Plain;
         _saslUsername = username;
         _saslPassword = password;
@@ -2022,6 +2070,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
 
     public ShareConsumerBuilder<TKey, TValue> WithSaslScram256(string username, string password)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = username;
         _saslPassword = password;
@@ -2030,6 +2079,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
 
     public ShareConsumerBuilder<TKey, TValue> WithSaslScram512(string username, string password)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = username;
         _saslPassword = password;
@@ -2038,6 +2088,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
 
     public ShareConsumerBuilder<TKey, TValue> WithGssapiConfig(GssapiConfig config)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.Gssapi;
         _gssapiConfig = config;
         return this;
@@ -2045,6 +2096,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
 
     public ShareConsumerBuilder<TKey, TValue> WithOAuthBearer(OAuthBearerConfig config)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthConfig = config;
         return this;
@@ -2052,18 +2104,21 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
 
     public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerTokenProvider(Func<CancellationToken, ValueTask<OAuthBearerToken>> provider)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _oauthTokenProvider = provider;
         return this;
     }
 
     public ShareConsumerBuilder<TKey, TValue> WithSocketSendBufferBytes(int bytes)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _socketSendBufferBytes = bytes;
         return this;
     }
 
     public ShareConsumerBuilder<TKey, TValue> WithSocketReceiveBufferBytes(int bytes)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _socketReceiveBufferBytes = bytes;
         return this;
     }
@@ -2088,6 +2143,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
 
     public ShareConsumerBuilder<TKey, TValue> WithConnectionsPerBroker(int connectionsPerBroker)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _connectionsPerBroker = connectionsPerBroker;
         return this;
     }
@@ -2211,5 +2267,11 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     {
         if (_clientInfrastructure is not null)
             throw new InvalidOperationException("Bootstrap servers are owned by KafkaClient. Configure them on Kafka.Connect(...).");
+    }
+
+    private void ThrowIfClientOwnedConnectionSettings()
+    {
+        if (_clientInfrastructure is not null)
+            throw new InvalidOperationException("Connection settings are owned by KafkaClient. Configure them on Kafka.Connect(...).");
     }
 }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -489,6 +489,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
     private readonly ClientTelemetryManager _telemetryManager;
+    private readonly IDekafMemoryBudget _memoryBudget;
+    private readonly bool _ownsInfrastructure;
     private readonly ConsumerCoordinator? _coordinator;
     private readonly CompressionCodecRegistry _compressionCodecs;
     private readonly ILogger _logger;
@@ -614,7 +616,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         MetadataOptions? metadataOptions = null)
         : this(options, keyDeserializer, valueDeserializer,
             CreateInfrastructure(options, loggerFactory, metadataOptions),
-            loggerFactory)
+            loggerFactory,
+            ownsInfrastructure: true,
+            DekafMemoryBudget.Global)
     {
     }
 
@@ -631,7 +635,25 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         ILoggerFactory? loggerFactory = null)
         : this(options, keyDeserializer, valueDeserializer,
             (connectionPool, metadataManager, new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer)),
-            loggerFactory)
+            loggerFactory,
+            ownsInfrastructure: false,
+            DekafMemoryBudget.Global)
+    {
+    }
+
+    internal KafkaConsumer(
+        ConsumerOptions options,
+        IDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer,
+        IConnectionPool connectionPool,
+        MetadataManager metadataManager,
+        IDekafMemoryBudget memoryBudget,
+        ILoggerFactory? loggerFactory = null)
+        : this(options, keyDeserializer, valueDeserializer,
+            (connectionPool, metadataManager, new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer)),
+            loggerFactory,
+            ownsInfrastructure: false,
+            memoryBudget)
     {
     }
 
@@ -674,7 +696,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         IDeserializer<TKey> keyDeserializer,
         IDeserializer<TValue> valueDeserializer,
         (IConnectionPool Pool, MetadataManager Metadata, ClientTelemetryMetricCollector TelemetryMetricCollector) infrastructure,
-        ILoggerFactory? loggerFactory)
+        ILoggerFactory? loggerFactory,
+        bool ownsInfrastructure,
+        IDekafMemoryBudget memoryBudget)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(options.ConnectionsPerBroker, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(options.ConnectionsPerBroker, options.MaxConnectionsPerBroker);
@@ -708,6 +732,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
 
         _connectionPool = infrastructure.Pool;
         _metadataManager = infrastructure.Metadata;
+        _ownsInfrastructure = ownsInfrastructure;
+        _memoryBudget = memoryBudget;
         _telemetryManager = new ClientTelemetryManager(
             _connectionPool,
             _metadataManager,
@@ -4261,9 +4287,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             return;
 
         if (_options.IsAutoTuned)
-            DekafMemoryBudget.UnregisterConsumer(this);
+            _memoryBudget.UnregisterConsumer(this);
         else
-            DekafMemoryBudget.ReleaseExplicit((ulong)_options.QueuedMaxMessagesKbytes * 1024);
+            _memoryBudget.ReleaseExplicit((ulong)_options.QueuedMaxMessagesKbytes * 1024);
 
         var disposeStart = System.Diagnostics.Stopwatch.GetTimestamp();
         LogConsumerDisposing();
@@ -4351,8 +4377,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             await _coordinator.DisposeAsync().ConfigureAwait(false);
 
         await _telemetryManager.DisposeAsync().ConfigureAwait(false);
-        await _metadataManager.DisposeAsync().ConfigureAwait(false);
-        await _connectionPool.DisposeAsync().ConfigureAwait(false);
+        if (_ownsInfrastructure)
+        {
+            await _metadataManager.DisposeAsync().ConfigureAwait(false);
+            await _connectionPool.DisposeAsync().ConfigureAwait(false);
+        }
 
         var disposeElapsedMs = System.Diagnostics.Stopwatch.GetElapsedTime(disposeStart).TotalMilliseconds;
         LogConsumerDisposed(disposeElapsedMs);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -636,7 +636,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         : this(options, keyDeserializer, valueDeserializer,
             (connectionPool, metadataManager, new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer)),
             loggerFactory,
-            ownsInfrastructure: false,
+            ownsInfrastructure: true,
             DekafMemoryBudget.Global)
     {
     }

--- a/src/Dekaf/Internal/ClientMemoryBudget.cs
+++ b/src/Dekaf/Internal/ClientMemoryBudget.cs
@@ -1,0 +1,222 @@
+namespace Dekaf.Internal;
+
+internal sealed class ClientMemoryBudget : IDekafMemoryBudget
+{
+    private const double DefaultPercentOfAvailable = 0.40;
+    private const double ProducerShareWhenBoth = 0.75;
+    private const double ConsumerShareWhenBoth = 0.25;
+    private const ulong ProducerFloorBytes = 32UL * 1024 * 1024;
+    private const ulong ConsumerFloorBytes = 16UL * 1024 * 1024;
+    private const ulong FallbackBudgetBytes = 320UL * 1024 * 1024;
+
+    private readonly object _lock = new();
+    private readonly ulong? _explicitBudget;
+    private readonly double _percentOfAvailable;
+    private ulong _explicitlyReserved;
+    private readonly List<IBudgetedInstance> _producers = [];
+    private readonly List<IBudgetedInstance> _consumers = [];
+
+    public ClientMemoryBudget(ulong? explicitBudget = null, double percentOfAvailable = DefaultPercentOfAvailable)
+    {
+        if (explicitBudget is 0)
+            throw new ArgumentOutOfRangeException(nameof(explicitBudget));
+        if (percentOfAvailable is <= 0.0 or > 1.0)
+            throw new ArgumentOutOfRangeException(nameof(percentOfAvailable),
+                "Must be in the range (0.0, 1.0].");
+
+        _explicitBudget = explicitBudget;
+        _percentOfAvailable = percentOfAvailable;
+    }
+
+    public ulong PreviewProducerLimit()
+    {
+        lock (_lock)
+        {
+            var producerCount = _producers.Count + 1;
+            var auto = AutoBudgetUnlocked();
+            var share = _consumers.Count == 0 ? auto : (ulong)(auto * ProducerShareWhenBoth);
+            var perInstance = share / (ulong)producerCount / (ulong)DekafMemoryBudget.ProducerOverheadDivisor;
+            return Math.Max(perInstance, ProducerFloorBytes);
+        }
+    }
+
+    public ulong PreviewConsumerLimit()
+    {
+        lock (_lock)
+        {
+            var consumerCount = _consumers.Count + 1;
+            var auto = AutoBudgetUnlocked();
+            var share = _producers.Count == 0 ? auto : (ulong)(auto * ConsumerShareWhenBoth);
+            return Math.Max(share / (ulong)consumerCount, ConsumerFloorBytes);
+        }
+    }
+
+    public void RegisterProducer(IBudgetedInstance instance)
+    {
+        RebalanceSnapshot snapshot;
+        lock (_lock)
+        {
+            _producers.Add(instance);
+            snapshot = SnapshotRebalanceUnlocked();
+        }
+        snapshot.Dispatch();
+    }
+
+    public void UnregisterProducer(IBudgetedInstance instance)
+    {
+        try
+        {
+            RebalanceSnapshot snapshot;
+            lock (_lock)
+            {
+                if (!_producers.Remove(instance))
+                    return;
+                snapshot = SnapshotRebalanceUnlocked();
+            }
+            snapshot.Dispatch();
+        }
+        catch (Exception ex)
+        {
+            ReportBookkeepingError(ex);
+        }
+    }
+
+    public void RegisterConsumer(IBudgetedInstance instance)
+    {
+        RebalanceSnapshot snapshot;
+        lock (_lock)
+        {
+            _consumers.Add(instance);
+            snapshot = SnapshotRebalanceUnlocked();
+        }
+        snapshot.Dispatch();
+    }
+
+    public void UnregisterConsumer(IBudgetedInstance instance)
+    {
+        try
+        {
+            RebalanceSnapshot snapshot;
+            lock (_lock)
+            {
+                if (!_consumers.Remove(instance))
+                    return;
+                snapshot = SnapshotRebalanceUnlocked();
+            }
+            snapshot.Dispatch();
+        }
+        catch (Exception ex)
+        {
+            ReportBookkeepingError(ex);
+        }
+    }
+
+    public void ReserveExplicit(ulong bytes)
+    {
+        RebalanceSnapshot snapshot;
+        lock (_lock)
+        {
+            _explicitlyReserved += bytes;
+            snapshot = SnapshotRebalanceUnlocked();
+        }
+        snapshot.Dispatch();
+    }
+
+    public void ReleaseExplicit(ulong bytes)
+    {
+        try
+        {
+            RebalanceSnapshot snapshot;
+            lock (_lock)
+            {
+                _explicitlyReserved = _explicitlyReserved >= bytes
+                    ? _explicitlyReserved - bytes
+                    : 0;
+                snapshot = SnapshotRebalanceUnlocked();
+            }
+            snapshot.Dispatch();
+        }
+        catch (Exception ex)
+        {
+            ReportBookkeepingError(ex);
+        }
+    }
+
+    private ulong ComputeTotalBudgetUnlocked()
+    {
+        if (_explicitBudget.HasValue)
+            return _explicitBudget.Value;
+
+        var available = (ulong)GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+        if (available == 0)
+            return FallbackBudgetBytes;
+
+        return (ulong)(available * _percentOfAvailable);
+    }
+
+    private ulong AutoBudgetUnlocked()
+    {
+        var total = ComputeTotalBudgetUnlocked();
+        return total > _explicitlyReserved ? total - _explicitlyReserved : 0;
+    }
+
+    private ulong ComputePerProducerLimitUnlocked()
+    {
+        if (_producers.Count == 0)
+            return 0;
+
+        var auto = AutoBudgetUnlocked();
+        var share = _consumers.Count == 0 ? auto : (ulong)(auto * ProducerShareWhenBoth);
+        var perInstance = share / (ulong)_producers.Count / (ulong)DekafMemoryBudget.ProducerOverheadDivisor;
+        return Math.Max(perInstance, ProducerFloorBytes);
+    }
+
+    private ulong ComputePerConsumerLimitUnlocked()
+    {
+        if (_consumers.Count == 0)
+            return 0;
+
+        var auto = AutoBudgetUnlocked();
+        var share = _producers.Count == 0 ? auto : (ulong)(auto * ConsumerShareWhenBoth);
+        var perInstance = share / (ulong)_consumers.Count;
+        return Math.Max(perInstance, ConsumerFloorBytes);
+    }
+
+    private RebalanceSnapshot SnapshotRebalanceUnlocked()
+    {
+        return new RebalanceSnapshot
+        {
+            Producers = _producers.ToArray(),
+            Consumers = _consumers.ToArray(),
+            ProducerLimit = ComputePerProducerLimitUnlocked(),
+            ConsumerLimit = ComputePerConsumerLimitUnlocked(),
+        };
+    }
+
+    private readonly struct RebalanceSnapshot
+    {
+        public required IBudgetedInstance[] Producers { get; init; }
+        public required IBudgetedInstance[] Consumers { get; init; }
+        public required ulong ProducerLimit { get; init; }
+        public required ulong ConsumerLimit { get; init; }
+
+        public void Dispatch()
+        {
+            foreach (var p in Producers)
+            {
+                try { p.OnBudgetChanged(ProducerLimit); }
+                catch (Exception ex) { ReportBookkeepingError(ex); }
+            }
+            foreach (var c in Consumers)
+            {
+                try { c.OnBudgetChanged(ConsumerLimit); }
+                catch (Exception ex) { ReportBookkeepingError(ex); }
+            }
+        }
+    }
+
+    private static void ReportBookkeepingError(Exception exception)
+    {
+        try { DekafMemoryBudget.OnBookkeepingError?.Invoke(exception); } catch { }
+    }
+}

--- a/src/Dekaf/Internal/DekafMemoryBudget.cs
+++ b/src/Dekaf/Internal/DekafMemoryBudget.cs
@@ -62,6 +62,8 @@ public static class DekafMemoryBudget
     private static readonly List<IBudgetedInstance> _producers = new();
     private static readonly List<IBudgetedInstance> _consumers = new();
 
+    internal static IDekafMemoryBudget Global { get; } = new GlobalDekafMemoryBudget();
+
     /// <summary>
     /// The total memory budget in bytes available to all Dekaf instances in the process.
     /// <para>
@@ -352,5 +354,24 @@ public static class DekafMemoryBudget
             ProducerLimit = ComputePerProducerLimitUnlocked(),
             ConsumerLimit = ComputePerConsumerLimitUnlocked(),
         };
+    }
+
+    private sealed class GlobalDekafMemoryBudget : IDekafMemoryBudget
+    {
+        public ulong PreviewProducerLimit() => DekafMemoryBudget.PreviewProducerLimit();
+
+        public ulong PreviewConsumerLimit() => DekafMemoryBudget.PreviewConsumerLimit();
+
+        public void RegisterProducer(IBudgetedInstance instance) => DekafMemoryBudget.RegisterProducer(instance);
+
+        public void UnregisterProducer(IBudgetedInstance instance) => DekafMemoryBudget.UnregisterProducer(instance);
+
+        public void RegisterConsumer(IBudgetedInstance instance) => DekafMemoryBudget.RegisterConsumer(instance);
+
+        public void UnregisterConsumer(IBudgetedInstance instance) => DekafMemoryBudget.UnregisterConsumer(instance);
+
+        public void ReserveExplicit(ulong bytes) => DekafMemoryBudget.ReserveExplicit(bytes);
+
+        public void ReleaseExplicit(ulong bytes) => DekafMemoryBudget.ReleaseExplicit(bytes);
     }
 }

--- a/src/Dekaf/Internal/IDekafMemoryBudget.cs
+++ b/src/Dekaf/Internal/IDekafMemoryBudget.cs
@@ -1,0 +1,20 @@
+namespace Dekaf.Internal;
+
+internal interface IDekafMemoryBudget
+{
+    ulong PreviewProducerLimit();
+
+    ulong PreviewConsumerLimit();
+
+    void RegisterProducer(IBudgetedInstance instance);
+
+    void UnregisterProducer(IBudgetedInstance instance);
+
+    void RegisterConsumer(IBudgetedInstance instance);
+
+    void UnregisterConsumer(IBudgetedInstance instance);
+
+    void ReserveExplicit(ulong bytes);
+
+    void ReleaseExplicit(ulong bytes);
+}

--- a/src/Dekaf/Kafka.cs
+++ b/src/Dekaf/Kafka.cs
@@ -11,6 +11,40 @@ using ShareConsumer;
 public static class Kafka
 {
     /// <summary>
+    /// Creates a root Kafka client builder.
+    /// </summary>
+    public static KafkaClientBuilder Connect()
+    {
+        return new KafkaClientBuilder();
+    }
+
+    /// <summary>
+    /// Creates a root Kafka client for the specified bootstrap servers.
+    /// </summary>
+    /// <param name="bootstrapServers">Comma-separated list of bootstrap servers.</param>
+    public static KafkaClient Connect(string bootstrapServers)
+    {
+        return new KafkaClientBuilder()
+            .WithBootstrapServers(bootstrapServers)
+            .Build();
+    }
+
+    /// <summary>
+    /// Creates a root Kafka client for the specified bootstrap servers.
+    /// </summary>
+    /// <param name="bootstrapServers">Comma-separated list of bootstrap servers.</param>
+    /// <param name="configure">Optional root-client configuration.</param>
+    public static KafkaClient Connect(string bootstrapServers, Action<KafkaClientBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var builder = new KafkaClientBuilder()
+            .WithBootstrapServers(bootstrapServers);
+        configure(builder);
+        return builder.Build();
+    }
+
+    /// <summary>
     /// Creates a producer builder.
     /// </summary>
     public static ProducerBuilder<TKey, TValue> CreateProducer<TKey, TValue>()

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -322,6 +322,8 @@ internal sealed class KafkaClientOptions
 
 internal sealed class KafkaClientInfrastructure : IAsyncDisposable
 {
+    private const int SharedResponseBufferFetchMaxBytes = 200 * 1024 * 1024;
+
     private int _disposed;
 
     private KafkaClientInfrastructure(
@@ -378,7 +380,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             },
             options.LoggerFactory,
             options.ConnectionsPerBroker,
-            ResponseBufferPool.Create(52428800),
+            ResponseBufferPool.Create(SharedResponseBufferFetchMaxBytes),
             pipeMemoryBucketCapacity: poolSizes.PipeMemoryArraysPerBucket);
 
         var metadataOptions = new MetadataOptions

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -1,0 +1,415 @@
+namespace Dekaf;
+
+using Admin;
+using Consumer;
+using Dekaf.Internal;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Security;
+using Dekaf.Security.Sasl;
+using Dekaf.ShareConsumer;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Root client that owns shared Kafka infrastructure for related producers, consumers, and admin clients.
+/// </summary>
+public sealed class KafkaClient : IAsyncDisposable
+{
+    private readonly KafkaClientInfrastructure _infrastructure;
+    private int _disposed;
+
+    internal KafkaClient(KafkaClientInfrastructure infrastructure)
+    {
+        _infrastructure = infrastructure;
+    }
+
+    public ProducerBuilder<TKey, TValue> CreateProducer<TKey, TValue>()
+    {
+        ThrowIfDisposed();
+        return new ProducerBuilder<TKey, TValue>(_infrastructure);
+    }
+
+    public ConsumerBuilder<TKey, TValue> CreateConsumer<TKey, TValue>()
+    {
+        ThrowIfDisposed();
+        return new ConsumerBuilder<TKey, TValue>(_infrastructure);
+    }
+
+    public ConsumerBuilder<TKey, TValue> CreateConsumer<TKey, TValue>(string groupId)
+    {
+        return CreateConsumer<TKey, TValue>().WithGroupId(groupId);
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> CreateShareConsumer<TKey, TValue>()
+    {
+        ThrowIfDisposed();
+        return new ShareConsumerBuilder<TKey, TValue>(_infrastructure);
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> CreateShareConsumer<TKey, TValue>(string groupId)
+    {
+        return CreateShareConsumer<TKey, TValue>().WithGroupId(groupId);
+    }
+
+    public AdminClientBuilder CreateAdminClient()
+    {
+        ThrowIfDisposed();
+        return new AdminClientBuilder(_infrastructure);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        await _infrastructure.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(KafkaClient));
+    }
+}
+/// <summary>
+/// Builder for <see cref="KafkaClient"/>.
+/// </summary>
+public sealed class KafkaClientBuilder
+{
+    private IReadOnlyList<string> _bootstrapServers = [];
+    private string? _clientId;
+    private int _requestTimeoutMs = 30000;
+    private bool _useTls;
+    private TlsConfig? _tlsConfig;
+    private SaslMechanism _saslMechanism = SaslMechanism.None;
+    private string? _saslUsername;
+    private string? _saslPassword;
+    private GssapiConfig? _gssapiConfig;
+    private OAuthBearerConfig? _oauthConfig;
+    private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
+    private int _socketSendBufferBytes;
+    private int _socketReceiveBufferBytes;
+    private int _connectionsPerBroker = 1;
+    private int _maxInFlightRequestsPerConnection = 5;
+    private int _maxConnectionsPerBroker = 10;
+    private TimeSpan? _metadataMaxAge;
+    private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
+    private int _metadataRecoveryRebootstrapTriggerMs = 300000;
+    private ulong? _memoryBudgetBytes;
+    private ILoggerFactory? _loggerFactory;
+
+    public KafkaClientBuilder WithBootstrapServers(string servers)
+    {
+        _bootstrapServers = servers.Split(',').Select(s => s.Trim()).ToArray();
+        return this;
+    }
+
+    public KafkaClientBuilder WithBootstrapServers(params string[] servers)
+    {
+        _bootstrapServers = [..servers];
+        return this;
+    }
+
+    public KafkaClientBuilder WithClientId(string clientId)
+    {
+        _clientId = clientId;
+        return this;
+    }
+
+    public KafkaClientBuilder WithRequestTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Request timeout must be positive");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+
+        _requestTimeoutMs = (int)timeout.TotalMilliseconds;
+        return this;
+    }
+
+    public KafkaClientBuilder UseTls()
+    {
+        _useTls = true;
+        return this;
+    }
+
+    public KafkaClientBuilder UseTls(TlsConfig config)
+    {
+        _useTls = true;
+        _tlsConfig = config;
+        return this;
+    }
+
+    public KafkaClientBuilder WithSaslPlain(string username, string password)
+    {
+        _saslMechanism = SaslMechanism.Plain;
+        _saslUsername = username;
+        _saslPassword = password;
+        return this;
+    }
+
+    public KafkaClientBuilder WithSaslScramSha256(string username, string password)
+    {
+        _saslMechanism = SaslMechanism.ScramSha256;
+        _saslUsername = username;
+        _saslPassword = password;
+        return this;
+    }
+
+    public KafkaClientBuilder WithSaslScramSha512(string username, string password)
+    {
+        _saslMechanism = SaslMechanism.ScramSha512;
+        _saslUsername = username;
+        _saslPassword = password;
+        return this;
+    }
+
+    public KafkaClientBuilder WithGssapi(GssapiConfig config)
+    {
+        _saslMechanism = SaslMechanism.Gssapi;
+        _gssapiConfig = config ?? throw new ArgumentNullException(nameof(config));
+        return this;
+    }
+
+    public KafkaClientBuilder WithOAuthBearer(OAuthBearerConfig config)
+    {
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = config ?? throw new ArgumentNullException(nameof(config));
+        _oauthTokenProvider = null;
+        return this;
+    }
+
+    public KafkaClientBuilder WithOAuthBearer(Func<CancellationToken, ValueTask<OAuthBearerToken>> tokenProvider)
+    {
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthTokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
+        _oauthConfig = null;
+        return this;
+    }
+
+    public KafkaClientBuilder WithSocketSendBufferBytes(int bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        _socketSendBufferBytes = bytes;
+        return this;
+    }
+
+    public KafkaClientBuilder WithSocketReceiveBufferBytes(int bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        _socketReceiveBufferBytes = bytes;
+        return this;
+    }
+
+    public KafkaClientBuilder WithConnectionsPerBroker(int connectionsPerBroker)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(connectionsPerBroker, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(connectionsPerBroker, 32);
+        _connectionsPerBroker = connectionsPerBroker;
+        return this;
+    }
+
+    public KafkaClientBuilder WithMaxInFlightRequestsPerConnection(int maxInFlightRequestsPerConnection)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxInFlightRequestsPerConnection, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(maxInFlightRequestsPerConnection, 1000000);
+        _maxInFlightRequestsPerConnection = maxInFlightRequestsPerConnection;
+        return this;
+    }
+
+    public KafkaClientBuilder WithMaxConnectionsPerBroker(int maxConnectionsPerBroker)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxConnectionsPerBroker, 1);
+        _maxConnectionsPerBroker = maxConnectionsPerBroker;
+        return this;
+    }
+
+    public KafkaClientBuilder WithMetadataMaxAge(TimeSpan interval)
+    {
+        if (interval <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(interval), "Metadata max age must be positive");
+
+        _metadataMaxAge = interval;
+        return this;
+    }
+
+    public KafkaClientBuilder WithMetadataRecoveryStrategy(MetadataRecoveryStrategy strategy)
+    {
+        _metadataRecoveryStrategy = strategy;
+        return this;
+    }
+
+    public KafkaClientBuilder WithMetadataRecoveryRebootstrapTrigger(TimeSpan trigger)
+    {
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(trigger.TotalMilliseconds, int.MaxValue, nameof(trigger));
+        _metadataRecoveryRebootstrapTriggerMs = (int)trigger.TotalMilliseconds;
+        return this;
+    }
+
+    public KafkaClientBuilder WithMemoryBudget(ulong bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(bytes);
+        _memoryBudgetBytes = bytes;
+        return this;
+    }
+
+    public KafkaClientBuilder WithLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        _loggerFactory = loggerFactory;
+        return this;
+    }
+
+    public KafkaClient Build()
+    {
+        if (_bootstrapServers.Count == 0)
+            throw new InvalidOperationException("Bootstrap servers must be specified. Call WithBootstrapServers() before Build().");
+        if (_maxConnectionsPerBroker < _connectionsPerBroker)
+            throw new InvalidOperationException(
+                $"MaxConnectionsPerBroker ({_maxConnectionsPerBroker}) must be >= ConnectionsPerBroker ({_connectionsPerBroker}).");
+
+        var options = new KafkaClientOptions
+        {
+            BootstrapServers = _bootstrapServers,
+            ClientId = _clientId,
+            RequestTimeoutMs = _requestTimeoutMs,
+            UseTls = _useTls,
+            TlsConfig = _tlsConfig,
+            SaslMechanism = _saslMechanism,
+            SaslUsername = _saslUsername,
+            SaslPassword = _saslPassword,
+            GssapiConfig = _gssapiConfig,
+            OAuthBearerConfig = _oauthConfig,
+            OAuthBearerTokenProvider = _oauthTokenProvider,
+            SocketSendBufferBytes = _socketSendBufferBytes,
+            SocketReceiveBufferBytes = _socketReceiveBufferBytes,
+            ConnectionsPerBroker = _connectionsPerBroker,
+            MaxInFlightRequestsPerConnection = _maxInFlightRequestsPerConnection,
+            MaxConnectionsPerBroker = _maxConnectionsPerBroker,
+            MetadataMaxAge = _metadataMaxAge,
+            MetadataRecoveryStrategy = _metadataRecoveryStrategy,
+            MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
+            MemoryBudgetBytes = _memoryBudgetBytes,
+            LoggerFactory = _loggerFactory
+        };
+
+        return new KafkaClient(KafkaClientInfrastructure.Create(options));
+    }
+}
+internal sealed class KafkaClientOptions
+{
+    public required IReadOnlyList<string> BootstrapServers { get; init; }
+    public string? ClientId { get; init; }
+    public int RequestTimeoutMs { get; init; }
+    public bool UseTls { get; init; }
+    public TlsConfig? TlsConfig { get; init; }
+    public SaslMechanism SaslMechanism { get; init; }
+    public string? SaslUsername { get; init; }
+    public string? SaslPassword { get; init; }
+    public GssapiConfig? GssapiConfig { get; init; }
+    public OAuthBearerConfig? OAuthBearerConfig { get; init; }
+    public Func<CancellationToken, ValueTask<OAuthBearerToken>>? OAuthBearerTokenProvider { get; init; }
+    public int SocketSendBufferBytes { get; init; }
+    public int SocketReceiveBufferBytes { get; init; }
+    public int ConnectionsPerBroker { get; init; }
+    public int MaxInFlightRequestsPerConnection { get; init; }
+    public int MaxConnectionsPerBroker { get; init; }
+    public TimeSpan? MetadataMaxAge { get; init; }
+    public MetadataRecoveryStrategy MetadataRecoveryStrategy { get; init; }
+    public int MetadataRecoveryRebootstrapTriggerMs { get; init; }
+    public ulong? MemoryBudgetBytes { get; init; }
+    public ILoggerFactory? LoggerFactory { get; init; }
+}
+
+internal sealed class KafkaClientInfrastructure : IAsyncDisposable
+{
+    private int _disposed;
+
+    private KafkaClientInfrastructure(
+        IReadOnlyList<string> bootstrapServers,
+        ConnectionPool connectionPool,
+        MetadataManager metadataManager,
+        IDekafMemoryBudget memoryBudget,
+        ILoggerFactory? loggerFactory,
+        int connectionsPerBroker,
+        int maxConnectionsPerBroker)
+    {
+        BootstrapServers = bootstrapServers;
+        ConnectionPool = connectionPool;
+        MetadataManager = metadataManager;
+        MemoryBudget = memoryBudget;
+        LoggerFactory = loggerFactory;
+        ConnectionsPerBroker = connectionsPerBroker;
+        MaxConnectionsPerBroker = maxConnectionsPerBroker;
+    }
+
+    public IReadOnlyList<string> BootstrapServers { get; }
+    public ConnectionPool ConnectionPool { get; }
+    public MetadataManager MetadataManager { get; }
+    public IDekafMemoryBudget MemoryBudget { get; }
+    public ILoggerFactory? LoggerFactory { get; }
+    public int ConnectionsPerBroker { get; }
+    public int MaxConnectionsPerBroker { get; }
+
+    public static KafkaClientInfrastructure Create(KafkaClientOptions options)
+    {
+        var poolSizes = PoolSizing.ForSharedPools(
+            brokerCount: options.BootstrapServers.Count,
+            connectionsPerBroker: options.ConnectionsPerBroker,
+            maxInFlightRequestsPerConnection: options.MaxInFlightRequestsPerConnection,
+            batchSize: 1048576,
+            maxConnectionsPerBroker: options.MaxConnectionsPerBroker);
+
+        var connectionPool = new ConnectionPool(
+            options.ClientId,
+            new ConnectionOptions
+            {
+                UseTls = options.UseTls,
+                TlsConfig = options.TlsConfig,
+                RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
+                SaslMechanism = options.SaslMechanism,
+                SaslUsername = options.SaslUsername,
+                SaslPassword = options.SaslPassword,
+                GssapiConfig = options.GssapiConfig,
+                OAuthBearerConfig = options.OAuthBearerConfig,
+                OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
+                SendBufferSize = options.SocketSendBufferBytes,
+                ReceiveBufferSize = options.SocketReceiveBufferBytes,
+                MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection
+            },
+            options.LoggerFactory,
+            options.ConnectionsPerBroker,
+            ResponseBufferPool.Create(52428800),
+            pipeMemoryBucketCapacity: poolSizes.PipeMemoryArraysPerBucket);
+
+        var metadataOptions = new MetadataOptions
+        {
+            MetadataRefreshInterval = options.MetadataMaxAge ?? TimeSpan.FromMinutes(15),
+            MetadataRecoveryStrategy = options.MetadataRecoveryStrategy,
+            MetadataRecoveryRebootstrapTriggerMs = options.MetadataRecoveryRebootstrapTriggerMs
+        };
+
+        var metadataManager = new MetadataManager(
+            connectionPool,
+            options.BootstrapServers,
+            options: metadataOptions,
+            logger: options.LoggerFactory?.CreateLogger<MetadataManager>());
+
+        return new KafkaClientInfrastructure(
+            options.BootstrapServers,
+            connectionPool,
+            metadataManager,
+            new ClientMemoryBudget(options.MemoryBudgetBytes),
+            options.LoggerFactory,
+            options.ConnectionsPerBroker,
+            options.MaxConnectionsPerBroker);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        await MetadataManager.DisposeAsync().ConfigureAwait(false);
+        await ConnectionPool.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -45,10 +45,32 @@ public sealed partial class MetadataManager : IAsyncDisposable
     private long _allBrokersUnavailableSince;
 
     /// <summary>
-    /// Optional callback invoked after each successful metadata refresh with the discovered broker count.
-    /// Used by the producer to re-ratchet shared pool sizes once the real cluster size is known.
+    /// Optional callbacks invoked after each successful metadata refresh with the discovered broker count.
+    /// Used by producers to re-ratchet shared pool sizes once the real cluster size is known.
     /// </summary>
-    internal Action<int>? OnBrokerCountDiscovered { get; set; }
+    private readonly object _brokerCountDiscoveredLock = new();
+    private Action<int>? _brokerCountDiscoveredCallbacks;
+
+    internal void AddBrokerCountDiscoveredCallback(Action<int> callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        lock (_brokerCountDiscoveredLock)
+        {
+            _brokerCountDiscoveredCallbacks += callback;
+        }
+    }
+
+    internal void NotifyBrokerCountDiscovered(int brokerCount)
+    {
+        Action<int>? callbacks;
+        lock (_brokerCountDiscoveredLock)
+        {
+            callbacks = _brokerCountDiscoveredCallbacks;
+        }
+
+        callbacks?.Invoke(brokerCount);
+    }
 
     public MetadataManager(
         IConnectionPool connectionPool,
@@ -525,7 +547,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
                 LogMetadataRefreshed(response.Brokers.Count, response.Topics.Count);
 
-                OnBrokerCountDiscovered?.Invoke(response.Brokers.Count);
+                NotifyBrokerCountDiscovered(response.Brokers.Count);
 
                 // Success - reset the rebootstrap timer
                 ResetAllBrokersUnavailableTimestamp();
@@ -646,7 +668,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
                 LogRebootstrapSuccessful(response.Brokers.Count, host, port);
 
-                OnBrokerCountDiscovered?.Invoke(response.Brokers.Count);
+                NotifyBrokerCountDiscovered(response.Brokers.Count);
 
                 // Success - reset the rebootstrap timer
                 ResetAllBrokersUnavailableTimestamp();

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -51,13 +51,26 @@ public sealed partial class MetadataManager : IAsyncDisposable
     private readonly object _brokerCountDiscoveredLock = new();
     private Action<int>? _brokerCountDiscoveredCallbacks;
 
-    internal void AddBrokerCountDiscoveredCallback(Action<int> callback)
+    internal IDisposable AddBrokerCountDiscoveredCallback(Action<int> callback)
     {
         ArgumentNullException.ThrowIfNull(callback);
 
         lock (_brokerCountDiscoveredLock)
         {
             _brokerCountDiscoveredCallbacks += callback;
+        }
+
+        return new BrokerCountDiscoveredCallbackRegistration(this, callback);
+    }
+
+    internal int BrokerCountDiscoveredCallbackCount
+    {
+        get
+        {
+            lock (_brokerCountDiscoveredLock)
+            {
+                return _brokerCountDiscoveredCallbacks?.GetInvocationList().Length ?? 0;
+            }
         }
     }
 
@@ -70,6 +83,25 @@ public sealed partial class MetadataManager : IAsyncDisposable
         }
 
         callbacks?.Invoke(brokerCount);
+    }
+
+    private sealed class BrokerCountDiscoveredCallbackRegistration(
+        MetadataManager metadataManager,
+        Action<int> callback) : IDisposable
+    {
+        private Action<int>? _callback = callback;
+
+        public void Dispose()
+        {
+            lock (metadataManager._brokerCountDiscoveredLock)
+            {
+                if (_callback is null)
+                    return;
+
+                metadataManager._brokerCountDiscoveredCallbacks -= _callback;
+                _callback = null;
+            }
+        }
     }
 
     public MetadataManager(

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -326,7 +326,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var batchSize = options.BatchSize;
         var maxConns = options.MaxConnectionsPerBroker;
         var connectionPool = _connectionPool;
-        _metadataManager.OnBrokerCountDiscovered = brokerCount =>
+        _metadataManager.AddBrokerCountDiscoveredCallback(brokerCount =>
         {
             var sizes = PoolSizing.ForSharedPools(brokerCount, connectionsPerBroker, maxInFlight, batchSize, maxConns);
             ProducerDataPool.RatchetBucketCapacity(sizes.ProducerDataArraysPerBucket);
@@ -334,7 +334,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             DekafPools.RatchetSerializationBucketCapacity(sizes.SerializationArraysPerBucket);
             ProduceResponse.RatchetPoolSize(sizes.ProduceResponsePoolSize);
             connectionPool.RatchetPipeMemoryBucketCapacity(sizes.PipeMemoryArraysPerBucket);
-        };
+        });
 
         _compressionCodecs = CreateCompressionCodecRegistry(options);
         Action<string, int>? batchCompletionCallback = _partitioner is IBatchCompletionAwarePartitioner batchCompletionAware

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -49,6 +49,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     internal RecordAccumulator RecordAccumulator => _accumulator;
     private readonly CompressionCodecRegistry _compressionCodecs;
     private readonly ILogger _logger;
+    private readonly IDekafMemoryBudget _memoryBudget;
+    private readonly bool _ownsInfrastructure;
 
     private readonly CancellationTokenSource _senderCts;
     private readonly Task _senderTask;
@@ -162,17 +164,100 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private const int DefaultKeyBufferSize = 512;
     private const int DefaultValueBufferSize = 2048;
 
-
     public KafkaProducer(
         ProducerOptions options,
         ISerializer<TKey> keySerializer,
         ISerializer<TValue> valueSerializer,
         ILoggerFactory? loggerFactory = null,
         MetadataOptions? metadataOptions = null)
+        : this(
+            options,
+            keySerializer,
+            valueSerializer,
+            CreateInfrastructure(options, loggerFactory, metadataOptions),
+            loggerFactory,
+            ownsInfrastructure: true,
+            DekafMemoryBudget.Global)
+    {
+    }
+
+    internal KafkaProducer(
+        ProducerOptions options,
+        ISerializer<TKey> keySerializer,
+        ISerializer<TValue> valueSerializer,
+        ConnectionPool connectionPool,
+        MetadataManager metadataManager,
+        IDekafMemoryBudget memoryBudget,
+        ILoggerFactory? loggerFactory = null)
+        : this(
+            options,
+            keySerializer,
+            valueSerializer,
+            (connectionPool, metadataManager, new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer)),
+            loggerFactory,
+            ownsInfrastructure: false,
+            memoryBudget)
+    {
+    }
+
+    private static (ConnectionPool Pool, MetadataManager Metadata, ClientTelemetryMetricCollector TelemetryMetricCollector) CreateInfrastructure(
+        ProducerOptions options,
+        ILoggerFactory? loggerFactory,
+        MetadataOptions? metadataOptions)
+    {
+        var sharedPoolSizes = PoolSizing.ForSharedPools(
+            brokerCount: options.BootstrapServers.Count,
+            connectionsPerBroker: options.ConnectionsPerBroker,
+            maxInFlightRequestsPerConnection: options.MaxInFlightRequestsPerConnection,
+            batchSize: options.BatchSize,
+            maxConnectionsPerBroker: options.MaxConnectionsPerBroker);
+        var telemetryMetricCollector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);
+        var connectionPool = new ConnectionPool(
+            options.ClientId,
+            new ConnectionOptions
+            {
+                UseTls = options.UseTls,
+                TlsConfig = options.TlsConfig,
+                RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
+                SaslMechanism = options.SaslMechanism,
+                SaslUsername = options.SaslUsername,
+                SaslPassword = options.SaslPassword,
+                GssapiConfig = options.GssapiConfig,
+                OAuthBearerConfig = options.OAuthBearerConfig,
+                OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
+                SendBufferSize = options.SocketSendBufferBytes,
+                ReceiveBufferSize = options.SocketReceiveBufferBytes,
+                MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection
+            },
+            loggerFactory,
+            options.ConnectionsPerBroker,
+            ResponseBufferPool.Default,
+            pipeMemoryBucketCapacity: sharedPoolSizes.PipeMemoryArraysPerBucket,
+            telemetryMetricCollector: telemetryMetricCollector);
+
+        var metadataManager = new MetadataManager(
+            connectionPool,
+            options.BootstrapServers,
+            options: metadataOptions,
+            logger: loggerFactory?.CreateLogger<MetadataManager>());
+
+        return (connectionPool, metadataManager, telemetryMetricCollector);
+    }
+
+    private KafkaProducer(
+        ProducerOptions options,
+        ISerializer<TKey> keySerializer,
+        ISerializer<TValue> valueSerializer,
+        (ConnectionPool Pool, MetadataManager Metadata, ClientTelemetryMetricCollector TelemetryMetricCollector) infrastructure,
+        ILoggerFactory? loggerFactory,
+        bool ownsInfrastructure,
+        IDekafMemoryBudget memoryBudget)
     {
         _options = options;
         _keySerializer = keySerializer;
         _valueSerializer = valueSerializer;
+        _memoryBudget = memoryBudget;
+        _ownsInfrastructure = ownsInfrastructure;
         _logger = loggerFactory?.CreateLogger<KafkaProducer<TKey, TValue>>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaProducer<TKey, TValue>>.Instance;
 
         // Initialize interceptors from options
@@ -224,42 +309,14 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             _ => new DefaultPartitioner()
         };
 
-        var telemetryMetricCollector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);
-
-        _connectionPool = new ConnectionPool(
-            options.ClientId,
-            new ConnectionOptions
-            {
-                UseTls = options.UseTls,
-                TlsConfig = options.TlsConfig,
-                RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
-                SaslMechanism = options.SaslMechanism,
-                SaslUsername = options.SaslUsername,
-                SaslPassword = options.SaslPassword,
-                GssapiConfig = options.GssapiConfig,
-                OAuthBearerConfig = options.OAuthBearerConfig,
-                OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
-                SendBufferSize = options.SocketSendBufferBytes,
-                ReceiveBufferSize = options.SocketReceiveBufferBytes,
-                MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection
-            },
-            loggerFactory,
-            options.ConnectionsPerBroker,
-            ResponseBufferPool.Default,
-            pipeMemoryBucketCapacity: sharedPoolSizes.PipeMemoryArraysPerBucket,
-            telemetryMetricCollector: telemetryMetricCollector);
-
-        _metadataManager = new MetadataManager(
-            _connectionPool,
-            options.BootstrapServers,
-            options: metadataOptions,
-            logger: loggerFactory?.CreateLogger<MetadataManager>());
+        _connectionPool = infrastructure.Pool;
+        _metadataManager = infrastructure.Metadata;
 
         _telemetryManager = new ClientTelemetryManager(
             _connectionPool,
             _metadataManager,
             loggerFactory?.CreateLogger<ClientTelemetryManager>(),
-            telemetryMetricCollector);
+            infrastructure.TelemetryMetricCollector);
 
         // Re-ratchet shared pool sizes after metadata refresh discovers the real broker count.
         // Bootstrap servers are seed nodes — the actual cluster may have more brokers.
@@ -268,6 +325,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var maxInFlight = options.MaxInFlightRequestsPerConnection;
         var batchSize = options.BatchSize;
         var maxConns = options.MaxConnectionsPerBroker;
+        var connectionPool = _connectionPool;
         _metadataManager.OnBrokerCountDiscovered = brokerCount =>
         {
             var sizes = PoolSizing.ForSharedPools(brokerCount, connectionsPerBroker, maxInFlight, batchSize, maxConns);
@@ -275,7 +333,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             ProducerContainerPools.RatchetHeaderBucketCapacity(sizes.HeaderArraysPerBucket);
             DekafPools.RatchetSerializationBucketCapacity(sizes.SerializationArraysPerBucket);
             ProduceResponse.RatchetPoolSize(sizes.ProduceResponsePoolSize);
-            _connectionPool.RatchetPipeMemoryBucketCapacity(sizes.PipeMemoryArraysPerBucket);
+            connectionPool.RatchetPipeMemoryBucketCapacity(sizes.PipeMemoryArraysPerBucket);
         };
 
         _compressionCodecs = CreateCompressionCodecRegistry(options);
@@ -3032,9 +3090,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             return;
 
         if (_options.IsAutoTuned)
-            DekafMemoryBudget.UnregisterProducer(this);
+            _memoryBudget.UnregisterProducer(this);
         else
-            DekafMemoryBudget.ReleaseExplicit(_options.BufferMemory);
+            _memoryBudget.ReleaseExplicit(_options.BufferMemory);
 
         var disposeStart = Stopwatch.GetTimestamp();
         LogProducerDisposing();
@@ -3238,15 +3296,18 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         await DisposeWithBudgetAsync(
             _telemetryManager.DisposeAsync(), Math.Max(100, RemainingMs() / 10), "telemetryManager");
 
-        // Dispose metadata manager and connection pool in parallel.
-        // Connection pool disposal waits up to ConnectionTimeout (30s default) per connection,
-        // which can single-handedly exceed CloseTimeoutMs. Cap with remaining budget.
-        await DisposeWithBudgetAsync(
-            new ValueTask(Task.WhenAll(
-                _metadataManager.DisposeAsync().AsTask(),
-                _connectionPool.DisposeAsync().AsTask())),
-            Math.Max(500, RemainingMs()),
-            "network");
+        if (_ownsInfrastructure)
+        {
+            // Dispose metadata manager and connection pool in parallel.
+            // Connection pool disposal waits up to ConnectionTimeout (30s default) per connection,
+            // which can single-handedly exceed CloseTimeoutMs. Cap with remaining budget.
+            await DisposeWithBudgetAsync(
+                new ValueTask(Task.WhenAll(
+                    _metadataManager.DisposeAsync().AsTask(),
+                    _connectionPool.DisposeAsync().AsTask())),
+                Math.Max(500, RemainingMs()),
+                "network");
+        }
 
         var disposeElapsedMs = Stopwatch.GetElapsedTime(disposeStart).TotalMilliseconds;
         LogProducerDisposed(disposeElapsedMs, gracefulShutdown);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -44,6 +44,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly bool _usesCustomPartitioner;
     private readonly ConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
+    private readonly IDisposable _brokerCountDiscoveredRegistration;
     private readonly ClientTelemetryManager _telemetryManager;
     private readonly RecordAccumulator _accumulator;
     internal RecordAccumulator RecordAccumulator => _accumulator;
@@ -326,7 +327,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var batchSize = options.BatchSize;
         var maxConns = options.MaxConnectionsPerBroker;
         var connectionPool = _connectionPool;
-        _metadataManager.AddBrokerCountDiscoveredCallback(brokerCount =>
+        _brokerCountDiscoveredRegistration = _metadataManager.AddBrokerCountDiscoveredCallback(brokerCount =>
         {
             var sizes = PoolSizing.ForSharedPools(brokerCount, connectionsPerBroker, maxInFlight, batchSize, maxConns);
             ProducerDataPool.RatchetBucketCapacity(sizes.ProducerDataArraysPerBucket);
@@ -3096,6 +3097,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         var disposeStart = Stopwatch.GetTimestamp();
         LogProducerDisposing();
+        _brokerCountDiscoveredRegistration.Dispose();
 
         // Time budget allocation within CloseTimeoutMs:
         //   40% → graceful flush (accumulator close + sender drain)

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -1,0 +1,87 @@
+using System.Reflection;
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Builder;
+
+public sealed class KafkaClientBuilderTests
+{
+    [Test]
+    public async Task RootClient_CreatedClients_ShareConnectionPoolAndMetadata()
+    {
+        await using var client = Kafka.Connect("broker1:9092,broker2:9092");
+        await using var producer = client.CreateProducer<string, string>().Build();
+        await using var consumer = client.CreateConsumer<string, string>("group-a").Build();
+        await using var admin = client.CreateAdminClient().Build();
+
+        var producerPool = GetField<ConnectionPool>(producer, "_connectionPool");
+        var consumerPool = GetField<IConnectionPool>(consumer, "_connectionPool");
+        var adminPool = GetField<IConnectionPool>(admin, "_connectionPool");
+
+        await Assert.That(ReferenceEquals(producerPool, consumerPool)).IsTrue();
+        await Assert.That(ReferenceEquals(producerPool, adminPool)).IsTrue();
+
+        var producerMetadata = GetField<MetadataManager>(producer, "_metadataManager");
+        var consumerMetadata = GetField<MetadataManager>(consumer, "_metadataManager");
+        var adminMetadata = GetField<MetadataManager>(admin, "_metadataManager");
+
+        await Assert.That(ReferenceEquals(producerMetadata, consumerMetadata)).IsTrue();
+        await Assert.That(ReferenceEquals(producerMetadata, adminMetadata)).IsTrue();
+    }
+
+    [Test]
+    public async Task RootClient_CreatedProducer_DisposeDoesNotDisposeSharedPool()
+    {
+        var client = Kafka.Connect("localhost:9092");
+        var producer = client.CreateProducer<string, string>().Build();
+        var pool = GetField<ConnectionPool>(producer, "_connectionPool");
+
+        await producer.DisposeAsync();
+
+        await Assert.That(GetField<int>(pool, "_disposed")).IsEqualTo(0);
+
+        await client.DisposeAsync();
+
+        await Assert.That(GetField<int>(pool, "_disposed")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task RootClient_CreatedBuilders_RejectBootstrapOverrides()
+    {
+        await using var client = Kafka.Connect("localhost:9092");
+
+        await Assert.That(() => client.CreateProducer<string, string>().WithBootstrapServers("other:9092"))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithBootstrapServers("other:9092"))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithBootstrapServers("other:9092"))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithBootstrapServers("other:9092"))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task RootClient_WithMemoryBudget_UsesIndependentProducerBudget()
+    {
+        await using var client = Kafka.Connect("localhost:9092", builder =>
+            builder.WithMemoryBudget(768UL * 1024 * 1024));
+        await using var first = client.CreateProducer<string, string>().Build();
+        await using var second = client.CreateProducer<string, string>().Build();
+
+        var firstAccumulator = GetField<RecordAccumulator>(first, "_accumulator");
+        var secondAccumulator = GetField<RecordAccumulator>(second, "_accumulator");
+
+        await Assert.That(firstAccumulator.MaxBufferMemory).IsEqualTo(64UL * 1024 * 1024);
+        await Assert.That(secondAccumulator.MaxBufferMemory).IsEqualTo(64UL * 1024 * 1024);
+    }
+
+    private static T GetField<T>(object instance, string name)
+    {
+        var field = instance.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"Could not find {name} on {instance.GetType()}");
+        return (T)field.GetValue(instance)!;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -130,6 +130,20 @@ public sealed class KafkaClientBuilderTests
     }
 
     [Test]
+    public async Task RootClient_CreatedProducer_DisposeRemovesBrokerCountCallback()
+    {
+        await using var client = Kafka.Connect("localhost:9092");
+        var producer = client.CreateProducer<string, string>().Build();
+        var metadataManager = GetField<MetadataManager>(producer, "_metadataManager");
+
+        await Assert.That(metadataManager.BrokerCountDiscoveredCallbackCount).IsEqualTo(1);
+
+        await producer.DisposeAsync();
+
+        await Assert.That(metadataManager.BrokerCountDiscoveredCallbackCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task RootClient_WithMemoryBudget_UsesIndependentProducerBudget()
     {
         await using var client = Kafka.Connect("localhost:9092", builder =>

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -64,6 +64,72 @@ public sealed class KafkaClientBuilderTests
     }
 
     [Test]
+    public async Task RootClient_CreatedBuilders_RejectConnectionOverrides()
+    {
+        await using var client = Kafka.Connect("localhost:9092");
+
+        await Assert.That(() => client.CreateProducer<string, string>().UseTls())
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithSaslPlain("user", "pass"))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithSocketSendBufferBytes(4096))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithConnectionsPerBroker(2))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(() => client.CreateConsumer<string, string>().UseTls())
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithSaslPlain("user", "pass"))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithConnectionsPerBroker(2))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithTls())
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithSaslPlain("user", "pass"))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithSocketReceiveBufferBytes(4096))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithConnectionsPerBroker(2))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(() => client.CreateAdminClient().UseTls())
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithSaslPlain("user", "pass"))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task RootClient_SharedConnectionPool_UsesAdaptiveFetchResponseBufferCeiling()
+    {
+        await using var client = Kafka.Connect("localhost:9092");
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var pool = GetField<ConnectionPool>(producer, "_connectionPool");
+        var responseBufferPool = GetField<ResponseBufferPool>(pool, "_responseBufferPool");
+
+        await Assert.That(responseBufferPool.MaxArrayLength)
+            .IsEqualTo(200 * 1024 * 1024 + ResponseBufferPool.ProtocolOverheadBytes);
+    }
+
+    [Test]
+    public async Task MetadataManager_BrokerCountCallbacks_AreMulticast()
+    {
+        await using var metadataManager = new MetadataManager(
+            connectionPool: null!,
+            bootstrapServers: ["localhost:9092"]);
+        var first = 0;
+        var second = 0;
+
+        metadataManager.AddBrokerCountDiscoveredCallback(count => first = count);
+        metadataManager.AddBrokerCountDiscoveredCallback(count => second = count);
+        metadataManager.NotifyBrokerCountDiscovered(3);
+
+        await Assert.That(first).IsEqualTo(3);
+        await Assert.That(second).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task RootClient_WithMemoryBudget_UsesIndependentProducerBudget()
     {
         await using var client = Kafka.Connect("localhost:9092", builder =>


### PR DESCRIPTION
Closes #1017

## Summary
- add `KafkaClient` / `KafkaClientBuilder` via `Kafka.Connect(...)` as a root client for shared cluster infrastructure
- route root-created producers, consumers, share consumers, and admin clients through one connection pool, metadata manager, and per-root memory budget
- keep child disposal from tearing down root-owned infrastructure and document root-client usage
- cover sharing, disposal, bootstrap ownership, and independent root memory budgeting in unit tests

## Test plan
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaClientBuilderTests/*" --no-ansi --output Normal`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `git diff --check origin/main...HEAD`

Note: a full unit executable run was attempted earlier and did not finish within 5 minutes, so it was stopped without a summary. Focused root-client tests and related builder/admin focused tests passed locally.