### PR TITLE
perf(consumer): avoid blocking idle polls

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2223,11 +2223,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private async ValueTask<bool> WaitForPrefetchDataAsync(CancellationToken cancellationToken)
     {
-        if (_prefetchBuffer.WaitToRead(0, cancellationToken))
-            return true;
+        cancellationToken.ThrowIfCancellationRequested();
 
-        if (_prefetchBuffer.IsCompleted)
-            return false;
+        if (_prefetchBuffer.HasDataAvailable())
+            return true;
 
         return await _prefetchBuffer.WaitToReadAsync(_options.FetchMaxWaitMs, cancellationToken)
             .ConfigureAwait(false);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1150,14 +1150,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     }
                     else
                     {
-                        // Wait for prefetch with timeout using synchronous WaitToRead —
-                        // the consumer thread has nothing else to do while waiting.
+                        // Use a synchronous zero-timeout recheck before async wait so the
+                        // idle path does not hold a thread-pool thread indefinitely.
                         cancellationToken.ThrowIfCancellationRequested();
 
                         try
                         {
                             // WaitToRead throws stored completion errors directly.
-                            if (_prefetchBuffer.WaitToRead(_options.FetchMaxWaitMs, cancellationToken))
+                            if (await WaitForPrefetchDataAsync(cancellationToken).ConfigureAwait(false))
                             {
                                 if (_prefetchBuffer.TryRead(out var fetched))
                                 {
@@ -1421,12 +1421,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     }
                     else
                     {
-                        // Wait for prefetch with timeout using synchronous WaitToRead
+                        // Use a synchronous zero-timeout recheck before async wait so the
+                        // idle path does not hold a thread-pool thread indefinitely.
                         cancellationToken.ThrowIfCancellationRequested();
 
                         try
                         {
-                            if (_prefetchBuffer.WaitToRead(_options.FetchMaxWaitMs, cancellationToken))
+                            if (await WaitForPrefetchDataAsync(cancellationToken).ConfigureAwait(false))
                             {
                                 if (_prefetchBuffer.TryRead(out PendingFetchData? fetched))
                                 {
@@ -1555,12 +1556,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     }
                     else
                     {
-                        // Wait for prefetch with timeout using synchronous WaitToRead
+                        // Use a synchronous zero-timeout recheck before async wait so the
+                        // idle path does not hold a thread-pool thread indefinitely.
                         cancellationToken.ThrowIfCancellationRequested();
 
                         try
                         {
-                            if (_prefetchBuffer.WaitToRead(_options.FetchMaxWaitMs, cancellationToken))
+                            if (await WaitForPrefetchDataAsync(cancellationToken).ConfigureAwait(false))
                             {
                                 if (_prefetchBuffer.TryRead(out PendingFetchData? fetched))
                                 {
@@ -2217,6 +2219,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _pendingFetches.Enqueue(additional);
             TrackPrefetchedBytes(additional, release: true);
         }
+    }
+
+    private async ValueTask<bool> WaitForPrefetchDataAsync(CancellationToken cancellationToken)
+    {
+        if (_prefetchBuffer.WaitToRead(0, cancellationToken))
+            return true;
+
+        if (_prefetchBuffer.IsCompleted)
+            return false;
+
+        return await _prefetchBuffer.WaitToReadAsync(_options.FetchMaxWaitMs, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private void TrackPrefetchedBytes(PendingFetchData pending, bool release)

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -319,7 +319,7 @@ internal sealed class MpscFetchBuffer
     public bool IsCompleted => _completed;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool HasDataAvailable() =>
+    internal bool HasDataAvailable() =>
         Volatile.Read(ref _headCommitted.Value) > Volatile.Read(ref _tail.Value);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -24,7 +24,9 @@ internal sealed class MpscFetchBuffer
 
     private readonly ManualResetEventSlim _dataAvailable = new(false);
     private readonly SemaphoreSlim _spaceAvailable = new(0, int.MaxValue);
+    private readonly object _dataAvailableWaiterLock = new();
     private readonly Action? _afterProducerWaiterCountIncrementedForTesting;
+    private TaskCompletionSource<bool>? _dataAvailableWaiter;
     private int _producerWaiterCount;
     private int _consumerWaiting;
     private volatile bool _completed;
@@ -86,7 +88,7 @@ internal sealed class MpscFetchBuffer
             Interlocked.MemoryBarrier();
 
             if (Volatile.Read(ref _consumerWaiting) != 0)
-                _dataAvailable.Set();
+                SignalConsumerWaitingForData();
 
             return true;
         }
@@ -161,14 +163,14 @@ internal sealed class MpscFetchBuffer
     public bool WaitToRead(int timeoutMs, CancellationToken cancellationToken)
     {
         // Fast check: data already available?
-        if (Volatile.Read(ref _headCommitted.Value) > Volatile.Read(ref _tail.Value))
+        if (HasDataAvailable())
             return true;
 
         if (_completed)
         {
             if (_completionError is not null)
                 throw _completionError;
-            return Volatile.Read(ref _headCommitted.Value) > Volatile.Read(ref _tail.Value);
+            return HasDataAvailable();
         }
 
         // Slow path: wait for signal
@@ -180,14 +182,14 @@ internal sealed class MpscFetchBuffer
             Interlocked.MemoryBarrier();
 
             // Re-check after reset to avoid missed signal
-            if (Volatile.Read(ref _headCommitted.Value) > Volatile.Read(ref _tail.Value))
+            if (HasDataAvailable())
                 return true;
 
             if (_completed)
             {
                 if (_completionError is not null)
                     throw _completionError;
-                return Volatile.Read(ref _headCommitted.Value) > Volatile.Read(ref _tail.Value);
+                return HasDataAvailable();
             }
 
             _dataAvailable.Wait(timeoutMs, cancellationToken);
@@ -195,10 +197,105 @@ internal sealed class MpscFetchBuffer
             if (_completionError is not null)
                 throw _completionError;
 
-            return Volatile.Read(ref _headCommitted.Value) > Volatile.Read(ref _tail.Value);
+            return HasDataAvailable();
         }
         finally
         {
+            Volatile.Write(ref _consumerWaiting, 0);
+        }
+    }
+
+    /// <summary>
+    /// Waits asynchronously until data is available or the buffer is completed.
+    /// Returns false if the wait times out or the buffer is completed and empty.
+    /// </summary>
+    public async ValueTask<bool> WaitToReadAsync(int timeoutMs, CancellationToken cancellationToken)
+    {
+        if (timeoutMs < Timeout.Infinite)
+            throw new ArgumentOutOfRangeException(nameof(timeoutMs), "Timeout must be non-negative or Timeout.Infinite.");
+
+        // Fast check: data already available?
+        if (HasDataAvailable())
+            return true;
+
+        if (_completed)
+        {
+            if (_completionError is not null)
+                throw _completionError;
+            return HasDataAvailable();
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (timeoutMs == 0)
+        {
+            if (_completionError is not null)
+                throw _completionError;
+            return HasDataAvailable();
+        }
+
+        TaskCompletionSource<bool>? waiter = null;
+        Volatile.Write(ref _consumerWaiting, 1);
+
+        try
+        {
+            Interlocked.MemoryBarrier();
+
+            lock (_dataAvailableWaiterLock)
+            {
+                // Re-check after publishing the waiter flag to avoid missed signals.
+                if (HasDataAvailable())
+                    return true;
+
+                if (_completed)
+                {
+                    if (_completionError is not null)
+                        throw _completionError;
+                    return HasDataAvailable();
+                }
+
+                if (_dataAvailableWaiter is null || _dataAvailableWaiter.Task.IsCompleted)
+                {
+                    _dataAvailableWaiter =
+                        new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                }
+
+                waiter = _dataAvailableWaiter;
+            }
+
+            try
+            {
+                if (timeoutMs == Timeout.Infinite)
+                {
+                    await waiter.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await waiter.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs), cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+            catch (TimeoutException)
+            {
+                return false;
+            }
+
+            if (_completionError is not null)
+                throw _completionError;
+
+            return HasDataAvailable();
+        }
+        finally
+        {
+            if (waiter is not null)
+            {
+                lock (_dataAvailableWaiterLock)
+                {
+                    if (ReferenceEquals(_dataAvailableWaiter, waiter))
+                        _dataAvailableWaiter = null;
+                }
+            }
+
             Volatile.Write(ref _consumerWaiting, 0);
         }
     }
@@ -216,14 +313,31 @@ internal sealed class MpscFetchBuffer
 
         _completionError = error;
         _completed = true;
-        _dataAvailable.Set();
+        SignalConsumerWaitingForData();
     }
 
     public bool IsCompleted => _completed;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool HasDataAvailable() =>
+        Volatile.Read(ref _headCommitted.Value) > Volatile.Read(ref _tail.Value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool HasSpaceAvailable() =>
         Volatile.Read(ref _headReserved.Value) - Volatile.Read(ref _tail.Value) < _buffer.Length;
+
+    private void SignalConsumerWaitingForData()
+    {
+        _dataAvailable.Set();
+
+        TaskCompletionSource<bool>? waiter;
+        lock (_dataAvailableWaiterLock)
+        {
+            waiter = _dataAvailableWaiter;
+        }
+
+        waiter?.TrySetResult(true);
+    }
 
     private void DrainAvailableSpaceSignals()
     {

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Protocol.Records;
@@ -248,6 +249,70 @@ public class MpscFetchBufferTests
 
         var act = () => buffer.WaitToRead(5000, cts.Token);
         await Assert.That(act).Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task WaitToReadAsync_EmptyBuffer_ReturnsWithoutBlockingCaller()
+    {
+        var buffer = new MpscFetchBuffer(4);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var elapsed = Stopwatch.StartNew();
+        var waitTask = buffer.WaitToReadAsync(30_000, cts.Token).AsTask();
+        elapsed.Stop();
+
+        await Assert.That(elapsed.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
+        await Assert.That(waitTask.IsCompleted).IsFalse();
+
+        await cts.CancelAsync();
+        await Assert.That(async () => await waitTask).Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task WaitToReadAsync_DataArrivesAfterWait_ReturnsTrue()
+    {
+        var buffer = new MpscFetchBuffer(4);
+        var item = CreateDummy();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var waitTask = buffer.WaitToReadAsync(30_000, cts.Token).AsTask();
+        await Assert.That(waitTask.IsCompleted).IsFalse();
+
+        await Assert.That(buffer.TryWrite(item)).IsTrue();
+
+        await Assert.That(await waitTask).IsTrue();
+        await Assert.That(buffer.TryRead(out var result)).IsTrue();
+        await Assert.That(result).IsEqualTo(item);
+
+        item.Dispose();
+    }
+
+    [Test]
+    public async Task WaitToReadAsync_ManyIdleBuffers_CompleteUnblocksAll()
+    {
+        const int BufferCount = 32;
+        var buffers = Enumerable.Range(0, BufferCount)
+            .Select(_ => new MpscFetchBuffer(4))
+            .ToArray();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var elapsed = Stopwatch.StartNew();
+        var waitTasks = buffers
+            .Select(buffer => buffer.WaitToReadAsync(30_000, cts.Token).AsTask())
+            .ToArray();
+        elapsed.Stop();
+
+        await Assert.That(elapsed.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
+        await Assert.That(waitTasks.All(task => !task.IsCompleted)).IsTrue();
+
+        foreach (var buffer in buffers)
+        {
+            buffer.Complete();
+        }
+
+        var results = await Task.WhenAll(waitTasks).WaitAsync(cts.Token);
+
+        await Assert.That(results.All(result => !result)).IsTrue();
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -269,6 +269,28 @@ public class MpscFetchBufferTests
     }
 
     [Test]
+    public async Task WaitToReadAsync_Timeout_ReturnsFalseAndClearsWaiterState()
+    {
+        var buffer = new MpscFetchBuffer(4);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var timedOut = await buffer.WaitToReadAsync(25, cts.Token).AsTask().WaitAsync(cts.Token);
+
+        await Assert.That(timedOut).IsFalse();
+        await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
+        await Assert.That(GetDataAvailableWaiter(buffer)).IsNull();
+
+        var waitTask = buffer.WaitToReadAsync(30_000, cts.Token).AsTask();
+        await Assert.That(waitTask.IsCompleted).IsFalse();
+
+        buffer.Complete();
+
+        await Assert.That(await waitTask.WaitAsync(cts.Token)).IsFalse();
+        await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
+        await Assert.That(GetDataAvailableWaiter(buffer)).IsNull();
+    }
+
+    [Test]
     public async Task WaitToReadAsync_DataArrivesAfterWait_ReturnsTrue()
     {
         var buffer = new MpscFetchBuffer(4);
@@ -510,5 +532,21 @@ public class MpscFetchBufferTests
             BindingFlags.NonPublic | BindingFlags.Instance)!;
         var semaphore = (SemaphoreSlim)field.GetValue(buffer)!;
         return semaphore.CurrentCount;
+    }
+
+    private static int GetConsumerWaiting(MpscFetchBuffer buffer)
+    {
+        var field = typeof(MpscFetchBuffer).GetField(
+            "_consumerWaiting",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (int)field.GetValue(buffer)!;
+    }
+
+    private static TaskCompletionSource<bool>? GetDataAvailableWaiter(MpscFetchBuffer buffer)
+    {
+        var field = typeof(MpscFetchBuffer).GetField(
+            "_dataAvailableWaiter",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (TaskCompletionSource<bool>?)field.GetValue(buffer);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -291,6 +291,37 @@ public class MpscFetchBufferTests
     }
 
     [Test]
+    public async Task WaitToReadAsync_AlreadyCompletedWithError_ThrowsError()
+    {
+        var buffer = new MpscFetchBuffer(4);
+        var expectedException = new InvalidOperationException("test error");
+        buffer.Complete(expectedException);
+
+        await Assert.That(async () => await buffer.WaitToReadAsync(1000, CancellationToken.None))
+            .Throws<InvalidOperationException>()
+            .WithMessage("test error");
+    }
+
+    [Test]
+    public async Task WaitToReadAsync_CompletedWithErrorWhileWaiting_ThrowsError()
+    {
+        var buffer = new MpscFetchBuffer(4);
+        var expectedException = new InvalidOperationException("test error");
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var waitTask = buffer.WaitToReadAsync(30_000, cts.Token).AsTask();
+        await Assert.That(waitTask.IsCompleted).IsFalse();
+
+        buffer.Complete(expectedException);
+
+        await Assert.That(async () => await waitTask.WaitAsync(cts.Token))
+            .Throws<InvalidOperationException>()
+            .WithMessage("test error");
+        await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
+        await Assert.That(GetDataAvailableWaiter(buffer)).IsNull();
+    }
+
+    [Test]
     public async Task WaitToReadAsync_DataArrivesAfterWait_ReturnsTrue()
     {
         var buffer = new MpscFetchBuffer(4);


### PR DESCRIPTION
## Summary
- Add async `MpscFetchBuffer.WaitToReadAsync` for idle read waits without parking a worker thread.
- Keep the synchronous zero-timeout fast recheck before consumer idle waits fall back to async waiting.
- Add concurrency coverage for async read wait wake-up, cancellation, and many idle buffers.

## Validation
- `dotnet build Dekaf.sln --no-restore`
- `./tests/Dekaf.Tests.Unit/bin/Debug/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/MpscFetchBufferTests/*"`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/MpscFetchBufferTests/*"`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PrefetchPipelineRunnerTests/*"`
- `./tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration.exe --treenode-filter "/*/*/*/Consumer_SubscribeAndConsume_ReceivesMessages"`

Closes #1092