### PR TITLE
ci(benchmarks): merge results PR with owner PAT

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -454,8 +454,13 @@ jobs:
           delete-branch: true
 
       - name: Auto-merge Pull Request
+        # NOTE: GITHUB_TOKEN / github-actions[bot] cannot merge here. The default-branch
+        # ruleset requires 19 status checks, and on a user-owned repo the bot cannot be a
+        # bypass actor. Only Admin/Maintain users can bypass, so --admin must run as a token
+        # that represents such a user. BENCHMARK_MERGE_TOKEN is a fine-grained PAT (owner)
+        # with Contents: write + Pull requests: write.
         if: steps.cpr.outputs.pull-request-number && steps.cpr.outputs.pull-request-operation != 'closed'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BENCHMARK_MERGE_TOKEN }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         run: gh pr merge "$PR_NUMBER" --squash --delete-branch --admin


### PR DESCRIPTION
## Problem

The `benchmarks.yml` **Auto-merge Pull Request** step fails with:

```
GraphQL: Repository rule violations found
19 of 19 required status checks are expected.
```

### Root cause
- The step ran `gh pr merge --admin` as `GITHUB_TOKEN` (`github-actions[bot]`).
- The default-branch "Main" ruleset requires 19 status checks; its bypass list contains only Admin + Maintain repository roles.
- `github-actions[bot]` is neither, so `--admin` cannot bypass. On a **user-owned** repo the bot *cannot* be added as a bypass actor (GitHub returns 422: `integration must be part of the ruleset source or owner organization`).
- Compounding: PRs opened by `GITHUB_TOKEN` never trigger CI, so those 19 checks stay permanently "expected".

## Fix
Change **only the merge step** to use `BENCHMARK_MERGE_TOKEN` — a fine-grained PAT representing the repo owner (Admin, `bypass: always`). The bot still opens the PR (no wasteful CI on a docs-only change); the owner-scoped token performs the `--admin` merge and bypasses the ruleset.

Secret `BENCHMARK_MERGE_TOKEN` (Contents: RW, Pull requests: RW) has been added to the repo.