### PR TITLE
Encode telemetry MetricsData payloads

### DIFF
--- a/src/Dekaf/Telemetry/ClientTelemetryManager.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryManager.cs
@@ -1,9 +1,11 @@
+using Dekaf.Compression;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using CompressionType = Dekaf.Protocol.Records.CompressionType;
 
 namespace Dekaf.Telemetry;
 
@@ -42,6 +44,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
     private readonly ClientTelemetryMetricCollector? _metricCollector;
+    private readonly CompressionCodecRegistry _compressionCodecs;
     private readonly IClientTelemetryPayloadProvider _payloadProvider;
     private readonly ILogger<ClientTelemetryManager> _logger;
     private readonly SemaphoreSlim _startLock = new(1, 1);
@@ -59,13 +62,15 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         MetadataManager metadataManager,
         ILogger<ClientTelemetryManager>? logger = null,
         ClientTelemetryMetricCollector? metricCollector = null,
+        CompressionCodecRegistry? compressionCodecs = null,
         IClientTelemetryPayloadProvider? payloadProvider = null)
     {
         _connectionPool = connectionPool;
         _metadataManager = metadataManager;
         _metricCollector = metricCollector;
+        _compressionCodecs = compressionCodecs ?? CompressionCodecRegistry.Default;
         _logger = logger ?? NullLogger<ClientTelemetryManager>.Instance;
-        _payloadProvider = payloadProvider ?? EmptyClientTelemetryPayloadProvider.Instance;
+        _payloadProvider = payloadProvider ?? new ClientTelemetryPayloadProvider(_compressionCodecs);
     }
 
     internal Guid ClientInstanceId => _subscription?.ClientInstanceId ?? Guid.Empty;
@@ -337,17 +342,26 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
                 payload = ReadOnlyMemory<byte>.Empty;
             }
 
-            var response = await connection.SendAsync<PushTelemetryRequest, PushTelemetryResponse>(
-                new PushTelemetryRequest
-                {
-                    ClientInstanceId = subscription.ClientInstanceId,
-                    SubscriptionId = subscription.SubscriptionId,
-                    Terminating = terminating,
-                    CompressionType = subscription.CompressionType,
-                    Metrics = payload
-                },
+            var response = await SendPushTelemetryAsync(
+                connection,
+                subscription,
+                terminating,
+                payload,
                 apiVersion,
                 cancellationToken).ConfigureAwait(false);
+
+            if (response.ErrorCode == ErrorCode.TelemetryTooLarge && payload.Length > 0)
+            {
+                LogTelemetryPayloadRejectedTooLarge(payload.Length);
+                payload = ReadOnlyMemory<byte>.Empty;
+                response = await SendPushTelemetryAsync(
+                    connection,
+                    subscription,
+                    terminating,
+                    payload,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+            }
 
             if (response.ErrorCode == ErrorCode.UnsupportedVersion)
             {
@@ -371,6 +385,25 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
             return ErrorCode.NetworkException;
         }
     }
+
+    private static ValueTask<PushTelemetryResponse> SendPushTelemetryAsync(
+        IKafkaConnection connection,
+        ClientTelemetrySubscription subscription,
+        bool terminating,
+        ReadOnlyMemory<byte> payload,
+        short apiVersion,
+        CancellationToken cancellationToken) =>
+        connection.SendAsync<PushTelemetryRequest, PushTelemetryResponse>(
+            new PushTelemetryRequest
+            {
+                ClientInstanceId = subscription.ClientInstanceId,
+                SubscriptionId = subscription.SubscriptionId,
+                Terminating = terminating,
+                CompressionType = subscription.CompressionType,
+                Metrics = payload
+            },
+            apiVersion,
+            cancellationToken);
 
     private async ValueTask<IKafkaConnection?> GetTelemetryConnectionAsync(CancellationToken cancellationToken)
     {
@@ -410,10 +443,9 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         return true;
     }
 
-    private static bool TrySelectCompression(IReadOnlyList<sbyte> acceptedCompressionTypes, out sbyte compressionType)
+    private bool TrySelectCompression(IReadOnlyList<sbyte> acceptedCompressionTypes, out sbyte compressionType)
     {
-        const sbyte noCompression = 0;
-        compressionType = noCompression;
+        compressionType = (sbyte)CompressionType.None;
 
         if (acceptedCompressionTypes.Count == 0)
         {
@@ -422,13 +454,30 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
 
         for (var i = 0; i < acceptedCompressionTypes.Count; i++)
         {
-            if (acceptedCompressionTypes[i] == noCompression)
+            if (TryGetTelemetryCompressionType(acceptedCompressionTypes[i], out var type) &&
+                _compressionCodecs.IsSupported(type))
             {
+                compressionType = acceptedCompressionTypes[i];
                 return true;
             }
         }
 
         return false;
+    }
+
+    private static bool TryGetTelemetryCompressionType(sbyte compressionTypeId, out CompressionType compressionType)
+    {
+        compressionType = compressionTypeId switch
+        {
+            0 => CompressionType.None,
+            1 => CompressionType.Gzip,
+            2 => CompressionType.Snappy,
+            3 => CompressionType.Lz4,
+            4 => CompressionType.Zstd,
+            _ => default
+        };
+
+        return compressionTypeId is >= 0 and <= 4;
     }
 
     private void Disable()
@@ -459,4 +508,7 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Client telemetry payload too large ({PayloadSize} > {MaxSize}); sending empty payload")]
     private partial void LogTelemetryPayloadTooLarge(int payloadSize, int maxSize);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Client telemetry payload rejected as too large ({PayloadSize}); retrying with empty payload")]
+    private partial void LogTelemetryPayloadRejectedTooLarge(int payloadSize);
 }

--- a/src/Dekaf/Telemetry/ClientTelemetryPayloadProvider.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryPayloadProvider.cs
@@ -1,0 +1,207 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using Dekaf.Compression;
+using CompressionType = Dekaf.Protocol.Records.CompressionType;
+
+namespace Dekaf.Telemetry;
+
+internal sealed class ClientTelemetryPayloadProvider : IClientTelemetryPayloadProvider
+{
+    private const int WireVarint = 0;
+    private const int WireFixed64 = 1;
+    private const int WireLengthDelimited = 2;
+    private const int AggregationTemporalityDelta = 1;
+    private const int AggregationTemporalityCumulative = 2;
+
+    private readonly CompressionCodecRegistry _compressionCodecs;
+    private readonly Func<long> _unixNanoClock;
+    private readonly long _startTimeUnixNano;
+    private long _lastCollectionTimeUnixNano;
+
+    public ClientTelemetryPayloadProvider(
+        CompressionCodecRegistry? compressionCodecs = null,
+        Func<long>? unixNanoClock = null)
+    {
+        _compressionCodecs = compressionCodecs ?? CompressionCodecRegistry.Default;
+        _unixNanoClock = unixNanoClock ?? GetUnixTimeNanoseconds;
+        _startTimeUnixNano = Math.Max(1, _unixNanoClock());
+        _lastCollectionTimeUnixNano = _startTimeUnixNano;
+    }
+
+    public ReadOnlyMemory<byte> Collect(
+        ClientTelemetrySubscription subscription,
+        ClientTelemetryMetricSnapshot metrics,
+        bool terminating)
+    {
+        var now = Math.Max(1, _unixNanoClock());
+        var startTime = metrics.DeltaTemporality
+            ? Interlocked.Exchange(ref _lastCollectionTimeUnixNano, now)
+            : _startTimeUnixNano;
+
+        if (metrics.Metrics.Count == 0)
+        {
+            return ReadOnlyMemory<byte>.Empty;
+        }
+
+        var payload = EncodeMetricsData(metrics, (ulong)Math.Max(1, startTime), (ulong)now);
+        var compressionType = (CompressionType)subscription.CompressionType;
+        if (compressionType == CompressionType.None)
+        {
+            return payload.WrittenMemory;
+        }
+
+        var compressed = new ArrayBufferWriter<byte>();
+        _compressionCodecs.GetCodec(compressionType)
+            .Compress(new ReadOnlySequence<byte>(payload.WrittenMemory), compressed);
+        return compressed.WrittenMemory;
+    }
+
+    private static ArrayBufferWriter<byte> EncodeMetricsData(
+        ClientTelemetryMetricSnapshot snapshot,
+        ulong startTimeUnixNano,
+        ulong timeUnixNano)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        WriteMessage(buffer, 1, resourceMetrics =>
+        {
+            WriteMessage(resourceMetrics, 2, scopeMetrics =>
+            {
+                foreach (var metric in snapshot.Metrics)
+                {
+                    WriteMetric(scopeMetrics, metric, startTimeUnixNano, timeUnixNano, snapshot.DeltaTemporality);
+                }
+            });
+        });
+        return buffer;
+    }
+
+    private static void WriteMetric(
+        IBufferWriter<byte> writer,
+        ClientTelemetryMetric metric,
+        ulong startTimeUnixNano,
+        ulong timeUnixNano,
+        bool deltaTemporality)
+    {
+        WriteMessage(writer, 2, metricWriter =>
+        {
+            WriteString(metricWriter, 1, metric.Name);
+
+            if (metric.Kind == ClientTelemetryMetricKind.Counter)
+            {
+                WriteMessage(metricWriter, 7, sum =>
+                {
+                    WriteMessage(sum, 1, point =>
+                        WriteNumberDataPoint(point, metric, startTimeUnixNano, timeUnixNano));
+                    WriteVarintField(
+                        sum,
+                        2,
+                        deltaTemporality ? AggregationTemporalityDelta : AggregationTemporalityCumulative);
+                    WriteVarintField(sum, 3, 1);
+                });
+            }
+            else
+            {
+                WriteMessage(metricWriter, 5, gauge =>
+                {
+                    WriteMessage(gauge, 1, point =>
+                        WriteNumberDataPoint(point, metric, startTimeUnixNano, timeUnixNano));
+                });
+            }
+        });
+    }
+
+    private static void WriteNumberDataPoint(
+        IBufferWriter<byte> writer,
+        ClientTelemetryMetric metric,
+        ulong startTimeUnixNano,
+        ulong timeUnixNano)
+    {
+        WriteFixed64Field(writer, 2, startTimeUnixNano);
+        WriteFixed64Field(writer, 3, timeUnixNano);
+        WriteDoubleField(writer, 4, metric.Value);
+
+        foreach (var attribute in metric.Attributes)
+        {
+            WriteMessage(writer, 7, keyValue =>
+            {
+                WriteString(keyValue, 1, attribute.Name);
+                WriteMessage(keyValue, 2, anyValue => WriteString(anyValue, 1, attribute.Value));
+            });
+        }
+    }
+
+    private static void WriteMessage(
+        IBufferWriter<byte> writer,
+        int fieldNumber,
+        Action<IBufferWriter<byte>> writePayload)
+    {
+        var payload = new ArrayBufferWriter<byte>();
+        writePayload(payload);
+        WriteTag(writer, fieldNumber, WireLengthDelimited);
+        WriteVarint(writer, (ulong)payload.WrittenCount);
+        WriteBytes(writer, payload.WrittenSpan);
+    }
+
+    private static void WriteString(IBufferWriter<byte> writer, int fieldNumber, string value)
+    {
+        var byteCount = System.Text.Encoding.UTF8.GetByteCount(value);
+        WriteTag(writer, fieldNumber, WireLengthDelimited);
+        WriteVarint(writer, (ulong)byteCount);
+        var span = writer.GetSpan(byteCount);
+        var written = System.Text.Encoding.UTF8.GetBytes(value, span);
+        writer.Advance(written);
+    }
+
+    private static void WriteVarintField(IBufferWriter<byte> writer, int fieldNumber, int value)
+    {
+        WriteTag(writer, fieldNumber, WireVarint);
+        WriteVarint(writer, (ulong)value);
+    }
+
+    private static void WriteFixed64Field(IBufferWriter<byte> writer, int fieldNumber, ulong value)
+    {
+        WriteTag(writer, fieldNumber, WireFixed64);
+        var span = writer.GetSpan(sizeof(ulong));
+        BinaryPrimitives.WriteUInt64LittleEndian(span, value);
+        writer.Advance(sizeof(ulong));
+    }
+
+    private static void WriteDoubleField(IBufferWriter<byte> writer, int fieldNumber, double value)
+    {
+        WriteFixed64Field(writer, fieldNumber, (ulong)BitConverter.DoubleToInt64Bits(value));
+    }
+
+    private static void WriteTag(IBufferWriter<byte> writer, int fieldNumber, int wireType) =>
+        WriteVarint(writer, (ulong)((fieldNumber << 3) | wireType));
+
+    private static void WriteVarint(IBufferWriter<byte> writer, ulong value)
+    {
+        while (value >= 0x80)
+        {
+            WriteByte(writer, (byte)((value & 0x7f) | 0x80));
+            value >>= 7;
+        }
+
+        WriteByte(writer, (byte)value);
+    }
+
+    private static void WriteByte(IBufferWriter<byte> writer, byte value)
+    {
+        var span = writer.GetSpan(1);
+        span[0] = value;
+        writer.Advance(1);
+    }
+
+    private static void WriteBytes(IBufferWriter<byte> writer, ReadOnlySpan<byte> value)
+    {
+        var span = writer.GetSpan(value.Length);
+        value.CopyTo(span);
+        writer.Advance(value.Length);
+    }
+
+    private static long GetUnixTimeNanoseconds()
+    {
+        var ticksSinceUnixEpoch = DateTimeOffset.UtcNow.UtcTicks - DateTime.UnixEpoch.Ticks;
+        return checked(ticksSinceUnixEpoch * 100);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Dekaf.Compression;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
@@ -88,6 +89,98 @@ public sealed class ClientTelemetryManagerTests
     }
 
     [Test]
+    public async Task StartAsync_SelectsFirstAcceptedSupportedCompression()
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);
+        collector.RecordConnectionCreated();
+        await using var context = new TelemetryTestContext(
+            metricCollector: collector,
+            compressionCodecs: new CompressionCodecRegistry());
+        var clientInstanceId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+        context.Connection.Enqueue(Subscription(
+            clientInstanceId,
+            subscriptionId: 11,
+            pushIntervalMs: 10,
+            acceptedCompressionTypes: [4, 1, 0],
+            requestedMetrics: [string.Empty]));
+
+        await context.Manager.StartAsync();
+
+        var pushes = await context.Connection.WaitForRequestsAsync<PushTelemetryRequest>(
+            count: 1,
+            timeout: TimeSpan.FromSeconds(2));
+
+        await Assert.That(pushes[0].CompressionType).IsEqualTo((sbyte)1);
+        await Assert.That(pushes[0].Metrics.Length).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task StartAsync_DisablesTelemetryWhenNoAcceptedCompressionIsSupported()
+    {
+        await using var context = new TelemetryTestContext(compressionCodecs: new CompressionCodecRegistry());
+        context.Connection.Enqueue(Subscription(
+            Guid.Parse("66666666-6666-6666-6666-666666666666"),
+            subscriptionId: 12,
+            pushIntervalMs: 10,
+            acceptedCompressionTypes: [4]));
+
+        await context.Manager.StartAsync();
+
+        await Assert.That(context.Manager.IsDisabled).IsTrue();
+        await Assert.That(context.Manager.IsStarted).IsFalse();
+    }
+
+    [Test]
+    public async Task PushTelemetry_DropsPayloadWhenTelemetryMaxBytesExceeded()
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);
+        collector.RecordConnectionCreated();
+        await using var context = new TelemetryTestContext(metricCollector: collector);
+        var clientInstanceId = Guid.Parse("77777777-7777-7777-7777-777777777777");
+        context.Connection.Enqueue(Subscription(
+            clientInstanceId,
+            subscriptionId: 13,
+            pushIntervalMs: 10,
+            telemetryMaxBytes: 1,
+            requestedMetrics: [string.Empty]));
+
+        await context.Manager.StartAsync();
+
+        var pushes = await context.Connection.WaitForRequestsAsync<PushTelemetryRequest>(
+            count: 1,
+            timeout: TimeSpan.FromSeconds(2));
+
+        await Assert.That(pushes[0].Metrics.Length).IsEqualTo(0);
+        await Assert.That(pushes[0].CompressionType).IsEqualTo((sbyte)0);
+    }
+
+    [Test]
+    public async Task PushTelemetry_RetriesWithEmptyPayloadWhenBrokerRejectsTelemetryTooLarge()
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);
+        collector.RecordConnectionCreated();
+        await using var context = new TelemetryTestContext(metricCollector: collector);
+        var clientInstanceId = Guid.Parse("88888888-8888-8888-8888-888888888888");
+        context.Connection.Enqueue(Subscription(
+            clientInstanceId,
+            subscriptionId: 14,
+            pushIntervalMs: 10,
+            requestedMetrics: [string.Empty]));
+        context.Connection.Enqueue(new PushTelemetryResponse { ErrorCode = ErrorCode.TelemetryTooLarge });
+        context.Connection.Enqueue(new PushTelemetryResponse { ErrorCode = ErrorCode.None });
+
+        await context.Manager.StartAsync();
+
+        var pushes = await context.Connection.WaitForRequestsAsync<PushTelemetryRequest>(
+            count: 2,
+            timeout: TimeSpan.FromSeconds(2));
+
+        await Assert.That(pushes[0].Metrics.Length).IsGreaterThan(0);
+        await Assert.That(pushes[1].Metrics.Length).IsEqualTo(0);
+        await Assert.That(pushes[1].CompressionType).IsEqualTo(pushes[0].CompressionType);
+    }
+
+    [Test]
     public async Task UnsupportedVersion_DisablesBrokerPushTelemetry()
     {
         await using var context = new TelemetryTestContext();
@@ -106,16 +199,20 @@ public sealed class ClientTelemetryManagerTests
     private static GetTelemetrySubscriptionsResponse Subscription(
         Guid clientInstanceId,
         int subscriptionId,
-        int pushIntervalMs) => new()
+        int pushIntervalMs,
+        IReadOnlyList<sbyte>? acceptedCompressionTypes = null,
+        int telemetryMaxBytes = 1024,
+        bool deltaTemporality = true,
+        IReadOnlyList<string>? requestedMetrics = null) => new()
     {
         ErrorCode = ErrorCode.None,
         ClientInstanceId = clientInstanceId,
         SubscriptionId = subscriptionId,
-        AcceptedCompressionTypes = [0],
+        AcceptedCompressionTypes = acceptedCompressionTypes ?? [0],
         PushIntervalMs = pushIntervalMs,
-        TelemetryMaxBytes = 1024,
-        DeltaTemporality = true,
-        RequestedMetrics = ["kafka."]
+        TelemetryMaxBytes = telemetryMaxBytes,
+        DeltaTemporality = deltaTemporality,
+        RequestedMetrics = requestedMetrics ?? ["kafka."]
     };
 
     private sealed class TelemetryTestContext : IAsyncDisposable
@@ -123,7 +220,10 @@ public sealed class ClientTelemetryManagerTests
         private readonly MetadataManager _metadataManager;
         private readonly TestConnectionPool _pool;
 
-        public TelemetryTestContext()
+        public TelemetryTestContext(
+            ClientTelemetryMetricCollector? metricCollector = null,
+            CompressionCodecRegistry? compressionCodecs = null,
+            IClientTelemetryPayloadProvider? payloadProvider = null)
         {
             _pool = new TestConnectionPool();
             _metadataManager = new MetadataManager(_pool, ["localhost:9092"]);
@@ -145,7 +245,12 @@ public sealed class ClientTelemetryManagerTests
                 Topics = []
             });
 
-            Manager = new ClientTelemetryManager(_pool, _metadataManager);
+            Manager = new ClientTelemetryManager(
+                _pool,
+                _metadataManager,
+                metricCollector: metricCollector,
+                compressionCodecs: compressionCodecs,
+                payloadProvider: payloadProvider);
         }
 
         public ClientTelemetryManager Manager { get; }

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryPayloadProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryPayloadProviderTests.cs
@@ -1,0 +1,481 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Text;
+using Dekaf.Compression;
+using Dekaf.Telemetry;
+using CompressionType = Dekaf.Protocol.Records.CompressionType;
+
+namespace Dekaf.Tests.Unit.Telemetry;
+
+public sealed class ClientTelemetryPayloadProviderTests
+{
+    [Test]
+    public async Task Collect_CumulativeMetrics_EncodesOtlpMetricsData()
+    {
+        var clock = new SequenceClock(10, 20);
+        var provider = new ClientTelemetryPayloadProvider(unixNanoClock: clock.Next);
+        var snapshot = new ClientTelemetryMetricSnapshot(
+            DeltaTemporality: false,
+            Metrics:
+            [
+                new ClientTelemetryMetric(
+                    ClientTelemetryMetricNames.ProducerConnectionCreationTotal,
+                    ClientTelemetryMetricKind.Counter,
+                    2.0,
+                    []),
+                new ClientTelemetryMetric(
+                    ClientTelemetryMetricNames.ProducerNodeRequestLatencyAvg,
+                    ClientTelemetryMetricKind.Gauge,
+                    12.5,
+                    [new ClientTelemetryMetricAttribute("node_id", "3")])
+            ]);
+
+        var payload = provider.Collect(Subscription(deltaTemporality: false), snapshot, terminating: false);
+
+        var metrics = DecodeMetricsData(payload);
+        var counter = metrics.Single(m => m.Name == ClientTelemetryMetricNames.ProducerConnectionCreationTotal);
+        var gauge = metrics.Single(m => m.Name == ClientTelemetryMetricNames.ProducerNodeRequestLatencyAvg);
+        var sum = counter.Sum ?? throw new InvalidOperationException("Counter metric was not encoded as a sum.");
+        var counterPoint = sum.DataPoints.Single();
+        var gaugePoint = (gauge.Gauge ?? throw new InvalidOperationException("Gauge metric was not encoded as a gauge."))
+            .DataPoints.Single();
+
+        await Assert.That(counter.Gauge).IsNull();
+        await Assert.That(sum.Temporality).IsEqualTo(2);
+        await Assert.That(sum.IsMonotonic).IsTrue();
+        await Assert.That(counterPoint.StartTimeUnixNano).IsEqualTo((ulong)10);
+        await Assert.That(counterPoint.TimeUnixNano).IsEqualTo((ulong)20);
+        await Assert.That(counterPoint.Value).IsEqualTo(2.0);
+
+        await Assert.That(gauge.Sum).IsNull();
+        await Assert.That(gaugePoint.StartTimeUnixNano).IsEqualTo((ulong)10);
+        await Assert.That(gaugePoint.TimeUnixNano).IsEqualTo((ulong)20);
+        await Assert.That(gaugePoint.Value).IsEqualTo(12.5);
+        await Assert.That(gaugePoint.Attributes["node_id"]).IsEqualTo("3");
+    }
+
+    [Test]
+    public async Task Collect_DeltaMetrics_UsesDeltaTemporalityAndPreviousCollectionStart()
+    {
+        var clock = new SequenceClock(100, 200, 300);
+        var provider = new ClientTelemetryPayloadProvider(unixNanoClock: clock.Next);
+        var snapshot = new ClientTelemetryMetricSnapshot(
+            DeltaTemporality: true,
+            Metrics:
+            [
+                new ClientTelemetryMetric(
+                    ClientTelemetryMetricNames.ConsumerConnectionCreationTotal,
+                    ClientTelemetryMetricKind.Counter,
+                    1.0,
+                    [])
+            ]);
+
+        var first = DecodeMetricsData(provider.Collect(Subscription(deltaTemporality: true), snapshot, terminating: false))
+            .Single().Sum ?? throw new InvalidOperationException("First counter metric was not encoded as a sum.");
+        var second = DecodeMetricsData(provider.Collect(Subscription(deltaTemporality: true), snapshot, terminating: false))
+            .Single().Sum ?? throw new InvalidOperationException("Second counter metric was not encoded as a sum.");
+
+        await Assert.That(first.Temporality).IsEqualTo(1);
+        await Assert.That(first.DataPoints.Single().StartTimeUnixNano).IsEqualTo((ulong)100);
+        await Assert.That(first.DataPoints.Single().TimeUnixNano).IsEqualTo((ulong)200);
+        await Assert.That(second.DataPoints.Single().StartTimeUnixNano).IsEqualTo((ulong)200);
+        await Assert.That(second.DataPoints.Single().TimeUnixNano).IsEqualTo((ulong)300);
+    }
+
+    [Test]
+    public async Task Collect_GzipCompression_CompressesMetricsData()
+    {
+        var clock = new SequenceClock(10, 20);
+        var compressionCodecs = new CompressionCodecRegistry();
+        var provider = new ClientTelemetryPayloadProvider(compressionCodecs, clock.Next);
+        var snapshot = new ClientTelemetryMetricSnapshot(
+            DeltaTemporality: false,
+            Metrics:
+            [
+                new ClientTelemetryMetric(
+                    ClientTelemetryMetricNames.ProducerConnectionCreationTotal,
+                    ClientTelemetryMetricKind.Counter,
+                    3.0,
+                    [])
+            ]);
+
+        var payload = provider.Collect(
+            Subscription(deltaTemporality: false, compressionType: (sbyte)CompressionType.Gzip),
+            snapshot,
+            terminating: false);
+
+        var decompressed = new ArrayBufferWriter<byte>();
+        compressionCodecs.GetCodec(CompressionType.Gzip)
+            .Decompress(new ReadOnlySequence<byte>(payload), decompressed);
+        var metric = DecodeMetricsData(decompressed.WrittenMemory).Single();
+
+        await Assert.That(payload.Length).IsGreaterThan(0);
+        await Assert.That(payload.Span[0]).IsEqualTo((byte)0x1f);
+        await Assert.That(metric.Name).IsEqualTo(ClientTelemetryMetricNames.ProducerConnectionCreationTotal);
+        await Assert.That((metric.Sum ?? throw new InvalidOperationException("Counter metric was not encoded as a sum."))
+            .DataPoints.Single().Value).IsEqualTo(3.0);
+    }
+
+    private static ClientTelemetrySubscription Subscription(
+        bool deltaTemporality,
+        sbyte compressionType = 0) =>
+        new(
+            ClientInstanceId: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            SubscriptionId: 1,
+            CompressionType: compressionType,
+            PushIntervalMs: 60000,
+            TelemetryMaxBytes: 65536,
+            DeltaTemporality: deltaTemporality,
+            RequestedMetrics: [string.Empty]);
+
+    private static IReadOnlyList<OtlpMetric> DecodeMetricsData(ReadOnlyMemory<byte> payload)
+    {
+        var metrics = new List<OtlpMetric>();
+        var reader = new ProtoReader(payload);
+        while (reader.TryReadField(out var fieldNumber, out var wireType))
+        {
+            if (fieldNumber == 1 && wireType == ProtoReader.WireLengthDelimited)
+            {
+                ReadResourceMetrics(reader.ReadLengthDelimited(), metrics);
+            }
+            else
+            {
+                reader.Skip(wireType);
+            }
+        }
+
+        return metrics;
+    }
+
+    private static void ReadResourceMetrics(ReadOnlyMemory<byte> payload, List<OtlpMetric> metrics)
+    {
+        var reader = new ProtoReader(payload);
+        while (reader.TryReadField(out var fieldNumber, out var wireType))
+        {
+            if (fieldNumber == 2 && wireType == ProtoReader.WireLengthDelimited)
+            {
+                ReadScopeMetrics(reader.ReadLengthDelimited(), metrics);
+            }
+            else
+            {
+                reader.Skip(wireType);
+            }
+        }
+    }
+
+    private static void ReadScopeMetrics(ReadOnlyMemory<byte> payload, List<OtlpMetric> metrics)
+    {
+        var reader = new ProtoReader(payload);
+        while (reader.TryReadField(out var fieldNumber, out var wireType))
+        {
+            if (fieldNumber == 2 && wireType == ProtoReader.WireLengthDelimited)
+            {
+                metrics.Add(ReadMetric(reader.ReadLengthDelimited()));
+            }
+            else
+            {
+                reader.Skip(wireType);
+            }
+        }
+    }
+
+    private static OtlpMetric ReadMetric(ReadOnlyMemory<byte> payload)
+    {
+        var name = string.Empty;
+        OtlpGauge? gauge = null;
+        OtlpSum? sum = null;
+        var reader = new ProtoReader(payload);
+
+        while (reader.TryReadField(out var fieldNumber, out var wireType))
+        {
+            if (fieldNumber == 1 && wireType == ProtoReader.WireLengthDelimited)
+            {
+                name = reader.ReadString();
+            }
+            else if (fieldNumber == 5 && wireType == ProtoReader.WireLengthDelimited)
+            {
+                gauge = ReadGauge(reader.ReadLengthDelimited());
+            }
+            else if (fieldNumber == 7 && wireType == ProtoReader.WireLengthDelimited)
+            {
+                sum = ReadSum(reader.ReadLengthDelimited());
+            }
+            else
+            {
+                reader.Skip(wireType);
+            }
+        }
+
+        return new OtlpMetric(name, gauge, sum);
+    }
+
+    private static OtlpGauge ReadGauge(ReadOnlyMemory<byte> payload)
+    {
+        var dataPoints = new List<OtlpNumberDataPoint>();
+        var reader = new ProtoReader(payload);
+        while (reader.TryReadField(out var fieldNumber, out var wireType))
+        {
+            if (fieldNumber == 1 && wireType == ProtoReader.WireLengthDelimited)
+            {
+                dataPoints.Add(ReadNumberDataPoint(reader.ReadLengthDelimited()));
+            }
+            else
+            {
+                reader.Skip(wireType);
+            }
+        }
+
+        return new OtlpGauge(dataPoints);
+    }
+
+    private static OtlpSum ReadSum(ReadOnlyMemory<byte> payload)
+    {
+        var dataPoints = new List<OtlpNumberDataPoint>();
+        var temporality = 0;
+        var isMonotonic = false;
+        var reader = new ProtoReader(payload);
+        while (reader.TryReadField(out var fieldNumber, out var wireType))
+        {
+            if (fieldNumber == 1 && wireType == ProtoReader.WireLengthDelimited)
+            {
+                dataPoints.Add(ReadNumberDataPoint(reader.ReadLengthDelimited()));
+            }
+            else if (fieldNumber == 2 && wireType == ProtoReader.WireVarint)
+            {
+                temporality = checked((int)reader.ReadVarint());
+            }
+            else if (fieldNumber == 3 && wireType == ProtoReader.WireVarint)
+            {
+                isMonotonic = reader.ReadVarint() != 0;
+            }
+            else
+            {
+                reader.Skip(wireType);
+            }
+        }
+
+        return new OtlpSum(dataPoints, temporality, isMonotonic);
+    }
+
+    private static OtlpNumberDataPoint ReadNumberDataPoint(ReadOnlyMemory<byte> payload)
+    {
+        var attributes = new Dictionary<string, string>(StringComparer.Ordinal);
+        ulong startTimeUnixNano = 0;
+        ulong timeUnixNano = 0;
+        double value = 0;
+        var reader = new ProtoReader(payload);
+
+        while (reader.TryReadField(out var fieldNumber, out var wireType))
+        {
+            if (fieldNumber == 2 && wireType == ProtoReader.WireFixed64)
+            {
+                startTimeUnixNano = reader.ReadFixed64();
+            }
+            else if (fieldNumber == 3 && wireType == ProtoReader.WireFixed64)
+            {
+                timeUnixNano = reader.ReadFixed64();
+            }
+            else if (fieldNumber == 4 && wireType == ProtoReader.WireFixed64)
+            {
+                value = reader.ReadDouble();
+            }
+            else if (fieldNumber == 7 && wireType == ProtoReader.WireLengthDelimited)
+            {
+                var attribute = ReadKeyValue(reader.ReadLengthDelimited());
+                attributes[attribute.Key] = attribute.Value;
+            }
+            else
+            {
+                reader.Skip(wireType);
+            }
+        }
+
+        return new OtlpNumberDataPoint(startTimeUnixNano, timeUnixNano, value, attributes);
+    }
+
+    private static KeyValuePair<string, string> ReadKeyValue(ReadOnlyMemory<byte> payload)
+    {
+        var key = string.Empty;
+        var value = string.Empty;
+        var reader = new ProtoReader(payload);
+
+        while (reader.TryReadField(out var fieldNumber, out var wireType))
+        {
+            if (fieldNumber == 1 && wireType == ProtoReader.WireLengthDelimited)
+            {
+                key = reader.ReadString();
+            }
+            else if (fieldNumber == 2 && wireType == ProtoReader.WireLengthDelimited)
+            {
+                value = ReadAnyValue(reader.ReadLengthDelimited());
+            }
+            else
+            {
+                reader.Skip(wireType);
+            }
+        }
+
+        return new KeyValuePair<string, string>(key, value);
+    }
+
+    private static string ReadAnyValue(ReadOnlyMemory<byte> payload)
+    {
+        var reader = new ProtoReader(payload);
+        while (reader.TryReadField(out var fieldNumber, out var wireType))
+        {
+            if (fieldNumber == 1 && wireType == ProtoReader.WireLengthDelimited)
+            {
+                return reader.ReadString();
+            }
+
+            reader.Skip(wireType);
+        }
+
+        return string.Empty;
+    }
+
+    private sealed record OtlpMetric(string Name, OtlpGauge? Gauge, OtlpSum? Sum);
+
+    private sealed record OtlpGauge(IReadOnlyList<OtlpNumberDataPoint> DataPoints);
+
+    private sealed record OtlpSum(
+        IReadOnlyList<OtlpNumberDataPoint> DataPoints,
+        int Temporality,
+        bool IsMonotonic);
+
+    private sealed record OtlpNumberDataPoint(
+        ulong StartTimeUnixNano,
+        ulong TimeUnixNano,
+        double Value,
+        IReadOnlyDictionary<string, string> Attributes);
+
+    private sealed class SequenceClock
+    {
+        private readonly long[] _values;
+        private int _index;
+
+        public SequenceClock(params long[] values)
+        {
+            _values = values;
+        }
+
+        public long Next()
+        {
+            var index = Interlocked.Increment(ref _index) - 1;
+            return _values[Math.Min(index, _values.Length - 1)];
+        }
+    }
+
+    private sealed class ProtoReader
+    {
+        public const int WireVarint = 0;
+        public const int WireFixed64 = 1;
+        public const int WireLengthDelimited = 2;
+
+        private readonly ReadOnlyMemory<byte> _data;
+        private int _position;
+
+        public ProtoReader(ReadOnlyMemory<byte> data)
+        {
+            _data = data;
+        }
+
+        public bool TryReadField(out int fieldNumber, out int wireType)
+        {
+            if (_position >= _data.Length)
+            {
+                fieldNumber = 0;
+                wireType = 0;
+                return false;
+            }
+
+            var tag = ReadVarint();
+            if (tag == 0)
+            {
+                fieldNumber = 0;
+                wireType = 0;
+                return false;
+            }
+
+            fieldNumber = checked((int)(tag >> 3));
+            wireType = (int)(tag & 0x7);
+            return true;
+        }
+
+        public ReadOnlyMemory<byte> ReadLengthDelimited()
+        {
+            var length = checked((int)ReadVarint());
+            EnsureAvailable(length);
+            var value = _data.Slice(_position, length);
+            _position += length;
+            return value;
+        }
+
+        public string ReadString() =>
+            Encoding.UTF8.GetString(ReadLengthDelimited().Span);
+
+        public ulong ReadFixed64()
+        {
+            EnsureAvailable(sizeof(ulong));
+            var value = BinaryPrimitives.ReadUInt64LittleEndian(_data.Span.Slice(_position, sizeof(ulong)));
+            _position += sizeof(ulong);
+            return value;
+        }
+
+        public double ReadDouble() =>
+            BitConverter.Int64BitsToDouble((long)ReadFixed64());
+
+        public ulong ReadVarint()
+        {
+            ulong value = 0;
+            var shift = 0;
+            while (shift < 64)
+            {
+                EnsureAvailable(1);
+                var next = _data.Span[_position++];
+                value |= (ulong)(next & 0x7f) << shift;
+                if ((next & 0x80) == 0)
+                {
+                    return value;
+                }
+
+                shift += 7;
+            }
+
+            throw new InvalidDataException("Invalid protobuf varint.");
+        }
+
+        public void Skip(int wireType)
+        {
+            switch (wireType)
+            {
+                case WireVarint:
+                    _ = ReadVarint();
+                    break;
+                case WireFixed64:
+                    EnsureAvailable(sizeof(ulong));
+                    _position += sizeof(ulong);
+                    break;
+                case WireLengthDelimited:
+                    var length = checked((int)ReadVarint());
+                    EnsureAvailable(length);
+                    _position += length;
+                    break;
+                case 5:
+                    EnsureAvailable(sizeof(uint));
+                    _position += sizeof(uint);
+                    break;
+                default:
+                    throw new InvalidDataException($"Unsupported protobuf wire type {wireType}.");
+            }
+        }
+
+        private void EnsureAvailable(int length)
+        {
+            if (length < 0 || _position + length > _data.Length)
+            {
+                throw new InvalidDataException("Unexpected end of protobuf payload.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- encode broker telemetry snapshots as OpenTelemetry MetricsData v1 protobuf payloads
- select broker-accepted compression from registered codecs and enforce TelemetryMaxBytes before push
- retry TELEMETRY_TOO_LARGE responses once with an empty truncated payload

## Tests
- dotnet build Dekaf.sln --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --disable-logo --no-progress --maximum-parallel-tests 8 --timeout 10m --report-trx --report-trx-filename telemetry-full.trx

Closes #1006