### PR TITLE
perf(consumer): pool fetch wrappers

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -435,6 +435,68 @@ internal sealed class PendingFetchData : IDisposable
     }
 }
 
+internal static class ConsumerFetchPools
+{
+    private static readonly PendingFetchDataListPool s_pendingFetchDataLists = new();
+    private static readonly FetchRequestTopicListPool s_fetchRequestTopicLists = new();
+    private static readonly FetchRequestPartitionListPool s_fetchRequestPartitionLists = new();
+
+    internal static List<PendingFetchData> RentPendingFetchDataList()
+    {
+        var list = s_pendingFetchDataLists.Rent();
+        return list;
+    }
+
+    internal static void ReturnPendingFetchDataList(List<PendingFetchData> list)
+        => s_pendingFetchDataLists.Return(list);
+
+    internal static List<FetchRequestTopic> RentFetchRequestTopicList(int capacity)
+    {
+        var list = s_fetchRequestTopicLists.Rent();
+        list.EnsureCapacity(capacity);
+        return list;
+    }
+
+    internal static List<FetchRequestPartition> RentFetchRequestPartitionList(int capacity)
+    {
+        var list = s_fetchRequestPartitionLists.Rent();
+        list.EnsureCapacity(capacity);
+        return list;
+    }
+
+    internal static void ReturnFetchRequestTopics(List<FetchRequestTopic> topics)
+    {
+        for (var i = 0; i < topics.Count; i++)
+        {
+            if (topics[i].Partitions is List<FetchRequestPartition> partitions)
+                s_fetchRequestPartitionLists.Return(partitions);
+        }
+
+        s_fetchRequestTopicLists.Return(topics);
+    }
+
+    private sealed class PendingFetchDataListPool() : ObjectPool<List<PendingFetchData>>(maxPoolSize: 64)
+    {
+        protected override List<PendingFetchData> Create() => [];
+
+        protected override void Reset(List<PendingFetchData> item) => item.Clear();
+    }
+
+    private sealed class FetchRequestTopicListPool() : ObjectPool<List<FetchRequestTopic>>(maxPoolSize: 64)
+    {
+        protected override List<FetchRequestTopic> Create() => [];
+
+        protected override void Reset(List<FetchRequestTopic> item) => item.Clear();
+    }
+
+    private sealed class FetchRequestPartitionListPool() : ObjectPool<List<FetchRequestPartition>>(maxPoolSize: 128)
+    {
+        protected override List<FetchRequestPartition> Create() => [];
+
+        protected override void Reset(List<FetchRequestPartition> item) => item.Clear();
+    }
+}
+
 /// <summary>
 /// Kafka consumer implementation.
 /// </summary>
@@ -1854,6 +1916,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             finally
             {
                 request.ReturnToPool();
+                ConsumerFetchPools.ReturnFetchRequestTopics(topicData);
             }
 
             // Record fetch round-trip duration (~3ns no-op when no listener)
@@ -3131,9 +3194,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                     var pendingItems = fetchTasks[j].Result;
                     if (pendingItems is not null)
                     {
-                        foreach (var pending in pendingItems)
+                        try
                         {
-                            _pendingFetches.Enqueue(pending);
+                            foreach (var pending in pendingItems)
+                            {
+                                _pendingFetches.Enqueue(pending);
+                            }
+                        }
+                        finally
+                        {
+                            ConsumerFetchPools.ReturnPendingFetchDataList(pendingItems);
                         }
                     }
                 }
@@ -3362,6 +3432,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         finally
         {
             request.ReturnToPool();
+            ConsumerFetchPools.ReturnFetchRequestTopics(topicData);
         }
 
         // Record fetch round-trip duration (~3ns no-op when no listener)
@@ -3430,7 +3501,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
                         _eofEmitted.TryRemove(tp, out _);
 
                         // Collect pending fetch data for lazy record iteration
-                        pendingItems ??= [];
+                        pendingItems ??= ConsumerFetchPools.RentPendingFetchDataList();
                         pendingItems.Add(PendingFetchData.Create(
                             topic,
                             partitionResponse.PartitionIndex,
@@ -3478,7 +3549,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
     /// </summary>
     private static void AssignSharedMemoryOwner(List<PendingFetchData> pendingItems, IPooledMemory memoryOwner)
     {
-        var shared = new RefCountedMemoryOwner(memoryOwner, pendingItems.Count);
+        var shared = RefCountedMemoryOwner.Create(memoryOwner, pendingItems.Count);
         for (var i = 0; i < pendingItems.Count; i++)
         {
             pendingItems[i].SetMemoryOwner(shared);
@@ -3730,7 +3801,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         List<TopicPartition> partitions, int startIndex, int count)
     {
         if (count == 0)
-            return [];
+            return ConsumerFetchPools.RentFetchRequestTopicList(0);
 
         var isFullList = startIndex == 0 && count == partitions.Count;
 
@@ -3834,12 +3905,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
         int? adaptivePartitionMaxBytes = null,
         ClusterMetadata? clusterMetadata = null)
     {
-        var result = new List<FetchRequestTopic>(templateDict.Count);
+        var result = ConsumerFetchPools.RentFetchRequestTopicList(templateDict.Count);
 
         foreach (var kvp in templateDict)
         {
             var cachedPartitions = kvp.Value;
-            var partitionList = new List<FetchRequestPartition>(cachedPartitions.Count);
+            var partitionList = ConsumerFetchPools.RentFetchRequestPartitionList(cachedPartitions.Count);
 
             foreach (var (template, tp) in cachedPartitions)
             {

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks.Sources;
 using Dekaf.Errors;
 using Dekaf.Internal;
+using Dekaf.Producer;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Security;
@@ -2695,7 +2696,7 @@ internal readonly struct PooledResponseBuffer : IDisposable
     /// </summary>
     public PooledResponseMemory TransferOwnership()
     {
-        return new PooledResponseMemory(_buffer, Length, IsPooled, _offset, _pool);
+        return PooledResponseMemory.Create(_buffer, Length, IsPooled, _offset, _pool);
     }
 
     public void Dispose()
@@ -2715,19 +2716,39 @@ internal readonly struct PooledResponseBuffer : IDisposable
 /// </summary>
 internal sealed class PooledResponseMemory : IPooledMemory
 {
+    private static readonly PooledResponseMemoryPool s_pool = new();
+
     private byte[]? _buffer;
-    private readonly int _length;
-    private readonly bool _isPooled;
-    private readonly int _offset;
-    private readonly ResponseBufferPool? _pool;
+    private int _length;
+    private bool _isPooled;
+    private int _offset;
+    private ResponseBufferPool? _pool;
+    private int _pooled;
+    private int _disposed = 1;
+
+    private PooledResponseMemory() { }
 
     public PooledResponseMemory(byte[] buffer, int length, bool isPooled, int offset, ResponseBufferPool? pool = null)
+    {
+        Initialize(buffer, length, isPooled, offset, pool, pooled: false);
+    }
+
+    internal static PooledResponseMemory Create(byte[] buffer, int length, bool isPooled, int offset, ResponseBufferPool? pool = null)
+    {
+        var memory = s_pool.Rent();
+        memory.Initialize(buffer, length, isPooled, offset, pool, pooled: true);
+        return memory;
+    }
+
+    private void Initialize(byte[] buffer, int length, bool isPooled, int offset, ResponseBufferPool? pool, bool pooled)
     {
         _buffer = buffer;
         _length = length;
         _isPooled = isPooled;
         _offset = offset;
         _pool = pool;
+        _pooled = pooled ? 1 : 0;
+        Volatile.Write(ref _disposed, 0);
     }
 
     public ReadOnlyMemory<byte> Memory => _buffer is not null
@@ -2736,11 +2757,33 @@ internal sealed class PooledResponseMemory : IPooledMemory
 
     public void Dispose()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
         var buffer = Interlocked.Exchange(ref _buffer, null);
         if (_isPooled && buffer is not null)
         {
             Debug.Assert(_pool is not null, "Pooled buffer must have a non-null pool reference");
             _pool!.Pool.Return(buffer);
+        }
+
+        if (Volatile.Read(ref _pooled) != 0)
+            s_pool.Return(this);
+    }
+
+    private sealed class PooledResponseMemoryPool() : ObjectPool<PooledResponseMemory>(maxPoolSize: 256)
+    {
+        protected override PooledResponseMemory Create() => new();
+
+        protected override void Reset(PooledResponseMemory item)
+        {
+            item._buffer = null;
+            item._length = 0;
+            item._isPooled = false;
+            item._offset = 0;
+            item._pool = null;
+            item._pooled = 0;
+            Volatile.Write(ref item._disposed, 1);
         }
     }
 }

--- a/src/Dekaf/Protocol/RefCountedMemoryOwner.cs
+++ b/src/Dekaf/Protocol/RefCountedMemoryOwner.cs
@@ -1,3 +1,5 @@
+using Dekaf.Producer;
+
 namespace Dekaf.Protocol;
 
 /// <summary>
@@ -12,17 +14,36 @@ namespace Dekaf.Protocol;
 /// </remarks>
 internal sealed class RefCountedMemoryOwner : IPooledMemory
 {
-    private readonly IPooledMemory _inner;
+    private static readonly RefCountedMemoryOwnerPool s_pool = new();
+
+    private IPooledMemory? _inner;
     private int _refCount;
+    private int _pooled;
+
+    private RefCountedMemoryOwner() { }
 
     public RefCountedMemoryOwner(IPooledMemory inner, int initialRefCount)
+    {
+        Initialize(inner, initialRefCount, pooled: false);
+    }
+
+    internal static RefCountedMemoryOwner Create(IPooledMemory inner, int initialRefCount)
+    {
+        var owner = s_pool.Rent();
+        owner.Initialize(inner, initialRefCount, pooled: true);
+        return owner;
+    }
+
+    private void Initialize(IPooledMemory inner, int initialRefCount, bool pooled)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(initialRefCount, 1);
         _inner = inner;
         _refCount = initialRefCount;
+        _pooled = pooled ? 1 : 0;
     }
 
-    public ReadOnlyMemory<byte> Memory => _inner.Memory;
+    public ReadOnlyMemory<byte> Memory => _inner?.Memory
+        ?? throw new ObjectDisposedException(nameof(RefCountedMemoryOwner));
 
     public void Dispose()
     {
@@ -30,12 +51,26 @@ internal sealed class RefCountedMemoryOwner : IPooledMemory
 
         if (newCount == 0)
         {
-            _inner.Dispose();
+            _inner?.Dispose();
+            if (Volatile.Read(ref _pooled) != 0)
+                s_pool.Return(this);
         }
         else if (newCount < 0)
         {
             // Already fully disposed — increment back to prevent further underflow.
             Interlocked.Increment(ref _refCount);
+        }
+    }
+
+    private sealed class RefCountedMemoryOwnerPool() : ObjectPool<RefCountedMemoryOwner>(maxPoolSize: 128)
+    {
+        protected override RefCountedMemoryOwner Create() => new();
+
+        protected override void Reset(RefCountedMemoryOwner item)
+        {
+            item._inner = null;
+            item._refCount = 0;
+            item._pooled = 0;
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
@@ -136,6 +136,27 @@ public class ResponseBufferPoolTests
     }
 
     [Test]
+    public async Task PooledResponseBuffer_TransferOwnershipReusesMemoryWrapper()
+    {
+        var pool = ResponseBufferPool.Create(20 * 1024 * 1024);
+        var firstArray = pool.Pool.Rent(1024);
+        var firstBuffer = new PooledResponseBuffer(firstArray, 1024, isPooled: true, pool: pool);
+        var firstMemory = firstBuffer.TransferOwnership();
+
+        firstMemory.Dispose();
+        firstMemory.Dispose();
+
+        var secondArray = pool.Pool.Rent(1024);
+        secondArray[0] = 123;
+        var secondBuffer = new PooledResponseBuffer(secondArray, 1024, isPooled: true, pool: pool);
+        var secondMemory = secondBuffer.TransferOwnership();
+
+        await Assert.That(secondMemory.Memory.Span[0]).IsEqualTo((byte)123);
+
+        secondMemory.Dispose();
+    }
+
+    [Test]
     public async Task PooledResponseBuffer_UnpooledBuffer_DoesNotReturnToPool()
     {
         var array = new byte[100];

--- a/tests/Dekaf.Tests.Unit/Protocol/RefCountedMemoryOwnerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RefCountedMemoryOwnerTests.cs
@@ -144,4 +144,23 @@ public class RefCountedMemoryOwnerTests
         // Act & Assert
         await Assert.That(owner.Memory.ToArray()).IsEquivalentTo(inner.Memory.ToArray());
     }
+
+    [Test]
+    public async Task Create_FromPool_CanBeReusedAfterDispose()
+    {
+        var firstInner = new TrackingPooledMemory();
+        var first = RefCountedMemoryOwner.Create(firstInner, initialRefCount: 1);
+
+        first.Dispose();
+        first.Dispose();
+        await Assert.That(firstInner.DisposeCount).IsEqualTo(1);
+
+        var secondInner = new TrackingPooledMemory();
+        var second = RefCountedMemoryOwner.Create(secondInner, initialRefCount: 1);
+
+        await Assert.That(second.Memory.ToArray()).IsEquivalentTo(secondInner.Memory.ToArray());
+
+        second.Dispose();
+        await Assert.That(secondInner.DisposeCount).IsEqualTo(1);
+    }
 }


### PR DESCRIPTION
## Summary
- pool `PooledResponseMemory` wrappers created by fetch response ownership transfer
- pool `RefCountedMemoryOwner` wrappers used when multiple pending fetch items share one response buffer
- pool direct-fetch pending item lists and fetch request topic/partition lists while preserving public request object shapes

Closes #1056.

## Validation
- `dotnet restore tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj`
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/RefCountedMemoryOwnerTests/*"` (10/10 pass)
- `Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/ResponseBufferPoolTests/*"` (15/15 pass)
- `Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/BuildFetchResultTests/*"` (9/9 pass)
- `git diff --check origin/main..HEAD`