### PR TITLE
perf(consumer): avoid fetch metric tag work

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -649,6 +649,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // Cached metric tags per topic to avoid per-message TagList allocation
     // Plain Dictionary is safe: only accessed from the single ConsumeAsync loop thread
     private readonly Dictionary<string, System.Diagnostics.TagList> _metricTagsCache = [];
+    private readonly ConcurrentDictionary<int, TagList> _fetchDurationMetricTagsCache = new();
 
     private const long EarliestOffsetTimestamp = -2;
     private const long LatestOffsetTimestamp = -1;
@@ -1959,10 +1960,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 ConsumerFetchPools.ReturnFetchRequestTopics(topicData);
             }
 
-            // Record fetch round-trip duration (~3ns no-op when no listener)
-            Diagnostics.DekafMetrics.FetchDuration.Record(
-                System.Diagnostics.Stopwatch.GetElapsedTime(fetchStarted).TotalSeconds,
-                new System.Diagnostics.TagList { { Diagnostics.DekafDiagnostics.MessagingKafkaBrokerId, brokerId } });
+            RecordFetchDuration(fetchStarted, brokerId);
 
             // Take ownership of pooled memory from the response (if zero-copy was used)
             var memoryOwner = response.PooledMemoryOwner;
@@ -2428,6 +2426,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         Diagnostics.DekafMetrics.MessagesReceived.Add(fetch.MessageCount, metricTags);
         Diagnostics.DekafMetrics.BytesReceived.Add(fetch.TotalBytesConsumed, metricTags);
     }
+
+    private void RecordFetchDuration(long fetchStarted, int brokerId)
+    {
+        if (!Diagnostics.DekafMetrics.FetchDuration.Enabled)
+            return;
+
+        Diagnostics.DekafMetrics.FetchDuration.Record(
+            Stopwatch.GetElapsedTime(fetchStarted).TotalSeconds,
+            GetFetchDurationMetricTags(brokerId));
+    }
+
+    private TagList GetFetchDurationMetricTags(int brokerId) =>
+        _fetchDurationMetricTagsCache.GetOrAdd(
+            brokerId,
+            static id => new TagList { { Diagnostics.DekafDiagnostics.MessagingKafkaBrokerId, id } });
 
     public void Seek(TopicPartitionOffset offset)
     {
@@ -3450,10 +3463,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             ConsumerFetchPools.ReturnFetchRequestTopics(topicData);
         }
 
-        // Record fetch round-trip duration (~3ns no-op when no listener)
-        Diagnostics.DekafMetrics.FetchDuration.Record(
-            System.Diagnostics.Stopwatch.GetElapsedTime(fetchStarted).TotalSeconds,
-            new System.Diagnostics.TagList { { Diagnostics.DekafDiagnostics.MessagingKafkaBrokerId, brokerId } });
+        RecordFetchDuration(fetchStarted, brokerId);
 
         // Take ownership of pooled memory from the response (if zero-copy was used)
         var memoryOwner = response.PooledMemoryOwner;

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerFetchMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerFetchMetricsTests.cs
@@ -1,0 +1,113 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Diagnostics;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+[NotInParallel]
+public sealed class KafkaConsumerFetchMetricsTests
+{
+    [Test]
+    public async Task RecordFetchDuration_WhenDisabled_DoesNotCreateBrokerTags()
+    {
+        await using var consumer = CreateConsumer();
+
+        InvokeRecordFetchDuration(consumer, brokerId: 7);
+
+        await Assert.That(GetFetchDurationMetricTagsCache(consumer).Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RecordFetchDuration_WhenEnabled_ReusesBrokerTags()
+    {
+        double? duration = null;
+        string? brokerId = null;
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
+                instrument.Name == "messaging.consumer.fetch.duration")
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
+        {
+            if (instrument.Name == "messaging.consumer.fetch.duration")
+            {
+                duration = measurement;
+                brokerId = GetTag(tags, DekafDiagnostics.MessagingKafkaBrokerId);
+            }
+        });
+        listener.Start();
+
+        await Assert.That(DekafMetrics.FetchDuration.Enabled).IsTrue();
+
+        await using var consumer = CreateConsumer();
+
+        InvokeRecordFetchDuration(consumer, brokerId: 7);
+        InvokeRecordFetchDuration(consumer, brokerId: 7);
+
+        await Assert.That(duration).IsNotNull();
+        await Assert.That(brokerId).IsEqualTo("7");
+        await Assert.That(GetFetchDurationMetricTagsCache(consumer).Count).IsEqualTo(1);
+    }
+
+    private static KafkaConsumer<string, string> CreateConsumer()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var metadataManager = new MetadataManager(connectionPool, ["localhost:9092"]);
+        return new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                GroupId = "metrics-test"
+            },
+            Serializers.String,
+            Serializers.String,
+            connectionPool,
+            metadataManager);
+    }
+
+    private static void InvokeRecordFetchDuration(
+        KafkaConsumer<string, string> consumer,
+        int brokerId)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "RecordFetchDuration",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("RecordFetchDuration method not found.");
+
+        method.Invoke(consumer, [Stopwatch.GetTimestamp(), brokerId]);
+    }
+
+    private static ConcurrentDictionary<int, TagList> GetFetchDurationMetricTagsCache(
+        KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_fetchDurationMetricTagsCache",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_fetchDurationMetricTagsCache field not found.");
+
+        return (ConcurrentDictionary<int, TagList>)field.GetValue(consumer)!;
+    }
+
+    private static string? GetTag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string key)
+    {
+        foreach (var tag in tags)
+        {
+            if (tag.Key == key)
+                return tag.Value?.ToString();
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- guard consumer fetch-duration metric recording behind FetchDuration.Enabled
- cache broker-id fetch metric tags per broker so enabled metrics reuse boxed tag values
- add focused tests for disabled/enabled fetch-duration metric paths

## Test plan
- [x] dotnet restore tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj
- [x] dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/KafkaConsumerFetchMetricsTests/*"
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/QueryWatermarkOffsetsTests/*"
- [x] git diff --check

Part of #934
Closes #1088
