### PR TITLE
perf(producer): cache partition deques by topic

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1024,32 +1024,24 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             }
 
             // Determine partition
-            int resolvedPartition;
-            if (partition is { } explicitPartition)
+            if (partition is null && _usesCustomPartitioner)
             {
-                resolvedPartition = explicitPartition;
-            }
-            else
-            {
-                if (_usesCustomPartitioner)
+                // User partitioners can run arbitrary code, including reentrant ProduceAsync.
+                // Keep serialized bytes independent of thread-local buffers until append copies them.
+                if (!keyIsNull && keySpan.Length > 0)
                 {
-                    // User partitioners can run arbitrary code, including reentrant ProduceAsync.
-                    // Keep serialized bytes independent of thread-local buffers until append copies them.
-                    if (!keyIsNull && keySpan.Length > 0)
-                    {
-                        customPartitionerKey = CopySpanToPooledMemory(keySpan);
-                        keySpan = customPartitionerKey.Span;
-                    }
-
-                    if (!valueIsNull && valueSpan.Length > 0)
-                    {
-                        customPartitionerValue = CopySpanToPooledMemory(valueSpan);
-                        valueSpan = customPartitionerValue.Span;
-                    }
+                    customPartitionerKey = CopySpanToPooledMemory(keySpan);
+                    keySpan = customPartitionerKey.Span;
                 }
 
-                resolvedPartition = _partitioner.Partition(topic, keySpan, keyIsNull, topicInfo.PartitionCount);
+                if (!valueIsNull && valueSpan.Length > 0)
+                {
+                    customPartitionerValue = CopySpanToPooledMemory(valueSpan);
+                    valueSpan = customPartitionerValue.Span;
+                }
             }
+
+            var resolvedPartition = ResolvePartition(topic, partition, keySpan, keyIsNull, topicInfo.PartitionCount);
 
             var batchCompletionPartitionCount = partition is null && keyIsNull
                 ? topicInfo.PartitionCount
@@ -1308,8 +1300,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var value = valueIsNull ? PooledMemory.Null : SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
 
         // Determine partition
-        var partition = message.Partition
-            ?? _partitioner.Partition(message.Topic, key.Span, keyIsNull, topicInfo.PartitionCount);
+        var partition = ResolvePartition(
+            message.Topic,
+            message.Partition,
+            key.Span,
+            keyIsNull,
+            topicInfo.PartitionCount);
         var batchCompletionPartitionCount = message.Partition is null && keyIsNull
             ? topicInfo.PartitionCount
             : 0;
@@ -2626,6 +2622,32 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         return new ProduceException($"Topic '{topic}' not found or has no partitions") { Topic = topic };
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int ResolvePartition(
+        string topic,
+        int? partition,
+        ReadOnlySpan<byte> key,
+        bool keyIsNull,
+        int partitionCount)
+    {
+        var resolvedPartition = partition
+            ?? _partitioner.Partition(topic, key, keyIsNull, partitionCount);
+
+        if ((uint)resolvedPartition >= (uint)partitionCount)
+            ThrowInvalidPartition(topic, resolvedPartition, partitionCount);
+
+        return resolvedPartition;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowInvalidPartition(string topic, int partition, int partitionCount)
+        => throw new ProduceException(
+            $"Invalid partition {partition} for topic '{topic}'. Valid partitions are 0 through {partitionCount - 1}.")
+        {
+            Topic = topic,
+            Partition = partition
+        };
+
     /// <summary>
     /// Async slow path for fire-and-forget produce with delivery callback when metadata is not cached.
     /// </summary>
@@ -2708,8 +2730,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         var keySpan = keyIsNull ? ReadOnlySpan<byte>.Empty : cache.KeySerializationBuffer.AsSpan(0, keyLength);
-        var resolvedPartition = partition
-            ?? _partitioner.Partition(topic, keySpan, keyIsNull, topicInfo.PartitionCount);
+        var resolvedPartition = ResolvePartition(topic, partition, keySpan, keyIsNull, topicInfo.PartitionCount);
         var batchCompletionPartitionCount = partition is null && keyIsNull
             ? topicInfo.PartitionCount
             : 0;

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1078,7 +1078,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 pooledHeaderArray,
                 headerCount,
                 completion,
-                batchCompletionPartitionCount))
+                partitionCount: batchCompletionPartitionCount,
+                cachePartitionCount: topicInfo.PartitionCount))
             {
                 // Clean up headers — the async slow path will re-serialize.
                 RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray);
@@ -1337,7 +1338,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             headerCount,
             completion,
             cancellationToken,
-            batchCompletionPartitionCount);
+            partitionCount: batchCompletionPartitionCount,
+            cachePartitionCount: topicInfo.PartitionCount);
     }
 
     public ValueTask<RecordMetadata> ProduceAsync(
@@ -2729,7 +2731,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             keySpan, keyIsNull,
             valueIsNull ? ReadOnlySpan<byte>.Empty : cache.ValueSerializationBuffer.AsSpan(0, valueLength),
             valueIsNull,
-            pooledHeaderArray, headerCount, callback, CancellationToken.None, batchCompletionPartitionCount);
+            pooledHeaderArray, headerCount, callback, CancellationToken.None,
+            partitionCount: batchCompletionPartitionCount,
+            cachePartitionCount: topicInfo.PartitionCount);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1293,49 +1293,68 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             throw NoUsablePartitionsException(message.Topic, topicInfo);
         }
 
-        // Serialize key and value to pooled memory (returned to pool when batch completes)
-        var keyIsNull = message.Key is null;
-        var key = keyIsNull ? PooledMemory.Null : SerializeKeyToPooled(message.Key!, message.Topic, message.Headers);
-        var valueIsNull = message.Value is null;
-        var value = valueIsNull ? PooledMemory.Null : SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
-
-        // Determine partition
-        var partition = ResolvePartition(
-            message.Topic,
-            message.Partition,
-            key.Span,
-            keyIsNull,
-            topicInfo.PartitionCount);
-        var batchCompletionPartitionCount = message.Partition is null && keyIsNull
-            ? topicInfo.PartitionCount
-            : 0;
-
-        // Get timestamp
-        var timestamp = message.Timestamp ?? DateTimeOffset.UtcNow;
-        var timestampMs = timestamp.ToUnixTimeMilliseconds();
-
-        // Convert headers with minimal allocations
+        var key = PooledMemory.Null;
+        var value = PooledMemory.Null;
         Header[]? pooledHeaderArray = null;
-        var headerCount = 0;
-        if (message.Headers is not null && message.Headers.Count > 0)
+        var ownershipTransferred = false;
+        try
         {
-            RentAndFillHeaders(message.Headers, out pooledHeaderArray, out headerCount);
-        }
+            // Serialize key and value to pooled memory (returned to pool when batch completes)
+            var keyIsNull = message.Key is null;
+            key = keyIsNull ? PooledMemory.Null : SerializeKeyToPooled(message.Key!, message.Topic, message.Headers);
+            var valueIsNull = message.Value is null;
+            value = valueIsNull ? PooledMemory.Null : SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
 
-        // Enqueue to per-partition-affine worker instead of calling AppendAsync inline.
-        // The worker will call AppendAsync and set the completion source on success/failure.
-        _accumulator.EnqueueAppend(
-            message.Topic,
-            partition,
-            timestampMs,
-            key,
-            value,
-            pooledHeaderArray,
-            headerCount,
-            completion,
-            cancellationToken,
-            partitionCount: batchCompletionPartitionCount,
-            cachePartitionCount: topicInfo.PartitionCount);
+            // Determine partition
+            var partition = ResolvePartition(
+                message.Topic,
+                message.Partition,
+                key.Span,
+                keyIsNull,
+                topicInfo.PartitionCount);
+            var batchCompletionPartitionCount = message.Partition is null && keyIsNull
+                ? topicInfo.PartitionCount
+                : 0;
+
+            // Get timestamp
+            var timestamp = message.Timestamp ?? DateTimeOffset.UtcNow;
+            var timestampMs = timestamp.ToUnixTimeMilliseconds();
+
+            // Convert headers with minimal allocations
+            var headerCount = 0;
+            if (message.Headers is not null && message.Headers.Count > 0)
+            {
+                RentAndFillHeaders(message.Headers, out pooledHeaderArray, out headerCount);
+            }
+
+            // Enqueue to per-partition-affine worker instead of calling AppendAsync inline.
+            // The worker will call AppendAsync and set the completion source on success/failure.
+            _accumulator.EnqueueAppend(
+                message.Topic,
+                partition,
+                timestampMs,
+                key,
+                value,
+                pooledHeaderArray,
+                headerCount,
+                completion,
+                cancellationToken,
+                partitionCount: batchCompletionPartitionCount,
+                cachePartitionCount: topicInfo.PartitionCount);
+
+            ownershipTransferred = true;
+        }
+        catch
+        {
+            if (!ownershipTransferred)
+            {
+                key.Return();
+                value.Return();
+                RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray);
+            }
+
+            throw;
+        }
     }
 
     public ValueTask<RecordMetadata> ProduceAsync(

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -40,6 +40,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     private string _topic = null!;
     private int _partition;
     private int _partitionCount;
+    private int _cachePartitionCount;
     private long _timestamp;
     private PooledMemory _key;
     private PooledMemory _value;
@@ -73,6 +74,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     internal string Topic => _topic;
     internal int Partition => _partition;
     internal int PartitionCount => _partitionCount;
+    internal int CachePartitionCount => _cachePartitionCount;
     internal long Timestamp => _timestamp;
     internal PooledMemory Key => _key;
     internal PooledMemory Value => _value;
@@ -101,6 +103,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         string topic,
         int partition,
         int partitionCount,
+        int cachePartitionCount,
         long timestamp,
         PooledMemory key,
         PooledMemory value,
@@ -118,6 +121,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _topic = topic;
         _partition = partition;
         _partitionCount = partitionCount;
+        _cachePartitionCount = cachePartitionCount;
         _timestamp = timestamp;
         _key = key;
         _value = value;
@@ -248,6 +252,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         // Clear references to avoid rooting objects across pool rentals
         _topic = null!;
         _partitionCount = 0;
+        _cachePartitionCount = 0;
         _key = default;
         _value = default;
         _headers = null;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1876,12 +1876,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // If partition eviction is ever added, the cache must be invalidated on removal.
     [ThreadStatic]
     private static AccumulatorThreadCache? t_cache;
-    private const int TopicDequeCacheSlots = 8;
-
-    private struct CachedTopicDequeArray
+    private const int MaxDequeCacheCapacity = 65_536;
+    private sealed class CachedTopicDequeArray(string topic, PartitionDeque?[] deques)
     {
-        public string? Topic;
-        public PartitionDeque?[]? Deques;
+        public string Topic { get; } = topic;
+        public PartitionDeque?[] Deques = deques;
     }
 
     /// <summary>
@@ -1891,10 +1890,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private sealed class AccumulatorThreadCache
     {
         public RecordAccumulator? CachedAccumulator;
-        public string? CachedTopic;
-        public PartitionDeque?[]? CachedTopicDeques;
-        public CachedTopicDequeArray[]? CachedTopicEntries;
-        public int NextTopicSlot;
+        public CachedTopicDequeArray? CachedTopicEntry;
+        public Dictionary<string, CachedTopicDequeArray>? CachedTopicEntries;
     }
 
     /// <summary>
@@ -1906,13 +1903,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private PartitionDeque GetOrCreateDeque(string topic, int partition, int cachePartitionCount)
     {
         var cache = t_cache ??= new AccumulatorThreadCache();
-        var cachedTopic = cache.CachedTopic;
-        var cachedDeques = cache.CachedTopicDeques;
+        var cachedEntry = cache.CachedTopicEntry;
 
         if (cache.CachedAccumulator == this && Volatile.Read(ref _disposed) == 0)
         {
-            if (TopicMatches(cachedTopic, topic) &&
-                TryGetCachedDeque(cachedDeques, partition, out var cached))
+            if (cachedEntry is not null &&
+                TopicMatches(cachedEntry.Topic, topic) &&
+                TryGetCachedDeque(cachedEntry.Deques, partition, out var cached))
             {
                 return cached!;
             }
@@ -1933,7 +1930,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         var tp = new TopicPartition(topic, partition);
         var deque = _partitionDeques.GetOrAdd(tp, static _ => new PartitionDeque());
-        var deques = GetOrCreateCachedDequeArray(topic, partition, cachePartitionCount, cache);
+
+        if (!TryGetDequeCacheCapacity(partition, cachePartitionCount, out var requiredCapacity))
+            return deque;
+
+        var deques = GetOrCreateCachedDequeArray(topic, requiredCapacity, cache);
         deques[partition] = deque;
         return deque;
     }
@@ -1941,45 +1942,31 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     [MethodImpl(MethodImplOptions.NoInlining)]
     private PartitionDeque?[] GetOrCreateCachedDequeArray(
         string topic,
-        int partition,
-        int cachePartitionCount,
+        int requiredCapacity,
         AccumulatorThreadCache cache)
     {
-        var requiredCapacity = GetDequeCacheCapacity(partition, cachePartitionCount);
-
         if (cache.CachedAccumulator != this)
             ResetCacheForAccumulator(cache, this);
 
-        if (cache.CachedAccumulator == this &&
-            TopicMatches(cache.CachedTopic, topic) &&
-            cache.CachedTopicDeques is { } existing)
+        if (cache.CachedTopicEntry is { } cachedEntry &&
+            TopicMatches(cachedEntry.Topic, topic))
         {
-            var resizedDeques = EnsureDequeCacheCapacity(existing, requiredCapacity);
-            cache.CachedTopicDeques = resizedDeques;
-            UpdateCachedTopicEntry(cache, topic, resizedDeques);
-            return resizedDeques;
+            cachedEntry.Deques = EnsureDequeCacheCapacity(cachedEntry.Deques, requiredCapacity);
+            return cachedEntry.Deques;
         }
 
-        var entries = cache.CachedTopicEntries ??= new CachedTopicDequeArray[TopicDequeCacheSlots];
-        for (var i = 0; i < entries.Length; i++)
+        var entries = cache.CachedTopicEntries ??= new Dictionary<string, CachedTopicDequeArray>(StringComparer.Ordinal);
+        if (entries.TryGetValue(topic, out var entry))
         {
-            ref var entry = ref entries[i];
-            if (!TopicMatches(entry.Topic, topic) || entry.Deques is not { } entryDeques)
-                continue;
-
-            entryDeques = EnsureDequeCacheCapacity(entryDeques, requiredCapacity);
-            entry.Deques = entryDeques;
-            cache.CachedTopic = entry.Topic;
-            cache.CachedTopicDeques = entryDeques;
-            return entryDeques;
+            entry.Deques = EnsureDequeCacheCapacity(entry.Deques, requiredCapacity);
+            cache.CachedTopicEntry = entry;
+            return entry.Deques;
         }
 
         var newDeques = new PartitionDeque?[requiredCapacity];
-        var slot = (int)((uint)cache.NextTopicSlot++ % (uint)entries.Length);
-        entries[slot] = new CachedTopicDequeArray { Topic = topic, Deques = newDeques };
-        cache.CachedAccumulator = this;
-        cache.CachedTopic = topic;
-        cache.CachedTopicDeques = newDeques;
+        entry = new CachedTopicDequeArray(topic, newDeques);
+        entries.Add(topic, entry);
+        cache.CachedTopicEntry = entry;
         return newDeques;
     }
 
@@ -2004,20 +1991,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int partition,
         out PartitionDeque? cached)
     {
-        var entries = cache.CachedTopicEntries;
-        if (entries is not null)
+        if (cache.CachedTopicEntries is not null &&
+            cache.CachedTopicEntries.TryGetValue(topic, out var entry) &&
+            TryGetCachedDeque(entry.Deques, partition, out cached))
         {
-            for (var i = 0; i < entries.Length; i++)
-            {
-                var entry = entries[i];
-                if (TopicMatches(entry.Topic, topic) &&
-                    TryGetCachedDeque(entry.Deques, partition, out cached))
-                {
-                    cache.CachedTopic = entry.Topic;
-                    cache.CachedTopicDeques = entry.Deques;
-                    return true;
-                }
-            }
+            cache.CachedTopicEntry = entry;
+            return true;
         }
 
         cached = null;
@@ -2027,36 +2006,29 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private static void ResetCacheForAccumulator(AccumulatorThreadCache cache, RecordAccumulator accumulator)
     {
         cache.CachedAccumulator = accumulator;
-        cache.CachedTopic = null;
-        cache.CachedTopicDeques = null;
-        cache.NextTopicSlot = 0;
-
-        if (cache.CachedTopicEntries is not null)
-            Array.Clear(cache.CachedTopicEntries);
-    }
-
-    private static void UpdateCachedTopicEntry(
-        AccumulatorThreadCache cache,
-        string topic,
-        PartitionDeque?[] deques)
-    {
-        var entries = cache.CachedTopicEntries;
-        if (entries is null)
-            return;
-
-        for (var i = 0; i < entries.Length; i++)
-        {
-            if (TopicMatches(entries[i].Topic, topic))
-            {
-                entries[i].Deques = deques;
-                return;
-            }
-        }
+        cache.CachedTopicEntry = null;
+        cache.CachedTopicEntries?.Clear();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int GetDequeCacheCapacity(int partition, int cachePartitionCount) =>
-        Math.Max(1, Math.Max(partition + 1, cachePartitionCount));
+    private static bool TryGetDequeCacheCapacity(int partition, int cachePartitionCount, out int capacity)
+    {
+        if (partition < 0)
+        {
+            capacity = 0;
+            return false;
+        }
+
+        var requestedCapacity = Math.Max((long)partition + 1, Math.Max(1, cachePartitionCount));
+        if (requestedCapacity > MaxDequeCacheCapacity)
+        {
+            capacity = 0;
+            return false;
+        }
+
+        capacity = (int)requestedCapacity;
+        return true;
+    }
 
     private static PartitionDeque?[] EnsureDequeCacheCapacity(
         PartitionDeque?[] existing,

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -391,6 +391,7 @@ internal readonly struct AppendWorkItem
     public readonly string Topic;
     public readonly int Partition;
     public readonly int PartitionCount;
+    public readonly int CachePartitionCount;
     public readonly long Timestamp;
     public readonly PooledMemory Key;
     public readonly PooledMemory Value;
@@ -403,6 +404,7 @@ internal readonly struct AppendWorkItem
         string topic,
         int partition,
         int partitionCount,
+        int cachePartitionCount,
         long timestamp,
         PooledMemory key,
         PooledMemory value,
@@ -414,6 +416,7 @@ internal readonly struct AppendWorkItem
         Topic = topic;
         Partition = partition;
         PartitionCount = partitionCount;
+        CachePartitionCount = cachePartitionCount;
         Timestamp = timestamp;
         Key = key;
         Value = value;
@@ -1527,7 +1530,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         var result = AppendAfterReservation(
                             op.Topic, op.Partition, op.Timestamp,
                             op.Key, op.Value, op.Headers, op.HeaderCount,
-                            op.CompletionSource, op.Callback, op.RecordSize, op.PartitionCount);
+                            op.CompletionSource, op.Callback, op.RecordSize, op.PartitionCount, op.CachePartitionCount);
 
                         op.CompleteResult(result);
                     }
@@ -1783,7 +1786,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     workItem.Completion,
                     null,
                     workItem.CancellationToken,
-                    partitionCount: workItem.PartitionCount).ConfigureAwait(false))
+                    partitionCount: workItem.PartitionCount,
+                    cachePartitionCount: workItem.CachePartitionCount).ConfigureAwait(false))
                 {
                     CleanupWorkItemResources(in workItem);
                     workItem.Completion.TrySetException(new ObjectDisposedException(nameof(RecordAccumulator)));
@@ -1836,11 +1840,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int headerCount,
         PooledValueTaskSource<RecordMetadata> completion,
         CancellationToken cancellationToken,
-        int partitionCount = 0)
+        int partitionCount = 0,
+        int cachePartitionCount = 0)
     {
         EnsureAppendWorkersStarted();
         var workerIndex = (int)((uint)partition % (uint)_appendWorkerCount);
-        var workItem = new AppendWorkItem(topic, partition, partitionCount, timestamp, key, value,
+        var workItem = new AppendWorkItem(topic, partition, partitionCount, cachePartitionCount, timestamp, key, value,
             headers, headerCount, completion, cancellationToken);
 
         if (!_appendWorkerChannels[workerIndex].Writer.TryWrite(workItem))
@@ -1871,6 +1876,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // If partition eviction is ever added, the cache must be invalidated on removal.
     [ThreadStatic]
     private static AccumulatorThreadCache? t_cache;
+    private const int TopicDequeCacheSlots = 8;
+
+    private struct CachedTopicDequeArray
+    {
+        public string? Topic;
+        public PartitionDeque?[]? Deques;
+    }
 
     /// <summary>
     /// Holds per-thread cached state for partition deque lookups.
@@ -1881,6 +1893,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         public RecordAccumulator? CachedAccumulator;
         public string? CachedTopic;
         public PartitionDeque?[]? CachedTopicDeques;
+        public CachedTopicDequeArray[]? CachedTopicEntries;
+        public int NextTopicSlot;
     }
 
     /// <summary>
@@ -1889,38 +1903,37 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// same thread rotates through partitions of one topic.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private PartitionDeque GetOrCreateDeque(string topic, int partition, int partitionCount)
+    private PartitionDeque GetOrCreateDeque(string topic, int partition, int cachePartitionCount)
     {
         var cache = t_cache ??= new AccumulatorThreadCache();
         var cachedTopic = cache.CachedTopic;
         var cachedDeques = cache.CachedTopicDeques;
 
-        if (cache.CachedAccumulator == this &&
-            Volatile.Read(ref _disposed) == 0 &&
-            TopicMatches(cachedTopic, topic) &&
-            cachedDeques is not null &&
-            (uint)partition < (uint)cachedDeques.Length &&
-            cachedDeques[partition] is { } cached)
+        if (cache.CachedAccumulator == this && Volatile.Read(ref _disposed) == 0)
         {
-            return cached;
+            if (TopicMatches(cachedTopic, topic) &&
+                TryGetCachedDeque(cachedDeques, partition, out var cached))
+            {
+                return cached!;
+            }
+
+            if (TryGetCachedTopicDeque(cache, topic, partition, out cached))
+                return cached!;
         }
 
-        return GetOrCreateDequeSlow(topic, partition, partitionCount, cache);
+        return GetOrCreateDequeSlow(topic, partition, cachePartitionCount, cache);
     }
-
-    private PartitionDeque GetOrCreateDeque(string topic, int partition) =>
-        GetOrCreateDeque(topic, partition, partition + 1);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private PartitionDeque GetOrCreateDequeSlow(
         string topic,
         int partition,
-        int partitionCount,
+        int cachePartitionCount,
         AccumulatorThreadCache cache)
     {
         var tp = new TopicPartition(topic, partition);
         var deque = _partitionDeques.GetOrAdd(tp, static _ => new PartitionDeque());
-        var deques = GetOrCreateCachedDequeArray(topic, partition, partitionCount, cache);
+        var deques = GetOrCreateCachedDequeArray(topic, partition, cachePartitionCount, cache);
         deques[partition] = deque;
         return deque;
     }
@@ -1929,29 +1942,133 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private PartitionDeque?[] GetOrCreateCachedDequeArray(
         string topic,
         int partition,
-        int partitionCount,
+        int cachePartitionCount,
         AccumulatorThreadCache cache)
     {
-        var cachedTopic = cache.CachedTopic;
-        var capacity = Math.Max(partition + 1, partitionCount);
+        var requiredCapacity = GetDequeCacheCapacity(partition, cachePartitionCount);
+
+        if (cache.CachedAccumulator != this)
+            ResetCacheForAccumulator(cache, this);
 
         if (cache.CachedAccumulator == this &&
-            TopicMatches(cachedTopic, topic) &&
+            TopicMatches(cache.CachedTopic, topic) &&
             cache.CachedTopicDeques is { } existing)
         {
-            if (existing.Length >= capacity)
-                return existing;
-
-            Array.Resize(ref existing, capacity);
-            cache.CachedTopicDeques = existing;
-            return existing;
+            var resizedDeques = EnsureDequeCacheCapacity(existing, requiredCapacity);
+            cache.CachedTopicDeques = resizedDeques;
+            UpdateCachedTopicEntry(cache, topic, resizedDeques);
+            return resizedDeques;
         }
 
-        var deques = new PartitionDeque?[capacity];
+        var entries = cache.CachedTopicEntries ??= new CachedTopicDequeArray[TopicDequeCacheSlots];
+        for (var i = 0; i < entries.Length; i++)
+        {
+            ref var entry = ref entries[i];
+            if (!TopicMatches(entry.Topic, topic) || entry.Deques is not { } entryDeques)
+                continue;
+
+            entryDeques = EnsureDequeCacheCapacity(entryDeques, requiredCapacity);
+            entry.Deques = entryDeques;
+            cache.CachedTopic = entry.Topic;
+            cache.CachedTopicDeques = entryDeques;
+            return entryDeques;
+        }
+
+        var newDeques = new PartitionDeque?[requiredCapacity];
+        var slot = (int)((uint)cache.NextTopicSlot++ % (uint)entries.Length);
+        entries[slot] = new CachedTopicDequeArray { Topic = topic, Deques = newDeques };
         cache.CachedAccumulator = this;
         cache.CachedTopic = topic;
-        cache.CachedTopicDeques = deques;
-        return deques;
+        cache.CachedTopicDeques = newDeques;
+        return newDeques;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TryGetCachedDeque(PartitionDeque?[]? deques, int partition, out PartitionDeque? cached)
+    {
+        if (deques is not null &&
+            (uint)partition < (uint)deques.Length &&
+            deques[partition] is { } deque)
+        {
+            cached = deque;
+            return true;
+        }
+
+        cached = null;
+        return false;
+    }
+
+    private static bool TryGetCachedTopicDeque(
+        AccumulatorThreadCache cache,
+        string topic,
+        int partition,
+        out PartitionDeque? cached)
+    {
+        var entries = cache.CachedTopicEntries;
+        if (entries is not null)
+        {
+            for (var i = 0; i < entries.Length; i++)
+            {
+                var entry = entries[i];
+                if (TopicMatches(entry.Topic, topic) &&
+                    TryGetCachedDeque(entry.Deques, partition, out cached))
+                {
+                    cache.CachedTopic = entry.Topic;
+                    cache.CachedTopicDeques = entry.Deques;
+                    return true;
+                }
+            }
+        }
+
+        cached = null;
+        return false;
+    }
+
+    private static void ResetCacheForAccumulator(AccumulatorThreadCache cache, RecordAccumulator accumulator)
+    {
+        cache.CachedAccumulator = accumulator;
+        cache.CachedTopic = null;
+        cache.CachedTopicDeques = null;
+        cache.NextTopicSlot = 0;
+
+        if (cache.CachedTopicEntries is not null)
+            Array.Clear(cache.CachedTopicEntries);
+    }
+
+    private static void UpdateCachedTopicEntry(
+        AccumulatorThreadCache cache,
+        string topic,
+        PartitionDeque?[] deques)
+    {
+        var entries = cache.CachedTopicEntries;
+        if (entries is null)
+            return;
+
+        for (var i = 0; i < entries.Length; i++)
+        {
+            if (TopicMatches(entries[i].Topic, topic))
+            {
+                entries[i].Deques = deques;
+                return;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int GetDequeCacheCapacity(int partition, int cachePartitionCount) =>
+        Math.Max(1, Math.Max(partition + 1, cachePartitionCount));
+
+    private static PartitionDeque?[] EnsureDequeCacheCapacity(
+        PartitionDeque?[] existing,
+        int requiredCapacity)
+    {
+        if (existing.Length >= requiredCapacity)
+            return existing;
+
+        var doubled = existing.Length <= int.MaxValue / 2 ? existing.Length * 2 : int.MaxValue;
+        var newCapacity = Math.Max(requiredCapacity, doubled);
+        Array.Resize(ref existing, newCapacity);
+        return existing;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2008,7 +2125,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
         CancellationToken cancellationToken,
-        int partitionCount = 0)
+        int partitionCount = 0,
+        int cachePartitionCount = 0)
     {
         if (Volatile.Read(ref _disposed) != 0)
             return new ValueTask<bool>(false);
@@ -2018,11 +2136,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // Hot path: non-blocking CAS reservation — no async state machine allocated
         if (TryReserveMemory(recordSize))
             return new ValueTask<bool>(AppendAfterReservation(topic, partition, timestamp, key, value,
-                headers, headerCount, completionSource, callback, recordSize, partitionCount));
+                headers, headerCount, completionSource, callback, recordSize, partitionCount, cachePartitionCount));
 
         // Cold path: buffer full — enqueue pooled PendingAppend (zero async state machine allocation)
         return AppendSlowPathPooled(topic, partition, timestamp, key, value,
-            headers, headerCount, completionSource, callback, recordSize, cancellationToken, partitionCount);
+            headers, headerCount, completionSource, callback, recordSize, cancellationToken, partitionCount, cachePartitionCount);
     }
 
     private bool AppendAfterReservation(
@@ -2036,13 +2154,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
         int recordSize,
-        int partitionCount)
+        int partitionCount,
+        int cachePartitionCount)
     {
         if (completionSource is not null)
             Interlocked.Increment(ref _pendingAwaitedProduceCount);
 
         return AppendPooledAfterReservationCore(topic, partition, timestamp, key, value, headers, headerCount,
-            completionSource, callback, recordSize, partitionCount);
+            completionSource, callback, recordSize, partitionCount, cachePartitionCount);
     }
 
     private bool AppendPooledAfterReservationCore(
@@ -2056,10 +2175,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
         int recordSize,
-        int partitionCount)
+        int partitionCount,
+        int cachePartitionCount)
     {
         var topicPartition = new TopicPartition(topic, partition);
-        var pd = GetOrCreateDeque(topic, partition, partitionCount);
+        var pd = GetOrCreateDeque(topic, partition, cachePartitionCount);
         ReadyBatch? sealedBatchToEnqueue = null;
         PartitionBatch? rentedBatch = null;
         var ownsRotation = false;
@@ -2238,7 +2358,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Action<RecordMetadata, Exception?>? callback,
         int recordSize,
         CancellationToken cancellationToken,
-        int partitionCount = 0)
+        int partitionCount = 0,
+        int cachePartitionCount = 0)
     {
         if (Volatile.Read(ref _disposed) != 0)
         {
@@ -2259,7 +2380,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var (startTicks, deadline) = BeginReservationWait(recordSize);
 
         var op = _pendingAppendPool.Rent();
-        op.Initialize(topic, partition, partitionCount, timestamp, key, value, headers, headerCount,
+        op.Initialize(topic, partition, partitionCount, cachePartitionCount, timestamp, key, value, headers, headerCount,
             completionSource, callback, recordSize, startTicks, deadline,
             this, _pendingAppendPool, cancellationToken);
 
@@ -2301,7 +2422,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Header[]? headers,
         int headerCount,
         PooledValueTaskSource<RecordMetadata> completionSource,
-        int partitionCount = 0)
+        int partitionCount = 0,
+        int cachePartitionCount = 0)
     {
         if (Volatile.Read(ref _disposed) != 0)
             return false;
@@ -2317,7 +2439,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Interlocked.Increment(ref _pendingAwaitedProduceCount);
 
         return AppendPooledAfterReservationCore(topic, partition, timestamp, key, value, headers, headerCount,
-            completionSource, callback: null, recordSize, partitionCount);
+            completionSource, callback: null, recordSize, partitionCount, cachePartitionCount);
     }
 
     /// <summary>
@@ -2336,7 +2458,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Header[]? headers,
         int headerCount,
         PooledValueTaskSource<RecordMetadata> completionSource,
-        int partitionCount = 0)
+        int partitionCount = 0,
+        int cachePartitionCount = 0)
     {
         if (Volatile.Read(ref _disposed) != 0)
             return false;
@@ -2352,7 +2475,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         return AppendFromSpansAfterReservationCore(topic, partition, timestamp, keyData, keyIsNull,
             valueData, valueIsNull, headers, headerCount, completionSource, callback: null,
-            recordSize, partitionCount, returnHeadersOnFailure: false);
+            recordSize, partitionCount, cachePartitionCount, returnHeadersOnFailure: false);
     }
 
     private bool AppendFromSpansAfterReservationCore(
@@ -2369,10 +2492,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Action<RecordMetadata, Exception?>? callback,
         int recordSize,
         int partitionCount,
+        int cachePartitionCount,
         bool returnHeadersOnFailure)
     {
         var topicPartition = new TopicPartition(topic, partition);
-        var pd = GetOrCreateDeque(topic, partition, partitionCount);
+        var pd = GetOrCreateDeque(topic, partition, cachePartitionCount);
         ReadyBatch? sealedBatchToEnqueue = null;
         PartitionBatch? rentedBatch = null;
         var ownsRotation = false;
@@ -2579,7 +2703,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int headerCount,
         Action<RecordMetadata, Exception?>? callback,
         CancellationToken cancellationToken,
-        int partitionCount = 0)
+        int partitionCount = 0,
+        int cachePartitionCount = 0)
     {
         if (Volatile.Read(ref _disposed) != 0)
             return new ValueTask<bool>(false);
@@ -2591,7 +2716,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // Hot path: non-blocking CAS reservation — no async state machine allocated
         if (TryReserveMemory(recordSize))
             return new ValueTask<bool>(AppendFromSpansAfterReservation(topic, partition, timestamp,
-                keyData, keyIsNull, valueData, valueIsNull, headers, headerCount, callback, recordSize, partitionCount));
+                keyData, keyIsNull, valueData, valueIsNull, headers, headerCount, callback, recordSize, partitionCount, cachePartitionCount));
 
         // Cold path: buffer full. Copy spans to PooledMemory BEFORE the await boundary
         // (ReadOnlySpan<byte> cannot survive across async suspension points).
@@ -2599,7 +2724,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var valuePooled = valueIsNull ? PooledMemory.Null : CopySpanToPooledMemory(valueData);
 
         return AppendFromSpansSlowPathPooled(topic, partition, timestamp, keyPooled, valuePooled,
-            headers, headerCount, callback, recordSize, partitionCount, cancellationToken);
+            headers, headerCount, callback, recordSize, partitionCount, cachePartitionCount, cancellationToken);
     }
 
     /// <summary>
@@ -2617,11 +2742,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int headerCount,
         Action<RecordMetadata, Exception?>? callback,
         int recordSize,
-        int partitionCount)
+        int partitionCount,
+        int cachePartitionCount)
     {
         return AppendFromSpansAfterReservationCore(topic, partition, timestamp, keyData, keyIsNull,
             valueData, valueIsNull, headers, headerCount, completionSource: null, callback,
-            recordSize, partitionCount, returnHeadersOnFailure: true);
+            recordSize, partitionCount, cachePartitionCount, returnHeadersOnFailure: true);
     }
 
     /// <summary>
@@ -2639,10 +2765,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Action<RecordMetadata, Exception?>? callback,
         int recordSize,
         int partitionCount,
+        int cachePartitionCount,
         CancellationToken cancellationToken)
     {
         return AppendSlowPathPooled(topic, partition, timestamp, keyPooled, valuePooled,
-            headers, headerCount, null, callback, recordSize, cancellationToken, partitionCount);
+            headers, headerCount, null, callback, recordSize, cancellationToken, partitionCount, cachePartitionCount);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1863,9 +1863,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     // Single thread-local cache consolidating all per-thread deque lookup state.
     // Reduces 3 separate [ThreadStatic] lookups to 1.
-    // Per-thread one-slot cache for GetOrCreateDeque to avoid ConcurrentDictionary hash+lookup
-    // on every message. The cache stores (accumulator instance, TopicPartition, PartitionDeque).
-    // Hit rate is high in partition-affine append workers and single-partition scenarios.
+    // Per-thread topic cache for GetOrCreateDeque to avoid ConcurrentDictionary hash+lookup
+    // when a thread rotates through partitions of the same topic.
     // Note: holds a strong reference to the accumulator until the thread reuses the cache slot.
     // This is acceptable because producers are typically singleton-lifetime objects.
     // IMPORTANT: This cache is only valid because _partitionDeques never removes entries.
@@ -1880,40 +1879,85 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private sealed class AccumulatorThreadCache
     {
         public RecordAccumulator? CachedAccumulator;
-        public TopicPartition CachedTopicPartition;
-        public PartitionDeque? CachedDeque;
+        public string? CachedTopic;
+        public PartitionDeque?[]? CachedTopicDeques;
     }
 
     /// <summary>
     /// Gets or creates the PartitionDeque for a topic-partition pair.
-    /// Uses a per-thread one-slot cache to avoid ConcurrentDictionary lookup when the
-    /// same thread repeatedly accesses the same partition (common in append workers).
+    /// Uses a per-thread topic cache to avoid ConcurrentDictionary lookup when the
+    /// same thread rotates through partitions of one topic.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private PartitionDeque GetOrCreateDeque(string topic, int partition)
+    private PartitionDeque GetOrCreateDeque(string topic, int partition, int partitionCount)
+    {
+        var cache = t_cache ??= new AccumulatorThreadCache();
+        var cachedTopic = cache.CachedTopic;
+        var cachedDeques = cache.CachedTopicDeques;
+
+        if (cache.CachedAccumulator == this &&
+            Volatile.Read(ref _disposed) == 0 &&
+            TopicMatches(cachedTopic, topic) &&
+            cachedDeques is not null &&
+            (uint)partition < (uint)cachedDeques.Length &&
+            cachedDeques[partition] is { } cached)
+        {
+            return cached;
+        }
+
+        return GetOrCreateDequeSlow(topic, partition, partitionCount, cache);
+    }
+
+    private PartitionDeque GetOrCreateDeque(string topic, int partition) =>
+        GetOrCreateDeque(topic, partition, partition + 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private PartitionDeque GetOrCreateDequeSlow(
+        string topic,
+        int partition,
+        int partitionCount,
+        AccumulatorThreadCache cache)
     {
         var tp = new TopicPartition(topic, partition);
-
-        // Fast path: check thread-local cache (skip if disposed to avoid serving stale data)
-        var cache = t_cache ??= new AccumulatorThreadCache();
-        if (cache.CachedAccumulator == this && Volatile.Read(ref _disposed) == 0 && cache.CachedTopicPartition == tp && cache.CachedDeque is { } cached)
-            return cached;
-
-        return GetOrCreateDequeSlow(tp, cache);
+        var deque = _partitionDeques.GetOrAdd(tp, static _ => new PartitionDeque());
+        var deques = GetOrCreateCachedDequeArray(topic, partition, partitionCount, cache);
+        deques[partition] = deque;
+        return deque;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private PartitionDeque GetOrCreateDequeSlow(TopicPartition tp, AccumulatorThreadCache cache)
+    private PartitionDeque?[] GetOrCreateCachedDequeArray(
+        string topic,
+        int partition,
+        int partitionCount,
+        AccumulatorThreadCache cache)
     {
-        var deque = _partitionDeques.GetOrAdd(tp, static _ => new PartitionDeque());
+        var cachedTopic = cache.CachedTopic;
+        var capacity = Math.Max(partition + 1, partitionCount);
 
-        // Update thread-local cache
+        if (cache.CachedAccumulator == this &&
+            TopicMatches(cachedTopic, topic) &&
+            cache.CachedTopicDeques is { } existing)
+        {
+            if (existing.Length >= capacity)
+                return existing;
+
+            Array.Resize(ref existing, capacity);
+            cache.CachedTopicDeques = existing;
+            return existing;
+        }
+
+        var deques = new PartitionDeque?[capacity];
         cache.CachedAccumulator = this;
-        cache.CachedTopicPartition = tp;
-        cache.CachedDeque = deque;
-
-        return deque;
+        cache.CachedTopic = topic;
+        cache.CachedTopicDeques = deques;
+        return deques;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TopicMatches(string? cachedTopic, string topic) =>
+        ReferenceEquals(cachedTopic, topic) ||
+        string.Equals(cachedTopic, topic, StringComparison.Ordinal);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void TrackCurrentBatchForLinger(PartitionDeque pd, TopicPartition topicPartition, PartitionBatch batch)
@@ -2015,7 +2059,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int partitionCount)
     {
         var topicPartition = new TopicPartition(topic, partition);
-        var pd = GetOrCreateDeque(topic, partition);
+        var pd = GetOrCreateDeque(topic, partition, partitionCount);
         ReadyBatch? sealedBatchToEnqueue = null;
         PartitionBatch? rentedBatch = null;
         var ownsRotation = false;
@@ -2328,7 +2372,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         bool returnHeadersOnFailure)
     {
         var topicPartition = new TopicPartition(topic, partition);
-        var pd = GetOrCreateDeque(topic, partition);
+        var pd = GetOrCreateDeque(topic, partition, partitionCount);
         ReadyBatch? sealedBatchToEnqueue = null;
         PartitionBatch? rentedBatch = null;
         var ownsRotation = false;

--- a/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
@@ -119,16 +119,40 @@ public class AppendWorkerAffinityTests
         GetThreadCacheField().SetValue(null, null);
         var getOrCreateDeque = GetOrCreateDequeMethod();
 
-        var first = getOrCreateDeque.Invoke(accumulator, ["test-topic", 0, 1]);
+        var first = getOrCreateDeque.Invoke(accumulator, ["test-topic", 0, 0]);
         var firstArray = GetCachedTopicDeques();
 
-        var fourth = getOrCreateDeque.Invoke(accumulator, ["test-topic", 3, 1]);
+        var second = getOrCreateDeque.Invoke(accumulator, ["test-topic", 1, 0]);
+        var secondArray = GetCachedTopicDeques();
+
+        var third = getOrCreateDeque.Invoke(accumulator, ["test-topic", 2, 0]);
         var grownArray = GetCachedTopicDeques();
 
-        await Assert.That(grownArray.Length).IsGreaterThanOrEqualTo(4);
+        await Assert.That(firstArray.Length).IsEqualTo(1);
+        await Assert.That(secondArray.Length).IsEqualTo(2);
+        await Assert.That(grownArray.Length).IsEqualTo(4);
+        await Assert.That(secondArray).IsNotSameReferenceAs(firstArray);
+        await Assert.That(grownArray).IsNotSameReferenceAs(secondArray);
         await Assert.That(grownArray).IsNotSameReferenceAs(firstArray);
         await Assert.That(grownArray.GetValue(0)).IsSameReferenceAs(first);
-        await Assert.That(grownArray.GetValue(3)).IsSameReferenceAs(fourth);
+        await Assert.That(grownArray.GetValue(1)).IsSameReferenceAs(second);
+        await Assert.That(grownArray.GetValue(2)).IsSameReferenceAs(third);
+
+        await accumulator.DisposeAsync();
+    }
+
+    [Test]
+    public async Task GetOrCreateDeque_KeyedCacheHint_SizesArrayWithTopicPartitionCount()
+    {
+        var accumulator = new RecordAccumulator(CreateTestOptions());
+        GetThreadCacheField().SetValue(null, null);
+        var getOrCreateDeque = GetOrCreateDequeMethod();
+
+        var deque = getOrCreateDeque.Invoke(accumulator, ["test-topic", 2, 6]);
+        var cachedDeques = GetCachedTopicDeques();
+
+        await Assert.That(cachedDeques.Length).IsEqualTo(6);
+        await Assert.That(cachedDeques.GetValue(2)).IsSameReferenceAs(deque);
 
         await accumulator.DisposeAsync();
     }
@@ -150,6 +174,28 @@ public class AppendWorkerAffinityTests
         await Assert.That(secondArray).IsNotSameReferenceAs(firstArray);
         await Assert.That(secondArray.GetValue(0)).IsSameReferenceAs(secondTopicDeque);
         await Assert.That(secondTopicDeque).IsNotSameReferenceAs(firstTopicDeque);
+
+        await accumulator.DisposeAsync();
+    }
+
+    [Test]
+    public async Task GetOrCreateDeque_WhenTopicReturns_ReusesCachedTopicArray()
+    {
+        var accumulator = new RecordAccumulator(CreateTestOptions());
+        GetThreadCacheField().SetValue(null, null);
+        var getOrCreateDeque = GetOrCreateDequeMethod();
+
+        var firstTopicDeque = getOrCreateDeque.Invoke(accumulator, ["topic-a", 0, 4]);
+        var firstArray = GetCachedTopicDeques();
+
+        _ = getOrCreateDeque.Invoke(accumulator, ["topic-b", 0, 4]);
+
+        var firstTopicAgain = getOrCreateDeque.Invoke(accumulator, ["topic-a", 0, 4]);
+        var firstArrayAgain = GetCachedTopicDeques();
+
+        await Assert.That(GetCachedTopic()).IsEqualTo("topic-a");
+        await Assert.That(firstTopicAgain).IsSameReferenceAs(firstTopicDeque);
+        await Assert.That(firstArrayAgain).IsSameReferenceAs(firstArray);
 
         await accumulator.DisposeAsync();
     }

--- a/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
@@ -70,17 +70,23 @@ public class AppendWorkerAffinityTests
         GetThreadCacheField().GetValue(null)
         ?? throw new InvalidOperationException("Accumulator thread cache not initialized.");
 
-    private static Array GetCachedTopicDeques()
+    private static object GetCachedTopicEntry()
     {
         var cache = GetThreadCache();
-        return (Array?)cache.GetType().GetField("CachedTopicDeques")!.GetValue(cache)
+        return cache.GetType().GetField("CachedTopicEntry")!.GetValue(cache)
             ?? throw new InvalidOperationException("Cached topic deque array not initialized.");
+    }
+
+    private static Array GetCachedTopicDeques()
+    {
+        var entry = GetCachedTopicEntry();
+        return (Array)entry.GetType().GetField("Deques")!.GetValue(entry)!;
     }
 
     private static string? GetCachedTopic()
     {
-        var cache = GetThreadCache();
-        return (string?)cache.GetType().GetField("CachedTopic")!.GetValue(cache);
+        var entry = GetCachedTopicEntry();
+        return (string?)entry.GetType().GetProperty("Topic")!.GetValue(entry);
     }
 
     [Test]
@@ -100,8 +106,10 @@ public class AppendWorkerAffinityTests
 
         var cache = cacheField.GetValue(null)
             ?? throw new InvalidOperationException("Accumulator thread cache not initialized.");
-        var cachedTopic = (string?)cache.GetType().GetField("CachedTopic")!.GetValue(cache);
-        var cachedDeques = (Array?)cache.GetType().GetField("CachedTopicDeques")!.GetValue(cache);
+        var cachedEntry = cache.GetType().GetField("CachedTopicEntry")!.GetValue(cache)
+            ?? throw new InvalidOperationException("Cached topic entry not initialized.");
+        var cachedTopic = (string?)cachedEntry.GetType().GetProperty("Topic")!.GetValue(cachedEntry);
+        var cachedDeques = (Array?)cachedEntry.GetType().GetField("Deques")!.GetValue(cachedEntry);
 
         await Assert.That(firstAgain).IsSameReferenceAs(first);
         await Assert.That(cachedTopic).IsEqualTo("test-topic");
@@ -196,6 +204,50 @@ public class AppendWorkerAffinityTests
         await Assert.That(GetCachedTopic()).IsEqualTo("topic-a");
         await Assert.That(firstTopicAgain).IsSameReferenceAs(firstTopicDeque);
         await Assert.That(firstArrayAgain).IsSameReferenceAs(firstArray);
+
+        await accumulator.DisposeAsync();
+    }
+
+    [Test]
+    public async Task GetOrCreateDeque_WhenMoreThanEightTopicsReturn_ReusesCachedTopicArrays()
+    {
+        var accumulator = new RecordAccumulator(CreateTestOptions());
+        GetThreadCacheField().SetValue(null, null);
+        var getOrCreateDeque = GetOrCreateDequeMethod();
+        var deques = new object[12];
+        var arrays = new Array[12];
+
+        for (var i = 0; i < deques.Length; i++)
+        {
+            deques[i] = getOrCreateDeque.Invoke(accumulator, [$"topic-{i}", 0, 4])!;
+            arrays[i] = GetCachedTopicDeques();
+        }
+
+        for (var i = 0; i < deques.Length; i++)
+        {
+            var deque = getOrCreateDeque.Invoke(accumulator, [$"topic-{i}", 0, 4]);
+            var cachedArray = GetCachedTopicDeques();
+
+            await Assert.That(deque).IsSameReferenceAs(deques[i]);
+            await Assert.That(cachedArray).IsSameReferenceAs(arrays[i]);
+        }
+
+        await accumulator.DisposeAsync();
+    }
+
+    [Test]
+    public async Task GetOrCreateDeque_InvalidPartition_DoesNotIndexDequeCache()
+    {
+        var accumulator = new RecordAccumulator(CreateTestOptions());
+        GetThreadCacheField().SetValue(null, null);
+        var getOrCreateDeque = GetOrCreateDequeMethod();
+
+        var negative = getOrCreateDeque.Invoke(accumulator, ["test-topic", -1, 4]);
+        var negativeAgain = getOrCreateDeque.Invoke(accumulator, ["test-topic", -1, 4]);
+        var large = getOrCreateDeque.Invoke(accumulator, ["test-topic", int.MaxValue, 4]);
+
+        await Assert.That(negativeAgain).IsSameReferenceAs(negative);
+        await Assert.That(large).IsNotNull();
 
         await accumulator.DisposeAsync();
     }

--- a/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
@@ -52,24 +52,47 @@ public class AppendWorkerAffinityTests
         return (int)deques.GetType().GetProperty("Count")!.GetValue(deques)!;
     }
 
+    private static FieldInfo GetThreadCacheField() =>
+        typeof(RecordAccumulator).GetField(
+            "t_cache",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static MethodInfo GetOrCreateDequeMethod() =>
+        typeof(RecordAccumulator).GetMethod(
+            "GetOrCreateDeque",
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null,
+            [typeof(string), typeof(int), typeof(int)],
+            modifiers: null)
+        ?? throw new InvalidOperationException("GetOrCreateDeque overload not found.");
+
+    private static object GetThreadCache() =>
+        GetThreadCacheField().GetValue(null)
+        ?? throw new InvalidOperationException("Accumulator thread cache not initialized.");
+
+    private static Array GetCachedTopicDeques()
+    {
+        var cache = GetThreadCache();
+        return (Array?)cache.GetType().GetField("CachedTopicDeques")!.GetValue(cache)
+            ?? throw new InvalidOperationException("Cached topic deque array not initialized.");
+    }
+
+    private static string? GetCachedTopic()
+    {
+        var cache = GetThreadCache();
+        return (string?)cache.GetType().GetField("CachedTopic")!.GetValue(cache);
+    }
+
     [Test]
     public async Task GetOrCreateDeque_RoundRobinPartitions_CachesPerTopicArray()
     {
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
 
-        var cacheField = typeof(RecordAccumulator).GetField(
-            "t_cache",
-            BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cacheField = GetThreadCacheField();
         cacheField.SetValue(null, null);
 
-        var getOrCreateDeque = typeof(RecordAccumulator).GetMethod(
-            "GetOrCreateDeque",
-            BindingFlags.NonPublic | BindingFlags.Instance,
-            binder: null,
-            [typeof(string), typeof(int), typeof(int)],
-            modifiers: null)
-            ?? throw new InvalidOperationException("GetOrCreateDeque overload not found.");
+        var getOrCreateDeque = GetOrCreateDequeMethod();
 
         var first = getOrCreateDeque.Invoke(accumulator, ["test-topic", 0, 4]);
         var second = getOrCreateDeque.Invoke(accumulator, ["test-topic", 1, 4]);
@@ -85,6 +108,48 @@ public class AppendWorkerAffinityTests
         await Assert.That(cachedDeques).IsNotNull();
         await Assert.That(cachedDeques!.GetValue(0)).IsSameReferenceAs(first);
         await Assert.That(cachedDeques.GetValue(1)).IsSameReferenceAs(second);
+
+        await accumulator.DisposeAsync();
+    }
+
+    [Test]
+    public async Task GetOrCreateDeque_PartitionBeyondCachedArray_GrowsTopicArray()
+    {
+        var accumulator = new RecordAccumulator(CreateTestOptions());
+        GetThreadCacheField().SetValue(null, null);
+        var getOrCreateDeque = GetOrCreateDequeMethod();
+
+        var first = getOrCreateDeque.Invoke(accumulator, ["test-topic", 0, 1]);
+        var firstArray = GetCachedTopicDeques();
+
+        var fourth = getOrCreateDeque.Invoke(accumulator, ["test-topic", 3, 1]);
+        var grownArray = GetCachedTopicDeques();
+
+        await Assert.That(grownArray.Length).IsGreaterThanOrEqualTo(4);
+        await Assert.That(grownArray).IsNotSameReferenceAs(firstArray);
+        await Assert.That(grownArray.GetValue(0)).IsSameReferenceAs(first);
+        await Assert.That(grownArray.GetValue(3)).IsSameReferenceAs(fourth);
+
+        await accumulator.DisposeAsync();
+    }
+
+    [Test]
+    public async Task GetOrCreateDeque_WhenTopicChanges_ReplacesCachedTopicArray()
+    {
+        var accumulator = new RecordAccumulator(CreateTestOptions());
+        GetThreadCacheField().SetValue(null, null);
+        var getOrCreateDeque = GetOrCreateDequeMethod();
+
+        var firstTopicDeque = getOrCreateDeque.Invoke(accumulator, ["topic-a", 0, 4]);
+        var firstArray = GetCachedTopicDeques();
+
+        var secondTopicDeque = getOrCreateDeque.Invoke(accumulator, ["topic-b", 0, 4]);
+        var secondArray = GetCachedTopicDeques();
+
+        await Assert.That(GetCachedTopic()).IsEqualTo("topic-b");
+        await Assert.That(secondArray).IsNotSameReferenceAs(firstArray);
+        await Assert.That(secondArray.GetValue(0)).IsSameReferenceAs(secondTopicDeque);
+        await Assert.That(secondTopicDeque).IsNotSameReferenceAs(firstTopicDeque);
 
         await accumulator.DisposeAsync();
     }

--- a/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Reflection;
 using Dekaf.Producer;
 using Dekaf.Protocol.Records;
 using Dekaf.Tests.Unit;
@@ -49,6 +50,43 @@ public class AppendWorkerAffinityTests
     private static int GetDequeCount(object deques)
     {
         return (int)deques.GetType().GetProperty("Count")!.GetValue(deques)!;
+    }
+
+    [Test]
+    public async Task GetOrCreateDeque_RoundRobinPartitions_CachesPerTopicArray()
+    {
+        var options = CreateTestOptions();
+        var accumulator = new RecordAccumulator(options);
+
+        var cacheField = typeof(RecordAccumulator).GetField(
+            "t_cache",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        cacheField.SetValue(null, null);
+
+        var getOrCreateDeque = typeof(RecordAccumulator).GetMethod(
+            "GetOrCreateDeque",
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null,
+            [typeof(string), typeof(int), typeof(int)],
+            modifiers: null)
+            ?? throw new InvalidOperationException("GetOrCreateDeque overload not found.");
+
+        var first = getOrCreateDeque.Invoke(accumulator, ["test-topic", 0, 4]);
+        var second = getOrCreateDeque.Invoke(accumulator, ["test-topic", 1, 4]);
+        var firstAgain = getOrCreateDeque.Invoke(accumulator, ["test-topic", 0, 4]);
+
+        var cache = cacheField.GetValue(null)
+            ?? throw new InvalidOperationException("Accumulator thread cache not initialized.");
+        var cachedTopic = (string?)cache.GetType().GetField("CachedTopic")!.GetValue(cache);
+        var cachedDeques = (Array?)cache.GetType().GetField("CachedTopicDeques")!.GetValue(cache);
+
+        await Assert.That(firstAgain).IsSameReferenceAs(first);
+        await Assert.That(cachedTopic).IsEqualTo("test-topic");
+        await Assert.That(cachedDeques).IsNotNull();
+        await Assert.That(cachedDeques!.GetValue(0)).IsSameReferenceAs(first);
+        await Assert.That(cachedDeques.GetValue(1)).IsSameReferenceAs(second);
+
+        await accumulator.DisposeAsync();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text;
+using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Producer;
 using Dekaf.Protocol;
@@ -112,6 +113,80 @@ public class KafkaProducerFastPathTests
         await Assert.That(metadata.Offset).IsEqualTo(7);
     }
 
+    [Test]
+    public async Task ProduceAsync_InvalidExplicitPartition_FaultsBeforeAccumulatorAppend()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 4096,
+            LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000
+        };
+
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        await StopProducerBackgroundLoopsAsync(producer);
+        SeedProducerMetadata(producer);
+        SetInstanceField(producer, "_initialized", true);
+
+        var exception = await CaptureProduceExceptionAsync(() => producer.ProduceAsync(
+            new ProducerMessage<string, string>
+            {
+                Topic = Topic,
+                Key = "key",
+                Value = "value",
+                Partition = -1
+            }));
+
+        await Assert.That(exception.Topic).IsEqualTo(Topic);
+        await Assert.That(exception.Partition).IsEqualTo(-1);
+        await Assert.That(GetPartitionDequeCount(producer.RecordAccumulator)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ProduceAsync_InvalidPartitionerResult_FaultsBeforeAccumulatorAppend()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 4096,
+            LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000,
+            CustomPartitioner = new FixedPartitioner(int.MaxValue)
+        };
+
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        await StopProducerBackgroundLoopsAsync(producer);
+        SeedProducerMetadata(producer);
+        SetInstanceField(producer, "_initialized", true);
+
+        var exception = await CaptureProduceExceptionAsync(() => producer.ProduceAsync(
+            new ProducerMessage<string, string>
+            {
+                Topic = Topic,
+                Key = "key",
+                Value = "value"
+            }));
+
+        await Assert.That(exception.Topic).IsEqualTo(Topic);
+        await Assert.That(exception.Partition).IsEqualTo(int.MaxValue);
+        await Assert.That(GetPartitionDequeCount(producer.RecordAccumulator)).IsEqualTo(0);
+    }
+
     private static TopicInfo CreateTopicInfo() => new()
     {
         Name = Topic,
@@ -214,6 +289,26 @@ public class KafkaProducerFastPathTests
         throw new InvalidOperationException("Partition deque did not contain a current or sealed batch.");
     }
 
+    private static int GetPartitionDequeCount(RecordAccumulator accumulator)
+    {
+        var deques = GetInstanceField<object>(accumulator, "_partitionDeques");
+        return (int)deques.GetType().GetProperty("Count")!.GetValue(deques)!;
+    }
+
+    private static async Task<ProduceException> CaptureProduceExceptionAsync(Func<ValueTask<RecordMetadata>> action)
+    {
+        try
+        {
+            _ = await action().ConfigureAwait(false);
+        }
+        catch (ProduceException ex)
+        {
+            return ex;
+        }
+
+        throw new InvalidOperationException("Expected ProduceException was not thrown.");
+    }
+
     private static async Task StopProducerBackgroundLoopsAsync(KafkaProducer<string, string> producer)
     {
         var cts = GetInstanceField<CancellationTokenSource>(producer, "_senderCts");
@@ -262,5 +357,11 @@ public class KafkaProducerFastPathTests
 
             return 0;
         }
+    }
+
+    private sealed class FixedPartitioner(int partition) : IPartitioner
+    {
+        public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+            => partition;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -187,6 +187,88 @@ public class KafkaProducerFastPathTests
         await Assert.That(GetPartitionDequeCount(producer.RecordAccumulator)).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task ProduceInternalAsync_InvalidExplicitPartition_FaultsBeforeAccumulatorAppend()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 4096,
+            LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000
+        };
+
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        await StopProducerBackgroundLoopsAsync(producer);
+        SeedProducerMetadata(producer);
+        SetInstanceField(producer, "_initialized", true);
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var completion = pool.Rent();
+
+        var exception = await CaptureProduceExceptionAsync(() => InvokeProduceInternalAsync(
+            producer,
+            new ProducerMessage<string, string>
+            {
+                Topic = Topic,
+                Key = "key",
+                Value = "value",
+                Partition = -1
+            },
+            completion));
+
+        await Assert.That(exception.Topic).IsEqualTo(Topic);
+        await Assert.That(exception.Partition).IsEqualTo(-1);
+        await Assert.That(GetPartitionDequeCount(producer.RecordAccumulator)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ProduceInternalAsync_InvalidPartitionerResult_FaultsBeforeAccumulatorAppend()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 4096,
+            LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000,
+            CustomPartitioner = new FixedPartitioner(int.MaxValue)
+        };
+
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        await StopProducerBackgroundLoopsAsync(producer);
+        SeedProducerMetadata(producer);
+        SetInstanceField(producer, "_initialized", true);
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var completion = pool.Rent();
+
+        var exception = await CaptureProduceExceptionAsync(() => InvokeProduceInternalAsync(
+            producer,
+            new ProducerMessage<string, string>
+            {
+                Topic = Topic,
+                Key = "key",
+                Value = "value"
+            },
+            completion));
+
+        await Assert.That(exception.Topic).IsEqualTo(Topic);
+        await Assert.That(exception.Partition).IsEqualTo(int.MaxValue);
+        await Assert.That(GetPartitionDequeCount(producer.RecordAccumulator)).IsEqualTo(0);
+    }
+
     private static TopicInfo CreateTopicInfo() => new()
     {
         Name = Topic,
@@ -264,6 +346,29 @@ public class KafkaProducerFastPathTests
         }
     }
 
+    private static ValueTask InvokeProduceInternalAsync(
+        KafkaProducer<string, string> producer,
+        ProducerMessage<string, string> message,
+        PooledValueTaskSource<RecordMetadata> completion)
+    {
+        var method = typeof(KafkaProducer<string, string>).GetMethod(
+            "ProduceInternalAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null,
+            [typeof(ProducerMessage<string, string>), typeof(PooledValueTaskSource<RecordMetadata>), typeof(CancellationToken)],
+            modifiers: null);
+
+        try
+        {
+            return (ValueTask)method!.Invoke(producer, [message, completion, CancellationToken.None])!;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
+    }
+
     private static ReadyBatch CompleteCurrentBatch(RecordAccumulator accumulator, TopicPartition topicPartition)
     {
         var deques = GetInstanceField<object>(accumulator, "_partitionDeques");
@@ -300,6 +405,20 @@ public class KafkaProducerFastPathTests
         try
         {
             _ = await action().ConfigureAwait(false);
+        }
+        catch (ProduceException ex)
+        {
+            return ex;
+        }
+
+        throw new InvalidOperationException("Expected ProduceException was not thrown.");
+    }
+
+    private static async Task<ProduceException> CaptureProduceExceptionAsync(Func<ValueTask> action)
+    {
+        try
+        {
+            await action().ConfigureAwait(false);
         }
         catch (ProduceException ex)
         {

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -1091,8 +1091,8 @@ public class RecordAccumulatorReadyTests
         var method = typeof(RecordAccumulator).GetMethod(
             "GetOrCreateDeque",
             BindingFlags.NonPublic | BindingFlags.Instance,
-            [typeof(string), typeof(int)]);
-        return method!.Invoke(accumulator, [topic, partition])!;
+            [typeof(string), typeof(int), typeof(int)]);
+        return method!.Invoke(accumulator, [topic, partition, 0])!;
     }
 
     private static void SetInstanceField<T>(object instance, string fieldName, T value)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AccumulatorAppendBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AccumulatorAppendBenchmarks.cs
@@ -20,6 +20,7 @@ public class AccumulatorAppendBenchmarks
     private byte[] _keyBytes = null!;
     private byte[] _valueBytes = null!;
     private string[] _topics = null!;
+    private string[] _manyTopics = null!;
     private CancellationTokenSource _drainerCts = null!;
     private Task _drainerTask = null!;
 
@@ -47,6 +48,7 @@ public class AccumulatorAppendBenchmarks
             "bench-topic-2",
             "bench-topic-3"
         ];
+        _manyTopics = Enumerable.Range(0, 12).Select(static i => $"bench-many-topic-{i}").ToArray();
 
         // Warmup: fill and drain multiple complete batches to warm all pools:
         // BatchArena static pool, PartitionBatchPool, ReadyBatchPool, and BatchArrayReuseQueue.
@@ -66,6 +68,12 @@ public class AccumulatorAppendBenchmarks
         {
             for (var p = 0; p < 10; p++)
                 FillAndDrain(_topics[t], partition: p, batchCount: 1, msgsPerBatch, ts, cachePartitionCount: 10);
+        }
+
+        for (var t = 0; t < _manyTopics.Length; t++)
+        {
+            for (var p = 0; p < 10; p++)
+                FillAndDrain(_manyTopics[t], partition: p, batchCount: 1, msgsPerBatch, ts, cachePartitionCount: 10);
         }
 
         // Start background drainer to prevent buffer from filling
@@ -100,7 +108,7 @@ public class AccumulatorAppendBenchmarks
 
     /// <summary>
     /// Same as AppendHotPath but spreads across multiple partitions.
-    /// Tests whether partition-switching adds allocation (cache misses, new deques).
+    /// Tests whether partition-switching stays allocation-free after cache warmup.
     /// </summary>
     [Benchmark(OperationsPerInvoke = 100)]
     public void AppendMultiPartition()
@@ -117,8 +125,7 @@ public class AccumulatorAppendBenchmarks
 
     /// <summary>
     /// Keyed traffic uses partitionCount: 0 for batch rotation, but still has the topic
-    /// partition count as the cache sizing hint. Rotates topics on one thread to catch
-    /// per-switch allocations in the thread-local deque cache.
+    /// partition count as the cache sizing hint. Rotates a small warmed topic set on one thread.
     /// </summary>
     [Benchmark(OperationsPerInvoke = 100)]
     public void AppendKeyedMultiTopic()
@@ -128,6 +135,25 @@ public class AccumulatorAppendBenchmarks
         {
             _accumulator.AppendFromSpansAsync(
                 _topics[i % _topics.Length], i % 10, ts,
+                _keyBytes, false, _valueBytes, false,
+                null, 0, null, CancellationToken.None,
+                partitionCount: 0,
+                cachePartitionCount: 10).GetAwaiter().GetResult();
+        }
+    }
+
+    /// <summary>
+    /// Keeps a warmed working set larger than the former 8-topic thread-local cache.
+    /// Expected: zero allocation per call after warmup.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = 120)]
+    public void AppendKeyedManyTopics()
+    {
+        var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        for (var i = 0; i < 120; i++)
+        {
+            _accumulator.AppendFromSpansAsync(
+                _manyTopics[i % _manyTopics.Length], i % 10, ts,
                 _keyBytes, false, _valueBytes, false,
                 null, 0, null, CancellationToken.None,
                 partitionCount: 0,

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AccumulatorAppendBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AccumulatorAppendBenchmarks.cs
@@ -19,6 +19,7 @@ public class AccumulatorAppendBenchmarks
     private RecordAccumulator _accumulator = null!;
     private byte[] _keyBytes = null!;
     private byte[] _valueBytes = null!;
+    private string[] _topics = null!;
     private CancellationTokenSource _drainerCts = null!;
     private Task _drainerTask = null!;
 
@@ -39,6 +40,13 @@ public class AccumulatorAppendBenchmarks
         _accumulator = new RecordAccumulator(options);
         _keyBytes = Encoding.UTF8.GetBytes("benchmark-key-0");
         _valueBytes = new byte[MessageSize];
+        _topics =
+        [
+            "bench-topic-0",
+            "bench-topic-1",
+            "bench-topic-2",
+            "bench-topic-3"
+        ];
 
         // Warmup: fill and drain multiple complete batches to warm all pools:
         // BatchArena static pool, PartitionBatchPool, ReadyBatchPool, and BatchArrayReuseQueue.
@@ -53,6 +61,12 @@ public class AccumulatorAppendBenchmarks
         // Warm multi-partition deques used by AppendMultiPartition
         for (var p = 0; p < 10; p++)
             FillAndDrain(partition: p, batchCount: 1, msgsPerBatch, ts);
+
+        for (var t = 0; t < _topics.Length; t++)
+        {
+            for (var p = 0; p < 10; p++)
+                FillAndDrain(_topics[t], partition: p, batchCount: 1, msgsPerBatch, ts, cachePartitionCount: 10);
+        }
 
         // Start background drainer to prevent buffer from filling
         _drainerCts = new CancellationTokenSource();
@@ -101,15 +115,46 @@ public class AccumulatorAppendBenchmarks
         }
     }
 
-    private void FillAndDrain(int partition, int batchCount, int msgsPerBatch, long ts)
+    /// <summary>
+    /// Keyed traffic uses partitionCount: 0 for batch rotation, but still has the topic
+    /// partition count as the cache sizing hint. Rotates topics on one thread to catch
+    /// per-switch allocations in the thread-local deque cache.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = 100)]
+    public void AppendKeyedMultiTopic()
+    {
+        var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        for (var i = 0; i < 100; i++)
+        {
+            _accumulator.AppendFromSpansAsync(
+                _topics[i % _topics.Length], i % 10, ts,
+                _keyBytes, false, _valueBytes, false,
+                null, 0, null, CancellationToken.None,
+                partitionCount: 0,
+                cachePartitionCount: 10).GetAwaiter().GetResult();
+        }
+    }
+
+    private void FillAndDrain(int partition, int batchCount, int msgsPerBatch, long ts) =>
+        FillAndDrain("bench-topic", partition, batchCount, msgsPerBatch, ts, cachePartitionCount: 0);
+
+    private void FillAndDrain(
+        string topic,
+        int partition,
+        int batchCount,
+        int msgsPerBatch,
+        long ts,
+        int cachePartitionCount)
     {
         var totalMessages = msgsPerBatch * batchCount;
         for (var i = 0; i < totalMessages; i++)
         {
             _accumulator.AppendFromSpansAsync(
-                "bench-topic", partition, ts,
+                topic, partition, ts,
                 _keyBytes, false, _valueBytes, false,
-                null, 0, null, CancellationToken.None).GetAwaiter().GetResult();
+                null, 0, null, CancellationToken.None,
+                partitionCount: 0,
+                cachePartitionCount: cachePartitionCount).GetAwaiter().GetResult();
 
             // Drain periodically to release memory and return arenas/arrays to pools
             if (i % msgsPerBatch == msgsPerBatch - 1)


### PR DESCRIPTION
Refs #935.

Summary:
- Replace the one-slot per-thread `RecordAccumulator` deque cache with a per-topic `PartitionDeque?[]` indexed by partition.
- Keep the existing two-arg private helper for reflection-based tests while routing hot append paths through the partition-count-aware cache.
- Add coverage for round-robin partition lookups staying cached for the same topic.

Validation:
- `dotnet restore`
- `dotnet build Dekaf.sln -c Release --no-restore`
- `./tests/Dekaf.Tests.Unit/bin/Debug/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/AppendWorkerAffinityTests/*"`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/AppendWorkerAffinityTests/*"`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordAccumulatorReadyTests/*"`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordAccumulatorTests/*"`
- `dotnet format --verify-no-changes --verbosity minimal --include src\Dekaf\Producer\RecordAccumulator.cs tests\Dekaf.Tests.Unit\Producer\AppendWorkerAffinityTests.cs`