### PR TITLE
perf(consumer): share response buffer pools

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -2644,12 +2644,14 @@ internal sealed class ResponseBufferPool
     /// Matches the previous static pool size (16 MB).
     /// </summary>
     internal const int DefaultMaxArrayLength = 16 * 1024 * 1024;
+    private const int SizeTierBytes = 1024 * 1024;
 
     /// <summary>
     /// Default shared instance used by producers, admin clients, and connections
     /// that don't have consumer-specific configuration.
     /// </summary>
     internal static readonly ResponseBufferPool Default = new(DefaultMaxArrayLength);
+    private static readonly ConcurrentDictionary<int, ResponseBufferPool> s_sharedPools = new();
 
     internal ArrayPool<byte> Pool { get; }
     internal int MaxArrayLength { get; }
@@ -2667,16 +2669,33 @@ internal sealed class ResponseBufferPool
     }
 
     /// <summary>
-    /// Creates a <see cref="ResponseBufferPool"/> sized for the given <c>FetchMaxBytes</c>
-    /// configuration. The pool's max array length is <c>max(fetchMaxBytes + ProtocolOverheadBytes, DefaultMaxArrayLength)</c>
-    /// so it always accommodates at least the default 16 MB.
+    /// Returns a process-shared <see cref="ResponseBufferPool"/> sized for the given
+    /// <c>FetchMaxBytes</c> configuration. The pool's max array length is rounded up to
+    /// a MiB tier after adding protocol overhead, with a minimum of <see cref="DefaultMaxArrayLength"/>.
     /// </summary>
     internal static ResponseBufferPool Create(int fetchMaxBytes)
     {
+        var maxArrayLength = ComputeMaxArrayLength(fetchMaxBytes);
+        return maxArrayLength == DefaultMaxArrayLength
+            ? Default
+            : s_sharedPools.GetOrAdd(maxArrayLength, static length => new ResponseBufferPool(length));
+    }
+
+    internal static int ComputeMaxArrayLength(int fetchMaxBytes)
+    {
         // Use long arithmetic to avoid silent overflow when fetchMaxBytes is near int.MaxValue
-        var maxArrayLength = (int)Math.Min((long)fetchMaxBytes + ProtocolOverheadBytes, int.MaxValue);
-        maxArrayLength = Math.Max(maxArrayLength, DefaultMaxArrayLength);
-        return new ResponseBufferPool(maxArrayLength);
+        var requiredLength = Math.Min((long)fetchMaxBytes + ProtocolOverheadBytes, int.MaxValue);
+        var tieredLength = RoundUpToMiBTier(requiredLength);
+        return Math.Max(tieredLength, DefaultMaxArrayLength);
+    }
+
+    private static int RoundUpToMiBTier(long value)
+    {
+        if (value >= int.MaxValue)
+            return int.MaxValue;
+
+        var rounded = ((value + SizeTierBytes - 1) / SizeTierBytes) * SizeTierBytes;
+        return rounded >= int.MaxValue ? int.MaxValue : (int)rounded;
     }
 }
 

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
@@ -19,6 +19,7 @@ public class ResponseBufferPoolTests
 
         await Assert.That(pool.MaxArrayLength)
             .IsEqualTo(ResponseBufferPool.DefaultMaxArrayLength);
+        await Assert.That(pool).IsSameReferenceAs(ResponseBufferPool.Default);
     }
 
     [Test]
@@ -43,6 +44,38 @@ public class ResponseBufferPoolTests
         var expected = fetchMaxBytes + ResponseBufferPool.ProtocolOverheadBytes;
 
         await Assert.That(pool.MaxArrayLength).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task Create_WithSameFetchMaxBytes_ReturnsSharedInstance()
+    {
+        const int fetchMaxBytes = 24 * 1024 * 1024;
+
+        var first = ResponseBufferPool.Create(fetchMaxBytes);
+        var second = ResponseBufferPool.Create(fetchMaxBytes);
+
+        await Assert.That(first).IsSameReferenceAs(second);
+    }
+
+    [Test]
+    public async Task Create_WithFetchMaxBytesInSameMiBTier_ReturnsSharedInstance()
+    {
+        const int baseFetchMaxBytes = 24 * 1024 * 1024;
+
+        var first = ResponseBufferPool.Create(baseFetchMaxBytes + 1);
+        var second = ResponseBufferPool.Create(baseFetchMaxBytes + 512 * 1024);
+
+        await Assert.That(first.MaxArrayLength).IsEqualTo(26 * 1024 * 1024);
+        await Assert.That(first).IsSameReferenceAs(second);
+    }
+
+    [Test]
+    public async Task Create_WithDifferentMiBTiers_ReturnsDifferentInstances()
+    {
+        var first = ResponseBufferPool.Create(24 * 1024 * 1024);
+        var second = ResponseBufferPool.Create(25 * 1024 * 1024);
+
+        await Assert.That(first).IsNotSameReferenceAs(second);
     }
 
     [Test]


### PR DESCRIPTION
Closes #1055

## Summary
- make `ResponseBufferPool.Create(fetchMaxBytes)` return process-shared pools instead of constructing a new pool per consumer
- bucket shared pools by MiB-rounded max response length, with small/default sizes reusing `ResponseBufferPool.Default`
- keep existing `PooledResponseBuffer` / `PooledResponseMemory` ownership and return path unchanged
- add tests for default reuse, same-size reuse, same-tier reuse, and separate larger tiers

## Test plan
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -m:1 -p:UseSharedCompilation=false`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ResponseBufferPoolTests/*" --no-ansi --output Normal`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/IncrementalFrameConsumptionTests/*" --no-ansi --output Normal`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -m:1 -p:UseSharedCompilation=false`
- `git diff --cached --check`