### PR TITLE
feat(api): simplify Kafka factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ await producer.FlushAsync();
 When you're always producing to the same topic, use a topic producer for a cleaner API:
 
 ```csharp
-await using var producer = Kafka.CreateTopicProducer<string, string>(
-    "localhost:9092", "orders");
+await using var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .BuildForTopicAsync("orders");
 
 // No topic parameter needed
 await producer.ProduceAsync("order-123", orderJson);
@@ -63,7 +64,9 @@ producer.Produce("order-456", orderJson);
 You can also create multiple topic producers that share the same connection:
 
 ```csharp
-await using var baseProducer = Kafka.CreateProducer<string, string>("localhost:9092");
+await using var baseProducer = Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .Build();
 
 var orders = baseProducer.ForTopic("orders");
 var events = baseProducer.ForTopic("events");

--- a/docs/docs/producer/topic-producer.md
+++ b/docs/docs/producer/topic-producer.md
@@ -8,20 +8,21 @@ When your application produces to a single topic, you can use `ITopicProducer<TK
 
 ## Creating a Topic Producer
 
-### Direct Creation
+### Builder Creation
 
 The simplest way to create a topic producer:
 
 ```csharp
 using Dekaf;
 
-await using var producer = Kafka.CreateTopicProducer<string, string>(
-    "localhost:9092", "orders");
+await using var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .BuildForTopicAsync("orders");
 
 await producer.ProduceAsync("order-123", orderJson);
 ```
 
-### From the Builder
+### With More Options
 
 Use the builder for more configuration options:
 
@@ -158,8 +159,7 @@ The disposal behavior depends on how the topic producer was created:
 
 | Creation Method | On Dispose |
 |----------------|------------|
-| `CreateTopicProducer()` | Disposes underlying producer |
-| `BuildForTopic()` | Disposes underlying producer |
+| `BuildForTopic()` / `BuildForTopicAsync()` | Disposes underlying producer |
 | `ForTopic()` | Does NOT dispose base producer |
 
 This allows safe resource sharing:
@@ -167,7 +167,9 @@ This allows safe resource sharing:
 ```csharp
 using Dekaf;
 
-await using var baseProducer = Kafka.CreateProducer<string, string>("localhost:9092");
+await using var baseProducer = Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .Build();
 
 var orders = baseProducer.ForTopic("orders");
 var events = baseProducer.ForTopic("events");

--- a/src/Dekaf/Kafka.cs
+++ b/src/Dekaf/Kafka.cs
@@ -53,135 +53,11 @@ public static class Kafka
     }
 
     /// <summary>
-    /// Creates a producer with the specified bootstrap servers.
-    /// </summary>
-    /// <param name="bootstrapServers">Comma-separated list of bootstrap servers.</param>
-    public static IKafkaProducer<TKey, TValue> CreateProducer<TKey, TValue>(string bootstrapServers)
-    {
-        return new ProducerBuilder<TKey, TValue>()
-            .WithBootstrapServers(bootstrapServers)
-            .Build();
-    }
-
-    /// <summary>
-    /// Creates a topic-specific producer with the specified bootstrap servers and topic.
-    /// </summary>
-    /// <param name="bootstrapServers">Comma-separated list of bootstrap servers.</param>
-    /// <param name="topic">The topic to bind the producer to.</param>
-    /// <typeparam name="TKey">Key type.</typeparam>
-    /// <typeparam name="TValue">Value type.</typeparam>
-    /// <returns>A producer bound to the specified topic.</returns>
-    public static ITopicProducer<TKey, TValue> CreateTopicProducer<TKey, TValue>(string bootstrapServers, string topic)
-    {
-        return new ProducerBuilder<TKey, TValue>()
-            .WithBootstrapServers(bootstrapServers)
-            .BuildForTopic(topic);
-    }
-
-    /// <summary>
-    /// Creates and initializes a producer with the specified bootstrap servers.
-    /// </summary>
-    /// <param name="bootstrapServers">Comma-separated list of bootstrap servers.</param>
-    /// <param name="cancellationToken">Cancellation token for the initialization.</param>
-    public static ValueTask<IKafkaProducer<TKey, TValue>> CreateProducerAsync<TKey, TValue>(
-        string bootstrapServers,
-        CancellationToken cancellationToken = default)
-    {
-        return new ProducerBuilder<TKey, TValue>()
-            .WithBootstrapServers(bootstrapServers)
-            .BuildAsync(cancellationToken);
-    }
-
-    /// <summary>
-    /// Creates and initializes a topic-specific producer with the specified bootstrap servers and topic.
-    /// </summary>
-    /// <param name="bootstrapServers">Comma-separated list of bootstrap servers.</param>
-    /// <param name="topic">The topic to bind the producer to.</param>
-    /// <param name="cancellationToken">Cancellation token for the initialization.</param>
-    public static ValueTask<ITopicProducer<TKey, TValue>> CreateTopicProducerAsync<TKey, TValue>(
-        string bootstrapServers,
-        string topic,
-        CancellationToken cancellationToken = default)
-    {
-        return new ProducerBuilder<TKey, TValue>()
-            .WithBootstrapServers(bootstrapServers)
-            .BuildForTopicAsync(topic, cancellationToken);
-    }
-
-    /// <summary>
     /// Creates a consumer builder.
     /// </summary>
     public static ConsumerBuilder<TKey, TValue> CreateConsumer<TKey, TValue>()
     {
         return new ConsumerBuilder<TKey, TValue>();
-    }
-
-    /// <summary>
-    /// Creates a consumer with the specified bootstrap servers and group ID.
-    /// </summary>
-    /// <param name="bootstrapServers">Comma-separated list of bootstrap servers.</param>
-    /// <param name="groupId">The consumer group ID.</param>
-    public static IKafkaConsumer<TKey, TValue> CreateConsumer<TKey, TValue>(string bootstrapServers, string groupId)
-    {
-        return new ConsumerBuilder<TKey, TValue>()
-            .WithBootstrapServers(bootstrapServers)
-            .WithGroupId(groupId)
-            .Build();
-    }
-
-    /// <summary>
-    /// Creates a consumer with the specified bootstrap servers, group ID, and topic subscriptions.
-    /// </summary>
-    /// <param name="bootstrapServers">Comma-separated list of bootstrap servers.</param>
-    /// <param name="groupId">The consumer group ID.</param>
-    /// <param name="topics">The topics to subscribe to.</param>
-    public static IKafkaConsumer<TKey, TValue> CreateConsumer<TKey, TValue>(string bootstrapServers, string groupId, params string[] topics)
-    {
-        return new ConsumerBuilder<TKey, TValue>()
-            .WithBootstrapServers(bootstrapServers)
-            .WithGroupId(groupId)
-            .SubscribeTo(topics)
-            .Build();
-    }
-
-    /// <summary>
-    /// Creates and initializes a consumer with the specified bootstrap servers and group ID.
-    /// </summary>
-    /// <param name="bootstrapServers">Comma-separated list of bootstrap servers.</param>
-    /// <param name="groupId">The consumer group ID.</param>
-    /// <param name="cancellationToken">Cancellation token for the initialization.</param>
-    public static ValueTask<IKafkaConsumer<TKey, TValue>> CreateConsumerAsync<TKey, TValue>(
-        string bootstrapServers,
-        string groupId,
-        CancellationToken cancellationToken = default)
-    {
-        return new ConsumerBuilder<TKey, TValue>()
-            .WithBootstrapServers(bootstrapServers)
-            .WithGroupId(groupId)
-            .BuildAsync(cancellationToken);
-    }
-
-    /// <summary>
-    /// Creates and initializes a consumer with the specified bootstrap servers, group ID, and topic subscriptions.
-    /// </summary>
-    /// <param name="bootstrapServers">Comma-separated list of bootstrap servers.</param>
-    /// <param name="groupId">The consumer group ID.</param>
-    /// <param name="cancellationToken">Cancellation token for the initialization.</param>
-    /// <param name="topics">The topics to subscribe to.</param>
-    public static async ValueTask<IKafkaConsumer<TKey, TValue>> CreateConsumerAsync<TKey, TValue>(
-        string bootstrapServers,
-        string groupId,
-        CancellationToken cancellationToken,
-        params string[] topics)
-    {
-        var consumer = await new ConsumerBuilder<TKey, TValue>()
-            .WithBootstrapServers(bootstrapServers)
-            .WithGroupId(groupId)
-            .SubscribeTo(topics)
-            .BuildAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return consumer;
     }
 
     /// <summary>
@@ -193,77 +69,10 @@ public static class Kafka
     }
 
     /// <summary>
-    /// Creates a share consumer with the specified bootstrap servers and group ID.
-    /// </summary>
-    public static IKafkaShareConsumer<TKey, TValue> CreateShareConsumer<TKey, TValue>(string bootstrapServers, string groupId)
-    {
-        return new ShareConsumerBuilder<TKey, TValue>()
-            .WithBootstrapServers(bootstrapServers)
-            .WithGroupId(groupId)
-            .Build();
-    }
-
-    /// <summary>
-    /// Creates a share consumer with the specified bootstrap servers, group ID, and topic subscriptions.
-    /// </summary>
-    public static IKafkaShareConsumer<TKey, TValue> CreateShareConsumer<TKey, TValue>(string bootstrapServers, string groupId, params string[] topics)
-    {
-        return new ShareConsumerBuilder<TKey, TValue>()
-            .WithBootstrapServers(bootstrapServers)
-            .WithGroupId(groupId)
-            .SubscribeTo(topics)
-            .Build();
-    }
-
-    /// <summary>
-    /// Creates and initializes a share consumer with the specified bootstrap servers and group ID.
-    /// </summary>
-    public static ValueTask<IKafkaShareConsumer<TKey, TValue>> CreateShareConsumerAsync<TKey, TValue>(
-        string bootstrapServers,
-        string groupId,
-        CancellationToken cancellationToken = default)
-    {
-        return new ShareConsumerBuilder<TKey, TValue>()
-            .WithBootstrapServers(bootstrapServers)
-            .WithGroupId(groupId)
-            .BuildAsync(cancellationToken);
-    }
-
-    /// <summary>
-    /// Creates and initializes a share consumer with the specified bootstrap servers, group ID, and topic subscriptions.
-    /// </summary>
-    public static async ValueTask<IKafkaShareConsumer<TKey, TValue>> CreateShareConsumerAsync<TKey, TValue>(
-        string bootstrapServers,
-        string groupId,
-        CancellationToken cancellationToken,
-        params string[] topics)
-    {
-        var consumer = await new ShareConsumerBuilder<TKey, TValue>()
-            .WithBootstrapServers(bootstrapServers)
-            .WithGroupId(groupId)
-            .SubscribeTo(topics)
-            .BuildAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return consumer;
-    }
-
-    /// <summary>
     /// Creates an admin client builder.
     /// </summary>
     public static AdminClientBuilder CreateAdminClient()
     {
         return new AdminClientBuilder();
-    }
-
-    /// <summary>
-    /// Creates an admin client with the specified bootstrap servers.
-    /// </summary>
-    /// <param name="bootstrapServers">Comma-separated list of bootstrap servers.</param>
-    public static IAdminClient CreateAdminClient(string bootstrapServers)
-    {
-        return new AdminClientBuilder()
-            .WithBootstrapServers(bootstrapServers)
-            .Build();
     }
 }

--- a/src/Dekaf/Producer/ITopicProducer.cs
+++ b/src/Dekaf/Producer/ITopicProducer.cs
@@ -6,11 +6,10 @@ namespace Dekaf.Producer;
 /// A producer bound to a specific topic, providing a simplified API without topic parameters.
 /// </summary>
 /// <remarks>
-/// <para>Topic producers can be created in several ways:</para>
+/// <para>Topic producers can be created in two ways:</para>
 /// <list type="bullet">
-/// <item><description>From the builder: <c>Dekaf.CreateProducer&lt;K,V&gt;().WithBootstrapServers(...).BuildForTopic("my-topic")</c></description></item>
+/// <item><description>From the builder: <c>Kafka.CreateProducer&lt;K,V&gt;().WithBootstrapServers(...).BuildForTopic("my-topic")</c></description></item>
 /// <item><description>From an existing producer: <c>producer.ForTopic("my-topic")</c></description></item>
-/// <item><description>Direct factory: <c>Kafka.CreateTopicProducer&lt;K,V&gt;("localhost:9092", "my-topic")</c></description></item>
 /// </list>
 /// <para>When created from an existing producer via <see cref="IKafkaProducer{TKey,TValue}.ForTopic"/>,
 /// multiple topic producers can share the same underlying connections and worker threads.</para>

--- a/tests/Dekaf.Tests.Integration/RealWorld/AdminWorkflowTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/AdminWorkflowTests.cs
@@ -155,10 +155,11 @@ public sealed class AdminWorkflowTests(KafkaTestContainer kafka) : KafkaIntegrat
     }
 
     [Test]
-    public async Task AdminClient_FactoryShortcut_WorksWithConnectionString()
+    public async Task AdminClient_Builder_WorksWithConnectionString()
     {
-        // Test the convenience factory: Kafka.CreateAdminClient(servers)
-        await using var admin = Kafka.CreateAdminClient(KafkaContainer.BootstrapServers);
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .Build();
 
         var cluster = await admin.DescribeClusterAsync();
         await Assert.That(cluster.Nodes).IsNotEmpty();

--- a/tests/Dekaf.Tests.Integration/RealWorld/ConvenienceApiTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/ConvenienceApiTests.cs
@@ -12,12 +12,13 @@ namespace Dekaf.Tests.Integration.RealWorld;
 public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
-    public async Task FactoryShortcut_CreateProducerWithServers_ProducesSuccessfully()
+    public async Task ProducerBuilder_WithBootstrapServers_ProducesSuccessfully()
     {
-        // Simplest possible producer creation
         var topic = await KafkaContainer.CreateTestTopicAsync();
 
-        await using var producer = await Kafka.CreateProducerAsync<string, string>(KafkaContainer.BootstrapServers);
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .BuildAsync();
 
         var metadata = await producer.ProduceAsync(new ProducerMessage<string, string>
         {
@@ -31,14 +32,16 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
     }
 
     [Test]
-    public async Task FactoryShortcut_CreateConsumerWithTopics_ConsumesSuccessfully()
+    public async Task ConsumerBuilder_SubscribeTo_ConsumesSuccessfully()
     {
-        // Simplest possible consumer creation with auto-subscribe
         var topic = await KafkaContainer.CreateTestTopicAsync();
 
         var groupId = $"shortcut-consumer-{Guid.NewGuid():N}";
-        await using var consumer = await Kafka.CreateConsumerAsync<string, string>(
-            KafkaContainer.BootstrapServers, groupId, CancellationToken.None, topic);
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .SubscribeTo(topic)
+            .BuildAsync();
 
         // Start consuming in background (default offset is Latest, so produce after consumer joins)
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
@@ -57,7 +60,9 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
             () => consumer.Assignment.Count > 0,
             TimeSpan.FromSeconds(20));
 
-        await using var producer = await Kafka.CreateProducerAsync<string, string>(KafkaContainer.BootstrapServers);
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .BuildAsync();
 
         await producer.ProduceAsync(new ProducerMessage<string, string>
         {
@@ -400,7 +405,9 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();
 
-        await using var producer = await Kafka.CreateProducerAsync<string, string>(KafkaContainer.BootstrapServers);
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .BuildAsync();
         await producer.ProduceAsync(new ProducerMessage<string, string>
         {
             Topic = topic,

--- a/tests/Dekaf.Tests.Integration/TopicProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/TopicProducerTests.cs
@@ -10,14 +10,21 @@ namespace Dekaf.Tests.Integration;
 [Category("Producer")]
 public class TopicProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
+    private ValueTask<ITopicProducer<string, string>> BuildTopicProducerAsync(string topic)
+    {
+        return Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildForTopicAsync(topic);
+    }
+
     [Test]
     public async Task TopicProducer_ProduceAsync_MessageDelivered()
     {
         // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync();
 
-        await using var producer = await Kafka.CreateTopicProducerAsync<string, string>(
-            KafkaContainer.BootstrapServers, topic);
+        await using var producer = await BuildTopicProducerAsync(topic);
 
         // Act
         var metadata = await producer.ProduceAsync("key1", "value1", CancellationToken.None);
@@ -34,8 +41,7 @@ public class TopicProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync();
 
-        await using var producer = await Kafka.CreateTopicProducerAsync<string, string>(
-            KafkaContainer.BootstrapServers, topic);
+        await using var producer = await BuildTopicProducerAsync(topic);
 
         var headers = Headers.Create("trace-id", "abc123");
 
@@ -53,8 +59,7 @@ public class TopicProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 3);
 
-        await using var producer = await Kafka.CreateTopicProducerAsync<string, string>(
-            KafkaContainer.BootstrapServers, topic);
+        await using var producer = await BuildTopicProducerAsync(topic);
 
         // Act
         var metadata = await producer.ProduceAsync(partition: 1, "key1", "value1", CancellationToken.None);
@@ -72,8 +77,7 @@ public class TopicProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         var topic = await KafkaContainer.CreateTestTopicAsync();
         var timestamp = DateTimeOffset.UtcNow.AddMinutes(-5);
 
-        await using var producer = await Kafka.CreateTopicProducerAsync<string, string>(
-            KafkaContainer.BootstrapServers, topic);
+        await using var producer = await BuildTopicProducerAsync(topic);
 
         var message = new TopicProducerMessage<string, string>
         {
@@ -96,8 +100,7 @@ public class TopicProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync();
 
-        await using var producer = await Kafka.CreateTopicProducerAsync<string, string>(
-            KafkaContainer.BootstrapServers, topic);
+        await using var producer = await BuildTopicProducerAsync(topic);
 
         // Act - fire-and-forget
         await producer.ProduceAsync("key1", "value1");
@@ -127,8 +130,7 @@ public class TopicProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync();
 
-        await using var producer = await Kafka.CreateTopicProducerAsync<string, string>(
-            KafkaContainer.BootstrapServers, topic);
+        await using var producer = await BuildTopicProducerAsync(topic);
 
         var headers = Headers.Create("custom-header", "header-value");
 
@@ -162,8 +164,7 @@ public class TopicProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         var topic = await KafkaContainer.CreateTestTopicAsync();
         var callbackInvoked = new TaskCompletionSource<(RecordMetadata, Exception?)>();
 
-        await using var producer = await Kafka.CreateTopicProducerAsync<string, string>(
-            KafkaContainer.BootstrapServers, topic);
+        await using var producer = await BuildTopicProducerAsync(topic);
 
         // Act
         await producer.FireAsync("key1", "value1", (metadata, ex) => callbackInvoked.TrySetResult((metadata, ex)));
@@ -186,8 +187,7 @@ public class TopicProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         var topic = await KafkaContainer.CreateTestTopicAsync();
         const int messageCount = 10;
 
-        await using var producer = await Kafka.CreateTopicProducerAsync<string, string>(
-            KafkaContainer.BootstrapServers, topic);
+        await using var producer = await BuildTopicProducerAsync(topic);
 
         var messages = Enumerable.Range(0, messageCount)
             .Select(i => ((string?)$"key-{i}", $"value-{i}"))
@@ -211,8 +211,7 @@ public class TopicProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync();
 
-        await using var producer = await Kafka.CreateTopicProducerAsync<string, string>(
-            KafkaContainer.BootstrapServers, topic);
+        await using var producer = await BuildTopicProducerAsync(topic);
 
         var messages = new[]
         {
@@ -321,8 +320,7 @@ public class TopicProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 3);
         const int messageCount = 100;
 
-        await using var producer = await Kafka.CreateTopicProducerAsync<string, string>(
-            KafkaContainer.BootstrapServers, topic);
+        await using var producer = await BuildTopicProducerAsync(topic);
 
         // Act - produce concurrently
         var tasks = Enumerable.Range(0, messageCount)
@@ -346,8 +344,7 @@ public class TopicProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         // Arrange
         var topic = await KafkaContainer.CreateTestTopicAsync();
 
-        await using var producer = await Kafka.CreateTopicProducerAsync<string, string>(
-            KafkaContainer.BootstrapServers, topic);
+        await using var producer = await BuildTopicProducerAsync(topic);
 
         // Assert
         await Assert.That(producer.Topic).IsEqualTo(topic);

--- a/tests/Dekaf.Tests.Unit/KafkaFactoryTests.cs
+++ b/tests/Dekaf.Tests.Unit/KafkaFactoryTests.cs
@@ -1,105 +1,98 @@
+using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
+using Dekaf.ShareConsumer;
 
 namespace Dekaf.Tests.Unit;
 
 public sealed class KafkaFactoryTests
 {
-    #region CreateProducer
-
     [Test]
-    public async Task CreateProducer_Generic_ReturnsBuilder()
+    public async Task CreateProducer_ReturnsBuilder()
     {
         var builder = Kafka.CreateProducer<string, string>();
+
         await Assert.That(builder).IsNotNull();
     }
 
     [Test]
-    public async Task CreateProducer_WithBootstrapServers_ReturnsProducer()
+    public async Task CreateProducer_BuilderCanBuildProducer()
     {
-        var producer = Kafka.CreateProducer<string, string>("localhost:9092");
-        await Assert.That(producer).IsNotNull();
-        await producer.DisposeAsync();
-    }
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
 
-    [Test]
-    public async Task CreateProducer_ImplementsIKafkaProducer()
-    {
-        var producer = Kafka.CreateProducer<string, string>("localhost:9092");
         await Assert.That(producer).IsAssignableTo<IKafkaProducer<string, string>>();
-        await producer.DisposeAsync();
     }
 
-    #endregion
-
-    #region CreateTopicProducer
-
     [Test]
-    public async Task CreateTopicProducer_ReturnsTopicProducer()
+    public async Task CreateProducer_BuilderCanBuildTopicProducer()
     {
-        await using var producer = Kafka.CreateTopicProducer<string, string>("localhost:9092", "my-topic");
-        await Assert.That(producer).IsNotNull();
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .BuildForTopic("my-topic");
+
+        await Assert.That(producer).IsAssignableTo<ITopicProducer<string, string>>();
         await Assert.That(producer.Topic).IsEqualTo("my-topic");
     }
 
     [Test]
-    public async Task CreateTopicProducer_ImplementsITopicProducer()
-    {
-        await using var producer = Kafka.CreateTopicProducer<string, string>("localhost:9092", "my-topic");
-        await Assert.That(producer).IsAssignableTo<ITopicProducer<string, string>>();
-    }
-
-    #endregion
-
-    #region CreateConsumer
-
-    [Test]
-    public async Task CreateConsumer_Generic_ReturnsBuilder()
+    public async Task CreateConsumer_ReturnsBuilder()
     {
         var builder = Kafka.CreateConsumer<string, string>();
+
         await Assert.That(builder).IsNotNull();
     }
 
     [Test]
-    public async Task CreateConsumer_WithBootstrapAndGroupId_ReturnsConsumer()
+    public async Task CreateConsumer_BuilderCanBuildConsumerWithSubscription()
     {
-        await using var consumer = Kafka.CreateConsumer<string, string>("localhost:9092", "my-group");
-        await Assert.That(consumer).IsNotNull();
-    }
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("my-group")
+            .SubscribeTo("topic-a", "topic-b")
+            .Build();
 
-    [Test]
-    public async Task CreateConsumer_WithBootstrapAndGroupId_ImplementsIKafkaConsumer()
-    {
-        await using var consumer = Kafka.CreateConsumer<string, string>("localhost:9092", "my-group");
         await Assert.That(consumer).IsAssignableTo<IKafkaConsumer<string, string>>();
-    }
-
-    [Test]
-    public async Task CreateConsumer_WithTopics_ReturnsConsumerWithSubscription()
-    {
-        await using var consumer = Kafka.CreateConsumer<string, string>("localhost:9092", "my-group", "topic-a", "topic-b");
-        await Assert.That(consumer).IsNotNull();
         await Assert.That(consumer.Subscription).Contains("topic-a");
         await Assert.That(consumer.Subscription).Contains("topic-b");
     }
 
-    #endregion
-
-    #region CreateAdminClient
-
     [Test]
-    public async Task CreateAdminClient_Generic_ReturnsBuilder()
+    public async Task CreateShareConsumer_ReturnsBuilder()
     {
-        var builder = Kafka.CreateAdminClient();
+        var builder = Kafka.CreateShareConsumer<string, string>();
+
         await Assert.That(builder).IsNotNull();
     }
 
     [Test]
-    public async Task CreateAdminClient_WithBootstrapServers_ReturnsAdminClient()
+    public async Task CreateShareConsumer_BuilderCanBuildShareConsumer()
     {
-        await using var admin = Kafka.CreateAdminClient("localhost:9092");
-        await Assert.That(admin).IsNotNull();
+        await using var consumer = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("my-group")
+            .SubscribeTo("topic-a")
+            .Build();
+
+        await Assert.That(consumer).IsAssignableTo<IKafkaShareConsumer<string, string>>();
     }
 
-    #endregion
+    [Test]
+    public async Task CreateAdminClient_ReturnsBuilder()
+    {
+        var builder = Kafka.CreateAdminClient();
+
+        await Assert.That(builder).IsNotNull();
+    }
+
+    [Test]
+    public async Task CreateAdminClient_BuilderCanBuildAdminClient()
+    {
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+
+        await Assert.That(admin).IsAssignableTo<IAdminClient>();
+    }
 }


### PR DESCRIPTION
## Summary
- remove redundant static shortcut overloads from `Kafka`, leaving builder entrypoints only
- update topic-producer, admin, producer, and consumer tests to use builder flows
- refresh README and topic-producer docs for the collapsed API surface

## Test plan
- [x] `dotnet restore`
- [x] `dotnet build Dekaf.sln --no-restore`
- [x] `tests\Dekaf.Tests.Unit\bin\Debug\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaFactoryTests/*"`
- [x] `tests\Dekaf.Tests.Integration\bin\Debug\net10.0\Dekaf.Tests.Integration.exe --treenode-filter "/*/*/ConvenienceApiTests/ProducerBuilder_WithBootstrapServers_ProducesSuccessfully"`
- [x] `tests\Dekaf.Tests.Integration\bin\Debug\net10.0\Dekaf.Tests.Integration.exe --treenode-filter "/*/*/ConvenienceApiTests/ConsumerBuilder_SubscribeTo_ConsumesSuccessfully"`
- [x] `tests\Dekaf.Tests.Integration\bin\Debug\net10.0\Dekaf.Tests.Integration.exe --treenode-filter "/*/*/AdminWorkflowTests/AdminClient_Builder_WorksWithConnectionString"`
- [x] `tests\Dekaf.Tests.Integration\bin\Debug\net10.0\Dekaf.Tests.Integration.exe --treenode-filter "/*/*/TopicProducerTests/TopicProducer_Topic_ReturnsConfiguredTopic"`
- [x] `npm ci` (docs; reported existing 41 npm audit vulnerabilities)
- [x] `npm run build` (docs)

Closes #1019
