### PR TITLE
fix(stress-tests): survive broker retention startup gap, fail loudly on dead broker

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -142,6 +142,9 @@ jobs:
           # dir on tmpfs so neither broker CPU starvation nor disk I/O caps ingestion.
           # mode=1777: the Kafka image runs as a non-root user, which cannot write to
           # a default root-owned tmpfs mount.
+          # KAFKA_LOG_INITIAL_TASK_DELAY_MS=1000 is load-bearing — without it the broker
+          # dies of tmpfs fill before its first retention sweep; see the rationale on
+          # KafkaEnvironment.RetentionConfig.
           docker run -d --name kafka \
             --cpuset-cpus="${BROKER_CPUS}" \
             --tmpfs /var/lib/kafka/data:rw,size=${BROKER_TMPFS},mode=1777 \
@@ -164,6 +167,7 @@ jobs:
             -e KAFKA_LOG_SEGMENT_BYTES=33554432 \
             -e KAFKA_LOG_SEGMENT_DELETE_DELAY_MS=100 \
             -e KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS=1000 \
+            -e KAFKA_LOG_INITIAL_TASK_DELAY_MS=1000 \
             -e KAFKA_LOG_CLEANUP_POLICY=delete \
             apache/kafka:latest
 
@@ -199,7 +203,13 @@ jobs:
           # cycles from the client cores whose isolation this job exists to provide.
           taskset -c "${BROKER_CPUS}" bash -c '
             while true; do
-              for c in $(docker ps --format "{{.Names}}"); do
+              containers=$(docker ps --format "{{.Names}}")
+              if [ -z "$containers" ]; then
+                # A dead broker vanishes from docker ps; log that instead of going
+                # silent so the artifact shows *when* it died, not just that it did.
+                echo "[$(date -u "+%H:%M:%S")] no running containers"
+              fi
+              for c in $containers; do
                 line=$(docker exec "$c" df -h /var/lib/kafka/data 2>/dev/null | tail -n 1) \
                   && echo "[$(date -u "+%H:%M:%S")] $c: $line"
               done
@@ -236,6 +246,23 @@ jobs:
             echo "=== Broker last 60 log lines ==="
             docker logs --tail 60 kafka 2>&1 || true
           fi
+
+      # A broker that dies mid-run (e.g. log dir full -> LogManager shutdown) makes
+      # every number in this job's results meaningless; fail the job so they are never
+      # published. Producer scenarios also fail client-side (a dead broker fails the
+      # post-run end-offset query — that is what covers multi-broker runs, whose
+      # containers the test process owns and disposes), but consumer scenarios have no
+      # such check and would otherwise report near-zero throughput as a valid result;
+      # this step also gives a clearer verdict than the client's exception trace.
+      - name: Verify Broker Survived
+        if: matrix.brokers == 1
+        run: |
+          status=$(docker inspect -f '{{.State.Status}}' kafka 2>/dev/null || echo "missing")
+          if [ "$status" != "running" ]; then
+            echo "::error::Broker container is '$status' — it died during the run; see Broker Diagnostics above"
+            exit 1
+          fi
+          echo "Broker container is running"
 
       - name: Upload Results
         if: always()
@@ -381,9 +408,11 @@ jobs:
 
   publish-to-docs:
     name: Publish Stress Test Results to Documentation
-    needs: generate-summary
+    needs: [stress-test, generate-summary]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && needs.generate-summary.result == 'success'
+    # stress-test success is required: a failed scenario (e.g. broker died mid-run)
+    # must block the docs update rather than publish a partial or invalid table.
+    if: github.ref == 'refs/heads/main' && needs.stress-test.result == 'success' && needs.generate-summary.result == 'success'
 
     permissions:
       contents: write

--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -26,6 +26,12 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
     // overshoot the retention caps by roughly (produce rate × check interval) between
     // sweeps. A 10s interval meant ~10 GB overshoot windows — more than the broker tmpfs —
     // which filled the log dir and halted ingestion seconds into producer runs.
+    //
+    // The 1s initial task delay is equally load-bearing: LogManager runs its first
+    // retention sweep only after log.initial.task.delay.ms (internal config, default
+    // 30s; Kafka 3.8+). At ~1 GB/s a 6 GB tmpfs fills in ~5s, so with the default
+    // delay the broker died of "No space left on device" before retention ever ran —
+    // none of the settings above mattered.
     private static readonly Dictionary<string, string> RetentionConfig = new()
     {
         ["KAFKA_LOG_RETENTION_MS"] = "300000",
@@ -33,6 +39,7 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
         ["KAFKA_LOG_SEGMENT_BYTES"] = "16777216",
         ["KAFKA_LOG_SEGMENT_DELETE_DELAY_MS"] = "1000",
         ["KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS"] = "1000",
+        ["KAFKA_LOG_INITIAL_TASK_DELAY_MS"] = "1000",
         ["KAFKA_LOG_CLEANUP_POLICY"] = "delete",
     };
 
@@ -112,7 +119,9 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
     private static async Task<KafkaEnvironment> CreateSingleBrokerAsync()
     {
         Console.WriteLine("Starting Kafka container via Testcontainers...");
-        var builder = new KafkaBuilder("confluentinc/cp-kafka:7.5.0")
+        // 7.8.x = Kafka 3.8, the first release with log.initial.task.delay.ms — see
+        // RetentionConfig; older images silently ignore it and die on tmpfs fill.
+        var builder = new KafkaBuilder("confluentinc/cp-kafka:7.8.0")
             .WithPortBinding(9092, true)
             // Explicit log dir so the optional tmpfs mount target always matches
             .WithEnvironment("KAFKA_LOG_DIRS", KafkaLogDir)

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -39,8 +39,10 @@ internal sealed class StressTestResult
 
     /// <summary>
     /// Headline throughput: the broker-confirmed delivered rate when the scenario
-    /// measured it (producers), falling back to the client-side tracker average
-    /// (consumers). Serialized so both reporters (including the Python CI summary)
+    /// measured it (producers), falling back to the client-side tracker average.
+    /// Producer scenarios fail outright when the delivered count is unavailable
+    /// (see StressTestHelpers.ComputeDelivered), so the fallback only ever applies
+    /// to consumers. Serialized so both reporters (including the Python CI summary)
     /// read one field instead of re-deriving the selection policy.
     /// </summary>
     public double EffectiveMessagesPerSecond =>

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -77,7 +77,8 @@ internal static class StressTestHelpers
     /// group). Producer scenarios snapshot this before and after the run: the delta is
     /// the broker-confirmed delivered count, independent of how many appends the client
     /// accepted into its local buffer. Returns null on failure (e.g. broker unresponsive
-    /// after the run) so delivered stats are omitted rather than failing the scenario.
+    /// after the run); <see cref="ComputeDelivered"/> escalates that to a scenario
+    /// failure so a dead broker can never masquerade as a throughput result.
     /// </summary>
     internal static async Task<long?> QueryTotalEndOffsetAsync(string bootstrapServers, string topic, int partitionCount)
     {
@@ -109,13 +110,19 @@ internal static class StressTestHelpers
     /// <summary>
     /// Computes the delivered-message count from before/after end-offset snapshots and
     /// logs it against the client-accepted count so the gap (buffered-but-never-delivered
-    /// messages) is visible in run output.
+    /// messages) is visible in run output. Throws when either snapshot is missing: that
+    /// means the broker was unreachable, the producer result is meaningless, and the
+    /// scenario must fail loudly instead of letting reporting fall back to the
+    /// client-side append rate (which once published a dead broker's buffer churn as
+    /// headline throughput).
     /// </summary>
-    internal static long? ComputeDelivered(long? startOffset, long? endOffset, ThroughputTracker throughput)
+    internal static long ComputeDelivered(long? startOffset, long? endOffset, ThroughputTracker throughput)
     {
         if (startOffset is not { } start || endOffset is not { } end)
         {
-            return null;
+            throw new InvalidOperationException(
+                "Broker-confirmed delivered count unavailable (end-offset query failed — broker likely " +
+                "unhealthy or dead). Failing the scenario rather than reporting the client-side append rate.");
         }
 
         var delivered = end - start;


### PR DESCRIPTION
## Problem

Every published producer stress number is invalid. The broker dies **6 seconds** into every 15-minute producer run:

```
[10:45:07] ERROR ... java.io.IOException: No space left on device
[10:45:07] ERROR Shutdown broker because all log dirs in /var/lib/kafka/data have failed
```

Root cause chain (diagnosed from run 28655395763 artifacts + broker logs):

1. Kafka's `LogManager` schedules its **first** retention sweep only after `log.initial.task.delay.ms` — an internal config defaulting to **30s** (Kafka 3.8+, KAFKA-16552). Retention settings (128 MB/partition, 1s check interval) were applied correctly but never got a chance to run: at ~1–1.3 GB/s ingest the 6 GB tmpfs fills in ~5s. End offsets at death ≈ total ingest — zero deletions ever happened. No retention tuning could fix this.
2. With the broker dead, the post-run end-offset query fails, and `EffectiveMessagesPerSecond` **silently fell back** to the client-side append rate — publishing 15 minutes of buffer-expiry churn against a dead broker as headline "delivered" throughput (~9k msg/s, identical for both clients). The tell on the docs page: `Accepted msg/s` is `-` on every producer row.
3. The broker-disk.log monitor went silent (dead container vanishes from `docker ps`) and the CI job still concluded **success**.

Actual client capability while the broker was alive: Dekaf ~1.0–1.3M msg/s (1.67M peak with 3conn), Confluent ~0.8–1.2M msg/s.

## Fixes

1. **`KAFKA_LOG_INITIAL_TASK_DELAY_MS=1000`** on all broker paths (workflow `docker run`, Testcontainers single- and multi-broker). Verified applied on both images (`apache/kafka:4.1.0`, `cp-kafka:7.8.0` — effective config shows `log.initial.task.delay.ms = 1000`). cp-kafka bumped 7.5.0 → 7.8.0 since Kafka 3.8 is the first release with the config.
2. **`ComputeDelivered` now throws** when either end-offset snapshot is missing, failing the producer scenario instead of letting reporting fall back to append rates. Single chokepoint shared by all six producer scenarios.
3. **`Verify Broker Survived` workflow step** fails the job when the broker container is not running post-run (also the only broker-death coverage for consumer scenarios, which don't measure delivered counts). `publish-to-docs` additionally now requires the full stress-test matrix to succeed, so failed scenarios block the docs update instead of publishing partial tables. Disk monitor logs `no running containers` instead of going silent.

## Verification

- Stress test project builds clean.
- Both broker images verified locally to honor the env var (effective-config dump).
- Short validation run triggered on this branch (workflow_dispatch, 2 min) — results below when complete. Docs publishing is main-only, so the validation run cannot touch the published page.