### PR TITLE
perf(consumer): skip unchanged assignment checks

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -25,6 +25,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private volatile int _coordinatorId = -1;
     private volatile string? _memberId;
     private volatile int _generationId = -1;
+    private int _assignmentVersion;
     // Volatile ensures cross-thread visibility of the reference. Thread-safety relies on
     // all writes replacing the reference entirely (never in-place mutation) — verified at
     // every assignment site: ProcessConsumerGroupAssignment() and DisposeAsync().
@@ -74,6 +75,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     public int GenerationId => _generationId;
     public CoordinatorState State => _state;
     public IReadOnlySet<TopicPartition> Assignment => _assignedPartitions;
+    internal int AssignmentVersion => Volatile.Read(ref _assignmentVersion);
 
     private static void RemoveEmptyTopicGroups<TItem>(Dictionary<string, List<TItem>> topicGroups)
     {
@@ -560,10 +562,13 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// </summary>
     private void ResetMemberState()
     {
+        var hadAssignment = _assignedPartitions.Count != 0;
         _memberId = null;
         _generationId = -1;
         _assignedPartitions = [];
         _state = CoordinatorState.Unjoined;
+        if (hadAssignment)
+            Interlocked.Increment(ref _assignmentVersion);
     }
 
     /// <summary>
@@ -791,11 +796,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             }
         }
 
-        _assignedPartitions = newAssignment;
-
         var changed = revoked is { Count: > 0 } || assigned is { Count: > 0 };
         if (changed)
         {
+            _assignedPartitions = newAssignment;
+            Interlocked.Increment(ref _assignmentVersion);
             LogConsumerProtocolAssignmentUpdate(assigned?.Count ?? 0, revoked?.Count ?? 0);
         }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3298,6 +3298,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// <summary>
     /// Publishes an immutable snapshot of <see cref="_assignment"/> for lock-free reads.
     /// Must be called after every mutation to <see cref="_assignment"/>.
+    /// Also marks manual assignment state dirty and invalidates the coordinator assignment
+    /// fast path, so all assignment mutation paths must use this method.
     /// </summary>
     private void PublishAssignmentSnapshot()
     {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -678,6 +678,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private List<TopicPartition>? _cachedPartitionsList;
     private readonly object _leaderRefreshTasksLock = new();
     private readonly ConcurrentDictionary<string, Task> _pendingLeaderRefreshTasks = new();
+    private int _assignmentEnsureVersion;
+    private int _lastManualAssignmentEnsureVersion = -1;
+    private int _lastCoordinatorAssignmentVersion = -1;
 
     public KafkaConsumer(
         ConsumerOptions options,
@@ -2863,6 +2866,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             await RefreshFilteredTopicsAsync(topicFilter, cancellationToken).ConfigureAwait(false);
         }
 
+        var subscriptionSnapshot = _subscriptionSnapshot;
+        var coordinator = _coordinator;
+        if (subscriptionSnapshot.Count != 0 && coordinator is not null)
+        {
+            await coordinator.EnsureActiveGroupAsync(subscriptionSnapshot, cancellationToken).ConfigureAwait(false);
+
+            var coordinatorAssignmentVersion = coordinator.AssignmentVersion;
+            if (Volatile.Read(ref _lastCoordinatorAssignmentVersion) == coordinatorAssignmentVersion)
+                return;
+        }
+        else if (IsManualAssignmentEnsureCurrent())
+        {
+            return;
+        }
+
         // Serialize the write path: both ConsumeAsync and PrefetchLoopAsync call this method
         // concurrently. Without synchronization, concurrent access to non-thread-safe
         // _assignment HashSet causes NullReferenceException during enumeration.
@@ -2870,17 +2888,22 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         await SemaphoreHelper.AcquireOrThrowDisposedAsync(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>), cancellationToken).ConfigureAwait(false);
         try
         {
-            if (!_subscription.IsEmpty && _coordinator is not null)
+            coordinator = _coordinator;
+            if (!_subscription.IsEmpty && coordinator is not null)
             {
-                await _coordinator.EnsureActiveGroupAsync(_subscriptionSnapshot, cancellationToken).ConfigureAwait(false);
+                var coordinatorAssignmentVersion = coordinator.AssignmentVersion;
+                var coordinatorAssignment = coordinator.Assignment;
 
                 // Fast path: skip all work if assignment hasn't changed (common case after stable join)
-                if (_assignment.SetEquals(_coordinator.Assignment))
+                if (_assignment.SetEquals(coordinatorAssignment))
+                {
+                    Volatile.Write(ref _lastCoordinatorAssignmentVersion, coordinatorAssignmentVersion);
                     return;
+                }
 
                 // Check for new partitions that need initialization
                 List<TopicPartition>? newPartitions = null;
-                foreach (var partition in _coordinator.Assignment)
+                foreach (var partition in coordinatorAssignment)
                 {
                     if (!_assignment.Contains(partition))
                     {
@@ -2893,7 +2916,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 List<TopicPartition>? removedPartitions = null;
                 foreach (var partition in _assignment)
                 {
-                    if (!_coordinator.Assignment.Contains(partition))
+                    if (!coordinatorAssignment.Contains(partition))
                     {
                         removedPartitions ??= new List<TopicPartition>();
                         removedPartitions.Add(partition);
@@ -2907,7 +2930,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                 // Update assignment from coordinator
                 _assignment.Clear();
-                foreach (var partition in _coordinator.Assignment)
+                foreach (var partition in coordinatorAssignment)
                 {
                     _assignment.Add(partition);
                 }
@@ -2930,27 +2953,34 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 {
                     await InitializePositionsAsync(newPartitions, cancellationToken).ConfigureAwait(false);
                 }
-            }
-            else if (_assignment.Count > 0)
-            {
-                // Ratchet pool sizes based on actual partition count (manual assignment)
-                RatchetConsumerPoolSizes(_assignment.Count);
 
-                // Manual assignment - initialize positions for partitions that don't have positions yet
-                List<TopicPartition>? uninitializedPartitions = null;
-                foreach (var p in _assignment)
+                Volatile.Write(ref _lastCoordinatorAssignmentVersion, coordinatorAssignmentVersion);
+            }
+            else
+            {
+                if (_assignment.Count > 0)
                 {
-                    if (!_fetchPositions.ContainsKey(p))
+                    // Ratchet pool sizes based on actual partition count (manual assignment)
+                    RatchetConsumerPoolSizes(_assignment.Count);
+
+                    // Manual assignment - initialize positions for partitions that don't have positions yet
+                    List<TopicPartition>? uninitializedPartitions = null;
+                    foreach (var p in _assignment)
                     {
-                        uninitializedPartitions ??= new List<TopicPartition>();
-                        uninitializedPartitions.Add(p);
+                        if (!_fetchPositions.ContainsKey(p))
+                        {
+                            uninitializedPartitions ??= new List<TopicPartition>();
+                            uninitializedPartitions.Add(p);
+                        }
+                    }
+
+                    if (uninitializedPartitions is not null)
+                    {
+                        await InitializeManualAssignmentPositionsAsync(uninitializedPartitions, cancellationToken).ConfigureAwait(false);
                     }
                 }
 
-                if (uninitializedPartitions is not null)
-                {
-                    await InitializeManualAssignmentPositionsAsync(uninitializedPartitions, cancellationToken).ConfigureAwait(false);
-                }
+                Volatile.Write(ref _lastManualAssignmentEnsureVersion, Volatile.Read(ref _assignmentEnsureVersion));
             }
         }
         finally
@@ -2959,6 +2989,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
+    private bool IsManualAssignmentEnsureCurrent()
+    {
+        if (_topicFilter is not null || !_subscription.IsEmpty)
+            return false;
+
+        var assignmentEnsureVersion = Volatile.Read(ref _assignmentEnsureVersion);
+        return Volatile.Read(ref _lastManualAssignmentEnsureVersion) == assignmentEnsureVersion;
+    }
 
     private async ValueTask InitializeManualAssignmentPositionsAsync(List<TopicPartition> partitions, CancellationToken cancellationToken)
     {
@@ -3264,6 +3302,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private void PublishAssignmentSnapshot()
     {
         _assignmentSnapshot = new HashSet<TopicPartition>(_assignment);
+        Interlocked.Increment(ref _assignmentEnsureVersion);
+        Volatile.Write(ref _lastCoordinatorAssignmentVersion, -1);
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1,11 +1,18 @@
 using System.Reflection;
 using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
 using Dekaf.Serialization;
+using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
 public sealed class ConsumerAssignmentFastPathTests
 {
+    private static readonly Guid TestTopicId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
     [Test]
     public async Task EnsureAssignmentAsync_UnchangedManualAssignment_SkipsAssignmentLock()
     {
@@ -51,6 +58,36 @@ public sealed class ConsumerAssignmentFastPathTests
         }
     }
 
+    [Test]
+    public async Task EnsureAssignmentAsync_UnchangedCoordinatorAssignment_SkipsAssignmentLock()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupConsumerGroupHeartbeat(connection, CreateAssignment(0));
+        SetupOffsetFetch(connection);
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var assignmentLock = GetAssignmentLock(consumer);
+        await assignmentLock.WaitAsync(CancellationToken.None);
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+            await consumer.EnsureAssignmentAsync(cts.Token);
+        }
+        finally
+        {
+            assignmentLock.Release();
+        }
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer()
     {
         return new KafkaConsumer<string, string>(
@@ -62,6 +99,153 @@ public sealed class ConsumerAssignmentFastPathTests
             },
             Serializers.String,
             Serializers.String);
+    }
+
+    private static KafkaConsumer<string, string> CreateGroupConsumer(
+        IConnectionPool connectionPool,
+        MetadataManager metadataManager)
+    {
+        return new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                GroupId = "group-a",
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1
+            },
+            Serializers.String,
+            Serializers.String,
+            connectionPool,
+            metadataManager);
+    }
+
+    private static MetadataManager CreateMetadataManager(IConnectionPool connectionPool)
+    {
+        var metadataManager = new MetadataManager(connectionPool, ["localhost:9092"]);
+        metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 0);
+        metadataManager.SetApiVersion(ApiKey.FindCoordinator, 4, 5);
+        metadataManager.SetApiVersion(ApiKey.OffsetFetch, OffsetFetchRequest.LowestSupportedVersion, OffsetFetchRequest.HighestSupportedVersion);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    Name = "test-topic",
+                    TopicId = TestTopicId,
+                    ErrorCode = ErrorCode.None,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            PartitionIndex = 0,
+                            LeaderId = 0,
+                            ErrorCode = ErrorCode.None,
+                            ReplicaNodes = [0],
+                            IsrNodes = [0]
+                        }
+                    ]
+                }
+            ]
+        });
+
+        return metadataManager;
+    }
+
+    private static void SetupConnectionPool(IConnectionPool connectionPool, IKafkaConnection connection)
+    {
+        connectionPool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+        connectionPool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+    }
+
+    private static void SetupFindCoordinator(IKafkaConnection connection)
+    {
+        connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                Coordinators =
+                [
+                    new Coordinator
+                    {
+                        Key = "group-a",
+                        NodeId = 0,
+                        Host = "localhost",
+                        Port = 9092,
+                        ErrorCode = ErrorCode.None
+                    }
+                ]
+            }));
+    }
+
+    private static void SetupConsumerGroupHeartbeat(
+        IKafkaConnection connection,
+        ConsumerGroupHeartbeatAssignment assignment)
+    {
+        connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+            {
+                ErrorCode = ErrorCode.None,
+                MemberId = "member-1",
+                MemberEpoch = 1,
+                HeartbeatIntervalMs = 60000,
+                Assignment = assignment
+            }));
+    }
+
+    private static void SetupOffsetFetch(IKafkaConnection connection)
+    {
+        connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
+                Arg.Any<OffsetFetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new OffsetFetchResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Topics =
+                [
+                    new OffsetFetchResponseTopic
+                    {
+                        Name = "test-topic",
+                        Partitions =
+                        [
+                            new OffsetFetchResponsePartition
+                            {
+                                PartitionIndex = 0,
+                                CommittedOffset = 10,
+                                ErrorCode = ErrorCode.None
+                            }
+                        ]
+                    }
+                ]
+            }));
+    }
+
+    private static ConsumerGroupHeartbeatAssignment CreateAssignment(params int[] partitions)
+    {
+        return new ConsumerGroupHeartbeatAssignment
+        {
+            AssignedTopicPartitions =
+            [
+                new ConsumerGroupHeartbeatTopicPartitions
+                {
+                    TopicId = TestTopicId,
+                    Partitions = partitions
+                }
+            ],
+            PendingTopicPartitions = []
+        };
     }
 
     private static SemaphoreSlim GetAssignmentLock(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -88,6 +88,44 @@ public sealed class ConsumerAssignmentFastPathTests
         }
     }
 
+    [Test]
+    public async Task EnsureAssignmentAsync_ChangedCoordinatorAssignment_RequiresAssignmentLock()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupChangingConsumerGroupHeartbeat(connection);
+        SetupOffsetFetch(connection);
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        GetCoordinator(consumer).RequestRejoin();
+
+        var assignmentLock = GetAssignmentLock(consumer);
+        await assignmentLock.WaitAsync(CancellationToken.None);
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+            await Assert.That(async () => await consumer.EnsureAssignmentAsync(cts.Token))
+                .Throws<OperationCanceledException>();
+        }
+        finally
+        {
+            assignmentLock.Release();
+        }
+
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        await Assert.That(consumer.Assignment).Contains(new TopicPartition("test-topic", 0));
+        await Assert.That(consumer.Assignment).Contains(new TopicPartition("test-topic", 1));
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer()
     {
         return new KafkaConsumer<string, string>(
@@ -143,6 +181,14 @@ public sealed class ConsumerAssignmentFastPathTests
                         new PartitionMetadata
                         {
                             PartitionIndex = 0,
+                            LeaderId = 0,
+                            ErrorCode = ErrorCode.None,
+                            ReplicaNodes = [0],
+                            IsrNodes = [0]
+                        },
+                        new PartitionMetadata
+                        {
+                            PartitionIndex = 1,
                             LeaderId = 0,
                             ErrorCode = ErrorCode.None,
                             ReplicaNodes = [0],
@@ -204,6 +250,27 @@ public sealed class ConsumerAssignmentFastPathTests
             }));
     }
 
+    private static void SetupChangingConsumerGroupHeartbeat(IKafkaConnection connection)
+    {
+        var callCount = 0;
+        connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = count,
+                    HeartbeatIntervalMs = 60000,
+                    Assignment = count == 1 ? CreateAssignment(0) : CreateAssignment(0, 1)
+                });
+            });
+    }
+
     private static void SetupOffsetFetch(IKafkaConnection connection)
     {
         connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
@@ -224,6 +291,12 @@ public sealed class ConsumerAssignmentFastPathTests
                             {
                                 PartitionIndex = 0,
                                 CommittedOffset = 10,
+                                ErrorCode = ErrorCode.None
+                            },
+                            new OffsetFetchResponsePartition
+                            {
+                                PartitionIndex = 1,
+                                CommittedOffset = 20,
                                 ErrorCode = ErrorCode.None
                             }
                         ]
@@ -256,5 +329,15 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("_assignmentLock field not found.");
 
         return (SemaphoreSlim)field.GetValue(consumer)!;
+    }
+
+    private static ConsumerCoordinator GetCoordinator(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_coordinator",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_coordinator field not found.");
+
+        return (ConsumerCoordinator)field.GetValue(consumer)!;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1,0 +1,76 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerAssignmentFastPathTests
+{
+    [Test]
+    public async Task EnsureAssignmentAsync_UnchangedManualAssignment_SkipsAssignmentLock()
+    {
+        await using var consumer = CreateConsumer();
+        consumer.IncrementalAssign([new TopicPartitionOffset("topic-a", 0, 10)]);
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var assignmentLock = GetAssignmentLock(consumer);
+        await assignmentLock.WaitAsync(CancellationToken.None);
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+            await consumer.EnsureAssignmentAsync(cts.Token);
+        }
+        finally
+        {
+            assignmentLock.Release();
+        }
+    }
+
+    [Test]
+    public async Task EnsureAssignmentAsync_ChangedManualAssignment_RequiresAssignmentLock()
+    {
+        await using var consumer = CreateConsumer();
+        consumer.IncrementalAssign([new TopicPartitionOffset("topic-a", 0, 10)]);
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        consumer.IncrementalAssign([new TopicPartitionOffset("topic-a", 1, 20)]);
+
+        var assignmentLock = GetAssignmentLock(consumer);
+        await assignmentLock.WaitAsync(CancellationToken.None);
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+            await Assert.That(async () => await consumer.EnsureAssignmentAsync(cts.Token))
+                .Throws<OperationCanceledException>();
+        }
+        finally
+        {
+            assignmentLock.Release();
+        }
+    }
+
+    private static KafkaConsumer<string, string> CreateConsumer()
+    {
+        return new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1
+            },
+            Serializers.String,
+            Serializers.String);
+    }
+
+    private static SemaphoreSlim GetAssignmentLock(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_assignmentLock",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_assignmentLock field not found.");
+
+        return (SemaphoreSlim)field.GetValue(consumer)!;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -252,6 +252,106 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_AssignmentVersion_ChangesOnlyWhenAssignmentChanges()
+    {
+        SetupFindCoordinator();
+
+        var callCount = 0;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                var assignment = count switch
+                {
+                    1 => CreateAssignment(TestTopicId, 0),
+                    2 => CreateAssignment(TestTopicId, 0),
+                    _ => CreateAssignment(TestTopicId, 0, 1)
+                };
+
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = count,
+                    HeartbeatIntervalMs = 60000,
+                    Assignment = assignment
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 60000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var topics = new HashSet<string> { "test-topic" };
+
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        var versionAfterInitialAssignment = coordinator.AssignmentVersion;
+        await Assert.That(versionAfterInitialAssignment).IsEqualTo(1);
+
+        coordinator.RequestRejoin();
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        await Assert.That(coordinator.AssignmentVersion).IsEqualTo(versionAfterInitialAssignment);
+
+        coordinator.RequestRejoin();
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        await Assert.That(coordinator.AssignmentVersion).IsEqualTo(versionAfterInitialAssignment + 1);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_AssignmentVersion_IncrementsWhenResetClearsAssignment()
+    {
+        SetupFindCoordinator();
+
+        var callCount = 0;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                if (count == 2)
+                {
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.UnknownMemberId,
+                        ErrorMessage = "Unknown member",
+                        HeartbeatIntervalMs = 60000
+                    });
+                }
+
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = $"member-{count}",
+                    MemberEpoch = count,
+                    HeartbeatIntervalMs = 60000,
+                    Assignment = count == 1 ? CreateAssignment(TestTopicId, 0) : null
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 60000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var topics = new HashSet<string> { "test-topic" };
+
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        await Assert.That(coordinator.AssignmentVersion).IsEqualTo(1);
+
+        coordinator.RequestRejoin();
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+
+        await Assert.That(coordinator.AssignmentVersion).IsEqualTo(2);
+        await Assert.That(coordinator.Assignment).IsEmpty();
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+    }
+
+    [Test]
     public async Task ConsumerProtocol_WhenAlreadyStable_ReturnsImmediately()
     {
         SetupSuccessfulConsumerProtocolJoin();


### PR DESCRIPTION
Closes #1090.

Summary:
- Add coordinator assignment version tracking for group assignment changes.
- Cache the last ensured manual/coordinator assignment versions in KafkaConsumer.
- Fast-return from EnsureAssignmentAsync when assignment state is unchanged, avoiding assignment-lock/semaphore and partition scans on repeated poll paths.
- Keep changed manual assignments on the existing locked path and preserve pool ratcheting/position initialization.

Validation:
- dotnet restore Dekaf.sln
- dotnet build Dekaf.sln -c Release --no-restore
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/ConsumerAssignmentFastPathTests/*" --disable-logo --no-progress --minimum-expected-tests 4
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/IncrementalAssignmentTests/*" --disable-logo --no-progress --minimum-expected-tests 18
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --framework net10.0 --no-build -- --treenode-filter "/*/*/ConsumerCoordinatorKip848Tests/*" --disable-logo --no-progress --minimum-expected-tests 28
- dotnet format Dekaf.sln whitespace --include src\Dekaf\Consumer\KafkaConsumer.cs tests\Dekaf.Tests.Unit\Consumer\ConsumerAssignmentFastPathTests.cs --verify-no-changes --no-restore
