### PR TITLE
fix(api): normalize bootstrap servers

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -74,7 +74,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 
 | Fluent API | Config key | Notes |
 |------------|------------|-------|
-| `WithBootstrapServers(...)` | `BootstrapServers` | Comma-separated string or JSON array |
+| `WithBootstrapServers(...)` | `BootstrapServers` | Server list (prefer `params string[]` in code; comma-separated string and JSON arrays are also supported) |
 | `WithClientId(...)` | `ClientId` | String |
 | `WithGroupId(...)` | `GroupId` | String |
 | `WithGroupInstanceId(...)` | `GroupInstanceId` | String |
@@ -112,10 +112,11 @@ Topics, deserializers, rebalance listeners, interceptors, and retry policies are
 
 ### WithBootstrapServers
 
-Kafka broker addresses:
+Kafka broker addresses. Prefer the typed `params string[]` overload in code; the single-string overload remains a convenience for configuration-style comma-separated values.
 
 ```csharp
 .WithBootstrapServers("localhost:9092")
+.WithBootstrapServers("broker1:9092", "broker2:9092")
 .WithBootstrapServers("broker1:9092,broker2:9092")
 ```
 

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -68,7 +68,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 
 | Fluent API | Config key | Notes |
 |------------|------------|-------|
-| `WithBootstrapServers(...)` | `BootstrapServers` | Comma-separated string or JSON array |
+| `WithBootstrapServers(...)` | `BootstrapServers` | Server list (prefer `params string[]` in code; comma-separated string and JSON arrays are also supported) |
 | `WithClientId(...)` | `ClientId` | String |
 | `WithAcks(...)` | `Acks` | `None`, `Leader`, `All` |
 | `WithLinger(...)` | `LingerMs` | Milliseconds |
@@ -100,17 +100,17 @@ Serializers, custom partitioners, interceptors, and retry policies are objects, 
 
 ### WithBootstrapServers
 
-Kafka broker addresses for initial connection:
+Kafka broker addresses for initial connection. Prefer the typed `params string[]` overload in code; the single-string overload remains a convenience for configuration-style comma-separated values.
 
 ```csharp
 // Single server
 .WithBootstrapServers("localhost:9092")
 
-// Multiple servers (comma-separated)
-.WithBootstrapServers("broker1:9092,broker2:9092,broker3:9092")
-
-// Multiple servers (params)
+// Multiple servers (typed params)
 .WithBootstrapServers("broker1:9092", "broker2:9092", "broker3:9092")
+
+// Convenience for comma-separated configuration values
+.WithBootstrapServers("broker1:9092,broker2:9092,broker3:9092")
 ```
 
 ### WithClientId

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -2517,14 +2517,14 @@ public sealed class AdminClientBuilder
     public AdminClientBuilder WithBootstrapServers(string servers)
     {
         ThrowIfClientOwnedBootstrap();
-        _bootstrapServers = servers.Split(',').Select(s => s.Trim()).ToArray();
+        _bootstrapServers = BootstrapServerList.FromCommaSeparated(servers);
         return this;
     }
 
     public AdminClientBuilder WithBootstrapServers(params string[] servers)
     {
         ThrowIfClientOwnedBootstrap();
-        _bootstrapServers = [..servers];
+        _bootstrapServers = BootstrapServerList.FromValues(servers);
         return this;
     }
 

--- a/src/Dekaf/BootstrapServerList.cs
+++ b/src/Dekaf/BootstrapServerList.cs
@@ -1,0 +1,34 @@
+namespace Dekaf;
+
+internal static class BootstrapServerList
+{
+    internal static string[] FromCommaSeparated(string servers)
+    {
+        ArgumentNullException.ThrowIfNull(servers);
+        return FromValues(servers.Split(','));
+    }
+
+    internal static string[] FromValues(params string[] servers)
+    {
+        ArgumentNullException.ThrowIfNull(servers);
+
+        if (servers.Length == 0)
+            throw new ArgumentException("At least one bootstrap server must be specified.", nameof(servers));
+
+        var normalized = new string[servers.Length];
+        for (var i = 0; i < servers.Length; i++)
+        {
+            var server = servers[i];
+            if (server is null)
+                throw new ArgumentException("Bootstrap server entries cannot be null.", nameof(servers));
+
+            var trimmed = server.Trim();
+            if (trimmed.Length == 0)
+                throw new ArgumentException("Bootstrap server entries cannot be empty.", nameof(servers));
+
+            normalized[i] = trimmed;
+        }
+
+        return normalized;
+    }
+}

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -84,14 +84,14 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithBootstrapServers(string servers)
     {
         ThrowIfClientOwnedBootstrap();
-        _bootstrapServers = servers.Split(',').Select(s => s.Trim()).ToArray();
+        _bootstrapServers = BootstrapServerList.FromCommaSeparated(servers);
         return this;
     }
 
     public ProducerBuilder<TKey, TValue> WithBootstrapServers(params string[] servers)
     {
         ThrowIfClientOwnedBootstrap();
-        _bootstrapServers = [..servers];
+        _bootstrapServers = BootstrapServerList.FromValues(servers);
         return this;
     }
 
@@ -1027,14 +1027,14 @@ public sealed class ConsumerBuilder<TKey, TValue>
     public ConsumerBuilder<TKey, TValue> WithBootstrapServers(string servers)
     {
         ThrowIfClientOwnedBootstrap();
-        _bootstrapServers = servers.Split(',').Select(s => s.Trim()).ToArray();
+        _bootstrapServers = BootstrapServerList.FromCommaSeparated(servers);
         return this;
     }
 
     public ConsumerBuilder<TKey, TValue> WithBootstrapServers(params string[] servers)
     {
         ThrowIfClientOwnedBootstrap();
-        _bootstrapServers = [..servers];
+        _bootstrapServers = BootstrapServerList.FromValues(servers);
         return this;
     }
 
@@ -1967,14 +1967,14 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     public ShareConsumerBuilder<TKey, TValue> WithBootstrapServers(string servers)
     {
         ThrowIfClientOwnedBootstrap();
-        _bootstrapServers = servers.Split(',').Select(s => s.Trim()).ToArray();
+        _bootstrapServers = BootstrapServerList.FromCommaSeparated(servers);
         return this;
     }
 
     public ShareConsumerBuilder<TKey, TValue> WithBootstrapServers(params string[] servers)
     {
         ThrowIfClientOwnedBootstrap();
-        _bootstrapServers = [..servers];
+        _bootstrapServers = BootstrapServerList.FromValues(servers);
         return this;
     }
 

--- a/src/Dekaf/Consumer/DeadLetter/DeadLetterQueueBuilder.cs
+++ b/src/Dekaf/Consumer/DeadLetter/DeadLetterQueueBuilder.cs
@@ -64,7 +64,7 @@ public sealed class DeadLetterQueueBuilder
     /// <returns>The builder instance for method chaining.</returns>
     public DeadLetterQueueBuilder WithBootstrapServers(string servers)
     {
-        _bootstrapServers = servers;
+        _bootstrapServers = string.Join(",", BootstrapServerList.FromCommaSeparated(servers));
         return this;
     }
 
@@ -85,7 +85,7 @@ public sealed class DeadLetterQueueBuilder
     /// </summary>
     internal DeadLetterQueueBuilder WithDefaultBootstrapServers(string servers)
     {
-        _bootstrapServers ??= servers;
+        _bootstrapServers ??= string.Join(",", BootstrapServerList.FromCommaSeparated(servers));
         return this;
     }
 

--- a/tests/Dekaf.Tests.Unit/Builder/BootstrapServerListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/BootstrapServerListTests.cs
@@ -1,0 +1,48 @@
+namespace Dekaf.Tests.Unit.Builder;
+
+public class BootstrapServerListTests
+{
+    [Test]
+    public async Task FromCommaSeparated_TrimsEntries()
+    {
+        var servers = BootstrapServerList.FromCommaSeparated(" broker1:9092, broker2:9092 ");
+
+        await Assert.That(servers).IsEquivalentTo(["broker1:9092", "broker2:9092"]);
+    }
+
+    [Test]
+    public async Task FromValues_TrimsEntries()
+    {
+        var servers = BootstrapServerList.FromValues(" broker1:9092 ", "broker2:9092");
+
+        await Assert.That(servers).IsEquivalentTo(["broker1:9092", "broker2:9092"]);
+    }
+
+    [Test]
+    public void FromCommaSeparated_RejectsEmptyEntries()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            BootstrapServerList.FromCommaSeparated("broker1:9092,,broker2:9092"));
+    }
+
+    [Test]
+    public void FromValues_RejectsEmptyEntries()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            BootstrapServerList.FromValues("broker1:9092", " "));
+    }
+
+    [Test]
+    public void FromValues_RejectsNullEntries()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            BootstrapServerList.FromValues("broker1:9092", null!));
+    }
+
+    [Test]
+    public void FromValues_RejectsEmptyList()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            BootstrapServerList.FromValues());
+    }
+}


### PR DESCRIPTION
## Summary
- normalize bootstrap server inputs through one shared helper
- trim `params string[]` entries and reject null/empty entries for string and params overloads
- apply the same normalization to producer, consumer, share-consumer, admin, and DLQ bootstrap configuration
- update producer/consumer configuration docs to show the typed `params string[]` overload first

Addresses the `WithBootstrapServers(string)` checklist item in #1021.

## Validation
- `dotnet restore tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj`
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/BootstrapServerListTests/*"` (6/6 pass)
- `Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/ProducerBuilderValidationTests/*"` (44/44 pass)
- `Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/ConsumerBuilderValidationTests/*"` (33/33 pass)
- `Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/AdminClientBuilderTests/*"` (17/17 pass)
- `Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/DeadLetterQueueBuilderTests/*"` (8/8 pass)
- `git diff --check origin/main..HEAD`