### PR TITLE
feat(protocol): add streams group API keys

### DIFF
--- a/src/Dekaf/Protocol/ApiKey.cs
+++ b/src/Dekaf/Protocol/ApiKey.cs
@@ -85,6 +85,8 @@ public enum ApiKey : short
     ShareGroupDescribe = 77,
     ShareFetch = 78,
     ShareAcknowledge = 79,
+    StreamsGroupHeartbeat = 88,
+    StreamsGroupDescribe = 89,
     DescribeShareGroupOffsets = 90,
     AlterShareGroupOffsets = 91,
     DeleteShareGroupOffsets = 92

--- a/tests/Dekaf.Tests.Unit/Protocol/ApiKeyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ApiKeyTests.cs
@@ -1,0 +1,16 @@
+using Dekaf.Protocol;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class ApiKeyTests
+{
+    [Test]
+    public async Task StreamsGroupApiKeys_HaveKafkaAssignedValues()
+    {
+        var heartbeat = Enum.Parse<ApiKey>(nameof(ApiKey.StreamsGroupHeartbeat));
+        var describe = Enum.Parse<ApiKey>(nameof(ApiKey.StreamsGroupDescribe));
+
+        await Assert.That((short)heartbeat).IsEqualTo((short)88);
+        await Assert.That((short)describe).IsEqualTo((short)89);
+    }
+}


### PR DESCRIPTION
## Summary
- Add StreamsGroupHeartbeat and StreamsGroupDescribe to ApiKey with Kafka-assigned keys 88 and 89.
- Add protocol enum coverage for the assigned values.

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/ApiKeyTests/*"
- [x] git diff --check origin/main..HEAD

Closes #831
