### PR TITLE
feat(producer)!: drop message factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ Need to send a bunch of messages? `ProduceAllAsync` handles the tricky `ValueTas
 ```csharp
 var messages = new[]
 {
-    ProducerMessage<string, string>.Create("orders", "order-1", orderJson1),
-    ProducerMessage<string, string>.Create("orders", "order-2", orderJson2),
-    ProducerMessage<string, string>.Create("orders", "order-3", orderJson3),
+    new ProducerMessage<string, string> { Topic = "orders", Key = "order-1", Value = orderJson1 },
+    new ProducerMessage<string, string> { Topic = "orders", Key = "order-2", Value = orderJson2 },
+    new ProducerMessage<string, string> { Topic = "orders", Key = "order-3", Value = orderJson3 },
 };
 
 var results = await producer.ProduceAllAsync(messages);

--- a/docs/docs/producer/basics.md
+++ b/docs/docs/producer/basics.md
@@ -62,13 +62,6 @@ var message = new ProducerMessage<string, string>
 await producer.ProduceAsync(message);
 ```
 
-Or use the factory method:
-
-```csharp
-var message = ProducerMessage<string, string>.Create("my-topic", "key", "value");
-await producer.ProduceAsync(message);
-```
-
 ## Delivery Guarantees (Acks)
 
 The `Acks` setting controls when the broker considers a message "delivered":

--- a/docs/docs/producer/batch-production.md
+++ b/docs/docs/producer/batch-production.md
@@ -30,9 +30,9 @@ var results = await producer.ProduceAllAsync(messages);
 ```csharp
 var messages = new[]
 {
-    ProducerMessage<string, string>.Create("orders", "order-1", orderJson1),
-    ProducerMessage<string, string>.Create("orders", "order-2", orderJson2),
-    ProducerMessage<string, string>.Create("orders", "order-3", orderJson3),
+    new ProducerMessage<string, string> { Topic = "orders", Key = "order-1", Value = orderJson1 },
+    new ProducerMessage<string, string> { Topic = "orders", Key = "order-2", Value = orderJson2 },
+    new ProducerMessage<string, string> { Topic = "orders", Key = "order-3", Value = orderJson3 },
 };
 
 var results = await producer.ProduceAllAsync(messages);
@@ -67,7 +67,12 @@ Works with any `IEnumerable`:
 var orders = await GetPendingOrdersAsync();
 
 var messages = orders.Select(order =>
-    ProducerMessage<string, string>.Create("orders", order.Id, JsonSerializer.Serialize(order))
+    new ProducerMessage<string, string>
+    {
+        Topic = "orders",
+        Key = order.Id,
+        Value = JsonSerializer.Serialize(order)
+    }
 );
 
 var results = await producer.ProduceAllAsync(messages);
@@ -172,14 +177,15 @@ Here's a complete example processing a batch of orders:
 ```csharp
 public async Task ProcessOrderBatchAsync(IReadOnlyList<Order> orders)
 {
-    var messages = orders.Select(order => ProducerMessage<string, Order>.Create(
-        topic: "orders",
-        key: order.Id,
-        value: order,
-        headers: Headers.Create()
+    var messages = orders.Select(order => new ProducerMessage<string, Order>
+    {
+        Topic = "orders",
+        Key = order.Id,
+        Value = order,
+        Headers = Headers.Create()
             .Add("source", "batch-processor")
             .Add("batch-size", orders.Count.ToString())
-    )).ToList();
+    }).ToList();
 
     try
     {

--- a/docs/docs/producer/fire-and-forget.md
+++ b/docs/docs/producer/fire-and-forget.md
@@ -60,7 +60,7 @@ If you need to know about delivery success/failure without blocking, use the cal
 
 ```csharp
 producer.Produce(
-    ProducerMessage<string, string>.Create("orders", orderId, orderJson),
+    new ProducerMessage<string, string> { Topic = "orders", Key = orderId, Value = orderJson },
     (metadata, error) =>
     {
         if (error != null)

--- a/docs/docs/producer/partitioning.md
+++ b/docs/docs/producer/partitioning.md
@@ -47,17 +47,6 @@ var message = new ProducerMessage<string, string>
 await producer.ProduceAsync(message);
 ```
 
-Or using the factory method:
-
-```csharp
-var message = ProducerMessage<string, string>.Create(
-    topic: "events",
-    partition: 2,
-    key: "key",
-    value: "value"
-);
-```
-
 :::warning
 Using explicit partitions couples your code to the topic's partition count. If the topic is re-partitioned, your code may break.
 :::

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -221,55 +221,6 @@ public sealed record ProducerMessage<TKey, TValue>
     /// Optional timestamp. If not set, current time will be used.
     /// </summary>
     public DateTimeOffset? Timestamp { get; init; }
-
-    /// <summary>
-    /// Creates a new producer message with a null key.
-    /// </summary>
-    /// <param name="topic">The topic to produce to.</param>
-    /// <param name="value">The message value.</param>
-    /// <returns>A new producer message with a null key.</returns>
-#pragma warning disable CA1000 // Do not declare static members on generic types - factory method pattern
-    public static ProducerMessage<TKey, TValue> Create(string topic, TValue value)
-#pragma warning restore CA1000
-        => new() { Topic = topic, Value = value };
-
-    /// <summary>
-    /// Creates a new producer message.
-    /// </summary>
-    /// <param name="topic">The topic to produce to.</param>
-    /// <param name="key">The message key (can be null).</param>
-    /// <param name="value">The message value.</param>
-    /// <returns>A new producer message.</returns>
-#pragma warning disable CA1000 // Do not declare static members on generic types - factory method pattern
-    public static ProducerMessage<TKey, TValue> Create(string topic, TKey? key, TValue value)
-#pragma warning restore CA1000
-        => new() { Topic = topic, Key = key, Value = value };
-
-    /// <summary>
-    /// Creates a new producer message with headers.
-    /// </summary>
-    /// <param name="topic">The topic to produce to.</param>
-    /// <param name="key">The message key (can be null).</param>
-    /// <param name="value">The message value.</param>
-    /// <param name="headers">The message headers.</param>
-    /// <returns>A new producer message.</returns>
-#pragma warning disable CA1000 // Do not declare static members on generic types - factory method pattern
-    public static ProducerMessage<TKey, TValue> Create(string topic, TKey? key, TValue value, Headers headers)
-#pragma warning restore CA1000
-        => new() { Topic = topic, Key = key, Value = value, Headers = headers };
-
-    /// <summary>
-    /// Creates a new producer message with a specific partition.
-    /// </summary>
-    /// <param name="topic">The topic to produce to.</param>
-    /// <param name="partition">The partition to produce to.</param>
-    /// <param name="key">The message key (can be null).</param>
-    /// <param name="value">The message value.</param>
-    /// <returns>A new producer message.</returns>
-#pragma warning disable CA1000 // Do not declare static members on generic types - factory method pattern
-    public static ProducerMessage<TKey, TValue> Create(string topic, int partition, TKey? key, TValue value)
-#pragma warning restore CA1000
-        => new() { Topic = topic, Partition = partition, Key = key, Value = value };
 }
 
 /// <summary>

--- a/tests/Dekaf.Tests.Integration/RealWorld/ConvenienceApiTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/ConvenienceApiTests.cs
@@ -165,7 +165,7 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
     }
 
     [Test]
-    public async Task ProducerMessage_Create_TopicAndValueOnly()
+    public async Task ProducerMessage_Init_TopicAndValueOnly()
     {
         // Simplest message creation - no key
         var topic = await KafkaContainer.CreateTestTopicAsync();
@@ -175,7 +175,7 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        var message = ProducerMessage<string, string>.Create(topic, "keyless-value");
+        var message = new ProducerMessage<string, string> { Topic = topic, Value = "keyless-value" };
         var metadata = await producer.ProduceAsync(message, CancellationToken.None);
 
         await Assert.That(metadata.Topic).IsEqualTo(topic);
@@ -197,7 +197,7 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
     }
 
     [Test]
-    public async Task ProducerMessage_Create_WithKeyAndValue()
+    public async Task ProducerMessage_Init_WithKeyAndValue()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();
 
@@ -206,7 +206,7 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        var message = ProducerMessage<string, string>.Create(topic, "my-key", "my-value");
+        var message = new ProducerMessage<string, string> { Topic = topic, Key = "my-key", Value = "my-value" };
         var metadata = await producer.ProduceAsync(message, CancellationToken.None);
 
         await Assert.That(metadata.Topic).IsEqualTo(topic);
@@ -228,7 +228,7 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
     }
 
     [Test]
-    public async Task ProducerMessage_Create_WithHeaders()
+    public async Task ProducerMessage_Init_WithHeaders()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();
 
@@ -238,7 +238,13 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
             .BuildAsync();
 
         var headers = new Headers { { "source", "test" } };
-        var message = ProducerMessage<string, string>.Create(topic, "key", "value", headers);
+        var message = new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key",
+            Value = "value",
+            Headers = headers
+        };
         await producer.FireAsync(message);
 
         await producer.FlushWithTimeoutAsync();

--- a/tests/Dekaf.Tests.Unit/ApiImprovementsTests.cs
+++ b/tests/Dekaf.Tests.Unit/ApiImprovementsTests.cs
@@ -5,62 +5,11 @@ using Dekaf.Serialization;
 namespace Dekaf.Tests.Unit;
 
 /// <summary>
-/// Tests for the API improvements: ProducerMessage.Create, Headers convenience methods,
-/// configuration presets, and consumer extensions.
+/// Tests for the API improvements: Headers convenience methods, configuration presets,
+/// and consumer extensions.
 /// </summary>
 public class ApiImprovementsTests
 {
-    #region ProducerMessage.Create Tests
-
-    [Test]
-    public async Task ProducerMessage_Create_WithTopicKeyValue_SetsProperties()
-    {
-        var message = ProducerMessage<string, string>.Create("my-topic", "my-key", "my-value");
-
-        await Assert.That(message.Topic).IsEqualTo("my-topic");
-        await Assert.That(message.Key).IsEqualTo("my-key");
-        await Assert.That(message.Value).IsEqualTo("my-value");
-        await Assert.That(message.Headers).IsNull();
-        await Assert.That(message.Partition).IsNull();
-        await Assert.That(message.Timestamp).IsNull();
-    }
-
-    [Test]
-    public async Task ProducerMessage_Create_WithNullKey_SetsKeyToNull()
-    {
-        var message = ProducerMessage<string, string>.Create("my-topic", null, "my-value");
-
-        await Assert.That(message.Topic).IsEqualTo("my-topic");
-        await Assert.That(message.Key).IsNull();
-        await Assert.That(message.Value).IsEqualTo("my-value");
-    }
-
-    [Test]
-    public async Task ProducerMessage_Create_WithHeaders_SetsHeaders()
-    {
-        var headers = Headers.Create().Add("key1", "value1");
-        var message = ProducerMessage<string, string>.Create("my-topic", "my-key", "my-value", headers);
-
-        await Assert.That(message.Topic).IsEqualTo("my-topic");
-        await Assert.That(message.Key).IsEqualTo("my-key");
-        await Assert.That(message.Value).IsEqualTo("my-value");
-        await Assert.That(message.Headers).IsNotNull();
-        await Assert.That(message.Headers!.Count).IsEqualTo(1);
-    }
-
-    [Test]
-    public async Task ProducerMessage_Create_WithPartition_SetsPartition()
-    {
-        var message = ProducerMessage<string, string>.Create("my-topic", 3, "my-key", "my-value");
-
-        await Assert.That(message.Topic).IsEqualTo("my-topic");
-        await Assert.That(message.Partition).IsEqualTo(3);
-        await Assert.That(message.Key).IsEqualTo("my-key");
-        await Assert.That(message.Value).IsEqualTo("my-value");
-    }
-
-    #endregion
-
     #region Headers Factory and Convenience Method Tests
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -46,7 +46,7 @@ public class KafkaProducerFastPathTests
         {
             var innerResult = InvokeTryProduceSyncCore(
                 producer,
-                ProducerMessage<string, string>.Create(Topic, "inner", "inner-value"),
+                new ProducerMessage<string, string> { Topic = Topic, Key = "inner", Value = "inner-value" },
                 topicInfo,
                 innerCompletion);
 
@@ -56,7 +56,7 @@ public class KafkaProducerFastPathTests
 
         var outerResult = InvokeTryProduceSyncCore(
             producer,
-            ProducerMessage<string, string>.Create(Topic, "outer", "outer-value"),
+            new ProducerMessage<string, string> { Topic = Topic, Key = "outer", Value = "outer-value" },
             topicInfo,
             outerCompletion);
 

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerMessageTests.cs
@@ -5,61 +5,32 @@ namespace Dekaf.Tests.Unit.Producer;
 
 public class ProducerMessageTests
 {
-    #region Create Factory Method Tests
+    #region Init Property Tests
 
     [Test]
-    public async Task Create_WithTopicKeyValue_SetsProperties()
+    public async Task Init_WithTopicKeyValue_SetsProperties()
     {
-        var message = ProducerMessage<string, string>.Create("my-topic", "key", "value");
-        await Assert.That(message.Topic).IsEqualTo("my-topic");
+        var message = new ProducerMessage<string, string> { Topic = "topic", Key = "key", Value = "value" };
+        await Assert.That(message.Topic).IsEqualTo("topic");
         await Assert.That(message.Key).IsEqualTo("key");
         await Assert.That(message.Value).IsEqualTo("value");
     }
 
     [Test]
-    public async Task Create_WithTopicKeyValue_DefaultsAreNull()
+    public async Task Init_WithTopicKeyValue_DefaultsAreNull()
     {
-        var message = ProducerMessage<string, string>.Create("my-topic", "key", "value");
+        var message = new ProducerMessage<string, string> { Topic = "topic", Key = "key", Value = "value" };
         await Assert.That(message.Partition).IsNull();
         await Assert.That(message.Timestamp).IsNull();
         await Assert.That(message.Headers).IsNull();
     }
 
     [Test]
-    public async Task Create_WithNullKey_Succeeds()
+    public async Task Init_WithNullKey_Succeeds()
     {
-        var message = ProducerMessage<string, string>.Create("my-topic", null, "value");
+        var message = new ProducerMessage<string, string> { Topic = "topic", Key = null, Value = "value" };
         await Assert.That(message.Key).IsNull();
         await Assert.That(message.Value).IsEqualTo("value");
-    }
-
-    [Test]
-    public async Task Create_WithHeaders_SetsHeaders()
-    {
-        var headers = new Headers().Add("h1", "v1");
-        var message = ProducerMessage<string, string>.Create("my-topic", "key", "value", headers);
-        await Assert.That(message.Headers).IsSameReferenceAs(headers);
-    }
-
-    [Test]
-    public async Task Create_WithPartition_SetsPartition()
-    {
-        var message = ProducerMessage<string, string>.Create("my-topic", 5, "key", "value");
-        await Assert.That(message.Partition).IsEqualTo(5);
-        await Assert.That(message.Topic).IsEqualTo("my-topic");
-        await Assert.That(message.Key).IsEqualTo("key");
-        await Assert.That(message.Value).IsEqualTo("value");
-    }
-
-    #endregion
-
-    #region Init Property Tests
-
-    [Test]
-    public async Task Topic_IsRequired()
-    {
-        var message = new ProducerMessage<string, string> { Topic = "topic", Value = "value" };
-        await Assert.That(message.Topic).IsEqualTo("topic");
     }
 
     [Test]
@@ -118,9 +89,9 @@ public class ProducerMessageTests
     #region Int Key Type Tests
 
     [Test]
-    public async Task Create_WithIntKey_SetsProperties()
+    public async Task Init_WithIntKey_SetsProperties()
     {
-        var message = ProducerMessage<int, string>.Create("topic", 42, "value");
+        var message = new ProducerMessage<int, string> { Topic = "topic", Key = 42, Value = "value" };
         await Assert.That(message.Key).IsEqualTo(42);
         await Assert.That(message.Value).IsEqualTo("value");
     }


### PR DESCRIPTION
## Summary
- remove the redundant ProducerMessage<TKey,TValue>.Create factory overloads
- update tests to use required/init object initializers
- replace README and producer docs examples that used ProducerMessage.Create

## Validation
- dotnet restore Dekaf.sln
- dotnet build Dekaf.sln -c Release --no-restore
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/ProducerMessageTests/*" --disable-logo --no-progress --minimum-expected-tests 1
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/KafkaProducerFastPathTests/*" --disable-logo --no-progress --minimum-expected-tests 1
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/ApiImprovementsTests/*" --disable-logo --no-progress --minimum-expected-tests 1
- dotnet format --verify-no-changes --verbosity minimal --include changed C# files
- verified no ProducerMessage.Create usages remain

Closes #1020