### PR TITLE
fix(api): polish DX nits

### DIFF
--- a/docs/docs/dependency-injection.md
+++ b/docs/docs/dependency-injection.md
@@ -337,7 +337,7 @@ Hosted consumer services should use the async disposal path provided by the gene
 Before:
 
 ```csharp
-service.Dispose(); // synchronous fallback; cancels the BackgroundService only
+service.Dispose(); // synchronous fallback; blocks while cleanup completes
 ```
 
 After:

--- a/docs/docs/dependency-injection.md
+++ b/docs/docs/dependency-injection.md
@@ -332,6 +332,22 @@ The section keys match `ProducerOptions`, `ConsumerOptions`, and `AdminClientOpt
 
 Both producers and consumers are registered as singletons. This is intentional—they're expensive to create, thread-safe, and meant to be reused. They'll be disposed automatically when your app shuts down.
 
+Hosted consumer services should use the async disposal path provided by the generic host. `KafkaConsumerService<TKey, TValue>` implements `IAsyncDisposable`, so shutdown can flush and dispose its consumer and optional dead-letter producer without blocking a thread.
+
+Before:
+
+```csharp
+service.Dispose(); // synchronous fallback; cancels the BackgroundService only
+```
+
+After:
+
+```csharp
+await service.DisposeAsync(); // awaits consumer and DLQ producer disposal
+```
+
+When the service is registered with `AddHostedService`, the host calls the async path during normal shutdown.
+
 ## Complete Example
 
 ```csharp

--- a/docs/docs/producer/fire-and-forget.md
+++ b/docs/docs/producer/fire-and-forget.md
@@ -4,21 +4,28 @@ sidebar_position: 3
 
 # Fire-and-Forget Production
 
-For high-throughput scenarios where you don't need to wait for acknowledgment, Dekaf provides fire-and-forget methods that return immediately.
+For high-throughput scenarios where you don't need to wait for acknowledgment, Dekaf provides `FireAsync` methods. `FireAsync` means "enqueue this record and return once local backpressure has accepted it"; it does not wait for broker acknowledgment.
 
-## The Produce() Method
+## FireAsync vs ProduceAsync
 
-`Produce()` queues a message for delivery and returns immediately without waiting:
+Before:
 
 ```csharp
-// Returns immediately - doesn't wait for broker acknowledgment
+// Old fire-and-forget syntax
 producer.Produce("my-topic", "key", "value");
 ```
 
-Compare this to `ProduceAsync()`:
+After:
 
 ```csharp
-// Waits for broker acknowledgment
+// Enqueues locally; does not wait for broker acknowledgment
+await producer.FireAsync("my-topic", "key", "value");
+```
+
+Use `ProduceAsync` when the caller needs the delivery result:
+
+```csharp
+// Waits for broker acknowledgment and returns metadata
 await producer.ProduceAsync("my-topic", "key", "value");
 ```
 
@@ -37,13 +44,13 @@ Fire-and-forget means you won't know if a message fails to deliver. Use it only 
 
 ## Ensuring Delivery
 
-Messages sent via `Produce()` are buffered internally. To ensure all buffered messages are delivered:
+Messages sent via `FireAsync` are buffered internally. To ensure all buffered messages are delivered:
 
 ```csharp
 // Send many messages quickly
 for (int i = 0; i < 10000; i++)
 {
-    producer.Produce("events", $"event-{i}", eventData);
+    await producer.FireAsync("events", $"event-{i}", eventData);
 }
 
 // Wait for all to be delivered
@@ -59,7 +66,7 @@ Always call `FlushAsync()` before disposing the producer, or use `await using` w
 If you need to know about delivery success/failure without blocking, use the callback overload:
 
 ```csharp
-producer.Produce(
+await producer.FireAsync(
     new ProducerMessage<string, string> { Topic = "orders", Key = orderId, Value = orderJson },
     (metadata, error) =>
     {
@@ -94,18 +101,18 @@ var headers = Headers.Create()
     .Add("trace-id", traceId)
     .Add("source", "event-generator");
 
-producer.Produce("events", eventKey, eventValue, headers);
+await producer.FireAsync("events", eventKey, eventValue, headers);
 ```
 
 ## Performance Comparison
 
 Here's how the different methods compare:
 
-| Method | Blocks? | Knows Result? | Throughput |
-|--------|---------|---------------|------------|
-| `await ProduceAsync()` | Yes | Immediately | Lower |
-| `Produce()` | No | Never | Highest |
-| `Produce(..., callback)` | No | Via callback | High |
+| Method | Waits for broker ack? | Knows delivery result? | Throughput |
+|--------|-----------------------|------------------------|------------|
+| `await ProduceAsync(...)` | Yes | Immediately | Lower |
+| `await FireAsync(...)` | No | Not directly | Highest |
+| `await FireAsync(..., callback)` | No | Via callback | High |
 
 ## Real-World Example: Event Streaming
 
@@ -125,7 +132,7 @@ public class EventPublisher : IAsyncDisposable
         _logger = logger;
     }
 
-    public void Publish(string eventType, byte[] payload)
+    public async ValueTask PublishAsync(string eventType, byte[] payload)
     {
         var message = new ProducerMessage<string, byte[]>
         {
@@ -137,7 +144,7 @@ public class EventPublisher : IAsyncDisposable
                 .Add("timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString())
         };
 
-        _producer.Produce(message, (metadata, error) =>
+        await _producer.FireAsync(message, (metadata, error) =>
         {
             if (error != null)
             {
@@ -171,7 +178,7 @@ var publisher = new EventPublisher(producer, logger);
 // Publish many events quickly
 foreach (var evt in events)
 {
-    publisher.Publish(evt.Type, evt.Serialize());
+    await publisher.PublishAsync(evt.Type, evt.Serialize());
 }
 
 // When shutting down

--- a/docs/docs/serialization/built-in.md
+++ b/docs/docs/serialization/built-in.md
@@ -156,7 +156,30 @@ using Dekaf;
 // This throws InvalidOperationException at BuildAsync()
 var producer = await Kafka.CreateProducer<string, MyCustomType>()
     .WithBootstrapServers("localhost:9092")
-    .BuildAsync();  // Error: No default serializer for type MyCustomType
+    .BuildAsync();
+```
+
+The exception names the missing builder call:
+
+```text
+No built-in value serializer exists for type 'MyCustomType'. Configure .WithValueSerializer(...) on the producer builder...
+```
+
+Before:
+
+```csharp
+var producer = await Kafka.CreateProducer<string, MyCustomType>()
+    .WithBootstrapServers("localhost:9092")
+    .BuildAsync();
+```
+
+After:
+
+```csharp
+var producer = await Kafka.CreateProducer<string, MyCustomType>()
+    .WithBootstrapServers("localhost:9092")
+    .WithValueSerializer(new JsonSerializer<MyCustomType>())
+    .BuildAsync();
 ```
 
 For custom types, see [JSON Serialization](./json) or [Custom Serializers](./custom).

--- a/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
+++ b/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
@@ -14,7 +14,7 @@ namespace Dekaf.Extensions.Hosting;
 /// </summary>
 /// <typeparam name="TKey">Key type.</typeparam>
 /// <typeparam name="TValue">Value type.</typeparam>
-public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundService
+public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundService, IAsyncDisposable
 {
     private readonly IKafkaConsumer<TKey, TValue> _consumer;
     private readonly ILogger _logger;
@@ -23,6 +23,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
     private readonly IRetryPolicy? _retryPolicy;
     private readonly KafkaConsumerServiceOptions _serviceOptions;
     private IKafkaProducer<byte[]?, byte[]?>? _dlqProducer;
+    private int _disposeStarted;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="KafkaConsumerService{TKey, TValue}"/> class.
@@ -188,16 +189,41 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
 
     public override void Dispose()
     {
+        if (Interlocked.Exchange(ref _disposeStarted, 1) == 0)
+        {
+            base.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposeStarted, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await DisposeAsyncCore().ConfigureAwait(false);
+        }
+        finally
+        {
+            base.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    private async ValueTask DisposeAsyncCore()
+    {
         // Flush and dispose DLQ producer
         if (_dlqProducer is not null)
         {
             try
             {
-                _dlqProducer.FlushAsync().AsTask()
+                await _dlqProducer.FlushAsync().AsTask()
                     .WaitAsync(TimeSpan.FromSeconds(5))
-                    .ConfigureAwait(false)
-                    .GetAwaiter()
-                    .GetResult();
+                    .ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -206,11 +232,9 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
 
             try
             {
-                _dlqProducer.DisposeAsync().AsTask()
+                await _dlqProducer.DisposeAsync().AsTask()
                     .WaitAsync(TimeSpan.FromSeconds(5))
-                    .ConfigureAwait(false)
-                    .GetAwaiter()
-                    .GetResult();
+                    .ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -218,16 +242,11 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
             }
         }
 
-        // Add timeout to prevent indefinite hang during disposal
-        // This is necessary because BackgroundService.Dispose is synchronous
-        // but consumer disposal may involve network operations
         try
         {
-            _consumer.DisposeAsync().AsTask()
+            await _consumer.DisposeAsync().AsTask()
                 .WaitAsync(_serviceOptions.ShutdownTimeout)
-                .ConfigureAwait(false)
-                .GetAwaiter()
-                .GetResult();
+                .ConfigureAwait(false);
         }
         catch (TimeoutException)
         {
@@ -237,9 +256,6 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
         {
             LogConsumerDisposalError(ex);
         }
-
-        base.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     private async ValueTask ProcessWithRetriesAsync(

--- a/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
+++ b/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
@@ -191,8 +191,15 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
     {
         if (Interlocked.Exchange(ref _disposeStarted, 1) == 0)
         {
-            base.Dispose();
-            GC.SuppressFinalize(this);
+            try
+            {
+                DisposeAsyncCore().AsTask().GetAwaiter().GetResult();
+            }
+            finally
+            {
+                base.Dispose();
+                GC.SuppressFinalize(this);
+            }
         }
     }
 

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -874,8 +874,8 @@ public sealed class ProducerBuilder<TKey, TValue>
             _acks = Acks.All;
         }
 
-        var keySerializer = _keySerializer ?? GetDefaultSerializer<TKey>();
-        var valueSerializer = _valueSerializer ?? GetDefaultSerializer<TValue>();
+        var keySerializer = _keySerializer ?? GetDefaultSerializer<TKey>("key", "WithKeySerializer");
+        var valueSerializer = _valueSerializer ?? GetDefaultSerializer<TValue>("value", "WithValueSerializer");
 
         var memoryBudget = _clientInfrastructure?.MemoryBudget ?? DekafMemoryBudget.Global;
 
@@ -978,7 +978,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         return new TopicProducer<TKey, TValue>(producer, topic, ownsProducer: true);
     }
 
-    private static ISerializer<T> GetDefaultSerializer<T>()
+    private static ISerializer<T> GetDefaultSerializer<T>(string componentName, string configureMethod)
     {
         if (typeof(T) == typeof(string))
             return (ISerializer<T>)(object)Serializers.String;
@@ -995,7 +995,10 @@ public sealed class ProducerBuilder<TKey, TValue>
         if (typeof(T) == typeof(Ignore))
             return (ISerializer<T>)(object)Serializers.Ignore;
 
-        throw new InvalidOperationException($"No default serializer for type {typeof(T)}. Please specify a serializer.");
+        throw new InvalidOperationException(
+            $"No built-in {componentName} serializer exists for type '{typeof(T).FullName}'. " +
+            $"Configure .{configureMethod}(...) on the producer builder, or use a supported built-in type: " +
+            "string, byte[], ReadOnlyMemory<byte>, int, long, Guid, or Ignore.");
     }
 
     private void ThrowIfClientOwnedBootstrap()
@@ -1893,8 +1896,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
         if (_bootstrapServers.Count == 0)
             throw new InvalidOperationException("Bootstrap servers must be specified. Call WithBootstrapServers() before Build().");
 
-        var keyDeserializer = _keyDeserializer ?? GetDefaultDeserializer<TKey>();
-        var valueDeserializer = _valueDeserializer ?? GetDefaultDeserializer<TValue>();
+        var keyDeserializer = _keyDeserializer ?? GetDefaultDeserializer<TKey>("key", "WithKeyDeserializer");
+        var valueDeserializer = _valueDeserializer ?? GetDefaultDeserializer<TValue>("value", "WithValueDeserializer");
 
         // Wrap the built-in string key deserializer with caching to avoid per-message string
         // allocation for repeated keys. Kafka workloads typically reuse a bounded set of key
@@ -2002,7 +2005,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
         return consumer;
     }
 
-    private static IDeserializer<T> GetDefaultDeserializer<T>()
+    private static IDeserializer<T> GetDefaultDeserializer<T>(string componentName, string configureMethod)
     {
         if (typeof(T) == typeof(string))
             return (IDeserializer<T>)(object)Serializers.String;
@@ -2019,7 +2022,10 @@ public sealed class ConsumerBuilder<TKey, TValue>
         if (typeof(T) == typeof(Ignore))
             return (IDeserializer<T>)(object)Serializers.Ignore;
 
-        throw new InvalidOperationException($"No default deserializer for type {typeof(T)}. Please specify a deserializer.");
+        throw new InvalidOperationException(
+            $"No built-in {componentName} deserializer exists for type '{typeof(T).FullName}'. " +
+            $"Configure .{configureMethod}(...) on the consumer builder, or use a supported built-in type: " +
+            "string, byte[], ReadOnlyMemory<byte>, int, long, Guid, or Ignore.");
     }
 
     private void ThrowIfClientOwnedBootstrap()
@@ -2332,8 +2338,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             throw new InvalidOperationException("Bootstrap servers must be specified. Call WithBootstrapServers() before Build().");
         ArgumentNullException.ThrowIfNullOrEmpty(_groupId, nameof(_groupId));
 
-        var keyDeserializer = _keyDeserializer ?? GetDefaultDeserializer<TKey>();
-        var valueDeserializer = _valueDeserializer ?? GetDefaultDeserializer<TValue>();
+        var keyDeserializer = _keyDeserializer ?? GetDefaultDeserializer<TKey>("key", "WithKeyDeserializer");
+        var valueDeserializer = _valueDeserializer ?? GetDefaultDeserializer<TValue>("value", "WithValueDeserializer");
 
         var options = new ShareConsumerOptions
         {
@@ -2381,7 +2387,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         return consumer;
     }
 
-    private static IDeserializer<T> GetDefaultDeserializer<T>()
+    private static IDeserializer<T> GetDefaultDeserializer<T>(string componentName, string configureMethod)
     {
         if (typeof(T) == typeof(string))
             return (IDeserializer<T>)(object)Serializers.String;
@@ -2398,7 +2404,10 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         if (typeof(T) == typeof(Ignore))
             return (IDeserializer<T>)(object)Serializers.Ignore;
 
-        throw new InvalidOperationException($"No default deserializer for type {typeof(T)}. Please specify a deserializer.");
+        throw new InvalidOperationException(
+            $"No built-in {componentName} deserializer exists for type '{typeof(T).FullName}'. " +
+            $"Configure .{configureMethod}(...) on the share consumer builder, or use a supported built-in type: " +
+            "string, byte[], ReadOnlyMemory<byte>, int, long, Guid, or Ignore.");
     }
 
     private void ThrowIfClientOwnedBootstrap()

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -34,7 +34,9 @@ public class ConsumerBuilderValidationTests
 
         var act = () => builder.Build();
 
-        await Assert.That(act).Throws<InvalidOperationException>();
+        await Assert.That(act).Throws<InvalidOperationException>()
+            .And.HasMessageContaining("key deserializer")
+            .And.HasMessageContaining("WithKeyDeserializer");
     }
 
     [Test]
@@ -45,7 +47,9 @@ public class ConsumerBuilderValidationTests
 
         var act = () => builder.Build();
 
-        await Assert.That(act).Throws<InvalidOperationException>();
+        await Assert.That(act).Throws<InvalidOperationException>()
+            .And.HasMessageContaining("value deserializer")
+            .And.HasMessageContaining("WithValueDeserializer");
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
@@ -32,7 +32,9 @@ public class ProducerBuilderValidationTests
 
         var act = () => builder.Build();
 
-        await Assert.That(act).Throws<InvalidOperationException>();
+        await Assert.That(act).Throws<InvalidOperationException>()
+            .And.HasMessageContaining("key serializer")
+            .And.HasMessageContaining("WithKeySerializer");
     }
 
     [Test]
@@ -43,7 +45,9 @@ public class ProducerBuilderValidationTests
 
         var act = () => builder.Build();
 
-        await Assert.That(act).Throws<InvalidOperationException>();
+        await Assert.That(act).Throws<InvalidOperationException>()
+            .And.HasMessageContaining("value serializer")
+            .And.HasMessageContaining("WithValueSerializer");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
@@ -310,6 +310,29 @@ public sealed class KafkaConsumerServiceTests
 
     #endregion
 
+    #region Disposal
+
+    [Test]
+    public async Task DisposeAsync_AwaitsConsumerDisposal()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var disposal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        consumer.DisposeAsync().Returns(_ => new ValueTask(disposal.Task));
+        var service = new TestConsumerService(consumer, ["topic-a"]);
+
+        var disposeTask = service.DisposeAsync().AsTask();
+        await Task.Yield();
+
+        await Assert.That(disposeTask.IsCompleted).IsFalse();
+
+        disposal.SetResult();
+        await disposeTask;
+
+        await consumer.Received(1).DisposeAsync();
+    }
+
+    #endregion
+
     #region Helpers
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
@@ -331,6 +331,17 @@ public sealed class KafkaConsumerServiceTests
         await consumer.Received(1).DisposeAsync();
     }
 
+    [Test]
+    public async Task Dispose_InvokesConsumerDisposal()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var service = new TestConsumerService(consumer, ["topic-a"]);
+
+        service.Dispose();
+
+        await consumer.Received(1).DisposeAsync();
+    }
+
     #endregion
 
     #region Helpers


### PR DESCRIPTION
## Summary
- clarify unsupported serializer/deserializer errors with key/value context and builder method guidance
- make KafkaConsumerService implement IAsyncDisposable so async cleanup awaits producer/consumer disposal without sync-over-async
- refresh FireAsync and disposal docs for current APIs

## Validation
- dotnet restore tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/ProducerBuilderValidationTests/*"
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/ConsumerBuilderValidationTests/*"
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-progress --treenode-filter "/*/*/KafkaConsumerServiceTests/*"
- dotnet format Dekaf.sln whitespace --include src\Dekaf\Builders.cs src\Dekaf.Extensions.Hosting\KafkaConsumerService.cs tests\Dekaf.Tests.Unit\Builder\ProducerBuilderValidationTests.cs tests\Dekaf.Tests.Unit\Builder\ConsumerBuilderValidationTests.cs tests\Dekaf.Tests.Unit\Hosting\KafkaConsumerServiceTests.cs --verify-no-changes --no-restore --verbosity minimal
- git diff --check
- npm ci --prefix docs
- npm run build --prefix docs

Closes #1021