### PR TITLE
test: deflake residual wall-clock caps left by #1113

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -71,7 +71,9 @@ public sealed class ConsumerLeaderDiscoveryTests
         };
 
         await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
-        await connectionRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        // The background refresh signals connectionRequested when it calls GetConnectionAsync.
+        // Await it directly: a 5s cap raced that continuation under CI thread-pool starvation.
+        await connectionRequested.Task;
 
         await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
 
@@ -113,7 +115,9 @@ public sealed class ConsumerLeaderDiscoveryTests
 
         await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
 
-        var refreshToken = await refreshTokenCaptured.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        // The background refresh signals refreshTokenCaptured when it calls SendAsync.
+        // Await directly: a 5s cap raced that continuation under CI thread-pool starvation.
+        var refreshToken = await refreshTokenCaptured.Task;
         await Assert.That(refreshToken.IsCancellationRequested).IsFalse();
 
         refreshResponse.SetResult(CreateMetadataResponse());
@@ -152,7 +156,9 @@ public sealed class ConsumerLeaderDiscoveryTests
 
         await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
 
-        var refreshToken = await refreshTokenCaptured.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        // The background refresh signals refreshTokenCaptured when it calls SendAsync.
+        // Await directly: a 5s cap raced that continuation under CI thread-pool starvation.
+        var refreshToken = await refreshTokenCaptured.Task;
 
         await Assert.That(refreshToken.IsCancellationRequested).IsFalse();
 
@@ -208,15 +214,19 @@ public sealed class ConsumerLeaderDiscoveryTests
             };
 
             await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
-            await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            // Each step below is gated by a deterministic signal (the mock's SendAsync, the
+            // refresh cancellation callback, and the dispose completing after the refresh
+            // response is set). The previous 5s caps raced those continuations under CI
+            // thread-pool starvation; TUnit's test-level timeout is the backstop for a real hang.
+            await refreshStarted.Task;
 
             disposeTask = consumer.DisposeAsync().AsTask();
-            await refreshCancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await refreshCancellationObserved.Task;
 
             await Assert.That(poolDisposeStarted.Task.IsCompleted).IsFalse();
 
             refreshResponse.SetResult(CreateMetadataResponse());
-            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+            await disposeTask;
 
             await Assert.That(poolDisposeStarted.Task.IsCompleted).IsTrue();
         }
@@ -225,7 +235,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             refreshResponse.TrySetCanceled();
 
             if (disposeTask is not null)
-                await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+                await disposeTask;
             else
                 await consumer.DisposeAsync();
         }

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Protocol.Records;
@@ -161,8 +160,10 @@ public class MpscFetchBufferTests
         await Assert.That(buffer.TryWrite(first)).IsTrue();
         await Assert.That(buffer.TryWrite(second)).IsTrue();
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await buffer.WaitToWriteAsync(cts.Token).AsTask().WaitAsync(cts.Token);
+        // No wall-clock deadline: the read callback above frees slots and releases the
+        // waiter deterministically. A short cts previously flaked under CI thread-pool
+        // starvation delaying the release continuation; the suite hang dump is the backstop.
+        await buffer.WaitToWriteAsync(CancellationToken.None).AsTask();
 
         await Assert.That(callbackCount).IsEqualTo(1);
         await Assert.That(GetSpaceAvailableSignalCount(buffer)).IsEqualTo(0);
@@ -255,13 +256,12 @@ public class MpscFetchBufferTests
     public async Task WaitToReadAsync_EmptyBuffer_ReturnsWithoutBlockingCaller()
     {
         var buffer = new MpscFetchBuffer(4);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var cts = new CancellationTokenSource();
 
-        var elapsed = Stopwatch.StartNew();
+        // The synchronous call returns a pending wait without blocking the caller;
+        // IsCompleted == false proves that without a flaky wall-clock measurement.
         var waitTask = buffer.WaitToReadAsync(30_000, cts.Token).AsTask();
-        elapsed.Stop();
 
-        await Assert.That(elapsed.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
         await Assert.That(waitTask.IsCompleted).IsFalse();
 
         await cts.CancelAsync();
@@ -272,20 +272,22 @@ public class MpscFetchBufferTests
     public async Task WaitToReadAsync_Timeout_ReturnsFalseAndClearsWaiterState()
     {
         var buffer = new MpscFetchBuffer(4);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
-        var timedOut = await buffer.WaitToReadAsync(25, cts.Token).AsTask().WaitAsync(cts.Token);
+        // The 25ms argument is the buffer's own timeout under test; it completes the wait
+        // deterministically. The previous outer .WaitAsync(cts) cap raced that release
+        // continuation under CI thread-pool starvation. The suite hang dump is the backstop.
+        var timedOut = await buffer.WaitToReadAsync(25, CancellationToken.None).AsTask();
 
         await Assert.That(timedOut).IsFalse();
         await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
         await Assert.That(GetDataAvailableWaiter(buffer)).IsNull();
 
-        var waitTask = buffer.WaitToReadAsync(30_000, cts.Token).AsTask();
+        var waitTask = buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None).AsTask();
         await Assert.That(waitTask.IsCompleted).IsFalse();
 
         buffer.Complete();
 
-        await Assert.That(await waitTask.WaitAsync(cts.Token)).IsFalse();
+        await Assert.That(await waitTask).IsFalse();
         await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
         await Assert.That(GetDataAvailableWaiter(buffer)).IsNull();
     }
@@ -307,14 +309,15 @@ public class MpscFetchBufferTests
     {
         var buffer = new MpscFetchBuffer(4);
         var expectedException = new InvalidOperationException("test error");
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
-        var waitTask = buffer.WaitToReadAsync(30_000, cts.Token).AsTask();
+        // Complete(error) releases the waiter deterministically; the previous 10s cts cap
+        // raced the completion continuation under CI thread-pool starvation.
+        var waitTask = buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None).AsTask();
         await Assert.That(waitTask.IsCompleted).IsFalse();
 
         buffer.Complete(expectedException);
 
-        await Assert.That(async () => await waitTask.WaitAsync(cts.Token))
+        await Assert.That(async () => await waitTask)
             .Throws<InvalidOperationException>()
             .WithMessage("test error");
         await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
@@ -351,15 +354,15 @@ public class MpscFetchBufferTests
         var buffers = Enumerable.Range(0, BufferCount)
             .Select(_ => new MpscFetchBuffer(4))
             .ToArray();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
-        var elapsed = Stopwatch.StartNew();
+        // No wall-clock caps: Complete() below releases every waiter deterministically.
+        // The previous 10s cts + elapsed<1s assertions raced the RunContinuationsAsynchronously
+        // waiter continuations under CI thread-pool starvation (this test still flaked after
+        // #1113 deflaked its siblings). The suite hang dump is the backstop for a real hang.
         var waitTasks = buffers
-            .Select(buffer => buffer.WaitToReadAsync(30_000, cts.Token).AsTask())
+            .Select(buffer => buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None).AsTask())
             .ToArray();
-        elapsed.Stop();
 
-        await Assert.That(elapsed.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
         await Assert.That(waitTasks.All(task => !task.IsCompleted)).IsTrue();
 
         foreach (var buffer in buffers)
@@ -367,7 +370,7 @@ public class MpscFetchBufferTests
             buffer.Complete();
         }
 
-        var results = await Task.WhenAll(waitTasks).WaitAsync(cts.Token);
+        var results = await Task.WhenAll(waitTasks);
 
         await Assert.That(results.All(result => !result)).IsTrue();
     }

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -655,13 +655,10 @@ public class PooledValueTaskSourceTests
         // Complete after observing - should trigger continuation
         source.SetResult(42);
 
-        // Spin-wait with timeout for the continuation to execute,
-        // as Task.Delay(1) is too short under thread pool starvation on CI
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        while (pool.ApproximateCount == 0 && sw.Elapsed < TimeSpan.FromSeconds(10))
-        {
-            await Task.Yield();
-        }
+        // The completion continuation returns the source to the pool. Poll for it with no
+        // wall-clock deadline: a fixed cap flaked when CI thread-pool starvation delayed the
+        // continuation past it. TUnit's test-level timeout is the backstop for a real hang.
+        await TestWait.UntilAsync(() => pool.ApproximateCount == 1, CancellationToken.None);
 
         // Source should have been returned to pool
         await Assert.That(pool.ApproximateCount).IsEqualTo(1);


### PR DESCRIPTION
## Problem

Unit tests kept failing intermittently on `main` even after PR #1113 deflaked a batch of timing tests. Surveying the last several `main` CI failures, the **Build & Unit Test** job flaked on:

| Test | Failure | Status |
|------|---------|--------|
| `WaitToReadAsync_ManyIdleBuffers_CompleteUnblocksAll` | `TaskCanceledException [Timeout]` | **still flaked at 09:16, _after_ #1113 merged at 09:06** |
| `WaitToReadAsync_Timeout_ReturnsFalseAndClearsWaiterState` | `TaskCanceledException [Timeout]` | not fixed by #1113 |
| `DisposeAsync_WithInFlightLeaderRefresh_WaitsBeforeDisposingDependencies` | `TimeoutException` | not fixed by #1113 |
| `ObserveForFireAndForget_ReturnsToPool_WhenCompletedAsynchronously` | `Assert count == 1` | never in #1113 scope |

## Root cause

All share the single root cause #1113 documented: a test gates a background/async continuation with an **arbitrary wall-clock cap** (a `cts` deadline, an outer `.WaitAsync(TimeSpan)`, a spin-wait timeout, or an `elapsed < 1s` assertion). On a loaded CI runner the thread pool is briefly starved, the continuation isn't scheduled within the cap, and the test times out or asserts a stalled count.

**#1113 fixed a subset and left same-class siblings carrying the identical anti-pattern** — which is why `main` is still flaking. This PR finishes that pass.

## Fix

Rely on the deterministic completion signal each test already has (`TryWrite`/`Complete`, the mock's `SendAsync`/cancellation callback, the pool-return continuation) and drop the arbitrary cap. TUnit's test-level timeout / 15m hang dump remains the sole backstop for a genuine hang.

- **MpscFetchBufferTests** — drop `10s cts` + `.WaitAsync(cts)` caps and `elapsed<1s` assertions from `ManyIdleBuffers` (proven flake), `Timeout`, `CompletedWithErrorWhileWaiting`, `EmptyBuffer`, `RecheckDrainsAllReleasedPermits`; use `Timeout.Infinite` / `CancellationToken.None`.
- **ConsumerLeaderDiscoveryTests** — drop the `5s .WaitAsync` caps on deterministic TCS signals in `DisposeAsync_WithInFlightLeaderRefresh` and the three `HandleNotLeaderOrFollower` siblings.
- **PooledValueTaskSourceTests** — replace the 10s spin-wait with `TestWait.UntilAsync(cond, CancellationToken.None)`.

Deliberately scoped to the evidence-backed flakes + their direct same-class siblings, matching #1113's targeted approach rather than rewriting every `.WaitAsync(TimeSpan)` in the suite.

## Verification

Clean Release build under CI's SDK (10.0.x): 0 warnings, 0 errors. The three affected classes (23 + 5 + 37 tests) pass across repeated local runs, 0 failures.