### PR TITLE
perf(producer): pre-serialize uncompressed batches off the send-loop thread

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -136,8 +136,18 @@ public sealed class AdminClient : IAdminClient
             }).ToList()
         }).ToList();
 
+        // Tracks whether a previous attempt may have applied the create on the broker.
+        // A retriable failure after the broker accepted the create (e.g. a response
+        // timeout, or waiting for leader election) makes the retry hit TopicAlreadyExists
+        // for a topic this call created — treat that as success instead of failing the
+        // whole operation. This is a heuristic: a topic created concurrently by another
+        // client between attempts is also reported as success. Validate-only requests
+        // never mutate cluster state, so they never arm the tolerance.
+        var createMayHaveApplied = false;
+
         await WithRetryAsync(async () =>
         {
+            var isRetryAttempt = createMayHaveApplied;
             var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
 
             var request = new CreateTopicsRequest
@@ -152,6 +162,7 @@ public sealed class AdminClient : IAdminClient
                 CreateTopicsRequest.LowestSupportedVersion,
                 CreateTopicsRequest.HighestSupportedVersion);
 
+            createMayHaveApplied = !opts.ValidateOnly;
             var response = await controller.SendAsync<CreateTopicsRequest, CreateTopicsResponse>(
                 request,
                 apiVersion,
@@ -161,7 +172,8 @@ public sealed class AdminClient : IAdminClient
             var createdTopicNames = new List<string>(response.Topics.Count);
             foreach (var topic in response.Topics)
             {
-                if (topic.ErrorCode != Protocol.ErrorCode.None)
+                if (topic.ErrorCode != Protocol.ErrorCode.None &&
+                    !(isRetryAttempt && topic.ErrorCode == Protocol.ErrorCode.TopicAlreadyExists))
                 {
                     throw new KafkaException(topic.ErrorCode,
                         $"Failed to create topic '{topic.Name}': {topic.ErrorMessage ?? topic.ErrorCode.ToString()}");

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1167,9 +1167,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             if (head is null)
                 continue;
 
-            if (!head.IsCompressionReady)
-                CompressBatch(head);
-
             // Check retry backoff
             if (head.IsRetry && head.RetryNotBefore > 0)
             {
@@ -1199,6 +1196,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 _readyPartitions.Enqueue(tp);
                 continue;
             }
+
+            // Pre-serialize only batches that will actually drain this cycle — batches
+            // deferred above (backoff, unknown leader) would waste the encode and hold
+            // the pooled buffer for the whole deferral window.
+            if (!head.IsPreSerialized)
+                PreSerializeBatch(head);
 
             // Sealed batches in the deque are always sendable. The linger/micro-linger
             // timer already determined readiness when it sealed the batch, so re-checking
@@ -1333,10 +1336,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 if (batch is null)
                     continue;
 
-                // Safety check: Ready() should have compressed the head batch before
+                // Safety check: Ready() should have pre-serialized the head batch before
                 // marking this node ready. If another path exposes an unready batch,
                 // leave it in the deque until the next notification.
-                if (!batch.IsCompressionReady)
+                if (!batch.IsPreSerialized)
                     continue;
 
                 if (batch.IsRetry && batch.RetryNotBefore > 0
@@ -2702,47 +2705,43 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Publishes a sealed batch to the sender loop. Compression, when enabled, is deferred
-    /// to <see cref="Ready"/> so the append caller only pays the queue notification cost.
+    /// Publishes a sealed batch to the sender loop. Record serialization (and compression,
+    /// when enabled) is deferred to <see cref="Ready"/> so the append caller only pays the
+    /// queue notification cost.
     /// </summary>
     private void PublishSealedBatch(ReadyBatch readyBatch, bool signalWakeup = true)
     {
-        if (_options.CompressionType == CompressionType.None)
-            readyBatch.MarkCompressionReady();
-
         _readyPartitions.Enqueue(readyBatch.TopicPartition);
         if (signalWakeup)
             SignalWakeup();
     }
 
     /// <summary>
-    /// Compresses a sealed batch (if compression is configured). Called by the sender thread
-    /// from <see cref="Ready"/>, outside the partition SpinLock, before the batch can drain.
+    /// Pre-serializes a sealed batch's records (compressing when configured). Called by the
+    /// sender thread from <see cref="Ready"/>, outside the partition SpinLock, before the
+    /// batch can drain. Doing this here keeps the per-record wire encoding off the per-broker
+    /// send-loop thread, which only has to copy + CRC the pre-serialized payload — the
+    /// coordinator encodes the next batch while the send loop writes the previous one.
     ///
     /// Thread safety: the batch is already sealed and in the deque; no other thread can
-    /// modify it. The drain loop skips batches where <see cref="ReadyBatch.IsCompressionReady"/>
+    /// modify it. The drain loop skips batches where <see cref="ReadyBatch.IsPreSerialized"/>
     /// is false, so the sender won't pick it up until we finish and set the flag.
     /// </summary>
-    private void CompressBatch(ReadyBatch readyBatch)
+    private void PreSerializeBatch(ReadyBatch readyBatch)
     {
-        if (_options.CompressionType != CompressionType.None)
+        try
         {
-            try
-            {
-                readyBatch.RecordBatch.PreCompress(_options.CompressionType, _compressionCodecs);
-            }
-            catch (Exception ex)
-            {
-                // Fail delivery tasks so callers aren't stuck waiting, then mark ready
-                // so subsequent batches in this partition aren't permanently blocked.
-                readyBatch.Fail(ex);
-                readyBatch.MarkCompressionReady();
-                return;
-            }
+            readyBatch.RecordBatch.PreCompress(_options.CompressionType, _compressionCodecs);
+        }
+        catch (Exception ex)
+        {
+            // Fail delivery tasks so callers aren't stuck waiting, then mark ready
+            // so subsequent batches in this partition aren't permanently blocked.
+            readyBatch.Fail(ex);
         }
 
-        // Mark compression complete so the drain loop can pick up this batch.
-        readyBatch.MarkCompressionReady();
+        // Mark pre-serialization complete so the drain loop can pick up this batch.
+        readyBatch.MarkPreSerialized();
     }
 
     /// <summary>
@@ -4873,24 +4872,26 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     internal void RewriteRecordBatch(RecordBatch newRecordBatch) => _recordBatch = newRecordBatch;
 
     /// <summary>
-    /// Whether compression has completed (or was not needed) for this batch.
-    /// Set after <see cref="RecordAccumulator.CompressBatch"/> finishes.
-    /// The drain loop skips batches where this is false to avoid sending uncompressed data.
+    /// Whether the batch's records have been pre-serialized (and compressed, when
+    /// configured). Set after <see cref="RecordAccumulator.PreSerializeBatch"/> finishes.
+    /// The drain loop skips batches where this is false so the per-broker send loop
+    /// only ever handles wire-ready payloads.
     /// Uses Volatile reads for lock-free checking from the sender thread.
     /// </summary>
-    internal bool IsCompressionReady
+    internal bool IsPreSerialized
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Volatile.Read(ref _compressionReady) != 0;
+        get => Volatile.Read(ref _preSerialized) != 0;
     }
-    private int _compressionReady;
+    private int _preSerialized;
 
     /// <summary>
-    /// Marks compression as complete. Called by <see cref="RecordAccumulator.CompressBatch"/>
-    /// after compression finishes (or immediately if no compression is configured).
+    /// Marks pre-serialization as complete. Called by
+    /// <see cref="RecordAccumulator.PreSerializeBatch"/> after the records are encoded
+    /// (and compressed, when configured).
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void MarkCompressionReady() => Volatile.Write(ref _compressionReady, 1);
+    internal void MarkPreSerialized() => Volatile.Write(ref _preSerialized, 1);
 
     /// <summary>
     /// Whether BufferMemory has already been released for this batch.
@@ -5013,7 +5014,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         Interlocked.Exchange(ref _sendCompleted, 0);
         Interlocked.Exchange(ref _returnedToPool, 0);
         Interlocked.Exchange(ref _memoryReleased, 0);
-        Volatile.Write(ref _compressionReady, 0);
+        Volatile.Write(ref _preSerialized, 0);
         Interlocked.Increment(ref _generation);
 
         _topicPartition = topicPartition;

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -447,17 +447,30 @@ public sealed class RecordBatch : IDisposable
     internal bool HasPreCompressedRecords => PreCompressedRecords is not null;
 
     /// <summary>
-    /// Pre-compresses the records in this batch. Producer send paths call this before
-    /// request serialization so <see cref="Write"/> can skip re-compression.
-    /// The compressed data is stored in a pooled array and used by <see cref="Write"/>
-    /// to skip re-compression. This is a per-batch allocation (acceptable).
+    /// Pre-serializes the records in this batch, compressing when a codec is configured.
+    /// Producer send paths call this before request serialization so <see cref="Write"/>
+    /// can emit the records with a single copy + CRC instead of re-encoding every record
+    /// on the send-loop thread. The data is stored in a pooled array (a per-batch
+    /// allocation, acceptable).
     /// </summary>
-    /// <param name="compression">The compression type to apply.</param>
+    /// <param name="compression">The compression type to apply. <see cref="CompressionType.None"/>
+    /// stores the plain encoded records.</param>
     /// <param name="codecs">The codec registry to use.</param>
     internal void PreCompress(CompressionType compression, CompressionCodecRegistry? codecs)
     {
         if (compression == CompressionType.None)
+        {
+            var uncompressedRecords = Records;
+            using var encodedBuffer = new DetachableBufferWriter(
+                ProducerDataPool.BytePool, GetEncodedRecordsLength(uncompressedRecords));
+            var writer = new KafkaProtocolWriter(encodedBuffer);
+            WriteRecords(uncompressedRecords, ref writer);
+
+            PreCompressedRecords = encodedBuffer.DetachBuffer(out var encodedLength);
+            PreCompressedLength = encodedLength;
+            PreCompressedType = CompressionType.None;
             return;
+        }
 
         var cache = RentSerializationCache();
         try

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientCreateTopicsRetryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientCreateTopicsRetryTests.cs
@@ -1,0 +1,211 @@
+using Dekaf.Admin;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+/// <summary>
+/// Tests that CreateTopicsAsync retries are idempotent: a retriable failure after the
+/// broker accepted the create must not surface TopicAlreadyExists from the retry attempt.
+/// </summary>
+public sealed class AdminClientCreateTopicsRetryTests
+{
+    private const string TopicName = "retry-topic";
+
+    [Test]
+    public async Task CreateTopicsAsync_TopicAlreadyExistsOnRetry_TreatedAsSuccess()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection();
+
+        var createCalls = 0;
+        connection.SendAsync<CreateTopicsRequest, CreateTopicsResponse>(
+                Arg.Any<CreateTopicsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                // First attempt: broker processed the create but the client saw a
+                // retriable failure (e.g. response timeout). Retry hits AlreadyExists.
+                if (Interlocked.Increment(ref createCalls) == 1)
+                {
+                    throw new KafkaException(ErrorCode.RequestTimedOut, "simulated timeout");
+                }
+
+                return ValueTask.FromResult(new CreateTopicsResponse
+                {
+                    Topics =
+                    [
+                        new CreateTopicsResponseTopic
+                        {
+                            Name = TopicName,
+                            ErrorCode = ErrorCode.TopicAlreadyExists,
+                            ErrorMessage = $"Topic '{TopicName}' already exists."
+                        }
+                    ]
+                });
+            });
+
+        await admin.CreateTopicsAsync([new NewTopic { Name = TopicName, NumPartitions = 1 }]);
+
+        await Assert.That(createCalls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task CreateTopicsAsync_ValidateOnly_TopicAlreadyExistsOnRetry_Throws()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection();
+
+        var createCalls = 0;
+        connection.SendAsync<CreateTopicsRequest, CreateTopicsResponse>(
+                Arg.Any<CreateTopicsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref createCalls) == 1)
+                {
+                    throw new KafkaException(ErrorCode.RequestTimedOut, "simulated timeout");
+                }
+
+                return ValueTask.FromResult(new CreateTopicsResponse
+                {
+                    Topics =
+                    [
+                        new CreateTopicsResponseTopic
+                        {
+                            Name = TopicName,
+                            ErrorCode = ErrorCode.TopicAlreadyExists,
+                            ErrorMessage = $"Topic '{TopicName}' already exists."
+                        }
+                    ]
+                });
+            });
+
+        // Validate-only never mutates cluster state, so AlreadyExists on a retry is a
+        // genuine conflict and must surface.
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await admin.CreateTopicsAsync(
+                [new NewTopic { Name = TopicName, NumPartitions = 1 }],
+                new CreateTopicsOptions { ValidateOnly = true }));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.TopicAlreadyExists);
+    }
+
+    [Test]
+    public async Task CreateTopicsAsync_TopicAlreadyExistsOnFirstAttempt_Throws()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection();
+
+        connection.SendAsync<CreateTopicsRequest, CreateTopicsResponse>(
+                Arg.Any<CreateTopicsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new CreateTopicsResponse
+            {
+                Topics =
+                [
+                    new CreateTopicsResponseTopic
+                    {
+                        Name = TopicName,
+                        ErrorCode = ErrorCode.TopicAlreadyExists,
+                        ErrorMessage = $"Topic '{TopicName}' already exists."
+                    }
+                ]
+            }));
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await admin.CreateTopicsAsync([new NewTopic { Name = TopicName, NumPartitions = 1 }]));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.TopicAlreadyExists);
+    }
+
+    private static (AdminClient Admin, IKafkaConnection Connection) CreateAdminWithMockConnection()
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.BrokerId.Returns(1);
+        connection.Host.Returns("localhost");
+        connection.Port.Returns(9092);
+        connection.IsConnected.Returns(true);
+
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.Metadata.Update(CreateMetadataResponse());
+        metadataManager.SetApiVersion(ApiKey.CreateTopics, 5, 7);
+        metadataManager.SetApiVersion(ApiKey.Metadata, 9, 13);
+
+        // Metadata refreshes (retry helper + WaitForTopicLeadersAsync) must observe the
+        // topic with all partition leaders elected so the create completes.
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateMetadataResponse()));
+
+        // Metadata refresh negotiates API versions on the connection first.
+        connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(ApiKey.Metadata, 9, 13),
+                    new ApiVersion(ApiKey.CreateTopics, 5, 7)
+                ]
+            }));
+
+        var admin = new AdminClient(
+            new AdminClientOptions { BootstrapServers = ["localhost:9092"] },
+            pool,
+            metadataManager);
+
+        return (admin, connection);
+    }
+
+    private static MetadataResponse CreateMetadataResponse() => new()
+    {
+        Brokers =
+        [
+            new BrokerMetadata
+            {
+                NodeId = 1,
+                Host = "localhost",
+                Port = 9092
+            }
+        ],
+        ClusterId = "test-cluster",
+        ControllerId = 1,
+        Topics =
+        [
+            new TopicMetadata
+            {
+                Name = TopicName,
+                ErrorCode = ErrorCode.None,
+                Partitions =
+                [
+                    new PartitionMetadata
+                    {
+                        PartitionIndex = 0,
+                        LeaderId = 1,
+                        LeaderEpoch = 1,
+                        ReplicaNodes = [1],
+                        IsrNodes = [1],
+                        OfflineReplicas = [],
+                        ErrorCode = ErrorCode.None
+                    }
+                ]
+            }
+        ]
+    };
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -534,6 +534,77 @@ public class RecordBatchTests
     }
 
     [Test]
+    public async Task PreCompress_None_PreSerializesRecords()
+    {
+        using var batch = CreateTwoRecordBatch();
+
+        batch.PreCompress(CompressionType.None, null);
+
+        await Assert.That(batch.PreCompressedRecords).IsNotNull();
+        await Assert.That(batch.PreCompressedLength).IsGreaterThan(0);
+        await Assert.That(batch.PreCompressedType).IsEqualTo(CompressionType.None);
+    }
+
+    [Test]
+    public async Task PreCompress_None_WriteOutputMatchesInlineSerialization()
+    {
+        using var inlineBatch = CreateTwoRecordBatch();
+        var inlineBuffer = new ArrayBufferWriter<byte>();
+        inlineBatch.Write(inlineBuffer);
+
+        using var preSerializedBatch = CreateTwoRecordBatch();
+        preSerializedBatch.PreCompress(CompressionType.None, null);
+        var preSerializedBuffer = new ArrayBufferWriter<byte>();
+        preSerializedBatch.Write(preSerializedBuffer);
+
+        await Assert.That(preSerializedBuffer.WrittenSpan.SequenceEqual(inlineBuffer.WrittenSpan)).IsTrue();
+    }
+
+    [Test]
+    public async Task PreCompress_None_RoundTripsThroughRead()
+    {
+        using var batch = CreateTwoRecordBatch();
+        batch.PreCompress(CompressionType.None, null);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        batch.Write(buffer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var readBatch = RecordBatch.Read(ref reader);
+
+        await Assert.That(readBatch.Records.Count).IsEqualTo(2);
+        await Assert.That(readBatch.Records[0].Key.ToArray()).IsEquivalentTo("key-0"u8.ToArray());
+        await Assert.That(readBatch.Records[0].Value.ToArray()).IsEquivalentTo("value-0"u8.ToArray());
+        await Assert.That(readBatch.Records[1].Key.ToArray()).IsEquivalentTo("key-1"u8.ToArray());
+        await Assert.That(readBatch.Records[1].Value.ToArray()).IsEquivalentTo("value-1"u8.ToArray());
+    }
+
+    private static RecordBatch CreateTwoRecordBatch() => new()
+    {
+        BaseOffset = 0,
+        BaseTimestamp = 1000,
+        MaxTimestamp = 1001,
+        LastOffsetDelta = 1,
+        Records =
+        [
+            new Record
+            {
+                OffsetDelta = 0,
+                TimestampDelta = 0,
+                Key = "key-0"u8.ToArray(),
+                Value = "value-0"u8.ToArray()
+            },
+            new Record
+            {
+                OffsetDelta = 1,
+                TimestampDelta = 1,
+                Key = "key-1"u8.ToArray(),
+                Value = "value-1"u8.ToArray()
+            }
+        ]
+    };
+
+    [Test]
     public async Task ReturnPreCompressedBuffer_CalledTwice_IsIdempotent()
     {
         var batch = new RecordBatch

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtocolBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtocolBenchmarks.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using BenchmarkDotNet.Attributes;
+using Dekaf.Compression;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
 
@@ -142,23 +143,35 @@ public class ProtocolBenchmarks
     [Benchmark(Description = "Write RecordBatch (10 records)")]
     public void WriteRecordBatch()
     {
-        var batch = new RecordBatch
-        {
-            BaseOffset = 0,
-            BaseTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            MaxTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            LastOffsetDelta = 9,
-            Records = Enumerable.Range(0, 10).Select(i => new Record
-            {
-                TimestampDelta = i,
-                OffsetDelta = i,
-                Key = System.Text.Encoding.UTF8.GetBytes($"key-{i}"),
-                Value = System.Text.Encoding.UTF8.GetBytes($"value-{i}")
-            }).ToList()
-        };
+        var batch = CreateTenRecordBatch();
 
         batch.Write(_buffer);
     }
+
+    [Benchmark(Description = "Write RecordBatch pre-serialized (10 records)")]
+    public void WriteRecordBatchPreSerialized()
+    {
+        var batch = CreateTenRecordBatch();
+
+        batch.PreCompress(CompressionType.None, null);
+        batch.Write(_buffer);
+        batch.ReturnPreCompressedBuffer();
+    }
+
+    private static RecordBatch CreateTenRecordBatch() => new()
+    {
+        BaseOffset = 0,
+        BaseTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        MaxTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        LastOffsetDelta = 9,
+        Records = Enumerable.Range(0, 10).Select(i => new Record
+        {
+            TimestampDelta = i,
+            OffsetDelta = i,
+            Key = System.Text.Encoding.UTF8.GetBytes($"key-{i}"),
+            Value = System.Text.Encoding.UTF8.GetBytes($"value-{i}")
+        }).ToList()
+    };
 
     [Benchmark(Description = "Read RecordBatch (10 records)")]
     public RecordBatch ReadRecordBatch()

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -28,8 +28,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
             .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
-            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
-            .WithSocketSendBufferBytes(options.BatchSize);
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
 
         _ = options.Compression switch
         {

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
@@ -30,8 +30,7 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
             .WithAcks(Acks.All)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
-            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
-            .WithSocketSendBufferBytes(options.BatchSize);
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
 
         _ = options.Compression switch
         {

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
@@ -30,8 +30,7 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
             .WithAcks(Acks.Leader)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
-            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
-            .WithSocketSendBufferBytes(options.BatchSize);
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
 
         _ = options.Compression switch
         {

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -27,8 +27,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
             .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
-            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
-            .WithSocketSendBufferBytes(options.BatchSize);
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
 
         _ = options.Compression switch
         {

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -28,8 +28,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
             .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
-            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
-            .WithSocketSendBufferBytes(options.BatchSize);
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
 
         _ = options.Compression switch
         {


### PR DESCRIPTION
## Why

Investigation of the stress-test results showed Dekaf losing to Confluent.Kafka only in the **single-broker fire-and-forget** scenario (1.29M vs 1.42M msg/s) — while using *less* CPU (1.45 vs 1.76 of 2 pinned cores). The client was pipeline-bound, not CPU-bound. Two causes:

1. **Harness asymmetry**: the stress scenarios forced `SocketSendBufferBytes = 1MB` on Dekaf only. An explicit `SO_SNDBUF` disables Linux socket-buffer autotuning, while librdkafka (`socket.send.buffer.bytes=0`) got the kernel-autotuned buffer (~4MB+) on the one connection carrying all traffic.
2. **Structural**: with `CompressionType.None`, the per-broker send-loop thread did the full record wire-encode (`RecordBatch.Write` → `WriteRecords`), a full buffer copy, and CRC32C **inline with the socket write** — strictly `serialize R_n → write R_n → serialize R_n+1`, no overlap. Compressed batches already avoided this via seal-time `PreCompress`.

## What

- `RecordBatch.PreCompress` now pre-serializes records when compression is `None`, writing straight into a pooled `DetachableBufferWriter`. The send loop then only copies + CRCs the wire-ready payload, and the coordinator encodes batch N+1 while the send loop writes batch N. Wire output is byte-identical (test asserts this).
- Pre-serialization runs in `Ready()` **after** the retry-backoff and leader checks, so deferred batches don''t waste the encode or hold pooled buffers.
- Renamed `CompressBatch` → `PreSerializeBatch` and `IsCompressionReady` → `IsPreSerialized` to match the broadened behavior.
- Removed the Dekaf-only `WithSocketSendBufferBytes` from all five producer stress scenarios (Dekaf''s default, like librdkafka''s, is OS autotune).
- **AdminClient**: `CreateTopicsAsync` retries are now idempotent — a retriable failure after the broker accepted the create (e.g. leader-election wait timeout) no longer surfaces `TopicAlreadyExists` from the retry. The faster producer exposed this latent race as parallel integration-test flakes. Validate-only requests never arm the tolerance. (Sibling admin ops have the same hazard; the deeper fix is a `RetryHelper` overload with retry context — follow-up.)

## Testing

- Full unit suite: 3841/3841 pass (3 new `RecordBatch` pre-serialize tests incl. byte-identical output + round-trip, 3 new `AdminClient` retry tests).
- Producer integration suite: 209/209 pass (was flaking on the AdminClient race before the fix; failures confirmed absent on this branch and reproduced the mechanism before fixing).
- New benchmark `Write RecordBatch pre-serialized` pairs with the existing write benchmark; total work is equivalent (~18µs vs ~17.6µs for 10 records) — the win is *which thread* pays, not total CPU.
- Stress CI run should be triggered on this branch to measure the fire-and-forget gap; watch the 3-broker numbers too (encode now runs on the coordinator for all brokers, same as compression always has).

Long-term fix (append-time wire-format encoding in the arena, eliminating the encode stage entirely) is tracked in #1136.