### PR TITLE
fix(api): harden KafkaClient metadata sharing

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -2748,9 +2748,12 @@ public sealed class AdminClientBuilder
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs
         };
 
-        var metadataOptions = _metadataMaxAge.HasValue
-            ? new MetadataOptions { MetadataRefreshInterval = _metadataMaxAge.Value }
-            : null;
+        var metadataOptions = new MetadataOptions
+        {
+            MetadataRefreshInterval = _metadataMaxAge ?? TimeSpan.FromMinutes(15),
+            MetadataRecoveryStrategy = _metadataRecoveryStrategy,
+            MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs
+        };
 
         return _clientInfrastructure is null
             ? new AdminClient(options, _loggerFactory, metadataOptions)

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -2664,6 +2664,7 @@ public sealed class AdminClientBuilder
     /// <param name="strategy">The recovery strategy to use.</param>
     public AdminClientBuilder WithMetadataRecoveryStrategy(MetadataRecoveryStrategy strategy)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _metadataRecoveryStrategy = strategy;
         return this;
     }
@@ -2675,6 +2676,7 @@ public sealed class AdminClientBuilder
     /// <param name="trigger">The trigger delay. Default is 5 minutes.</param>
     public AdminClientBuilder WithMetadataRecoveryRebootstrapTrigger(TimeSpan trigger)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _metadataRecoveryRebootstrapTriggerMs = (int)trigger.TotalMilliseconds;
         return this;
     }
@@ -2689,6 +2691,7 @@ public sealed class AdminClientBuilder
     /// <returns>The builder instance for method chaining.</returns>
     public AdminClientBuilder WithMetadataMaxAge(TimeSpan interval)
     {
+        ThrowIfClientOwnedConnectionSettings();
         if (interval <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(interval), "Metadata max age must be positive");
 

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -484,6 +484,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <param name="strategy">The recovery strategy to use.</param>
     public ProducerBuilder<TKey, TValue> WithMetadataRecoveryStrategy(MetadataRecoveryStrategy strategy)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _metadataRecoveryStrategy = strategy;
         return this;
     }
@@ -495,6 +496,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <param name="trigger">The trigger delay. Default is 5 minutes.</param>
     public ProducerBuilder<TKey, TValue> WithMetadataRecoveryRebootstrapTrigger(TimeSpan trigger)
     {
+        ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfGreaterThan(trigger.TotalMilliseconds, int.MaxValue, nameof(trigger));
         _metadataRecoveryRebootstrapTriggerMs = (int)trigger.TotalMilliseconds;
         return this;
@@ -510,6 +512,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <returns>The builder instance for method chaining.</returns>
     public ProducerBuilder<TKey, TValue> WithMetadataMaxAge(TimeSpan interval)
     {
+        ThrowIfClientOwnedConnectionSettings();
         if (interval <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(interval), "Metadata max age must be positive");
 
@@ -1549,6 +1552,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="strategy">The recovery strategy to use.</param>
     public ConsumerBuilder<TKey, TValue> WithMetadataRecoveryStrategy(MetadataRecoveryStrategy strategy)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _metadataRecoveryStrategy = strategy;
         return this;
     }
@@ -1560,6 +1564,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="trigger">The trigger delay. Default is 5 minutes.</param>
     public ConsumerBuilder<TKey, TValue> WithMetadataRecoveryRebootstrapTrigger(TimeSpan trigger)
     {
+        ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfGreaterThan(trigger.TotalMilliseconds, int.MaxValue, nameof(trigger));
         _metadataRecoveryRebootstrapTriggerMs = (int)trigger.TotalMilliseconds;
         return this;
@@ -1575,6 +1580,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <returns>The builder instance for method chaining.</returns>
     public ConsumerBuilder<TKey, TValue> WithMetadataMaxAge(TimeSpan interval)
     {
+        ThrowIfClientOwnedConnectionSettings();
         if (interval <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(interval), "Metadata max age must be positive");
 

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -873,9 +873,12 @@ public sealed class ProducerBuilder<TKey, TValue>
             MaxConnectionsPerBroker = _maxConnectionsPerBroker
         };
 
-        var metadataOptions = _metadataMaxAge.HasValue
-            ? new MetadataOptions { MetadataRefreshInterval = _metadataMaxAge.Value }
-            : null;
+        var metadataOptions = new MetadataOptions
+        {
+            MetadataRefreshInterval = _metadataMaxAge ?? TimeSpan.FromMinutes(15),
+            MetadataRecoveryStrategy = _metadataRecoveryStrategy,
+            MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs
+        };
 
         var producer = _clientInfrastructure is null
             ? new KafkaProducer<TKey, TValue>(options, keySerializer, valueSerializer, _loggerFactory, metadataOptions)
@@ -1856,9 +1859,12 @@ public sealed class ConsumerBuilder<TKey, TValue>
             AdaptiveFetchSizingOptions = _adaptiveFetchSizingOptions
         };
 
-        var metadataOptions = _metadataMaxAge.HasValue
-            ? new MetadataOptions { MetadataRefreshInterval = _metadataMaxAge.Value }
-            : null;
+        var metadataOptions = new MetadataOptions
+        {
+            MetadataRefreshInterval = _metadataMaxAge ?? TimeSpan.FromMinutes(15),
+            MetadataRecoveryStrategy = _metadataRecoveryStrategy,
+            MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs
+        };
 
         var consumer = _clientInfrastructure is null
             ? new KafkaConsumer<TKey, TValue>(options, keyDeserializer, valueDeserializer, _loggerFactory, metadataOptions)

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -28,6 +28,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
     private readonly ConcurrentDictionary<ApiKey, (short MinVersion, short MaxVersion)> _brokerApiVersions = new();
     private readonly ConcurrentDictionary<(ApiKey, short, short), short> _negotiatedVersionCache = new();
     private volatile IReadOnlyList<FinalizedFeature>? _finalizedFeatures;
+    private readonly SemaphoreSlim _initializeLock = new(1, 1);
+    private bool _initialized;
     private int _disposed;
     private readonly CancellationTokenSource _disposalCts = new();
     private CancellationTokenSource? _backgroundRefreshCts;
@@ -220,26 +222,42 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
     public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)
     {
-        var backoffMs = _options.RetryBackoffMs;
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(MetadataManager));
 
-        for (var attempt = 0; ; attempt++)
+        await _initializeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            try
+            if (_initialized)
+                return;
+
+            var backoffMs = _options.RetryBackoffMs;
+
+            for (var attempt = 0; ; attempt++)
             {
-                await RefreshMetadataAsync(cancellationToken).ConfigureAwait(false);
-                break;
+                try
+                {
+                    await RefreshMetadataAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                }
+                catch (Exception ex) when (!IsFatalMetadataError(ex) && attempt < _options.MaxInitRetries && !cancellationToken.IsCancellationRequested)
+                {
+                    LogMetadataInitializationFailed(ex, attempt + 1, backoffMs);
+                    await Task.Delay(backoffMs, cancellationToken).ConfigureAwait(false);
+                    backoffMs = Math.Min(backoffMs * 2, _options.RetryBackoffMaxMs);
+                }
             }
-            catch (Exception ex) when (!IsFatalMetadataError(ex) && attempt < _options.MaxInitRetries && !cancellationToken.IsCancellationRequested)
+
+            if (_options.EnableBackgroundRefresh)
             {
-                LogMetadataInitializationFailed(ex, attempt + 1, backoffMs);
-                await Task.Delay(backoffMs, cancellationToken).ConfigureAwait(false);
-                backoffMs = Math.Min(backoffMs * 2, _options.RetryBackoffMaxMs);
+                StartBackgroundRefresh();
             }
+
+            _initialized = true;
         }
-
-        if (_options.EnableBackgroundRefresh)
+        finally
         {
-            StartBackgroundRefresh();
+            _initializeLock.Release();
         }
     }
 
@@ -906,6 +924,9 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
     private void StartBackgroundRefresh()
     {
+        if (_backgroundRefreshTask is not null)
+            return;
+
         _backgroundRefreshCts = new CancellationTokenSource();
         _backgroundRefreshTask = BackgroundRefreshLoopAsync(_backgroundRefreshCts.Token);
     }
@@ -977,6 +998,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
         _backgroundRefreshCts?.Dispose();
         _disposalCts.Dispose();
+        _initializeLock.Dispose();
         _refreshLock.Dispose();
     }
 

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -30,9 +30,10 @@ public sealed partial class MetadataManager : IAsyncDisposable
     private readonly ConcurrentDictionary<(ApiKey, short, short), short> _negotiatedVersionCache = new();
     private volatile IReadOnlyList<FinalizedFeature>? _finalizedFeatures;
     private readonly SemaphoreSlim _initializeLock = new(1, 1);
-    private bool _initialized;
+    private volatile bool _initialized;
     private int _disposed;
     private readonly CancellationTokenSource _disposalCts = new();
+    private readonly object _backgroundRefreshGate = new();
     private CancellationTokenSource? _backgroundRefreshCts;
     private Task? _backgroundRefreshTask;
 
@@ -219,41 +220,62 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// real cause instead of masking it as a generic metadata-refresh failure.
     /// </summary>
     private static bool IsFatalMetadataError(Exception ex) =>
-        ex is BrokerVersionException or AuthenticationException or AuthorizationException;
+        ex is BrokerVersionException or AuthenticationException or AuthorizationException or ObjectDisposedException;
 
     public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)
     {
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(MetadataManager));
 
+        if (_initialized)
+            return;
+
         await SemaphoreHelper.AcquireOrThrowDisposedAsync(_initializeLock, nameof(MetadataManager), cancellationToken)
             .ConfigureAwait(false);
         try
         {
+            if (Volatile.Read(ref _disposed) != 0)
+                throw new ObjectDisposedException(nameof(MetadataManager));
+
             if (_initialized)
                 return;
 
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposalCts.Token);
+            var initializationToken = linkedCts.Token;
             var backoffMs = _options.RetryBackoffMs;
 
-            for (var attempt = 0; ; attempt++)
+            try
             {
-                try
+                for (var attempt = 0; ; attempt++)
                 {
-                    await RefreshMetadataAsync(cancellationToken).ConfigureAwait(false);
-                    break;
-                }
-                catch (Exception ex) when (!IsFatalMetadataError(ex) && attempt < _options.MaxInitRetries && !cancellationToken.IsCancellationRequested)
-                {
-                    LogMetadataInitializationFailed(ex, attempt + 1, backoffMs);
-                    await Task.Delay(backoffMs, cancellationToken).ConfigureAwait(false);
-                    backoffMs = Math.Min(backoffMs * 2, _options.RetryBackoffMaxMs);
+                    try
+                    {
+                        await RefreshMetadataAsync(initializationToken).ConfigureAwait(false);
+                        break;
+                    }
+                    catch (Exception ex) when (!IsFatalMetadataError(ex) && attempt < _options.MaxInitRetries && !initializationToken.IsCancellationRequested)
+                    {
+                        LogMetadataInitializationFailed(ex, attempt + 1, backoffMs);
+                        await Task.Delay(backoffMs, initializationToken).ConfigureAwait(false);
+                        backoffMs = Math.Min(backoffMs * 2, _options.RetryBackoffMaxMs);
+                    }
                 }
             }
+            catch (OperationCanceledException) when (_disposalCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                throw new ObjectDisposedException(nameof(MetadataManager));
+            }
+
+            if (Volatile.Read(ref _disposed) != 0)
+                throw new ObjectDisposedException(nameof(MetadataManager));
 
             if (_options.EnableBackgroundRefresh)
             {
                 StartBackgroundRefresh();
             }
+
+            if (Volatile.Read(ref _disposed) != 0)
+                throw new ObjectDisposedException(nameof(MetadataManager));
 
             _initialized = true;
         }
@@ -927,11 +949,21 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
     private void StartBackgroundRefresh()
     {
-        if (_backgroundRefreshTask is not null)
+        if (Volatile.Read(ref _disposed) != 0)
             return;
 
-        _backgroundRefreshCts = new CancellationTokenSource();
-        _backgroundRefreshTask = BackgroundRefreshLoopAsync(_backgroundRefreshCts.Token);
+        lock (_backgroundRefreshGate)
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+                return;
+
+            if (_backgroundRefreshTask is { IsCompleted: false })
+                return;
+
+            _backgroundRefreshCts?.Dispose();
+            _backgroundRefreshCts = new CancellationTokenSource();
+            _backgroundRefreshTask = BackgroundRefreshLoopAsync(_backgroundRefreshCts.Token);
+        }
     }
 
     private async Task BackgroundRefreshLoopAsync(CancellationToken cancellationToken)
@@ -951,11 +983,16 @@ public sealed partial class MetadataManager : IAsyncDisposable
             {
                 break;
             }
+            catch (ObjectDisposedException) when (Volatile.Read(ref _disposed) != 0)
+            {
+                break;
+            }
             catch (Exception ex) when (IsFatalMetadataError(ex))
             {
                 // Credentials or authorization changed mid-session: retrying forever would mask the
-                // failure. Stop the background loop; the next foreground metadata operation will
-                // surface the fatal exception to the caller.
+                // failure. Stop the background loop and require a later InitializeAsync call to
+                // re-establish refresh after the caller handles the fatal error.
+                _initialized = false;
                 LogBackgroundMetadataRefreshFatal(ex);
                 break;
             }
@@ -987,6 +1024,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
         _disposalCts.Cancel();
         _backgroundRefreshCts?.Cancel();
 
+        await WaitForInitializationToDrainAsync().ConfigureAwait(false);
+
         if (_backgroundRefreshTask is not null)
         {
             try
@@ -1003,6 +1042,20 @@ public sealed partial class MetadataManager : IAsyncDisposable
         _disposalCts.Dispose();
         _initializeLock.Dispose();
         _refreshLock.Dispose();
+    }
+
+    private async ValueTask WaitForInitializationToDrainAsync()
+    {
+        try
+        {
+            await _initializeLock.WaitAsync().ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
+
+        SemaphoreHelper.ReleaseSafely(_initializeLock);
     }
 
     #region Logging

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -219,8 +219,15 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// credentials, or authorization decision applies everywhere, so fail fast and surface the
     /// real cause instead of masking it as a generic metadata-refresh failure.
     /// </summary>
-    private static bool IsFatalMetadataError(Exception ex) =>
-        ex is BrokerVersionException or AuthenticationException or AuthorizationException or ObjectDisposedException;
+    private bool IsFatalMetadataError(Exception ex)
+    {
+        if (ex is BrokerVersionException or AuthenticationException or AuthorizationException)
+            return true;
+
+        // KafkaConnection instances can be disposed independently during pool churn. Only the
+        // manager's own disposal is fatal; recycled connections should fall through to retry.
+        return ex is ObjectDisposedException && Volatile.Read(ref _disposed) != 0;
+    }
 
     public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -1025,6 +1025,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
         _backgroundRefreshCts?.Cancel();
 
         await WaitForInitializationToDrainAsync().ConfigureAwait(false);
+        // An InitializeAsync racing disposal can create the background CTS while we drain it.
+        _backgroundRefreshCts?.Cancel();
 
         if (_backgroundRefreshTask is not null)
         {

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Runtime.CompilerServices;
 using Dekaf.Errors;
+using Dekaf.Internal;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
@@ -225,7 +226,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(MetadataManager));
 
-        await _initializeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await SemaphoreHelper.AcquireOrThrowDisposedAsync(_initializeLock, nameof(MetadataManager), cancellationToken)
+            .ConfigureAwait(false);
         try
         {
             if (_initialized)
@@ -257,7 +259,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
         }
         finally
         {
-            _initializeLock.Release();
+            SemaphoreHelper.ReleaseSafely(_initializeLock);
         }
     }
 
@@ -502,7 +504,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
             throw new ObjectDisposedException(nameof(MetadataManager));
 
         LogMetadataRefreshRequested();
-        await _refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await SemaphoreHelper.AcquireOrThrowDisposedAsync(_refreshLock, nameof(MetadataManager), cancellationToken)
+            .ConfigureAwait(false);
         try
         {
             // Re-check cache after acquiring lock — another thread may have refreshed
@@ -519,7 +522,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
         }
         finally
         {
-            _refreshLock.Release();
+            SemaphoreHelper.ReleaseSafely(_refreshLock);
         }
     }
 

--- a/tests/Dekaf.Tests.Integration/MultiConnectionProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/MultiConnectionProducerTests.cs
@@ -78,7 +78,10 @@ public sealed class MultiConnectionProducerTests(KafkaTestContainer kafka) : Kaf
         for (var p = 0; p < partitionCount; p++)
             await producer.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic, Key = "warmup", Value = "warmup", Partition = p
+                Topic = topic,
+                Key = "warmup",
+                Value = "warmup",
+                Partition = p
             }, CancellationToken.None);
 
         // Produce sequenced messages to each partition
@@ -96,25 +99,38 @@ public sealed class MultiConnectionProducerTests(KafkaTestContainer kafka) : Kaf
             }
         }
 
-        // Consume per-partition and verify ordering
+        // Consume all partitions in one assignment and verify ordering per partition.
+        // Reassigning the same consumer partition-by-partition can observe buffered
+        // records from the prior assignment, which is unrelated to producer ordering.
         await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
 
+        consumer.Assign(Enumerable.Range(0, partitionCount)
+            .Select(p => new TopicPartition(topic, p))
+            .ToArray());
+
+        var messagesByPartition = new Dictionary<int, List<string>>();
+        for (var p = 0; p < partitionCount; p++)
+            messagesByPartition[p] = [];
+
+        var totalExpected = partitionCount * messagesPerPartition;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        await foreach (var msg in consumer.ConsumeAsync(cts.Token))
+        {
+            if (msg.Value != "warmup")
+                messagesByPartition[msg.Partition].Add(msg.Value!);
+
+            var total = messagesByPartition.Values.Sum(messages => messages.Count);
+            if (total >= totalExpected)
+                break;
+        }
+
         for (var p = 0; p < partitionCount; p++)
         {
-            consumer.Assign(new TopicPartition(topic, p));
-            var messages = new List<string>();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-
-            await foreach (var msg in consumer.ConsumeAsync(cts.Token))
-            {
-                if (msg.Value == "warmup") continue;
-                messages.Add(msg.Value!);
-                if (messages.Count >= messagesPerPartition) break;
-            }
-
+            var messages = messagesByPartition[p];
             await Assert.That(messages).Count().IsEqualTo(messagesPerPartition);
 
             // Verify strict ordering within this partition

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -76,12 +76,24 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithConnectionsPerBroker(2))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithMetadataRecoveryStrategy(MetadataRecoveryStrategy.None))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMinutes(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithMetadataMaxAge(TimeSpan.FromMinutes(1)))
+            .Throws<InvalidOperationException>();
 
         await Assert.That(() => client.CreateConsumer<string, string>().UseTls())
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithSaslPlain("user", "pass"))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithConnectionsPerBroker(2))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithMetadataRecoveryStrategy(MetadataRecoveryStrategy.None))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMinutes(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithMetadataMaxAge(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
 
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithTls())
@@ -96,6 +108,12 @@ public sealed class KafkaClientBuilderTests
         await Assert.That(() => client.CreateAdminClient().UseTls())
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateAdminClient().WithSaslPlain("user", "pass"))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithMetadataRecoveryStrategy(MetadataRecoveryStrategy.None))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMinutes(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithMetadataMaxAge(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
     }
 

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -298,7 +298,7 @@ public class MetadataManagerTests
     }
 
     [Test]
-    public async Task InitializeAsync_DisposeDuringRefresh_DoesNotThrowFromDisposedLocks()
+    public async Task InitializeAsync_DisposeDuringRefresh_DoesNotStartBackgroundRefresh()
     {
         var pool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
@@ -321,7 +321,11 @@ public class MetadataManagerTests
         var manager = new MetadataManager(
             pool,
             ["localhost:9092"],
-            new MetadataOptions { EnableBackgroundRefresh = false });
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = true,
+                MetadataRefreshInterval = TimeSpan.FromHours(1)
+            });
         SetMetadataApiVersion(manager);
 
         var initializeTask = manager.InitializeAsync().AsTask();
@@ -330,18 +334,55 @@ public class MetadataManagerTests
         var disposeTask = manager.DisposeAsync().AsTask();
         releaseRefresh.SetResult(CreateMetadataResponse((1, "broker1", 9092)));
 
-        Exception? initializeException = null;
-        try
-        {
-            await initializeTask.WaitAsync(TimeSpan.FromSeconds(5));
-        }
-        catch (Exception ex)
-        {
-            initializeException = ex;
-        }
+        var act = () => initializeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(act).Throws<ObjectDisposedException>();
 
         await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
-        await Assert.That(initializeException).IsNull();
+        object? backgroundRefreshTask = GetInstanceField<Task?>(manager, "_backgroundRefreshTask");
+        await Assert.That(backgroundRefreshTask).IsNull();
+    }
+
+    [Test]
+    public async Task ObjectDisposedException_IsFatalMetadataError()
+    {
+        await Assert.That(IsFatalMetadataError(new ObjectDisposedException(nameof(MetadataManager)))).IsTrue();
+    }
+
+    [Test]
+    public async Task BackgroundRefreshLoop_FatalError_ResetsInitialized()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromException<IKafkaConnection>(new AuthenticationException("auth failed")));
+
+        var manager = new MetadataManager(
+            pool,
+            ["localhost:9092"],
+            new MetadataOptions { MetadataRefreshInterval = TimeSpan.Zero });
+        SetInstanceField(manager, "_initialized", true);
+
+        var loop = InvokeBackgroundRefreshLoop(manager, CancellationToken.None);
+        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(GetInstanceField<bool>(manager, "_initialized")).IsFalse();
+        await manager.DisposeAsync();
+    }
+
+    [Test]
+    public async Task StartBackgroundRefresh_CompletedTask_AllowsRestart()
+    {
+        var manager = new MetadataManager(
+            Substitute.For<IConnectionPool>(),
+            ["localhost:9092"],
+            new MetadataOptions { MetadataRefreshInterval = TimeSpan.FromHours(1) });
+        SetInstanceField<Task?>(manager, "_backgroundRefreshTask", Task.CompletedTask);
+
+        InvokeStartBackgroundRefresh(manager);
+
+        var backgroundTask = GetInstanceField<Task?>(manager, "_backgroundRefreshTask");
+        await Assert.That(backgroundTask).IsNotNull();
+        await Assert.That(backgroundTask!.IsCompleted).IsFalse();
+        await manager.DisposeAsync();
     }
 
     private static void SetMetadataApiVersion(MetadataManager metadataManager)
@@ -351,5 +392,50 @@ public class MetadataManagerTests
             ?? throw new InvalidOperationException("_metadataApiVersion field not found");
 
         field.SetValue(metadataManager, MetadataRequest.HighestSupportedVersion);
+    }
+
+    private static bool IsFatalMetadataError(Exception exception)
+    {
+        var method = typeof(MetadataManager)
+            .GetMethod("IsFatalMetadataError", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("IsFatalMetadataError method not found");
+
+        return (bool)method.Invoke(null, [exception])!;
+    }
+
+    private static Task InvokeBackgroundRefreshLoop(MetadataManager metadataManager, CancellationToken cancellationToken)
+    {
+        var method = typeof(MetadataManager)
+            .GetMethod("BackgroundRefreshLoopAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("BackgroundRefreshLoopAsync method not found");
+
+        return (Task)method.Invoke(metadataManager, [cancellationToken])!;
+    }
+
+    private static void InvokeStartBackgroundRefresh(MetadataManager metadataManager)
+    {
+        var method = typeof(MetadataManager)
+            .GetMethod("StartBackgroundRefresh", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("StartBackgroundRefresh method not found");
+
+        method.Invoke(metadataManager, null);
+    }
+
+    private static T GetInstanceField<T>(object instance, string name)
+    {
+        var field = instance.GetType()
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{name} field not found");
+
+        return (T)field.GetValue(instance)!;
+    }
+
+    private static void SetInstanceField<T>(object instance, string name, T value)
+    {
+        var field = instance.GetType()
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{name} field not found");
+
+        field.SetValue(instance, value);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -248,4 +248,52 @@ public class MetadataManagerTests
         // No assertion needed - successful completion proves thread-safety
     }
 
+    [Test]
+    public async Task InitializeAsync_ConcurrentCalls_StartsOnce()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var metadataRequests = 0;
+
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(connection));
+
+        connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<ApiVersionsResponse>(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                ]
+            }));
+
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref metadataRequests);
+                return new ValueTask<MetadataResponse>(CreateMetadataResponse((1, "localhost", 9092)));
+            });
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["localhost:9092"],
+            new MetadataOptions { MetadataRefreshInterval = TimeSpan.FromHours(1) });
+
+        await Task.WhenAll(
+            manager.InitializeAsync().AsTask(),
+            manager.InitializeAsync().AsTask());
+
+        await Assert.That(metadataRequests).IsEqualTo(1);
+    }
+
 }

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -372,9 +372,81 @@ public class MetadataManagerTests
     }
 
     [Test]
-    public async Task ObjectDisposedException_IsFatalMetadataError()
+    public async Task RefreshMetadataAsync_ObjectDisposedConnection_TriesNextEndpoint()
     {
-        await Assert.That(IsFatalMetadataError(new ObjectDisposedException(nameof(MetadataManager)))).IsTrue();
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var firstEndpointAttempts = 0;
+        var secondEndpointAttempts = 0;
+
+        pool.GetConnectionAsync("broker1", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref firstEndpointAttempts);
+                return ValueTask.FromException<IKafkaConnection>(new ObjectDisposedException("KafkaConnection"));
+            });
+
+        pool.GetConnectionAsync("broker2", 9093, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref secondEndpointAttempts);
+                return new ValueTask<IKafkaConnection>(connection);
+            });
+
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<MetadataResponse>(CreateMetadataResponse((2, "broker2", 9093))));
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["broker1:9092", "broker2:9093"],
+            new MetadataOptions { EnableBackgroundRefresh = false });
+        SetMetadataApiVersion(manager);
+
+        await manager.RefreshMetadataAsync();
+
+        await Assert.That(firstEndpointAttempts).IsEqualTo(1);
+        await Assert.That(secondEndpointAttempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task BackgroundRefreshLoop_ObjectDisposedConnection_DoesNotResetInitialized()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        using var cts = new CancellationTokenSource();
+
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                cts.Cancel();
+                return ValueTask.FromException<IKafkaConnection>(new ObjectDisposedException("KafkaConnection"));
+            });
+
+        var manager = new MetadataManager(
+            pool,
+            ["localhost:9092"],
+            new MetadataOptions { MetadataRefreshInterval = TimeSpan.Zero });
+        SetMetadataApiVersion(manager);
+        SetInstanceField(manager, "_initialized", true);
+
+        var loop = InvokeBackgroundRefreshLoop(manager, cts.Token);
+        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(GetInstanceField<bool>(manager, "_initialized")).IsTrue();
+        await manager.DisposeAsync();
+    }
+
+    [Test]
+    public async Task ObjectDisposedException_IsFatalMetadataErrorOnlyWhenManagerDisposed()
+    {
+        var manager = CreateTestManager();
+        await Assert.That(IsFatalMetadataError(manager, new ObjectDisposedException("KafkaConnection"))).IsFalse();
+
+        await manager.DisposeAsync();
+
+        await Assert.That(IsFatalMetadataError(manager, new ObjectDisposedException(nameof(MetadataManager)))).IsTrue();
     }
 
     [Test]
@@ -423,13 +495,13 @@ public class MetadataManagerTests
         field.SetValue(metadataManager, MetadataRequest.HighestSupportedVersion);
     }
 
-    private static bool IsFatalMetadataError(Exception exception)
+    private static bool IsFatalMetadataError(MetadataManager metadataManager, Exception exception)
     {
         var method = typeof(MetadataManager)
-            .GetMethod("IsFatalMetadataError", BindingFlags.NonPublic | BindingFlags.Static)
+            .GetMethod("IsFatalMetadataError", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("IsFatalMetadataError method not found");
 
-        return (bool)method.Invoke(null, [exception])!;
+        return (bool)method.Invoke(metadataManager, [exception])!;
     }
 
     private static Task InvokeBackgroundRefreshLoop(MetadataManager metadataManager, CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -343,6 +343,35 @@ public class MetadataManagerTests
     }
 
     [Test]
+    public async Task DisposeAsync_CancelsBackgroundRefreshCtsCreatedWhileInitializationDrains()
+    {
+        var manager = new MetadataManager(
+            Substitute.For<IConnectionPool>(),
+            ["localhost:9092"],
+            new MetadataOptions { MetadataRefreshInterval = TimeSpan.FromHours(1) });
+        var initializeLock = GetInstanceField<SemaphoreSlim>(manager, "_initializeLock");
+        await initializeLock.WaitAsync();
+        var firstCancelObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var firstCts = new CancellationTokenSource();
+        using var registration = firstCts.Token.Register(
+            static state => ((TaskCompletionSource)state!).TrySetResult(),
+            firstCancelObserved);
+        SetInstanceField(manager, "_backgroundRefreshCts", firstCts);
+
+        var disposeTask = manager.DisposeAsync().AsTask();
+        await firstCancelObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(disposeTask.IsCompleted).IsFalse();
+
+        var racedCts = new CancellationTokenSource();
+        SetInstanceField(manager, "_backgroundRefreshCts", racedCts);
+        initializeLock.Release();
+
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(racedCts.IsCancellationRequested).IsTrue();
+    }
+
+    [Test]
     public async Task ObjectDisposedException_IsFatalMetadataError()
     {
         await Assert.That(IsFatalMetadataError(new ObjectDisposedException(nameof(MetadataManager)))).IsTrue();

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -296,4 +297,59 @@ public class MetadataManagerTests
         await Assert.That(metadataRequests).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task InitializeAsync_DisposeDuringRefresh_DoesNotThrowFromDisposedLocks()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var refreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRefresh = new TaskCompletionSource<MetadataResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(connection));
+
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                refreshStarted.TrySetResult();
+                return new ValueTask<MetadataResponse>(releaseRefresh.Task);
+            });
+
+        var manager = new MetadataManager(
+            pool,
+            ["localhost:9092"],
+            new MetadataOptions { EnableBackgroundRefresh = false });
+        SetMetadataApiVersion(manager);
+
+        var initializeTask = manager.InitializeAsync().AsTask();
+        await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var disposeTask = manager.DisposeAsync().AsTask();
+        releaseRefresh.SetResult(CreateMetadataResponse((1, "broker1", 9092)));
+
+        Exception? initializeException = null;
+        try
+        {
+            await initializeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (Exception ex)
+        {
+            initializeException = ex;
+        }
+
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(initializeException).IsNull();
+    }
+
+    private static void SetMetadataApiVersion(MetadataManager metadataManager)
+    {
+        var field = typeof(MetadataManager)
+            .GetField("_metadataApiVersion", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_metadataApiVersion field not found");
+
+        field.SetValue(metadataManager, MetadataRequest.HighestSupportedVersion);
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataRecoveryStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataRecoveryStrategyTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Metadata;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
@@ -255,6 +256,23 @@ public sealed class MetadataRecoveryStrategyTests
         await Assert.That(producer).IsNotNull();
     }
 
+    [Test]
+    public async Task ProducerBuilder_MetadataRecoveryOptions_AreAppliedToMetadataManager()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithMetadataRecoveryStrategy(MetadataRecoveryStrategy.None)
+            .WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromSeconds(42))
+            .WithMetadataMaxAge(TimeSpan.FromSeconds(7))
+            .Build();
+
+        var options = GetMetadataOptions(producer);
+
+        await Assert.That(options.MetadataRecoveryStrategy).IsEqualTo(MetadataRecoveryStrategy.None);
+        await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(42000);
+        await Assert.That(options.MetadataRefreshInterval).IsEqualTo(TimeSpan.FromSeconds(7));
+    }
+
     #endregion
 
     #region ConsumerBuilder Methods
@@ -297,6 +315,23 @@ public sealed class MetadataRecoveryStrategyTests
         await Assert.That(consumer).IsNotNull();
     }
 
+    [Test]
+    public async Task ConsumerBuilder_MetadataRecoveryOptions_AreAppliedToMetadataManager()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithMetadataRecoveryStrategy(MetadataRecoveryStrategy.None)
+            .WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromSeconds(42))
+            .WithMetadataMaxAge(TimeSpan.FromSeconds(7))
+            .Build();
+
+        var options = GetMetadataOptions(consumer);
+
+        await Assert.That(options.MetadataRecoveryStrategy).IsEqualTo(MetadataRecoveryStrategy.None);
+        await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(42000);
+        await Assert.That(options.MetadataRefreshInterval).IsEqualTo(TimeSpan.FromSeconds(7));
+    }
+
     #endregion
 
     #region AdminClientBuilder Methods
@@ -315,6 +350,23 @@ public sealed class MetadataRecoveryStrategyTests
         var builder = new Dekaf.Admin.AdminClientBuilder();
         var result = builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(60000));
         await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task AdminClientBuilder_MetadataRecoveryOptions_AreAppliedToMetadataManager()
+    {
+        await using var admin = new Dekaf.Admin.AdminClientBuilder()
+            .WithBootstrapServers("localhost:9092")
+            .WithMetadataRecoveryStrategy(MetadataRecoveryStrategy.None)
+            .WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromSeconds(42))
+            .WithMetadataMaxAge(TimeSpan.FromSeconds(7))
+            .Build();
+
+        var options = GetMetadataOptions(admin);
+
+        await Assert.That(options.MetadataRecoveryStrategy).IsEqualTo(MetadataRecoveryStrategy.None);
+        await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(42000);
+        await Assert.That(options.MetadataRefreshInterval).IsEqualTo(TimeSpan.FromSeconds(7));
     }
 
     #endregion
@@ -619,6 +671,20 @@ public sealed class MetadataRecoveryStrategyTests
             connectionPool: null!,
             bootstrapServers: bootstrapServers ?? ["localhost:9092"],
             options: options);
+    }
+
+    private static MetadataOptions GetMetadataOptions(object client)
+    {
+        var metadataManager = GetField<MetadataManager>(client, "_metadataManager");
+        return GetField<MetadataOptions>(metadataManager, "_options");
+    }
+
+    private static T GetField<T>(object instance, string name)
+    {
+        var field = instance.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{name} field not found");
+
+        return (T)field.GetValue(instance)!;
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- make `MetadataManager.InitializeAsync()` idempotent for shared KafkaClient infrastructure
- reject root-owned metadata setting overrides on Producer, Consumer, and Admin builders
- add unit coverage for concurrent metadata initialization and root-owned metadata guards

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/MetadataManagerTests/*"
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/KafkaClientBuilderTests/*"
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/MetadataRecoveryStrategyTests/*"
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/MetadataMaxAgeBuilderTests/*"
- [x] git diff --check origin/main..HEAD

Follow-up to #1051.
Closes #1077
