### PR TITLE
feat(telemetry): add app metric registry

### DIFF
--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -245,23 +245,24 @@ The zero-allocation design pays off here. Once warmed up, Dekaf doesn't trigger 
 
 ## Keeping an Eye on Things
 
-### Built-in Metrics
+### Broker Telemetry Application Metrics
 
-Hook into Dekaf's metrics to see what's happening:
+Register application metrics when you want the broker client telemetry subscription to request
+and receive your own measurements alongside Dekaf client metrics:
 
 ```csharp
 using Dekaf;
+using Dekaf.Telemetry;
 
 var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("localhost:9092")
-    .WithMetrics(metrics =>
-    {
-        metrics.OnMessageProduced += (topic, partition, latency) =>
-        {
-            // Record metrics
-        };
-    })
+    .RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+        "com.example.queue.depth",
+        ApplicationTelemetryMetricKind.Gauge,
+        () => queueDepth))
     .BuildAsync();
+
+producer.UnregisterMetricFromSubscription("com.example.queue.depth");
 ```
 
 ### Logging

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Dekaf.Protocol.Records;
 using Dekaf.Producer;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
+using Dekaf.Telemetry;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -455,6 +456,18 @@ public sealed class AdminClientServiceBuilder
     public AdminClientServiceBuilder UseTls()
     {
         _builder.UseTls();
+        return this;
+    }
+
+    public AdminClientServiceBuilder RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        _builder.RegisterMetricForSubscription(metric);
+        return this;
+    }
+
+    public AdminClientServiceBuilder UnregisterMetricFromSubscription(string name)
+    {
+        _builder.UnregisterMetricFromSubscription(name);
         return this;
     }
 

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -92,12 +92,22 @@ public sealed class AdminClient : IAdminClient
     public ClusterMetadata Metadata => _metadataManager.Metadata;
 
     /// <inheritdoc />
-    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric) =>
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(AdminClient));
+
         _telemetryMetricCollector.RegisterMetricForSubscription(metric);
+    }
 
     /// <inheritdoc />
-    public void UnregisterMetricFromSubscription(string name) =>
+    public void UnregisterMetricFromSubscription(string name)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(AdminClient));
+
         _telemetryMetricCollector.UnregisterMetricFromSubscription(name);
+    }
 
     public async ValueTask CreateTopicsAsync(
         IEnumerable<NewTopic> topics,

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -22,6 +22,7 @@ public sealed class AdminClient : IAdminClient
     private readonly AdminClientOptions _options;
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
+    private readonly ClientTelemetryMetricCollector _telemetryMetricCollector;
     private readonly ClientTelemetryManager _telemetryManager;
     private readonly ILogger<AdminClient>? _logger;
     private readonly bool _ownsResources;
@@ -33,6 +34,8 @@ public sealed class AdminClient : IAdminClient
         _options = options;
         _logger = loggerFactory?.CreateLogger<AdminClient>();
         _ownsResources = true;
+        _telemetryMetricCollector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Admin);
+        _telemetryMetricCollector.RegisterMetricsForSubscription(options.ApplicationMetrics);
 
         _connectionPool = new ConnectionPool(
             options.ClientId,
@@ -60,7 +63,8 @@ public sealed class AdminClient : IAdminClient
         _telemetryManager = new ClientTelemetryManager(
             _connectionPool,
             _metadataManager,
-            loggerFactory?.CreateLogger<ClientTelemetryManager>());
+            loggerFactory?.CreateLogger<ClientTelemetryManager>(),
+            _telemetryMetricCollector);
         _ownsResources = true;
     }
 
@@ -75,14 +79,25 @@ public sealed class AdminClient : IAdminClient
         _logger = loggerFactory?.CreateLogger<AdminClient>();
         _connectionPool = connectionPool;
         _metadataManager = metadataManager;
+        _telemetryMetricCollector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Admin);
+        _telemetryMetricCollector.RegisterMetricsForSubscription(options.ApplicationMetrics);
         _telemetryManager = new ClientTelemetryManager(
             _connectionPool,
             _metadataManager,
-            loggerFactory?.CreateLogger<ClientTelemetryManager>());
+            loggerFactory?.CreateLogger<ClientTelemetryManager>(),
+            _telemetryMetricCollector);
         _ownsResources = ownsResources;
     }
 
     public ClusterMetadata Metadata => _metadataManager.Metadata;
+
+    /// <inheritdoc />
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric) =>
+        _telemetryMetricCollector.RegisterMetricForSubscription(metric);
+
+    /// <inheritdoc />
+    public void UnregisterMetricFromSubscription(string name) =>
+        _telemetryMetricCollector.UnregisterMetricFromSubscription(name);
 
     public async ValueTask CreateTopicsAsync(
         IEnumerable<NewTopic> topics,
@@ -2479,6 +2494,11 @@ public sealed class AdminClientOptions
     /// Default is 300000 (5 minutes).
     /// </summary>
     public int MetadataRecoveryRebootstrapTriggerMs { get; init; } = 300000;
+
+    /// <summary>
+    /// Application metrics registered for broker telemetry subscriptions.
+    /// </summary>
+    public IReadOnlyList<ApplicationTelemetryMetric> ApplicationMetrics { get; init; } = [];
 }
 
 /// <summary>
@@ -2502,6 +2522,7 @@ public sealed class AdminClientBuilder
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
     private TimeSpan? _metadataMaxAge;
+    private readonly Dictionary<string, ApplicationTelemetryMetric> _applicationMetrics = new(StringComparer.Ordinal);
 
     public AdminClientBuilder()
     {
@@ -2659,6 +2680,30 @@ public sealed class AdminClientBuilder
     }
 
     /// <summary>
+    /// Registers an application metric for broker telemetry subscriptions on built admin clients.
+    /// Duplicate names replace the previous metric.
+    /// </summary>
+    /// <param name="metric">The application metric to register.</param>
+    public AdminClientBuilder RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        ArgumentNullException.ThrowIfNull(metric);
+        _applicationMetrics[metric.Name] = metric;
+        return this;
+    }
+
+    /// <summary>
+    /// Removes an application metric registration from this builder.
+    /// Missing names are ignored.
+    /// </summary>
+    /// <param name="name">The application metric name.</param>
+    public AdminClientBuilder UnregisterMetricFromSubscription(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _applicationMetrics.Remove(name);
+        return this;
+    }
+
+    /// <summary>
     /// Sets the metadata recovery strategy for when all known brokers become unavailable.
     /// </summary>
     /// <param name="strategy">The recovery strategy to use.</param>
@@ -2742,7 +2787,8 @@ public sealed class AdminClientBuilder
             OAuthBearerConfig = _oauthConfig,
             OAuthBearerTokenProvider = _oauthTokenProvider,
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
-            MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs
+            MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
+            ApplicationMetrics = _applicationMetrics.Count > 0 ? _applicationMetrics.Values.ToArray() : []
         };
 
         var metadataOptions = _metadataMaxAge.HasValue

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -1,5 +1,6 @@
 using Dekaf.Metadata;
 using Dekaf.Producer;
+using Dekaf.Telemetry;
 
 namespace Dekaf.Admin;
 
@@ -8,6 +9,19 @@ namespace Dekaf.Admin;
 /// </summary>
 public interface IAdminClient : IAsyncDisposable
 {
+    /// <summary>
+    /// Registers or replaces an application metric for broker telemetry subscriptions.
+    /// </summary>
+    /// <param name="metric">The application metric to register.</param>
+    void RegisterMetricForSubscription(ApplicationTelemetryMetric metric);
+
+    /// <summary>
+    /// Unregisters an application metric from broker telemetry subscriptions.
+    /// Missing names are ignored.
+    /// </summary>
+    /// <param name="name">The application metric name.</param>
+    void UnregisterMetricFromSubscription(string name);
+
     /// <summary>
     /// Creates topics.
     /// </summary>

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -9,6 +9,7 @@ using Dekaf.Security.Sasl;
 using Dekaf.Protocol.Messages;
 using Dekaf.Serialization;
 using Dekaf.ShareConsumer;
+using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
 
 namespace Dekaf;
@@ -67,6 +68,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private IRetryPolicy? _retryPolicy;
     private bool _enableAdaptiveConnections = true;
     private int _maxConnectionsPerBroker = 10;
+    private readonly Dictionary<string, ApplicationTelemetryMetric> _applicationMetrics = new(StringComparer.Ordinal);
 
     public ProducerBuilder()
     {
@@ -648,6 +650,30 @@ public sealed class ProducerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>
+    /// Registers an application metric for broker telemetry subscriptions on built producers.
+    /// Duplicate names replace the previous metric.
+    /// </summary>
+    /// <param name="metric">The application metric to register.</param>
+    public ProducerBuilder<TKey, TValue> RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        ArgumentNullException.ThrowIfNull(metric);
+        _applicationMetrics[metric.Name] = metric;
+        return this;
+    }
+
+    /// <summary>
+    /// Removes an application metric registration from this builder.
+    /// Missing names are ignored.
+    /// </summary>
+    /// <param name="name">The application metric name.</param>
+    public ProducerBuilder<TKey, TValue> UnregisterMetricFromSubscription(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _applicationMetrics.Remove(name);
+        return this;
+    }
+
     internal ProducerBuilder<TKey, TValue> WithMaxInFlightRequestsPerConnection(int maxInFlightRequestsPerConnection)
     {
         ThrowIfClientOwnedConnectionSettings();
@@ -867,7 +893,8 @@ public sealed class ProducerBuilder<TKey, TValue>
             Interceptors = _interceptors?.Count > 0 ? _interceptors.ToArray() : null,
             RetryPolicy = _retryPolicy,
             EnableAdaptiveConnections = _enableAdaptiveConnections,
-            MaxConnectionsPerBroker = _maxConnectionsPerBroker
+            MaxConnectionsPerBroker = _maxConnectionsPerBroker,
+            ApplicationMetrics = _applicationMetrics.Count > 0 ? _applicationMetrics.Values.ToArray() : []
         };
 
         var metadataOptions = _metadataMaxAge.HasValue
@@ -1010,6 +1037,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private bool _enableAdaptiveFetchSizing;
     private AdaptiveFetchSizingOptions? _adaptiveFetchSizingOptions;
     private bool _enableFetchSessions = true;
+    private readonly Dictionary<string, ApplicationTelemetryMetric> _applicationMetrics = new(StringComparer.Ordinal);
 
     public ConsumerBuilder()
     {
@@ -1682,6 +1710,30 @@ public sealed class ConsumerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>
+    /// Registers an application metric for broker telemetry subscriptions on built consumers.
+    /// Duplicate names replace the previous metric.
+    /// </summary>
+    /// <param name="metric">The application metric to register.</param>
+    public ConsumerBuilder<TKey, TValue> RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        ArgumentNullException.ThrowIfNull(metric);
+        _applicationMetrics[metric.Name] = metric;
+        return this;
+    }
+
+    /// <summary>
+    /// Removes an application metric registration from this builder.
+    /// Missing names are ignored.
+    /// </summary>
+    /// <param name="name">The application metric name.</param>
+    public ConsumerBuilder<TKey, TValue> UnregisterMetricFromSubscription(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _applicationMetrics.Remove(name);
+        return this;
+    }
+
     internal ConsumerBuilder<TKey, TValue> WithMaxPollInterval(TimeSpan interval)
     {
         if (interval <= TimeSpan.Zero)
@@ -1847,7 +1899,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
             EnableAdaptiveConnections = _enableAdaptiveConnections,
             MaxConnectionsPerBroker = _maxConnectionsPerBroker,
             EnableAdaptiveFetchSizing = _enableAdaptiveFetchSizing,
-            AdaptiveFetchSizingOptions = _adaptiveFetchSizingOptions
+            AdaptiveFetchSizingOptions = _adaptiveFetchSizingOptions,
+            ApplicationMetrics = _applicationMetrics.Count > 0 ? _applicationMetrics.Values.ToArray() : []
         };
 
         var metadataOptions = _metadataMaxAge.HasValue

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -3,6 +3,7 @@ using Dekaf.Protocol.Messages;
 using Dekaf.Retry;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
+using Dekaf.Telemetry;
 
 namespace Dekaf.Consumer;
 
@@ -285,6 +286,11 @@ public sealed class ConsumerOptions
     /// When <c>null</c>, existing retry behavior is unchanged.
     /// </summary>
     public IRetryPolicy? RetryPolicy { get; init; }
+
+    /// <summary>
+    /// Application metrics registered for broker telemetry subscriptions.
+    /// </summary>
+    public IReadOnlyList<ApplicationTelemetryMetric> ApplicationMetrics { get; init; } = [];
 
     /// <summary>
     /// Maximum number of overlapping prefetch operations.

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -1,5 +1,6 @@
 using Dekaf.Producer;
 using Dekaf.Serialization;
+using Dekaf.Telemetry;
 
 namespace Dekaf.Consumer;
 
@@ -92,6 +93,19 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Partition EOF events are not surfaced by this method; use <see cref="ConsumeAsync"/> for EOF notification.
     /// </summary>
     IAsyncEnumerable<ConsumeRawBatch> ConsumeRawBatchAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Registers or replaces an application metric for broker telemetry subscriptions.
+    /// </summary>
+    /// <param name="metric">The application metric to register.</param>
+    void RegisterMetricForSubscription(ApplicationTelemetryMetric metric);
+
+    /// <summary>
+    /// Unregisters an application metric from broker telemetry subscriptions.
+    /// Missing names are ignored.
+    /// </summary>
+    /// <param name="name">The application metric name.</param>
+    void UnregisterMetricFromSubscription(string name);
 
     /// <summary>
     /// Commits the offsets of all consumed messages.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -876,12 +876,22 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     public IConsumerOffsets Offsets => this;
 
     /// <inheritdoc />
-    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric) =>
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        if (Volatile.Read(ref _consumerDisposed) != 0)
+            throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));
+
         _telemetryMetricCollector.RegisterMetricForSubscription(metric);
+    }
 
     /// <inheritdoc />
-    public void UnregisterMetricFromSubscription(string name) =>
+    public void UnregisterMetricFromSubscription(string name)
+    {
+        if (Volatile.Read(ref _consumerDisposed) != 0)
+            throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));
+
         _telemetryMetricCollector.UnregisterMetricFromSubscription(name);
+    }
 
     /// <summary>
     /// Forces the coordinator to rejoin the group on the next <see cref="EnsureAssignmentAsync"/> call.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2701,56 +2701,67 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         ThrowIfNotInitialized();
 
-        var connection = await GetPartitionLeaderConnectionAsync(topicPartition, cancellationToken).ConfigureAwait(false);
-        if (connection is null)
-            throw new InvalidOperationException($"No leader found for partition {topicPartition}");
-
-        var listOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
-            ApiKey.ListOffsets,
-            ListOffsetsRequest.LowestSupportedVersion,
-            ListOffsetsRequest.HighestSupportedVersion);
-
-        var earliestRequest = CreateWatermarkListOffsetsRequest(topicPartition, _options.IsolationLevel, EarliestOffsetTimestamp);
-        var latestRequest = CreateWatermarkListOffsetsRequest(topicPartition, _options.IsolationLevel, LatestOffsetTimestamp);
-
-        var earliestResponseTask = connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
-            earliestRequest,
-            listOffsetsVersion,
-            cancellationToken).AsTask();
-
-        var latestResponseTask = connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
-            latestRequest,
-            listOffsetsVersion,
-            cancellationToken).AsTask();
-
-        await Task.WhenAll(earliestResponseTask, latestResponseTask).ConfigureAwait(false);
-
-        var earliestPartitionResponse = FindListOffsetsPartition(earliestResponseTask.Result, topicPartition);
-
-        if (earliestPartitionResponse?.ErrorCode != ErrorCode.None)
+        return await RetryHelper.WithRetryAsync(async () =>
         {
-            throw new InvalidOperationException(
-                $"Failed to query earliest offset for {topicPartition}: {earliestPartitionResponse?.ErrorCode}");
-        }
+            var connection = await GetPartitionLeaderConnectionAsync(topicPartition, cancellationToken).ConfigureAwait(false);
+            if (connection is null)
+                throw new KafkaException(ErrorCode.LeaderNotAvailable, $"No leader found for partition {topicPartition}");
 
-        var lowWatermark = earliestPartitionResponse?.Offset ?? 0;
+            var listOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
+                ApiKey.ListOffsets,
+                ListOffsetsRequest.LowestSupportedVersion,
+                ListOffsetsRequest.HighestSupportedVersion);
 
-        var latestPartitionResponse = FindListOffsetsPartition(latestResponseTask.Result, topicPartition);
+            var earliestRequest = CreateWatermarkListOffsetsRequest(topicPartition, _options.IsolationLevel, EarliestOffsetTimestamp);
+            var latestRequest = CreateWatermarkListOffsetsRequest(topicPartition, _options.IsolationLevel, LatestOffsetTimestamp);
 
-        if (latestPartitionResponse?.ErrorCode != ErrorCode.None)
-        {
-            throw new InvalidOperationException(
-                $"Failed to query latest offset for {topicPartition}: {latestPartitionResponse?.ErrorCode}");
-        }
+            var earliestResponseTask = connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                earliestRequest,
+                listOffsetsVersion,
+                cancellationToken).AsTask();
 
-        var highWatermark = latestPartitionResponse?.Offset ?? 0;
+            var latestResponseTask = connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                latestRequest,
+                listOffsetsVersion,
+                cancellationToken).AsTask();
 
-        var watermarks = new WatermarkOffsets(lowWatermark, highWatermark);
+            await Task.WhenAll(earliestResponseTask, latestResponseTask).ConfigureAwait(false);
 
-        // Cache the result
-        _watermarks[topicPartition] = watermarks;
+            var earliestPartitionResponse = FindListOffsetsPartition(earliestResponseTask.Result, topicPartition);
 
-        return watermarks;
+            if (earliestPartitionResponse is null)
+                throw new KafkaException(ErrorCode.UnknownServerError,
+                    $"Failed to query earliest offset for {topicPartition}: missing partition response");
+
+            if (earliestPartitionResponse.ErrorCode != ErrorCode.None)
+            {
+                throw KafkaException.FromErrorCode(earliestPartitionResponse.ErrorCode,
+                    $"Failed to query earliest offset for {topicPartition}: {earliestPartitionResponse.ErrorCode}");
+            }
+
+            var lowWatermark = earliestPartitionResponse.Offset;
+
+            var latestPartitionResponse = FindListOffsetsPartition(latestResponseTask.Result, topicPartition);
+
+            if (latestPartitionResponse is null)
+                throw new KafkaException(ErrorCode.UnknownServerError,
+                    $"Failed to query latest offset for {topicPartition}: missing partition response");
+
+            if (latestPartitionResponse.ErrorCode != ErrorCode.None)
+            {
+                throw KafkaException.FromErrorCode(latestPartitionResponse.ErrorCode,
+                    $"Failed to query latest offset for {topicPartition}: {latestPartitionResponse.ErrorCode}");
+            }
+
+            var highWatermark = latestPartitionResponse.Offset;
+
+            var watermarks = new WatermarkOffsets(lowWatermark, highWatermark);
+
+            // Cache the result
+            _watermarks[topicPartition] = watermarks;
+
+            return watermarks;
+        }, _metadataManager, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -556,6 +556,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly IDeserializer<TValue> _valueDeserializer;
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
+    private readonly ClientTelemetryMetricCollector _telemetryMetricCollector;
     private readonly ClientTelemetryManager _telemetryManager;
     private readonly IDekafMemoryBudget _memoryBudget;
     private readonly bool _ownsInfrastructure;
@@ -805,11 +806,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _metadataManager = infrastructure.Metadata;
         _ownsInfrastructure = ownsInfrastructure;
         _memoryBudget = memoryBudget;
+        _telemetryMetricCollector = infrastructure.TelemetryMetricCollector;
+        _telemetryMetricCollector.RegisterMetricsForSubscription(options.ApplicationMetrics);
         _telemetryManager = new ClientTelemetryManager(
             _connectionPool,
             _metadataManager,
             loggerFactory?.CreateLogger<ClientTelemetryManager>(),
-            infrastructure.TelemetryMetricCollector);
+            _telemetryMetricCollector);
 
         _compressionCodecs = CompressionCodecRegistry.Default;
 
@@ -871,6 +874,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     public IConsumerPositions Positions => this;
     public IConsumerPartitions Partitions => this;
     public IConsumerOffsets Offsets => this;
+
+    /// <inheritdoc />
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric) =>
+        _telemetryMetricCollector.RegisterMetricForSubscription(metric);
+
+    /// <inheritdoc />
+    public void UnregisterMetricFromSubscription(string name) =>
+        _telemetryMetricCollector.UnregisterMetricFromSubscription(name);
 
     /// <summary>
     /// Forces the coordinator to rejoin the group on the next <see cref="EnsureAssignmentAsync"/> call.

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -1,4 +1,5 @@
 using Dekaf.Serialization;
+using Dekaf.Telemetry;
 
 namespace Dekaf.Producer;
 
@@ -159,6 +160,19 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Flushes any pending messages.
     /// </summary>
     ValueTask FlushAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Registers or replaces an application metric for broker telemetry subscriptions.
+    /// </summary>
+    /// <param name="metric">The application metric to register.</param>
+    void RegisterMetricForSubscription(ApplicationTelemetryMetric metric);
+
+    /// <summary>
+    /// Unregisters an application metric from broker telemetry subscriptions.
+    /// Missing names are ignored.
+    /// </summary>
+    /// <param name="name">The application metric name.</param>
+    void UnregisterMetricFromSubscription(string name);
 
     /// <summary>
     /// Begins a transaction (if transactional).

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1425,12 +1425,22 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     }
 
     /// <inheritdoc />
-    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric) =>
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>));
+
         _telemetryMetricCollector.RegisterMetricForSubscription(metric);
+    }
 
     /// <inheritdoc />
-    public void UnregisterMetricFromSubscription(string name) =>
+    public void UnregisterMetricFromSubscription(string name)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>));
+
         _telemetryMetricCollector.UnregisterMetricFromSubscription(name);
+    }
 
     public ITransaction<TKey, TValue> BeginTransaction()
     {

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -45,6 +45,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly ConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
     private readonly IDisposable _brokerCountDiscoveredRegistration;
+    private readonly ClientTelemetryMetricCollector _telemetryMetricCollector;
     private readonly ClientTelemetryManager _telemetryManager;
     private readonly RecordAccumulator _accumulator;
     internal RecordAccumulator RecordAccumulator => _accumulator;
@@ -312,12 +313,14 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         _connectionPool = infrastructure.Pool;
         _metadataManager = infrastructure.Metadata;
+        _telemetryMetricCollector = infrastructure.TelemetryMetricCollector;
+        _telemetryMetricCollector.RegisterMetricsForSubscription(options.ApplicationMetrics);
 
         _telemetryManager = new ClientTelemetryManager(
             _connectionPool,
             _metadataManager,
             loggerFactory?.CreateLogger<ClientTelemetryManager>(),
-            infrastructure.TelemetryMetricCollector);
+            _telemetryMetricCollector);
 
         // Re-ratchet shared pool sizes after metadata refresh discovers the real broker count.
         // Bootstrap servers are seed nodes — the actual cluster may have more brokers.
@@ -1420,6 +1423,14 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // No channel to drain — all produce paths append directly to the accumulator.
         return _accumulator.FlushAsync(cancellationToken);
     }
+
+    /// <inheritdoc />
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric) =>
+        _telemetryMetricCollector.RegisterMetricForSubscription(metric);
+
+    /// <inheritdoc />
+    public void UnregisterMetricFromSubscription(string name) =>
+        _telemetryMetricCollector.UnregisterMetricFromSubscription(name);
 
     public ITransaction<TKey, TValue> BeginTransaction()
     {

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -4,6 +4,7 @@ using Dekaf.Protocol.Records;
 using Dekaf.Retry;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
+using Dekaf.Telemetry;
 
 namespace Dekaf.Producer;
 
@@ -357,6 +358,11 @@ public sealed class ProducerOptions
     /// retried according to this policy. When <c>null</c>, no application-level retries occur.
     /// </summary>
     public IRetryPolicy? RetryPolicy { get; init; }
+
+    /// <summary>
+    /// Application metrics registered for broker telemetry subscriptions.
+    /// </summary>
+    public IReadOnlyList<ApplicationTelemetryMetric> ApplicationMetrics { get; init; } = [];
 
     /// <summary>
     /// Enable adaptive connection scaling based on buffer pressure.

--- a/src/Dekaf/Telemetry/ApplicationTelemetryMetric.cs
+++ b/src/Dekaf/Telemetry/ApplicationTelemetryMetric.cs
@@ -31,7 +31,7 @@ public sealed class ApplicationTelemetryMetric
     /// </summary>
     /// <param name="name">Metric name exposed to broker subscription prefixes.</param>
     /// <param name="kind">Metric kind used for OpenTelemetry encoding.</param>
-    /// <param name="observe">Callback invoked when telemetry is collected.</param>
+    /// <param name="observe">Callback invoked when telemetry is collected. Keep it fast and non-blocking.</param>
     /// <param name="attributes">Optional metric attributes.</param>
     public ApplicationTelemetryMetric(
         string name,
@@ -59,7 +59,7 @@ public sealed class ApplicationTelemetryMetric
     public ApplicationTelemetryMetricKind Kind { get; }
 
     /// <summary>
-    /// Callback invoked when telemetry is collected.
+    /// Callback invoked when telemetry is collected. Keep it fast and non-blocking.
     /// </summary>
     public Func<double> Observe { get; }
 

--- a/src/Dekaf/Telemetry/ApplicationTelemetryMetric.cs
+++ b/src/Dekaf/Telemetry/ApplicationTelemetryMetric.cs
@@ -1,0 +1,97 @@
+using System.Collections.ObjectModel;
+
+namespace Dekaf.Telemetry;
+
+/// <summary>
+/// Application metric kind used for broker client telemetry subscriptions.
+/// </summary>
+public enum ApplicationTelemetryMetricKind
+{
+    /// <summary>
+    /// Monotonic sum encoded as an OpenTelemetry Sum.
+    /// </summary>
+    Counter,
+
+    /// <summary>
+    /// Current value encoded as an OpenTelemetry Gauge.
+    /// </summary>
+    Gauge
+}
+
+/// <summary>
+/// Application metric made available to broker client telemetry subscriptions.
+/// </summary>
+public sealed class ApplicationTelemetryMetric
+{
+    private static readonly IReadOnlyDictionary<string, string> EmptyAttributes =
+        new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(0, StringComparer.Ordinal));
+
+    /// <summary>
+    /// Creates an application telemetry metric.
+    /// </summary>
+    /// <param name="name">Metric name exposed to broker subscription prefixes.</param>
+    /// <param name="kind">Metric kind used for OpenTelemetry encoding.</param>
+    /// <param name="observe">Callback invoked when telemetry is collected.</param>
+    /// <param name="attributes">Optional metric attributes.</param>
+    public ApplicationTelemetryMetric(
+        string name,
+        ApplicationTelemetryMetricKind kind,
+        Func<double> observe,
+        IReadOnlyDictionary<string, string>? attributes = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(observe);
+
+        Name = name;
+        Kind = kind;
+        Observe = observe;
+        Attributes = CopyAttributes(attributes);
+    }
+
+    /// <summary>
+    /// Metric name exposed to broker subscription prefixes.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Metric kind used for OpenTelemetry encoding.
+    /// </summary>
+    public ApplicationTelemetryMetricKind Kind { get; }
+
+    /// <summary>
+    /// Callback invoked when telemetry is collected.
+    /// </summary>
+    public Func<double> Observe { get; }
+
+    /// <summary>
+    /// Optional metric attributes.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Attributes { get; }
+
+    private static IReadOnlyDictionary<string, string> CopyAttributes(
+        IReadOnlyDictionary<string, string>? attributes)
+    {
+        if (attributes is null || attributes.Count == 0)
+        {
+            return EmptyAttributes;
+        }
+
+        var copy = new Dictionary<string, string>(attributes.Count, StringComparer.Ordinal);
+        foreach (var (name, value) in attributes)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Attribute names must not be null or whitespace.", nameof(attributes));
+            }
+
+            if (value is null)
+            {
+                throw new ArgumentException("Attribute values must not be null.", nameof(attributes));
+            }
+
+            copy[name] = value;
+        }
+
+        return new ReadOnlyDictionary<string, string>(copy);
+    }
+}

--- a/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
@@ -7,7 +7,8 @@ namespace Dekaf.Telemetry;
 internal enum ClientTelemetryClientRole
 {
     Producer,
-    Consumer
+    Consumer,
+    Admin
 }
 
 internal enum ClientTelemetryMetricKind
@@ -50,9 +51,13 @@ internal sealed class ClientTelemetryMetricCollector
     private static readonly IReadOnlyList<ClientTelemetryMetricAttribute> EmptyAttributes = [];
 
     private readonly ConcurrentDictionary<int, NodeRequestLatency> _nodeRequestLatencies = new();
-    private readonly string _connectionCreationTotalName;
-    private readonly string _nodeRequestLatencyAvgName;
-    private readonly string _nodeRequestLatencyMaxName;
+    private readonly ConcurrentDictionary<string, ApplicationTelemetryMetric> _applicationMetrics =
+        new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, double> _applicationCounterPreviousValues =
+        new(StringComparer.Ordinal);
+    private readonly string? _connectionCreationTotalName;
+    private readonly string? _nodeRequestLatencyAvgName;
+    private readonly string? _nodeRequestLatencyMaxName;
 
     private long _connectionCreationTotal;
     private long _connectionCreationDelta;
@@ -69,8 +74,33 @@ internal sealed class ClientTelemetryMetricCollector
                 ClientTelemetryMetricNames.ConsumerConnectionCreationTotal,
                 ClientTelemetryMetricNames.ConsumerNodeRequestLatencyAvg,
                 ClientTelemetryMetricNames.ConsumerNodeRequestLatencyMax),
+            ClientTelemetryClientRole.Admin => (null, null, null),
             _ => throw new ArgumentOutOfRangeException(nameof(role), role, "Unsupported telemetry client role")
         };
+    }
+
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        ArgumentNullException.ThrowIfNull(metric);
+        _applicationMetrics[metric.Name] = metric;
+        _applicationCounterPreviousValues.TryRemove(metric.Name, out _);
+    }
+
+    public void RegisterMetricsForSubscription(IEnumerable<ApplicationTelemetryMetric> metrics)
+    {
+        ArgumentNullException.ThrowIfNull(metrics);
+
+        foreach (var metric in metrics)
+        {
+            RegisterMetricForSubscription(metric);
+        }
+    }
+
+    public void UnregisterMetricFromSubscription(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _applicationMetrics.TryRemove(name, out _);
+        _applicationCounterPreviousValues.TryRemove(name, out _);
     }
 
     public void RecordConnectionCreated()
@@ -109,20 +139,17 @@ internal sealed class ClientTelemetryMetricCollector
             return ClientTelemetryMetricSnapshot.Empty(subscription.DeltaTemporality);
         }
 
-        var includeConnectionCreationTotal = IsRequested(_connectionCreationTotalName, requestedMetrics);
-        var includeRequestLatencyAvg = IsRequested(_nodeRequestLatencyAvgName, requestedMetrics);
-        var includeRequestLatencyMax = IsRequested(_nodeRequestLatencyMaxName, requestedMetrics);
-
-        if (!includeConnectionCreationTotal &&
-            !includeRequestLatencyAvg &&
-            !includeRequestLatencyMax)
-        {
-            return ClientTelemetryMetricSnapshot.Empty(subscription.DeltaTemporality);
-        }
+        var includeConnectionCreationTotal = _connectionCreationTotalName is not null &&
+            IsRequested(_connectionCreationTotalName, requestedMetrics);
+        var includeRequestLatencyAvg = _nodeRequestLatencyAvgName is not null &&
+            IsRequested(_nodeRequestLatencyAvgName, requestedMetrics);
+        var includeRequestLatencyMax = _nodeRequestLatencyMaxName is not null &&
+            IsRequested(_nodeRequestLatencyMaxName, requestedMetrics);
 
         var capacity = (includeConnectionCreationTotal ? 1 : 0) +
             ((includeRequestLatencyAvg ? 1 : 0) + (includeRequestLatencyMax ? 1 : 0)) *
-            Math.Max(1, _nodeRequestLatencies.Count);
+            Math.Max(1, _nodeRequestLatencies.Count) +
+            _applicationMetrics.Count;
         var metrics = new List<ClientTelemetryMetric>(capacity);
 
         if (includeConnectionCreationTotal)
@@ -134,7 +161,7 @@ internal sealed class ClientTelemetryMetricCollector
             if (value != 0)
             {
                 metrics.Add(new ClientTelemetryMetric(
-                    _connectionCreationTotalName,
+                    _connectionCreationTotalName!,
                     ClientTelemetryMetricKind.Counter,
                     value,
                     EmptyAttributes));
@@ -162,7 +189,7 @@ internal sealed class ClientTelemetryMetricCollector
                 if (includeRequestLatencyAvg)
                 {
                     metrics.Add(new ClientTelemetryMetric(
-                        _nodeRequestLatencyAvgName,
+                        _nodeRequestLatencyAvgName!,
                         ClientTelemetryMetricKind.Gauge,
                         StopwatchTicksToMilliseconds(snapshot.TotalTimestampTicks) / snapshot.Count,
                         attributes));
@@ -171,13 +198,15 @@ internal sealed class ClientTelemetryMetricCollector
                 if (includeRequestLatencyMax)
                 {
                     metrics.Add(new ClientTelemetryMetric(
-                        _nodeRequestLatencyMaxName,
+                        _nodeRequestLatencyMaxName!,
                         ClientTelemetryMetricKind.Gauge,
                         StopwatchTicksToMilliseconds(snapshot.MaxTimestampTicks),
                         attributes));
                 }
             }
         }
+
+        AddApplicationMetrics(subscription, requestedMetrics, metrics);
 
         return metrics.Count == 0
             ? ClientTelemetryMetricSnapshot.Empty(subscription.DeltaTemporality)
@@ -210,6 +239,96 @@ internal sealed class ClientTelemetryMetricCollector
 
     private static double StopwatchTicksToMilliseconds(long stopwatchTicks) =>
         stopwatchTicks * 1000.0 / Stopwatch.Frequency;
+
+    private void AddApplicationMetrics(
+        ClientTelemetrySubscription subscription,
+        IReadOnlyList<string> requestedMetrics,
+        List<ClientTelemetryMetric> metrics)
+    {
+        foreach (var (_, metric) in _applicationMetrics)
+        {
+            if (!IsRequested(metric.Name, requestedMetrics))
+            {
+                continue;
+            }
+
+            double value;
+            try
+            {
+                value = metric.Observe();
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (!double.IsFinite(value))
+            {
+                continue;
+            }
+
+            metrics.Add(new ClientTelemetryMetric(
+                metric.Name,
+                ToClientMetricKind(metric.Kind),
+                ToClientMetricValue(metric, value, subscription.DeltaTemporality),
+                ToClientMetricAttributes(metric.Attributes)));
+        }
+    }
+
+    private double ToClientMetricValue(
+        ApplicationTelemetryMetric metric,
+        double value,
+        bool deltaTemporality) =>
+        metric.Kind == ApplicationTelemetryMetricKind.Counter && deltaTemporality
+            ? GetApplicationCounterDelta(metric.Name, value)
+            : value;
+
+    private double GetApplicationCounterDelta(string name, double value)
+    {
+        while (true)
+        {
+            if (!_applicationCounterPreviousValues.TryGetValue(name, out var previous))
+            {
+                if (_applicationCounterPreviousValues.TryAdd(name, value))
+                {
+                    return value;
+                }
+
+                continue;
+            }
+
+            if (_applicationCounterPreviousValues.TryUpdate(name, value, previous))
+            {
+                return value >= previous ? value - previous : value;
+            }
+        }
+    }
+
+    private static ClientTelemetryMetricKind ToClientMetricKind(ApplicationTelemetryMetricKind kind) =>
+        kind switch
+        {
+            ApplicationTelemetryMetricKind.Counter => ClientTelemetryMetricKind.Counter,
+            ApplicationTelemetryMetricKind.Gauge => ClientTelemetryMetricKind.Gauge,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unsupported application metric kind")
+        };
+
+    private static IReadOnlyList<ClientTelemetryMetricAttribute> ToClientMetricAttributes(
+        IReadOnlyDictionary<string, string> attributes)
+    {
+        if (attributes.Count == 0)
+        {
+            return EmptyAttributes;
+        }
+
+        var result = new ClientTelemetryMetricAttribute[attributes.Count];
+        var i = 0;
+        foreach (var (name, value) in attributes)
+        {
+            result[i++] = new ClientTelemetryMetricAttribute(name, value);
+        }
+
+        return result;
+    }
 
     private readonly record struct LatencySnapshot(
         long Count,

--- a/tests/Dekaf.Tests.Unit/Builder/ApplicationTelemetryBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ApplicationTelemetryBuilderTests.cs
@@ -1,0 +1,95 @@
+using System.Reflection;
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Telemetry;
+
+namespace Dekaf.Tests.Unit.Builder;
+
+public sealed class ApplicationTelemetryBuilderTests
+{
+    [Test]
+    public async Task ProducerBuilder_RegistersApplicationMetrics()
+    {
+        var metric = Metric("com.example.producer.depth");
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var result = builder.RegisterMetricForSubscription(metric);
+        await Assert.That(result).IsSameReferenceAs(builder);
+
+        await using var producer = builder
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        var options = GetPrivateField<ProducerOptions>(producer, "_options");
+
+        await Assert.That(options.ApplicationMetrics.Count).IsEqualTo(1);
+        await Assert.That(options.ApplicationMetrics[0]).IsSameReferenceAs(metric);
+    }
+
+    [Test]
+    public async Task ConsumerBuilder_RegistersAndUnregistersApplicationMetrics()
+    {
+        var kept = Metric("com.example.consumer.kept");
+        var removed = Metric("com.example.consumer.removed");
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var registered = builder.RegisterMetricForSubscription(kept);
+        var unregistered = builder
+            .RegisterMetricForSubscription(removed)
+            .UnregisterMetricFromSubscription(removed.Name);
+        await Assert.That(registered).IsSameReferenceAs(builder);
+        await Assert.That(unregistered).IsSameReferenceAs(builder);
+
+        await using var consumer = builder
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        var options = GetPrivateField<ConsumerOptions>(consumer, "_options");
+
+        await Assert.That(options.ApplicationMetrics.Count).IsEqualTo(1);
+        await Assert.That(options.ApplicationMetrics[0]).IsSameReferenceAs(kept);
+    }
+
+    [Test]
+    public async Task AdminClientBuilder_RegistersApplicationMetrics()
+    {
+        var first = Metric("com.example.admin.depth", () => 1);
+        var replacement = Metric("com.example.admin.depth", () => 2);
+        var builder = new AdminClientBuilder();
+
+        var result = builder.RegisterMetricForSubscription(first)
+            .RegisterMetricForSubscription(replacement);
+        await Assert.That(result).IsSameReferenceAs(builder);
+
+        await using var client = builder
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        var options = GetPrivateField<AdminClientOptions>(client, "_options");
+
+        await Assert.That(options.ApplicationMetrics.Count).IsEqualTo(1);
+        await Assert.That(options.ApplicationMetrics[0]).IsSameReferenceAs(replacement);
+    }
+
+    [Test]
+    public async Task RegisterMetricForSubscription_Null_ThrowsArgumentNullException()
+    {
+        await Assert.That(() => Kafka.CreateProducer<string, string>()
+                .RegisterMetricForSubscription(null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => Kafka.CreateConsumer<string, string>()
+                .RegisterMetricForSubscription(null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => new AdminClientBuilder()
+                .RegisterMetricForSubscription(null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    private static ApplicationTelemetryMetric Metric(string name, Func<double>? observe = null) =>
+        new(name, ApplicationTelemetryMetricKind.Gauge, observe ?? (() => 1));
+
+    private static TField GetPrivateField<TField>(object target, string fieldName)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"Could not find {fieldName} field.");
+        return (TField)field.GetValue(target)!;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Builder/ApplicationTelemetryBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ApplicationTelemetryBuilderTests.cs
@@ -83,6 +83,40 @@ public sealed class ApplicationTelemetryBuilderTests
             .Throws<ArgumentNullException>();
     }
 
+    [Test]
+    public async Task ClientMetricRegistration_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var metric = Metric("com.example.disposed");
+
+        var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        await producer.DisposeAsync();
+
+        var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        await consumer.DisposeAsync();
+
+        var admin = new AdminClientBuilder()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        await admin.DisposeAsync();
+
+        await Assert.That(() => producer.RegisterMetricForSubscription(metric))
+            .Throws<ObjectDisposedException>();
+        await Assert.That(() => producer.UnregisterMetricFromSubscription(metric.Name))
+            .Throws<ObjectDisposedException>();
+        await Assert.That(() => consumer.RegisterMetricForSubscription(metric))
+            .Throws<ObjectDisposedException>();
+        await Assert.That(() => consumer.UnregisterMetricFromSubscription(metric.Name))
+            .Throws<ObjectDisposedException>();
+        await Assert.That(() => admin.RegisterMetricForSubscription(metric))
+            .Throws<ObjectDisposedException>();
+        await Assert.That(() => admin.UnregisterMetricFromSubscription(metric.Name))
+            .Throws<ObjectDisposedException>();
+    }
+
     private static ApplicationTelemetryMetric Metric(string name, Func<double>? observe = null) =>
         new(name, ApplicationTelemetryMetricKind.Gauge, observe ?? (() => 1));
 

--- a/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsRetryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsRetryTests.cs
@@ -1,0 +1,151 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class QueryWatermarkOffsetsRetryTests
+{
+    private const string Topic = "test-topic";
+    private static readonly TopicPartition TopicPartition = new(Topic, 0);
+
+    [Test]
+    public async Task QueryWatermarkOffsetsAsync_NotLeaderOrFollower_RefreshesMetadataAndRetries()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var listOffsetCalls = 0;
+
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(connection));
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(connection));
+
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<MetadataResponse>(CreateMetadataResponse()));
+
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                listOffsetCalls++;
+
+                return new ValueTask<ListOffsetsResponse>(listOffsetCalls switch
+                {
+                    1 => CreateListOffsetsResponse(ErrorCode.NotLeaderOrFollower, -1),
+                    2 => CreateListOffsetsResponse(ErrorCode.None, 10),
+                    _ => CreateListOffsetsResponse(ErrorCode.None, 42)
+                });
+            });
+
+        await using var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.SetApiVersion(
+            ApiKey.ListOffsets,
+            ListOffsetsRequest.LowestSupportedVersion,
+            ListOffsetsRequest.HighestSupportedVersion);
+        SetMetadataApiVersion(metadataManager);
+        metadataManager.Metadata.Update(CreateMetadataResponse());
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "test-consumer"
+            },
+            Serializers.String,
+            Serializers.String,
+            pool,
+            metadataManager);
+        SetInitialized(consumer);
+
+        var watermarks = await consumer.QueryWatermarkOffsetsAsync(TopicPartition);
+
+        await Assert.That(watermarks.Low).IsEqualTo(10);
+        await Assert.That(watermarks.High).IsEqualTo(42);
+        await Assert.That(listOffsetCalls).IsEqualTo(3);
+        _ = connection.Received(1).SendAsync<MetadataRequest, MetadataResponse>(
+            Arg.Any<MetadataRequest>(),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static void SetInitialized(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_initialized", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_initialized field not found");
+
+        field.SetValue(consumer, true);
+    }
+
+    private static void SetMetadataApiVersion(MetadataManager metadataManager)
+    {
+        var field = typeof(MetadataManager)
+            .GetField("_metadataApiVersion", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_metadataApiVersion field not found");
+
+        field.SetValue(metadataManager, MetadataRequest.HighestSupportedVersion);
+    }
+
+    private static MetadataResponse CreateMetadataResponse()
+        => new()
+        {
+            ClusterId = "test-cluster",
+            ControllerId = 1,
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = Topic,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 1,
+                            LeaderEpoch = 1,
+                            ReplicaNodes = [1],
+                            IsrNodes = [1]
+                        }
+                    ]
+                }
+            ]
+        };
+
+    private static ListOffsetsResponse CreateListOffsetsResponse(ErrorCode errorCode, long offset)
+        => new()
+        {
+            Topics =
+            [
+                new ListOffsetsResponseTopic
+                {
+                    Name = Topic,
+                    Partitions =
+                    [
+                        new ListOffsetsResponsePartition
+                        {
+                            PartitionIndex = 0,
+                            ErrorCode = errorCode,
+                            Offset = offset
+                        }
+                    ]
+                }
+            ]
+        };
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsRetryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsRetryTests.cs
@@ -20,6 +20,7 @@ public sealed class QueryWatermarkOffsetsRetryTests
         var pool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
         var listOffsetCalls = 0;
+        var earliestOffsetCalls = 0;
 
         pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IKafkaConnection>(connection));
@@ -39,13 +40,18 @@ public sealed class QueryWatermarkOffsetsRetryTests
             .Returns(_ =>
             {
                 listOffsetCalls++;
+                var request = (ListOffsetsRequest)_[0]!;
+                var timestamp = request.Topics[0].Partitions[0].Timestamp;
 
-                return new ValueTask<ListOffsetsResponse>(listOffsetCalls switch
+                if (timestamp == -2)
                 {
-                    1 => CreateListOffsetsResponse(ErrorCode.NotLeaderOrFollower, -1),
-                    2 => CreateListOffsetsResponse(ErrorCode.None, 10),
-                    _ => CreateListOffsetsResponse(ErrorCode.None, 42)
-                });
+                    earliestOffsetCalls++;
+                    return new ValueTask<ListOffsetsResponse>(earliestOffsetCalls == 1
+                        ? CreateListOffsetsResponse(ErrorCode.NotLeaderOrFollower, -1)
+                        : CreateListOffsetsResponse(ErrorCode.None, 10));
+                }
+
+                return new ValueTask<ListOffsetsResponse>(CreateListOffsetsResponse(ErrorCode.None, 42));
             });
 
         await using var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
@@ -72,7 +78,7 @@ public sealed class QueryWatermarkOffsetsRetryTests
 
         await Assert.That(watermarks.Low).IsEqualTo(10);
         await Assert.That(watermarks.High).IsEqualTo(42);
-        await Assert.That(listOffsetCalls).IsEqualTo(3);
+        await Assert.That(listOffsetCalls).IsEqualTo(4);
         _ = connection.Received(1).SendAsync<MetadataRequest, MetadataResponse>(
             Arg.Any<MetadataRequest>(),
             Arg.Any<short>(),

--- a/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
@@ -1,5 +1,6 @@
 using Dekaf.Producer;
 using Dekaf.Serialization;
+using Dekaf.Telemetry;
 
 namespace Dekaf.Tests.Unit.Producer;
 
@@ -89,6 +90,14 @@ internal sealed class FastPathProducerSpy<TKey, TValue> : IKafkaProducer<TKey, T
         => Task.FromResult(Array.Empty<RecordMetadata>());
 
     public ValueTask FlushAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+    }
+
+    public void UnregisterMetricFromSubscription(string name)
+    {
+    }
 
     public ITransaction<TKey, TValue> BeginTransaction() => throw new NotSupportedException();
 

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
@@ -89,6 +89,36 @@ public sealed class ClientTelemetryManagerTests
     }
 
     [Test]
+    public async Task StopAsync_TerminatingPushIncludesApplicationMetrics()
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);
+        collector.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.shutdown.depth",
+            ApplicationTelemetryMetricKind.Gauge,
+            () => 9));
+        var payloadProvider = new CapturingPayloadProvider();
+        await using var context = new TelemetryTestContext(
+            metricCollector: collector,
+            payloadProvider: payloadProvider);
+        var clientInstanceId = Guid.Parse("99999999-9999-9999-9999-999999999999");
+        context.Connection.Enqueue(Subscription(
+            clientInstanceId,
+            subscriptionId: 100,
+            pushIntervalMs: 60000,
+            requestedMetrics: ["com.example."]));
+        context.Connection.Enqueue(new PushTelemetryResponse { ErrorCode = ErrorCode.None });
+
+        await context.Manager.StartAsync();
+        await context.Manager.StopAsync(TimeSpan.FromSeconds(2));
+
+        var call = payloadProvider.Calls.Single();
+        await Assert.That(call.Terminating).IsTrue();
+        await Assert.That(call.Metrics.Metrics.Count).IsEqualTo(1);
+        await Assert.That(call.Metrics.Metrics[0].Name).IsEqualTo("com.example.shutdown.depth");
+        await Assert.That(call.Metrics.Metrics[0].Value).IsEqualTo(9.0);
+    }
+
+    [Test]
     public async Task StartAsync_SelectsFirstAcceptedSupportedCompression()
     {
         var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);
@@ -263,6 +293,26 @@ public sealed class ClientTelemetryManagerTests
             await _pool.DisposeAsync().ConfigureAwait(false);
         }
     }
+
+    private sealed class CapturingPayloadProvider : IClientTelemetryPayloadProvider
+    {
+        private readonly ConcurrentQueue<PayloadCall> _calls = new();
+
+        public IReadOnlyList<PayloadCall> Calls => _calls.ToArray();
+
+        public ReadOnlyMemory<byte> Collect(
+            ClientTelemetrySubscription subscription,
+            ClientTelemetryMetricSnapshot metrics,
+            bool terminating)
+        {
+            _calls.Enqueue(new PayloadCall(terminating, metrics));
+            return new byte[] { 1 };
+        }
+    }
+
+    private sealed record PayloadCall(
+        bool Terminating,
+        ClientTelemetryMetricSnapshot Metrics);
 
     private sealed class TestConnectionPool : IConnectionPool
     {

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryMetricCollectorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryMetricCollectorTests.cs
@@ -86,6 +86,124 @@ public sealed class ClientTelemetryMetricCollectorTests
             .IsEqualTo(25.0);
     }
 
+    [Test]
+    public async Task Collect_ApplicationMetric_ReturnsOnlyWhenRequested()
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Admin);
+        collector.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.queue.depth",
+            ApplicationTelemetryMetricKind.Gauge,
+            () => 42.5,
+            new Dictionary<string, string> { ["queue"] = "orders" }));
+
+        var included = collector.Collect(Subscription(deltaTemporality: false, "com.example."));
+        var excluded = collector.Collect(Subscription(deltaTemporality: false, "org.apache.kafka."));
+
+        await Assert.That(included.Metrics.Count).IsEqualTo(1);
+        await Assert.That(excluded.Metrics.Count).IsEqualTo(0);
+
+        var metric = included.Metrics[0];
+        await Assert.That(metric.Name).IsEqualTo("com.example.queue.depth");
+        await Assert.That(metric.Kind).IsEqualTo(ClientTelemetryMetricKind.Gauge);
+        await Assert.That(metric.Value).IsEqualTo(42.5);
+        await Assert.That(metric.Attributes.Single(a => a.Name == "queue").Value).IsEqualTo("orders");
+    }
+
+    [Test]
+    public async Task RegisterMetricForSubscription_DuplicateName_ReplacesMetric()
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Admin);
+        collector.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.total",
+            ApplicationTelemetryMetricKind.Gauge,
+            () => 1));
+        collector.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.total",
+            ApplicationTelemetryMetricKind.Counter,
+            () => 2));
+
+        var snapshot = collector.Collect(Subscription(deltaTemporality: true, "com.example."));
+
+        await Assert.That(snapshot.Metrics.Count).IsEqualTo(1);
+        await Assert.That(snapshot.Metrics[0].Name).IsEqualTo("com.example.total");
+        await Assert.That(snapshot.Metrics[0].Kind).IsEqualTo(ClientTelemetryMetricKind.Counter);
+        await Assert.That(snapshot.Metrics[0].Value).IsEqualTo(2.0);
+    }
+
+    [Test]
+    public async Task RegisterMetricForSubscription_CounterReplacement_ResetsDeltaBaseline()
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Admin);
+        collector.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.total",
+            ApplicationTelemetryMetricKind.Counter,
+            () => 100));
+        var first = collector.Collect(Subscription(deltaTemporality: true, "com.example."));
+
+        collector.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.total",
+            ApplicationTelemetryMetricKind.Counter,
+            () => 150));
+        var second = collector.Collect(Subscription(deltaTemporality: true, "com.example."));
+
+        await Assert.That(first.Metrics[0].Value).IsEqualTo(100.0);
+        await Assert.That(second.Metrics[0].Value).IsEqualTo(150.0);
+    }
+
+    [Test]
+    public async Task Collect_ApplicationCounterDeltaTemporality_ReturnsDelta()
+    {
+        double total = 5;
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Admin);
+        collector.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.processed.total",
+            ApplicationTelemetryMetricKind.Counter,
+            () => total));
+
+        var first = collector.Collect(Subscription(deltaTemporality: true, "com.example."));
+        total = 8;
+        var second = collector.Collect(Subscription(deltaTemporality: true, "com.example."));
+
+        await Assert.That(first.Metrics[0].Value).IsEqualTo(5.0);
+        await Assert.That(second.Metrics[0].Value).IsEqualTo(3.0);
+    }
+
+    [Test]
+    public async Task UnregisterMetricFromSubscription_RemovesMetricAndIgnoresMissingName()
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Admin);
+        collector.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.depth",
+            ApplicationTelemetryMetricKind.Gauge,
+            () => 3));
+
+        await Assert.That(() => collector.UnregisterMetricFromSubscription("com.example.missing"))
+            .ThrowsNothing();
+        collector.UnregisterMetricFromSubscription("com.example.depth");
+
+        var snapshot = collector.Collect(Subscription(deltaTemporality: true, "com.example."));
+
+        await Assert.That(snapshot.Metrics.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Collect_ApplicationMetricObserverFails_SkipsMetric()
+    {
+        var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Admin);
+        collector.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.bad",
+            ApplicationTelemetryMetricKind.Gauge,
+            () => throw new InvalidOperationException("boom")));
+        collector.RegisterMetricForSubscription(new ApplicationTelemetryMetric(
+            "com.example.nan",
+            ApplicationTelemetryMetricKind.Gauge,
+            () => double.NaN));
+
+        var snapshot = collector.Collect(Subscription(deltaTemporality: true, "com.example."));
+
+        await Assert.That(snapshot.Metrics.Count).IsEqualTo(0);
+    }
+
     private static ClientTelemetrySubscription Subscription(
         bool deltaTemporality,
         params string[] requestedMetrics) =>


### PR DESCRIPTION
## Summary
- add public KIP-1076 application metric descriptor plus register/unregister APIs on producer, consumer, and admin clients/builders
- feed registered metrics through broker client telemetry only for requested subscription prefixes, with duplicate replacement, no-op unregister, observer-failure skips, and counter delta handling
- cover terminating telemetry push and update docs sample

Closes #1007

## Validation
- `dotnet restore Dekaf.sln`
- `dotnet build Dekaf.sln --no-restore`
- `./tests/Dekaf.Tests.Unit/bin/Debug/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ClientTelemetryMetricCollectorTests/*" --minimum-expected-tests 8`
- `./tests/Dekaf.Tests.Unit/bin/Debug/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ClientTelemetryManagerTests/*" --minimum-expected-tests 10`
- `./tests/Dekaf.Tests.Unit/bin/Debug/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ApplicationTelemetryBuilderTests/*" --minimum-expected-tests 4`
- `npm ci` in `docs`
- `npm run build` in `docs`

## Notes
- Full unit executable was attempted with `--timeout 10m`, but the outer command timed out after roughly 11 minutes without a TUnit summary; the leftover test process was killed.