### PR TITLE
perf(consumer): query watermarks concurrently

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -588,6 +588,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // Plain Dictionary is safe: only accessed from the single ConsumeAsync loop thread
     private readonly Dictionary<string, System.Diagnostics.TagList> _metricTagsCache = [];
 
+    private const long EarliestOffsetTimestamp = -2;
+    private const long LatestOffsetTimestamp = -1;
+
     // Cached activity names per topic to avoid repeated string interpolation in fetch paths
     // Instance-level to avoid unbounded growth with dynamic topic names across consumer instances
     private readonly ConcurrentDictionary<string, string> _activityNameCache = new();
@@ -2568,6 +2571,52 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return null;
     }
 
+    private static ListOffsetsRequest CreateWatermarkListOffsetsRequest(
+        TopicPartition topicPartition,
+        IsolationLevel isolationLevel,
+        long timestamp) => new()
+        {
+            ReplicaId = -1,
+            IsolationLevel = isolationLevel,
+            Topics =
+            [
+                new ListOffsetsRequestTopic
+                {
+                    Name = topicPartition.Topic,
+                    Partitions =
+                    [
+                        new ListOffsetsRequestPartition
+                        {
+                            PartitionIndex = topicPartition.Partition,
+                            Timestamp = timestamp,
+                            CurrentLeaderEpoch = -1
+                        }
+                    ]
+                }
+            ]
+        };
+
+    private static ListOffsetsResponsePartition? FindListOffsetsPartition(
+        ListOffsetsResponse response,
+        TopicPartition topicPartition)
+    {
+        foreach (var topic in response.Topics)
+        {
+            if (topic.Name != topicPartition.Topic)
+                continue;
+
+            foreach (var partition in topic.Partitions)
+            {
+                if (partition.PartitionIndex == topicPartition.Partition)
+                    return partition;
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
     public async ValueTask<WatermarkOffsets> QueryWatermarkOffsetsAsync(
         TopicPartition topicPartition,
         CancellationToken cancellationToken = default)
@@ -2586,50 +2635,22 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             ListOffsetsRequest.LowestSupportedVersion,
             ListOffsetsRequest.HighestSupportedVersion);
 
-        // Query for earliest offset (low watermark) with timestamp -2
-        var earliestRequest = new ListOffsetsRequest
-        {
-            ReplicaId = -1,
-            IsolationLevel = _options.IsolationLevel,
-            Topics =
-            [
-                new ListOffsetsRequestTopic
-                {
-                    Name = topicPartition.Topic,
-                    Partitions =
-                    [
-                        new ListOffsetsRequestPartition
-                        {
-                            PartitionIndex = topicPartition.Partition,
-                            Timestamp = -2, // Earliest
-                            CurrentLeaderEpoch = -1
-                        }
-                    ]
-                }
-            ]
-        };
+        var earliestRequest = CreateWatermarkListOffsetsRequest(topicPartition, _options.IsolationLevel, EarliestOffsetTimestamp);
+        var latestRequest = CreateWatermarkListOffsetsRequest(topicPartition, _options.IsolationLevel, LatestOffsetTimestamp);
 
-        var earliestResponse = await connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+        var earliestResponseTask = connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
             earliestRequest,
             listOffsetsVersion,
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken).AsTask();
 
-        ListOffsetsResponsePartition? earliestPartitionResponse = null;
-        foreach (var topic in earliestResponse.Topics)
-        {
-            if (topic.Name == topicPartition.Topic)
-            {
-                foreach (var partition in topic.Partitions)
-                {
-                    if (partition.PartitionIndex == topicPartition.Partition)
-                    {
-                        earliestPartitionResponse = partition;
-                        break;
-                    }
-                }
-                break;
-            }
-        }
+        var latestResponseTask = connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+            latestRequest,
+            listOffsetsVersion,
+            cancellationToken).AsTask();
+
+        await Task.WhenAll(earliestResponseTask, latestResponseTask).ConfigureAwait(false);
+
+        var earliestPartitionResponse = FindListOffsetsPartition(earliestResponseTask.Result, topicPartition);
 
         if (earliestPartitionResponse?.ErrorCode != ErrorCode.None)
         {
@@ -2639,50 +2660,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         var lowWatermark = earliestPartitionResponse?.Offset ?? 0;
 
-        // Query for latest offset (high watermark) with timestamp -1
-        var latestRequest = new ListOffsetsRequest
-        {
-            ReplicaId = -1,
-            IsolationLevel = _options.IsolationLevel,
-            Topics =
-            [
-                new ListOffsetsRequestTopic
-                {
-                    Name = topicPartition.Topic,
-                    Partitions =
-                    [
-                        new ListOffsetsRequestPartition
-                        {
-                            PartitionIndex = topicPartition.Partition,
-                            Timestamp = -1, // Latest
-                            CurrentLeaderEpoch = -1
-                        }
-                    ]
-                }
-            ]
-        };
-
-        var latestResponse = await connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
-            latestRequest,
-            listOffsetsVersion,
-            cancellationToken).ConfigureAwait(false);
-
-        ListOffsetsResponsePartition? latestPartitionResponse = null;
-        foreach (var topic in latestResponse.Topics)
-        {
-            if (topic.Name == topicPartition.Topic)
-            {
-                foreach (var partition in topic.Partitions)
-                {
-                    if (partition.PartitionIndex == topicPartition.Partition)
-                    {
-                        latestPartitionResponse = partition;
-                        break;
-                    }
-                }
-                break;
-            }
-        }
+        var latestPartitionResponse = FindListOffsetsPartition(latestResponseTask.Result, topicPartition);
 
         if (latestPartitionResponse?.ErrorCode != ErrorCode.None)
         {

--- a/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsTests.cs
@@ -1,0 +1,153 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class QueryWatermarkOffsetsTests
+{
+    private const string Topic = "watermark-topic";
+    private const int Partition = 0;
+    private const long EarliestOffsetTimestamp = -2;
+    private const long LatestOffsetTimestamp = -1;
+
+    [Test]
+    public async Task QueryWatermarkOffsetsAsync_StartsEarliestAndLatestRequestsBeforeAwaitingResponses()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        connectionPool.GetConnectionByIndexAsync(0, 0, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        var metadataManager = new MetadataManager(connectionPool, ["localhost:9092"]);
+        metadataManager.SetApiVersion(ApiKey.ListOffsets, ListOffsetsRequest.LowestSupportedVersion, ListOffsetsRequest.HighestSupportedVersion);
+        metadataManager.Metadata.Update(CreateMetadataResponse());
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                GroupId = "test-group"
+            },
+            Serializers.String,
+            Serializers.String,
+            connectionPool,
+            metadataManager);
+        SetInitialized(consumer);
+
+        var earliestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var latestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseResponses = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var request = ci.Arg<ListOffsetsRequest>();
+                var timestamp = request.Topics[0].Partitions[0].Timestamp;
+
+                if (timestamp == EarliestOffsetTimestamp)
+                    earliestStarted.TrySetResult();
+                else if (timestamp == LatestOffsetTimestamp)
+                    latestStarted.TrySetResult();
+                else
+                    throw new InvalidOperationException($"Unexpected ListOffsets timestamp {timestamp}");
+
+                return new ValueTask<ListOffsetsResponse>(CreateListOffsetsResponseAsync(timestamp, releaseResponses.Task));
+            });
+
+        var queryTask = consumer.QueryWatermarkOffsetsAsync(new TopicPartition(Topic, Partition), CancellationToken.None).AsTask();
+
+        await earliestStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        try
+        {
+            await latestStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+        catch
+        {
+            releaseResponses.TrySetResult();
+            await queryTask.WaitAsync(TimeSpan.FromSeconds(1));
+            throw;
+        }
+
+        releaseResponses.SetResult();
+        var watermarks = await queryTask.WaitAsync(TimeSpan.FromSeconds(1));
+
+        await Assert.That(watermarks.Low).IsEqualTo(10);
+        await Assert.That(watermarks.High).IsEqualTo(42);
+    }
+
+    private static async Task<ListOffsetsResponse> CreateListOffsetsResponseAsync(long timestamp, Task release)
+    {
+        await release.ConfigureAwait(false);
+        var offset = timestamp == EarliestOffsetTimestamp ? 10 : 42;
+
+        return new ListOffsetsResponse
+        {
+            Topics =
+            [
+                new ListOffsetsResponseTopic
+                {
+                    Name = Topic,
+                    Partitions =
+                    [
+                        new ListOffsetsResponsePartition
+                        {
+                            PartitionIndex = Partition,
+                            ErrorCode = ErrorCode.None,
+                            Offset = offset
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    private static MetadataResponse CreateMetadataResponse() => new()
+    {
+        Brokers =
+        [
+            new BrokerMetadata
+            {
+                NodeId = 0,
+                Host = "localhost",
+                Port = 9092
+            }
+        ],
+        Topics =
+        [
+            new TopicMetadata
+            {
+                Name = Topic,
+                ErrorCode = ErrorCode.None,
+                Partitions =
+                [
+                    new PartitionMetadata
+                    {
+                        PartitionIndex = Partition,
+                        LeaderId = 0,
+                        ErrorCode = ErrorCode.None,
+                        ReplicaNodes = [0],
+                        IsrNodes = [0]
+                    }
+                ]
+            }
+        ]
+    };
+
+    private static void SetInitialized(KafkaConsumer<string, string> consumer)
+    {
+        var initializedField = typeof(KafkaConsumer<string, string>)
+            .GetField("_initialized", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_initialized field not found - was it renamed?");
+
+        initializedField.SetValue(consumer, true);
+    }
+}


### PR DESCRIPTION
## Summary
- start earliest and latest ListOffsets requests together in QueryWatermarkOffsetsAsync
- factor watermark ListOffsets request creation and response partition lookup
- add a unit test proving latest request starts before earliest response is released

## Validation
- dotnet restore Dekaf.sln
- dotnet build Dekaf.sln -c Release --no-restore
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/QueryWatermarkOffsetsTests/*" --disable-logo --no-progress --minimum-expected-tests 1
- dotnet format --verify-no-changes --verbosity minimal --include src\Dekaf\Consumer\KafkaConsumer.cs tests\Dekaf.Tests.Unit\Consumer\QueryWatermarkOffsetsTests.cs

Refs #934