### PR TITLE
fix(networking): bound cancelled correlation IDs

### DIFF
--- a/src/Dekaf/Networking/CancelledCorrelationIdTracker.cs
+++ b/src/Dekaf/Networking/CancelledCorrelationIdTracker.cs
@@ -1,0 +1,46 @@
+using System.Collections.Concurrent;
+
+namespace Dekaf.Networking;
+
+internal sealed class CancelledCorrelationIdTracker
+{
+    private readonly int _capacity;
+    private readonly ConcurrentDictionary<int, byte> _ids = new();
+    private readonly ConcurrentQueue<int> _order = new();
+
+    public CancelledCorrelationIdTracker(int capacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+        _capacity = capacity;
+    }
+
+    public bool TryAdd(int correlationId)
+    {
+        if (!_ids.TryAdd(correlationId, 0))
+            return false;
+
+        _order.Enqueue(correlationId);
+        Trim();
+        return true;
+    }
+
+    public bool TryRemove(int correlationId)
+        => _ids.TryRemove(correlationId, out _);
+
+    public void Clear()
+    {
+        _ids.Clear();
+
+        while (_order.TryDequeue(out _))
+        {
+        }
+    }
+
+    private void Trim()
+    {
+        while (_ids.Count > _capacity && _order.TryDequeue(out var oldestCorrelationId))
+        {
+            _ids.TryRemove(oldestCorrelationId, out _);
+        }
+    }
+}

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -159,8 +159,9 @@ public sealed partial class KafkaConnection : IKafkaConnection
     // correlation ID, it could be incorrectly matched to the wrong pending request.
     // Using globally unique correlation IDs prevents this issue.
 
-    // Cap on _cancelledCorrelationIds to prevent unbounded growth when brokers
-    // silently drop responses for timed-out requests.
+    // Cap on cancelled correlation IDs to prevent unbounded growth when brokers
+    // silently drop responses for timed-out requests. The tracker evicts oldest IDs
+    // so recent cancellations continue suppressing late responses after the cap is hit.
     private const int MaxCancelledCorrelationIds = 10_000;
     private const int PendingRequestShardCount = 16;
     private const int MinimumResponseFrameSize = 4; // Correlation ID is always first in the response header.
@@ -172,7 +173,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int _pendingRequestSlotOperationCount;
     private int _pendingRequestSlotsClosed;
-    private readonly ConcurrentDictionary<int, byte> _cancelledCorrelationIds = new();
+    private readonly CancelledCorrelationIdTracker _cancelledCorrelationIds = new(MaxCancelledCorrelationIds);
     private readonly PendingRequestPool _pendingRequestPool;
     private readonly CancellationTokenSourcePool _timeoutCtsPool;
     private readonly ClientTelemetryMetricCollector? _telemetryMetricCollector;
@@ -796,11 +797,9 @@ public sealed partial class KafkaConnection : IKafkaConnection
                 // Record it so the receive loop discards silently instead of warning.
                 // If the receive loop already called TryComplete (and lost the CAS),
                 // this entry becomes a harmless no-op cleaned up by DisposeAsync.
-                // Count check + TryAdd is not atomic, so the cap is approximate (soft cap).
-                // This is fine — the goal is preventing unbounded growth, not enforcing an exact limit.
-                if (!responseReceived && _cancelledCorrelationIds.Count < MaxCancelledCorrelationIds)
+                if (!responseReceived)
                 {
-                    _cancelledCorrelationIds.TryAdd(correlationId, 0);
+                    _cancelledCorrelationIds.TryAdd(correlationId);
                 }
             }
         }
@@ -1149,7 +1148,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
                 responseData.Dispose();
             }
         }
-        else if (_cancelledCorrelationIds.TryRemove(correlationId, out _))
+        else if (_cancelledCorrelationIds.TryRemove(correlationId))
         {
             LogLateResponseForCancelledRequest(correlationId);
             responseData.Dispose();

--- a/tests/Dekaf.Tests.Unit/Networking/CancelledCorrelationIdTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/CancelledCorrelationIdTrackerTests.cs
@@ -1,0 +1,46 @@
+using Dekaf.Networking;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public sealed class CancelledCorrelationIdTrackerTests
+{
+    [Test]
+    public async Task TryAdd_WhenCapacityExceeded_EvictsOldestCorrelationId()
+    {
+        var tracker = new CancelledCorrelationIdTracker(capacity: 2);
+
+        tracker.TryAdd(1);
+        tracker.TryAdd(2);
+        tracker.TryAdd(3);
+
+        await Assert.That(tracker.TryRemove(1)).IsFalse();
+        await Assert.That(tracker.TryRemove(2)).IsTrue();
+        await Assert.That(tracker.TryRemove(3)).IsTrue();
+    }
+
+    [Test]
+    public async Task TryRemove_WhenCorrelationIdTracked_RemovesOnce()
+    {
+        var tracker = new CancelledCorrelationIdTracker(capacity: 2);
+
+        tracker.TryAdd(42);
+
+        await Assert.That(tracker.TryRemove(42)).IsTrue();
+        await Assert.That(tracker.TryRemove(42)).IsFalse();
+    }
+
+    [Test]
+    public async Task Clear_RemovesTrackedIdsAndQueuedEvictions()
+    {
+        var tracker = new CancelledCorrelationIdTracker(capacity: 2);
+        tracker.TryAdd(1);
+        tracker.TryAdd(2);
+
+        tracker.Clear();
+        tracker.TryAdd(3);
+
+        await Assert.That(tracker.TryRemove(1)).IsFalse();
+        await Assert.That(tracker.TryRemove(2)).IsFalse();
+        await Assert.That(tracker.TryRemove(3)).IsTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the count-gated cancelled-correlation dictionary with a bounded recency tracker.
- Evict oldest cancelled correlation IDs when the cap is exceeded so newer late responses are still suppressed.
- Add unit coverage for eviction, late-response removal, and clear behavior.

## Test plan
- [x] `dotnet restore tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj`
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/CancelledCorrelationIdTrackerTests/*" --no-ansi --output Normal`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaConnectionTests/*" --no-ansi --output Normal`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PooledPendingRequestTests/*" --no-ansi --output Normal`
- [x] `git diff --check`

Closes #1046
