### PR TITLE
fix(stress-tests): measure delivered throughput, not client-side appends

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -55,14 +55,32 @@ def format_cpu_columns(result):
     )
 
 
+def effective_rate(result):
+    """Headline throughput. The selection policy (broker-confirmed delivered rate when
+    measured, else the client-side tracker average) lives in StressTestResult and is
+    serialized as effectiveMessagesPerSecond; the throughput fallback here only covers
+    result files written before that field existed."""
+    rate = result.get('effectiveMessagesPerSecond')
+    if rate is not None:
+        return rate
+    return result.get('throughput', {}).get('averageMessagesPerSecond', 0)
+
+
+def effective_mb_rate(result):
+    rate = result.get('effectiveMegabytesPerSecond')
+    if rate is not None:
+        return rate
+    return result.get('throughput', {}).get('averageMegabytesPerSecond', 0)
+
+
 def find_confluent_baseline(results):
     """Find Confluent throughput as a baseline for ratio calculations."""
     for r in results:
         if r.get('client', '').lower() == 'confluent':
-            rate = r.get('throughput', {}).get('averageMessagesPerSecond', 0)
+            rate = effective_rate(r)
             if rate > 0:
                 return rate
-    return min((r.get('throughput', {}).get('averageMessagesPerSecond', 1) for r in results), default=1)
+    return min((effective_rate(r) or 1 for r in results), default=1)
 
 
 def format_throughput_table(results, title, include_ratio=False):
@@ -78,31 +96,39 @@ def format_throughput_table(results, title, include_ratio=False):
     lines.append("")
 
     if include_ratio:
-        lines.append("| Client | Messages/sec | MB/sec | Total Messages | Errors | CPU μs/msg | Cores Used | Ratio |")
+        lines.append("| Client | Messages/sec | MB/sec | Accepted msg/s | Errors | CPU μs/msg | Cores Used | Ratio |")
         lines.append("|--------|--------------|--------|----------------|--------|------------|------------|-------|")
     else:
-        lines.append("| Client | Messages/sec | MB/sec | Total | Errors | CPU μs/msg | Cores Used |")
-        lines.append("|--------|--------------|--------|-------|--------|------------|------------|")
+        lines.append("| Client | Messages/sec | MB/sec | Accepted msg/s | Errors | CPU μs/msg | Cores Used |")
+        lines.append("|--------|--------------|--------|----------------|--------|------------|------------|")
 
     baseline = find_confluent_baseline(results) if include_ratio else 0
-    sorted_results = sorted(results, key=lambda r: r.get('throughput', {}).get('averageMessagesPerSecond', 0), reverse=True)
+    sorted_results = sorted(results, key=effective_rate, reverse=True)
 
     for r in sorted_results:
         client = r.get('client', 'Unknown')
         throughput = r.get('throughput', {})
-        msg_sec = throughput.get('averageMessagesPerSecond', 0)
-        mb_sec = throughput.get('averageMegabytesPerSecond', 0)
-        total = throughput.get('totalMessages', 0)
+        msg_sec = effective_rate(r)
+        mb_sec = effective_mb_rate(r)
+        accepted_rate = r.get('acceptedMessagesPerSecond')
+        accepted = f"{accepted_rate:,.0f}" if accepted_rate is not None else '-'
         errors = throughput.get('totalErrors', 0)
         cpu_us_per_msg, cores_used = format_cpu_columns(r)
 
         if include_ratio:
             ratio = msg_sec / baseline if baseline > 0 else 1.0
-            lines.append(f"| {client} | {msg_sec:,.0f} | {mb_sec:.2f} | {total:,} | {errors} | {cpu_us_per_msg} | {cores_used} | {ratio:.2f}x |")
+            lines.append(f"| {client} | {msg_sec:,.0f} | {mb_sec:.2f} | {accepted} | {errors} | {cpu_us_per_msg} | {cores_used} | {ratio:.2f}x |")
         else:
-            lines.append(f"| {client} | {msg_sec:,.0f} | {mb_sec:.2f} | {total:,} | {errors} | {cpu_us_per_msg} | {cores_used} |")
+            lines.append(f"| {client} | {msg_sec:,.0f} | {mb_sec:.2f} | {accepted} | {errors} | {cpu_us_per_msg} | {cores_used} |")
 
     lines.append("")
+
+    if any(r.get('deliveredMessages') is not None for r in results):
+        lines.append("*Messages/sec counts broker-confirmed deliveries (end-offset delta). "
+                     "Accepted msg/s is the client-side append rate — a large gap means messages "
+                     "were buffered or dropped without ever reaching the broker.*")
+        lines.append("")
+
     return lines
 
 
@@ -114,8 +140,8 @@ def format_comparison_callout(results, title):
     if not (dekaf and confluent):
         return []
 
-    dekaf_rate = dekaf.get('throughput', {}).get('averageMessagesPerSecond', 0)
-    confluent_rate = confluent.get('throughput', {}).get('averageMessagesPerSecond', 0)
+    dekaf_rate = effective_rate(dekaf)
+    confluent_rate = effective_rate(confluent)
     if confluent_rate <= 0:
         return []
 

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -115,11 +115,13 @@ jobs:
     env:
       BROKER_CPUS: 0-5
       CLIENT_CPUS: 6,7
-      # Broker log dirs live on tmpfs so disk I/O never caps ingestion. Sized well
-      # above the ~1.5 GB worst case (768 MB byte-retention cap plus produce-rate
-      # overshoot between retention checks, or the 2 GB seeded consumer topic):
-      # running out of log-dir space shuts the broker down.
+      # Broker log dirs live on tmpfs so disk I/O never caps ingestion. Sized above the
+      # worst-case retention overshoot (see KafkaEnvironment.RetentionConfig for the
+      # math); a fill halts the broker, so the disk monitor below samples usage during
+      # the run to make one visible in the job output.
       BROKER_TMPFS: 6g
+      # Broker JVM heap: the image default (1 GB) is undersized for ~1 GB/s ingestion.
+      BROKER_HEAP: -Xmx2g -Xms2g
 
     steps:
       - name: Checkout
@@ -144,6 +146,7 @@ jobs:
             --cpuset-cpus="${BROKER_CPUS}" \
             --tmpfs /var/lib/kafka/data:rw,size=${BROKER_TMPFS},mode=1777 \
             -p 9092:9092 \
+            -e KAFKA_HEAP_OPTS="${BROKER_HEAP}" \
             -e KAFKA_NODE_ID=1 \
             -e KAFKA_PROCESS_ROLES=broker,controller \
             -e KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093 \
@@ -174,6 +177,11 @@ jobs:
             sleep 2
           done
 
+          # The retention settings above are what keeps the tmpfs from filling; verify
+          # the image actually applied them rather than assuming the env mapping worked.
+          echo "=== Effective broker retention/segment config ==="
+          docker logs kafka 2>&1 | grep -E 'log\.retention\.|log\.segment\.|log\.cleanup' | head -15 || true
+
       - name: Run ${{ matrix.name }} Stress Test
         env:
           KAFKA_BOOTSTRAP_SERVERS: ${{ matrix.brokers == 1 && 'localhost:9092' || '' }}
@@ -181,7 +189,25 @@ jobs:
           # process; these apply the same core pinning and tmpfs as the docker run above.
           STRESS_BROKER_CPUSET: ${{ env.BROKER_CPUS }}
           STRESS_BROKER_TMPFS: ${{ env.BROKER_TMPFS }}
+          STRESS_BROKER_HEAP: ${{ env.BROKER_HEAP }}
         run: |
+          # Background disk monitor: samples every broker's log-dir usage so a tmpfs
+          # fill (ingestion outpacing retention — the known broker-halt failure mode)
+          # is visible in the uploaded artifacts. Iterates docker ps each tick because
+          # multi-broker containers are started later by the test process itself.
+          # Pinned to the broker cores: the docker exec round trips must not steal
+          # cycles from the client cores whose isolation this job exists to provide.
+          taskset -c "${BROKER_CPUS}" bash -c '
+            while true; do
+              for c in $(docker ps --format "{{.Names}}"); do
+                line=$(docker exec "$c" df -h /var/lib/kafka/data 2>/dev/null | tail -n 1) \
+                  && echo "[$(date -u "+%H:%M:%S")] $c: $line"
+              done
+              sleep 15
+            done
+          ' > "$GITHUB_WORKSPACE/broker-disk.log" 2>&1 &
+          DISK_MONITOR_PID=$!
+
           cd tools/Dekaf.StressTests
           # Client pinned to its own cores: whichever client pushes more through the
           # same cores is genuinely faster, instead of both saturating the broker.
@@ -194,11 +220,31 @@ jobs:
             --connections-per-broker ${{ matrix.connections_per_broker || '1' }} \
             --output ./results
 
+          kill $DISK_MONITOR_PID 2>/dev/null || true
+
+      - name: Broker Diagnostics
+        if: always()
+        run: |
+          echo "=== Broker log-dir usage over time ==="
+          cat "$GITHUB_WORKSPACE/broker-disk.log" 2>/dev/null || echo "(no disk log captured)"
+          # Multi-broker containers are owned by the test process, which dumps their
+          # diagnostics before disposing them; only the workflow-managed single broker
+          # is still around to inspect here.
+          if [ "${{ matrix.brokers }}" = "1" ]; then
+            echo "=== Broker errors/storage events ==="
+            docker logs kafka 2>&1 | grep -iE 'ERROR|FATAL|No space|IOException|offline|shutdown' | tail -40 || true
+            echo "=== Broker last 60 log lines ==="
+            docker logs --tail 60 kafka 2>&1 || true
+          fi
+
       - name: Upload Results
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: results-${{ matrix.client }}-${{ matrix.scenario }}-${{ matrix.brokers }}brokers${{ matrix.connections_per_broker && format('-{0}conn', matrix.connections_per_broker) || '' }}
-          path: tools/Dekaf.StressTests/results/
+          path: |
+            tools/Dekaf.StressTests/results/
+            broker-disk.log
           retention-days: 90
 
       - name: Stop Kafka
@@ -417,7 +463,8 @@ jobs:
           output.append("- **Real Kafka**: Tests run against actual Apache Kafka instances")
           output.append("- **CPU Isolation**: Brokers are pinned to dedicated cores and the client under test to its own cores, so the client — not the broker — is the measured bottleneck")
           output.append("- **RAM-backed Broker Logs**: Kafka log dirs are mounted on tmpfs so disk I/O never caps broker ingestion")
-          output.append("- **Backpressure Parity**: Confluent producers block and retry on a full local queue, mirroring Dekaf's BufferMemory backpressure, so throughput is delivered goodput for both clients")
+          output.append("- **Delivered Throughput**: producer tables report broker-confirmed throughput, measured as the end-offset delta across all partitions — not the client-side append rate, which can run far ahead of what the broker ever accepts")
+          output.append("- **Backpressure Parity**: both producers are bounded to the same 512 MB local buffer (Dekaf BufferMemory, librdkafka queue.buffering.max) and block on a full buffer, so neither client can absorb an unbounded backlog into RAM")
           output.append("- **Consumer Loop Replay**: Consumer tests re-read a pre-seeded topic (seek to beginning when drained) instead of racing a live feeder, so the consumer itself is measured")
           output.append("- **Delivery Latency Sampling**: 1 in 1000 produced messages is awaited end-to-end to record true broker round-trip latency")
           output.append("- **CPU Efficiency**: CPU time per message differentiates client efficiency even at equal throughput")

--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -21,15 +21,28 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
     // Solution: byte-based retention (128 MB/partition × 6 partitions ≈ 768 MB max disk) is
     // the primary bound. Time-based retention (5 min) is a secondary backstop. Small 16 MB
     // segments let Kafka reclaim space incrementally as the consumer keeps up.
+    //
+    // The 1s check interval is load-bearing: producers push ~1 GB/s, so disk usage can
+    // overshoot the retention caps by roughly (produce rate × check interval) between
+    // sweeps. A 10s interval meant ~10 GB overshoot windows — more than the broker tmpfs —
+    // which filled the log dir and halted ingestion seconds into producer runs.
     private static readonly Dictionary<string, string> RetentionConfig = new()
     {
         ["KAFKA_LOG_RETENTION_MS"] = "300000",
         ["KAFKA_LOG_RETENTION_BYTES"] = "134217728",
         ["KAFKA_LOG_SEGMENT_BYTES"] = "16777216",
         ["KAFKA_LOG_SEGMENT_DELETE_DELAY_MS"] = "1000",
-        ["KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS"] = "10000",
+        ["KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS"] = "1000",
         ["KAFKA_LOG_CLEANUP_POLICY"] = "delete",
     };
+
+    // The image default (1 GB) is undersized for sustained ~1 GB/s ingestion; give the
+    // broker JVM headroom so heap pressure doesn't masquerade as a client bottleneck.
+    // Overridable via STRESS_BROKER_HEAP — the same channel as STRESS_BROKER_CPUSET /
+    // STRESS_BROKER_TMPFS — so CI keeps this and its workflow-managed single broker in
+    // sync from one place.
+    private static readonly string BrokerHeapOpts =
+        Environment.GetEnvironmentVariable("STRESS_BROKER_HEAP") ?? "-Xmx2g -Xms2g";
 
     // Optional broker resource constraints, primarily for CI. STRESS_BROKER_CPUSET pins
     // broker containers to specific cores so the client under test keeps dedicated cores
@@ -102,7 +115,8 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
         var builder = new KafkaBuilder("confluentinc/cp-kafka:7.5.0")
             .WithPortBinding(9092, true)
             // Explicit log dir so the optional tmpfs mount target always matches
-            .WithEnvironment("KAFKA_LOG_DIRS", KafkaLogDir);
+            .WithEnvironment("KAFKA_LOG_DIRS", KafkaLogDir)
+            .WithEnvironment("KAFKA_HEAP_OPTS", BrokerHeapOpts);
 
         foreach (var (key, value) in RetentionConfig)
         {
@@ -172,7 +186,8 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
                 .WithEnvironment("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER")
                 .WithEnvironment("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", Math.Min(brokerCount, 3).ToString())
                 // Explicit log dir so the optional tmpfs mount target always matches
-                .WithEnvironment("KAFKA_LOG_DIRS", KafkaLogDir);
+                .WithEnvironment("KAFKA_LOG_DIRS", KafkaLogDir)
+                .WithEnvironment("KAFKA_HEAP_OPTS", BrokerHeapOpts);
 
             foreach (var (key, value) in RetentionConfig)
             {
@@ -339,10 +354,83 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
         Console.WriteLine($"Created topic: {topic} (partitions={partitions}, replication={replicationFactor})");
     }
 
+    /// <summary>
+    /// Dumps broker log-dir usage and error/storage log lines before a container is
+    /// stopped. Broker-side failures (e.g. a full tmpfs halting ingestion mid-run) are
+    /// otherwise invisible: Testcontainers removes the container and its logs with it.
+    /// </summary>
+    private static async Task DumpBrokerDiagnosticsAsync(IContainer container, string name)
+    {
+        try
+        {
+            var df = await container.ExecAsync(["df", "-h", KafkaLogDir]).ConfigureAwait(false);
+            Console.WriteLine($"[{name}] log-dir usage:");
+            Console.WriteLine(df.Stdout.TrimEnd());
+
+            var (stdout, stderr) = await container.GetLogsAsync(timestampsEnabled: false).ConfigureAwait(false);
+
+            // Bounded scan instead of concat+Split: broker logs can be tens of MB after
+            // a 15-minute run and several containers dispose concurrently.
+            const int maxLines = 30;
+            var interesting = new Queue<string>(maxLines);
+            foreach (var line in EnumerateLines(stdout).Concat(EnumerateLines(stderr)))
+            {
+                if (!IsInterestingLogLine(line))
+                {
+                    continue;
+                }
+
+                if (interesting.Count == maxLines)
+                {
+                    interesting.Dequeue();
+                }
+
+                interesting.Enqueue(line);
+            }
+
+            if (interesting.Count > 0)
+            {
+                Console.WriteLine($"[{name}] broker errors/storage events (last {interesting.Count}):");
+                foreach (var line in interesting)
+                {
+                    Console.WriteLine($"  {line}");
+                }
+            }
+            else
+            {
+                Console.WriteLine($"[{name}] no broker errors/storage events logged");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[{name}] broker diagnostics failed: {ex.Message}");
+        }
+
+        // Keep in sync with the triage grep in .github/workflows/stress-tests.yml
+        // (Broker Diagnostics step), which covers the workflow-managed single broker.
+        static bool IsInterestingLogLine(string line) =>
+            line.Contains("ERROR", StringComparison.OrdinalIgnoreCase)
+            || line.Contains("FATAL", StringComparison.OrdinalIgnoreCase)
+            || line.Contains("No space", StringComparison.OrdinalIgnoreCase)
+            || line.Contains("IOException", StringComparison.OrdinalIgnoreCase)
+            || line.Contains("offline", StringComparison.OrdinalIgnoreCase)
+            || line.Contains("shutdown", StringComparison.OrdinalIgnoreCase);
+
+        static IEnumerable<string> EnumerateLines(string text)
+        {
+            using var reader = new StringReader(text);
+            while (reader.ReadLine() is { } line)
+            {
+                yield return line;
+            }
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_container is not null)
         {
+            await DumpBrokerDiagnosticsAsync(_container, "kafka").ConfigureAwait(false);
             Console.WriteLine("Stopping Kafka container...");
             await _container.DisposeAsync().ConfigureAwait(false);
         }
@@ -354,6 +442,7 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
             {
                 try
                 {
+                    await DumpBrokerDiagnosticsAsync(c, c.Name).ConfigureAwait(false);
                     await c.DisposeAsync().ConfigureAwait(false);
                     return (Exception?)null;
                 }

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -67,28 +67,38 @@ internal static class MarkdownReporter
             var messageSizeKb = messageSize >= 1024 ? $"{messageSize / 1024.0:F1}KB" : $"{messageSize}B";
             sb.AppendLine($"## {title} ({durationMinutes} minutes, {messageSizeKb} messages)");
             sb.AppendLine();
-            sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Messages/sec | MB/sec | Errors | CPU μs/msg | Cores Used | Ratio |");
-            sb.AppendLine($"|{new string('-', clientWidth + 2)}|--------------|--------|--------|------------|------------|-------|");
+            sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Messages/sec | MB/sec | Accepted msg/s | Errors | CPU μs/msg | Cores Used | Ratio |");
+            sb.AppendLine($"|{new string('-', clientWidth + 2)}|--------------|--------|----------------|--------|------------|------------|-------|");
 
             var baseline = sizeResults
                 .Where(r => r.Client.Equals("Confluent", StringComparison.OrdinalIgnoreCase))
-                .Select(r => r.Throughput.AverageMessagesPerSecond)
+                .Select(r => r.EffectiveMessagesPerSecond)
                 .FirstOrDefault();
 
             if (baseline == 0)
             {
-                baseline = sizeResults.Min(r => r.Throughput.AverageMessagesPerSecond);
+                baseline = sizeResults.Min(r => r.EffectiveMessagesPerSecond);
             }
 
-            foreach (var result in sizeResults.OrderByDescending(r => r.Throughput.AverageMessagesPerSecond))
+            foreach (var result in sizeResults.OrderByDescending(r => r.EffectiveMessagesPerSecond))
             {
-                var ratio = baseline > 0 ? result.Throughput.AverageMessagesPerSecond / baseline : 1.0;
+                var rate = result.EffectiveMessagesPerSecond;
+                var ratio = baseline > 0 ? rate / baseline : 1.0;
+                var accepted = result.AcceptedMessagesPerSecond is { } acceptedRate ? acceptedRate.ToString("N0") : "-";
                 var cpuPerMessage = result.CpuMicrosPerMessage is { } cpu ? $"{cpu:F2}" : "-";
                 var coresUsed = result.AverageCoresUsed is { } cores ? $"{cores:F2}" : "-";
-                sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {result.Throughput.AverageMessagesPerSecond,12:N0} | {result.Throughput.AverageMegabytesPerSecond,6:F2} | {result.Throughput.TotalErrors,6} | {cpuPerMessage,10} | {coresUsed,10} | {ratio:F2}x |");
+                sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {rate,12:N0} | {result.EffectiveMegabytesPerSecond,6:F2} | {accepted,14} | {result.Throughput.TotalErrors,6} | {cpuPerMessage,10} | {coresUsed,10} | {ratio:F2}x |");
             }
 
             sb.AppendLine();
+
+            if (sizeResults.Any(r => r.DeliveredMessages is not null))
+            {
+                sb.AppendLine("*Messages/sec counts broker-confirmed deliveries (end-offset delta). " +
+                    "Accepted msg/s is the client-side append rate — a large gap means messages were " +
+                    "buffered or dropped without ever reaching the broker.*");
+                sb.AppendLine();
+            }
         }
     }
 

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -18,6 +18,46 @@ internal sealed class StressTestResult
     public int BrokerCount { get; init; } = 1;
 
     /// <summary>
+    /// Broker-confirmed message count, measured as the end-offset (high watermark)
+    /// delta across all topic partitions between test start and end. Fire-and-forget
+    /// scenarios count client-side appends in <see cref="Throughput"/>; when the client
+    /// buffers faster than the broker accepts (or the broker degrades mid-run), accepted
+    /// and delivered diverge — this is the honest throughput number.
+    /// Null when the scenario doesn't measure it or the watermark query failed.
+    /// </summary>
+    public long? DeliveredMessages { get; init; }
+
+    public double? DeliveredMessagesPerSecond =>
+        DeliveredMessages is { } delivered && Throughput.ElapsedSeconds > 0
+            ? delivered / Throughput.ElapsedSeconds
+            : null;
+
+    public double? DeliveredMegabytesPerSecond =>
+        DeliveredMessagesPerSecond is { } rate
+            ? rate * MessageSizeBytes / (1024.0 * 1024.0)
+            : null;
+
+    /// <summary>
+    /// Headline throughput: the broker-confirmed delivered rate when the scenario
+    /// measured it (producers), falling back to the client-side tracker average
+    /// (consumers). Serialized so both reporters (including the Python CI summary)
+    /// read one field instead of re-deriving the selection policy.
+    /// </summary>
+    public double EffectiveMessagesPerSecond =>
+        DeliveredMessagesPerSecond ?? Throughput.AverageMessagesPerSecond;
+
+    public double EffectiveMegabytesPerSecond =>
+        DeliveredMegabytesPerSecond ?? Throughput.AverageMegabytesPerSecond;
+
+    /// <summary>
+    /// Client-side append rate, reported only when it is distinct from the headline
+    /// number (i.e. when delivered throughput was measured). Null means the headline
+    /// already is the client-side rate.
+    /// </summary>
+    public double? AcceptedMessagesPerSecond =>
+        DeliveredMessages is not null ? Throughput.AverageMessagesPerSecond : null;
+
+    /// <summary>
     /// Process CPU time consumed during the measurement window. CPU cost per message
     /// differentiates client efficiency even when the broker caps throughput.
     /// The derived values below are serialized so downstream reports (including the

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
@@ -34,12 +34,7 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
             .Select(p => new ConfluentKafka.TopicPartition(options.Topic, p))
             .ToArray();
 
-        var endOffsets = new long[partitions.Length];
-        for (var p = 0; p < partitions.Length; p++)
-        {
-            var watermarks = consumer.QueryWatermarkOffsets(partitions[p], TimeSpan.FromSeconds(30));
-            endOffsets[p] = watermarks.High.Value;
-        }
+        var endOffsets = ConfluentStressTestHelpers.QueryEndOffsets(consumer, options.Topic, options.Partitions, TimeSpan.FromSeconds(30));
 
         var replay = new PartitionReplayTracker(endOffsets);
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
@@ -24,6 +24,8 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
             Acks = ConfluentKafka.Acks.All,
             LingerMs = options.LingerMs,
             BatchSize = options.BatchSize,
+            QueueBufferingMaxKbytes = ConfluentStressTestHelpers.QueueBufferingMaxKbytes,
+            QueueBufferingMaxMessages = ConfluentStressTestHelpers.QueueBufferingMaxMessages,
             CompressionType = options.Compression switch
             {
                 "lz4" => ConfluentKafka.CompressionType.Lz4,
@@ -41,6 +43,8 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
             producer.Produce(options.Topic, new ConfluentKafka.Message<string, string> { Key = "warmup", Value = "warmup" });
         }
         producer.Flush(TimeSpan.FromSeconds(30));
+
+        var startOffset = ConfluentStressTestHelpers.QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -103,12 +107,20 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
         throughput.Stop();
         gcStats.Capture();
 
+        // Queried after the final flush — and outside the measurement window, so a slow
+        // query against a degraded broker can't skew elapsed/CPU stats — so the delta
+        // reflects what the broker actually accepted rather than what librdkafka's local
+        // queue absorbed.
+        var endOffset = ConfluentStressTestHelpers.QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
+
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
         StressTestHelpers.LogResourceUsage("Final");
+
+        var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
 
         return new StressTestResult
         {
@@ -120,6 +132,7 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
+            DeliveredMessages = delivered,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerIdempotentStressTest.cs
@@ -25,6 +25,8 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
             Acks = ConfluentKafka.Acks.All,
             LingerMs = options.LingerMs,
             BatchSize = options.BatchSize,
+            QueueBufferingMaxKbytes = ConfluentStressTestHelpers.QueueBufferingMaxKbytes,
+            QueueBufferingMaxMessages = ConfluentStressTestHelpers.QueueBufferingMaxMessages,
             CompressionType = options.Compression switch
             {
                 "lz4" => ConfluentKafka.CompressionType.Lz4,
@@ -42,6 +44,8 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
             producer.Produce(options.Topic, new ConfluentKafka.Message<string, string> { Key = "warmup", Value = "warmup" });
         }
         producer.Flush(TimeSpan.FromSeconds(30));
+
+        var startOffset = ConfluentStressTestHelpers.QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -114,12 +118,20 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
         throughput.Stop();
         gcStats.Capture();
 
+        // Queried after the final flush — and outside the measurement window, so a slow
+        // query against a degraded broker can't skew elapsed/CPU stats — so the delta
+        // reflects what the broker actually accepted rather than what librdkafka's local
+        // queue absorbed.
+        var endOffset = ConfluentStressTestHelpers.QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
+
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
         LogResourceUsage("Final");
+
+        var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
 
         return new StressTestResult
         {
@@ -131,6 +143,7 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
+            DeliveredMessages = delivered,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerStressTest.cs
@@ -24,6 +24,8 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
             Acks = ConfluentKafka.Acks.Leader,
             LingerMs = options.LingerMs,
             BatchSize = options.BatchSize,
+            QueueBufferingMaxKbytes = ConfluentStressTestHelpers.QueueBufferingMaxKbytes,
+            QueueBufferingMaxMessages = ConfluentStressTestHelpers.QueueBufferingMaxMessages,
             CompressionType = options.Compression switch
             {
                 "lz4" => ConfluentKafka.CompressionType.Lz4,
@@ -41,6 +43,8 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
             producer.Produce(options.Topic, new ConfluentKafka.Message<string, string> { Key = "warmup", Value = "warmup" });
         }
         producer.Flush(TimeSpan.FromSeconds(30));
+
+        var startOffset = ConfluentStressTestHelpers.QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -113,12 +117,20 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
         throughput.Stop();
         gcStats.Capture();
 
+        // Queried after the final flush — and outside the measurement window, so a slow
+        // query against a degraded broker can't skew elapsed/CPU stats — so the delta
+        // reflects what the broker actually accepted rather than what librdkafka's local
+        // queue absorbed.
+        var endOffset = ConfluentStressTestHelpers.QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
+
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
         LogResourceUsage("Final");
+
+        var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
 
         return new StressTestResult
         {
@@ -130,6 +142,7 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
+            DeliveredMessages = delivered,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
@@ -7,6 +7,67 @@ namespace Dekaf.StressTests.Scenarios;
 internal static class ConfluentStressTestHelpers
 {
     /// <summary>
+    /// librdkafka local queue byte bound, derived from Dekaf's
+    /// <see cref="StressTestHelpers.ProducerBufferMemoryBytes"/> so both clients absorb
+    /// the same backlog before backpressure kicks in.
+    /// </summary>
+    internal const int QueueBufferingMaxKbytes = (int)(StressTestHelpers.ProducerBufferMemoryBytes / 1024);
+
+    /// <summary>
+    /// librdkafka's maximum, so the byte bound above is always the binding limit —
+    /// matching Dekaf's bytes-only BufferMemory regardless of --message-size (the
+    /// default 100k count cap would bind first for messages under ~10 KB).
+    /// </summary>
+    internal const int QueueBufferingMaxMessages = 10_000_000;
+
+    /// <summary>
+    /// Queries the high watermark of each partition, mirroring
+    /// <see cref="StressTestHelpers.QueryEndOffsetsAsync"/> for Confluent scenarios
+    /// (which stay Dekaf-free end to end).
+    /// </summary>
+    internal static long[] QueryEndOffsets<TKey, TValue>(
+        ConfluentKafka.IConsumer<TKey, TValue> consumer,
+        string topic,
+        int partitionCount,
+        TimeSpan timeout)
+    {
+        var endOffsets = new long[partitionCount];
+        for (var p = 0; p < partitionCount; p++)
+        {
+            var watermarks = consumer.QueryWatermarkOffsets(new ConfluentKafka.TopicPartition(topic, p), timeout);
+            endOffsets[p] = watermarks.High.Value;
+        }
+        return endOffsets;
+    }
+
+    /// <summary>
+    /// Sums the high watermarks across all partitions of <paramref name="topic"/> via a
+    /// short-lived Confluent consumer. See
+    /// <see cref="StressTestHelpers.QueryTotalEndOffsetAsync"/> for why producer
+    /// scenarios snapshot this before and after the run.
+    /// </summary>
+    internal static long? QueryTotalEndOffset(string bootstrapServers, string topic, int partitionCount)
+    {
+        try
+        {
+            var config = new ConfluentKafka.ConsumerConfig
+            {
+                BootstrapServers = bootstrapServers,
+                ClientId = "stress-watermark-query",
+                GroupId = $"stress-watermark-{Guid.NewGuid():N}"
+            };
+
+            using var consumer = new ConfluentKafka.ConsumerBuilder<ConfluentKafka.Ignore, ConfluentKafka.Ignore>(config).Build();
+            return QueryEndOffsets(consumer, topic, partitionCount, TimeSpan.FromSeconds(10)).Sum();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"  Warning: end offset query failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Produces one message, blocking briefly and retrying while librdkafka's local
     /// queue is full. This mirrors Dekaf's BufferMemory backpressure: without it,
     /// queue-full messages are silently dropped and counted as errors, which makes

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -27,6 +27,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             .WithAcks(Acks.All)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
+            .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
             .WithConnectionsPerBroker(options.ConnectionsPerBroker)
             .WithSocketSendBufferBytes(options.BatchSize);
 
@@ -47,6 +48,8 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             await producer.FireAsync(options.Topic, "warmup", "warmup");
         }
         await producer.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var startOffset = await StressTestHelpers.QueryTotalEndOffsetAsync(options.BootstrapServers, options.Topic, options.Partitions);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -130,6 +133,11 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             Console.WriteLine($"  Warning: Dispose timed out after 30 seconds");
         }
 
+        // Queried after dispose so all delivery attempts (including the final flush)
+        // have finished — the delta is what the broker actually accepted.
+        var endOffset = await StressTestHelpers.QueryTotalEndOffsetAsync(options.BootstrapServers, options.Topic, options.Partitions);
+        var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
+
         return new StressTestResult
         {
             Scenario = Name,
@@ -140,6 +148,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
+            DeliveredMessages = delivered,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -26,6 +26,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             .WithAcks(Acks.All)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
+            .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
             .WithConnectionsPerBroker(options.ConnectionsPerBroker)
             .WithSocketSendBufferBytes(options.BatchSize);
 
@@ -46,6 +47,8 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             await producer.FireAsync(options.Topic, "warmup", "warmup");
         }
         await producer.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var startOffset = await StressTestHelpers.QueryTotalEndOffsetAsync(options.BootstrapServers, options.Topic, options.Partitions);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -129,6 +132,11 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             Console.WriteLine($"  Warning: Dispose timed out after 30 seconds");
         }
 
+        // Queried after dispose so all delivery attempts (including the final flush)
+        // have finished — the delta is what the broker actually accepted.
+        var endOffset = await StressTestHelpers.QueryTotalEndOffsetAsync(options.BootstrapServers, options.Topic, options.Partitions);
+        var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
+
         return new StressTestResult
         {
             Scenario = Name,
@@ -139,6 +147,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
+            DeliveredMessages = delivered,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -27,6 +27,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
             .WithAcks(Acks.Leader)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
+            .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
             .WithConnectionsPerBroker(options.ConnectionsPerBroker)
             .WithSocketSendBufferBytes(options.BatchSize);
 
@@ -50,6 +51,8 @@ internal sealed class ProducerStressTest : IStressTestScenario
             await producer.FireAsync(options.Topic, "warmup", "warmup");
         }
         await producer.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var startOffset = await StressTestHelpers.QueryTotalEndOffsetAsync(options.BootstrapServers, options.Topic, options.Partitions);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -133,6 +136,11 @@ internal sealed class ProducerStressTest : IStressTestScenario
             Console.WriteLine($"  Warning: Dispose timed out after 30 seconds");
         }
 
+        // Queried after dispose so all delivery attempts (including the final flush)
+        // have finished — the delta is what the broker actually accepted.
+        var endOffset = await StressTestHelpers.QueryTotalEndOffsetAsync(options.BootstrapServers, options.Topic, options.Partitions);
+        var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
+
         return new StressTestResult
         {
             Scenario = Name,
@@ -143,6 +151,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
+            DeliveredMessages = delivered,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.StressTests.Metrics;
@@ -15,6 +16,16 @@ internal static class StressTestHelpers
     /// stalling the produce loop.
     /// </summary>
     internal const int LatencySampleInterval = 1000;
+
+    /// <summary>
+    /// Explicit producer buffer bound, mirrored on the Confluent side
+    /// (<see cref="ConfluentStressTestHelpers.QueueBufferingMaxKbytes"/>). Without an
+    /// explicit value, Dekaf auto-tunes BufferMemory to a share of total system RAM
+    /// (multi-GB on CI runners), which lets fire-and-forget appends run far ahead of
+    /// what the broker ever accepts and makes accepted-message counts meaningless as
+    /// a throughput proxy.
+    /// </summary>
+    internal const ulong ProducerBufferMemoryBytes = 512UL * 1024 * 1024;
 
     private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
 
@@ -58,6 +69,62 @@ internal static class StressTestHelpers
             endOffsets[p] = watermarks.High;
         }
         return endOffsets;
+    }
+
+    /// <summary>
+    /// Sums the end offsets across all partitions of <paramref name="topic"/> via a
+    /// short-lived Dekaf admin client (one batched ListOffsets request, no consumer
+    /// group). Producer scenarios snapshot this before and after the run: the delta is
+    /// the broker-confirmed delivered count, independent of how many appends the client
+    /// accepted into its local buffer. Returns null on failure (e.g. broker unresponsive
+    /// after the run) so delivered stats are omitted rather than failing the scenario.
+    /// </summary>
+    internal static async Task<long?> QueryTotalEndOffsetAsync(string bootstrapServers, string topic, int partitionCount)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await using var adminClient = Kafka.CreateAdminClient()
+                .WithBootstrapServers(bootstrapServers)
+                .WithClientId("stress-watermark-query")
+                .Build();
+
+            var specs = Enumerable.Range(0, partitionCount)
+                .Select(p => new TopicPartitionOffsetSpec
+                {
+                    TopicPartition = new TopicPartition(topic, p),
+                    Spec = OffsetSpec.Latest
+                });
+
+            var offsets = await adminClient.ListOffsetsAsync(specs, cancellationToken: cts.Token).ConfigureAwait(false);
+            return offsets.Values.Sum(static info => info.Offset);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"  Warning: end offset query failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Computes the delivered-message count from before/after end-offset snapshots and
+    /// logs it against the client-accepted count so the gap (buffered-but-never-delivered
+    /// messages) is visible in run output.
+    /// </summary>
+    internal static long? ComputeDelivered(long? startOffset, long? endOffset, ThroughputTracker throughput)
+    {
+        if (startOffset is not { } start || endOffset is not { } end)
+        {
+            return null;
+        }
+
+        var delivered = end - start;
+        var elapsedSeconds = throughput.Elapsed.TotalSeconds;
+        var accepted = throughput.MessageCount;
+        var rate = elapsedSeconds > 0 ? delivered / elapsedSeconds : 0;
+        Console.WriteLine($"  Delivered (broker-confirmed): {delivered:N0} messages, {rate:N0} msg/sec " +
+            $"({(accepted > 0 ? delivered * 100.0 / accepted : 0):F1}% of {accepted:N0} accepted)");
+        return delivered;
     }
 
     /// <summary>


### PR DESCRIPTION
## Why

The published producer stress numbers (https://thomhurst.github.io/Dekaf/docs/stress-tests) are invalid. Per-second samples from run 28649851112 show:

- **Both clients push ~1M msg/s (~1 GB/s) for the first ~6 seconds**, then the broker stops accepting for the remaining ~15 minutes. Cumulative ingest at collapse ≈ the 6 GB broker tmpfs in both the Dekaf and Confluent runs.
- The published averages (Dekaf 15,937 vs Confluent 7,191 msg/s, "2.22x faster") measured **client-side buffering during dead time**, not throughput. Dekaf auto-tunes `BufferMemory` to 40% of system RAM, so it absorbed ~8 GB of appends that were counted as throughput and never delivered — 8,784 errors in the Dekaf run are exactly the failed 1-in-1000 sampled `ProduceAsync` calls (58% of samples), and the final flush timed out. Confluent's lone 99,990-message burst at ~311s is its 100k queue freed by the 300s `message.timeout.ms`.

## What

**Honest measurement**
- Producer scenarios now snapshot end offsets (admin `ListOffsets`, batched, no consumer group) before and after the run; the delta is the **broker-confirmed delivered count** and becomes the headline `Messages/sec` in both report generators, with the client-side accepted rate shown alongside. The selection policy lives in `StressTestResult` and is serialized, so the C# and Python reporters read fields instead of re-deriving it.
- Both clients are bounded to the same 512 MB local buffer (Dekaf `WithBufferMemory`; librdkafka `queue.buffering.max.kbytes` derived from the same constant, count cap lifted to librdkafka's max so bytes always bind regardless of `--message-size`).

**Diagnosing the broker collapse (root cause still needs one instrumented run)**
- Dump the broker's effective retention/segment config after startup (verifies the env mapping actually applied).
- Background disk monitor samples every broker's log-dir usage during the run (pinned to broker cores so it can't steal client cycles); uploaded with the results artifact.
- `KafkaEnvironment` prints each broker's `df` and error/storage log lines before Testcontainers disposal — multi-broker logs previously vanished with the containers.

**Broker hardening**
- 2 GB JVM heap (image default 1 GB), plumbed through the existing `STRESS_BROKER_*` env channel.
- Retention check interval 10s → 1s in `KafkaEnvironment` (at ~1 GB/s produce rates, 10s between sweeps allows ~10 GB overshoot — more than the tmpfs).

## Verification

- Local 1-minute runs (Testcontainers): `Delivered (broker-confirmed): 100.0-100.9% of accepted`, backpressure engaged throughout, no flush timeout; delivered fields present in the results JSON; broker diagnostics printed on dispose.
- `stress_report.py` verified against both the old result format (falls back to tracker average, accepted column shows `-`) and the new format.

## Follow-ups

- The first CI run after merge will show whether the collapse is tmpfs fill or broker JVM pressure (disk log + broker log grep will say which).
- The consumer scenario's 3.3 TB allocation figure and the docs' existing throughput claims should be revisited once a clean run exists.