### PR TITLE
fix(networking): preserve cancellation tokens

### DIFF
--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -184,6 +184,10 @@ public sealed partial class ConnectionPool : IConnectionPool
     /// Increases the shared PipeMemoryPool bucket capacity if <paramref name="bucketCapacity"/>
     /// exceeds the current value. New connections will use the larger pool; existing connections
     /// continue using the previous pool until they are recycled.
+    /// <para/>
+    /// The previous pool is not disposed during the swap because active pipes may still return
+    /// segments to it. Its lifetime is bounded by the connections that captured it: once those
+    /// connections and their in-flight pipe segments are gone, the old pool becomes GC-eligible.
     /// </summary>
     internal void RatchetPipeMemoryBucketCapacity(int bucketCapacity)
     {

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -731,6 +731,10 @@ public sealed partial class KafkaConnection : IKafkaConnection
                 {
                     pooledBuffer = await pending.AsValueTask().ConfigureAwait(false);
                 }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw new OperationCanceledException(cancellationToken);
+                }
                 catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
                     throw CreateResponseTimeoutException(TRequest.ApiKey, correlationId);
@@ -965,6 +969,10 @@ public sealed partial class KafkaConnection : IKafkaConnection
             try
             {
                 await _stream.WriteAsync(memory, timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(cancellationToken);
             }
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
@@ -1212,6 +1220,10 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
             _pendingRequestSlots.Release();
             throw new ObjectDisposedException(nameof(KafkaConnection));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(cancellationToken);
         }
         catch (OperationCanceledException) when (Volatile.Read(ref _disposed) != 0 && !cancellationToken.IsCancellationRequested)
         {
@@ -2841,6 +2853,7 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
     private ManualResetValueTaskSourceCore<PooledResponseBuffer> _core = new() { RunContinuationsAsynchronously = true };
     private short _responseHeaderVersion;
     private CancellationTokenRegistration _cancellationRegistration;
+    private CancellationToken _cancellationToken;
     private int _state; // High 16 bits = core version; low 16 bits = State*
 
     /// <summary>
@@ -2849,6 +2862,7 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
     public void Initialize(short responseHeaderVersion, CancellationToken cancellationToken, bool registerCancellation = true)
     {
         _responseHeaderVersion = responseHeaderVersion;
+        _cancellationToken = cancellationToken;
         _state = CreateState(_core.Version, StatePending);
 
         // Register for cancellation if the token can be cancelled
@@ -2866,6 +2880,7 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
     /// </summary>
     public void RegisterCancellation(CancellationToken cancellationToken)
     {
+        _cancellationToken = cancellationToken;
         var newRegistration = cancellationToken.CanBeCanceled
             ? cancellationToken.Register(
                 static state => ((PooledPendingRequest)state!).OnCancelled(),
@@ -2889,7 +2904,7 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
 
     private void OnCancelled()
     {
-        TrySetCanceled();
+        TrySetCanceled(_cancellationToken);
     }
 
     /// <summary>
@@ -2986,6 +3001,13 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
     /// Returns false if already completed.
     /// </summary>
     public bool TrySetCanceled()
+        => TrySetCanceled(_cancellationToken);
+
+    /// <summary>
+    /// Attempts to cancel the request with the token that triggered cancellation.
+    /// Returns false if already completed.
+    /// </summary>
+    public bool TrySetCanceled(CancellationToken cancellationToken)
     {
         var version = _core.Version;
         if (!TryClaimCompletion(version))
@@ -2996,7 +3018,7 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
         // Mark as completed before publishing completion; a continuation may
         // return this instance to the pool afterwards.
         Volatile.Write(ref _state, CreateState(version, StateCompleted));
-        _core.SetException(new OperationCanceledException());
+        _core.SetException(new OperationCanceledException(cancellationToken));
         return true;
     }
 
@@ -3108,6 +3130,7 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
         // Dispose cancellation registration
         _cancellationRegistration.Dispose();
         _cancellationRegistration = default;
+        _cancellationToken = default;
 
         // Reset the core for reuse
         _core.Reset();

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -161,6 +161,46 @@ public sealed class KafkaConnectionTests
 
     [Test]
     [Timeout(10_000)]
+    public async Task SendAsync_ResponseCancellation_PreservesCallerCancellationToken(CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            await using var connection = new KafkaConnection(
+                IPAddress.Loopback.ToString(),
+                port,
+                options: new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(30) });
+
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+            using var callerCancellation = new CancellationTokenSource();
+
+            var sendTask = connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                apiVersion: 3,
+                callerCancellation.Token).AsTask();
+
+            await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+            await callerCancellation.CancelAsync();
+
+            var thrown = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await sendTask.ConfigureAwait(false);
+            });
+            await Assert.That(thrown!.CancellationToken).IsEqualTo(callerCancellation.Token);
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    [Timeout(10_000)]
     public async Task IsConnected_StreamAssignedBeforeConnectionReady_ReturnsFalse(CancellationToken cancellationToken)
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);

--- a/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
@@ -145,10 +145,11 @@ public class PooledPendingRequestTests
         // Cancel before completion — callback fires synchronously
         cts.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        var thrown = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
         {
             await request.AsValueTask().ConfigureAwait(false);
         });
+        await Assert.That(thrown!.CancellationToken).IsEqualTo(cts.Token);
 
         pool.Return(request);
     }
@@ -400,10 +401,11 @@ public class PooledPendingRequestTests
         // Cancel via registered token — callback fires synchronously
         cts.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        var thrown = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
         {
             await request.AsValueTask().ConfigureAwait(false);
         });
+        await Assert.That(thrown!.CancellationToken).IsEqualTo(cts.Token);
 
         pool.Return(request);
     }
@@ -484,6 +486,7 @@ public class PooledPendingRequestTests
         });
 
         await Assert.That(thrown).IsNotNull();
+        await Assert.That(thrown!.CancellationToken).IsEqualTo(cts.Token);
 
         pool.Return(request);
     }


### PR DESCRIPTION
Closes #1048

## Summary
- preserve caller `CancellationToken` identity when `KafkaConnection` request/write/slot waits are canceled by the caller
- store the active token on pooled pending requests so cancellation completions carry the registered token
- document why ratcheted pipe memory pools are not disposed immediately and how old pool lifetime is bounded
- add public `SendAsync` and pooled pending request token identity assertions

## Test plan
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaConnectionTests/SendAsync_ResponseCancellation_PreservesCallerCancellationToken" --no-ansi --output Normal`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PooledPendingRequestTests/CancellationToken_CancelsRequest" --no-ansi --output Normal`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PooledPendingRequestTests/RegisterCancellation_CancelsRequest" --no-ansi --output Normal`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PooledPendingRequestTests/CancelAfter_WakesUpAwaitingTask" --no-ansi --output Normal`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaConnectionTests/*" --no-ansi --output Normal`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PipeMemoryPoolTests/*" --no-ansi --output Normal`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -m:1 -p:UseSharedCompilation=false`
- `git diff --check origin/main...HEAD`

Note: the full `PooledPendingRequestTests` class was attempted once and timed out after 120 seconds in this local environment; the modified tests were then run individually and passed.