### PR TITLE
perf(consumer): avoid prefetch key snapshot

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1617,9 +1617,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, T
             // across connections to issue concurrent fetches to the same broker.
 
             // Lazily prune stale entries from scaled-down connections.
-            // O(k) over a small dictionary (brokers × connections), once per fetch cycle — not hot path.
-            foreach (var key in _prefetchPendingItemsByBroker.Keys)
+            // Enumerate entries directly to avoid the allocating .Keys snapshot.
+            foreach (var entry in _prefetchPendingItemsByBroker)
             {
+                var key = entry.Key;
                 if (key.ConnectionIndex >= fetchConnectionCount)
                     _prefetchPendingItemsByBroker.TryRemove(key, out _);
             }


### PR DESCRIPTION
## Summary
- enumerate _prefetchPendingItemsByBroker directly during stale connection cleanup
- remove the per-prefetch-cycle ConcurrentDictionary.Keys snapshot allocation

## Validation
- dotnet restore Dekaf.sln
- dotnet build Dekaf.sln -c Release --no-restore
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/PrefetchPipelineRunnerTests/*" --disable-logo --no-progress --minimum-expected-tests 1
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/ConsumerConcurrencyTests/*" --disable-logo --no-progress --minimum-expected-tests 1
- verified _prefetchPendingItemsByBroker.Keys is no longer used

Refs #934