### PR TITLE
perf(consumer): add ConsumeOne fast path

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -121,6 +121,9 @@ internal sealed class PendingFetchData : IDisposable
     /// </summary>
     public long MessageCount { get; private set; }
 
+    private long _emittedMessageCount;
+    private long _emittedBytesConsumed;
+
     private PendingFetchData() { }
 
     /// <summary>
@@ -234,6 +237,21 @@ internal sealed class PendingFetchData : IDisposable
         LastYieldedOffset = offset;
         TotalBytesConsumed += messageBytes;
         MessageCount++;
+    }
+
+    public bool TryConsumeMetricDelta(out long messageCount, out long bytesConsumed)
+    {
+        messageCount = MessageCount - _emittedMessageCount;
+        if (messageCount <= 0)
+        {
+            bytesConsumed = 0;
+            return false;
+        }
+
+        bytesConsumed = TotalBytesConsumed - _emittedBytesConsumed;
+        _emittedMessageCount = MessageCount;
+        _emittedBytesConsumed = TotalBytesConsumed;
+        return true;
     }
 
     /// <summary>
@@ -431,6 +449,8 @@ internal sealed class PendingFetchData : IDisposable
         LastYieldedOffset = -1;
         TotalBytesConsumed = 0;
         MessageCount = 0;
+        _emittedMessageCount = 0;
+        _emittedBytesConsumed = 0;
         PartitionIndex = 0;
         TopicPartition = default;
         Topic = null!;
@@ -1128,9 +1148,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Start background prefetch if enabled (QueuedMinMessages > 1)
         var prefetchEnabled = _options.QueuedMinMessages > 1;
         _prefetchEnabled = prefetchEnabled;
-        if (prefetchEnabled)
+        if (prefetchEnabled && !cancellationToken.IsCancellationRequested)
         {
-            StartPrefetch(cancellationToken);
+            StartPrefetch();
         }
 
         while (!cancellationToken.IsCancellationRequested)
@@ -1399,9 +1419,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Start background prefetch if enabled (QueuedMinMessages > 1)
         bool prefetchEnabled = _options.QueuedMinMessages > 1;
         _prefetchEnabled = prefetchEnabled;
-        if (prefetchEnabled)
+        if (prefetchEnabled && !cancellationToken.IsCancellationRequested)
         {
-            StartPrefetch(cancellationToken);
+            StartPrefetch();
         }
 
         while (!cancellationToken.IsCancellationRequested)
@@ -1533,9 +1553,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Start background prefetch if enabled (QueuedMinMessages > 1)
         bool prefetchEnabled = _options.QueuedMinMessages > 1;
         _prefetchEnabled = prefetchEnabled;
-        if (prefetchEnabled)
+        if (prefetchEnabled && !cancellationToken.IsCancellationRequested)
         {
-            StartPrefetch(cancellationToken);
+            StartPrefetch();
         }
 
         while (!cancellationToken.IsCancellationRequested)
@@ -1648,12 +1668,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
-    private void StartPrefetch(CancellationToken cancellationToken)
+    private void StartPrefetch()
     {
         if (_prefetchTask is not null)
             return;
 
-        _prefetchCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _prefetchCts = new CancellationTokenSource();
         _prefetchTask = PrefetchLoopAsync(_prefetchCts.Token);
     }
 
@@ -2328,9 +2348,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         var prefetchEnabled = _options.QueuedMinMessages > 1;
         _prefetchEnabled = prefetchEnabled;
-        if (prefetchEnabled)
+        if (prefetchEnabled && !cancellationToken.IsCancellationRequested)
         {
-            StartPrefetch(cancellationToken);
+            StartPrefetch();
         }
 
         while (!cancellationToken.IsCancellationRequested)
@@ -2623,14 +2643,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void EmitFetchMetrics(PendingFetchData fetch)
     {
+        if (!fetch.TryConsumeMetricDelta(out var messageCount, out var bytesConsumed))
+            return;
+
         if (!_metricTagsCache.TryGetValue(fetch.Topic, out var metricTags))
         {
             metricTags = new System.Diagnostics.TagList
                 { { Diagnostics.DekafDiagnostics.MessagingDestinationName, fetch.Topic } };
             _metricTagsCache[fetch.Topic] = metricTags;
         }
-        Diagnostics.DekafMetrics.MessagesReceived.Add(fetch.MessageCount, metricTags);
-        Diagnostics.DekafMetrics.BytesReceived.Add(fetch.TotalBytesConsumed, metricTags);
+        Diagnostics.DekafMetrics.MessagesReceived.Add(messageCount, metricTags);
+        Diagnostics.DekafMetrics.BytesReceived.Add(bytesConsumed, metricTags);
     }
 
     private void RecordFetchDuration(long fetchStarted, int brokerId)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -73,6 +73,7 @@ internal sealed class PendingFetchData : IDisposable
     private int _recordIndex = -1;
     private int _disposed;
     private int _headerGeneration;
+    private bool _eagerParsed;
 
     public string Topic { get; private set; } = null!;
     public int PartitionIndex { get; private set; }
@@ -248,6 +249,9 @@ internal sealed class PendingFetchData : IDisposable
     /// </summary>
     public void EagerParseAll()
     {
+        if (_eagerParsed)
+            return;
+
         for (var i = 0; i < _batches.Count; i++)
         {
             if (_batches[i].Records is Protocol.Records.LazyRecordList lazyList)
@@ -255,6 +259,7 @@ internal sealed class PendingFetchData : IDisposable
                 lazyList.EnsureAllParsed();
             }
         }
+        _eagerParsed = true;
     }
 
     /// <summary>
@@ -413,6 +418,7 @@ internal sealed class PendingFetchData : IDisposable
         _currentRecordsArray = null;
         _currentRecords = null;
         _currentRecordsCount = 0;
+        _eagerParsed = false;
         unchecked
         {
             _headerGeneration++;
@@ -2283,10 +2289,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             try
             {
-                await foreach (var result in ConsumeAsync(timeoutCts.Token).ConfigureAwait(false))
-                {
-                    return result;
-                }
+                return await ConsumeOneCoreAsync(timeoutCts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
             {
@@ -2300,10 +2303,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         try
         {
-            await foreach (var result in ConsumeAsync(linkedCts.Token).ConfigureAwait(false))
-            {
-                return result;
-            }
+            return await ConsumeOneCoreAsync(linkedCts.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
@@ -2312,6 +2312,212 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         return null;
+    }
+
+    private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneCoreAsync(CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref _consumerDisposed) != 0)
+            throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));
+
+        ThrowIfNotInitialized();
+
+        if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null)
+        {
+            await StartAutoCommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var prefetchEnabled = _options.QueuedMinMessages > 1;
+        _prefetchEnabled = prefetchEnabled;
+        if (prefetchEnabled)
+        {
+            StartPrefetch(cancellationToken);
+        }
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+
+            if (_assignmentSnapshot.Count == 0)
+            {
+                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            if (_pendingFetches.Count == 0)
+            {
+                if (!await FillPendingFetchesForSingleConsumeAsync(prefetchEnabled, cancellationToken)
+                    .ConfigureAwait(false))
+                {
+                    return null;
+                }
+            }
+
+            if (TryConsumeOneFromPendingFetches(out var result))
+                return result;
+
+            if (_pendingEofEvents.TryDequeue(out var eofEvent))
+            {
+                return ConsumeResult<TKey, TValue>.CreatePartitionEof(
+                    eofEvent.Partition.Topic,
+                    eofEvent.Partition.Partition,
+                    eofEvent.Offset);
+            }
+        }
+
+        return null;
+    }
+
+    private async ValueTask<bool> FillPendingFetchesForSingleConsumeAsync(bool prefetchEnabled, CancellationToken cancellationToken)
+    {
+        if (!prefetchEnabled)
+        {
+            await FetchRecordsAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+
+        if (_prefetchBuffer.TryRead(out var prefetched))
+        {
+            _pendingFetches.Enqueue(prefetched);
+            TrackPrefetchedBytes(prefetched, release: true);
+            DrainPrefetchBuffer();
+            return true;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            if (_prefetchBuffer.WaitToRead(_options.FetchMaxWaitMs, cancellationToken))
+            {
+                if (_prefetchBuffer.TryRead(out var fetched))
+                {
+                    _pendingFetches.Enqueue(fetched);
+                    TrackPrefetchedBytes(fetched, release: true);
+                    DrainPrefetchBuffer();
+                }
+                else
+                {
+                    System.Diagnostics.Debug.Fail("WaitToRead signalled data available but TryRead returned false");
+                }
+            }
+            else if (_prefetchBuffer.IsCompleted)
+            {
+                return false;
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Prefetch was not ready before FetchMaxWaitMs. The caller loop will check EOF and retry.
+        }
+
+        return true;
+    }
+
+    private bool TryConsumeOneFromPendingFetches(out ConsumeResult<TKey, TValue> result)
+    {
+        result = default!;
+
+        var metricsEnabled = Diagnostics.DekafMetrics.MessagesReceived.Enabled
+                             || Diagnostics.DekafMetrics.BytesReceived.Enabled;
+        var hasTraceListeners = Diagnostics.DekafDiagnostics.Source.HasListeners();
+        var hasInterceptors = _interceptors is not null;
+        var rawTrackingEnabled = _rawRecordTrackingEnabled;
+
+        while (_pendingFetches.Count > 0)
+        {
+            var pending = _pendingFetches.Peek();
+            long? batchProcessingStarted = _adaptiveFetchSizer is not null
+                ? System.Diagnostics.Stopwatch.GetTimestamp() : null;
+
+            pending.EagerParseAll();
+
+            System.Diagnostics.Activity? activity = null;
+            try
+            {
+                while (true)
+                {
+                    try
+                    {
+                        if (!pending.MoveNext())
+                            break;
+
+                        var record = pending.CurrentRecord;
+                        var offset = pending.CurrentBaseOffset + record.OffsetDelta;
+                        var timestampMs = pending.CurrentBaseTimestamp + record.TimestampDelta;
+                        var timestampType = pending.CurrentTimestampType;
+                        var messageBytes = (record.IsKeyNull ? 0 : record.Key.Length) +
+                                           (record.IsValueNull ? 0 : record.Value.Length);
+
+                        if (hasTraceListeners)
+                        {
+                            var headers = LazyConsumeHeaders.Create(
+                                record.Headers,
+                                record.HeaderCount,
+                                pending,
+                                pending.HeaderGeneration);
+                            activity = StartConsumeActivity(pending, headers, offset, messageBytes);
+                        }
+
+                        result = new ConsumeResult<TKey, TValue>(
+                            topic: pending.Topic,
+                            partition: pending.PartitionIndex,
+                            offset: offset,
+                            keyData: record.Key,
+                            isKeyNull: record.IsKeyNull,
+                            valueData: record.Value,
+                            isValueNull: record.IsValueNull,
+                            pooledHeaders: record.Headers,
+                            pooledHeaderCount: record.HeaderCount,
+                            headerOwner: pending,
+                            timestampMs: timestampMs,
+                            timestampType: timestampType,
+                            leaderEpoch: null,
+                            keyDeserializer: _keyDeserializer,
+                            valueDeserializer: _valueDeserializer);
+
+                        pending.TrackConsumed(offset, messageBytes);
+
+                        if (hasInterceptors)
+                            result = ApplyOnConsumeInterceptors(result);
+
+                        if (rawTrackingEnabled)
+                        {
+                            _currentRawKey = record.IsKeyNull ? ReadOnlyMemory<byte>.Empty : record.Key;
+                            _currentRawValue = record.IsValueNull ? ReadOnlyMemory<byte>.Empty : record.Value;
+                        }
+
+                        return true;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex) when (ex is InsufficientDataException or ArgumentOutOfRangeException or MalformedProtocolDataException)
+                    {
+                        LogRecordParsingError(ex, pending.Topic, pending.PartitionIndex);
+                        break;
+                    }
+                }
+            }
+            finally
+            {
+                activity?.Dispose();
+                FlushConsumedPositions(pending);
+
+                if (metricsEnabled && pending.MessageCount > 0)
+                    EmitFetchMetrics(pending);
+            }
+
+            if (batchProcessingStarted.HasValue)
+            {
+                var processingDuration = System.Diagnostics.Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
+                _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
+            }
+
+            _pendingFetches.Dequeue().Dispose();
+        }
+
+        return false;
     }
 
     public async ValueTask CommitAsync(CancellationToken cancellationToken = default)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -1,13 +1,17 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
 using System.Reflection;
 using System.Text;
 using Dekaf.Consumer;
+using Dekaf.Diagnostics;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
+[NotInParallel]
 public sealed class ConsumeOneFastPathTests
 {
     private const string Topic = "test-topic";
@@ -68,6 +72,46 @@ public sealed class ConsumeOneFastPathTests
     }
 
     [Test]
+    public async Task ConsumeOneAsync_EmitsFetchMetricsAsDeltas()
+    {
+        var messagesReceived = new List<long>();
+        var bytesReceived = new List<long>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
+                (instrument.Name == "messaging.client.consumed.messages" ||
+                 instrument.Name == "messaging.client.consumed.bytes"))
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+        {
+            if (instrument.Name == "messaging.client.consumed.messages")
+                messagesReceived.Add(measurement);
+            else if (instrument.Name == "messaging.client.consumed.bytes")
+                bytesReceived.Add(measurement);
+        });
+        listener.Start();
+
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(40,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+
+        await using var consumer = CreateInitializedConsumer(fetch);
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None)).IsNotNull();
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None)).IsNotNull();
+
+        await Assert.That(messagesReceived).IsEquivalentTo([1L, 1L]);
+        await Assert.That(bytesReceived.Sum()).IsEqualTo(8L);
+    }
+
+    [Test]
     public async Task ConsumeOneAsync_WhenTimeoutExpires_ReturnsNull()
     {
         await using var consumer = CreateInitializedConsumer();
@@ -77,13 +121,102 @@ public sealed class ConsumeOneFastPathTests
         await Assert.That(result).IsNull();
     }
 
+    [Test]
+    public async Task ConsumeOneAsync_TimeoutDoesNotCancelPrefetchLoop()
+    {
+        await using var consumer = CreateInitializedConsumer(queuedMinMessages: 2, fetchMaxWaitMs: 1);
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+
+        await Assert.That(result).IsNull();
+        var prefetchCts = GetPrefetchCts(consumer);
+        await Assert.That(prefetchCts).IsNotNull();
+        await Assert.That(prefetchCts!.IsCancellationRequested).IsFalse();
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_WithPendingEof_ReturnsPartitionEof()
+    {
+        await using var consumer = CreateInitializedConsumer(queuedMinMessages: 2, fetchMaxWaitMs: 1);
+        AssignTestPartition(consumer);
+        SetPrefetchStarted(consumer);
+        GetPendingEofEvents(consumer).Enqueue((new TopicPartition(Topic, Partition), 55L));
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.IsPartitionEof).IsTrue();
+        await Assert.That(result.Value.Topic).IsEqualTo(Topic);
+        await Assert.That(result.Value.Partition).IsEqualTo(Partition);
+        await Assert.That(result.Value.Offset).IsEqualTo(55L);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_TruncatedFetch_LogsAndContinues()
+    {
+        var loggerFactory = new CapturingLoggerFactory();
+        var faultingFetch = PendingFetchData.Create(Topic, Partition,
+        [
+            new RecordBatch
+            {
+                BaseOffset = 0,
+                BaseTimestamp = 1700000000000L,
+                Attributes = 0,
+                Records = new ThrowingRecordList([], faultAtIndex: 0)
+            }
+        ]);
+        var goodFetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(100, CreateRecord(0, "k", "v"))
+        ]);
+
+        await using var consumer = CreateInitializedConsumer(loggerFactory, faultingFetch, goodFetch);
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Offset).IsEqualTo(100L);
+        await Assert.That(result.Value.Value).IsEqualTo("v");
+
+        var parsingErrorLog = loggerFactory.GetLogger()
+            .Entries
+            .First(entry => entry.LogLevel == LogLevel.Error && entry.Message.Contains("Record parsing error"));
+        await Assert.That(parsingErrorLog.Message).Contains(Topic);
+        await Assert.That(parsingErrorLog.Message).Contains(Partition.ToString());
+        await Assert.That(parsingErrorLog.Exception).IsNotNull();
+    }
+
     private static KafkaConsumer<string, string> CreateInitializedConsumer(params PendingFetchData[] fetches)
     {
-        return CreateInitializedConsumer(queuedMinMessages: 1, fetches);
+        return CreateInitializedConsumer(queuedMinMessages: 1, fetchMaxWaitMs: 200, fetches);
     }
 
     private static KafkaConsumer<string, string> CreateInitializedConsumer(
         int queuedMinMessages,
+        params PendingFetchData[] fetches)
+    {
+        return CreateInitializedConsumer(queuedMinMessages, fetchMaxWaitMs: 200, fetches);
+    }
+
+    private static KafkaConsumer<string, string> CreateInitializedConsumer(
+        int queuedMinMessages,
+        int fetchMaxWaitMs,
+        params PendingFetchData[] fetches)
+    {
+        return CreateInitializedConsumer(null, queuedMinMessages, fetchMaxWaitMs, fetches);
+    }
+
+    private static KafkaConsumer<string, string> CreateInitializedConsumer(
+        ILoggerFactory? loggerFactory,
+        params PendingFetchData[] fetches)
+    {
+        return CreateInitializedConsumer(loggerFactory, queuedMinMessages: 1, fetchMaxWaitMs: 200, fetches);
+    }
+
+    private static KafkaConsumer<string, string> CreateInitializedConsumer(
+        ILoggerFactory? loggerFactory,
+        int queuedMinMessages,
+        int fetchMaxWaitMs,
         params PendingFetchData[] fetches)
     {
         var consumer = new KafkaConsumer<string, string>(
@@ -91,10 +224,12 @@ public sealed class ConsumeOneFastPathTests
             {
                 BootstrapServers = ["localhost:9092"],
                 OffsetCommitMode = OffsetCommitMode.Manual,
-                QueuedMinMessages = queuedMinMessages
+                QueuedMinMessages = queuedMinMessages,
+                FetchMaxWaitMs = fetchMaxWaitMs
             },
             Serializers.String,
-            Serializers.String);
+            Serializers.String,
+            loggerFactory);
 
         SetInitialized(consumer);
 
@@ -153,6 +288,25 @@ public sealed class ConsumeOneFastPathTests
         return (MpscFetchBuffer)field.GetValue(consumer)!;
     }
 
+    private static ConcurrentQueue<(TopicPartition Partition, long Offset)> GetPendingEofEvents(
+        KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_pendingEofEvents", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_pendingEofEvents field not found.");
+
+        return (ConcurrentQueue<(TopicPartition Partition, long Offset)>)field.GetValue(consumer)!;
+    }
+
+    private static CancellationTokenSource? GetPrefetchCts(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_prefetchCts", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_prefetchCts field not found.");
+
+        return (CancellationTokenSource?)field.GetValue(consumer);
+    }
+
     private static void SetPrefetchStarted(KafkaConsumer<string, string> consumer)
     {
         var field = typeof(KafkaConsumer<string, string>)
@@ -205,4 +359,75 @@ public sealed class ConsumeOneFastPathTests
             HeaderCount = 0
         };
     }
+
+    private sealed class ThrowingRecordList : IReadOnlyList<Record>
+    {
+        private readonly Record[] _goodRecords;
+        private readonly int _faultAtIndex;
+
+        public ThrowingRecordList(Record[] goodRecords, int faultAtIndex)
+        {
+            _goodRecords = goodRecords;
+            _faultAtIndex = faultAtIndex;
+        }
+
+        public int Count => _faultAtIndex + 1;
+
+        public Record this[int index]
+        {
+            get
+            {
+                if (index >= _faultAtIndex)
+                    throw new ArgumentOutOfRangeException(nameof(index), $"Simulated truncated record at index {index}");
+                return _goodRecords[index];
+            }
+        }
+
+        public IEnumerator<Record> GetEnumerator()
+        {
+            for (var i = 0; i < Count; i++)
+                yield return this[i];
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class CapturingLoggerFactory : ILoggerFactory
+    {
+        private CapturingLogger? _logger;
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            _logger ??= new CapturingLogger();
+            return _logger;
+        }
+
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public void Dispose() { }
+
+        public CapturingLogger GetLogger() =>
+            _logger ?? throw new InvalidOperationException("CreateLogger was never called.");
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception), exception));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel LogLevel, string Message, Exception? Exception);
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -1,0 +1,208 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text;
+using Dekaf.Consumer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumeOneFastPathTests
+{
+    private const string Topic = "test-topic";
+    private const int Partition = 0;
+
+    [Test]
+    public async Task ConsumeOneAsync_WithPendingFetch_ReturnsSequentialRecordsWithoutAsyncIterator()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+
+        await using var consumer = CreateInitializedConsumer(fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        var firstTask = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+        await Assert.That(firstTask.IsCompletedSuccessfully).IsTrue();
+        var first = await firstTask;
+
+        var secondTask = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+        await Assert.That(secondTask.IsCompletedSuccessfully).IsTrue();
+        var second = await secondTask;
+
+        await Assert.That(first).IsNotNull();
+        await Assert.That(first!.Value.Offset).IsEqualTo(20L);
+        await Assert.That(first.Value.Value).IsEqualTo("one");
+        await Assert.That(second).IsNotNull();
+        await Assert.That(second!.Value.Offset).IsEqualTo(21L);
+        await Assert.That(second.Value.Value).IsEqualTo("two");
+        await Assert.That(consumer.GetPosition(tp)).IsEqualTo(22L);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_WithPrefetchBuffer_ReturnsRecord()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(30, CreateRecord(0, "a", "one"))
+        ]);
+
+        await using var consumer = CreateInitializedConsumer(queuedMinMessages: 2);
+        SetPrefetchStarted(consumer);
+        AssignTestPartition(consumer);
+        SetPrefetchedBytes(consumer, KafkaConsumer<string, string>.EstimatePendingFetchBytes(fetch));
+        await Assert.That(GetPrefetchBuffer(consumer).TryWrite(fetch)).IsTrue();
+
+        var resultTask = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+        await Assert.That(resultTask.IsCompletedSuccessfully).IsTrue();
+        var result = await resultTask;
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Offset).IsEqualTo(30L);
+        await Assert.That(result.Value.Value).IsEqualTo("one");
+        await Assert.That(GetPrefetchedBytes(consumer)).IsEqualTo(0L);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_WhenTimeoutExpires_ReturnsNull()
+    {
+        await using var consumer = CreateInitializedConsumer();
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+
+        await Assert.That(result).IsNull();
+    }
+
+    private static KafkaConsumer<string, string> CreateInitializedConsumer(params PendingFetchData[] fetches)
+    {
+        return CreateInitializedConsumer(queuedMinMessages: 1, fetches);
+    }
+
+    private static KafkaConsumer<string, string> CreateInitializedConsumer(
+        int queuedMinMessages,
+        params PendingFetchData[] fetches)
+    {
+        var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = queuedMinMessages
+            },
+            Serializers.String,
+            Serializers.String);
+
+        SetInitialized(consumer);
+
+        if (fetches.Length == 0)
+            return consumer;
+
+        AssignTestPartition(consumer);
+        var pendingFetches = GetPendingFetches(consumer);
+        foreach (var fetch in fetches)
+            pendingFetches.Enqueue(fetch);
+
+        return consumer;
+    }
+
+    private static void AssignTestPartition(KafkaConsumer<string, string> consumer)
+    {
+        var tp = new TopicPartition(Topic, Partition);
+        consumer.Assign(tp);
+        GetFetchPositions(consumer)[tp] = 0;
+    }
+
+    private static void SetInitialized(KafkaConsumer<string, string> consumer)
+    {
+        var initializedField = typeof(KafkaConsumer<string, string>)
+            .GetField("_initialized", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_initialized field not found.");
+
+        initializedField.SetValue(consumer, true);
+    }
+
+    private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions(
+        KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_fetchPositions", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_fetchPositions field not found.");
+
+        return (ConcurrentDictionary<TopicPartition, long>)field.GetValue(consumer)!;
+    }
+
+    private static Queue<PendingFetchData> GetPendingFetches(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_pendingFetches", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_pendingFetches field not found.");
+
+        return (Queue<PendingFetchData>)field.GetValue(consumer)!;
+    }
+
+    private static MpscFetchBuffer GetPrefetchBuffer(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_prefetchBuffer", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_prefetchBuffer field not found.");
+
+        return (MpscFetchBuffer)field.GetValue(consumer)!;
+    }
+
+    private static void SetPrefetchStarted(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_prefetchTask", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_prefetchTask field not found.");
+
+        field.SetValue(consumer, Task.CompletedTask);
+    }
+
+    private static long GetPrefetchedBytes(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_prefetchedBytes", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_prefetchedBytes field not found.");
+
+        return (long)field.GetValue(consumer)!;
+    }
+
+    private static void SetPrefetchedBytes(KafkaConsumer<string, string> consumer, long bytes)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_prefetchedBytes", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_prefetchedBytes field not found.");
+
+        field.SetValue(consumer, bytes);
+    }
+
+    private static RecordBatch CreateBatch(long baseOffset, params Record[] records)
+    {
+        return new RecordBatch
+        {
+            BaseOffset = baseOffset,
+            BaseTimestamp = 1700000000000L,
+            Attributes = 0,
+            Records = records
+        };
+    }
+
+    private static Record CreateRecord(int offsetDelta, string key, string value)
+    {
+        return new Record
+        {
+            OffsetDelta = offsetDelta,
+            TimestampDelta = 0,
+            Key = Encoding.UTF8.GetBytes(key),
+            IsKeyNull = false,
+            Value = Encoding.UTF8.GetBytes(value),
+            IsValueNull = false,
+            Headers = null,
+            HeaderCount = 0
+        };
+    }
+}


### PR DESCRIPTION
Closes #1091.

Summary:
- Replace `ConsumeOneAsync`'s await-foreach wrapper with a direct single-record consume loop.
- Preserve timeout/external-cancellation handling and EOF return behavior.
- Keep pending fetch state queued between single-message calls, flushing positions/metrics like async-iterator disposal did.
- Make `PendingFetchData.EagerParseAll` idempotent so repeated `ConsumeOneAsync` calls do not rescan already parsed batches.

Review follow-up:
- Emit fetch metrics as deltas for pending fetches drained one record at a time.
- Give the prefetch loop a consumer-lifetime `CancellationTokenSource` so one timed-out `ConsumeOneAsync` call cannot permanently stop prefetching.
- Add `ConsumeOneAsync` coverage for metrics deltas, timeout/prefetch lifetime, partition EOF, and truncated fetch recovery.

Validation:
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --no-restore`
- `dotnet format Dekaf.sln whitespace --include src\Dekaf\Consumer\KafkaConsumer.cs tests\Dekaf.Tests.Unit\Consumer\ConsumeOneFastPathTests.cs --verify-no-changes --no-restore`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumeOneFastPathTests/*"` (7 tests)
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaConsumerFetchMetricsTests/*"` (2 tests)
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumeAsyncRecoveryTests/*"` (11 tests)
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumeResultTests/*"` (11 tests)
