### PR TITLE
fix(networking): bound cancelled queue

### DIFF
--- a/src/Dekaf/Networking/CancelledCorrelationIdTracker.cs
+++ b/src/Dekaf/Networking/CancelledCorrelationIdTracker.cs
@@ -27,6 +27,8 @@ internal sealed class CancelledCorrelationIdTracker
     public bool TryRemove(int correlationId)
         => _ids.TryRemove(correlationId, out _);
 
+    internal int QueuedCount => _order.Count;
+
     public void Clear()
     {
         _ids.Clear();
@@ -38,7 +40,7 @@ internal sealed class CancelledCorrelationIdTracker
 
     private void Trim()
     {
-        while (_ids.Count > _capacity && _order.TryDequeue(out var oldestCorrelationId))
+        while (_order.Count > _capacity && _order.TryDequeue(out var oldestCorrelationId))
         {
             _ids.TryRemove(oldestCorrelationId, out _);
         }

--- a/tests/Dekaf.Tests.Unit/Networking/CancelledCorrelationIdTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/CancelledCorrelationIdTrackerTests.cs
@@ -30,6 +30,19 @@ public sealed class CancelledCorrelationIdTrackerTests
     }
 
     [Test]
+    public async Task TryAdd_WhenIdsAreRemovedBeforeCapacity_StillBoundsQueuedEntries()
+    {
+        var tracker = new CancelledCorrelationIdTracker(capacity: 2);
+
+        for (var correlationId = 0; correlationId < 100; correlationId++)
+        {
+            await Assert.That(tracker.TryAdd(correlationId)).IsTrue();
+            await Assert.That(tracker.TryRemove(correlationId)).IsTrue();
+            await Assert.That(tracker.QueuedCount).IsLessThanOrEqualTo(2);
+        }
+    }
+
+    [Test]
     public async Task Clear_RemovesTrackedIdsAndQueuedEvictions()
     {
         var tracker = new CancelledCorrelationIdTracker(capacity: 2);


### PR DESCRIPTION
## Summary
- Bound `CancelledCorrelationIdTracker` queue retention by trimming on queued entries, not only live IDs.
- Add churn coverage for add/remove patterns where late responses remove IDs before capacity is reached.

## Root cause
#1053 replaced the old soft cap with a dictionary plus FIFO queue, but `Trim()` only ran while live IDs exceeded capacity. If late responses removed IDs quickly, live count stayed low while stale queue entries accumulated for the lifetime of the connection.

## Test plan
- `dotnet restore tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj`
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/CancelledCorrelationIdTrackerTests/*"` (4/4)
- `git diff --check`

Refs #1046
Refs #1053