### PR TITLE
perf(consumer): avoid prefetch task boxing

### DIFF
--- a/src/Dekaf/Consumer/PrefetchPipelineRunner.cs
+++ b/src/Dekaf/Consumer/PrefetchPipelineRunner.cs
@@ -46,7 +46,8 @@ internal sealed class PrefetchPipelineRunner
     private readonly Action<Exception?>? _onComplete;
     private readonly int _pipelineDepth;
     private readonly Action<int, int>? _onIterationComplete;
-    private readonly Queue<Task> _inFlightQueue = new();
+    // Queued ValueTasks are awaited exactly once by the drain helpers.
+    private readonly Queue<ValueTask> _inFlightQueue;
 
     /// <summary>
     /// The number of currently in-flight prefetch tasks. Exposed for testing.
@@ -104,6 +105,7 @@ internal sealed class PrefetchPipelineRunner
         _onComplete = onComplete;
         _pipelineDepth = pipelineDepth;
         _onIterationComplete = onIterationComplete;
+        _inFlightQueue = new Queue<ValueTask>(Math.Max(pipelineDepth - 1, 0));
     }
 
     /// <summary>
@@ -176,7 +178,7 @@ internal sealed class PrefetchPipelineRunner
                         && currentPrefetchedBytes < maxBytes
                         && !cancellationToken.IsCancellationRequested)
                     {
-                        _inFlightQueue.Enqueue(_prefetchRecords(cancellationToken).AsTask());
+                        _inFlightQueue.Enqueue(_prefetchRecords(cancellationToken));
 
                         // Fast-drain completed fetches and refill: if the oldest in-flight fetch
                         // already completed (e.g., fast empty response), drain it immediately
@@ -194,7 +196,7 @@ internal sealed class PrefetchPipelineRunner
                             if (currentPrefetchedBytes >= maxBytes)
                                 break;
 
-                            _inFlightQueue.Enqueue(_prefetchRecords(cancellationToken).AsTask());
+                            _inFlightQueue.Enqueue(_prefetchRecords(cancellationToken));
                         }
                     }
 


### PR DESCRIPTION
## Summary
- store in-flight prefetch operations as ValueTask instead of Task
- remove hot-path ValueTask.AsTask() conversions in PrefetchPipelineRunner
- pre-size the in-flight queue to the configured eager pipeline depth

## Validation
- dotnet restore Dekaf.sln
- dotnet build Dekaf.sln -c Release --no-restore
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/PrefetchPipelineRunnerTests/*" --disable-logo --no-progress --minimum-expected-tests 1
- verified no AsTask() remains in src\Dekaf\Consumer\PrefetchPipelineRunner.cs

Closes #1057