### PR TITLE
perf(consumer): commit dirty offsets only

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2180,12 +2180,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _positions[partition] = position;
         if (dirty)
             _dirtyPositions[partition] = position;
+        else
+            _dirtyPositions.TryRemove(partition, out _);
     }
 
     private void ClearDirtyPositionIfCommitted(TopicPartition partition, long committedOffset)
     {
-        ((ICollection<KeyValuePair<TopicPartition, long>>)_dirtyPositions)
-            .Remove(new KeyValuePair<TopicPartition, long>(partition, committedOffset));
+        _dirtyPositions.TryRemove(new KeyValuePair<TopicPartition, long>(partition, committedOffset));
     }
 
     private void UpdateFetchPositionsFromPrefetch(PendingFetchData pending)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -583,6 +583,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     //   a single fetch using a stale position before being updated by the next operation.
     //   Adding locks would defeat the purpose of lock-free consumption.
     private readonly ConcurrentDictionary<TopicPartition, long> _positions = new();      // Consumed position (what app has seen)
+    private readonly ConcurrentDictionary<TopicPartition, long> _dirtyPositions = new(); // Positions changed since last successful commit
     private readonly ConcurrentDictionary<TopicPartition, long> _fetchPositions = new(); // Fetch position (what to fetch next)
     private readonly ConcurrentDictionary<TopicPartition, long> _committed = new();
     private readonly ConcurrentDictionary<TopicPartition, WatermarkOffsets> _watermarks = new(); // Cached watermark offsets from fetch responses
@@ -1055,7 +1056,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // If an offset is specified (>= 0), set the position
                 if (tpo.Offset >= 0)
                 {
-                    _positions[tp] = tpo.Offset;
+                    SetPosition(tp, tpo.Offset, dirty: false);
                     _fetchPositions[tp] = tpo.Offset;
                 }
                 // Otherwise, positions will be initialized lazily based on auto.offset.reset
@@ -2012,13 +2013,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 if (resetTimestamp == -1 || resetTimestamp == -2)
                                 {
                                     _fetchPositions[tp] = resetTimestamp;
-                                    _positions[tp] = resetTimestamp;
+                                    SetPosition(tp, resetTimestamp, dirty: false);
                                 }
                                 else
                                 {
                                     var resetOffset = await ResolveAutoResetOffsetAsync(tp, resetTimestamp, cancellationToken).ConfigureAwait(false);
                                     _fetchPositions[tp] = resetOffset;
-                                    _positions[tp] = resetOffset;
+                                    SetPosition(tp, resetOffset, dirty: false);
                                 }
 
                                 LogOffsetOutOfRangeReset(topic, partitionResponse.PartitionIndex, GetAutoOffsetResetName());
@@ -2124,7 +2125,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (!TryGetConsumedPosition(pending, out var tp, out var nextOffset))
             return;
 
-        _positions[tp] = nextOffset;
+        SetPosition(tp, nextOffset, dirty: true);
 
         if (!_prefetchEnabled)
         {
@@ -2139,7 +2140,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         var pending = _pendingFetches.Peek();
         if (TryGetConsumedPosition(pending, out var tp, out var nextOffset))
-            _positions[tp] = nextOffset;
+            SetPosition(tp, nextOffset, dirty: true);
     }
 
     private bool TryGetActiveConsumedPosition(TopicPartition partition, out long position)
@@ -2172,6 +2173,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         partition = pending.TopicPartition;
         nextOffset = pending.LastYieldedOffset + 1;
         return true;
+    }
+
+    private void SetPosition(TopicPartition partition, long position, bool dirty)
+    {
+        _positions[partition] = position;
+        if (dirty)
+            _dirtyPositions[partition] = position;
+    }
+
+    private void ClearDirtyPositionIfCommitted(TopicPartition partition, long committedOffset)
+    {
+        ((ICollection<KeyValuePair<TopicPartition, long>>)_dirtyPositions)
+            .Remove(new KeyValuePair<TopicPartition, long>(partition, committedOffset));
     }
 
     private void UpdateFetchPositionsFromPrefetch(PendingFetchData pending)
@@ -2328,10 +2342,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int offsetCount;
 
         {
-            // Commit all consumed positions
+            // Commit only positions that changed since the last successful commit.
             // Snapshot the concurrent dictionary to avoid race conditions during enumeration
-            var positionsSnapshot = _positions.ToArray();
-            offsetCount = positionsSnapshot.Length;
+            var dirtyPositionsSnapshot = _dirtyPositions.ToArray();
+            offsetCount = dirtyPositionsSnapshot.Length;
             if (offsetCount == 0)
                 return;
 
@@ -2342,7 +2356,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             try
             {
                 int index = 0;
-                foreach (var kvp in positionsSnapshot)
+                foreach (var kvp in dirtyPositionsSnapshot)
                 {
                     offsetsArray[index++] = new TopicPartitionOffset(kvp.Key.Topic, kvp.Key.Partition, kvp.Value);
                 }
@@ -2355,7 +2369,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // Update committed offsets tracking
                 foreach (var offset in offsets)
                 {
-                    _committed[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
+                    var partition = new TopicPartition(offset.Topic, offset.Partition);
+                    _committed[partition] = offset.Offset;
+                    ClearDirtyPositionIfCommitted(partition, offset.Offset);
                 }
 
                 // Invoke OnCommit interceptors - wrap array as ArraySegment to avoid Span→Array copy
@@ -2380,7 +2396,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         foreach (var offset in offsetsList)
         {
-            _committed[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
+            var partition = new TopicPartition(offset.Topic, offset.Partition);
+            _committed[partition] = offset.Offset;
+            ClearDirtyPositionIfCommitted(partition, offset.Offset);
         }
 
         // Invoke OnCommit interceptors
@@ -2410,7 +2428,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (_options.OffsetCommitMode == OffsetCommitMode.Manual
             && TryGetActiveConsumedPosition(partition, out var activePosition))
         {
-            _positions[partition] = activePosition;
+            SetPosition(partition, activePosition, dirty: true);
             return activePosition;
         }
 
@@ -2434,7 +2452,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         LogSeek(offset.Topic, offset.Partition, offset.Offset);
         var tp = new TopicPartition(offset.Topic, offset.Partition);
         // Update positions (thread-safe with ConcurrentDictionary)
-        _positions[tp] = offset.Offset;
+        SetPosition(tp, offset.Offset, dirty: true);
         _fetchPositions[tp] = offset.Offset;
 
         // Reset EOF state for this partition so it can fire again
@@ -2447,7 +2465,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Update positions (thread-safe with ConcurrentDictionary)
         foreach (var partition in partitions)
         {
-            _positions[partition] = 0;
+            SetPosition(partition, 0, dirty: true);
             _fetchPositions[partition] = 0;
         }
 
@@ -2464,7 +2482,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Update positions (thread-safe with ConcurrentDictionary)
         foreach (var partition in partitions)
         {
-            _positions[partition] = -1; // Special value meaning end
+            SetPosition(partition, -1, dirty: true); // Special value meaning end
             _fetchPositions[partition] = -1; // Special value meaning end
         }
 
@@ -2486,6 +2504,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         foreach (var partition in partitions)
         {
             _positions.TryRemove(partition, out _);
+            _dirtyPositions.TryRemove(partition, out _);
             _fetchPositions.TryRemove(partition, out _);
             _committed.TryRemove(partition, out _);
             _highWatermarks.TryRemove(partition, out _);
@@ -2966,7 +2985,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         foreach (var partition in partitions)
         {
             var offset = await GetResetOffsetAsync(partition, cancellationToken).ConfigureAwait(false);
-            _positions[partition] = offset;
+            SetPosition(partition, offset, dirty: false);
             _fetchPositions[partition] = offset;
         }
     }
@@ -2981,7 +3000,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (committedOffsets.TryGetValue(partition, out var committedOffset) && committedOffset >= 0)
             {
                 // Use committed offset
-                _positions[partition] = committedOffset;
+                SetPosition(partition, committedOffset, dirty: false);
                 _fetchPositions[partition] = committedOffset;
                 _committed[partition] = committedOffset;
             }
@@ -2989,7 +3008,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 // No committed offset, use auto offset reset
                 var offset = await GetResetOffsetAsync(partition, cancellationToken).ConfigureAwait(false);
-                _positions[partition] = offset;
+                SetPosition(partition, offset, dirty: false);
                 _fetchPositions[partition] = offset;
             }
         }
@@ -3036,7 +3055,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // -1 = latest, -2 = earliest
                 var resolvedOffset = await ResolveOffsetAsync(partition, fetchPosition, cancellationToken).ConfigureAwait(false);
                 _fetchPositions[partition] = resolvedOffset;
-                _positions[partition] = resolvedOffset;
+                SetPosition(partition, resolvedOffset, dirty: false);
             }
         }
     }
@@ -4152,7 +4171,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         // Step 5: Commit pending offsets (if auto-commit enabled and we have a coordinator)
-        if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null && !_positions.IsEmpty)
+        if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null && !_dirtyPositions.IsEmpty)
         {
             for (var attempt = 0; attempt < 3; attempt++)
             {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2189,6 +2189,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _dirtyPositions.TryRemove(new KeyValuePair<TopicPartition, long>(partition, committedOffset));
     }
 
+    private void MarkOffsetCommitted(TopicPartition partition, long committedOffset)
+    {
+        _committed[partition] = committedOffset;
+        ClearDirtyPositionIfCommitted(partition, committedOffset);
+    }
+
     private void UpdateFetchPositionsFromPrefetch(PendingFetchData pending)
     {
         // Calculate the last offset in the prefetched data
@@ -2371,8 +2377,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 foreach (var offset in offsets)
                 {
                     var partition = new TopicPartition(offset.Topic, offset.Partition);
-                    _committed[partition] = offset.Offset;
-                    ClearDirtyPositionIfCommitted(partition, offset.Offset);
+                    MarkOffsetCommitted(partition, offset.Offset);
                 }
 
                 // Invoke OnCommit interceptors - wrap array as ArraySegment to avoid Span→Array copy
@@ -2398,8 +2403,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         foreach (var offset in offsetsList)
         {
             var partition = new TopicPartition(offset.Topic, offset.Partition);
-            _committed[partition] = offset.Offset;
-            ClearDirtyPositionIfCommitted(partition, offset.Offset);
+            MarkOffsetCommitted(partition, offset.Offset);
         }
 
         // Invoke OnCommit interceptors

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -1,0 +1,181 @@
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerDirtyCommitTests
+{
+    [Test]
+    public async Task CommitAsync_AfterSuccessfulCommit_CommitsOnlyOffsetsChangedSinceLastCommit()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(requests, ErrorCode.None);
+
+        consumer.Seek(new TopicPartitionOffset("topic-a", 0, 10));
+        consumer.Seek(new TopicPartitionOffset("topic-a", 1, 20));
+
+        await consumer.CommitAsync(CancellationToken.None);
+
+        consumer.Seek(new TopicPartitionOffset("topic-a", 1, 21));
+
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(requests.Count).IsEqualTo(2);
+        await Assert.That(GetCommittedOffsets(requests[0])).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 0, 10),
+            new TopicPartitionOffset("topic-a", 1, 20)
+        ]);
+        await Assert.That(GetCommittedOffsets(requests[1])).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 1, 21)
+        ]);
+    }
+
+    [Test]
+    public async Task CommitAsync_WhenNoOffsetsChangedAfterSuccessfulCommit_DoesNotSendCommitRequest()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(requests, ErrorCode.None);
+
+        consumer.Seek(new TopicPartitionOffset("topic-a", 0, 10));
+
+        await consumer.CommitAsync(CancellationToken.None);
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(requests.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CommitAsync_WhenCommitFails_PreservesDirtyOffsetsForRetry()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        var responseErrors = new Queue<ErrorCode>([ErrorCode.InvalidCommitOffsetSize, ErrorCode.None]);
+        await using var consumer = CreateConsumer(requests, responseErrors);
+
+        consumer.Seek(new TopicPartitionOffset("topic-a", 0, 10));
+
+        await Assert.That(async () => await consumer.CommitAsync(CancellationToken.None))
+            .Throws<GroupException>();
+
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(requests.Count).IsEqualTo(2);
+        await Assert.That(GetCommittedOffsets(requests[0])).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 0, 10)
+        ]);
+        await Assert.That(GetCommittedOffsets(requests[1])).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 0, 10)
+        ]);
+    }
+
+    private static KafkaConsumer<string, string> CreateConsumer(
+        List<OffsetCommitRequest> requests,
+        ErrorCode responseError)
+        => CreateConsumer(requests, new Queue<ErrorCode>([responseError]));
+
+    private static KafkaConsumer<string, string> CreateConsumer(
+        List<OffsetCommitRequest> requests,
+        Queue<ErrorCode> responseErrors)
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+
+        connectionPool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var request = call.Arg<OffsetCommitRequest>();
+                requests.Add(CloneRequest(request));
+
+                var error = responseErrors.Count == 0 ? ErrorCode.None : responseErrors.Dequeue();
+                return ValueTask.FromResult(CreateResponse(request, error));
+            });
+
+        var metadataManager = new MetadataManager(connectionPool, ["localhost:9092"]);
+        metadataManager.SetApiVersion(
+            ApiKey.OffsetCommit,
+            OffsetCommitRequest.LowestSupportedVersion,
+            OffsetCommitRequest.HighestSupportedVersion);
+
+        return new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                GroupId = "group-a",
+                OffsetCommitMode = OffsetCommitMode.Manual
+            },
+            Serializers.String,
+            Serializers.String,
+            connectionPool,
+            metadataManager);
+    }
+
+    private static OffsetCommitRequest CloneRequest(OffsetCommitRequest request)
+    {
+        return new OffsetCommitRequest
+        {
+            GroupId = request.GroupId,
+            GenerationIdOrMemberEpoch = request.GenerationIdOrMemberEpoch,
+            MemberId = request.MemberId,
+            GroupInstanceId = request.GroupInstanceId,
+            Topics = request.Topics
+                .Select(static topic => new OffsetCommitRequestTopic
+                {
+                    Name = topic.Name,
+                    Partitions = topic.Partitions
+                        .Select(static partition => new OffsetCommitRequestPartition
+                        {
+                            PartitionIndex = partition.PartitionIndex,
+                            CommittedOffset = partition.CommittedOffset
+                        })
+                        .ToArray()
+                })
+                .ToArray()
+        };
+    }
+
+    private static OffsetCommitResponse CreateResponse(OffsetCommitRequest request, ErrorCode error)
+    {
+        return new OffsetCommitResponse
+        {
+            Topics = request.Topics
+                .Select(topic => new OffsetCommitResponseTopic
+                {
+                    Name = topic.Name,
+                    Partitions = topic.Partitions
+                        .Select(partition => new OffsetCommitResponsePartition
+                        {
+                            PartitionIndex = partition.PartitionIndex,
+                            ErrorCode = error
+                        })
+                        .ToArray()
+                })
+                .ToArray()
+        };
+    }
+
+    private static TopicPartitionOffset[] GetCommittedOffsets(OffsetCommitRequest request)
+    {
+        return request.Topics
+            .SelectMany(static topic => topic.Partitions.Select(partition =>
+                new TopicPartitionOffset(topic.Name, partition.PartitionIndex, partition.CommittedOffset)))
+            .OrderBy(static offset => offset.Topic, StringComparer.Ordinal)
+            .ThenBy(static offset => offset.Partition)
+            .ThenBy(static offset => offset.Offset)
+            .ToArray();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Metadata;
@@ -77,6 +78,23 @@ public sealed class ConsumerDirtyCommitTests
         ]);
     }
 
+    [Test]
+    public async Task CommitAsync_AfterNonDirtyPositionReset_DoesNotCommitStaleDirtyOffset()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(requests, ErrorCode.None);
+        var partition = new TopicPartition("topic-a", 0);
+
+        consumer.Seek(new TopicPartitionOffset("topic-a", 0, 10));
+        SetPosition(consumer, partition, 2, dirty: false);
+
+        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(2);
+
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(requests).IsEmpty();
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer(
         List<OffsetCommitRequest> requests,
         ErrorCode responseError)
@@ -122,6 +140,19 @@ public sealed class ConsumerDirtyCommitTests
             Serializers.String,
             connectionPool,
             metadataManager);
+    }
+
+    private static void SetPosition(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition partition,
+        long position,
+        bool dirty)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "SetPosition",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        method.Invoke(consumer, [partition, position, dirty]);
     }
 
     private static OffsetCommitRequest CloneRequest(OffsetCommitRequest request)


### PR DESCRIPTION
Closes #1089.

Summary:
- Track dirty consumer positions separately from all known positions.
- Make parameterless CommitAsync send only offsets changed since the last successful commit.
- Clear dirty entries after successful parameterless or explicit commits, while failed commits keep dirty state for retry.

Validation:
- dotnet restore Dekaf.sln
- dotnet build Dekaf.sln -c Release --no-restore
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/ConsumerDirtyCommitTests/*" --disable-logo --no-progress --minimum-expected-tests 3
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/ConsumeAsyncRecoveryTests/CommitAsync_AfterPartialBatchConsumed_FlushesCurrentPosition" --disable-logo --no-progress --minimum-expected-tests 1
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/OffsetCommitModeTests/*" --disable-logo --no-progress --minimum-expected-tests 8
- dotnet format --verify-no-changes --verbosity minimal --include src\Dekaf\Consumer\KafkaConsumer.cs tests\Dekaf.Tests.Unit\Consumer\ConsumerDirtyCommitTests.cs

Note: a full unit-suite run was attempted but exceeded the local 3-minute command timeout before a summary; focused consumer coverage above passed.

Tradeoff note:
- Parameterless `CommitAsync()` now only sends dirty offsets. Long-idle partitions are not re-sent on every auto-commit tick; Kafka 2.1+ ties offset retention to group liveness, but very old brokers or unusually short `offsets.retention.minutes` may fall back to `auto.offset.reset` if a stored offset expires.
