### PR TITLE
feat(auth): add OAuth JWT bearer grant

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -103,6 +103,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithSaslPlain(...)` / `WithSaslScramSha512(...)` | `SaslMechanism`, `SaslUsername`, `SaslPassword` | `SaslMechanism` values match the enum names |
 | `WithGssapi(...)` | `SaslMechanism`, `GssapiConfig` | Use `SaslMechanism: Gssapi` |
 | `WithOAuthBearer(...)` | `SaslMechanism`, `OAuthBearerConfig` | Use `SaslMechanism: OAuthBearer` |
+| `WithOAuthBearerJwtBearer(...)` | Runtime callback | Signs JWT assertions with RSA/ECDSA keys |
 | `WithMetadataRecoveryStrategy(...)` | `MetadataRecoveryStrategy` | `None` or `Rebootstrap` |
 | `WithMetadataRecoveryRebootstrapTrigger(...)` | `MetadataRecoveryRebootstrapTriggerMs` | Milliseconds |
 
@@ -265,6 +266,14 @@ Enable TLS:
 .WithSaslPlain("username", "password")
 .WithSaslScramSha256("username", "password")
 .WithSaslScramSha512("username", "password")
+.WithOAuthBearerJwtBearer(options =>
+{
+    options.TokenEndpoint = "https://auth.example.com/oauth2/token";
+    options.ClientId = "my-kafka-client";
+    options.PrivateKey = rsaOrEcdsaPrivateKey;
+    options.Audience = "kafka";
+    options.Scopes = ["kafka:consume"];
+})
 ```
 
 ## Serialization

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -89,6 +89,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithSaslPlain(...)` / `WithSaslScramSha512(...)` | `SaslMechanism`, `SaslUsername`, `SaslPassword` | `SaslMechanism` values match the enum names |
 | `WithGssapi(...)` | `SaslMechanism`, `GssapiConfig` | Use `SaslMechanism: Gssapi` |
 | `WithOAuthBearer(...)` | `SaslMechanism`, `OAuthBearerConfig` | Use `SaslMechanism: OAuthBearer` |
+| `WithOAuthBearerJwtBearer(...)` | Runtime callback | Signs JWT assertions with RSA/ECDSA keys |
 | `WithSocketSendBufferBytes(...)` | `SocketSendBufferBytes` | Bytes |
 | `WithSocketReceiveBufferBytes(...)` | `SocketReceiveBufferBytes` | Bytes |
 | `WithMetadataRecoveryStrategy(...)` | `MetadataRecoveryStrategy` | `None` or `Rebootstrap` |
@@ -223,6 +224,14 @@ Enable TLS encryption:
 .WithSaslScramSha512("username", "password")
 .WithGssapi(gssapiConfig)
 .WithOAuthBearer(oauthConfig)
+.WithOAuthBearerJwtBearer(options =>
+{
+    options.TokenEndpoint = "https://auth.example.com/oauth2/token";
+    options.ClientId = "my-kafka-client";
+    options.PrivateKey = rsaOrEcdsaPrivateKey;
+    options.Audience = "kafka";
+    options.Scopes = ["kafka:produce"];
+})
 ```
 
 ## Serialization

--- a/docs/docs/security/oauth.md
+++ b/docs/docs/security/oauth.md
@@ -13,7 +13,7 @@ using Dekaf;
 
 var oauthConfig = new OAuthBearerConfig
 {
-    TokenEndpoint = "https://auth.example.com/oauth2/token",
+    TokenEndpointUrl = "https://auth.example.com/oauth2/token",
     ClientId = "my-kafka-client",
     ClientSecret = "client-secret",
     Scope = "kafka"
@@ -41,13 +41,43 @@ var producer = await Kafka.CreateProducer<string, string>()
         var token = await GetTokenFromIdentityProviderAsync(ct);
         return new OAuthBearerToken
         {
-            Value = token.AccessToken,
-            ExpiresAt = token.ExpiresAt,
-            Principal = token.Subject
+            TokenValue = token.AccessToken,
+            Expiration = token.ExpiresAt,
+            PrincipalName = token.Subject
         };
     })
     .BuildAsync();
 ```
+
+## JWT-Bearer Grant
+
+Use the JWT-bearer grant when your identity provider exchanges a signed assertion for
+an access token:
+
+```csharp
+using System.Security.Cryptography;
+using Dekaf;
+
+using var privateKey = RSA.Create();
+privateKey.ImportFromPem(File.ReadAllText("client-key.pem"));
+
+var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("kafka.example.com:9092")
+    .UseTls()
+    .WithOAuthBearerJwtBearer(options =>
+    {
+        options.TokenEndpoint = "https://auth.example.com/oauth2/token";
+        options.ClientId = "my-kafka-client";
+        options.PrivateKey = privateKey;
+        options.Audience = "kafka";
+        options.Scopes = ["kafka:produce", "kafka:consume"];
+        options.KeyId = "key-2026-07";
+    })
+    .BuildAsync();
+```
+
+Dekaf signs assertions with RSA or ECDSA keys, posts `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer`
+and `assertion=<jwt>` to the token endpoint, then caches the returned access token until it nears expiration.
 
 ## Azure AD Example
 
@@ -68,8 +98,9 @@ var producer = await Kafka.CreateProducer<string, string>()
 
         return new OAuthBearerToken
         {
-            Value = token.Token,
-            ExpiresAt = token.ExpiresOn
+            TokenValue = token.Token,
+            Expiration = token.ExpiresOn,
+            PrincipalName = "azure-ad"
         };
     })
     .BuildAsync();
@@ -91,8 +122,9 @@ var producer = await Kafka.CreateProducer<string, string>()
         var token = await GenerateMskIamTokenAsync(ct);
         return new OAuthBearerToken
         {
-            Value = token,
-            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
+            TokenValue = token,
+            Expiration = DateTimeOffset.UtcNow.AddMinutes(5),
+            PrincipalName = "aws-msk"
         };
     })
     .BuildAsync();
@@ -109,7 +141,7 @@ Dekaf automatically refreshes tokens before they expire. The token provider is c
 
     var token = await _tokenService.GetTokenAsync(ct);
 
-    _logger.LogDebug("Token expires at {ExpiresAt}", token.ExpiresAt);
+    _logger.LogDebug("Token expires at {ExpiresAt}", token.Expiration);
 
     return token;
 })
@@ -149,9 +181,9 @@ public class OAuthKafkaClientFactory
 
         return new OAuthBearerToken
         {
-            Value = token.AccessToken,
-            ExpiresAt = token.ExpiresAt,
-            Principal = token.Claims.Subject
+            TokenValue = token.AccessToken,
+            Expiration = token.ExpiresAt,
+            PrincipalName = token.Claims.Subject
         };
     }
 }

--- a/docs/docs/security/oauth.md
+++ b/docs/docs/security/oauth.md
@@ -58,10 +58,10 @@ an access token:
 using System.Security.Cryptography;
 using Dekaf;
 
-using var privateKey = RSA.Create();
+var privateKey = RSA.Create();
 privateKey.ImportFromPem(File.ReadAllText("client-key.pem"));
 
-var producer = await Kafka.CreateProducer<string, string>()
+await using var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("kafka.example.com:9092")
     .UseTls()
     .WithOAuthBearerJwtBearer(options =>
@@ -78,6 +78,8 @@ var producer = await Kafka.CreateProducer<string, string>()
 
 Dekaf signs assertions with RSA or ECDSA keys, posts `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer`
 and `assertion=<jwt>` to the token endpoint, then caches the returned access token until it nears expiration.
+Keep the `PrivateKey` object alive until every client configured with it has been disposed; token refreshes reuse
+the same key object to sign new assertions.
 
 ## Azure AD Example
 

--- a/docs/docs/security/tls.md
+++ b/docs/docs/security/tls.md
@@ -105,7 +105,7 @@ using Dekaf;
 var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("broker1.msk.us-east-1.amazonaws.com:9098")
     .UseTls()
-    .WithSaslOAuthBearer(new AwsMskTokenProvider())
+    .WithOAuthBearer(GetAwsMskTokenAsync)
     .BuildAsync();
 ```
 

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -2646,8 +2646,10 @@ public sealed class AdminClientBuilder
     public AdminClientBuilder WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
     {
         ThrowIfClientOwnedConnectionSettings();
+        ArgumentNullException.ThrowIfNull(options);
+        var oauthConfig = options.ToOAuthBearerConfig();
         _saslMechanism = SaslMechanism.OAuthBearer;
-        _oauthConfig = (options ?? throw new ArgumentNullException(nameof(options))).ToOAuthBearerConfig();
+        _oauthConfig = oauthConfig;
         _oauthTokenProvider = null;
         return this;
     }

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -2640,6 +2640,31 @@ public sealed class AdminClientBuilder
     }
 
     /// <summary>
+    /// Configures SASL/OAUTHBEARER authentication using OAuth 2.0 JWT-bearer assertion flow.
+    /// </summary>
+    /// <param name="options">The JWT-bearer OAuth options.</param>
+    public AdminClientBuilder WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = (options ?? throw new ArgumentNullException(nameof(options))).ToOAuthBearerConfig();
+        _oauthTokenProvider = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures SASL/OAUTHBEARER authentication using OAuth 2.0 JWT-bearer assertion flow.
+    /// </summary>
+    /// <param name="configure">Callback that configures the JWT-bearer OAuth options.</param>
+    public AdminClientBuilder WithOAuthBearerJwtBearer(Action<OAuthBearerJwtBearerOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerJwtBearerOptions();
+        configure(options);
+        return WithOAuthBearerJwtBearer(options);
+    }
+
+    /// <summary>
     /// Configures SASL/OAUTHBEARER authentication using a custom token provider.
     /// </summary>
     /// <param name="tokenProvider">A callback that returns an OAuth bearer token on demand.</param>

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -448,6 +448,31 @@ public sealed class ProducerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Configures OAUTHBEARER authentication using OAuth 2.0 JWT-bearer assertion flow.
+    /// </summary>
+    /// <param name="options">The JWT-bearer OAuth options.</param>
+    public ProducerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = (options ?? throw new ArgumentNullException(nameof(options))).ToOAuthBearerConfig();
+        _oauthTokenProvider = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures OAUTHBEARER authentication using OAuth 2.0 JWT-bearer assertion flow.
+    /// </summary>
+    /// <param name="configure">Callback that configures the JWT-bearer OAuth options.</param>
+    public ProducerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(Action<OAuthBearerJwtBearerOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerJwtBearerOptions();
+        configure(options);
+        return WithOAuthBearerJwtBearer(options);
+    }
+
+    /// <summary>
     /// Configures OAUTHBEARER authentication using a custom token provider.
     /// </summary>
     /// <param name="tokenProvider">A function that provides OAuth tokens on demand.</param>
@@ -1393,6 +1418,31 @@ public sealed class ConsumerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Configures OAUTHBEARER authentication using OAuth 2.0 JWT-bearer assertion flow.
+    /// </summary>
+    /// <param name="options">The JWT-bearer OAuth options.</param>
+    public ConsumerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = (options ?? throw new ArgumentNullException(nameof(options))).ToOAuthBearerConfig();
+        _oauthTokenProvider = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures OAUTHBEARER authentication using OAuth 2.0 JWT-bearer assertion flow.
+    /// </summary>
+    /// <param name="configure">Callback that configures the JWT-bearer OAuth options.</param>
+    public ConsumerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(Action<OAuthBearerJwtBearerOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerJwtBearerOptions();
+        configure(options);
+        return WithOAuthBearerJwtBearer(options);
+    }
+
+    /// <summary>
     /// Configures OAUTHBEARER authentication using a custom token provider.
     /// </summary>
     /// <param name="tokenProvider">A function that provides OAuth tokens on demand.</param>
@@ -2100,6 +2150,23 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthConfig = config;
         return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = (options ?? throw new ArgumentNullException(nameof(options))).ToOAuthBearerConfig();
+        _oauthTokenProvider = null;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(Action<OAuthBearerJwtBearerOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerJwtBearerOptions();
+        configure(options);
+        return WithOAuthBearerJwtBearer(options);
     }
 
     public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerTokenProvider(Func<CancellationToken, ValueTask<OAuthBearerToken>> provider)

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -454,8 +454,10 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
     {
         ThrowIfClientOwnedConnectionSettings();
+        ArgumentNullException.ThrowIfNull(options);
+        var oauthConfig = options.ToOAuthBearerConfig();
         _saslMechanism = SaslMechanism.OAuthBearer;
-        _oauthConfig = (options ?? throw new ArgumentNullException(nameof(options))).ToOAuthBearerConfig();
+        _oauthConfig = oauthConfig;
         _oauthTokenProvider = null;
         return this;
     }
@@ -1424,8 +1426,10 @@ public sealed class ConsumerBuilder<TKey, TValue>
     public ConsumerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
     {
         ThrowIfClientOwnedConnectionSettings();
+        ArgumentNullException.ThrowIfNull(options);
+        var oauthConfig = options.ToOAuthBearerConfig();
         _saslMechanism = SaslMechanism.OAuthBearer;
-        _oauthConfig = (options ?? throw new ArgumentNullException(nameof(options))).ToOAuthBearerConfig();
+        _oauthConfig = oauthConfig;
         _oauthTokenProvider = null;
         return this;
     }
@@ -2155,8 +2159,10 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
     {
         ThrowIfClientOwnedConnectionSettings();
+        ArgumentNullException.ThrowIfNull(options);
+        var oauthConfig = options.ToOAuthBearerConfig();
         _saslMechanism = SaslMechanism.OAuthBearer;
-        _oauthConfig = (options ?? throw new ArgumentNullException(nameof(options))).ToOAuthBearerConfig();
+        _oauthConfig = oauthConfig;
         _oauthTokenProvider = null;
         return this;
     }

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -179,6 +179,22 @@ public sealed class KafkaClientBuilder
         return this;
     }
 
+    public KafkaClientBuilder WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
+    {
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = (options ?? throw new ArgumentNullException(nameof(options))).ToOAuthBearerConfig();
+        _oauthTokenProvider = null;
+        return this;
+    }
+
+    public KafkaClientBuilder WithOAuthBearerJwtBearer(Action<OAuthBearerJwtBearerOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerJwtBearerOptions();
+        configure(options);
+        return WithOAuthBearerJwtBearer(options);
+    }
+
     public KafkaClientBuilder WithOAuthBearer(Func<CancellationToken, ValueTask<OAuthBearerToken>> tokenProvider)
     {
         _saslMechanism = SaslMechanism.OAuthBearer;

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -107,7 +107,7 @@ public sealed class KafkaClientBuilder
 
     public KafkaClientBuilder WithBootstrapServers(params string[] servers)
     {
-        _bootstrapServers = [..servers];
+        _bootstrapServers = [.. servers];
         return this;
     }
 
@@ -181,8 +181,10 @@ public sealed class KafkaClientBuilder
 
     public KafkaClientBuilder WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
     {
+        ArgumentNullException.ThrowIfNull(options);
+        var oauthConfig = options.ToOAuthBearerConfig();
         _saslMechanism = SaslMechanism.OAuthBearer;
-        _oauthConfig = (options ?? throw new ArgumentNullException(nameof(options))).ToOAuthBearerConfig();
+        _oauthConfig = oauthConfig;
         _oauthTokenProvider = null;
         return this;
     }

--- a/src/Dekaf/Security/Sasl/OAuthBearerConfig.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerConfig.cs
@@ -6,6 +6,11 @@ namespace Dekaf.Security.Sasl;
 public sealed class OAuthBearerConfig
 {
     /// <summary>
+    /// OAuth grant type to use when fetching access tokens.
+    /// </summary>
+    public OAuthBearerGrantType GrantType { get; init; } = OAuthBearerGrantType.ClientCredentials;
+
+    /// <summary>
     /// The OAuth 2.0 / OIDC token endpoint URL for obtaining access tokens.
     /// </summary>
     public required string TokenEndpointUrl { get; init; }
@@ -31,8 +36,30 @@ public sealed class OAuthBearerConfig
     public IReadOnlyDictionary<string, string>? AdditionalParameters { get; init; }
 
     /// <summary>
+    /// JWT-bearer assertion settings. Required when <see cref="GrantType"/> is
+    /// <see cref="OAuthBearerGrantType.JwtBearer"/>.
+    /// </summary>
+    public OAuthBearerJwtBearerOptions? JwtBearer { get; init; }
+
+    /// <summary>
     /// The number of seconds before token expiration to trigger a refresh.
     /// Default is 60 seconds.
     /// </summary>
     public int TokenRefreshBufferSeconds { get; init; } = 60;
+}
+
+/// <summary>
+/// OAuth grant types supported by the built-in OAUTHBEARER token provider.
+/// </summary>
+public enum OAuthBearerGrantType
+{
+    /// <summary>
+    /// OAuth 2.0 client credentials grant.
+    /// </summary>
+    ClientCredentials,
+
+    /// <summary>
+    /// OAuth 2.0 JWT bearer assertion grant.
+    /// </summary>
+    JwtBearer
 }

--- a/src/Dekaf/Security/Sasl/OAuthBearerJwtAssertion.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerJwtAssertion.cs
@@ -1,0 +1,174 @@
+namespace Dekaf.Security.Sasl;
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+internal static class OAuthBearerJwtAssertion
+{
+    private static readonly HashSet<string> ReservedClaims = new(StringComparer.Ordinal)
+    {
+        "iss",
+        "sub",
+        "aud",
+        "exp",
+        "nbf",
+        "iat",
+        "jti"
+    };
+
+    internal static string Create(OAuthBearerConfig config, DateTimeOffset now)
+    {
+        var options = config.JwtBearer
+            ?? throw new InvalidOperationException("JWT-bearer OAuth config requires JwtBearer options");
+
+        var clientId = Required(config.ClientId, "OAuth client ID is required");
+        var audience = Required(options.Audience, "JWT-bearer OAuth audience is required");
+        var issuer = string.IsNullOrWhiteSpace(options.Issuer) ? clientId : options.Issuer!;
+        var subject = string.IsNullOrWhiteSpace(options.Subject) ? clientId : options.Subject!;
+        var privateKey = options.PrivateKey
+            ?? throw new InvalidOperationException("JWT-bearer OAuth private key is required");
+        if (options.AssertionLifetime <= TimeSpan.Zero)
+            throw new InvalidOperationException("JWT-bearer assertion lifetime must be positive");
+
+        ValidateAdditionalClaims(options.AdditionalClaims);
+
+        var algorithm = ResolveAlgorithm(privateKey, options.SigningAlgorithm);
+        var header = Base64UrlJson(writer =>
+        {
+            writer.WriteString("alg", AlgorithmName(algorithm));
+            writer.WriteString("typ", "JWT");
+            if (!string.IsNullOrWhiteSpace(options.KeyId))
+                writer.WriteString("kid", options.KeyId);
+        });
+
+        var expiresAt = now.Add(options.AssertionLifetime);
+        var payload = Base64UrlJson(writer =>
+        {
+            writer.WriteString("iss", issuer);
+            writer.WriteString("sub", subject);
+            writer.WriteString("aud", audience);
+            writer.WriteNumber("iat", now.ToUnixTimeSeconds());
+            writer.WriteNumber("exp", expiresAt.ToUnixTimeSeconds());
+            writer.WriteString("jti", Guid.NewGuid().ToString("N"));
+
+            if (options.AdditionalClaims is not null)
+            {
+                foreach (var (name, value) in options.AdditionalClaims)
+                {
+                    writer.WritePropertyName(name);
+                    JsonSerializer.Serialize(writer, value, value?.GetType() ?? typeof(object));
+                }
+            }
+        });
+
+        var signingInput = $"{header}.{payload}";
+        var signature = Sign(privateKey, algorithm, Encoding.ASCII.GetBytes(signingInput));
+        return $"{signingInput}.{Base64Url.EncodeToString(signature)}";
+    }
+
+    private static string Required(string? value, string message)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new InvalidOperationException(message);
+        return value;
+    }
+
+    private static void ValidateAdditionalClaims(IReadOnlyDictionary<string, object?>? claims)
+    {
+        if (claims is null)
+            return;
+
+        foreach (var name in claims.Keys)
+        {
+            if (ReservedClaims.Contains(name))
+                throw new InvalidOperationException($"JWT-bearer additional claim '{name}' conflicts with a reserved assertion claim");
+        }
+    }
+
+    private static string Base64UrlJson(Action<Utf8JsonWriter> writeProperties)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writeProperties(writer);
+            writer.WriteEndObject();
+        }
+
+        return Base64Url.EncodeToString(buffer.WrittenSpan);
+    }
+
+    private static OAuthBearerJwtSigningAlgorithm ResolveAlgorithm(
+        AsymmetricAlgorithm key,
+        OAuthBearerJwtSigningAlgorithm? configured)
+    {
+        if (configured is not null)
+            return configured.Value;
+
+        return key switch
+        {
+            RSA => OAuthBearerJwtSigningAlgorithm.Rs256,
+            ECDsa ecdsa when ecdsa.KeySize <= 256 => OAuthBearerJwtSigningAlgorithm.Es256,
+            ECDsa ecdsa when ecdsa.KeySize <= 384 => OAuthBearerJwtSigningAlgorithm.Es384,
+            ECDsa => OAuthBearerJwtSigningAlgorithm.Es512,
+            _ => throw new InvalidOperationException("JWT-bearer OAuth private key must be RSA or ECDSA")
+        };
+    }
+
+    private static string AlgorithmName(OAuthBearerJwtSigningAlgorithm algorithm) => algorithm switch
+    {
+        OAuthBearerJwtSigningAlgorithm.Rs256 => "RS256",
+        OAuthBearerJwtSigningAlgorithm.Rs384 => "RS384",
+        OAuthBearerJwtSigningAlgorithm.Rs512 => "RS512",
+        OAuthBearerJwtSigningAlgorithm.Ps256 => "PS256",
+        OAuthBearerJwtSigningAlgorithm.Ps384 => "PS384",
+        OAuthBearerJwtSigningAlgorithm.Ps512 => "PS512",
+        OAuthBearerJwtSigningAlgorithm.Es256 => "ES256",
+        OAuthBearerJwtSigningAlgorithm.Es384 => "ES384",
+        OAuthBearerJwtSigningAlgorithm.Es512 => "ES512",
+        _ => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null)
+    };
+
+    private static byte[] Sign(
+        AsymmetricAlgorithm key,
+        OAuthBearerJwtSigningAlgorithm algorithm,
+        byte[] signingInput) => algorithm switch
+    {
+        OAuthBearerJwtSigningAlgorithm.Rs256 => SignRsa(key, signingInput, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1),
+        OAuthBearerJwtSigningAlgorithm.Rs384 => SignRsa(key, signingInput, HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1),
+        OAuthBearerJwtSigningAlgorithm.Rs512 => SignRsa(key, signingInput, HashAlgorithmName.SHA512, RSASignaturePadding.Pkcs1),
+        OAuthBearerJwtSigningAlgorithm.Ps256 => SignRsa(key, signingInput, HashAlgorithmName.SHA256, RSASignaturePadding.Pss),
+        OAuthBearerJwtSigningAlgorithm.Ps384 => SignRsa(key, signingInput, HashAlgorithmName.SHA384, RSASignaturePadding.Pss),
+        OAuthBearerJwtSigningAlgorithm.Ps512 => SignRsa(key, signingInput, HashAlgorithmName.SHA512, RSASignaturePadding.Pss),
+        OAuthBearerJwtSigningAlgorithm.Es256 => SignEcdsa(key, signingInput, HashAlgorithmName.SHA256),
+        OAuthBearerJwtSigningAlgorithm.Es384 => SignEcdsa(key, signingInput, HashAlgorithmName.SHA384),
+        OAuthBearerJwtSigningAlgorithm.Es512 => SignEcdsa(key, signingInput, HashAlgorithmName.SHA512),
+        _ => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null)
+    };
+
+    private static byte[] SignRsa(
+        AsymmetricAlgorithm key,
+        byte[] signingInput,
+        HashAlgorithmName hashAlgorithm,
+        RSASignaturePadding padding)
+    {
+        if (key is not RSA rsa)
+            throw new InvalidOperationException("Selected JWT-bearer signing algorithm requires an RSA private key");
+
+        return rsa.SignData(signingInput, hashAlgorithm, padding);
+    }
+
+    private static byte[] SignEcdsa(
+        AsymmetricAlgorithm key,
+        byte[] signingInput,
+        HashAlgorithmName hashAlgorithm)
+    {
+        if (key is not ECDsa ecdsa)
+            throw new InvalidOperationException("Selected JWT-bearer signing algorithm requires an ECDSA private key");
+
+        return ecdsa.SignData(signingInput, hashAlgorithm, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+    }
+}

--- a/src/Dekaf/Security/Sasl/OAuthBearerJwtBearerOptions.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerJwtBearerOptions.cs
@@ -1,0 +1,154 @@
+namespace Dekaf.Security.Sasl;
+
+using System.Security.Cryptography;
+
+/// <summary>
+/// Configuration for OAuth 2.0 JWT-bearer assertion grants used with SASL/OAUTHBEARER.
+/// </summary>
+public sealed class OAuthBearerJwtBearerOptions
+{
+    /// <summary>
+    /// OAuth token endpoint that receives the JWT assertion.
+    /// </summary>
+    public string? TokenEndpoint { get; set; }
+
+    /// <summary>
+    /// OAuth client identifier. Used as <c>client_id</c> in the token request and as the
+    /// default JWT issuer and subject.
+    /// </summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>
+    /// Private key used to sign the assertion. RSA and ECDSA keys are supported.
+    /// </summary>
+    public AsymmetricAlgorithm? PrivateKey { get; set; }
+
+    /// <summary>
+    /// Intended audience for the JWT assertion.
+    /// </summary>
+    public string? Audience { get; set; }
+
+    /// <summary>
+    /// JWT issuer claim. Defaults to <see cref="ClientId"/>.
+    /// </summary>
+    public string? Issuer { get; set; }
+
+    /// <summary>
+    /// JWT subject claim. Defaults to <see cref="ClientId"/>.
+    /// </summary>
+    public string? Subject { get; set; }
+
+    /// <summary>
+    /// Optional key identifier to include in the JWT header.
+    /// </summary>
+    public string? KeyId { get; set; }
+
+    /// <summary>
+    /// Scopes to request. Values are sent as a space-delimited <c>scope</c> token request parameter.
+    /// </summary>
+    public IReadOnlyList<string>? Scopes { get; set; }
+
+    /// <summary>
+    /// Additional JWT claims to include in the assertion.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?>? AdditionalClaims { get; set; }
+
+    /// <summary>
+    /// Additional form parameters to include in the token request.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? AdditionalParameters { get; set; }
+
+    /// <summary>
+    /// Assertion lifetime. Defaults to five minutes.
+    /// </summary>
+    public TimeSpan AssertionLifetime { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Number of seconds before token expiration to trigger a refresh.
+    /// </summary>
+    public int TokenRefreshBufferSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Signing algorithm. When unset, RSA keys use RS256 and ECDSA keys infer ES256/ES384/ES512
+    /// from key size.
+    /// </summary>
+    public OAuthBearerJwtSigningAlgorithm? SigningAlgorithm { get; set; }
+
+    internal OAuthBearerConfig ToOAuthBearerConfig()
+    {
+        if (string.IsNullOrWhiteSpace(TokenEndpoint))
+            throw new InvalidOperationException("JWT-bearer OAuth token endpoint is required");
+        if (string.IsNullOrWhiteSpace(ClientId))
+            throw new InvalidOperationException("JWT-bearer OAuth client ID is required");
+        if (string.IsNullOrWhiteSpace(Audience))
+            throw new InvalidOperationException("JWT-bearer OAuth audience is required");
+        if (PrivateKey is null)
+            throw new InvalidOperationException("JWT-bearer OAuth private key is required");
+        if (AssertionLifetime <= TimeSpan.Zero)
+            throw new InvalidOperationException("JWT-bearer assertion lifetime must be positive");
+        if (TokenRefreshBufferSeconds < 0)
+            throw new InvalidOperationException("JWT-bearer token refresh buffer must be non-negative");
+
+        var options = Clone();
+        return new OAuthBearerConfig
+        {
+            GrantType = OAuthBearerGrantType.JwtBearer,
+            TokenEndpointUrl = options.TokenEndpoint!,
+            ClientId = options.ClientId!,
+            Scope = options.Scopes is { Count: > 0 } ? string.Join(' ', options.Scopes) : null,
+            AdditionalParameters = options.AdditionalParameters,
+            JwtBearer = options,
+            TokenRefreshBufferSeconds = TokenRefreshBufferSeconds
+        };
+    }
+
+    private OAuthBearerJwtBearerOptions Clone() => new()
+    {
+        TokenEndpoint = TokenEndpoint,
+        ClientId = ClientId,
+        PrivateKey = PrivateKey,
+        Audience = Audience,
+        Issuer = Issuer,
+        Subject = Subject,
+        KeyId = KeyId,
+        Scopes = Scopes is null ? null : Scopes.ToArray(),
+        AdditionalClaims = AdditionalClaims is null ? null : new Dictionary<string, object?>(AdditionalClaims, StringComparer.Ordinal),
+        AdditionalParameters = AdditionalParameters is null ? null : new Dictionary<string, string>(AdditionalParameters, StringComparer.Ordinal),
+        AssertionLifetime = AssertionLifetime,
+        TokenRefreshBufferSeconds = TokenRefreshBufferSeconds,
+        SigningAlgorithm = SigningAlgorithm
+    };
+}
+
+/// <summary>
+/// JWS signing algorithms supported for OAuth JWT-bearer assertions.
+/// </summary>
+public enum OAuthBearerJwtSigningAlgorithm
+{
+    /// <summary>RSA PKCS#1 v1.5 with SHA-256.</summary>
+    Rs256,
+
+    /// <summary>RSA PKCS#1 v1.5 with SHA-384.</summary>
+    Rs384,
+
+    /// <summary>RSA PKCS#1 v1.5 with SHA-512.</summary>
+    Rs512,
+
+    /// <summary>RSA-PSS with SHA-256.</summary>
+    Ps256,
+
+    /// <summary>RSA-PSS with SHA-384.</summary>
+    Ps384,
+
+    /// <summary>RSA-PSS with SHA-512.</summary>
+    Ps512,
+
+    /// <summary>ECDSA with SHA-256.</summary>
+    Es256,
+
+    /// <summary>ECDSA with SHA-384.</summary>
+    Es384,
+
+    /// <summary>ECDSA with SHA-512.</summary>
+    Es512
+}

--- a/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
@@ -6,7 +6,7 @@ using Dekaf.Errors;
 namespace Dekaf.Security.Sasl;
 
 /// <summary>
-/// OAuth 2.0 token provider that fetches tokens from a token endpoint using client credentials grant.
+/// OAuth 2.0 token provider that fetches tokens from a token endpoint.
 /// </summary>
 public sealed class OAuthBearerTokenProvider : IDisposable
 {
@@ -106,10 +106,11 @@ public sealed class OAuthBearerTokenProvider : IDisposable
 
     private Dictionary<string, string> BuildTokenRequestBody()
     {
-        var body = new Dictionary<string, string>
+        var body = _config.GrantType switch
         {
-            ["grant_type"] = "client_credentials",
-            ["client_id"] = _config.ClientId
+            OAuthBearerGrantType.ClientCredentials => BuildClientCredentialsTokenRequestBody(),
+            OAuthBearerGrantType.JwtBearer => BuildJwtBearerTokenRequestBody(),
+            _ => throw new InvalidOperationException($"Unsupported OAuth bearer grant type: {_config.GrantType}")
         };
 
         if (!string.IsNullOrEmpty(_config.Scope))
@@ -126,6 +127,30 @@ public sealed class OAuthBearerTokenProvider : IDisposable
         }
 
         return body;
+    }
+
+    private Dictionary<string, string> BuildClientCredentialsTokenRequestBody()
+    {
+        return new Dictionary<string, string>
+        {
+            ["grant_type"] = "client_credentials",
+            ["client_id"] = _config.ClientId
+        };
+    }
+
+    private Dictionary<string, string> BuildJwtBearerTokenRequestBody()
+    {
+        if (_config.JwtBearer is null)
+        {
+            throw new InvalidOperationException("JWT-bearer OAuth grant requires JwtBearer options");
+        }
+
+        return new Dictionary<string, string>
+        {
+            ["grant_type"] = "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            ["client_id"] = _config.ClientId,
+            ["assertion"] = OAuthBearerJwtAssertion.Create(_config, DateTimeOffset.UtcNow)
+        };
     }
 
     private static OAuthBearerToken ParseTokenResponse(string responseContent)

--- a/tests/Dekaf.Tests.Integration/Security/OAuthBearerAuthenticationTests.cs
+++ b/tests/Dekaf.Tests.Integration/Security/OAuthBearerAuthenticationTests.cs
@@ -1,3 +1,7 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.Security.Sasl;
@@ -41,6 +45,42 @@ public class OAuthBearerAuthenticationTests(OAuthBearerKafkaContainer oauthKafka
         await Assert.That(metadata.Topic).IsEqualTo(topic);
         await Assert.That(metadata.Partition).IsGreaterThanOrEqualTo(0);
         await Assert.That(metadata.Offset).IsGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
+    public async Task Producer_WithOAuthBearerJwtBearer_SuccessfullyProduces()
+    {
+        var topic = await oauthKafka.CreateTestTopicAsync();
+        using var rsa = RSA.Create(2048);
+        await using var tokenEndpoint = JwtBearerTokenEndpoint.Start(
+            OAuthBearerKafkaContainer.CreateToken(OAuthBearerKafkaContainer.Principal));
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(oauthKafka.BootstrapServers)
+            .WithClientId("oauth-jwt-bearer-producer")
+            .WithOAuthBearerJwtBearer(options =>
+            {
+                options.TokenEndpoint = tokenEndpoint.Url;
+                options.ClientId = OAuthBearerKafkaContainer.Principal;
+                options.PrivateKey = rsa;
+                options.Audience = tokenEndpoint.Url;
+                options.Scopes = ["kafka"];
+            })
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var metadata = await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "oauth-jwt-key",
+            Value = "oauth-jwt-value"
+        }, CancellationToken.None);
+
+        await Assert.That(metadata.Topic).IsEqualTo(topic);
+        await Assert.That(tokenEndpoint.RequestCount).IsEqualTo(1);
+        await Assert.That(tokenEndpoint.LastForm["grant_type"]).IsEqualTo("urn:ietf:params:oauth:grant-type:jwt-bearer");
+        await Assert.That(tokenEndpoint.LastForm["assertion"].Split('.').Length).IsEqualTo(3);
     }
 
     [Test]
@@ -169,5 +209,187 @@ public class OAuthBearerAuthenticationTests(OAuthBearerKafkaContainer oauthKafka
                 Value = "value"
             }, CancellationToken.None);
         });
+    }
+
+    private sealed class JwtBearerTokenEndpoint : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _acceptLoop;
+        private readonly OAuthBearerToken _token;
+        private IReadOnlyDictionary<string, string>? _lastForm;
+        private int _requestCount;
+
+        private JwtBearerTokenEndpoint(TcpListener listener, string url, OAuthBearerToken token)
+        {
+            _listener = listener;
+            Url = url;
+            _token = token;
+            _acceptLoop = Task.Run(AcceptLoopAsync);
+        }
+
+        public string Url { get; }
+        public int RequestCount => Volatile.Read(ref _requestCount);
+        public IReadOnlyDictionary<string, string> LastForm => _lastForm ?? throw new InvalidOperationException("No token request received");
+
+        public static JwtBearerTokenEndpoint Start(OAuthBearerToken token)
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            return new JwtBearerTokenEndpoint(listener, $"http://127.0.0.1:{port}/token", token);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+
+            try
+            {
+                await _acceptLoop;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+
+            _cts.Dispose();
+        }
+
+        private async Task AcceptLoopAsync()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                TcpClient client;
+                try
+                {
+                    client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+
+                await HandleClientAsync(client, _cts.Token);
+            }
+        }
+
+        private async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
+        {
+            using (client)
+            {
+                var stream = client.GetStream();
+                var request = await ReadHttpRequestAsync(stream, cancellationToken);
+                _lastForm = ParseForm(request.Body);
+                Interlocked.Increment(ref _requestCount);
+
+                var body = $$"""{"access_token":"{{_token.TokenValue}}","expires_in":3600,"sub":"{{_token.PrincipalName}}"}""";
+                var bodyBytes = Encoding.UTF8.GetBytes(body);
+                var headers = Encoding.ASCII.GetBytes(
+                    "HTTP/1.1 200 OK\r\n" +
+                    "Content-Type: application/json\r\n" +
+                    $"Content-Length: {bodyBytes.Length}\r\n" +
+                    "Connection: close\r\n\r\n");
+
+                await stream.WriteAsync(headers, cancellationToken);
+                await stream.WriteAsync(bodyBytes, cancellationToken);
+            }
+        }
+
+        private static async Task<HttpRequest> ReadHttpRequestAsync(NetworkStream stream, CancellationToken cancellationToken)
+        {
+            using var buffer = new MemoryStream();
+            var readBuffer = new byte[1024];
+            var headerEnd = -1;
+
+            while (headerEnd < 0)
+            {
+                var read = await stream.ReadAsync(readBuffer, cancellationToken);
+                if (read == 0)
+                    throw new InvalidOperationException("Token endpoint request ended before headers");
+
+                buffer.Write(readBuffer, 0, read);
+                headerEnd = IndexOf(buffer.GetBuffer(), (int)buffer.Length, "\r\n\r\n"u8.ToArray());
+            }
+
+            var requestBytes = buffer.ToArray();
+            var headerText = Encoding.ASCII.GetString(requestBytes, 0, headerEnd);
+            var contentLength = ParseContentLength(headerText);
+            var bodyStart = headerEnd + 4;
+            var bodyBytes = new byte[contentLength];
+            var bufferedBodyLength = Math.Min(contentLength, requestBytes.Length - bodyStart);
+            if (bufferedBodyLength > 0)
+                Array.Copy(requestBytes, bodyStart, bodyBytes, 0, bufferedBodyLength);
+
+            var remaining = contentLength - bufferedBodyLength;
+            while (remaining > 0)
+            {
+                var offset = contentLength - remaining;
+                var read = await stream.ReadAsync(bodyBytes.AsMemory(offset, remaining), cancellationToken);
+                if (read == 0)
+                    throw new InvalidOperationException("Token endpoint request ended before body");
+                remaining -= read;
+            }
+
+            return new HttpRequest(Encoding.UTF8.GetString(bodyBytes));
+        }
+
+        private static int ParseContentLength(string headerText)
+        {
+            foreach (var line in headerText.Split("\r\n"))
+            {
+                if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase))
+                    return int.Parse(line["Content-Length:".Length..].Trim());
+            }
+
+            return 0;
+        }
+
+        private static int IndexOf(byte[] buffer, int length, byte[] marker)
+        {
+            for (var i = 0; i <= length - marker.Length; i++)
+            {
+                var found = true;
+                for (var j = 0; j < marker.Length; j++)
+                {
+                    if (buffer[i + j] != marker[j])
+                    {
+                        found = false;
+                        break;
+                    }
+                }
+
+                if (found)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        private static IReadOnlyDictionary<string, string> ParseForm(string body)
+        {
+            var result = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var pair in body.Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var parts = pair.Split('=', 2);
+                var key = DecodeFormValue(parts[0]);
+                var value = parts.Length == 2 ? DecodeFormValue(parts[1]) : string.Empty;
+                result[key] = value;
+            }
+
+            return result;
+        }
+
+        private static string DecodeFormValue(string value) =>
+            Uri.UnescapeDataString(value.Replace('+', ' '));
+
+        private readonly record struct HttpRequest(string Body);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Builder/OAuthBearerJwtBearerBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/OAuthBearerJwtBearerBuilderTests.cs
@@ -1,0 +1,115 @@
+using System.Security.Cryptography;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.Builder;
+
+public sealed class OAuthBearerJwtBearerBuilderTests
+{
+    [Test]
+    public async Task Producer_WithOAuthBearerJwtBearer_ReturnsSameBuilder()
+    {
+        using var rsa = RSA.Create(2048);
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var result = builder.WithOAuthBearerJwtBearer(CreateOptions(rsa));
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task Producer_WithOAuthBearerJwtBearerAction_ReturnsSameBuilder()
+    {
+        using var rsa = RSA.Create(2048);
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var result = builder.WithOAuthBearerJwtBearer(options =>
+        {
+            options.TokenEndpoint = "https://auth.example.test/token";
+            options.ClientId = "client";
+            options.PrivateKey = rsa;
+            options.Audience = "kafka";
+            options.Scopes = ["kafka"];
+        });
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task Consumer_WithOAuthBearerJwtBearer_ReturnsSameBuilder()
+    {
+        using var rsa = RSA.Create(2048);
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var result = builder.WithOAuthBearerJwtBearer(CreateOptions(rsa));
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task ShareConsumer_WithOAuthBearerJwtBearer_ReturnsSameBuilder()
+    {
+        using var rsa = RSA.Create(2048);
+        var builder = Kafka.CreateShareConsumer<string, string>();
+
+        var result = builder.WithOAuthBearerJwtBearer(CreateOptions(rsa));
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task AdminClient_WithOAuthBearerJwtBearer_ReturnsSameBuilder()
+    {
+        using var rsa = RSA.Create(2048);
+        var builder = Kafka.CreateAdminClient();
+
+        var result = builder.WithOAuthBearerJwtBearer(CreateOptions(rsa));
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task KafkaClient_WithOAuthBearerJwtBearer_ReturnsSameBuilder()
+    {
+        using var rsa = RSA.Create(2048);
+        var builder = Kafka.Connect();
+
+        var result = builder.WithOAuthBearerJwtBearer(CreateOptions(rsa));
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task Producer_WithOAuthBearerJwtBearer_NullOptions_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        await Assert.That(() => builder.WithOAuthBearerJwtBearer((OAuthBearerJwtBearerOptions)null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Producer_WithOAuthBearerJwtBearer_NullConfigure_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        await Assert.That(() => builder.WithOAuthBearerJwtBearer((Action<OAuthBearerJwtBearerOptions>)null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Producer_WithOAuthBearerJwtBearer_MissingRequiredOptions_ThrowsInvalidOperationException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        await Assert.That(() => builder.WithOAuthBearerJwtBearer(new OAuthBearerJwtBearerOptions()))
+            .Throws<InvalidOperationException>();
+    }
+
+    private static OAuthBearerJwtBearerOptions CreateOptions(AsymmetricAlgorithm privateKey) => new()
+    {
+        TokenEndpoint = "https://auth.example.test/token",
+        ClientId = "client",
+        PrivateKey = privateKey,
+        Audience = "kafka"
+    };
+}

--- a/tests/Dekaf.Tests.Unit/Builder/OAuthBearerJwtBearerBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/OAuthBearerJwtBearerBuilderTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Security.Cryptography;
 using Dekaf.Security.Sasl;
 
@@ -105,6 +106,28 @@ public sealed class OAuthBearerJwtBearerBuilderTests
             .Throws<InvalidOperationException>();
     }
 
+    [Test]
+    public async Task WithOAuthBearerJwtBearer_WhenValidationFails_DoesNotChangeExistingSaslMechanism()
+    {
+        var invalidOptions = new OAuthBearerJwtBearerOptions();
+
+        await AssertInvalidJwtBearerDoesNotChangeSaslMechanism(
+            Kafka.CreateProducer<string, string>().WithSaslPlain("user", "pass"),
+            builder => builder.WithOAuthBearerJwtBearer(invalidOptions));
+        await AssertInvalidJwtBearerDoesNotChangeSaslMechanism(
+            Kafka.CreateConsumer<string, string>().WithSaslPlain("user", "pass"),
+            builder => builder.WithOAuthBearerJwtBearer(invalidOptions));
+        await AssertInvalidJwtBearerDoesNotChangeSaslMechanism(
+            Kafka.CreateShareConsumer<string, string>().WithSaslPlain("user", "pass"),
+            builder => builder.WithOAuthBearerJwtBearer(invalidOptions));
+        await AssertInvalidJwtBearerDoesNotChangeSaslMechanism(
+            Kafka.CreateAdminClient().WithSaslPlain("user", "pass"),
+            builder => builder.WithOAuthBearerJwtBearer(invalidOptions));
+        await AssertInvalidJwtBearerDoesNotChangeSaslMechanism(
+            Kafka.Connect().WithSaslPlain("user", "pass"),
+            builder => builder.WithOAuthBearerJwtBearer(invalidOptions));
+    }
+
     private static OAuthBearerJwtBearerOptions CreateOptions(AsymmetricAlgorithm privateKey) => new()
     {
         TokenEndpoint = "https://auth.example.test/token",
@@ -112,4 +135,22 @@ public sealed class OAuthBearerJwtBearerBuilderTests
         PrivateKey = privateKey,
         Audience = "kafka"
     };
+
+    private static async Task AssertInvalidJwtBearerDoesNotChangeSaslMechanism<TBuilder>(
+        TBuilder builder,
+        Action<TBuilder> configure)
+    {
+        await Assert.That(GetSaslMechanism(builder!)).IsEqualTo(SaslMechanism.Plain);
+        await Assert.That(() => configure(builder)).Throws<InvalidOperationException>();
+        await Assert.That(GetSaslMechanism(builder!)).IsEqualTo(SaslMechanism.Plain);
+    }
+
+    private static SaslMechanism GetSaslMechanism(object builder)
+    {
+        var field = builder.GetType()
+            .GetField("_saslMechanism", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_saslMechanism field not found");
+
+        return (SaslMechanism)field.GetValue(builder)!;
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
@@ -1,0 +1,221 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.Security.Sasl;
+
+public sealed class OAuthBearerTokenProviderTests
+{
+    [Test]
+    public async Task JwtBearerAssertion_WithRsaKey_SignsAssertionAndWritesClaims()
+    {
+        using var rsa = RSA.Create(2048);
+        var now = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
+        var config = CreateJwtBearerConfig(rsa, additionalClaims: new Dictionary<string, object?>
+        {
+            ["tenant"] = "alpha"
+        });
+
+        var assertion = OAuthBearerJwtAssertion.Create(config, now);
+
+        var parts = assertion.Split('.');
+        await Assert.That(parts.Length).IsEqualTo(3);
+
+        var header = DecodeJwtPart(parts[0]);
+        await Assert.That(header.GetProperty("alg").GetString()).IsEqualTo("RS256");
+        await Assert.That(header.GetProperty("typ").GetString()).IsEqualTo("JWT");
+        await Assert.That(header.GetProperty("kid").GetString()).IsEqualTo("key-1");
+
+        var payload = DecodeJwtPart(parts[1]);
+        await Assert.That(payload.GetProperty("iss").GetString()).IsEqualTo("client");
+        await Assert.That(payload.GetProperty("sub").GetString()).IsEqualTo("client");
+        await Assert.That(payload.GetProperty("aud").GetString()).IsEqualTo("kafka");
+        await Assert.That(payload.GetProperty("iat").GetInt64()).IsEqualTo(1_700_000_000);
+        await Assert.That(payload.GetProperty("exp").GetInt64()).IsEqualTo(1_700_000_300);
+        await Assert.That(payload.GetProperty("tenant").GetString()).IsEqualTo("alpha");
+        await Assert.That(payload.GetProperty("jti").GetString()).IsNotNull();
+
+        var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
+        var signature = Base64UrlDecode(parts[2]);
+        await Assert.That(rsa.VerifyData(signingInput, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task JwtBearerAssertion_WithEcdsaKey_SignsAssertion()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var config = CreateJwtBearerConfig(ecdsa, signingAlgorithm: OAuthBearerJwtSigningAlgorithm.Es256);
+
+        var assertion = OAuthBearerJwtAssertion.Create(config, DateTimeOffset.FromUnixTimeSeconds(1_700_000_000));
+
+        var parts = assertion.Split('.');
+        var header = DecodeJwtPart(parts[0]);
+        await Assert.That(header.GetProperty("alg").GetString()).IsEqualTo("ES256");
+
+        var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
+        var signature = Base64UrlDecode(parts[2]);
+        await Assert.That(ecdsa.VerifyData(
+                signingInput,
+                signature,
+                HashAlgorithmName.SHA256,
+                DSASignatureFormat.IeeeP1363FixedFieldConcatenation))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task GetTokenAsync_WithJwtBearer_SendsAssertionGrant()
+    {
+        using var rsa = RSA.Create(2048);
+        var handler = new CapturingTokenEndpointHandler();
+        using var provider = new OAuthBearerTokenProvider(CreateJwtBearerConfig(rsa), new HttpClient(handler));
+
+        var token = await provider.GetTokenAsync();
+
+        await Assert.That(token.TokenValue).IsEqualTo("access-token-1");
+        await Assert.That(token.PrincipalName).IsEqualTo("principal-1");
+        await Assert.That(handler.Requests.Count).IsEqualTo(1);
+
+        var form = handler.Requests[0];
+        await Assert.That(form["grant_type"]).IsEqualTo("urn:ietf:params:oauth:grant-type:jwt-bearer");
+        await Assert.That(form["client_id"]).IsEqualTo("client");
+        await Assert.That(form["scope"]).IsEqualTo("kafka:produce kafka:consume");
+        await Assert.That(form["resource"]).IsEqualTo("cluster-a");
+        await Assert.That(form["assertion"].Split('.').Length).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task GetTokenAsync_WithValidCachedToken_ReusesToken()
+    {
+        using var rsa = RSA.Create(2048);
+        var handler = new CapturingTokenEndpointHandler();
+        using var provider = new OAuthBearerTokenProvider(CreateJwtBearerConfig(rsa), new HttpClient(handler));
+
+        var first = await provider.GetTokenAsync();
+        var second = await provider.GetTokenAsync();
+
+        await Assert.That(ReferenceEquals(first, second)).IsTrue();
+        await Assert.That(handler.Requests.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task GetTokenAsync_WhenCachedTokenInsideRefreshBuffer_RefreshesToken()
+    {
+        using var rsa = RSA.Create(2048);
+        var handler = new CapturingTokenEndpointHandler { ExpiresInSeconds = 30 };
+        using var provider = new OAuthBearerTokenProvider(CreateJwtBearerConfig(rsa), new HttpClient(handler));
+
+        var first = await provider.GetTokenAsync();
+        var second = await provider.GetTokenAsync();
+
+        await Assert.That(first.TokenValue).IsEqualTo("access-token-1");
+        await Assert.That(second.TokenValue).IsEqualTo("access-token-2");
+        await Assert.That(handler.Requests.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ToOAuthBearerConfig_ClonesMutableJwtBearerOptions()
+    {
+        using var rsa = RSA.Create(2048);
+        var scopes = new List<string> { "kafka:produce" };
+        var additionalClaims = new Dictionary<string, object?> { ["tenant"] = "alpha" };
+        var additionalParameters = new Dictionary<string, string> { ["resource"] = "cluster-a" };
+        var options = new OAuthBearerJwtBearerOptions
+        {
+            TokenEndpoint = "https://auth.example.test/token",
+            ClientId = "client",
+            PrivateKey = rsa,
+            Audience = "kafka",
+            Scopes = scopes,
+            AdditionalClaims = additionalClaims,
+            AdditionalParameters = additionalParameters
+        };
+
+        var config = options.ToOAuthBearerConfig();
+
+        scopes[0] = "mutated";
+        additionalClaims["tenant"] = "mutated";
+        additionalParameters["resource"] = "mutated";
+
+        await Assert.That(config.Scope).IsEqualTo("kafka:produce");
+        await Assert.That(config.JwtBearer!.Scopes![0]).IsEqualTo("kafka:produce");
+        await Assert.That(config.JwtBearer.AdditionalClaims!["tenant"]).IsEqualTo("alpha");
+        await Assert.That(config.AdditionalParameters!["resource"]).IsEqualTo("cluster-a");
+    }
+
+    private static OAuthBearerConfig CreateJwtBearerConfig(
+        AsymmetricAlgorithm privateKey,
+        OAuthBearerJwtSigningAlgorithm? signingAlgorithm = null,
+        IReadOnlyDictionary<string, object?>? additionalClaims = null)
+    {
+        return new OAuthBearerJwtBearerOptions
+        {
+            TokenEndpoint = "https://auth.example.test/token",
+            ClientId = "client",
+            PrivateKey = privateKey,
+            Audience = "kafka",
+            KeyId = "key-1",
+            Scopes = ["kafka:produce", "kafka:consume"],
+            AdditionalClaims = additionalClaims,
+            AdditionalParameters = new Dictionary<string, string> { ["resource"] = "cluster-a" },
+            AssertionLifetime = TimeSpan.FromMinutes(5),
+            SigningAlgorithm = signingAlgorithm
+        }.ToOAuthBearerConfig();
+    }
+
+    private static JsonElement DecodeJwtPart(string value)
+    {
+        using var document = JsonDocument.Parse(Base64UrlDecode(value));
+        return document.RootElement.Clone();
+    }
+
+    private static byte[] Base64UrlDecode(string value)
+    {
+        var base64 = value.Replace('-', '+').Replace('_', '/');
+        var padding = base64.Length % 4;
+        if (padding > 0)
+            base64 += new string('=', 4 - padding);
+
+        return Convert.FromBase64String(base64);
+    }
+
+    private sealed class CapturingTokenEndpointHandler : HttpMessageHandler
+    {
+        public List<IReadOnlyDictionary<string, string>> Requests { get; } = [];
+        public int ExpiresInSeconds { get; init; } = 3600;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+            Requests.Add(ParseForm(body));
+
+            var count = Requests.Count;
+            var json = $$"""{"access_token":"access-token-{{count}}","expires_in":{{ExpiresInSeconds}},"sub":"principal-{{count}}"}""";
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+        }
+
+        private static IReadOnlyDictionary<string, string> ParseForm(string body)
+        {
+            var result = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var pair in body.Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var parts = pair.Split('=', 2);
+                var key = DecodeFormValue(parts[0]);
+                var value = parts.Length == 2 ? DecodeFormValue(parts[1]) : string.Empty;
+                result[key] = value;
+            }
+
+            return result;
+        }
+
+        private static string DecodeFormValue(string value) =>
+            Uri.UnescapeDataString(value.Replace('+', ' '));
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
@@ -66,6 +66,122 @@ public sealed class OAuthBearerTokenProviderTests
     }
 
     [Test]
+    public async Task JwtBearerAssertion_WithExplicitRsaAlgorithms_SignsAssertion()
+    {
+        var cases = new[]
+        {
+            (OAuthBearerJwtSigningAlgorithm.Rs384, "RS384", HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1),
+            (OAuthBearerJwtSigningAlgorithm.Rs512, "RS512", HashAlgorithmName.SHA512, RSASignaturePadding.Pkcs1),
+            (OAuthBearerJwtSigningAlgorithm.Ps256, "PS256", HashAlgorithmName.SHA256, RSASignaturePadding.Pss),
+            (OAuthBearerJwtSigningAlgorithm.Ps384, "PS384", HashAlgorithmName.SHA384, RSASignaturePadding.Pss),
+            (OAuthBearerJwtSigningAlgorithm.Ps512, "PS512", HashAlgorithmName.SHA512, RSASignaturePadding.Pss)
+        };
+
+        foreach (var (algorithm, headerValue, hashAlgorithm, padding) in cases)
+        {
+            using var rsa = RSA.Create(2048);
+            var config = CreateJwtBearerConfig(rsa, signingAlgorithm: algorithm);
+
+            var assertion = OAuthBearerJwtAssertion.Create(config, DateTimeOffset.FromUnixTimeSeconds(1_700_000_000));
+
+            var parts = assertion.Split('.');
+            var header = DecodeJwtPart(parts[0]);
+            await Assert.That(header.GetProperty("alg").GetString()).IsEqualTo(headerValue);
+
+            var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
+            var signature = Base64UrlDecode(parts[2]);
+            await Assert.That(rsa.VerifyData(signingInput, signature, hashAlgorithm, padding)).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task JwtBearerAssertion_WithEcdsaKey_InfersAlgorithmFromKeySize()
+    {
+        var cases = new[]
+        {
+            (ECCurve.NamedCurves.nistP256, "ES256", HashAlgorithmName.SHA256),
+            (ECCurve.NamedCurves.nistP384, "ES384", HashAlgorithmName.SHA384),
+            (ECCurve.NamedCurves.nistP521, "ES512", HashAlgorithmName.SHA512)
+        };
+
+        foreach (var (curve, headerValue, hashAlgorithm) in cases)
+        {
+            using var ecdsa = ECDsa.Create(curve);
+            var config = CreateJwtBearerConfig(ecdsa);
+
+            var assertion = OAuthBearerJwtAssertion.Create(config, DateTimeOffset.FromUnixTimeSeconds(1_700_000_000));
+
+            var parts = assertion.Split('.');
+            var header = DecodeJwtPart(parts[0]);
+            await Assert.That(header.GetProperty("alg").GetString()).IsEqualTo(headerValue);
+
+            var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
+            var signature = Base64UrlDecode(parts[2]);
+            await Assert.That(ecdsa.VerifyData(
+                    signingInput,
+                    signature,
+                    hashAlgorithm,
+                    DSASignatureFormat.IeeeP1363FixedFieldConcatenation))
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task JwtBearerAssertion_WithMismatchedAlgorithmAndKey_ThrowsInvalidOperationException()
+    {
+        using var rsa = RSA.Create(2048);
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        await Assert.That(() => OAuthBearerJwtAssertion.Create(
+                CreateJwtBearerConfig(rsa, signingAlgorithm: OAuthBearerJwtSigningAlgorithm.Es256),
+                DateTimeOffset.FromUnixTimeSeconds(1_700_000_000)))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(() => OAuthBearerJwtAssertion.Create(
+                CreateJwtBearerConfig(ecdsa, signingAlgorithm: OAuthBearerJwtSigningAlgorithm.Rs256),
+                DateTimeOffset.FromUnixTimeSeconds(1_700_000_000)))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task JwtBearerAssertion_WithReservedAdditionalClaim_ThrowsInvalidOperationException()
+    {
+        using var rsa = RSA.Create(2048);
+        var config = CreateJwtBearerConfig(rsa, additionalClaims: new Dictionary<string, object?>
+        {
+            ["iss"] = "other-issuer"
+        });
+
+        await Assert.That(() => OAuthBearerJwtAssertion.Create(
+                config,
+                DateTimeOffset.FromUnixTimeSeconds(1_700_000_000)))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task JwtBearerAssertion_WithNonPositiveLifetime_ThrowsInvalidOperationException()
+    {
+        using var rsa = RSA.Create(2048);
+        var config = new OAuthBearerConfig
+        {
+            GrantType = OAuthBearerGrantType.JwtBearer,
+            TokenEndpointUrl = "https://auth.example.test/token",
+            ClientId = "client",
+            JwtBearer = new OAuthBearerJwtBearerOptions
+            {
+                PrivateKey = rsa,
+                Audience = "kafka",
+                AssertionLifetime = TimeSpan.Zero
+            }
+        };
+
+        await Assert.That(() => OAuthBearerJwtAssertion.Create(
+                config,
+                DateTimeOffset.FromUnixTimeSeconds(1_700_000_000)))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task GetTokenAsync_WithJwtBearer_SendsAssertionGrant()
     {
         using var rsa = RSA.Create(2048);


### PR DESCRIPTION
## Summary
- add OAuth JWT-bearer grant support for SASL/OAUTHBEARER token acquisition
- add RSA/ECDSA signed assertion creation, token request exchange, cache/refresh coverage, and builder helpers
- document JWT-bearer usage and refresh stale OAuth docs syntax

## Test plan
- [x] `dotnet restore`
- [x] `dotnet build Dekaf.sln --no-restore`
- [x] `tests\Dekaf.Tests.Unit\bin\Debug\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/OAuthBearerTokenProviderTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Debug\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/OAuthBearerJwtBearerBuilderTests/*"`
- [x] `tests\Dekaf.Tests.Integration\bin\Debug\net10.0\Dekaf.Tests.Integration.exe --treenode-filter "/*/*/OAuthBearerAuthenticationTests/Producer_WithOAuthBearerJwtBearer_SuccessfullyProduces"`
- [x] `npm ci` (docs; reported existing 41 npm audit vulnerabilities)
- [x] `npm run build` (docs)

Closes #830
