### PR TITLE
fix(consumer): prune empty coordinator topics

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -75,6 +75,29 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     public CoordinatorState State => _state;
     public IReadOnlySet<TopicPartition> Assignment => _assignedPartitions;
 
+    private static void RemoveEmptyTopicGroups<TItem>(Dictionary<string, List<TItem>> topicGroups)
+    {
+        string[]? emptyTopics = null;
+        var emptyTopicCount = 0;
+
+        foreach (var kvp in topicGroups)
+        {
+            if (kvp.Value.Count != 0)
+                continue;
+
+            emptyTopics ??= new string[topicGroups.Count];
+            emptyTopics[emptyTopicCount++] = kvp.Key;
+        }
+
+        if (emptyTopics is null)
+            return;
+
+        for (var i = 0; i < emptyTopicCount; i++)
+        {
+            topicGroups.Remove(emptyTopics[i]);
+        }
+    }
+
     /// <summary>
     /// Forces the coordinator to rejoin the group on the next
     /// <see cref="EnsureActiveGroupAsync"/> call by transitioning to <see cref="CoordinatorState.Unjoined"/>.
@@ -307,6 +330,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     });
                 }
 
+                RemoveEmptyTopicGroups(_commitTopicGroups);
+
                 var topicOffsets = new List<OffsetCommitRequestTopic>(_commitTopicGroups.Count);
                 foreach (var kvp in _commitTopicGroups)
                 {
@@ -401,6 +426,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     }
                     indexes.Add(partition.Partition);
                 }
+
+                RemoveEmptyTopicGroups(_fetchTopicGroups);
 
                 var topicPartitions = new List<OffsetFetchRequestTopic>(_fetchTopicGroups.Count);
                 foreach (var kvp in _fetchTopicGroups)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -371,6 +371,83 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
     #endregion
 
+    #region Offset Request Grouping Tests
+
+    [Test]
+    public async Task CommitOffsetsAsync_RemovesEmptyPooledTopicGroups()
+    {
+        _metadataManager.SetApiVersion(ApiKey.OffsetCommit, OffsetCommitRequest.LowestSupportedVersion, OffsetCommitRequest.HighestSupportedVersion);
+
+        var topicSnapshots = new List<(string Name, int PartitionCount)[]>();
+        _connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var request = ci.Arg<OffsetCommitRequest>();
+                topicSnapshots.Add(request.Topics
+                    .Select(static topic => (topic.Name, topic.Partitions.Count))
+                    .ToArray());
+
+                return ValueTask.FromResult(new OffsetCommitResponse
+                {
+                    Topics = []
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.CommitOffsetsAsync([new TopicPartitionOffset("alpha", 0, 42)], CancellationToken.None);
+        await coordinator.CommitOffsetsAsync([new TopicPartitionOffset("beta", 1, 43)], CancellationToken.None);
+
+        await Assert.That(topicSnapshots.Count).IsEqualTo(2);
+        await Assert.That(topicSnapshots[1].Length).IsEqualTo(1);
+        await Assert.That(topicSnapshots[1][0].Name).IsEqualTo("beta");
+        await Assert.That(topicSnapshots[1][0].PartitionCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task FetchOffsetsAsync_RemovesEmptyPooledTopicGroups()
+    {
+        _metadataManager.SetApiVersion(ApiKey.OffsetFetch, OffsetFetchRequest.LowestSupportedVersion, OffsetFetchRequest.HighestSupportedVersion);
+        SetupSuccessfulConsumerProtocolJoin();
+
+        var topicSnapshots = new List<(string Name, int PartitionCount)[]>();
+        _connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
+                Arg.Any<OffsetFetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var request = ci.Arg<OffsetFetchRequest>();
+                topicSnapshots.Add(request.Topics!
+                    .Select(static topic => (topic.Name, topic.PartitionIndexes.Count))
+                    .ToArray());
+
+                return ValueTask.FromResult(new OffsetFetchResponse
+                {
+                    Topics = [],
+                    ErrorCode = ErrorCode.None
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await coordinator.FetchOffsetsAsync([new TopicPartition("alpha", 0)], CancellationToken.None);
+        await coordinator.FetchOffsetsAsync([new TopicPartition("beta", 1)], CancellationToken.None);
+
+        await Assert.That(topicSnapshots.Count).IsEqualTo(2);
+        await Assert.That(topicSnapshots[1].Length).IsEqualTo(1);
+        await Assert.That(topicSnapshots[1][0].Name).IsEqualTo("beta");
+        await Assert.That(topicSnapshots[1][0].PartitionCount).IsEqualTo(1);
+    }
+
+    #endregion
+
     #region Error Handling Tests
 
     [Test]


### PR DESCRIPTION
## Summary
- remove empty pooled coordinator topic groups before building OffsetCommit requests
- remove empty pooled coordinator topic groups before building OffsetFetch requests
- add regression coverage for stale topic keys across repeated requests

## Validation
- dotnet restore Dekaf.sln
- dotnet build Dekaf.sln -c Release --no-restore
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/ConsumerCoordinatorKip848Tests/*" --disable-logo --no-progress --minimum-expected-tests 1
- dotnet format --verify-no-changes --verbosity minimal --include src\Dekaf\Consumer\ConsumerCoordinator.cs tests\Dekaf.Tests.Unit\Consumer\ConsumerCoordinatorKip848Tests.cs

Refs #934