### PR TITLE
Split consumer API into focused facets

### DIFF
--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -50,7 +50,7 @@ consumer.Subscribe("my-topic").Pause(new TopicPartition("my-topic", 0));
 
 // After
 consumer.Subscribe("my-topic");
-consumer.Pause(new TopicPartition("my-topic", 0));
+consumer.Partitions.Pause(new TopicPartition("my-topic", 0));
 ```
 
 ## Consuming Messages
@@ -207,13 +207,13 @@ Temporarily stop consuming from specific partitions:
 
 ```csharp
 // Pause consumption from a partition
-consumer.Pause(new TopicPartition("my-topic", 0));
+consumer.Partitions.Pause(new TopicPartition("my-topic", 0));
 
 // Check what's paused
-var paused = consumer.Paused;
+var paused = consumer.Partitions.Paused;
 
 // Resume
-consumer.Resume(new TopicPartition("my-topic", 0));
+consumer.Partitions.Resume(new TopicPartition("my-topic", 0));
 ```
 
 This is useful for backpressure - if your processing can't keep up, pause some partitions.
@@ -225,7 +225,7 @@ This is useful for backpressure - if your processing can't keep up, pause some p
 IReadOnlySet<string> topics = consumer.Subscription;
 
 // Current assignment (partitions being consumed)
-IReadOnlySet<TopicPartition> partitions = consumer.Assignment;
+IReadOnlySet<TopicPartition> partitions = consumer.Partitions.Assignment;
 
 // Consumer's member ID in the group
 string? memberId = consumer.MemberId;

--- a/docs/docs/consumer/manual-assignment.md
+++ b/docs/docs/consumer/manual-assignment.md
@@ -28,7 +28,7 @@ var consumer = await Kafka.CreateConsumer<string, string>()
     .BuildAsync();
 
 // Assign specific partitions
-consumer.Assign(
+consumer.Partitions.Assign(
     new TopicPartition("my-topic", 0),
     new TopicPartition("my-topic", 1)
 );
@@ -44,10 +44,12 @@ await foreach (var msg in consumer.ConsumeAsync(ct))
 Specify where to start consuming:
 
 ```csharp
-consumer.Assign(
-    new TopicPartitionOffset("my-topic", 0, 100),  // Start at offset 100
-    new TopicPartitionOffset("my-topic", 1, 200)   // Start at offset 200
-);
+var first = new TopicPartition("my-topic", 0);
+var second = new TopicPartition("my-topic", 1);
+
+consumer.Partitions.Assign(first, second);
+consumer.Positions.Seek(new TopicPartitionOffset("my-topic", 0, 100));  // Start at offset 100
+consumer.Positions.Seek(new TopicPartitionOffset("my-topic", 1, 200));  // Start at offset 200
 ```
 
 ## Differences from Subscribe
@@ -78,9 +80,16 @@ var consumer = await Kafka.CreateConsumer<string, string>()
 // Load saved offsets from your storage
 var savedOffsets = await LoadOffsetsFromDatabaseAsync();
 
-consumer.Assign(savedOffsets.Select(o =>
-    new TopicPartitionOffset(o.Topic, o.Partition, o.Offset)
-));
+var partitions = savedOffsets
+    .Select(o => new TopicPartition(o.Topic, o.Partition))
+    .ToArray();
+
+consumer.Partitions.Assign(partitions);
+
+foreach (var offset in savedOffsets)
+{
+    consumer.Positions.Seek(new TopicPartitionOffset(offset.Topic, offset.Partition, offset.Offset));
+}
 
 await foreach (var msg in consumer.ConsumeAsync(ct))
 {
@@ -97,16 +106,16 @@ Add or remove partitions without replacing the entire assignment:
 
 ```csharp
 // Initial assignment
-consumer.Assign(new TopicPartition("my-topic", 0));
+consumer.Partitions.Assign(new TopicPartition("my-topic", 0));
 
 // Later, add partition 1
-consumer.IncrementalAssign(new[]
+consumer.Partitions.IncrementalAssign(new[]
 {
-    new TopicPartitionOffset("my-topic", 1, Offset.Beginning)
+    new TopicPartitionOffset("my-topic", 1, 0)
 });
 
 // Remove partition 0
-consumer.IncrementalUnassign(new[]
+consumer.Partitions.IncrementalUnassign(new[]
 {
     new TopicPartition("my-topic", 0)
 });
@@ -120,8 +129,8 @@ consumer.Assign(new TopicPartition("my-topic", 0))
     .SeekToBeginning(new TopicPartition("my-topic", 0));
 
 // After
-consumer.Assign(new TopicPartition("my-topic", 0));
-consumer.SeekToBeginning(new TopicPartition("my-topic", 0));
+consumer.Partitions.Assign(new TopicPartition("my-topic", 0));
+consumer.Positions.SeekToBeginning(new TopicPartition("my-topic", 0));
 ```
 
 ## Seeking
@@ -129,16 +138,16 @@ consumer.SeekToBeginning(new TopicPartition("my-topic", 0));
 With manual assignment, you can freely seek to any offset:
 
 ```csharp
-consumer.Assign(new TopicPartition("my-topic", 0));
+consumer.Partitions.Assign(new TopicPartition("my-topic", 0));
 
 // Seek to beginning
-consumer.SeekToBeginning(new TopicPartition("my-topic", 0));
+consumer.Positions.SeekToBeginning(new TopicPartition("my-topic", 0));
 
 // Seek to end
-consumer.SeekToEnd(new TopicPartition("my-topic", 0));
+consumer.Positions.SeekToEnd(new TopicPartition("my-topic", 0));
 
 // Seek to specific offset
-consumer.Seek(new TopicPartitionOffset("my-topic", 0, 12345));
+consumer.Positions.Seek(new TopicPartitionOffset("my-topic", 0, 12345));
 ```
 
 ## Unassigning
@@ -146,7 +155,7 @@ consumer.Seek(new TopicPartitionOffset("my-topic", 0, 12345));
 Remove all partition assignments:
 
 ```csharp
-consumer.Unassign();
+consumer.Partitions.Unassign();
 ```
 
 ## Complete Example: Partition Reader
@@ -170,7 +179,9 @@ public class PartitionReader
             .WithAutoOffsetReset(AutoOffsetReset.None)
             .BuildAsync();
 
-        consumer.Assign(new TopicPartitionOffset(topic, partition, startOffset));
+        var topicPartition = new TopicPartition(topic, partition);
+        consumer.Partitions.Assign(topicPartition);
+        consumer.Positions.Seek(new TopicPartitionOffset(topic, partition, startOffset));
 
         await foreach (var msg in consumer.ConsumeAsync(ct))
         {
@@ -225,9 +236,19 @@ public class MultiPartitionWorker
         }
 
         // Assign with loaded offsets
-        _consumer.Assign(partitions.Select(p =>
-            new TopicPartitionOffset(topic, p, _offsets[p])
-        ));
+        var assignedPartitions = partitions
+            .Select(p => new TopicPartition(topic, p))
+            .ToArray();
+
+        _consumer.Partitions.Assign(assignedPartitions);
+
+        foreach (var assignedPartition in assignedPartitions)
+        {
+            _consumer.Positions.Seek(new TopicPartitionOffset(
+                assignedPartition.Topic,
+                assignedPartition.Partition,
+                _offsets[assignedPartition.Partition]));
+        }
 
         // Process messages
         await foreach (var msg in _consumer.ConsumeAsync(ct))

--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -153,12 +153,12 @@ await foreach (var msg in consumer.ConsumeAsync(ct))
 
 ```csharp
 // Get committed offset for a partition
-long? committed = await consumer.GetCommittedOffsetAsync(
+long? committed = await consumer.Positions.GetCommittedOffsetAsync(
     new TopicPartition("my-topic", 0)
 );
 
 // Get current position (next offset to be consumed)
-long? position = consumer.GetPosition(new TopicPartition("my-topic", 0));
+long? position = consumer.Positions.GetPosition(new TopicPartition("my-topic", 0));
 ```
 
 ## Seeking to Offsets
@@ -167,13 +167,13 @@ Jump to a specific position:
 
 ```csharp
 // Seek to specific offset
-consumer.Seek(new TopicPartitionOffset("my-topic", 0, 100));
+consumer.Positions.Seek(new TopicPartitionOffset("my-topic", 0, 100));
 
 // Seek to beginning
-consumer.SeekToBeginning(new TopicPartition("my-topic", 0));
+consumer.Positions.SeekToBeginning(new TopicPartition("my-topic", 0));
 
 // Seek to end
-consumer.SeekToEnd(new TopicPartition("my-topic", 0));
+consumer.Positions.SeekToEnd(new TopicPartition("my-topic", 0));
 ```
 
 Seek and pause/resume operations mutate current consumer state and return `void`. Keep them as separate statements:
@@ -184,8 +184,8 @@ consumer.Seek(new TopicPartitionOffset("my-topic", 0, 100))
     .Pause(new TopicPartition("my-topic", 0));
 
 // After
-consumer.Seek(new TopicPartitionOffset("my-topic", 0, 100));
-consumer.Pause(new TopicPartition("my-topic", 0));
+consumer.Positions.Seek(new TopicPartitionOffset("my-topic", 0, 100));
+consumer.Partitions.Pause(new TopicPartition("my-topic", 0));
 ```
 
 ### Seek by Timestamp
@@ -195,14 +195,14 @@ Find offsets for a specific time:
 ```csharp
 var targetTime = DateTimeOffset.UtcNow.AddHours(-1);
 
-var offsets = await consumer.GetOffsetsForTimesAsync(new[]
+var offsets = await consumer.Offsets.GetOffsetsForTimesAsync(new[]
 {
     new TopicPartitionTimestamp("my-topic", 0, targetTime)
 });
 
 foreach (var (tp, offset) in offsets)
 {
-    consumer.Seek(new TopicPartitionOffset(tp, offset));
+    consumer.Positions.Seek(new TopicPartitionOffset(tp.Topic, tp.Partition, offset));
 }
 ```
 

--- a/src/Dekaf.Extensions.HealthChecks/DekafConsumerHealthCheck.cs
+++ b/src/Dekaf.Extensions.HealthChecks/DekafConsumerHealthCheck.cs
@@ -38,7 +38,10 @@ public sealed class DekafConsumerHealthCheck<TKey, TValue> : IHealthCheck
     {
         try
         {
-            var assignment = _consumer.Assignment;
+            var partitions = _consumer.Partitions;
+            var positions = _consumer.Positions;
+            var offsets = _consumer.Offsets;
+            var assignment = partitions.Assignment;
 
             if (assignment.Count == 0)
             {
@@ -52,7 +55,7 @@ public sealed class DekafConsumerHealthCheck<TKey, TValue> : IHealthCheck
 
             foreach (var topicPartition in assignment)
             {
-                var position = _consumer.GetPosition(topicPartition);
+                var position = positions.GetPosition(topicPartition);
 
                 if (position is not null)
                 {
@@ -72,7 +75,7 @@ public sealed class DekafConsumerHealthCheck<TKey, TValue> : IHealthCheck
             }
 
             var watermarkTasks = partitionsWithPositions
-                .Select(p => _consumer.QueryWatermarkOffsetsAsync(p.TopicPartition, timeoutCts.Token))
+                .Select(p => offsets.QueryWatermarkOffsetsAsync(p.TopicPartition, timeoutCts.Token))
                 .ToArray();
 
             var watermarkResults = await Task.WhenAll(

--- a/src/Dekaf/Consumer/ConsumerFacetExtensions.cs
+++ b/src/Dekaf/Consumer/ConsumerFacetExtensions.cs
@@ -1,0 +1,164 @@
+using Dekaf.Consumer;
+
+namespace Dekaf;
+
+/// <summary>
+/// Extension methods that forward advanced consumer operations to focused facets.
+/// </summary>
+public static class ConsumerFacetExtensions
+{
+    /// <summary>
+    /// Manually assigns partitions.
+    /// </summary>
+    public static void Assign<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        params TopicPartition[] partitions)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        consumer.Partitions.Assign(partitions);
+    }
+
+    /// <summary>
+    /// Unassigns all partitions.
+    /// </summary>
+    public static void Unassign<TKey, TValue>(this IKafkaConsumer<TKey, TValue> consumer)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        consumer.Partitions.Unassign();
+    }
+
+    /// <summary>
+    /// Incrementally adds partitions to the current assignment.
+    /// </summary>
+    public static void IncrementalAssign<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        IEnumerable<TopicPartitionOffset> partitions)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        consumer.Partitions.IncrementalAssign(partitions);
+    }
+
+    /// <summary>
+    /// Incrementally removes partitions from the current assignment.
+    /// </summary>
+    public static void IncrementalUnassign<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        IEnumerable<TopicPartition> partitions)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        consumer.Partitions.IncrementalUnassign(partitions);
+    }
+
+    /// <summary>
+    /// Gets the committed offset for a partition.
+    /// </summary>
+    public static ValueTask<long?> GetCommittedOffsetAsync<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        TopicPartition partition,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        return consumer.Positions.GetCommittedOffsetAsync(partition, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets the current position for a partition.
+    /// </summary>
+    public static long? GetPosition<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        TopicPartition partition)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        return consumer.Positions.GetPosition(partition);
+    }
+
+    /// <summary>
+    /// Seeks to a specific offset.
+    /// </summary>
+    public static void Seek<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        TopicPartitionOffset offset)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        consumer.Positions.Seek(offset);
+    }
+
+    /// <summary>
+    /// Seeks to the beginning of partitions.
+    /// </summary>
+    public static void SeekToBeginning<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        params TopicPartition[] partitions)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        consumer.Positions.SeekToBeginning(partitions);
+    }
+
+    /// <summary>
+    /// Seeks to the end of partitions.
+    /// </summary>
+    public static void SeekToEnd<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        params TopicPartition[] partitions)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        consumer.Positions.SeekToEnd(partitions);
+    }
+
+    /// <summary>
+    /// Pauses consumption from partitions.
+    /// </summary>
+    public static void Pause<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        params TopicPartition[] partitions)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        consumer.Partitions.Pause(partitions);
+    }
+
+    /// <summary>
+    /// Resumes consumption from partitions.
+    /// </summary>
+    public static void Resume<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        params TopicPartition[] partitions)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        consumer.Partitions.Resume(partitions);
+    }
+
+    /// <summary>
+    /// Looks up offsets for partitions by timestamp.
+    /// </summary>
+    public static ValueTask<IReadOnlyDictionary<TopicPartition, long>> GetOffsetsForTimesAsync<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        IEnumerable<TopicPartitionTimestamp> timestampsToSearch,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        return consumer.Offsets.GetOffsetsForTimesAsync(timestampsToSearch, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets cached watermark offsets for a partition.
+    /// </summary>
+    public static WatermarkOffsets? GetWatermarkOffsets<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        TopicPartition topicPartition)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        return consumer.Offsets.GetWatermarkOffsets(topicPartition);
+    }
+
+    /// <summary>
+    /// Queries current watermark offsets for a partition.
+    /// </summary>
+    public static ValueTask<WatermarkOffsets> QueryWatermarkOffsetsAsync<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        TopicPartition topicPartition,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        return consumer.Offsets.QueryWatermarkOffsetsAsync(topicPartition, cancellationToken);
+    }
+}

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -21,6 +21,11 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     IReadOnlySet<TopicPartition> Assignment { get; }
 
     /// <summary>
+    /// Gets the paused partitions.
+    /// </summary>
+    IReadOnlySet<TopicPartition> Paused { get; }
+
+    /// <summary>
     /// Gets the member ID if part of a consumer group.
     /// </summary>
     string? MemberId { get; }
@@ -30,6 +35,21 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Returns null if not part of a consumer group or if the group has not yet been joined.
     /// </summary>
     ConsumerGroupMetadata? ConsumerGroupMetadata { get; }
+
+    /// <summary>
+    /// Gets position and seek operations.
+    /// </summary>
+    IConsumerPositions Positions { get; }
+
+    /// <summary>
+    /// Gets assignment and pause/resume operations.
+    /// </summary>
+    IConsumerPartitions Partitions { get; }
+
+    /// <summary>
+    /// Gets offset lookup operations.
+    /// </summary>
+    IConsumerOffsets Offsets { get; }
 
     /// <summary>
     /// Subscribes to topics.
@@ -45,32 +65,6 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Unsubscribes from all topics.
     /// </summary>
     void Unsubscribe();
-
-    /// <summary>
-    /// Manually assigns partitions.
-    /// </summary>
-    void Assign(params TopicPartition[] partitions);
-
-    /// <summary>
-    /// Unassigns all partitions.
-    /// </summary>
-    void Unassign();
-
-    /// <summary>
-    /// Incrementally adds partitions to the current assignment.
-    /// Used with cooperative rebalancing (CooperativeSticky assignor).
-    /// Unlike <see cref="Assign"/>, does not replace the entire assignment.
-    /// </summary>
-    /// <param name="partitions">The partitions to add with optional starting offsets.</param>
-    void IncrementalAssign(IEnumerable<TopicPartitionOffset> partitions);
-
-    /// <summary>
-    /// Incrementally removes partitions from the current assignment.
-    /// Used with cooperative rebalancing (CooperativeSticky assignor).
-    /// Unlike <see cref="Unassign"/>, only removes the specified partitions.
-    /// </summary>
-    /// <param name="partitions">The partitions to remove.</param>
-    void IncrementalUnassign(IEnumerable<TopicPartition> partitions);
 
     /// <summary>
     /// Consumes messages as an async enumerable.
@@ -111,6 +105,32 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     ValueTask CommitAsync(IEnumerable<TopicPartitionOffset> offsets, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gracefully closes the consumer: stops background tasks (heartbeat, auto-commit, prefetch),
+    /// commits pending offsets, leaves the consumer group, and releases resources.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Optional:</b> Calling <c>CloseAsync</c> explicitly is not required.
+    /// <see cref="IAsyncDisposable.DisposeAsync"/> calls <c>CloseAsync</c> automatically if it
+    /// has not already been called. Use <c>CloseAsync</c> when you need explicit control over
+    /// close timing before disposal — for example, to observe close errors, to ensure a final
+    /// commit completes before the <c>await using</c> block exits, or to close with a specific
+    /// cancellation token.</para>
+    /// <para><b>Idempotent:</b> Safe to call multiple times. Subsequent calls after the first
+    /// return immediately with no side effects. It is also safe to call <c>DisposeAsync</c>
+    /// after <c>CloseAsync</c> — disposal will detect that close has already completed and
+    /// skip the close step.</para>
+    /// </remarks>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous close operation.</returns>
+    ValueTask CloseAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Position and seek operations for a Kafka consumer.
+/// </summary>
+public interface IConsumerPositions
+{
+    /// <summary>
     /// Gets the committed offset for a partition.
     /// </summary>
     ValueTask<long?> GetCommittedOffsetAsync(TopicPartition partition, CancellationToken cancellationToken = default);
@@ -136,6 +156,48 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Seeks to the end of partitions.
     /// </summary>
     void SeekToEnd(params TopicPartition[] partitions);
+}
+
+/// <summary>
+/// Assignment and pause/resume operations for a Kafka consumer.
+/// </summary>
+public interface IConsumerPartitions
+{
+    /// <summary>
+    /// Gets the current assignment.
+    /// </summary>
+    IReadOnlySet<TopicPartition> Assignment { get; }
+
+    /// <summary>
+    /// Gets the paused partitions.
+    /// </summary>
+    IReadOnlySet<TopicPartition> Paused { get; }
+
+    /// <summary>
+    /// Manually assigns partitions.
+    /// </summary>
+    void Assign(params TopicPartition[] partitions);
+
+    /// <summary>
+    /// Unassigns all partitions.
+    /// </summary>
+    void Unassign();
+
+    /// <summary>
+    /// Incrementally adds partitions to the current assignment.
+    /// Used with cooperative rebalancing (CooperativeSticky assignor).
+    /// Unlike <see cref="Assign"/>, does not replace the entire assignment.
+    /// </summary>
+    /// <param name="partitions">The partitions to add with optional starting offsets.</param>
+    void IncrementalAssign(IEnumerable<TopicPartitionOffset> partitions);
+
+    /// <summary>
+    /// Incrementally removes partitions from the current assignment.
+    /// Used with cooperative rebalancing (CooperativeSticky assignor).
+    /// Unlike <see cref="Unassign"/>, only removes the specified partitions.
+    /// </summary>
+    /// <param name="partitions">The partitions to remove.</param>
+    void IncrementalUnassign(IEnumerable<TopicPartition> partitions);
 
     /// <summary>
     /// Pauses consumption from partitions.
@@ -146,32 +208,13 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Resumes consumption from partitions.
     /// </summary>
     void Resume(params TopicPartition[] partitions);
+}
 
-    /// <summary>
-    /// Gets the paused partitions.
-    /// </summary>
-    IReadOnlySet<TopicPartition> Paused { get; }
-
-    /// <summary>
-    /// Gracefully closes the consumer: stops background tasks (heartbeat, auto-commit, prefetch),
-    /// commits pending offsets, leaves the consumer group, and releases resources.
-    /// </summary>
-    /// <remarks>
-    /// <para><b>Optional:</b> Calling <c>CloseAsync</c> explicitly is not required.
-    /// <see cref="IAsyncDisposable.DisposeAsync"/> calls <c>CloseAsync</c> automatically if it
-    /// has not already been called. Use <c>CloseAsync</c> when you need explicit control over
-    /// close timing before disposal — for example, to observe close errors, to ensure a final
-    /// commit completes before the <c>await using</c> block exits, or to close with a specific
-    /// cancellation token.</para>
-    /// <para><b>Idempotent:</b> Safe to call multiple times. Subsequent calls after the first
-    /// return immediately with no side effects. It is also safe to call <c>DisposeAsync</c>
-    /// after <c>CloseAsync</c> — disposal will detect that close has already completed and
-    /// skip the close step.</para>
-    /// </remarks>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A task representing the asynchronous close operation.</returns>
-    ValueTask CloseAsync(CancellationToken cancellationToken = default);
-
+/// <summary>
+/// Offset lookup operations for a Kafka consumer.
+/// </summary>
+public interface IConsumerOffsets
+{
     /// <summary>
     /// Look up the offsets for the given partitions by timestamp.
     /// The returned offset for each partition is the earliest offset whose timestamp is greater than or equal to the given timestamp.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -463,7 +463,13 @@ internal sealed class PendingFetchData : IDisposable
 /// </remarks>
 /// <typeparam name="TKey">Key type.</typeparam>
 /// <typeparam name="TValue">Value type.</typeparam>
-public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, TValue>, DeadLetter.IRawRecordAccessor, IBudgetedInstance
+public sealed partial class KafkaConsumer<TKey, TValue> :
+    IKafkaConsumer<TKey, TValue>,
+    IConsumerPositions,
+    IConsumerPartitions,
+    IConsumerOffsets,
+    DeadLetter.IRawRecordAccessor,
+    IBudgetedInstance
 {
     /// <summary>
     /// Delay in milliseconds when all assigned partitions are paused, to prevent
@@ -771,6 +777,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     public IReadOnlySet<TopicPartition> Assignment => _assignmentSnapshot;
     public string? MemberId => _coordinator?.MemberId;
     public IReadOnlySet<TopicPartition> Paused => _pausedSnapshot;
+    public IConsumerPositions Positions => this;
+    public IConsumerPartitions Partitions => this;
+    public IConsumerOffsets Offsets => this;
+
     /// <summary>
     /// Forces the coordinator to rejoin the group on the next <see cref="EnsureAssignmentAsync"/> call.
     /// No-op when the consumer has no group coordinator (manual assignment mode).

--- a/tests/Dekaf.Tests.Unit/Extensions/HealthCheckTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/HealthCheckTests.cs
@@ -17,8 +17,8 @@ public class HealthCheckTests
     [Test]
     public async Task ConsumerHealthCheck_NoAssignment_ReturnsUnhealthy()
     {
-        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
-        consumer.Assignment.Returns(new HashSet<TopicPartition>());
+        var consumer = CreateConsumerSubstitute(out var partitions, out _, out _);
+        partitions.Assignment.Returns(new HashSet<TopicPartition>());
 
         var healthCheck = new DekafConsumerHealthCheck<string, string>(
             consumer, new DekafConsumerHealthCheckOptions());
@@ -32,11 +32,11 @@ public class HealthCheckTests
     [Test]
     public async Task ConsumerHealthCheck_LowLag_ReturnsHealthy()
     {
-        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var consumer = CreateConsumerSubstitute(out var partitions, out var positions, out var offsets);
         var tp = new TopicPartition("test-topic", 0);
-        consumer.Assignment.Returns(new HashSet<TopicPartition> { tp });
-        consumer.GetPosition(tp).Returns(90L);
-        consumer.QueryWatermarkOffsetsAsync(tp, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 100));
+        partitions.Assignment.Returns(new HashSet<TopicPartition> { tp });
+        positions.GetPosition(tp).Returns(90L);
+        offsets.QueryWatermarkOffsetsAsync(tp, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 100));
 
         var healthCheck = new DekafConsumerHealthCheck<string, string>(
             consumer, new DekafConsumerHealthCheckOptions());
@@ -50,11 +50,11 @@ public class HealthCheckTests
     [Test]
     public async Task ConsumerHealthCheck_ModerateLag_ReturnsDegraded()
     {
-        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var consumer = CreateConsumerSubstitute(out var partitions, out var positions, out var offsets);
         var tp = new TopicPartition("test-topic", 0);
-        consumer.Assignment.Returns(new HashSet<TopicPartition> { tp });
-        consumer.GetPosition(tp).Returns(0L);
-        consumer.QueryWatermarkOffsetsAsync(tp, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 5000));
+        partitions.Assignment.Returns(new HashSet<TopicPartition> { tp });
+        positions.GetPosition(tp).Returns(0L);
+        offsets.QueryWatermarkOffsetsAsync(tp, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 5000));
 
         var options = new DekafConsumerHealthCheckOptions
         {
@@ -73,11 +73,11 @@ public class HealthCheckTests
     [Test]
     public async Task ConsumerHealthCheck_HighLag_ReturnsUnhealthy()
     {
-        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var consumer = CreateConsumerSubstitute(out var partitions, out var positions, out var offsets);
         var tp = new TopicPartition("test-topic", 0);
-        consumer.Assignment.Returns(new HashSet<TopicPartition> { tp });
-        consumer.GetPosition(tp).Returns(0L);
-        consumer.QueryWatermarkOffsetsAsync(tp, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 50000));
+        partitions.Assignment.Returns(new HashSet<TopicPartition> { tp });
+        positions.GetPosition(tp).Returns(0L);
+        offsets.QueryWatermarkOffsetsAsync(tp, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 50000));
 
         var options = new DekafConsumerHealthCheckOptions
         {
@@ -96,14 +96,14 @@ public class HealthCheckTests
     [Test]
     public async Task ConsumerHealthCheck_MultiplePartitions_ReportsMaxLag()
     {
-        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var consumer = CreateConsumerSubstitute(out var partitions, out var positions, out var offsets);
         var tp0 = new TopicPartition("test-topic", 0);
         var tp1 = new TopicPartition("test-topic", 1);
-        consumer.Assignment.Returns(new HashSet<TopicPartition> { tp0, tp1 });
-        consumer.GetPosition(tp0).Returns(90L);
-        consumer.QueryWatermarkOffsetsAsync(tp0, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 100));
-        consumer.GetPosition(tp1).Returns(0L);
-        consumer.QueryWatermarkOffsetsAsync(tp1, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 2000));
+        partitions.Assignment.Returns(new HashSet<TopicPartition> { tp0, tp1 });
+        positions.GetPosition(tp0).Returns(90L);
+        offsets.QueryWatermarkOffsetsAsync(tp0, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 100));
+        positions.GetPosition(tp1).Returns(0L);
+        offsets.QueryWatermarkOffsetsAsync(tp1, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 2000));
 
         var options = new DekafConsumerHealthCheckOptions
         {
@@ -122,13 +122,13 @@ public class HealthCheckTests
     [Test]
     public async Task ConsumerHealthCheck_NullPosition_SkipsPartition()
     {
-        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var consumer = CreateConsumerSubstitute(out var partitions, out var positions, out var offsets);
         var tp0 = new TopicPartition("test-topic", 0);
         var tp1 = new TopicPartition("test-topic", 1);
-        consumer.Assignment.Returns(new HashSet<TopicPartition> { tp0, tp1 });
-        consumer.GetPosition(tp0).Returns((long?)null);
-        consumer.GetPosition(tp1).Returns(95L);
-        consumer.QueryWatermarkOffsetsAsync(tp1, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 100));
+        partitions.Assignment.Returns(new HashSet<TopicPartition> { tp0, tp1 });
+        positions.GetPosition(tp0).Returns((long?)null);
+        positions.GetPosition(tp1).Returns(95L);
+        offsets.QueryWatermarkOffsetsAsync(tp1, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 100));
 
         var healthCheck = new DekafConsumerHealthCheck<string, string>(
             consumer, new DekafConsumerHealthCheckOptions());
@@ -142,12 +142,12 @@ public class HealthCheckTests
     [Test]
     public async Task ConsumerHealthCheck_AllNullPositions_ReturnsDegraded()
     {
-        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var consumer = CreateConsumerSubstitute(out var partitions, out var positions, out _);
         var tp0 = new TopicPartition("test-topic", 0);
         var tp1 = new TopicPartition("test-topic", 1);
-        consumer.Assignment.Returns(new HashSet<TopicPartition> { tp0, tp1 });
-        consumer.GetPosition(tp0).Returns((long?)null);
-        consumer.GetPosition(tp1).Returns((long?)null);
+        partitions.Assignment.Returns(new HashSet<TopicPartition> { tp0, tp1 });
+        positions.GetPosition(tp0).Returns((long?)null);
+        positions.GetPosition(tp1).Returns((long?)null);
 
         var healthCheck = new DekafConsumerHealthCheck<string, string>(
             consumer, new DekafConsumerHealthCheckOptions());
@@ -163,11 +163,11 @@ public class HealthCheckTests
     [Test]
     public async Task ConsumerHealthCheck_TimesOut_ReturnsUnhealthy()
     {
-        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var consumer = CreateConsumerSubstitute(out var partitions, out var positions, out var offsets);
         var tp = new TopicPartition("test-topic", 0);
-        consumer.Assignment.Returns(new HashSet<TopicPartition> { tp });
-        consumer.GetPosition(tp).Returns(90L);
-        consumer.QueryWatermarkOffsetsAsync(tp, Arg.Any<CancellationToken>())
+        partitions.Assignment.Returns(new HashSet<TopicPartition> { tp });
+        positions.GetPosition(tp).Returns(90L);
+        offsets.QueryWatermarkOffsetsAsync(tp, Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
                 var token = callInfo.Arg<CancellationToken>();
@@ -192,8 +192,8 @@ public class HealthCheckTests
     [Test]
     public async Task ConsumerHealthCheck_ExceptionThrown_ReturnsUnhealthy()
     {
-        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
-        consumer.Assignment.Throws(new InvalidOperationException("Consumer disposed"));
+        var consumer = CreateConsumerSubstitute(out var partitions, out _, out _);
+        partitions.Assignment.Throws(new InvalidOperationException("Consumer disposed"));
 
         var healthCheck = new DekafConsumerHealthCheck<string, string>(
             consumer, new DekafConsumerHealthCheckOptions());
@@ -207,11 +207,11 @@ public class HealthCheckTests
     [Test]
     public async Task ConsumerHealthCheck_NegativeLag_ClampsToZero()
     {
-        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var consumer = CreateConsumerSubstitute(out var partitions, out var positions, out var offsets);
         var tp = new TopicPartition("test-topic", 0);
-        consumer.Assignment.Returns(new HashSet<TopicPartition> { tp });
-        consumer.GetPosition(tp).Returns(200L);
-        consumer.QueryWatermarkOffsetsAsync(tp, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 100));
+        partitions.Assignment.Returns(new HashSet<TopicPartition> { tp });
+        positions.GetPosition(tp).Returns(200L);
+        offsets.QueryWatermarkOffsetsAsync(tp, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 100));
 
         var healthCheck = new DekafConsumerHealthCheck<string, string>(
             consumer, new DekafConsumerHealthCheckOptions());
@@ -271,16 +271,16 @@ public class HealthCheckTests
     [Test]
     public async Task ConsumerHealthCheck_PartialNullPositions_ReportsBothPartitionCounts()
     {
-        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var consumer = CreateConsumerSubstitute(out var partitions, out var positions, out var offsets);
         var tp0 = new TopicPartition("test-topic", 0);
         var tp1 = new TopicPartition("test-topic", 1);
         var tp2 = new TopicPartition("test-topic", 2);
-        consumer.Assignment.Returns(new HashSet<TopicPartition> { tp0, tp1, tp2 });
-        consumer.GetPosition(tp0).Returns(90L);
-        consumer.GetPosition(tp1).Returns((long?)null);
-        consumer.GetPosition(tp2).Returns(95L);
-        consumer.QueryWatermarkOffsetsAsync(tp0, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 100));
-        consumer.QueryWatermarkOffsetsAsync(tp2, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 100));
+        partitions.Assignment.Returns(new HashSet<TopicPartition> { tp0, tp1, tp2 });
+        positions.GetPosition(tp0).Returns(90L);
+        positions.GetPosition(tp1).Returns((long?)null);
+        positions.GetPosition(tp2).Returns(95L);
+        offsets.QueryWatermarkOffsetsAsync(tp0, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 100));
+        offsets.QueryWatermarkOffsetsAsync(tp2, Arg.Any<CancellationToken>()).Returns(new WatermarkOffsets(0, 100));
 
         var healthCheck = new DekafConsumerHealthCheck<string, string>(
             consumer, new DekafConsumerHealthCheckOptions());
@@ -624,6 +624,23 @@ public class HealthCheckTests
     #endregion
 
     #region Helpers
+
+    private static IKafkaConsumer<string, string> CreateConsumerSubstitute(
+        out IConsumerPartitions partitions,
+        out IConsumerPositions positions,
+        out IConsumerOffsets offsets)
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        partitions = Substitute.For<IConsumerPartitions>();
+        positions = Substitute.For<IConsumerPositions>();
+        offsets = Substitute.For<IConsumerOffsets>();
+
+        consumer.Partitions.Returns(partitions);
+        consumer.Positions.Returns(positions);
+        consumer.Offsets.Returns(offsets);
+
+        return consumer;
+    }
 
     private static HealthCheckContext CreateContext()
     {


### PR DESCRIPTION
## Summary
- add `Positions`, `Partitions`, and `Offsets` facets to `IKafkaConsumer<TKey, TValue>`
- keep root-namespace compatibility extension methods for existing advanced consumer calls
- update health checks/tests and consumer docs to use facet access

## Test plan
- [x] `dotnet build Dekaf.sln --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- [x] `npm run build` in `docs`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Extensions/HealthCheckTests/ConsumerHealthCheck_*"`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter "/*/Dekaf.Tests.Unit.Consumer/ConsumerInitializationTests/*|/*/Dekaf.Tests.Unit.Consumer/PatternSubscriptionTests/*"`
- [ ] Full unit suite: 3724/3727 passed; 3 unrelated `BrokerSenderSendLoopTests` timed out locally

Closes #1011
