### PR TITLE
feat(benchmarks): add native memory profiling for fair Dekaf vs Confluent comparison

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -109,10 +109,44 @@ jobs:
           path: tools/Dekaf.Benchmarks/BenchmarkResults/
           retention-days: 30
 
+  client-benchmarks-native-memory:
+    name: Client Benchmarks with Native Memory (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-quality: 'preview'
+
+      - name: Build
+        run: dotnet build --configuration Release
+
+      - name: Run Client Benchmarks with Native Memory Profiler
+        shell: pwsh
+        run: |
+          cd tools/Dekaf.Benchmarks
+          dotnet run -c Release --no-build -- --filter "*Client*" --profiler NativeMemory --exporters json --artifacts ./BenchmarkResults/ClientNative
+        continue-on-error: true
+
+      - name: Upload Results
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-results-client-native
+          path: tools/Dekaf.Benchmarks/BenchmarkResults/
+          retention-days: 30
+
   benchmark-summary:
     name: Generate Summary
     runs-on: ubuntu-latest
-    needs: [unit-benchmarks, client-benchmarks]
+    needs: [unit-benchmarks, client-benchmarks, client-benchmarks-native-memory]
     if: always()
 
     steps:
@@ -166,6 +200,24 @@ jobs:
                       if in_table:
                           output.append(line)
               output.append("")
+
+          # Native memory benchmarks (Windows, ETW-based NativeMemoryProfiler)
+          native_md = glob.glob("benchmark-results/ClientNative/results/*ConsumerBenchmarks*-github.md")
+          native_md += glob.glob("benchmark-results/ClientNative/results/*ProducerBenchmarks*-github.md")
+          if native_md:
+              output.append("## Native Memory Comparison (Windows, ETW)\n")
+              output.append("> **'Allocated native memory' captures librdkafka's unmanaged allocations, invisible to the managed Allocated column.** Compare Dekaf's Allocated against Confluent's Allocated + Allocated native memory for a fair total.\n")
+              for md in native_md:
+                  with open(md) as f:
+                      content = f.read()
+                      lines = content.split('\n')
+                      in_table = False
+                      for line in lines:
+                          if line.startswith('|'):
+                              in_table = True
+                          if in_table:
+                              output.append(line)
+                  output.append("")
 
           # Protocol benchmarks (zero-allocation)
           protocol_md = glob.glob("benchmark-results/Unit/results/*ProtocolBenchmarks*-github.md")
@@ -251,6 +303,10 @@ jobs:
 
           combined = {'Benchmarks': []}
           for root, dirs, files in os.walk('benchmark-results'):
+              # ClientNative runs on windows-latest; mixing its timings into the
+              # Linux-based history chart would corrupt trend data
+              if 'ClientNative' in root:
+                  continue
               for f in files:
                   if f.endswith('.json') and 'results' in root:
                       path = os.path.join(root, f)

--- a/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
+++ b/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
     <PackageReference Include="Confluent.Kafka" Version="2.15.0" />
     <PackageReference Include="Testcontainers.Kafka" Version="4.13.0" />
   </ItemGroup>


### PR DESCRIPTION
## Why

Benchmark run https://github.com/thomhurst/Dekaf/actions/runs/28628601339 showed Dekaf "allocating 500x more" than Confluent in consumer benchmarks (e.g. PollSingle 1000x1000: 2272 KB vs 4.18 KB). This is a measurement artifact: Confluent.Kafka wraps librdkafka, so all of its fetch buffers, protocol handling and message payloads live in **unmanaged memory that MemoryDiagnoser cannot see**. Its 4 KB is just the marshaling cost of one message; Dekaf, being pure C#, has its entire equivalent workload counted on the managed heap. The time column tells the same story from the other side (Confluent PollSingle mean: 3,155 ms vs Dekaf 7 ms).

## What

- Reference `BenchmarkDotNet.Diagnostics.Windows`, which makes the ETW-based `NativeMemoryProfiler` available via `--profiler NativeMemory`. It adds **"Allocated native memory"** and **"Native memory leak"** columns that capture librdkafka's unmanaged allocations per operation.
- New `client-benchmarks-native-memory` job on `windows-latest` (ETW is Windows-only) running the client benchmarks with the profiler. No manual `docker run` step: `KafkaTestEnvironment` falls back to Testcontainers when `KAFKA_BOOTSTRAP_SERVERS` is unset. The run step is `continue-on-error`, so if the runner cannot start the Linux Kafka container the rest of the workflow is unaffected and the summary section simply doesn't render.
- Benchmark summary gains a "Native Memory Comparison (Windows, ETW)" section: compare Dekaf's `Allocated` against Confluent's `Allocated` + `Allocated native memory` for a fair total.
- Windows results are excluded from the Linux-based benchmark history chart so cross-OS timings don't corrupt trend data.

## Verification

- Builds clean; workflow YAML validated.
- Ran locally on Windows (elevated): `dotnet run -c Release -- --filter "*Crc32C*" --profiler NativeMemory` — ETW sessions start and per-benchmark `.etl` traces are collected and processed.

## Related

Allocation audit of the consumer fetch path filed as #1055, #1056, #1057 — the genuine (non-artifact) part of the gap.