### PR TITLE
perf(stress): measure real client performance instead of shared-broker ceiling

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -45,6 +45,16 @@ def format_bytes(num_bytes):
         return f"{num_bytes / (1024 * 1024 * 1024):.2f} GB"
 
 
+def format_cpu_columns(result):
+    """Format the serialized CPU-per-message / cores-used values, or '-' when not recorded."""
+    cpu_us_per_msg = result.get('cpuMicrosPerMessage')
+    cores_used = result.get('averageCoresUsed')
+    return (
+        f"{cpu_us_per_msg:.2f}" if cpu_us_per_msg is not None else '-',
+        f"{cores_used:.2f}" if cores_used is not None else '-',
+    )
+
+
 def find_confluent_baseline(results):
     """Find Confluent throughput as a baseline for ratio calculations."""
     for r in results:
@@ -68,11 +78,11 @@ def format_throughput_table(results, title, include_ratio=False):
     lines.append("")
 
     if include_ratio:
-        lines.append("| Client | Messages/sec | MB/sec | Total Messages | Errors | Ratio |")
-        lines.append("|--------|--------------|--------|----------------|--------|-------|")
+        lines.append("| Client | Messages/sec | MB/sec | Total Messages | Errors | CPU μs/msg | Cores Used | Ratio |")
+        lines.append("|--------|--------------|--------|----------------|--------|------------|------------|-------|")
     else:
-        lines.append("| Client | Messages/sec | MB/sec | Total | Errors |")
-        lines.append("|--------|--------------|--------|-------|--------|")
+        lines.append("| Client | Messages/sec | MB/sec | Total | Errors | CPU μs/msg | Cores Used |")
+        lines.append("|--------|--------------|--------|-------|--------|------------|------------|")
 
     baseline = find_confluent_baseline(results) if include_ratio else 0
     sorted_results = sorted(results, key=lambda r: r.get('throughput', {}).get('averageMessagesPerSecond', 0), reverse=True)
@@ -84,12 +94,13 @@ def format_throughput_table(results, title, include_ratio=False):
         mb_sec = throughput.get('averageMegabytesPerSecond', 0)
         total = throughput.get('totalMessages', 0)
         errors = throughput.get('totalErrors', 0)
+        cpu_us_per_msg, cores_used = format_cpu_columns(r)
 
         if include_ratio:
             ratio = msg_sec / baseline if baseline > 0 else 1.0
-            lines.append(f"| {client} | {msg_sec:,.0f} | {mb_sec:.2f} | {total:,} | {errors} | {ratio:.2f}x |")
+            lines.append(f"| {client} | {msg_sec:,.0f} | {mb_sec:.2f} | {total:,} | {errors} | {cpu_us_per_msg} | {cores_used} | {ratio:.2f}x |")
         else:
-            lines.append(f"| {client} | {msg_sec:,.0f} | {mb_sec:.2f} | {total:,} | {errors} |")
+            lines.append(f"| {client} | {msg_sec:,.0f} | {mb_sec:.2f} | {total:,} | {errors} | {cpu_us_per_msg} | {cores_used} |")
 
     lines.append("")
     return lines

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -107,8 +107,19 @@ jobs:
             name: Dekaf Producer Idempotent (3conn, 3 Brokers)
 
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    # 8 vCPUs, split so the client under test is the measured bottleneck:
+    # brokers are pinned to BROKER_CPUS, the client to CLIENT_CPUS. On a shared-core
+    # runner both clients just saturate the broker and report identical numbers.
+    runs-on: ubicloud-standard-8
     timeout-minutes: ${{ matrix.brokers > 1 && 75 || 60 }}
+    env:
+      BROKER_CPUS: 0-5
+      CLIENT_CPUS: 6,7
+      # Broker log dirs live on tmpfs so disk I/O never caps ingestion. Sized well
+      # above the ~1.5 GB worst case (768 MB byte-retention cap plus produce-rate
+      # overshoot between retention checks, or the 2 GB seeded consumer topic):
+      # running out of log-dir space shuts the broker down.
+      BROKER_TMPFS: 6g
 
     steps:
       - name: Checkout
@@ -125,7 +136,13 @@ jobs:
       - name: Start Kafka
         if: matrix.brokers == 1
         run: |
+          # Broker pinned to its own cores (client under test gets the rest) and log
+          # dir on tmpfs so neither broker CPU starvation nor disk I/O caps ingestion.
+          # mode=1777: the Kafka image runs as a non-root user, which cannot write to
+          # a default root-owned tmpfs mount.
           docker run -d --name kafka \
+            --cpuset-cpus="${BROKER_CPUS}" \
+            --tmpfs /var/lib/kafka/data:rw,size=${BROKER_TMPFS},mode=1777 \
             -p 9092:9092 \
             -e KAFKA_NODE_ID=1 \
             -e KAFKA_PROCESS_ROLES=broker,controller \
@@ -160,9 +177,15 @@ jobs:
       - name: Run ${{ matrix.name }} Stress Test
         env:
           KAFKA_BOOTSTRAP_SERVERS: ${{ matrix.brokers == 1 && 'localhost:9092' || '' }}
+          # Multi-broker runs start brokers via Testcontainers from inside the client
+          # process; these apply the same core pinning and tmpfs as the docker run above.
+          STRESS_BROKER_CPUSET: ${{ env.BROKER_CPUS }}
+          STRESS_BROKER_TMPFS: ${{ env.BROKER_TMPFS }}
         run: |
           cd tools/Dekaf.StressTests
-          dotnet run --configuration Release --no-build -- \
+          # Client pinned to its own cores: whichever client pushes more through the
+          # same cores is genuinely faster, instead of both saturating the broker.
+          taskset -c ${CLIENT_CPUS} dotnet run --configuration Release --no-build -- \
             --duration ${{ github.event.inputs.duration_minutes || '15' }} \
             --message-size ${{ github.event.inputs.message_size || '1000' }} \
             --scenario ${{ matrix.scenario }} \
@@ -392,6 +415,12 @@ jobs:
           output.append("Stress tests measure sustained performance over extended periods:")
           output.append("")
           output.append("- **Real Kafka**: Tests run against actual Apache Kafka instances")
+          output.append("- **CPU Isolation**: Brokers are pinned to dedicated cores and the client under test to its own cores, so the client — not the broker — is the measured bottleneck")
+          output.append("- **RAM-backed Broker Logs**: Kafka log dirs are mounted on tmpfs so disk I/O never caps broker ingestion")
+          output.append("- **Backpressure Parity**: Confluent producers block and retry on a full local queue, mirroring Dekaf's BufferMemory backpressure, so throughput is delivered goodput for both clients")
+          output.append("- **Consumer Loop Replay**: Consumer tests re-read a pre-seeded topic (seek to beginning when drained) instead of racing a live feeder, so the consumer itself is measured")
+          output.append("- **Delivery Latency Sampling**: 1 in 1000 produced messages is awaited end-to-end to record true broker round-trip latency")
+          output.append("- **CPU Efficiency**: CPU time per message differentiates client efficiency even at equal throughput")
           output.append("- **Parallel Execution**: Each test runs in its own isolated environment")
           output.append("- **Both Clients**: Direct comparison between Dekaf and Confluent.Kafka")
           output.append("- **Memory Monitoring**: Tracks GC behavior and memory usage over time")

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -624,6 +624,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // Pending fetch responses for lazy record iteration
     private readonly Queue<PendingFetchData> _pendingFetches = new();
 
+    // Incremented whenever queued fetch data is disposed (Seek/Assign clear the buffer).
+    // ConsumeAsync iterates the front of _pendingFetches while it is still queued, and
+    // user code at the yield point can trigger such a clear; the version check lets the
+    // iterator detect that its current fetch was disposed underneath it.
+    private int _pendingFetchesVersion;
+
     // Background prefetch support
     private readonly MpscFetchBuffer _prefetchBuffer;
     private CancellationTokenSource? _prefetchCts;
@@ -1261,6 +1267,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 while (_pendingFetches.Count > 0)
                 {
                     var pending = _pendingFetches.Peek();
+                    var pendingFetchesVersion = Volatile.Read(ref _pendingFetchesVersion);
                     long? batchProcessingStarted = _adaptiveFetchSizer is not null
                         ? System.Diagnostics.Stopwatch.GetTimestamp() : null;
 
@@ -1368,11 +1375,24 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         }
 
                         yield return nextResult;
+
+                        // User code at the yield point may have called Seek/Assign, which
+                        // clears _pendingFetches and disposes `pending` while it is still
+                        // being iterated here; touching it again would read disposed
+                        // pooled buffers.
+                        if (Volatile.Read(ref _pendingFetchesVersion) != pendingFetchesVersion)
+                            break;
                     }
 
                     // Dispose last activity from this pending fetch
                     previousActivity?.Dispose();
                     previousActivity = null;
+
+                    // `pending` was disposed by a buffer clear (Seek/Assign at a yield
+                    // point); skip position/metric flushes that would read it and
+                    // re-evaluate the (rebuilt) queue.
+                    if (Volatile.Read(ref _pendingFetchesVersion) != pendingFetchesVersion)
+                        break;
 
                     // Batch-level position flush. _positions and _fetchPositions are updated
                     // once per partition-fetch (in prefetch mode it is managed by UpdateFetchPositionsFromPrefetch).
@@ -2799,12 +2819,25 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return hadPaused;
     }
 
+    /// <summary>
+    /// Disposes a fetch that was (or may still be) queued in _pendingFetches. Any queued
+    /// fetch can be the one an in-flight ConsumeAsync iteration holds (the iterator Peeks
+    /// and leaves it queued), so the version bump is what lets the iterator detect the
+    /// disposal instead of reading disposed pooled buffers. All disposal of queued fetches
+    /// must go through this method.
+    /// </summary>
+    private void DisposeQueuedFetch(PendingFetchData pending)
+    {
+        Interlocked.Increment(ref _pendingFetchesVersion);
+        pending.Dispose();
+    }
+
     private void ClearFetchBuffer()
     {
         // Dispose and clear pending fetches to release pooled memory
         while (_pendingFetches.TryDequeue(out var pending))
         {
-            pending.Dispose();
+            DisposeQueuedFetch(pending);
         }
         // Also drain prefetched items that haven't been moved to _pendingFetches yet.
         // Without this, stale data from old partitions would surface after reassignment.
@@ -2845,7 +2878,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             else
             {
                 // Dispose removed items to release pooled memory
-                pending.Dispose();
+                DisposeQueuedFetch(pending);
             }
         }
 

--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -703,6 +703,73 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
     }
 
     [Test]
+    public async Task Consumer_SeekToBeginningInsideConsumeLoop_ReplaysWithoutError()
+    {
+        // Seeking from user code at the yield point of an active ConsumeAsync loop
+        // clears the fetch buffer while the iterator is reading from it. This must
+        // invalidate the in-flight fetch cleanly and resume from the seeked position,
+        // not crash on disposed pooled buffers.
+
+        // Arrange
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        const int messageCount = 10;
+        for (var i = 0; i < messageCount; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = $"key-{i}",
+                Value = $"value-{i}"
+            }, CancellationToken.None);
+        }
+
+        // ForHighThroughput enables prefetching, which exercises the same
+        // fetch-buffer path the stress tests hit.
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-consumer")
+            .WithGroupId($"test-group-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .ForHighThroughput()
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        var tp = new TopicPartition(topic, 0);
+        consumer.Assign(tp);
+
+        // Act - consume one full pass, seek without leaving the loop, consume a second pass
+        var offsets = new List<long>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await foreach (var record in consumer.ConsumeAsync(cts.Token))
+        {
+            offsets.Add(record.Offset);
+
+            if (offsets.Count == messageCount)
+            {
+                consumer.SeekToBeginning(tp);
+            }
+            else if (offsets.Count == messageCount * 2)
+            {
+                break;
+            }
+        }
+
+        // Assert - both passes read offsets 0..9 in order
+        await Assert.That(offsets.Count).IsEqualTo(messageCount * 2);
+        for (var i = 0; i < messageCount; i++)
+        {
+            await Assert.That(offsets[i]).IsEqualTo(i);
+            await Assert.That(offsets[messageCount + i]).IsEqualTo(i);
+        }
+    }
+
+    [Test]
     public async Task Consumer_SeekToSpecificOffset_ReplaysFromThatPoint()
     {
         // Arrange

--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -1,3 +1,4 @@
+using Docker.DotNet.Models;
 using Dekaf.Admin;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
@@ -30,10 +31,40 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
         ["KAFKA_LOG_CLEANUP_POLICY"] = "delete",
     };
 
+    // Optional broker resource constraints, primarily for CI. STRESS_BROKER_CPUSET pins
+    // broker containers to specific cores so the client under test keeps dedicated cores
+    // (making the client, not the broker, the measured bottleneck); STRESS_BROKER_TMPFS
+    // mounts the Kafka log dir on a tmpfs of the given size (e.g. "4g") so disk I/O
+    // never caps broker ingestion.
+    private static readonly string? BrokerCpuset = Environment.GetEnvironmentVariable("STRESS_BROKER_CPUSET");
+    private static readonly string? BrokerTmpfsSize = Environment.GetEnvironmentVariable("STRESS_BROKER_TMPFS");
+    private const string KafkaLogDir = "/var/lib/kafka/data";
+
     public string BootstrapServers { get; }
     private readonly KafkaContainer? _container;
     private readonly List<IContainer>? _clusterContainers;
     private readonly INetwork? _network;
+
+    private static readonly Action<CreateContainerParameters>? BrokerResourceModifier =
+        string.IsNullOrEmpty(BrokerCpuset) && string.IsNullOrEmpty(BrokerTmpfsSize)
+            ? null
+            : parameters =>
+            {
+                parameters.HostConfig ??= new HostConfig();
+                if (!string.IsNullOrEmpty(BrokerCpuset))
+                {
+                    parameters.HostConfig.CpusetCpus = BrokerCpuset;
+                }
+                if (!string.IsNullOrEmpty(BrokerTmpfsSize))
+                {
+                    // mode=1777: Kafka images run as a non-root user, which cannot
+                    // write to a default root-owned tmpfs mount.
+                    parameters.HostConfig.Tmpfs = new Dictionary<string, string>
+                    {
+                        [KafkaLogDir] = $"rw,size={BrokerTmpfsSize},mode=1777"
+                    };
+                }
+            };
 
     private KafkaEnvironment(string bootstrapServers, KafkaContainer? container)
     {
@@ -69,11 +100,18 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
     {
         Console.WriteLine("Starting Kafka container via Testcontainers...");
         var builder = new KafkaBuilder("confluentinc/cp-kafka:7.5.0")
-            .WithPortBinding(9092, true);
+            .WithPortBinding(9092, true)
+            // Explicit log dir so the optional tmpfs mount target always matches
+            .WithEnvironment("KAFKA_LOG_DIRS", KafkaLogDir);
 
         foreach (var (key, value) in RetentionConfig)
         {
             builder = builder.WithEnvironment(key, value);
+        }
+
+        if (BrokerResourceModifier is { } modifier)
+        {
+            builder = builder.WithCreateParameterModifier(modifier);
         }
 
         var container = builder.Build();
@@ -132,11 +170,18 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
                 .WithEnvironment("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT")
                 .WithEnvironment("KAFKA_INTER_BROKER_LISTENER_NAME", "PLAINTEXT")
                 .WithEnvironment("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER")
-                .WithEnvironment("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", Math.Min(brokerCount, 3).ToString());
+                .WithEnvironment("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", Math.Min(brokerCount, 3).ToString())
+                // Explicit log dir so the optional tmpfs mount target always matches
+                .WithEnvironment("KAFKA_LOG_DIRS", KafkaLogDir);
 
             foreach (var (key, value) in RetentionConfig)
             {
                 containerBuilder = containerBuilder.WithEnvironment(key, value);
+            }
+
+            if (BrokerResourceModifier is { } modifier)
+            {
+                containerBuilder = containerBuilder.WithCreateParameterModifier(modifier);
             }
 
             var container = containerBuilder.Build();
@@ -205,7 +250,8 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
         throw new InvalidOperationException($"Kafka not ready after {maxAttempts} attempts");
     }
 
-    public async Task CreateTopicAsync(string topic, int partitions, int replicationFactor = 1)
+    public async Task CreateTopicAsync(string topic, int partitions, int replicationFactor = 1,
+        IReadOnlyDictionary<string, string>? configs = null)
     {
         if (_container is not null)
         {
@@ -213,7 +259,7 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
             // container. The cp-kafka broker advertises its external host port in metadata,
             // which the CLI inside the container can't reach — causing a 60-second timeout.
             // The admin client runs on the host and connects via the external bootstrap address.
-            await AdminCreateTopicAsync(BootstrapServers, topic, partitions, replicationFactor)
+            await AdminCreateTopicAsync(BootstrapServers, topic, partitions, replicationFactor, configs)
                 .ConfigureAwait(false);
             return;
         }
@@ -221,15 +267,16 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
         if (_clusterContainers is { Count: > 0 })
         {
             await ExecCreateTopicAsync(_clusterContainers[0], "/opt/kafka/bin/kafka-topics.sh", "kafka-1:9092",
-                topic, partitions, replicationFactor).ConfigureAwait(false);
+                topic, partitions, replicationFactor, configs).ConfigureAwait(false);
             return;
         }
 
-        await AdminCreateTopicAsync(BootstrapServers, topic, partitions, replicationFactor).ConfigureAwait(false);
+        await AdminCreateTopicAsync(BootstrapServers, topic, partitions, replicationFactor, configs).ConfigureAwait(false);
     }
 
     private static async Task AdminCreateTopicAsync(
-        string bootstrapServers, string topic, int partitions, int replicationFactor)
+        string bootstrapServers, string topic, int partitions, int replicationFactor,
+        IReadOnlyDictionary<string, string>? configs)
     {
         await using var adminClient = Kafka.CreateAdminClient()
             .WithBootstrapServers(bootstrapServers)
@@ -243,7 +290,8 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
                 {
                     Name = topic,
                     NumPartitions = partitions,
-                    ReplicationFactor = (short)replicationFactor
+                    ReplicationFactor = (short)replicationFactor,
+                    Configs = configs
                 }
             ]).ConfigureAwait(false);
 
@@ -257,9 +305,11 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
 
     private static async Task ExecCreateTopicAsync(
         IContainer container, string executablePath, string bootstrapServer,
-        string topic, int partitions, int replicationFactor)
+        string topic, int partitions, int replicationFactor,
+        IReadOnlyDictionary<string, string>? configs)
     {
-        var result = await container.ExecAsync([
+        var command = new List<string>
+        {
             executablePath,
             "--bootstrap-server", bootstrapServer,
             "--create",
@@ -267,7 +317,18 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
             "--partitions", partitions.ToString(),
             "--replication-factor", replicationFactor.ToString(),
             "--if-not-exists"
-        ]).ConfigureAwait(false);
+        };
+
+        if (configs is not null)
+        {
+            foreach (var (key, value) in configs)
+            {
+                command.Add("--config");
+                command.Add($"{key}={value}");
+            }
+        }
+
+        var result = await container.ExecAsync(command).ConfigureAwait(false);
 
         if (result.ExitCode != 0)
         {

--- a/tools/Dekaf.StressTests/Metrics/ThroughputTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/ThroughputTracker.cs
@@ -16,15 +16,25 @@ internal sealed class ThroughputTracker
     private readonly object _samplesLock = new();
     private long _lastSampleMessageCount;
     private DateTime _lastSampleTime;
+    private TimeSpan _cpuTimeStart;
+    private double _cpuTimeSeconds;
 
     public long MessageCount => Interlocked.Read(ref _messageCount);
     public long ByteCount => Interlocked.Read(ref _byteCount);
     public long ErrorCount => Interlocked.Read(ref _errorCount);
     public TimeSpan Elapsed => _stopwatch.Elapsed;
 
+    /// <summary>
+    /// Process CPU time consumed over the Start/Stop window (valid after Stop).
+    /// CPU cost per message differentiates client efficiency even when the broker
+    /// caps throughput.
+    /// </summary>
+    public double CpuTimeSeconds => _cpuTimeSeconds;
+
     public void Start()
     {
         _stopwatch.Start();
+        _cpuTimeStart = Environment.CpuUsage.TotalTime;
         _lastSampleTime = DateTime.UtcNow;
         _lastSampleMessageCount = 0;
     }
@@ -32,6 +42,7 @@ internal sealed class ThroughputTracker
     public void Stop()
     {
         _stopwatch.Stop();
+        _cpuTimeSeconds = (Environment.CpuUsage.TotalTime - _cpuTimeStart).TotalSeconds;
     }
 
     public void RecordMessage(int bytes)

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -87,7 +87,14 @@ public static class Program
 
         var replicationFactor = Math.Min(options.Brokers, 3);
         await kafka.CreateTopicAsync(producerTopic, options.Partitions, replicationFactor).ConfigureAwait(false);
-        await kafka.CreateTopicAsync(consumerTopic, options.Partitions, replicationFactor).ConfigureAwait(false);
+        // Consumer scenarios re-read the seeded data set in a loop for the full duration.
+        // Broker-level retention (tuned to bound producer-topic disk usage) must not
+        // delete it mid-run, so retention is disabled at the topic level.
+        await kafka.CreateTopicAsync(consumerTopic, options.Partitions, replicationFactor, new Dictionary<string, string>
+        {
+            ["retention.ms"] = "-1",
+            ["retention.bytes"] = "-1"
+        }).ConfigureAwait(false);
 
         if (options.Scenario is "consumer" or "consumer-batch" or "consumer-raw" or "consumer-raw-batch" or "all")
         {
@@ -192,8 +199,9 @@ public static class Program
         Console.WriteLine($"Seeding consumer topic with messages...");
 
         var messageValue = new string('x', options.MessageSizeBytes);
-        // Seed 500K messages - enough to test consumer throughput without excessive disk/time
-        var totalMessages = 500_000;
+        // Consumer scenarios loop over this data set (seek to beginning when drained),
+        // so it only needs to be large enough that rewind overhead is negligible.
+        var totalMessages = options.SeedMessages;
 
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(bootstrapServers)
@@ -341,6 +349,13 @@ public static class Program
                         throw new ArgumentException("--connections-per-broker must be at least 1");
                     }
                     break;
+                case "--seed-messages":
+                    options.SeedMessages = int.Parse(args[++i]);
+                    if (options.SeedMessages < 1)
+                    {
+                        throw new ArgumentException("--seed-messages must be at least 1");
+                    }
+                    break;
                 case "--help":
                 case "-h":
                     PrintHelp();
@@ -372,10 +387,13 @@ public static class Program
               --compression <type>   Compression type: none, lz4, snappy, zstd (default: none)
               --brokers <count>      Number of Kafka brokers (default: 1, use 3 for multi-broker)
               --connections-per-broker <n>  TCP connections per broker (default: 1, pass 3 for multi-connection comparison)
+              --seed-messages <count> Messages pre-seeded into the consumer topic (default: 2000000)
               report --input <path>   Generate report from existing results
 
             Environment Variables:
               KAFKA_BOOTSTRAP_SERVERS - Use external Kafka instead of Testcontainers
+              STRESS_BROKER_CPUSET    - Pin Testcontainers brokers to CPU cores (e.g. "0-5") so the client keeps dedicated cores
+              STRESS_BROKER_TMPFS     - Mount broker log dirs on tmpfs of this size (e.g. "6g") so disk I/O never caps ingestion
 
             Examples:
               dotnet run -c Release -- --duration 15 --message-size 1000
@@ -399,5 +417,6 @@ public static class Program
         public string Compression { get; set; } = "none";
         public int Brokers { get; set; } = 1;
         public int ConnectionsPerBroker { get; set; } = 1;
+        public int SeedMessages { get; set; } = 2_000_000;
     }
 }

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -67,8 +67,8 @@ internal static class MarkdownReporter
             var messageSizeKb = messageSize >= 1024 ? $"{messageSize / 1024.0:F1}KB" : $"{messageSize}B";
             sb.AppendLine($"## {title} ({durationMinutes} minutes, {messageSizeKb} messages)");
             sb.AppendLine();
-            sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Messages/sec | MB/sec | Errors | Ratio |");
-            sb.AppendLine($"|{new string('-', clientWidth + 2)}|--------------|--------|--------|-------|");
+            sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Messages/sec | MB/sec | Errors | CPU μs/msg | Cores Used | Ratio |");
+            sb.AppendLine($"|{new string('-', clientWidth + 2)}|--------------|--------|--------|------------|------------|-------|");
 
             var baseline = sizeResults
                 .Where(r => r.Client.Equals("Confluent", StringComparison.OrdinalIgnoreCase))
@@ -83,7 +83,9 @@ internal static class MarkdownReporter
             foreach (var result in sizeResults.OrderByDescending(r => r.Throughput.AverageMessagesPerSecond))
             {
                 var ratio = baseline > 0 ? result.Throughput.AverageMessagesPerSecond / baseline : 1.0;
-                sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {result.Throughput.AverageMessagesPerSecond,12:N0} | {result.Throughput.AverageMegabytesPerSecond,6:F2} | {result.Throughput.TotalErrors,6} | {ratio:F2}x |");
+                var cpuPerMessage = result.CpuMicrosPerMessage is { } cpu ? $"{cpu:F2}" : "-";
+                var coresUsed = result.AverageCoresUsed is { } cores ? $"{cores:F2}" : "-";
+                sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {result.Throughput.AverageMessagesPerSecond,12:N0} | {result.Throughput.AverageMegabytesPerSecond,6:F2} | {result.Throughput.TotalErrors,6} | {cpuPerMessage,10} | {coresUsed,10} | {ratio:F2}x |");
             }
 
             sb.AppendLine();

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -17,6 +17,24 @@ internal sealed class StressTestResult
     public required GcSnapshot GcStats { get; init; }
     public int BrokerCount { get; init; } = 1;
 
+    /// <summary>
+    /// Process CPU time consumed during the measurement window. CPU cost per message
+    /// differentiates client efficiency even when the broker caps throughput.
+    /// The derived values below are serialized so downstream reports (including the
+    /// Python CI summary) format them without re-deriving the math.
+    /// </summary>
+    public double? CpuTimeSeconds { get; init; }
+
+    public double? CpuMicrosPerMessage =>
+        CpuTimeSeconds is { } cpu && Throughput.TotalMessages > 0
+            ? cpu * 1_000_000.0 / Throughput.TotalMessages
+            : null;
+
+    public double? AverageCoresUsed =>
+        CpuTimeSeconds is { } cpu && Throughput.ElapsedSeconds > 0
+            ? cpu / Throughput.ElapsedSeconds
+            : null;
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 using ConfluentKafka = Confluent.Kafka;
@@ -7,8 +6,6 @@ namespace Dekaf.StressTests.Scenarios;
 
 internal sealed class ConfluentConsumerStressTest : IStressTestScenario
 {
-    private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
-
     public string Name => "consumer";
     public string Client => "Confluent";
 
@@ -16,40 +13,6 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
     {
         var throughput = new ThroughputTracker();
         var startedAt = DateTime.UtcNow;
-        var messageValue = new string('x', options.MessageSizeBytes);
-
-        // Create producer to feed messages to the consumer
-        var producerConfig = new ConfluentKafka.ProducerConfig
-        {
-            BootstrapServers = options.BootstrapServers,
-            ClientId = "stress-consumer-feeder-confluent",
-            Acks = ConfluentKafka.Acks.Leader,
-            LingerMs = options.LingerMs,
-            BatchSize = options.BatchSize
-        };
-
-        using var producer = new ConfluentKafka.ProducerBuilder<string, string>(producerConfig).Build();
-
-        // Pre-seed messages before starting consumer measurement.
-        // Confluent.Kafka's ProduceAsync() throws Queue full without backpressure,
-        // so flush in batches to avoid exceeding the internal queue.
-        Console.WriteLine($"  Pre-seeding messages for consumer test...");
-        const int preseedCount = 500_000;
-        const int flushInterval = 50_000;
-        for (var i = 0; i < preseedCount; i++)
-        {
-            producer.Produce(options.Topic, new ConfluentKafka.Message<string, string>
-            {
-                Key = GetKey(i),
-                Value = messageValue
-            });
-            if ((i + 1) % flushInterval == 0)
-            {
-                producer.Flush(TimeSpan.FromSeconds(60));
-            }
-        }
-        producer.Flush(TimeSpan.FromSeconds(60));
-        Console.WriteLine($"  Pre-seeded {preseedCount:N0} messages");
 
         var consumerConfig = new ConfluentKafka.ConsumerConfig
         {
@@ -60,14 +23,29 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
             EnableAutoCommit = true
         };
 
+        // The topic is pre-seeded by Program.SeedConsumerTopicAsync. The consumer re-reads
+        // that fixed data set in a loop (seek to beginning when all partitions are drained).
+        // A live feeder would compete with the consumer for CPU and cap throughput at the
+        // feeder's rate, measuring the feeder instead of the consumer.
         using var consumer = new ConfluentKafka.ConsumerBuilder<string, string>(consumerConfig).Build();
         consumer.Subscribe(options.Topic);
 
-        // Start background producer to continuously feed the consumer
-        var producerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var producerTask = RunBackgroundProducerAsync(producer, options.Topic, messageValue, producerCts.Token);
+        var partitions = Enumerable.Range(0, options.Partitions)
+            .Select(p => new ConfluentKafka.TopicPartition(options.Topic, p))
+            .ToArray();
 
-        // GC baseline after producer warmup but before consumer measurement
+        var endOffsets = new long[partitions.Length];
+        for (var p = 0; p < partitions.Length; p++)
+        {
+            var watermarks = consumer.QueryWatermarkOffsets(partitions[p], TimeSpan.FromSeconds(30));
+            endOffsets[p] = watermarks.High.Value;
+        }
+
+        var replay = new PartitionReplayTracker(endOffsets);
+
+        Console.WriteLine($"  Consuming pre-seeded topic in a loop ({endOffsets.Sum():N0} messages per pass)");
+
+        // GC baseline before consumer measurement
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
@@ -83,7 +61,7 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
         throughput.Start();
         var progress = new PeriodicProgressReporter(throughput);
 
-        var samplerTask = RunSamplerAsync(throughput, cts.Token);
+        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
         var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
 
         try
@@ -93,10 +71,20 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
                 try
                 {
                     var result = consumer.Consume(TimeSpan.FromMilliseconds(100));
-                    if (result is not null)
+                    if (result is null)
                     {
-                        throughput.RecordMessage(result.Message.Value?.Length ?? 0);
-                        progress.RecordMessage();
+                        continue;
+                    }
+
+                    throughput.RecordMessage(result.Message.Value?.Length ?? 0);
+                    progress.RecordMessage();
+
+                    if (replay.RecordConsumed(result.Partition.Value, result.Offset.Value))
+                    {
+                        foreach (var tp in partitions)
+                        {
+                            consumer.Seek(new ConfluentKafka.TopicPartitionOffset(tp, ConfluentKafka.Offset.Beginning));
+                        }
                     }
                 }
                 catch (ConfluentKafka.ConsumeException)
@@ -112,10 +100,6 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
 
         throughput.Stop();
         gcStats.Capture();
-
-        // Stop background producer
-        await producerCts.CancelAsync().ConfigureAwait(false);
-        try { await producerTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
 
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
@@ -135,74 +119,8 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = null,
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
     }
-
-    private static async Task RunBackgroundProducerAsync(
-        ConfluentKafka.IProducer<string, string> producer,
-        string topic,
-        string messageValue,
-        CancellationToken cancellationToken)
-    {
-        var messageIndex = 0L;
-
-        await Task.Yield(); // Ensure we're on a background thread
-
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                producer.Produce(topic, new ConfluentKafka.Message<string, string>
-                {
-                    Key = GetKey(messageIndex),
-                    Value = messageValue
-                });
-                messageIndex++;
-
-                // Yield periodically to avoid starving other tasks
-                if (messageIndex % 10_000 == 0)
-                {
-                    await Task.Yield();
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-            catch
-            {
-                // Ignore producer errors in the feeder
-            }
-        }
-    }
-
-    private static async Task RunSamplerAsync(ThroughputTracker throughput, CancellationToken cancellationToken)
-    {
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
-                throughput.TakeSample();
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-    }
-
-    private static string[] CreatePreAllocatedKeys(int count)
-    {
-        var keys = new string[count];
-        for (var i = 0; i < count; i++)
-        {
-            keys[i] = $"key-{i}";
-        }
-        return keys;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 using ConfluentKafka = Confluent.Kafka;
@@ -14,7 +13,7 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
     {
         var messageValue = new string('x', options.MessageSizeBytes);
         var throughput = new ThroughputTracker();
-        var latency = new LatencyTracker();
+        var latency = StressTestHelpers.CreateDeliveryLatencyTracker();
         var startedAt = DateTime.UtcNow;
 
         var config = new ConfluentKafka.ProducerConfig
@@ -66,13 +65,20 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
         {
             try
             {
-                var start = Stopwatch.GetTimestamp();
-                producer.Produce(options.Topic, new ConfluentKafka.Message<string, string>
+                var message = new ConfluentKafka.Message<string, string>
                 {
                     Key = StressTestHelpers.GetKey(messageIndex),
                     Value = messageValue
-                });
-                latency.RecordTicks(Stopwatch.GetTimestamp() - start);
+                };
+
+                if (messageIndex % StressTestHelpers.LatencySampleInterval == 0)
+                {
+                    ConfluentStressTestHelpers.SampleDeliveryLatency(producer, options.Topic, message, latency, throughput, cts.Token);
+                }
+                else
+                {
+                    ConfluentStressTestHelpers.ProduceWithBackpressure(producer, options.Topic, message, null, cts.Token);
+                }
                 throughput.RecordMessage(options.MessageSizeBytes);
                 messageIndex++;
 
@@ -115,7 +121,8 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = latency.GetSnapshot(),
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerIdempotentStressTest.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 using ConfluentKafka = Confluent.Kafka;
@@ -8,8 +7,6 @@ namespace Dekaf.StressTests.Scenarios;
 
 internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenario
 {
-    private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
-
     public string Name => "producer-idempotent";
     public string Client => "Confluent";
 
@@ -17,7 +14,7 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
     {
         var messageValue = new string('x', options.MessageSizeBytes);
         var throughput = new ThroughputTracker();
-        var latency = new LatencyTracker();
+        var latency = StressTestHelpers.CreateDeliveryLatencyTracker();
         var startedAt = DateTime.UtcNow;
 
         var config = new ConfluentKafka.ProducerConfig
@@ -70,13 +67,20 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
         {
             try
             {
-                var start = Stopwatch.GetTimestamp();
-                producer.Produce(options.Topic, new ConfluentKafka.Message<string, string>
+                var message = new ConfluentKafka.Message<string, string>
                 {
-                    Key = GetKey(messageIndex),
+                    Key = StressTestHelpers.GetKey(messageIndex),
                     Value = messageValue
-                });
-                latency.RecordTicks(Stopwatch.GetTimestamp() - start);
+                };
+
+                if (messageIndex % StressTestHelpers.LatencySampleInterval == 0)
+                {
+                    ConfluentStressTestHelpers.SampleDeliveryLatency(producer, options.Topic, message, latency, throughput, cts.Token);
+                }
+                else
+                {
+                    ConfluentStressTestHelpers.ProduceWithBackpressure(producer, options.Topic, message, null, cts.Token);
+                }
                 throughput.RecordMessage(options.MessageSizeBytes);
                 messageIndex++;
 
@@ -128,7 +132,8 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = latency.GetSnapshot(),
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
     }
 
@@ -147,19 +152,6 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
             }
         }
     }
-
-    private static string[] CreatePreAllocatedKeys(int count)
-    {
-        var keys = new string[count];
-        for (var i = 0; i < count; i++)
-        {
-            keys[i] = $"key-{i}";
-        }
-        return keys;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
 
     private static async Task RunResourceMonitorAsync(CancellationToken cancellationToken)
     {

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerStressTest.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 using ConfluentKafka = Confluent.Kafka;
@@ -8,8 +7,6 @@ namespace Dekaf.StressTests.Scenarios;
 
 internal sealed class ConfluentProducerStressTest : IStressTestScenario
 {
-    private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
-
     public string Name => "producer";
     public string Client => "Confluent";
 
@@ -17,7 +14,7 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
     {
         var messageValue = new string('x', options.MessageSizeBytes);
         var throughput = new ThroughputTracker();
-        var latency = new LatencyTracker();
+        var latency = StressTestHelpers.CreateDeliveryLatencyTracker();
         var startedAt = DateTime.UtcNow;
 
         var config = new ConfluentKafka.ProducerConfig
@@ -69,13 +66,20 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
         {
             try
             {
-                var start = Stopwatch.GetTimestamp();
-                producer.Produce(options.Topic, new ConfluentKafka.Message<string, string>
+                var message = new ConfluentKafka.Message<string, string>
                 {
-                    Key = GetKey(messageIndex),
+                    Key = StressTestHelpers.GetKey(messageIndex),
                     Value = messageValue
-                });
-                latency.RecordTicks(Stopwatch.GetTimestamp() - start);
+                };
+
+                if (messageIndex % StressTestHelpers.LatencySampleInterval == 0)
+                {
+                    ConfluentStressTestHelpers.SampleDeliveryLatency(producer, options.Topic, message, latency, throughput, cts.Token);
+                }
+                else
+                {
+                    ConfluentStressTestHelpers.ProduceWithBackpressure(producer, options.Topic, message, null, cts.Token);
+                }
                 throughput.RecordMessage(options.MessageSizeBytes);
                 messageIndex++;
 
@@ -127,7 +131,8 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = latency.GetSnapshot(),
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
     }
 
@@ -146,19 +151,6 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
             }
         }
     }
-
-    private static string[] CreatePreAllocatedKeys(int count)
-    {
-        var keys = new string[count];
-        for (var i = 0; i < count; i++)
-        {
-            keys[i] = $"key-{i}";
-        }
-        return keys;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
 
     private static async Task RunResourceMonitorAsync(CancellationToken cancellationToken)
     {

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+using Dekaf.StressTests.Metrics;
+using ConfluentKafka = Confluent.Kafka;
+
+namespace Dekaf.StressTests.Scenarios;
+
+internal static class ConfluentStressTestHelpers
+{
+    /// <summary>
+    /// Produces one message, blocking briefly and retrying while librdkafka's local
+    /// queue is full. This mirrors Dekaf's BufferMemory backpressure: without it,
+    /// queue-full messages are silently dropped and counted as errors, which makes
+    /// throughput numbers incomparable (drops vs. delivered goodput).
+    /// </summary>
+    internal static void ProduceWithBackpressure(
+        ConfluentKafka.IProducer<string, string> producer,
+        string topic,
+        ConfluentKafka.Message<string, string> message,
+        Action<ConfluentKafka.DeliveryReport<string, string>>? deliveryHandler,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            try
+            {
+                producer.Produce(topic, message, deliveryHandler);
+                return;
+            }
+            catch (ConfluentKafka.ProduceException<string, string> ex)
+                when (ex.Error.Code == ConfluentKafka.ErrorCode.Local_QueueFull)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                // The background poll thread drains the queue; a short sleep is the
+                // idiomatic librdkafka backpressure wait.
+                Thread.Sleep(1);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Produces one message and records the full delivery round-trip into
+    /// <paramref name="latency"/> via the delivery report callback, without
+    /// stalling the produce loop.
+    /// </summary>
+    internal static void SampleDeliveryLatency(
+        ConfluentKafka.IProducer<string, string> producer,
+        string topic,
+        ConfluentKafka.Message<string, string> message,
+        LatencyTracker latency,
+        ThroughputTracker throughput,
+        CancellationToken cancellationToken)
+    {
+        var start = Stopwatch.GetTimestamp();
+        ProduceWithBackpressure(producer, topic, message, report =>
+        {
+            if (report.Error.IsError)
+            {
+                throughput.RecordError();
+            }
+            else
+            {
+                latency.RecordTicks(Stopwatch.GetTimestamp() - start);
+            }
+        }, cancellationToken);
+    }
+}

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -1,5 +1,4 @@
 using Dekaf.Consumer;
-using Dekaf.Producer;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 
@@ -19,29 +18,11 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
     {
         var throughput = new ThroughputTracker();
         var startedAt = DateTime.UtcNow;
-        var messageValue = new string('x', options.MessageSizeBytes);
 
-        // Create producer to feed messages to the consumer
-        await using var producer = await Kafka.CreateProducer<string, string>()
-            .WithBootstrapServers(options.BootstrapServers)
-            .WithClientId("stress-consumer-batch-feeder-dekaf")
-            .WithAcks(Acks.Leader)
-            .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
-            .WithBatchSize(options.BatchSize)
-            .BuildAsync(cancellationToken);
-
-        // Pre-seed messages before starting consumer measurement.
-        // Note: Program.cs also seeds via SeedConsumerTopicAsync when running --scenario all.
-        // Both seeds are intentional — this ensures enough backlog regardless of invocation path.
-        Console.WriteLine("  Pre-seeding messages for consumer-batch test...");
-        const int preseedCount = 500_000;
-        for (var i = 0; i < preseedCount; i++)
-        {
-            await producer.FireAsync(options.Topic, StressTestHelpers.GetKey(i), messageValue).ConfigureAwait(false);
-        }
-        await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
-        Console.WriteLine($"  Pre-seeded {preseedCount:N0} messages");
-
+        // The topic is pre-seeded by Program.SeedConsumerTopicAsync. The consumer re-reads
+        // that fixed data set in a loop (seek to beginning when all partitions are drained).
+        // A live feeder would compete with the consumer for CPU and cap throughput at the
+        // feeder's rate, measuring the feeder instead of the consumer.
         await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-consumer-batch-dekaf")
@@ -52,11 +33,16 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
 
         consumer.Subscribe(options.Topic);
 
-        // Start background producer to continuously feed the consumer
-        var producerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var producerTask = StressTestHelpers.RunBackgroundProducerAsync(producer, options.Topic, messageValue, producerCts.Token);
+        var partitions = Enumerable.Range(0, options.Partitions)
+            .Select(p => new TopicPartition(options.Topic, p))
+            .ToArray();
 
-        // GC baseline after producer warmup but before consumer measurement
+        var endOffsets = await StressTestHelpers.QueryEndOffsetsAsync(consumer, options.Topic, options.Partitions, cancellationToken);
+        var replay = new PartitionReplayTracker(endOffsets);
+
+        Console.WriteLine($"  Consuming pre-seeded topic in a loop ({endOffsets.Sum():N0} messages per pass)");
+
+        // GC baseline before consumer measurement
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
@@ -79,10 +65,18 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
         {
             await foreach (var batch in consumer.ConsumeBatchAsync(cts.Token).ConfigureAwait(false))
             {
+                var lastOffset = -1L;
                 foreach (var record in batch)
                 {
                     throughput.RecordMessage(record.Value?.Length ?? 0);
                     progress.RecordMessage();
+                    lastOffset = record.Offset;
+                }
+
+                // Offsets are monotonic within a batch, so the last one decides drain state
+                if (lastOffset >= 0 && replay.RecordConsumed(batch.Partition, lastOffset))
+                {
+                    consumer.Positions.SeekToBeginning(partitions);
                 }
             }
         }
@@ -92,16 +86,12 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"  Consumer error: {ex.GetType().Name}: {ex.Message}");
+            Console.WriteLine($"  Consumer error: {ex}");
             throughput.RecordError();
         }
 
         throughput.Stop();
         gcStats.Capture();
-
-        // Stop background producer
-        await producerCts.CancelAsync().ConfigureAwait(false);
-        try { await producerTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
 
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
@@ -121,7 +111,8 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = null,
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -1,5 +1,4 @@
 using Dekaf.Consumer;
-using Dekaf.Producer;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 
@@ -19,29 +18,11 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
     {
         var throughput = new ThroughputTracker();
         var startedAt = DateTime.UtcNow;
-        var messageValue = new string('x', options.MessageSizeBytes);
 
-        // Create producer to feed messages to the consumer (uses string serialization for production)
-        await using var producer = await Kafka.CreateProducer<string, string>()
-            .WithBootstrapServers(options.BootstrapServers)
-            .WithClientId("stress-consumer-raw-batch-feeder-dekaf")
-            .WithAcks(Acks.Leader)
-            .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
-            .WithBatchSize(options.BatchSize)
-            .BuildAsync(cancellationToken);
-
-        // Pre-seed messages before starting consumer measurement.
-        // Note: Program.cs also seeds via SeedConsumerTopicAsync when running --scenario all.
-        // Both seeds are intentional — this ensures enough backlog regardless of invocation path.
-        Console.WriteLine("  Pre-seeding messages for consumer-raw-batch test...");
-        const int preseedCount = 500_000;
-        for (var i = 0; i < preseedCount; i++)
-        {
-            await producer.FireAsync(options.Topic, StressTestHelpers.GetKey(i), messageValue).ConfigureAwait(false);
-        }
-        await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
-        Console.WriteLine($"  Pre-seeded {preseedCount:N0} messages");
-
+        // The topic is pre-seeded by Program.SeedConsumerTopicAsync. The consumer re-reads
+        // that fixed data set in a loop (seek to beginning when all partitions are drained).
+        // A live feeder would compete with the consumer for CPU and cap throughput at the
+        // feeder's rate, measuring the feeder instead of the consumer.
         // Consumer uses string types but ConsumeRawBatchAsync skips deserialization
         await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(options.BootstrapServers)
@@ -53,11 +34,16 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
 
         consumer.Subscribe(options.Topic);
 
-        // Start background producer to continuously feed the consumer
-        var producerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var producerTask = StressTestHelpers.RunBackgroundProducerAsync(producer, options.Topic, messageValue, producerCts.Token);
+        var partitions = Enumerable.Range(0, options.Partitions)
+            .Select(p => new TopicPartition(options.Topic, p))
+            .ToArray();
 
-        // GC baseline after producer warmup but before consumer measurement
+        var endOffsets = await StressTestHelpers.QueryEndOffsetsAsync(consumer, options.Topic, options.Partitions, cancellationToken);
+        var replay = new PartitionReplayTracker(endOffsets);
+
+        Console.WriteLine($"  Consuming pre-seeded topic in a loop ({endOffsets.Sum():N0} messages per pass)");
+
+        // GC baseline before consumer measurement
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
@@ -80,10 +66,18 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
         {
             await foreach (var batch in consumer.ConsumeRawBatchAsync(cts.Token).ConfigureAwait(false))
             {
+                var lastOffset = -1L;
                 foreach (var record in batch)
                 {
                     throughput.RecordMessage(record.Value.Length);
                     progress.RecordMessage();
+                    lastOffset = record.Offset;
+                }
+
+                // Offsets are monotonic within a batch, so the last one decides drain state
+                if (lastOffset >= 0 && replay.RecordConsumed(batch.Partition, lastOffset))
+                {
+                    consumer.Positions.SeekToBeginning(partitions);
                 }
             }
         }
@@ -93,16 +87,12 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"  Consumer error: {ex.GetType().Name}: {ex.Message}");
+            Console.WriteLine($"  Consumer error: {ex}");
             throughput.RecordError();
         }
 
         throughput.Stop();
         gcStats.Capture();
-
-        // Stop background producer
-        await producerCts.CancelAsync().ConfigureAwait(false);
-        try { await producerTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
 
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
@@ -122,7 +112,8 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = null,
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -1,5 +1,4 @@
 using Dekaf.Consumer;
-using Dekaf.Producer;
 using Dekaf.Serialization;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
@@ -21,29 +20,11 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
     {
         var throughput = new ThroughputTracker();
         var startedAt = DateTime.UtcNow;
-        var messageValue = new string('x', options.MessageSizeBytes);
 
-        // Create producer to feed messages to the consumer (uses string serialization for production)
-        await using var producer = await Kafka.CreateProducer<string, string>()
-            .WithBootstrapServers(options.BootstrapServers)
-            .WithClientId("stress-consumer-raw-feeder-dekaf")
-            .WithAcks(Acks.Leader)
-            .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
-            .WithBatchSize(options.BatchSize)
-            .BuildAsync(cancellationToken);
-
-        // Pre-seed messages before starting consumer measurement.
-        // Note: Program.cs also seeds via SeedConsumerTopicAsync when running --scenario all.
-        // Both seeds are intentional — this ensures enough backlog regardless of invocation path.
-        Console.WriteLine("  Pre-seeding messages for consumer-raw test...");
-        const int preseedCount = 500_000;
-        for (var i = 0; i < preseedCount; i++)
-        {
-            await producer.FireAsync(options.Topic, StressTestHelpers.GetKey(i), messageValue).ConfigureAwait(false);
-        }
-        await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
-        Console.WriteLine($"  Pre-seeded {preseedCount:N0} messages");
-
+        // The topic is pre-seeded by Program.SeedConsumerTopicAsync. The consumer re-reads
+        // that fixed data set in a loop (seek to beginning when all partitions are drained).
+        // A live feeder would compete with the consumer for CPU and cap throughput at the
+        // feeder's rate, measuring the feeder instead of the consumer.
         // Consumer uses Ignore for key (don't care) and ReadOnlyMemory<byte> for zero-copy value access
         await using var consumer = await Kafka.CreateConsumer<Ignore, ReadOnlyMemory<byte>>()
             .WithBootstrapServers(options.BootstrapServers)
@@ -55,11 +36,16 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
 
         consumer.Subscribe(options.Topic);
 
-        // Start background producer to continuously feed the consumer
-        var producerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var producerTask = StressTestHelpers.RunBackgroundProducerAsync(producer, options.Topic, messageValue, producerCts.Token);
+        var partitions = Enumerable.Range(0, options.Partitions)
+            .Select(p => new TopicPartition(options.Topic, p))
+            .ToArray();
 
-        // GC baseline after producer warmup but before consumer measurement
+        var endOffsets = await StressTestHelpers.QueryEndOffsetsAsync(consumer, options.Topic, options.Partitions, cancellationToken);
+        var replay = new PartitionReplayTracker(endOffsets);
+
+        Console.WriteLine($"  Consuming pre-seeded topic in a loop ({endOffsets.Sum():N0} messages per pass)");
+
+        // GC baseline before consumer measurement
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
@@ -84,6 +70,11 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
             {
                 throughput.RecordMessage(record.Value.Length);
                 progress.RecordMessage();
+
+                if (replay.RecordConsumed(record.Partition, record.Offset))
+                {
+                    consumer.Positions.SeekToBeginning(partitions);
+                }
             }
         }
         catch (OperationCanceledException)
@@ -92,16 +83,12 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"  Consumer error: {ex.GetType().Name}: {ex.Message}");
+            Console.WriteLine($"  Consumer error: {ex}");
             throughput.RecordError();
         }
 
         throughput.Stop();
         gcStats.Capture();
-
-        // Stop background producer
-        await producerCts.CancelAsync().ConfigureAwait(false);
-        try { await producerTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
 
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
@@ -121,7 +108,8 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = null,
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -1,5 +1,4 @@
 using Dekaf.Consumer;
-using Dekaf.Producer;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 
@@ -14,29 +13,11 @@ internal sealed class ConsumerStressTest : IStressTestScenario
     {
         var throughput = new ThroughputTracker();
         var startedAt = DateTime.UtcNow;
-        var messageValue = new string('x', options.MessageSizeBytes);
 
-        // Create producer to feed messages to the consumer
-        await using var producer = await Kafka.CreateProducer<string, string>()
-            .WithBootstrapServers(options.BootstrapServers)
-            .WithClientId("stress-consumer-feeder-dekaf")
-            .WithAcks(Acks.Leader)
-            .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
-            .WithBatchSize(options.BatchSize)
-            .BuildAsync(cancellationToken);
-
-        // Pre-seed messages before starting consumer measurement.
-        // Note: Program.cs also seeds via SeedConsumerTopicAsync when running --scenario all.
-        // Both seeds are intentional — this ensures enough backlog regardless of invocation path.
-        Console.WriteLine("  Pre-seeding messages for consumer test...");
-        const int preseedCount = 500_000;
-        for (var i = 0; i < preseedCount; i++)
-        {
-            await producer.FireAsync(options.Topic, StressTestHelpers.GetKey(i), messageValue).ConfigureAwait(false);
-        }
-        await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
-        Console.WriteLine($"  Pre-seeded {preseedCount:N0} messages");
-
+        // The topic is pre-seeded by Program.SeedConsumerTopicAsync. The consumer re-reads
+        // that fixed data set in a loop (seek to beginning when all partitions are drained).
+        // A live feeder would compete with the consumer for CPU and cap throughput at the
+        // feeder's rate, measuring the feeder instead of the consumer.
         await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-consumer-dekaf")
@@ -47,11 +28,16 @@ internal sealed class ConsumerStressTest : IStressTestScenario
 
         consumer.Subscribe(options.Topic);
 
-        // Start background producer to continuously feed the consumer
-        var producerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var producerTask = StressTestHelpers.RunBackgroundProducerAsync(producer, options.Topic, messageValue, producerCts.Token);
+        var partitions = Enumerable.Range(0, options.Partitions)
+            .Select(p => new TopicPartition(options.Topic, p))
+            .ToArray();
 
-        // GC baseline after producer warmup but before consumer measurement
+        var endOffsets = await StressTestHelpers.QueryEndOffsetsAsync(consumer, options.Topic, options.Partitions, cancellationToken);
+        var replay = new PartitionReplayTracker(endOffsets);
+
+        Console.WriteLine($"  Consuming pre-seeded topic in a loop ({endOffsets.Sum():N0} messages per pass)");
+
+        // GC baseline before consumer measurement
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
@@ -76,6 +62,11 @@ internal sealed class ConsumerStressTest : IStressTestScenario
             {
                 throughput.RecordMessage(record.Value?.Length ?? 0);
                 progress.RecordMessage();
+
+                if (replay.RecordConsumed(record.Partition, record.Offset))
+                {
+                    consumer.Positions.SeekToBeginning(partitions);
+                }
             }
         }
         catch (OperationCanceledException)
@@ -84,16 +75,12 @@ internal sealed class ConsumerStressTest : IStressTestScenario
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"  Consumer error: {ex.GetType().Name}: {ex.Message}");
+            Console.WriteLine($"  Consumer error: {ex}");
             throughput.RecordError();
         }
 
         throughput.Stop();
         gcStats.Capture();
-
-        // Stop background producer
-        await producerCts.CancelAsync().ConfigureAwait(false);
-        try { await producerTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
 
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
@@ -113,7 +100,8 @@ internal sealed class ConsumerStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = null,
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/PartitionReplayTracker.cs
+++ b/tools/Dekaf.StressTests/Scenarios/PartitionReplayTracker.cs
@@ -1,0 +1,58 @@
+namespace Dekaf.StressTests.Scenarios;
+
+/// <summary>
+/// Tracks per-partition consumption against fixed end offsets so consumer scenarios can
+/// replay a pre-seeded topic in a loop instead of racing a live feeder. This bookkeeping
+/// IS the comparison methodology: every client scenario must share it, or the harness
+/// itself skews the Dekaf-vs-Confluent numbers.
+/// </summary>
+internal sealed class PartitionReplayTracker
+{
+    private readonly long[] _endOffsets;
+    private readonly bool[] _partitionsAtEnd;
+    private int _partitionsAtEndCount;
+
+    public PartitionReplayTracker(long[] endOffsets)
+    {
+        _endOffsets = endOffsets;
+        _partitionsAtEnd = new bool[endOffsets.Length];
+        Reset();
+    }
+
+    /// <summary>
+    /// Records a consumed offset. Returns true when every partition has reached its end
+    /// offset — the caller should seek back to the beginning; the tracker self-resets.
+    /// </summary>
+    public bool RecordConsumed(int partition, long offset)
+    {
+        if (_partitionsAtEnd[partition] || offset + 1 < _endOffsets[partition])
+        {
+            return false;
+        }
+
+        _partitionsAtEnd[partition] = true;
+        if (++_partitionsAtEndCount < _partitionsAtEnd.Length)
+        {
+            return false;
+        }
+
+        Reset();
+        return true;
+    }
+
+    private void Reset()
+    {
+        Array.Clear(_partitionsAtEnd);
+        _partitionsAtEndCount = 0;
+
+        // Partitions the seeder never wrote to would otherwise block the rewind forever.
+        for (var p = 0; p < _endOffsets.Length; p++)
+        {
+            if (_endOffsets[p] == 0)
+            {
+                _partitionsAtEnd[p] = true;
+                _partitionsAtEndCount++;
+            }
+        }
+    }
+}

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Dekaf.Compression.Lz4;
 using Dekaf.Compression.Snappy;
 using Dekaf.Compression.Zstd;
@@ -17,7 +16,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
     {
         var messageValue = new string('x', options.MessageSizeBytes);
         var throughput = new ThroughputTracker();
-        var latency = new LatencyTracker();
+        var latency = StressTestHelpers.CreateDeliveryLatencyTracker();
         var startedAt = DateTime.UtcNow;
 
         var builder = Kafka.CreateProducer<string, string>()
@@ -72,9 +71,14 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
         {
             try
             {
-                var start = Stopwatch.GetTimestamp();
-                await producer.FireAsync(options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue);
-                latency.RecordTicks(Stopwatch.GetTimestamp() - start);
+                if (messageIndex % StressTestHelpers.LatencySampleInterval == 0)
+                {
+                    StressTestHelpers.SampleDeliveryLatency(producer, options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue, latency, throughput);
+                }
+                else
+                {
+                    await producer.FireAsync(options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue);
+                }
                 throughput.RecordMessage(options.MessageSizeBytes);
                 messageIndex++;
 
@@ -137,7 +141,8 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = latency.GetSnapshot(),
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Dekaf.Compression.Lz4;
 using Dekaf.Compression.Snappy;
 using Dekaf.Compression.Zstd;
@@ -17,7 +16,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
     {
         var messageValue = new string('x', options.MessageSizeBytes);
         var throughput = new ThroughputTracker();
-        var latency = new LatencyTracker();
+        var latency = StressTestHelpers.CreateDeliveryLatencyTracker();
         var startedAt = DateTime.UtcNow;
 
         var builder = Kafka.CreateProducer<string, string>()
@@ -71,9 +70,14 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
         {
             try
             {
-                var start = Stopwatch.GetTimestamp();
-                await producer.FireAsync(options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue);
-                latency.RecordTicks(Stopwatch.GetTimestamp() - start);
+                if (messageIndex % StressTestHelpers.LatencySampleInterval == 0)
+                {
+                    StressTestHelpers.SampleDeliveryLatency(producer, options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue, latency, throughput);
+                }
+                else
+                {
+                    await producer.FireAsync(options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue);
+                }
                 throughput.RecordMessage(options.MessageSizeBytes);
                 messageIndex++;
 
@@ -136,7 +140,8 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = latency.GetSnapshot(),
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Dekaf.Compression.Lz4;
 using Dekaf.Compression.Snappy;
 using Dekaf.Compression.Zstd;
@@ -11,8 +9,6 @@ namespace Dekaf.StressTests.Scenarios;
 
 internal sealed class ProducerStressTest : IStressTestScenario
 {
-    private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
-
     public string Name => "producer";
     public string Client => "Dekaf";
 
@@ -20,7 +16,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
     {
         var messageValue = new string('x', options.MessageSizeBytes);
         var throughput = new ThroughputTracker();
-        var latency = new LatencyTracker();
+        var latency = StressTestHelpers.CreateDeliveryLatencyTracker();
         var startedAt = DateTime.UtcNow;
 
         var builder = Kafka.CreateProducer<string, string>()
@@ -78,9 +74,14 @@ internal sealed class ProducerStressTest : IStressTestScenario
         {
             try
             {
-                var start = Stopwatch.GetTimestamp();
-                await producer.FireAsync(options.Topic, GetKey(messageIndex), messageValue);
-                latency.RecordTicks(Stopwatch.GetTimestamp() - start);
+                if (messageIndex % StressTestHelpers.LatencySampleInterval == 0)
+                {
+                    StressTestHelpers.SampleDeliveryLatency(producer, options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue, latency, throughput);
+                }
+                else
+                {
+                    await producer.FireAsync(options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue);
+                }
                 throughput.RecordMessage(options.MessageSizeBytes);
                 messageIndex++;
 
@@ -143,20 +144,8 @@ internal sealed class ProducerStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = latency.GetSnapshot(),
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
     }
-
-    private static string[] CreatePreAllocatedKeys(int count)
-    {
-        var keys = new string[count];
-        for (var i = 0; i < count; i++)
-        {
-            keys[i] = $"key-{i}";
-        }
-        return keys;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
 }

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.StressTests.Metrics;
 
@@ -7,6 +8,14 @@ namespace Dekaf.StressTests.Scenarios;
 
 internal static class StressTestHelpers
 {
+    /// <summary>
+    /// Producer scenarios sample true end-to-end delivery latency on 1 in N messages.
+    /// Fire-and-forget latency only measures buffer-append time, which says nothing
+    /// about broker round-trips; sampling keeps the measurement honest without
+    /// stalling the produce loop.
+    /// </summary>
+    internal const int LatencySampleInterval = 1000;
+
     private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
 
     private static string[] CreatePreAllocatedKeys(int count)
@@ -23,64 +32,62 @@ internal static class StressTestHelpers
     internal static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
 
     /// <summary>
-    /// Yield frequency for the background producer. On low-CPU machines (4 or fewer processors),
-    /// yield more frequently to avoid starving the consumer and heartbeat threads.
-    /// This prevents the Dekaf background producer from dominating CPU and GC pressure,
-    /// which unfairly penalizes consumer throughput measurements vs Confluent (whose native
-    /// librdkafka producer has no .NET GC impact).
-    ///
-    /// The threshold of 4 CPUs was chosen because the stress test runs a producer, consumer,
-    /// heartbeat timer, and Kafka broker concurrently - at least 4 active threads. With 4 or
-    /// fewer processors there is no spare capacity, so the producer must yield aggressively.
-    /// GitHub Actions runners typically have 2-4 vCPUs, making this the common CI case.
+    /// Histogram for sampled delivery latency. The sample includes time queued in the
+    /// client's send buffer, which under saturation is seconds deep — so the range must
+    /// be much wider than the LatencyTracker default (coarser buckets keep it at ~2.4 MB).
     /// </summary>
-    private static readonly int BackgroundProducerYieldInterval =
-        Environment.ProcessorCount <= 4 ? 1_000 : 10_000;
+    internal static LatencyTracker CreateDeliveryLatencyTracker() =>
+        new(maxValueMs: 30_000, bucketWidthUs: 100);
 
     /// <summary>
-    /// Brief pause between yield batches on CPU-constrained machines to let the consumer
-    /// and heartbeat threads make progress. On well-provisioned machines, no delay is added.
+    /// Queries the high watermark of each partition, giving the fixed end offsets that
+    /// consumer scenarios replay against.
     /// </summary>
-    private static readonly int BackgroundProducerThrottleMs =
-        Environment.ProcessorCount <= 4 ? 10 : 0;
-
-    internal static async Task RunBackgroundProducerAsync(
-        IKafkaProducer<string, string> producer,
+    internal static async Task<long[]> QueryEndOffsetsAsync<TKey, TValue>(
+        IKafkaConsumer<TKey, TValue> consumer,
         string topic,
-        string messageValue,
+        int partitionCount,
         CancellationToken cancellationToken)
     {
-        var messageIndex = 0L;
-        var yieldInterval = BackgroundProducerYieldInterval;
-        var throttleMs = BackgroundProducerThrottleMs;
-
-        await Task.Yield();
-
-        while (!cancellationToken.IsCancellationRequested)
+        var endOffsets = new long[partitionCount];
+        for (var p = 0; p < partitionCount; p++)
         {
+            var watermarks = await consumer
+                .QueryWatermarkOffsetsAsync(new TopicPartition(topic, p), cancellationToken)
+                .ConfigureAwait(false);
+            endOffsets[p] = watermarks.High;
+        }
+        return endOffsets;
+    }
+
+    /// <summary>
+    /// Produces one message via ProduceAsync and records the full delivery round-trip
+    /// into <paramref name="latency"/> when it completes. The append (including
+    /// BufferMemory backpressure) runs synchronously like FireAsync; only the wait
+    /// for the broker acknowledgment is fire-and-forget, so the produce loop is not
+    /// stalled by the delivery round-trip.
+    /// </summary>
+    internal static void SampleDeliveryLatency(
+        IKafkaProducer<string, string> producer,
+        string topic,
+        string key,
+        string value,
+        LatencyTracker latency,
+        ThroughputTracker throughput)
+    {
+        _ = SampleAsync();
+
+        async Task SampleAsync()
+        {
+            var start = Stopwatch.GetTimestamp();
             try
             {
-                await producer.FireAsync(topic, GetKey(messageIndex), messageValue).ConfigureAwait(false);
-                messageIndex++;
-
-                // Yield periodically to avoid starving other tasks.
-                // On low-CPU machines, yield more frequently and add a brief pause
-                // to reduce GC pressure from the .NET producer competing with the consumer.
-                if (messageIndex % yieldInterval == 0)
-                {
-                    if (throttleMs > 0)
-                        await Task.Delay(throttleMs, cancellationToken).ConfigureAwait(false);
-                    else
-                        await Task.Yield();
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                break;
+                await producer.ProduceAsync(topic, key, value).ConfigureAwait(false);
+                latency.RecordTicks(Stopwatch.GetTimestamp() - start);
             }
             catch
             {
-                // Ignore producer errors in the feeder
+                throughput.RecordError();
             }
         }
     }


### PR DESCRIPTION
## Why

Stress tests reported near-identical Dekaf vs Confluent numbers ([run 28631457786](https://github.com/thomhurst/Dekaf/actions/runs/28631457786)): every 1-broker producer scenario landed within 0.1% of ~402.5k msg/s regardless of client, acks, or idempotence — the shared 4-vCPU runner's broker was the bottleneck, not the clients. Consumer scenarios were capped at ~100k msg/s by the throttled live feeder in the harness. Confluent additionally dropped 34M+ messages per run on local queue-full, invisible in the summary.

## What

**Make the client the measured bottleneck**
- Run on `ubicloud-standard-8` (8 vCPU): brokers pinned to cores 0-5, client under test pinned to cores 6-7 (`--cpuset-cpus` + `taskset`; `STRESS_BROKER_CPUSET`/`STRESS_BROKER_TMPFS` env vars drive the Testcontainers multi-broker path). Core split hoisted to job-level `env` so it lives in one place.
- Broker log dirs on tmpfs (`mode=1777` — Kafka images run as non-root and cannot write a root-owned tmpfs; found the hard way when the broker died with `No space left on device`/`AccessDenied` during smoke testing). Sized 6g against the ~1.5 GB worst case.

**Consumer scenarios measure the consumer, not the feeder**
- All five consumer scenarios now replay a pre-seeded, retention-exempt topic in a loop (seek to beginning when all partitions drain), via a shared `PartitionReplayTracker` so the methodology is identical across clients. The live feeder (hard-capped at ~100k msg/s on small runners) is gone.
- Seed size configurable via `--seed-messages` (default 2M ≈ 2 GB).

**Fair backpressure + honest metrics**
- Confluent producers block-and-retry on `Local_QueueFull`, mirroring Dekaf's BufferMemory backpressure — throughput is delivered goodput for both clients.
- True delivery latency sampled on 1-in-1000 messages (delivery-report callback for Confluent, awaited `ProduceAsync` for Dekaf) into a 30s-range histogram; the old fire-and-forget "latency" (buffer-append time, p50=p99=5µs) is gone.
- CPU time per measurement window recorded (`Environment.CpuUsage`) and reported as **CPU µs/msg** and **cores used** — differentiates client efficiency even where throughput is externally capped. Error counts now surface in all report tables.

**Consumer bug fix (src/Dekaf)**
- `ConsumeAsync` iterates the fetch at the head of `_pendingFetches` while leaving it queued; calling `Seek`/`Assign` from inside the consume loop cleared the buffer and disposed that fetch mid-iteration → `NullReferenceException` on disposed pooled buffers. Queued-fetch disposal now goes through one helper that bumps a version counter, and the iterator abandons the disposed fetch cleanly after the yield. Covered by a new integration test (`Consumer_SeekToBeginningInsideConsumeLoop_ReplaysWithoutError`). Found because the new replay methodology seeks mid-loop.

## Validation

- 3833/3833 unit tests pass; new + existing seek integration tests pass.
- 1-minute smoke runs of producer/consumer/consumer-batch scenarios for both clients against a local Kafka 4.x broker: zero errors, exact-pass replay counts (e.g. 42 × 200k), real latency percentiles (no histogram overflow), CPU fields serialized into results JSON.
- Local indicative numbers (Windows/WSL, unpinned): Dekaf 2.2 µs CPU/msg vs Confluent 6.8 µs CPU/msg at the same broker ceiling.

## Notes

- Expect the first CI run to shift all absolute numbers — that's the point: they become client-bound and comparable.
- Known pre-existing gap (unchanged): local single-broker Testcontainers uses `cp-kafka:7.5` (Kafka 3.5), which Dekaf's KIP-848 consumer can't run against; CI uses `apache/kafka:latest`.
- Prior run's anomaly worth a follow-up: Dekaf 3conn+idempotent+3-broker ran at half the 1conn throughput.