### PR TITLE
fix(scripts): block actionable review bodies

### DIFF
--- a/scripts/Assert-PrGreen.ps1
+++ b/scripts/Assert-PrGreen.ps1
@@ -29,6 +29,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'AssertPrGreenReviewHeuristics.ps1')
 
 function Deny([string]$reason) {
     [Console]::Error.WriteLine("DO NOT MERGE #${Pr} -- $reason")
@@ -85,7 +86,7 @@ if ($bad.Count -gt 0) {
 }
 
 # Top-level review comments are not review threads, so GitHub does not expose a
-# resolved flag for them. Fail closed on common review-finding headings instead
+# resolved flag for them. Fail closed on common review-finding shapes instead
 # of treating a COMMENTED review as automatically safe.
 $latestReviews = @($view.latestReviews | Where-Object { $null -ne $_ })
 $requestedChanges = @($latestReviews | Where-Object { $_.state -eq 'CHANGES_REQUESTED' })
@@ -94,15 +95,13 @@ if ($requestedChanges.Count -gt 0) {
     Deny "latest review requests changes from: $authors"
 }
 
-$actionableHeadingPattern = '(?im)^\s*#{2,4}\s+.*\b(Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|(?<!not )(?<!non-)Blocking|(?<!not )(?<!non-)Blocker|Test coverage gap|Required|Must fix)\b'
 $actionableReviews = @()
 foreach ($review in $latestReviews) {
     if ($review.state -ne 'COMMENTED') { continue }
     $body = [string]$review.body
-    if (-not $body) { continue }
-    if ($body -match $actionableHeadingPattern) {
-        $heading = $Matches[0].Trim()
-        $actionableReviews += "$($review.author.login): $heading"
+    $reason = Get-ActionableReviewBodyReason -Body $body
+    if ($reason) {
+        $actionableReviews += "$($review.author.login): $reason"
     }
 }
 if ($actionableReviews.Count -gt 0) {

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -1,0 +1,33 @@
+function Get-ActionableReviewBodyReason {
+    [CmdletBinding()]
+    param(
+        [AllowNull()][string]$Body
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Body)) {
+        return $null
+    }
+
+    $patterns = @(
+        @{
+            Reason = 'actionable heading'
+            Pattern = '(?im)^\s*#{2,4}\s+(?!(?:minor|optional|nit|non[- ]blocking)\b).*\b(Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Design|Leak|Leaks|Gap|Gaps|Silently|Blocking|Blocker|Test coverage gap|Required|Must fix)\b'
+        },
+        @{
+            Reason = 'numbered finding heading'
+            Pattern = '(?im)^\s*#{2,4}\s+\d+\.\s+(?!(?:minor|optional|nit|non[- ]blocking)\b).+'
+        },
+        @{
+            Reason = 'before-merge action'
+            Pattern = '(?im)\b(?:worth|needs?|should|must|required|please|recommend(?:ed)?)\s+(?:be\s+)?address(?:ed|ing)?\b[^\r\n.]{0,120}\bbefore\s+merge\b|\bbefore\s+merge\b[^\r\n.]{0,120}\b(?:worth|needs?|should|must|required|please|recommend(?:ed)?)\s+(?:be\s+)?address(?:ed|ing)?\b'
+        }
+    )
+
+    foreach ($entry in $patterns) {
+        if ($Body -match $entry.Pattern) {
+            return "$($entry.Reason): $($Matches[0].Trim())"
+        }
+    }
+
+    return $null
+}

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -11,7 +11,7 @@ function Get-ActionableReviewBodyReason {
     $patterns = @(
         @{
             Reason = 'actionable heading'
-            Pattern = '(?im)^\s*#{2,4}\s+(?!(?:minor|optional|nit|non[- ]blocking)\b).*\b(Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Design|Leak|Leaks|Gap|Gaps|Silently|Blocking|Blocker|Test coverage gap|Required|Must fix)\b'
+            Pattern = '(?im)^\s*#{2,4}\s+(?!(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking)\b).*\b(Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Design|Leak|Leaks|Gap|Gaps|Silently|(?<!not )(?<!non-)Blocking|(?<!not )(?<!non-)Blocker|Test coverage gap|Required|Must fix)\b'
         },
         @{
             Reason = 'numbered finding heading'
@@ -19,7 +19,7 @@ function Get-ActionableReviewBodyReason {
         },
         @{
             Reason = 'before-merge action'
-            Pattern = '(?im)\b(?:worth|needs?|should|must|required|please|recommend(?:ed)?)\s+(?:be\s+)?address(?:ed|ing)?\b[^\r\n.]{0,120}\bbefore\s+merge\b|\bbefore\s+merge\b[^\r\n.]{0,120}\b(?:worth|needs?|should|must|required|please|recommend(?:ed)?)\s+(?:be\s+)?address(?:ed|ing)?\b'
+            Pattern = '(?im)\b(?:worth|needs?|should|must|required|please|recommend(?:ed)?)\s+(?:be\s+)?(?:address(?:ed|ing)?|fix(?:ed|ing)?)\b[^\r\n.]{0,120}\b(?:before\s+merg(?:e|ing)|prior\s+to\s+merg(?:e|ing))\b|\b(?:before\s+merg(?:e|ing)|prior\s+to\s+merg(?:e|ing))\b[^\r\n.]{0,120}\b(?:worth|needs?|should|must|required|please|recommend(?:ed)?)\s+(?:be\s+)?(?:address(?:ed|ing)?|fix(?:ed|ing)?)\b'
         }
     )
 

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -35,6 +35,24 @@ Two things worth addressing before merge:
         Blocks = $true
     },
     @{
+        Name = 'blocks before-merging action'
+        Body = @'
+## Review
+
+This should be addressed before merging.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks prior-to-merge action'
+        Body = @'
+## Review
+
+This must be fixed prior to merge.
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'allows no-issue review'
         Body = @'
 ## Review
@@ -54,6 +72,16 @@ No issues found.
 
 Minor/optional, not blocking:
 - Worth a follow-up later, but not required for this PR.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows numbered non-blocking heading'
+        Body = @'
+## Review
+
+### 1. Non-blocking: rename variable
+This is optional.
 '@
         Blocks = $false
     }

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -1,0 +1,70 @@
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'AssertPrGreenReviewHeuristics.ps1')
+
+$cases = @(
+    @{
+        Name = 'blocks correctness heading'
+        Body = @'
+## Review
+
+### Correctness / Design — pool resize drops cached items
+This needs a fix.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks numbered finding heading'
+        Body = @'
+## Review
+
+### 1. `MetadataManager.cs` — shared MetadataManager leaks a background loop
+Failure scenario follows.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks before-merge action'
+        Body = @'
+## Review
+
+No correctness or security issues found.
+
+Two things worth addressing before merge:
+- Missing direct pool coverage.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'allows no-issue review'
+        Body = @'
+## Review
+
+**Correctness:** No issues. No correctness or security issues found.
+
+Scope check passed.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows optional follow-up'
+        Body = @'
+## Review
+
+No issues found.
+
+Minor/optional, not blocking:
+- Worth a follow-up later, but not required for this PR.
+'@
+        Blocks = $false
+    }
+)
+
+foreach ($case in $cases) {
+    $reason = Get-ActionableReviewBodyReason -Body $case.Body
+    $blocked = -not [string]::IsNullOrWhiteSpace($reason)
+    if ($blocked -ne $case.Blocks) {
+        throw "Case '$($case.Name)' expected Blocks=$($case.Blocks), got Blocks=$blocked reason='$reason'"
+    }
+}
+
+Write-Host "OK review heuristic tests passed ($($cases.Count) cases)."


### PR DESCRIPTION
## Summary
- move top-level review body detection into a reusable helper
- block actionable numbered/finding headings and “address before merge” wording
- add offline PowerShell coverage for blocking and non-blocking review samples

## Test plan
- [x] pwsh scripts\Test-AssertPrGreenReviewHeuristics.ps1
- [x] PowerShell syntax parse for changed scripts
- [x] git diff --check origin/main..HEAD
- [x] validated helper catches the missed review bodies from #1031, #1051, and #1069

Closes #1080
