### PR TITLE
Move producer record encoding to append time

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -861,6 +861,8 @@ public sealed class ProducerBuilder<TKey, TValue>
                 $"MaxConnectionsPerBroker ({_maxConnectionsPerBroker}) must be >= ConnectionsPerBroker ({_connectionsPerBroker}). " +
                 $"Adaptive scaling would be permanently disabled since the initial connection count already exceeds the maximum.");
 
+        ProducerOptions.ValidateArenaCapacity(_batchSize, _arenaCapacity);
+
         // Java Kafka client enforces acks=all when enable.idempotence=true.
         // With acks=leader, the leader acknowledges before ISR replication completes,
         // which can cause OutOfOrderSequenceNumber on leader failover and makes the

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -320,12 +320,37 @@ public sealed class ProducerOptions
     /// Capacity in bytes of the per-batch arena that records are encoded into at append time.
     /// Default is 0, which uses BatchSize + 12.5% margin as the arena capacity — the margin
     /// provides headroom so a record appended near the batch-size boundary still fits.
-    /// Values below the default are ignored (records encode directly into the arena, so a
+    /// Values below the default are rejected (records encode directly into the arena, so a
     /// smaller arena would silently cap batch fill below BatchSize). Set a larger value for
     /// workloads where individual records regularly exceed BatchSize, to avoid re-renting a
     /// larger arena for those batches.
     /// </summary>
     public int ArenaCapacity { get; init; } = 0;
+
+    internal const int ArenaOverflowMarginDivisor = 8;
+
+    internal static int GetMinimumArenaCapacity(int batchSize) =>
+        (int)Math.Min((long)batchSize + batchSize / ArenaOverflowMarginDivisor, int.MaxValue);
+
+    internal static int GetEffectiveArenaCapacity(int batchSize, int arenaCapacity)
+    {
+        var minimum = GetMinimumArenaCapacity(batchSize);
+        return arenaCapacity > 0 ? arenaCapacity : minimum;
+    }
+
+    internal static void ValidateArenaCapacity(int batchSize, int arenaCapacity)
+    {
+        if (arenaCapacity == 0)
+            return;
+
+        var minimum = GetMinimumArenaCapacity(batchSize);
+        if (arenaCapacity < minimum)
+        {
+            throw new InvalidOperationException(
+                $"ArenaCapacity ({arenaCapacity}) must be 0 or at least {minimum} bytes for BatchSize {batchSize}. " +
+                "Records are encoded directly into the arena, so smaller arenas can cap batch fill below BatchSize.");
+        }
+    }
 
     /// <summary>
     /// Initial capacity for record arrays in partition batches.

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -317,13 +317,13 @@ public sealed class ProducerOptions
     public int ValueTaskSourcePoolSize { get; init; }
 
     /// <summary>
-    /// Capacity of the arena buffer for zero-copy serialization in bytes.
-    /// Larger arenas reduce fallback allocations when messages are larger than expected.
-    /// Default is 0, which uses BatchSize + 12.5% overflow margin as the arena capacity.
-    /// The margin provides headroom so that messages appended near the end of a batch
-    /// can still be serialized in the arena instead of falling back to ArrayPool.
-    /// For workloads with very large messages (approaching BatchSize), consider setting
-    /// this to BatchSize * 2 to reduce slow-path fallbacks.
+    /// Capacity in bytes of the per-batch arena that records are encoded into at append time.
+    /// Default is 0, which uses BatchSize + 12.5% margin as the arena capacity — the margin
+    /// provides headroom so a record appended near the batch-size boundary still fits.
+    /// Values below the default are ignored (records encode directly into the arena, so a
+    /// smaller arena would silently cap batch fill below BatchSize). Set a larger value for
+    /// workloads where individual records regularly exceed BatchSize, to avoid re-renting a
+    /// larger arena for those batches.
     /// </summary>
     public int ArenaCapacity { get; init; } = 0;
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1804,31 +1804,24 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var reader = _appendWorkerChannels[workerIndex].Reader;
         await foreach (var workItem in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
         {
+            var appendStarted = false;
             try
             {
                 workItem.CancellationToken.ThrowIfCancellationRequested();
 
-                ValueTask<bool> appendTask;
-                try
-                {
-                    appendTask = AppendAsync(
-                        workItem.Topic,
-                        workItem.Partition,
-                        workItem.Timestamp,
-                        workItem.Key,
-                        workItem.Value,
-                        workItem.Headers,
-                        workItem.HeaderCount,
-                        workItem.Completion,
-                        null,
-                        workItem.CancellationToken,
-                        partitionCount: workItem.PartitionCount);
-                }
-                catch
-                {
-                    CleanupWorkItemResources(in workItem);
-                    throw;
-                }
+                appendStarted = true;
+                var appendTask = AppendAsync(
+                    workItem.Topic,
+                    workItem.Partition,
+                    workItem.Timestamp,
+                    workItem.Key,
+                    workItem.Value,
+                    workItem.Headers,
+                    workItem.HeaderCount,
+                    workItem.Completion,
+                    null,
+                    workItem.CancellationToken,
+                    partitionCount: workItem.PartitionCount);
 
                 if (!await appendTask.ConfigureAwait(false))
                 {
@@ -1838,7 +1831,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             }
             catch (OperationCanceledException) when (workItem.CancellationToken.IsCancellationRequested)
             {
-                CleanupWorkItemResources(in workItem);
+                if (!appendStarted)
+                    CleanupWorkItemResources(in workItem);
                 workItem.Completion.TrySetCanceled(workItem.CancellationToken);
             }
             catch (Exception ex)
@@ -2015,7 +2009,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (Volatile.Read(ref _disposed) != 0)
             return new ValueTask<bool>(false);
 
-        var recordSize = PartitionBatch.EstimateRecordSize(key.Length, value.Length, headers, headerCount);
+        int recordSize;
+        try
+        {
+            recordSize = PartitionBatch.EstimateRecordSize(key.Length, value.Length, headers, headerCount);
+        }
+        catch
+        {
+            key.Return();
+            value.Return();
+            ReturnPooledHeaders(headers);
+            throw;
+        }
 
         // Hot path: non-blocking CAS reservation — no async state machine allocated
         if (TryReserveMemory(recordSize))
@@ -2065,161 +2070,189 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         ReadyBatch? sealedBatchToEnqueue = null;
         PartitionBatch? rentedBatch = null;
         var ownsRotation = false;
+        var ownsReservation = true;
+        var ownsRecordResources = true;
+        var ownsPendingCount = completionSource is not null;
         var spinner = new SpinWait();
 
-        while (true)
+        void ReleaseOwnedAppendState()
         {
-            PartitionBatch? batchToComplete = null;
-            PartitionBatch? batchToReturn = null;
-            ReadyBatch? batchToPublish = null;
-            ReadyBatch? batchToFail = null;
-            var waitForRotation = false;
-            var needBatch = false;
-            var appendSucceeded = false;
-            var disposed = false;
-            var messageTooLarge = false;
-
+            if (ownsPendingCount)
             {
-                using var guard = new SpinLockGuard(ref pd.Lock);
+                Interlocked.Decrement(ref _pendingAwaitedProduceCount);
+                ownsPendingCount = false;
+            }
+            if (ownsReservation)
+            {
+                ReleaseMemory(recordSize);
+                ownsReservation = false;
+            }
+            if (ownsRecordResources)
+            {
+                key.Return();
+                value.Return();
+                ReturnPooledHeaders(headers);
+                ownsRecordResources = false;
+            }
+        }
 
-                if (Volatile.Read(ref _disposed) != 0)
+        try
+        {
+            while (true)
+            {
+                PartitionBatch? batchToComplete = null;
+                PartitionBatch? batchToReturn = null;
+                ReadyBatch? batchToPublish = null;
+                ReadyBatch? batchToFail = null;
+                var waitForRotation = false;
+                var needBatch = false;
+                var appendSucceeded = false;
+                var disposed = false;
+                var messageTooLarge = false;
+
                 {
-                    batchToReturn = rentedBatch;
-                    rentedBatch = null;
-                    batchToFail = sealedBatchToEnqueue;
-                    sealedBatchToEnqueue = null;
-                    if (ownsRotation)
+                    using var guard = new SpinLockGuard(ref pd.Lock);
+
+                    if (Volatile.Read(ref _disposed) != 0)
                     {
-                        ClearRotationInProgressUnderLock(pd);
-                        ownsRotation = false;
-                    }
-                    disposed = true;
-                }
-                else if (pd.RotationInProgress && !ownsRotation)
-                {
-                    waitForRotation = true;
-                }
-                else
-                {
-                    if (sealedBatchToEnqueue is not null)
-                    {
-                        EnqueueCompletedBatchUnderLock(pd, sealedBatchToEnqueue);
-                        batchToPublish = sealedBatchToEnqueue;
+                        batchToReturn = rentedBatch;
+                        rentedBatch = null;
+                        batchToFail = sealedBatchToEnqueue;
                         sealedBatchToEnqueue = null;
-                    }
-
-                    if (pd.CurrentBatch is { } currentBatch)
-                    {
-                        if (TryAppendToBatch(currentBatch, timestamp, key, value, headers, headerCount,
-                            completionSource, callback, recordSize))
+                        if (ownsRotation)
                         {
-                            if (completionSource is not null)
-                                QueueLingerPartition(pd, topicPartition);
-                            batchToReturn = rentedBatch;
-                            rentedBatch = null;
-                            appendSucceeded = true;
+                            ClearRotationInProgressUnderLock(pd);
+                            ownsRotation = false;
                         }
-                        else
-                        {
-                            batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
-                            ownsRotation = true;
-                            needBatch = true;
-                        }
+                        disposed = true;
                     }
-                    else if (rentedBatch is null)
+                    else if (pd.RotationInProgress && !ownsRotation)
                     {
-                        needBatch = true;
+                        waitForRotation = true;
                     }
                     else
                     {
-                        var newBatch = rentedBatch;
-                        rentedBatch = null;
-                        pd.CurrentBatch = newBatch;
-                        Interlocked.Increment(ref _unsealedBatchCount);
-                        TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
-
-                        if (TryAppendToBatch(newBatch, timestamp, key, value, headers, headerCount,
-                            completionSource, callback, recordSize))
+                        if (sealedBatchToEnqueue is not null)
                         {
-                            ClearRotationInProgressUnderLock(pd);
-                            ownsRotation = false;
-                            appendSucceeded = true;
+                            EnqueueCompletedBatchUnderLock(pd, sealedBatchToEnqueue);
+                            batchToPublish = sealedBatchToEnqueue;
+                            sealedBatchToEnqueue = null;
+                        }
+
+                        if (pd.CurrentBatch is { } currentBatch)
+                        {
+                            if (TryAppendToBatch(currentBatch, timestamp, key, value, headers, headerCount,
+                                completionSource, callback, recordSize))
+                            {
+                                ownsReservation = false;
+                                ownsRecordResources = false;
+                                ownsPendingCount = false;
+                                if (completionSource is not null)
+                                    QueueLingerPartition(pd, topicPartition);
+                                batchToReturn = rentedBatch;
+                                rentedBatch = null;
+                                appendSucceeded = true;
+                            }
+                            else
+                            {
+                                batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
+                                ownsRotation = true;
+                                needBatch = true;
+                            }
+                        }
+                        else if (rentedBatch is null)
+                        {
+                            needBatch = true;
                         }
                         else
                         {
-                            pd.CurrentBatch = null;
-                            MarkLingerPartitionDequeued(pd);
-                            Interlocked.Decrement(ref _unsealedBatchCount);
-                            ClearRotationInProgressUnderLock(pd);
-                            ownsRotation = false;
-                            batchToReturn = newBatch;
-                            messageTooLarge = true;
+                            var newBatch = rentedBatch;
+                            rentedBatch = null;
+                            pd.CurrentBatch = newBatch;
+                            Interlocked.Increment(ref _unsealedBatchCount);
+                            TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
+
+                            if (TryAppendToBatch(newBatch, timestamp, key, value, headers, headerCount,
+                                completionSource, callback, recordSize))
+                            {
+                                ownsReservation = false;
+                                ownsRecordResources = false;
+                                ownsPendingCount = false;
+                                ClearRotationInProgressUnderLock(pd);
+                                ownsRotation = false;
+                                appendSucceeded = true;
+                            }
+                            else
+                            {
+                                pd.CurrentBatch = null;
+                                MarkLingerPartitionDequeued(pd);
+                                Interlocked.Decrement(ref _unsealedBatchCount);
+                                ClearRotationInProgressUnderLock(pd);
+                                ownsRotation = false;
+                                batchToReturn = newBatch;
+                                messageTooLarge = true;
+                            }
                         }
                     }
                 }
-            }
 
-            if (batchToPublish is not null)
-                PublishSealedBatch(batchToPublish);
+                if (batchToPublish is not null)
+                    PublishSealedBatch(batchToPublish);
 
-            if (batchToReturn is not null)
-                _batchPool.Return(batchToReturn);
+                if (batchToReturn is not null)
+                    _batchPool.Return(batchToReturn);
 
-            if (batchToFail is not null)
-            {
-                var disposedException = new ObjectDisposedException(nameof(RecordAccumulator));
-                batchToFail.Fail(disposedException);
-                if (batchToFail.TrySetMemoryReleased())
-                    ReleaseMemory(batchToFail.DataSize);
-            }
-
-            if (disposed)
-            {
-                if (completionSource is not null)
-                    Interlocked.Decrement(ref _pendingAwaitedProduceCount);
-                ReleaseMemory(recordSize);
-                key.Return();
-                value.Return();
-                ReturnPooledHeaders(headers);
-                return false;
-            }
-
-            if (messageTooLarge)
-            {
-                if (completionSource is not null)
-                    Interlocked.Decrement(ref _pendingAwaitedProduceCount);
-                ReleaseMemory(recordSize);
-                key.Return();
-                value.Return();
-                ReturnPooledHeaders(headers);
-                throw new KafkaException(ErrorCode.MessageTooLarge,
-                    $"Record of size {recordSize} exceeds maximum batch size of {_options.BatchSize}");
-            }
-
-            if (appendSucceeded)
-                return true;
-
-            if (waitForRotation)
-            {
-                spinner.SpinOnce();
-                continue;
-            }
-
-            if (batchToComplete is not null)
-            {
-                try
+                if (batchToFail is not null)
                 {
-                    sealedBatchToEnqueue = CompleteDetachedBatch(batchToComplete);
+                    var disposedException = new ObjectDisposedException(nameof(RecordAccumulator));
+                    batchToFail.Fail(disposedException);
+                    if (batchToFail.TrySetMemoryReleased())
+                        ReleaseMemory(batchToFail.DataSize);
                 }
-                catch
-                {
-                    ClearRotationInProgress(pd);
-                    throw;
-                }
-            }
 
-            if (needBatch && rentedBatch is null)
-                rentedBatch = RentBatch(topicPartition, partitionCount);
+                if (disposed)
+                {
+                    ReleaseOwnedAppendState();
+                    return false;
+                }
+
+                if (messageTooLarge)
+                {
+                    ReleaseOwnedAppendState();
+                    throw new KafkaException(ErrorCode.MessageTooLarge,
+                        $"Record of size {recordSize} exceeds maximum batch size of {_options.BatchSize}");
+                }
+
+                if (appendSucceeded)
+                    return true;
+
+                if (waitForRotation)
+                {
+                    spinner.SpinOnce();
+                    continue;
+                }
+
+                if (batchToComplete is not null)
+                {
+                    try
+                    {
+                        sealedBatchToEnqueue = CompleteDetachedBatch(batchToComplete);
+                    }
+                    catch
+                    {
+                        ClearRotationInProgress(pd);
+                        throw;
+                    }
+                }
+
+                if (needBatch && rentedBatch is null)
+                    rentedBatch = RentBatch(topicPartition, partitionCount);
+            }
+        }
+        catch
+        {
+            ReleaseOwnedAppendState();
+            throw;
         }
     }
 
@@ -2378,159 +2411,187 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         ReadyBatch? sealedBatchToEnqueue = null;
         PartitionBatch? rentedBatch = null;
         var ownsRotation = false;
+        var ownsReservation = true;
+        var ownsHeaderResources = returnHeadersOnFailure;
+        var ownsPendingCount = completionSource is not null;
         var spinner = new SpinWait();
 
-        while (true)
+        void ReleaseOwnedAppendState()
         {
-            PartitionBatch? batchToComplete = null;
-            PartitionBatch? batchToReturn = null;
-            ReadyBatch? batchToPublish = null;
-            ReadyBatch? batchToFail = null;
-            var waitForRotation = false;
-            var needBatch = false;
-            var appendSucceeded = false;
-            var disposed = false;
-            var messageTooLarge = false;
-
+            if (ownsPendingCount)
             {
-                using var guard = new SpinLockGuard(ref pd.Lock);
+                Interlocked.Decrement(ref _pendingAwaitedProduceCount);
+                ownsPendingCount = false;
+            }
+            if (ownsReservation)
+            {
+                ReleaseMemory(recordSize);
+                ownsReservation = false;
+            }
+            if (ownsHeaderResources)
+            {
+                ReturnPooledHeaders(headers);
+                ownsHeaderResources = false;
+            }
+        }
 
-                if (Volatile.Read(ref _disposed) != 0)
+        try
+        {
+            while (true)
+            {
+                PartitionBatch? batchToComplete = null;
+                PartitionBatch? batchToReturn = null;
+                ReadyBatch? batchToPublish = null;
+                ReadyBatch? batchToFail = null;
+                var waitForRotation = false;
+                var needBatch = false;
+                var appendSucceeded = false;
+                var disposed = false;
+                var messageTooLarge = false;
+
                 {
-                    batchToReturn = rentedBatch;
-                    rentedBatch = null;
-                    batchToFail = sealedBatchToEnqueue;
-                    sealedBatchToEnqueue = null;
-                    if (ownsRotation)
+                    using var guard = new SpinLockGuard(ref pd.Lock);
+
+                    if (Volatile.Read(ref _disposed) != 0)
                     {
-                        ClearRotationInProgressUnderLock(pd);
-                        ownsRotation = false;
-                    }
-                    disposed = true;
-                }
-                else if (pd.RotationInProgress && !ownsRotation)
-                {
-                    waitForRotation = true;
-                }
-                else
-                {
-                    if (sealedBatchToEnqueue is not null)
-                    {
-                        EnqueueCompletedBatchUnderLock(pd, sealedBatchToEnqueue);
-                        batchToPublish = sealedBatchToEnqueue;
+                        batchToReturn = rentedBatch;
+                        rentedBatch = null;
+                        batchToFail = sealedBatchToEnqueue;
                         sealedBatchToEnqueue = null;
-                    }
-
-                    if (pd.CurrentBatch is { } currentBatch)
-                    {
-                        if (TryAppendFromSpansToBatch(currentBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                            headers, headerCount, completionSource, callback, recordSize, returnHeadersOnFailure))
+                        if (ownsRotation)
                         {
-                            if (completionSource is not null)
-                                QueueLingerPartition(pd, topicPartition);
-                            batchToReturn = rentedBatch;
-                            rentedBatch = null;
-                            appendSucceeded = true;
+                            ClearRotationInProgressUnderLock(pd);
+                            ownsRotation = false;
                         }
-                        else
-                        {
-                            batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
-                            ownsRotation = true;
-                            needBatch = true;
-                        }
+                        disposed = true;
                     }
-                    else if (rentedBatch is null)
+                    else if (pd.RotationInProgress && !ownsRotation)
                     {
-                        needBatch = true;
+                        waitForRotation = true;
                     }
                     else
                     {
-                        var newBatch = rentedBatch;
-                        rentedBatch = null;
-                        pd.CurrentBatch = newBatch;
-                        Interlocked.Increment(ref _unsealedBatchCount);
-                        TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
-
-                        if (TryAppendFromSpansToBatch(newBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                            headers, headerCount, completionSource, callback, recordSize, returnHeadersOnFailure))
+                        if (sealedBatchToEnqueue is not null)
                         {
-                            ClearRotationInProgressUnderLock(pd);
-                            ownsRotation = false;
-                            appendSucceeded = true;
+                            EnqueueCompletedBatchUnderLock(pd, sealedBatchToEnqueue);
+                            batchToPublish = sealedBatchToEnqueue;
+                            sealedBatchToEnqueue = null;
+                        }
+
+                        if (pd.CurrentBatch is { } currentBatch)
+                        {
+                            if (TryAppendFromSpansToBatch(currentBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
+                                headers, headerCount, completionSource, callback, recordSize))
+                            {
+                                ownsReservation = false;
+                                ownsHeaderResources = false;
+                                ownsPendingCount = false;
+                                if (completionSource is not null)
+                                    QueueLingerPartition(pd, topicPartition);
+                                batchToReturn = rentedBatch;
+                                rentedBatch = null;
+                                appendSucceeded = true;
+                            }
+                            else
+                            {
+                                batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
+                                ownsRotation = true;
+                                needBatch = true;
+                            }
+                        }
+                        else if (rentedBatch is null)
+                        {
+                            needBatch = true;
                         }
                         else
                         {
-                            pd.CurrentBatch = null;
-                            MarkLingerPartitionDequeued(pd);
-                            Interlocked.Decrement(ref _unsealedBatchCount);
-                            ClearRotationInProgressUnderLock(pd);
-                            ownsRotation = false;
-                            batchToReturn = newBatch;
-                            messageTooLarge = true;
+                            var newBatch = rentedBatch;
+                            rentedBatch = null;
+                            pd.CurrentBatch = newBatch;
+                            Interlocked.Increment(ref _unsealedBatchCount);
+                            TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
+
+                            if (TryAppendFromSpansToBatch(newBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
+                                headers, headerCount, completionSource, callback, recordSize))
+                            {
+                                ownsReservation = false;
+                                ownsHeaderResources = false;
+                                ownsPendingCount = false;
+                                ClearRotationInProgressUnderLock(pd);
+                                ownsRotation = false;
+                                appendSucceeded = true;
+                            }
+                            else
+                            {
+                                pd.CurrentBatch = null;
+                                MarkLingerPartitionDequeued(pd);
+                                Interlocked.Decrement(ref _unsealedBatchCount);
+                                ClearRotationInProgressUnderLock(pd);
+                                ownsRotation = false;
+                                batchToReturn = newBatch;
+                                messageTooLarge = true;
+                            }
                         }
                     }
                 }
-            }
 
-            if (batchToPublish is not null)
-                PublishSealedBatch(batchToPublish);
+                if (batchToPublish is not null)
+                    PublishSealedBatch(batchToPublish);
 
-            if (batchToReturn is not null)
-                _batchPool.Return(batchToReturn);
+                if (batchToReturn is not null)
+                    _batchPool.Return(batchToReturn);
 
-            if (batchToFail is not null)
-            {
-                var disposedException = new ObjectDisposedException(nameof(RecordAccumulator));
-                batchToFail.Fail(disposedException);
-                if (batchToFail.TrySetMemoryReleased())
-                    ReleaseMemory(batchToFail.DataSize);
-            }
-
-            if (disposed)
-            {
-                if (completionSource is not null)
-                    Interlocked.Decrement(ref _pendingAwaitedProduceCount);
-                ReleaseMemory(recordSize);
-                if (returnHeadersOnFailure)
-                    ReturnPooledHeaders(headers);
-                return false;
-            }
-
-            if (messageTooLarge)
-            {
-                if (completionSource is not null)
-                    Interlocked.Decrement(ref _pendingAwaitedProduceCount);
-                ReleaseMemory(recordSize);
-                if (returnHeadersOnFailure)
-                    ReturnPooledHeaders(headers);
-                throw new KafkaException(ErrorCode.MessageTooLarge,
-                    $"Record of size {recordSize} exceeds maximum batch size of {_options.BatchSize}");
-            }
-
-            if (appendSucceeded)
-                return true;
-
-            if (waitForRotation)
-            {
-                spinner.SpinOnce();
-                continue;
-            }
-
-            if (batchToComplete is not null)
-            {
-                try
+                if (batchToFail is not null)
                 {
-                    sealedBatchToEnqueue = CompleteDetachedBatch(batchToComplete);
+                    var disposedException = new ObjectDisposedException(nameof(RecordAccumulator));
+                    batchToFail.Fail(disposedException);
+                    if (batchToFail.TrySetMemoryReleased())
+                        ReleaseMemory(batchToFail.DataSize);
                 }
-                catch
-                {
-                    ClearRotationInProgress(pd);
-                    throw;
-                }
-            }
 
-            if (needBatch && rentedBatch is null)
-                rentedBatch = RentBatch(topicPartition, partitionCount);
+                if (disposed)
+                {
+                    ReleaseOwnedAppendState();
+                    return false;
+                }
+
+                if (messageTooLarge)
+                {
+                    ReleaseOwnedAppendState();
+                    throw new KafkaException(ErrorCode.MessageTooLarge,
+                        $"Record of size {recordSize} exceeds maximum batch size of {_options.BatchSize}");
+                }
+
+                if (appendSucceeded)
+                    return true;
+
+                if (waitForRotation)
+                {
+                    spinner.SpinOnce();
+                    continue;
+                }
+
+                if (batchToComplete is not null)
+                {
+                    try
+                    {
+                        sealedBatchToEnqueue = CompleteDetachedBatch(batchToComplete);
+                    }
+                    catch
+                    {
+                        ClearRotationInProgress(pd);
+                        throw;
+                    }
+                }
+
+                if (needBatch && rentedBatch is null)
+                    rentedBatch = RentBatch(topicPartition, partitionCount);
+            }
+        }
+        catch
+        {
+            ReleaseOwnedAppendState();
+            throw;
         }
     }
 
@@ -2549,21 +2610,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Action<RecordMetadata, Exception?>? callback,
         int estimatedSize)
     {
-        RecordAppendResult result;
-        try
-        {
-            result = batch.TryAppend(timestamp, key, value, headers, headerCount, completionSource, callback);
-        }
-        catch
-        {
-            if (completionSource is not null)
-                Interlocked.Decrement(ref _pendingAwaitedProduceCount);
-            ReleaseMemory(estimatedSize);
-            key.Return();
-            value.Return();
-            ReturnPooledHeaders(headers);
-            throw;
-        }
+        var result = batch.TryAppend(timestamp, key, value, headers, headerCount, completionSource, callback);
 
         if (result.Success)
         {
@@ -2602,7 +2649,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         var keyLength = keyIsNull ? 0 : keyData.Length;
         var valueLength = valueIsNull ? 0 : valueData.Length;
-        var recordSize = PartitionBatch.EstimateRecordSize(keyLength, valueLength, headers, headerCount);
+        int recordSize;
+        try
+        {
+            recordSize = PartitionBatch.EstimateRecordSize(keyLength, valueLength, headers, headerCount);
+        }
+        catch
+        {
+            ReturnPooledHeaders(headers);
+            throw;
+        }
 
         // Hot path: non-blocking CAS reservation — no async state machine allocated
         if (TryReserveMemory(recordSize))
@@ -2687,24 +2743,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int headerCount,
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
-        int estimatedSize,
-        bool returnHeadersOnFailure)
+        int estimatedSize)
     {
-        RecordAppendResult result;
-        try
-        {
-            result = batch.TryAppendFromSpans(timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                headers, headerCount, completionSource, callback);
-        }
-        catch
-        {
-            if (completionSource is not null)
-                Interlocked.Decrement(ref _pendingAwaitedProduceCount);
-            ReleaseMemory(estimatedSize);
-            if (returnHeadersOnFailure)
-                ReturnPooledHeaders(headers);
-            throw;
-        }
+        var result = batch.TryAppendFromSpans(timestamp, keyData, keyIsNull, valueData, valueIsNull,
+            headers, headerCount, completionSource, callback);
 
         if (result.Success)
         {

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading.Channels;
 using System.Threading.Tasks.Sources;
 using Dekaf.Compression;
@@ -666,6 +667,25 @@ internal sealed class BatchArena
     public ReadOnlySpan<byte> GetSpan(int offset, int length)
     {
         return _buffer.AsSpan(offset, length);
+    }
+
+    /// <summary>
+    /// Gets read-only memory for data at the specified offset and length.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ReadOnlyMemory<byte> GetMemory(int offset, int length)
+    {
+        return _buffer.AsMemory(offset, length);
+    }
+
+    /// <summary>
+    /// Rewinds the last allocation if no later allocation has occurred.
+    /// Used only while the owning partition lock is held to abandon a failed record encode.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryRewindLastAllocation(int offset, int length)
+    {
+        return Interlocked.CompareExchange(ref _position, offset, offset + length) == offset + length;
     }
 
     /// <summary>
@@ -1346,7 +1366,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     && now < batch.RetryNotBefore)
                     continue;
 
-                if (ready.Count > 0 && size + batch.DataSize > maxRequestSize)
+                var batchRequestSize = batch.EncodedSize;
+                if (ready.Count > 0 && size + batchRequestSize > maxRequestSize)
                 {
                     // Ready() already consumed notifications for all partitions on this node.
                     // Re-enqueue this and remaining partitions so they aren't orphaned.
@@ -1370,7 +1391,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             if (batch is not null)
             {
                 batch.AppendDiag('D');
-                size += batch.DataSize;
+                size += batch.EncodedSize;
                 ready.Add(batch);
             }
         }
@@ -2717,11 +2738,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Pre-serializes a sealed batch's records (compressing when configured). Called by the
+    /// Prepares a sealed batch's records for send, compressing when configured. Called by the
     /// sender thread from <see cref="Ready"/>, outside the partition SpinLock, before the
-    /// batch can drain. Doing this here keeps the per-record wire encoding off the per-broker
-    /// send-loop thread, which only has to copy + CRC the pre-serialized payload — the
-    /// coordinator encodes the next batch while the send loop writes the previous one.
+    /// batch can drain. Record bytes are already encoded at append time, so this step either
+    /// leaves the arena-backed records in place or compresses those encoded bytes.
     ///
     /// Thread safety: the batch is already sealed and in the deque; no other thread can
     /// modify it. The drain loop skips batches where <see cref="ReadyBatch.IsPreSerialized"/>
@@ -2732,6 +2752,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         try
         {
             readyBatch.RecordBatch.PreCompress(_options.CompressionType, _compressionCodecs);
+            readyBatch.SetEncodedSize(readyBatch.RecordBatch.GetEncodedSize(_options.CompressionType));
         }
         catch (Exception ex)
         {
@@ -4025,6 +4046,9 @@ internal sealed class PartitionBatch
     private int _pooledHeaderArrayCount;
 
     private long _baseTimestamp;
+    private long _maxTimestamp;
+    private int _encodedRecordsStart;
+    private int _encodedRecordsLength;
     private int _estimatedSize;
     // Note: _offsetDelta removed - it always equals _recordCount at assignment time
     private long _createdStopwatchTimestamp;
@@ -4138,6 +4162,9 @@ internal sealed class PartitionBatch
         _pooledArrayCount = 0;
         _pooledHeaderArrayCount = 0;
         _baseTimestamp = 0;
+        _maxTimestamp = 0;
+        _encodedRecordsStart = 0;
+        _encodedRecordsLength = 0;
         _estimatedSize = 0;
         _isCompleted = 0;  // Only reset here - see remarks
         _completedBatch = null;
@@ -4191,6 +4218,9 @@ internal sealed class PartitionBatch
         _pooledArrayCount = 0;
         _pooledHeaderArrayCount = 0;
         _baseTimestamp = 0;
+        _maxTimestamp = 0;
+        _encodedRecordsStart = 0;
+        _encodedRecordsLength = 0;
         _estimatedSize = 0;
         // _isCompleted stays at 1 - batch is "completed" while in pool
         _completedBatch = null;
@@ -4228,103 +4258,32 @@ internal sealed class PartitionBatch
         Action<RecordMetadata, Exception?>? callback,
         int estimatedRecordSize)
     {
-        // Check if batch was completed
-        if (Volatile.Read(ref _isCompleted) != 0)
+        var result = TryAppendEncoded(
+            timestamp,
+            key.Span,
+            key.IsNull,
+            key.Length,
+            value.Span,
+            value.IsNull,
+            value.Length,
+            headers,
+            headerCount,
+            completionSource,
+            callback,
+            estimatedRecordSize);
+
+        if (result.Success)
         {
-            return new RecordAppendResult(false);
+            key.Return();
+            value.Return();
+            RecordAccumulator.ReturnPooledHeaders(headers);
         }
 
-        // Defensive check: if arrays are null, batch is in inconsistent state (being pooled)
-        if (_records is null || _pooledArrays is null)
-        {
-            return new RecordAppendResult(false);
-        }
-
-        if (_recordCount == 0)
-        {
-            _baseTimestamp = timestamp;
-        }
-
-        // Check size limit
-        if (_estimatedSize + estimatedRecordSize > _options.BatchSize && _recordCount > 0)
-        {
-            return new RecordAppendResult(false);
-        }
-
-        // Grow arrays if needed (rare - only happens if batch fills beyond initial capacity)
-        if (_recordCount >= _records.Length)
-        {
-            GrowArray(ref _records, ref _recordCount, ProducerContainerPools.Records);
-        }
-        if (completionSource is not null && _completionSourceCount >= _completionSources.Length)
-        {
-            GrowArray(ref _completionSources, ref _completionSourceCount, ProducerContainerPools.CompletionSources);
-        }
-        if (_pooledArrayCount + 2 >= _pooledArrays.Length) // +2 for key and value
-        {
-            GrowArray(ref _pooledArrays, ref _pooledArrayCount, ProducerContainerPools.DataArrayRefs);
-        }
-        if (headers is not null && _pooledHeaderArrayCount >= _pooledHeaderArrays.Length)
-        {
-            GrowArray(ref _pooledHeaderArrays, ref _pooledHeaderArrayCount, ProducerContainerPools.HeaderArrayRefs);
-        }
-        if (callback is not null)
-        {
-            _callbacks ??= ProducerContainerPools.Callbacks.Rent(_initialRecordCapacity);
-            if (_callbackCount >= _callbacks.Length)
-            {
-                GrowArray(ref _callbacks!, ref _callbackCount, ProducerContainerPools.Callbacks);
-            }
-        }
-
-        // Track pooled arrays for returning to pool later
-        if (key.Array is not null)
-        {
-            _pooledArrays[_pooledArrayCount++] = key.Array;
-        }
-        if (value.Array is not null)
-        {
-            _pooledArrays[_pooledArrayCount++] = value.Array;
-        }
-        if (headers is not null)
-        {
-            _pooledHeaderArrays[_pooledHeaderArrayCount++] = headers;
-        }
-
-        var timestampDelta = timestamp - _baseTimestamp;
-        _records[_recordCount] = new Record
-        {
-            TimestampDelta = timestampDelta,
-            OffsetDelta = _recordCount,
-            Key = key.Memory,
-            IsKeyNull = key.IsNull,
-            Value = value.Memory,
-            IsValueNull = value.IsNull,
-            Headers = headers,
-            HeaderCount = headerCount,
-            CachedBodySize = Record.ComputeBodySize(timestampDelta, _recordCount, key.IsNull, key.Length, value.IsNull, value.Length, headers, headerCount)
-        };
-
-        if (completionSource is not null)
-        {
-            _completionSources[_completionSourceCount++] = completionSource;
-            ProducerDebugCounters.RecordCompletionSourceStoredInBatch();
-        }
-
-        if (callback is not null)
-        {
-            _callbacks![_callbackCount++] = callback;
-        }
-
-        _recordCount++;
-        _estimatedSize += estimatedRecordSize;
-
-        return new RecordAppendResult(Success: true, ActualSizeAdded: estimatedRecordSize);
+        return result;
     }
 
     /// <summary>
-    /// Appends a record from raw span data, using the arena for zero-copy when possible.
-    /// Falls back to ArrayPool rental when the arena is full.
+    /// Appends a record from raw span data, encoding directly into the batch arena.
     /// Caller must hold the per-partition deque lock.
     /// </summary>
     public RecordAppendResult TryAppendFromSpans(
@@ -4342,6 +4301,44 @@ internal sealed class PartitionBatch
         var keyLength = keyIsNull ? 0 : keyData.Length;
         var valueLength = valueIsNull ? 0 : valueData.Length;
 
+        var result = TryAppendEncoded(
+            timestamp,
+            keyData,
+            keyIsNull,
+            keyLength,
+            valueData,
+            valueIsNull,
+            valueLength,
+            headers,
+            headerCount,
+            completionSource,
+            callback,
+            estimatedRecordSize);
+
+        if (result.Success)
+        {
+            RecordAccumulator.ReturnPooledHeaders(headers);
+        }
+
+        return result;
+    }
+
+    private RecordAppendResult TryAppendEncoded(
+        long timestamp,
+        ReadOnlySpan<byte> keyData,
+        bool keyIsNull,
+        int keyLength,
+        ReadOnlySpan<byte> valueData,
+        bool valueIsNull,
+        int valueLength,
+        Header[]? headers,
+        int headerCount,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
+        Action<RecordMetadata, Exception?>? callback,
+        int estimatedRecordSize)
+    {
+        _ = estimatedRecordSize;
+
         // Check if batch was completed
         if (Volatile.Read(ref _isCompleted) != 0)
         {
@@ -4354,13 +4351,22 @@ internal sealed class PartitionBatch
             return new RecordAppendResult(false);
         }
 
-        if (_recordCount == 0)
-        {
-            _baseTimestamp = timestamp;
-        }
+        var recordIndex = _recordCount;
+        var baseTimestamp = recordIndex == 0 ? timestamp : _baseTimestamp;
+        var timestampDelta = timestamp - baseTimestamp;
+        var bodySize = Record.ComputeBodySize(
+            timestampDelta,
+            recordIndex,
+            keyIsNull,
+            keyLength,
+            valueIsNull,
+            valueLength,
+            headers,
+            headerCount);
+        var encodedRecordSize = checked(Record.VarIntSize(bodySize) + bodySize);
 
         // Check size limit
-        if (_estimatedSize + estimatedRecordSize > _options.BatchSize && _recordCount > 0)
+        if ((long)_estimatedSize + encodedRecordSize > _options.BatchSize && recordIndex > 0)
         {
             return new RecordAppendResult(false);
         }
@@ -4374,10 +4380,6 @@ internal sealed class PartitionBatch
         {
             GrowArray(ref _completionSources, ref _completionSourceCount, ProducerContainerPools.CompletionSources);
         }
-        if (headers is not null && _pooledHeaderArrayCount >= _pooledHeaderArrays.Length)
-        {
-            GrowArray(ref _pooledHeaderArrays, ref _pooledHeaderArrayCount, ProducerContainerPools.HeaderArrayRefs);
-        }
         if (callback is not null)
         {
             _callbacks ??= ProducerContainerPools.Callbacks.Rent(_initialRecordCapacity);
@@ -4387,75 +4389,40 @@ internal sealed class PartitionBatch
             }
         }
 
-        // Pre-grow _pooledArrays for worst case (key + value fallback to ArrayPool)
-        if (_pooledArrayCount + 2 >= _pooledArrays.Length)
+        if (_arena is null || !_arena.TryAllocate(encodedRecordSize, out var encodedRecord, out var encodedOffset))
         {
-            GrowArray(ref _pooledArrays, ref _pooledArrayCount, ProducerContainerPools.DataArrayRefs);
+            return new RecordAppendResult(false);
         }
 
-        // Try to use arena for zero-copy serialization
-        ReadOnlyMemory<byte> keyMemory = ReadOnlyMemory<byte>.Empty;
-        ReadOnlyMemory<byte> valueMemory = ReadOnlyMemory<byte>.Empty;
-        bool usedArenaForKey = false;
-        bool usedArenaForValue = false;
-
-        if (!keyIsNull && keyLength > 0 && _arena is not null)
+        try
         {
-            if (_arena.TryAllocate(keyLength, out var keySpan, out var keyOffset))
-            {
-                keyData.CopyTo(keySpan);
-                keyMemory = _arena.Buffer.AsMemory(keyOffset, keyLength);
-                usedArenaForKey = true;
-            }
+            WriteEncodedRecord(
+                encodedRecord,
+                bodySize,
+                timestampDelta,
+                recordIndex,
+                keyData,
+                keyIsNull,
+                valueData,
+                valueIsNull,
+                headers,
+                headerCount);
+        }
+        catch
+        {
+            _arena.TryRewindLastAllocation(encodedOffset, encodedRecordSize);
+            throw;
         }
 
-        if (!valueIsNull && valueLength > 0 && _arena is not null)
+        if (recordIndex == 0)
         {
-            if (_arena.TryAllocate(valueLength, out var valueSpan, out var valueOffset))
-            {
-                valueData.CopyTo(valueSpan);
-                valueMemory = _arena.Buffer.AsMemory(valueOffset, valueLength);
-                usedArenaForValue = true;
-            }
+            _baseTimestamp = baseTimestamp;
+            _encodedRecordsStart = encodedOffset;
         }
 
-        // Fall back to ProducerDataPool for data that didn't fit in the arena.
-        // Uses dedicated pool instead of ArrayPool<byte>.Shared to prevent TLS-based
-        // working set growth from cross-thread rent/return (see ProducerDataPool docs).
-        if (!keyIsNull && keyLength > 0 && !usedArenaForKey)
-        {
-            var keyArray = ProducerDataPool.BytePool.Rent(keyLength);
-            keyData.CopyTo(keyArray);
-            keyMemory = keyArray.AsMemory(0, keyLength);
-            _pooledArrays[_pooledArrayCount++] = keyArray;
-        }
-
-        if (!valueIsNull && valueLength > 0 && !usedArenaForValue)
-        {
-            var valueArray = ProducerDataPool.BytePool.Rent(valueLength);
-            valueData.CopyTo(valueArray);
-            valueMemory = valueArray.AsMemory(0, valueLength);
-            _pooledArrays[_pooledArrayCount++] = valueArray;
-        }
-
-        if (headers is not null)
-        {
-            _pooledHeaderArrays[_pooledHeaderArrayCount++] = headers;
-        }
-
-        var timestampDelta = timestamp - _baseTimestamp;
-        _records[_recordCount] = new Record
-        {
-            TimestampDelta = timestampDelta,
-            OffsetDelta = _recordCount,
-            Key = keyMemory,
-            IsKeyNull = keyIsNull,
-            Value = valueMemory,
-            IsValueNull = valueIsNull,
-            Headers = headers,
-            HeaderCount = headerCount,
-            CachedBodySize = Record.ComputeBodySize(timestampDelta, _recordCount, keyIsNull, keyLength, valueIsNull, valueLength, headers, headerCount)
-        };
+        Debug.Assert(encodedOffset == _encodedRecordsStart + _encodedRecordsLength);
+        _encodedRecordsLength += encodedRecordSize;
+        _maxTimestamp = recordIndex == 0 ? timestamp : Math.Max(_maxTimestamp, timestamp);
 
         if (completionSource is not null)
         {
@@ -4468,10 +4435,132 @@ internal sealed class PartitionBatch
             _callbacks![_callbackCount++] = callback;
         }
 
-        _recordCount++;
-        _estimatedSize += estimatedRecordSize;
+        _recordCount = recordIndex + 1;
+        _estimatedSize += encodedRecordSize;
 
-        return new RecordAppendResult(Success: true, ActualSizeAdded: estimatedRecordSize);
+        return new RecordAppendResult(Success: true, ActualSizeAdded: encodedRecordSize);
+    }
+
+    [SkipLocalsInit]
+    private static void WriteEncodedRecord(
+        Span<byte> destination,
+        int bodySize,
+        long timestampDelta,
+        int offsetDelta,
+        ReadOnlySpan<byte> keyData,
+        bool keyIsNull,
+        ReadOnlySpan<byte> valueData,
+        bool valueIsNull,
+        Header[]? headers,
+        int headerCount)
+    {
+        var offset = 0;
+
+        WriteVarInt(destination, ref offset, bodySize);
+        destination[offset++] = 0; // record attributes
+        WriteVarLong(destination, ref offset, timestampDelta);
+        WriteVarInt(destination, ref offset, offsetDelta);
+
+        if (keyIsNull)
+        {
+            WriteVarInt(destination, ref offset, -1);
+        }
+        else
+        {
+            WriteVarInt(destination, ref offset, keyData.Length);
+            keyData.CopyTo(destination[offset..]);
+            offset += keyData.Length;
+        }
+
+        if (valueIsNull)
+        {
+            WriteVarInt(destination, ref offset, -1);
+        }
+        else
+        {
+            WriteVarInt(destination, ref offset, valueData.Length);
+            valueData.CopyTo(destination[offset..]);
+            offset += valueData.Length;
+        }
+
+        WriteVarInt(destination, ref offset, headerCount);
+        if (headers is not null)
+        {
+            for (var i = 0; i < headerCount; i++)
+            {
+                WriteHeader(destination, ref offset, in headers[i]);
+            }
+        }
+
+        Debug.Assert(offset == destination.Length);
+    }
+
+    [SkipLocalsInit]
+    private static void WriteHeader(Span<byte> destination, ref int offset, in Header header)
+    {
+        var key = header.Key;
+        if (key.Length <= 128)
+        {
+            Span<byte> buffer = stackalloc byte[512];
+            var keyByteCount = Encoding.UTF8.GetBytes(key, buffer);
+            WriteVarInt(destination, ref offset, keyByteCount);
+            buffer[..keyByteCount].CopyTo(destination[offset..]);
+            offset += keyByteCount;
+        }
+        else
+        {
+            var keyByteCount = Encoding.UTF8.GetByteCount(key);
+            WriteVarInt(destination, ref offset, keyByteCount);
+            Encoding.UTF8.GetBytes(key, destination[offset..]);
+            offset += keyByteCount;
+        }
+
+        if (header.IsValueNull)
+        {
+            WriteVarInt(destination, ref offset, -1);
+        }
+        else
+        {
+            WriteVarInt(destination, ref offset, header.Value.Length);
+            header.Value.Span.CopyTo(destination[offset..]);
+            offset += header.Value.Length;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteVarInt(Span<byte> destination, ref int offset, int value)
+    {
+        WriteVarUInt(destination, ref offset, (uint)((value << 1) ^ (value >> 31)));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteVarLong(Span<byte> destination, ref int offset, long value)
+    {
+        WriteVarULong(destination, ref offset, (ulong)((value << 1) ^ (value >> 63)));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteVarUInt(Span<byte> destination, ref int offset, uint value)
+    {
+        while (value >= 0x80)
+        {
+            destination[offset++] = (byte)(value | 0x80);
+            value >>= 7;
+        }
+
+        destination[offset++] = (byte)value;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteVarULong(Span<byte> destination, ref int offset, ulong value)
+    {
+        while (value >= 0x80)
+        {
+            destination[offset++] = (byte)(value | 0x80);
+            value >>= 7;
+        }
+
+        destination[offset++] = (byte)value;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -4537,8 +4626,8 @@ internal sealed class PartitionBatch
             return null;
         }
 
-        // Use pooled records array directly with wrapper to avoid allocation
-        // ReadyBatch will return the array to pool in Cleanup()
+        // Keep the working records array with ReadyBatch so it can be recycled after cleanup.
+        // RecordBatch itself reads from the already-encoded arena bytes.
         var pooledRecordsArray = _records;
         var attributes = RecordBatchAttributes.None;
         if (_isTransactional)
@@ -4559,13 +4648,15 @@ internal sealed class PartitionBatch
         var batch = RecordBatch.RentFromPool();
         batch.BaseOffset = 0;
         batch.BaseTimestamp = _baseTimestamp;
-        batch.MaxTimestamp = _baseTimestamp + (_recordCount > 0 ? pooledRecordsArray[_recordCount - 1].TimestampDelta : 0);
+        batch.MaxTimestamp = _maxTimestamp;
         batch.LastOffsetDelta = _recordCount - 1;
         batch.ProducerId = _producerId;
         batch.ProducerEpoch = _producerEpoch;
         batch.BaseSequence = baseSequence;
         batch.Attributes = attributes;
-        batch.Records = new RecordListWrapper(pooledRecordsArray, _recordCount);
+        var encodedRecords = _arena!.GetMemory(_encodedRecordsStart, _encodedRecordsLength);
+        batch.SetPreEncodedRecords(encodedRecords);
+        batch.Records = LazyRecordList.Create(encodedRecords, _recordCount);
         _records = null!;
 
         // Rent ReadyBatch from pool or create new if no pool available
@@ -4644,7 +4735,10 @@ internal sealed class PartitionBatch
     /// </remarks>
     internal static int EstimateRecordSize(int keyLength, int valueLength, Header[]? headers, int headerCount)
     {
-        var size = 20; // Base overhead for varint lengths, timestamp delta, offset delta, etc.
+        // Upper bound for record wrapper/body metadata:
+        // record length (5) + attributes (1) + timestamp delta (10) + offset delta (5) +
+        // key length (5) + value length (5) + header count (5).
+        var size = 36;
         size += keyLength;
         size += valueLength;
 
@@ -4652,29 +4746,11 @@ internal sealed class PartitionBatch
         {
             for (var i = 0; i < headerCount; i++)
             {
-                var header = headers[i];
-                // OPTIMIZATION: For ASCII-only keys (99%+ of cases), string.Length == byte count.
-                // Only fall back to expensive UTF8.GetByteCount for non-ASCII keys.
-                var headerKeyByteCount = GetHeaderKeyByteCount(header.Key);
-                size += headerKeyByteCount + (header.IsValueNull ? 0 : header.Value.Length) + 10;
+                size += headers[i].CalculateSize();
             }
         }
 
         return size;
-    }
-
-    /// <summary>
-    /// Fast path for header key byte count. ASCII keys (the common case) use string length directly.
-    /// Uses SIMD-optimized Ascii.IsValid for efficient detection.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int GetHeaderKeyByteCount(string key)
-    {
-        // SIMD-optimized ASCII check: if all chars are ASCII, byte count == char count
-        // This is much faster than UTF8.GetByteCount for the common ASCII case
-        return System.Text.Ascii.IsValid(key)
-            ? key.Length
-            : System.Text.Encoding.UTF8.GetByteCount(key);
     }
 }
 
@@ -4795,9 +4871,14 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     public int CompletionSourcesCount => _completionSourcesCount;
 
     /// <summary>
-    /// Estimated size of all data in this batch (for buffer memory tracking).
+    /// Uncompressed encoded record bytes reserved against BufferMemory.
     /// </summary>
     public int DataSize { get; private set; }
+
+    /// <summary>
+    /// Full encoded record batch size used for MaxRequestSize drain accounting.
+    /// </summary>
+    public int EncodedSize { get; private set; }
 
     /// <summary>
     /// Gets a ValueTask that completes when this batch is done (either sent successfully or failed).
@@ -4870,6 +4951,8 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     /// Only called during epoch bump recovery — not in the hot path.
     /// </summary>
     internal void RewriteRecordBatch(RecordBatch newRecordBatch) => _recordBatch = newRecordBatch;
+
+    internal void SetEncodedSize(int encodedSize) => EncodedSize = encodedSize;
 
     /// <summary>
     /// Whether the batch's records have been pre-serialized (and compressed, when
@@ -5026,6 +5109,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         _pooledHeaderArrays = pooledHeaderArrays;
         _pooledHeaderArraysCount = pooledHeaderArraysCount;
         DataSize = dataSize;
+        EncodedSize = dataSize;
         _pooledRecordsArray = pooledRecordsArray;
         _arena = arena;
         _callbacks = callbacks;
@@ -5073,6 +5157,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         _pooledHeaderArrays = null;
         _pooledHeaderArraysCount = 0;
         DataSize = 0;
+        EncodedSize = 0;
         _pooledRecordsArray = null;
         _arena = null;
         _callbacks = null;
@@ -5387,6 +5472,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         if (_recordBatch is not null)
         {
             _recordBatch.ReturnPreCompressedBuffer();
+            _recordBatch.DisposeRecordList();
             _recordBatch.ReturnToPool();
         }
     }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Channels;
 using System.Threading.Tasks.Sources;
 using Dekaf.Compression;
@@ -236,9 +235,9 @@ internal static class ProducerDataPool
 /// Dedicated <see cref="ArrayPool{T}"/> instances for producer batch container arrays.
 /// <para/>
 /// <b>Why not <see cref="ArrayPool{T}.Shared"/>?</b>
-/// Batch container arrays (<c>Record[]</c>, <c>PooledValueTaskSource[]</c>, <c>byte[][]</c>,
-/// <c>Header[][]</c>, <c>Header[]</c>, <c>Action[]</c>) are rented on the producer/accumulator
-/// thread during batch creation but returned on BrokerSender LongRunning threads during
+/// Batch container arrays (<c>PooledValueTaskSource[]</c>, <c>Header[]</c>, <c>Action[]</c>)
+/// are rented on the producer/accumulator thread during batch creation but returned on
+/// BrokerSender LongRunning threads during
 /// <see cref="ReadyBatch.Cleanup"/>. <c>ArrayPool&lt;T&gt;.Shared</c> uses TLS-based caching
 /// (<c>TlsOverPerCoreLockedStacksArrayPool</c>) that retains returned arrays in per-thread slots
 /// that grow but never shrink. With N brokers, N BrokerSender threads each accumulate returned
@@ -268,22 +267,10 @@ internal static class ProducerContainerPools
         maxArrayLength: 1024,
         initialArraysPerBucket: 16);
 
-    /// <summary>Pool for Record[] container arrays used by PartitionBatch/ReadyBatch.</summary>
-    internal static readonly ArrayPool<Record> Records = ArrayPool<Record>.Create(
-        maxArrayLength: MaxRecordArrayLength, maxArraysPerBucket: 16);
-
     /// <summary>Pool for PooledValueTaskSource[] container arrays.</summary>
     internal static readonly ArrayPool<PooledValueTaskSource<RecordMetadata>> CompletionSources =
         ArrayPool<PooledValueTaskSource<RecordMetadata>>.Create(
             maxArrayLength: MaxRecordArrayLength, maxArraysPerBucket: 16);
-
-    /// <summary>Pool for byte[][] container arrays (pooled data array references).</summary>
-    internal static readonly ArrayPool<byte[]> DataArrayRefs = ArrayPool<byte[]>.Create(
-        maxArrayLength: MaxRecordArrayLength * 2, maxArraysPerBucket: 16);
-
-    /// <summary>Pool for Header[][] container arrays (pooled header array references).</summary>
-    internal static readonly ArrayPool<Header[]> HeaderArrayRefs = ArrayPool<Header[]>.Create(
-        maxArrayLength: 1024, maxArraysPerBucket: 16);
 
     /// <summary>Pool for Header[] arrays (per-message headers).</summary>
     internal static ArrayPool<Header> Headers => s_headers.Pool;
@@ -2527,7 +2514,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Action<RecordMetadata, Exception?>? callback,
         int estimatedSize)
     {
-        var result = batch.TryAppend(timestamp, key, value, headers, headerCount, completionSource, callback, estimatedSize);
+        var result = batch.TryAppend(timestamp, key, value, headers, headerCount, completionSource, callback);
 
         if (result.Success)
         {
@@ -2654,7 +2641,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int estimatedSize)
     {
         var result = batch.TryAppendFromSpans(timestamp, keyData, keyIsNull, valueData, valueIsNull,
-            headers, headerCount, completionSource, callback, estimatedSize);
+            headers, headerCount, completionSource, callback);
 
         if (result.Success)
         {
@@ -4024,26 +4011,18 @@ internal sealed class PartitionBatch
     private ReadyBatchPool? _readyBatchPool; // Pool for renting ReadyBatch objects
     private BatchArrayReuseQueue? _arrayReuseQueue; // Reuse queue for working arrays
 
-    // Arena for zero-copy serialization - all message data in one contiguous buffer
+    // Arena holding the encoded record bytes - all records in one contiguous buffer
     private BatchArena? _arena;
 
-    // Zero-allocation array management: use pooled arrays instead of List<T>
-    private Record[] _records;
     private int _recordCount;
 
+    // Zero-allocation array management: use pooled arrays instead of List<T>
     private PooledValueTaskSource<RecordMetadata>[] _completionSources;
     private int _completionSourceCount;
 
     // Callbacks for Send(message, callback) - stored directly in batch for inline invocation
     private Action<RecordMetadata, Exception?>?[]? _callbacks;
     private int _callbackCount;
-
-    // Legacy: pooled arrays for non-arena path (completion-tracked messages)
-    private byte[][] _pooledArrays;
-    private int _pooledArrayCount;
-
-    private Header[][] _pooledHeaderArrays;
-    private int _pooledHeaderArrayCount;
 
     private long _baseTimestamp;
     private long _maxTimestamp;
@@ -4061,21 +4040,22 @@ internal sealed class PartitionBatch
     private bool _isTransactional;
 
     /// <summary>
-    /// Divisor for computing the arena overflow margin from BatchSize.
-    /// A divisor of 8 gives a 12.5% margin (BatchSize / 8) above BatchSize,
-    /// reducing per-message ArrayPool fallback when batches near capacity.
+    /// Divisor for computing the arena headroom margin from BatchSize.
+    /// A divisor of 8 gives a 12.5% margin (BatchSize / 8) above BatchSize so a record
+    /// that lands near the batch-size boundary still fits in the arena.
     /// </summary>
     private const int ArenaOverflowMarginDivisor = 8;
 
     /// <summary>
-    /// Returns the effective arena capacity: explicit ArenaCapacity if set,
-    /// otherwise BatchSize + 12.5% margin to reduce per-message ArrayPool fallback.
+    /// Returns the effective arena capacity: BatchSize + 12.5% margin, or an explicit
+    /// ArenaCapacity when it is larger. Records encode directly into the arena, so a
+    /// capacity below BatchSize would silently cap batch fill — smaller values are ignored.
     /// Uses long arithmetic to avoid integer overflow when BatchSize is large.
     /// </summary>
     private static int GetEffectiveArenaCapacity(ProducerOptions options) =>
-        options.ArenaCapacity > 0
-            ? options.ArenaCapacity
-            : (int)Math.Min((long)options.BatchSize + options.BatchSize / ArenaOverflowMarginDivisor, int.MaxValue);
+        Math.Max(
+            options.ArenaCapacity,
+            (int)Math.Min((long)options.BatchSize + options.BatchSize / ArenaOverflowMarginDivisor, int.MaxValue));
 
     public PartitionBatch(TopicPartition topicPartition, ProducerOptions options)
     {
@@ -4087,21 +4067,13 @@ internal sealed class PartitionBatch
             ? Math.Clamp(options.InitialBatchRecordCapacity, 16, 16384)
             : ComputeInitialRecordCapacity(options.BatchSize);
 
-        // Create arena for zero-copy serialization
+        // Create arena for append-time record encoding
         _arena = new BatchArena(GetEffectiveArenaCapacity(options));
-
-        // Rent arrays from pool - eliminates List allocations
-        _records = ProducerContainerPools.Records.Rent(_initialRecordCapacity);
         _recordCount = 0;
 
+        // Rent arrays from pool - eliminates List allocations
         _completionSources = ProducerContainerPools.CompletionSources.Rent(_initialRecordCapacity);
         _completionSourceCount = 0;
-
-        _pooledArrays = ProducerContainerPools.DataArrayRefs.Rent(_initialRecordCapacity * 2);
-        _pooledArrayCount = 0;
-
-        _pooledHeaderArrays = ProducerContainerPools.HeaderArrayRefs.Rent(8); // Headers less common
-        _pooledHeaderArrayCount = 0;
     }
 
     private static int ComputeInitialRecordCapacity(int batchSize)
@@ -4159,8 +4131,6 @@ internal sealed class PartitionBatch
         _recordCount = 0;
         _completionSourceCount = 0;
         _callbackCount = 0;
-        _pooledArrayCount = 0;
-        _pooledHeaderArrayCount = 0;
         _baseTimestamp = 0;
         _maxTimestamp = 0;
         _encodedRecordsStart = 0;
@@ -4187,24 +4157,18 @@ internal sealed class PartitionBatch
         // Rent or create arena for the pooled batch
         _arena = BatchArena.RentOrCreate(GetEffectiveArenaCapacity(options));
 
-        // Arrays were transferred to ReadyBatch by Complete() and are now null.
-        // Try to reclaim arrays from the reuse queue first (returned by ReadyBatch.Cleanup()),
-        // avoiding 4 ArrayPool Rent operations per batch cycle.
+        // The completion sources array was transferred to ReadyBatch by Complete() and is now null.
+        // Try to reclaim one from the reuse queue first (returned by ReadyBatch.Cleanup()),
+        // avoiding an ArrayPool Rent operation per batch cycle.
         if (_arrayReuseQueue is not null && _arrayReuseQueue.TryDequeue(out var reusable))
         {
-            _records = reusable.Records;
-            _completionSources = reusable.CompletionSources;
-            _pooledArrays = reusable.DataArrays;
-            _pooledHeaderArrays = reusable.HeaderArrays;
+            _completionSources = reusable;
         }
         else
         {
-            // Fallback: rent fresh arrays from dedicated pools (not ArrayPool<T>.Shared)
+            // Fallback: rent a fresh array from the dedicated pool (not ArrayPool<T>.Shared)
             // to prevent TLS accumulation from cross-thread rent/return patterns
-            _records = ProducerContainerPools.Records.Rent(_initialRecordCapacity);
             _completionSources = ProducerContainerPools.CompletionSources.Rent(_initialRecordCapacity);
-            _pooledArrays = ProducerContainerPools.DataArrayRefs.Rent(_initialRecordCapacity * 2);
-            _pooledHeaderArrays = ProducerContainerPools.HeaderArrayRefs.Rent(8);
         }
 
         // Reset counters and state for reuse.
@@ -4215,8 +4179,6 @@ internal sealed class PartitionBatch
         // and those messages would be lost when Reset() is later called.
         _recordCount = 0;
         _completionSourceCount = 0;
-        _pooledArrayCount = 0;
-        _pooledHeaderArrayCount = 0;
         _baseTimestamp = 0;
         _maxTimestamp = 0;
         _encodedRecordsStart = 0;
@@ -4255,8 +4217,7 @@ internal sealed class PartitionBatch
         Header[]? headers,
         int headerCount,
         PooledValueTaskSource<RecordMetadata>? completionSource,
-        Action<RecordMetadata, Exception?>? callback,
-        int estimatedRecordSize)
+        Action<RecordMetadata, Exception?>? callback)
     {
         var result = TryAppendEncoded(
             timestamp,
@@ -4269,8 +4230,7 @@ internal sealed class PartitionBatch
             headers,
             headerCount,
             completionSource,
-            callback,
-            estimatedRecordSize);
+            callback);
 
         if (result.Success)
         {
@@ -4295,8 +4255,7 @@ internal sealed class PartitionBatch
         Header[]? headers,
         int headerCount,
         PooledValueTaskSource<RecordMetadata>? completionSource,
-        Action<RecordMetadata, Exception?>? callback,
-        int estimatedRecordSize)
+        Action<RecordMetadata, Exception?>? callback)
     {
         var keyLength = keyIsNull ? 0 : keyData.Length;
         var valueLength = valueIsNull ? 0 : valueData.Length;
@@ -4312,8 +4271,7 @@ internal sealed class PartitionBatch
             headers,
             headerCount,
             completionSource,
-            callback,
-            estimatedRecordSize);
+            callback);
 
         if (result.Success)
         {
@@ -4334,19 +4292,16 @@ internal sealed class PartitionBatch
         Header[]? headers,
         int headerCount,
         PooledValueTaskSource<RecordMetadata>? completionSource,
-        Action<RecordMetadata, Exception?>? callback,
-        int estimatedRecordSize)
+        Action<RecordMetadata, Exception?>? callback)
     {
-        _ = estimatedRecordSize;
-
         // Check if batch was completed
         if (Volatile.Read(ref _isCompleted) != 0)
         {
             return new RecordAppendResult(false);
         }
 
-        // Defensive check: if arrays are null, batch is in inconsistent state (being pooled)
-        if (_records is null || _pooledArrays is null)
+        // Defensive check: if the array is null, batch is in inconsistent state (being pooled)
+        if (_completionSources is null)
         {
             return new RecordAppendResult(false);
         }
@@ -4377,10 +4332,6 @@ internal sealed class PartitionBatch
         }
 
         // Grow arrays if needed (rare - only happens if batch fills beyond initial capacity)
-        if (_recordCount >= _records.Length)
-        {
-            GrowArray(ref _records, ref _recordCount, ProducerContainerPools.Records);
-        }
         if (completionSource is not null && _completionSourceCount >= _completionSources.Length)
         {
             GrowArray(ref _completionSources, ref _completionSourceCount, ProducerContainerPools.CompletionSources);
@@ -4401,7 +4352,7 @@ internal sealed class PartitionBatch
 
         try
         {
-            WriteEncodedRecord(
+            Record.Encode(
                 encodedRecord,
                 bodySize,
                 timestampDelta,
@@ -4461,128 +4412,6 @@ internal sealed class PartitionBatch
         }
 
         _arena = BatchArena.RentOrCreate(capacity);
-    }
-
-    [SkipLocalsInit]
-    private static void WriteEncodedRecord(
-        Span<byte> destination,
-        int bodySize,
-        long timestampDelta,
-        int offsetDelta,
-        ReadOnlySpan<byte> keyData,
-        bool keyIsNull,
-        ReadOnlySpan<byte> valueData,
-        bool valueIsNull,
-        Header[]? headers,
-        int headerCount)
-    {
-        var offset = 0;
-
-        WriteVarInt(destination, ref offset, bodySize);
-        destination[offset++] = 0; // record attributes
-        WriteVarLong(destination, ref offset, timestampDelta);
-        WriteVarInt(destination, ref offset, offsetDelta);
-
-        if (keyIsNull)
-        {
-            WriteVarInt(destination, ref offset, -1);
-        }
-        else
-        {
-            WriteVarInt(destination, ref offset, keyData.Length);
-            keyData.CopyTo(destination[offset..]);
-            offset += keyData.Length;
-        }
-
-        if (valueIsNull)
-        {
-            WriteVarInt(destination, ref offset, -1);
-        }
-        else
-        {
-            WriteVarInt(destination, ref offset, valueData.Length);
-            valueData.CopyTo(destination[offset..]);
-            offset += valueData.Length;
-        }
-
-        WriteVarInt(destination, ref offset, headerCount);
-        if (headers is not null)
-        {
-            for (var i = 0; i < headerCount; i++)
-            {
-                WriteHeader(destination, ref offset, in headers[i]);
-            }
-        }
-
-        Debug.Assert(offset == destination.Length);
-    }
-
-    [SkipLocalsInit]
-    private static void WriteHeader(Span<byte> destination, ref int offset, in Header header)
-    {
-        var key = header.Key;
-        if (key.Length <= 128)
-        {
-            Span<byte> buffer = stackalloc byte[512];
-            var keyByteCount = Encoding.UTF8.GetBytes(key, buffer);
-            WriteVarInt(destination, ref offset, keyByteCount);
-            buffer[..keyByteCount].CopyTo(destination[offset..]);
-            offset += keyByteCount;
-        }
-        else
-        {
-            var keyByteCount = Encoding.UTF8.GetByteCount(key);
-            WriteVarInt(destination, ref offset, keyByteCount);
-            Encoding.UTF8.GetBytes(key, destination[offset..]);
-            offset += keyByteCount;
-        }
-
-        if (header.IsValueNull)
-        {
-            WriteVarInt(destination, ref offset, -1);
-        }
-        else
-        {
-            WriteVarInt(destination, ref offset, header.Value.Length);
-            header.Value.Span.CopyTo(destination[offset..]);
-            offset += header.Value.Length;
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void WriteVarInt(Span<byte> destination, ref int offset, int value)
-    {
-        WriteVarUInt(destination, ref offset, (uint)((value << 1) ^ (value >> 31)));
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void WriteVarLong(Span<byte> destination, ref int offset, long value)
-    {
-        WriteVarULong(destination, ref offset, (ulong)((value << 1) ^ (value >> 63)));
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void WriteVarUInt(Span<byte> destination, ref int offset, uint value)
-    {
-        while (value >= 0x80)
-        {
-            destination[offset++] = (byte)(value | 0x80);
-            value >>= 7;
-        }
-
-        destination[offset++] = (byte)value;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void WriteVarULong(Span<byte> destination, ref int offset, ulong value)
-    {
-        while (value >= 0x80)
-        {
-            destination[offset++] = (byte)(value | 0x80);
-            value >>= 7;
-        }
-
-        destination[offset++] = (byte)value;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -4648,9 +4477,6 @@ internal sealed class PartitionBatch
             return null;
         }
 
-        // Keep the working records array with ReadyBatch so it can be recycled after cleanup.
-        // RecordBatch itself reads from the already-encoded arena bytes.
-        var pooledRecordsArray = _records;
         var attributes = RecordBatchAttributes.None;
         if (_isTransactional)
         {
@@ -4679,7 +4505,6 @@ internal sealed class PartitionBatch
         var encodedRecords = _arena!.GetMemory(_encodedRecordsStart, _encodedRecordsLength);
         batch.SetPreEncodedRecords(encodedRecords);
         batch.Records = LazyRecordList.Create(encodedRecords, _recordCount);
-        _records = null!;
 
         // Rent ReadyBatch from pool or create new if no pool available
         // This eliminates per-batch class allocations at high throughput
@@ -4692,12 +4517,7 @@ internal sealed class PartitionBatch
             batch,
             _completionSources,
             _completionSourceCount,
-            _pooledArrays,
-            _pooledArrayCount,
-            _pooledHeaderArrays,
-            _pooledHeaderArrayCount,
             _estimatedSize,
-            pooledRecordsArray,
             _arena,
             _callbacks,
             _callbackCount,
@@ -4707,8 +4527,6 @@ internal sealed class PartitionBatch
 
         // Null out references - ownership transferred to ReadyBatch
         _completionSources = null!;
-        _pooledArrays = null!;
-        _pooledHeaderArrays = null!;
         _arena = null;
         _callbacks = null;
 
@@ -4717,34 +4535,26 @@ internal sealed class PartitionBatch
 
     private void ReturnBatchArraysToPool()
     {
-        // Return all working arrays to dedicated pools (with null checks since they may have been transferred)
+        // Return working arrays to dedicated pools (with null checks since they may have been transferred)
         // clearArray: false for internal tracking arrays - they will be overwritten on next use
-        if (_records is not null)
-            ProducerContainerPools.Records.Return(_records, clearArray: false);
         if (_completionSources is not null)
             ProducerContainerPools.CompletionSources.Return(_completionSources, clearArray: false);
-        if (_pooledArrays is not null)
-            ProducerContainerPools.DataArrayRefs.Return(_pooledArrays, clearArray: false);
-        if (_pooledHeaderArrays is not null)
-            ProducerContainerPools.HeaderArrayRefs.Return(_pooledHeaderArrays, clearArray: false);
 
         // Return arena buffer if present
         _arena?.Return();
 
         // Null out references to prevent accidental reuse
-        _records = null!;
         _completionSources = null!;
-        _pooledArrays = null!;
-        _pooledHeaderArrays = null!;
         _arena = null;
     }
 
     /// <summary>
     /// Estimates the size of a record in the batch for buffer memory accounting.
     /// This is an upper-bound estimate that includes:
-    /// - 20 bytes base overhead (1 byte attributes + varint overhead for timestamp/offset/key-length/value-length/header-count)
+    /// - 36 bytes base overhead (worst-case varints for record length, timestamp delta,
+    ///   offset delta, key/value lengths, and header count, plus 1 byte attributes)
     /// - Key and value payload lengths
-    /// - Header sizes (10 bytes overhead per header + key/value lengths)
+    /// - Exact header sizes via <see cref="Header.CalculateSize"/>
     /// This must be internal so KafkaProducer can calculate size before reserving memory.
     /// </summary>
     /// <param name="keyLength">Length of the serialized key in bytes (0 if null)</param>
@@ -4795,76 +4605,37 @@ internal sealed class ReadyBatchPool(int maxPoolSize = BatchArena.DefaultPoolSiz
 }
 
 /// <summary>
-/// Reuse queue for the 4 working arrays that PartitionBatch rents from ArrayPool.
-/// When ReadyBatch finishes cleanup, it pushes the container arrays here instead of returning
-/// them to ArrayPool. PartitionBatch.PrepareForPooling() dequeues from here first, falling back
-/// to ArrayPool on miss. This eliminates ~4 ArrayPool Rent/Return pairs per batch cycle.
-/// Uses a single <see cref="LockFreeStack{T}"/> to keep all four arrays atomically together.
-/// One <see cref="ReusableArrays"/> wrapper is allocated per batch cycle (~32 bytes, amortized
-/// over ~1000 messages per batch).
+/// Reuse queue for the completion sources array that PartitionBatch rents from ArrayPool.
+/// When ReadyBatch finishes cleanup, it pushes the array here instead of returning it to
+/// ArrayPool. PartitionBatch.PrepareForPooling() dequeues from here first, falling back
+/// to ArrayPool on miss. This eliminates an ArrayPool Rent/Return pair per batch cycle.
 /// </summary>
 internal sealed class BatchArrayReuseQueue
 {
-    private readonly LockFreeStack<ReusableArrays> _queue;
+    private readonly LockFreeStack<PooledValueTaskSource<RecordMetadata>[]> _queue;
 
     public BatchArrayReuseQueue(int maxSize = 128)
     {
-        _queue = new LockFreeStack<ReusableArrays>(maxSize);
+        _queue = new LockFreeStack<PooledValueTaskSource<RecordMetadata>[]>(maxSize);
     }
 
     /// <summary>
-    /// Pushes all four arrays as an atomic unit for reuse. If the queue is full,
-    /// all arrays are returned to the global ArrayPools instead.
+    /// Pushes the array for reuse. If the queue is full, the array is returned
+    /// to the dedicated ArrayPool instead.
     /// </summary>
-    public void EnqueueOrReturn(
-        Record[] records,
-        PooledValueTaskSource<RecordMetadata>[] completionSources,
-        byte[][] pooledDataArrays,
-        Header[][] pooledHeaderArrays)
+    public void EnqueueOrReturn(PooledValueTaskSource<RecordMetadata>[] completionSources)
     {
-        if (_queue.Count >= _queue.Capacity)
+        if (!_queue.TryPush(completionSources))
         {
-            ProducerContainerPools.Records.Return(records, clearArray: false);
             ProducerContainerPools.CompletionSources.Return(completionSources, clearArray: false);
-            ProducerContainerPools.DataArrayRefs.Return(pooledDataArrays, clearArray: false);
-            ProducerContainerPools.HeaderArrayRefs.Return(pooledHeaderArrays, clearArray: false);
-            return;
-        }
-
-        var wrapper = new ReusableArrays(records, completionSources, pooledDataArrays, pooledHeaderArrays);
-
-        if (!_queue.TryPush(wrapper))
-        {
-            ProducerContainerPools.Records.Return(records, clearArray: false);
-            ProducerContainerPools.CompletionSources.Return(completionSources, clearArray: false);
-            ProducerContainerPools.DataArrayRefs.Return(pooledDataArrays, clearArray: false);
-            ProducerContainerPools.HeaderArrayRefs.Return(pooledHeaderArrays, clearArray: false);
         }
     }
 
     /// <summary>
-    /// Tries to pop a complete set of reusable arrays. All four arrays are always
-    /// returned together (atomic by construction via the wrapper).
+    /// Tries to pop a reusable completion sources array.
     /// </summary>
-    public bool TryDequeue([NotNullWhen(true)] out ReusableArrays? arrays)
-        => _queue.TryPop(out arrays);
-}
-
-/// <summary>
-/// Wrapper that keeps four batch arrays atomically together in
-/// <see cref="BatchArrayReuseQueue"/>. One allocation per batch (~32 bytes)
-/// is acceptable — amortized over ~1000 messages per batch.
-/// </summary>
-internal sealed class ReusableArrays(
-    Record[] records,
-    PooledValueTaskSource<RecordMetadata>[] completionSources,
-    byte[][] dataArrays,
-    Header[][] headerArrays)
-{
-    public Record[] Records { get; } = records;
-    public PooledValueTaskSource<RecordMetadata>[] CompletionSources { get; } = completionSources;
-    public byte[][] DataArrays { get; } = dataArrays;
-    public Header[][] HeaderArrays { get; } = headerArrays;
+    public bool TryDequeue([NotNullWhen(true)] out PooledValueTaskSource<RecordMetadata>[]? completionSources)
+        => _queue.TryPop(out completionSources);
 }
 
 /// <summary>
@@ -4914,15 +4685,10 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     // Working arrays from accumulator (pooled) - mutable for pooling
     private PooledValueTaskSource<RecordMetadata>[]? _completionSourcesArray;
     private int _completionSourcesCount;
-    private byte[][]? _pooledDataArrays;
-    private int _pooledDataArraysCount;
-    private Header[][]? _pooledHeaderArrays;
-    private int _pooledHeaderArraysCount;
-    private Record[]? _pooledRecordsArray; // Pooled records array from RecordBatch
 
     // Reuse queue for returning working arrays back to PartitionBatch without ArrayPool round-trip
     private BatchArrayReuseQueue? _arrayReuseQueue;
-    private BatchArena? _arena; // Arena for zero-copy serialization data
+    private BatchArena? _arena; // Arena holding the batch's encoded record bytes
 
     // Callbacks for Send(message, callback) - inline invocation without ThreadPool
     private Action<RecordMetadata, Exception?>?[]? _callbacks;
@@ -5098,12 +4864,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         RecordBatch recordBatch,
         PooledValueTaskSource<RecordMetadata>[]? completionSourcesArray,
         int completionSourcesCount,
-        byte[][]? pooledDataArrays,
-        int pooledDataArraysCount,
-        Header[][]? pooledHeaderArrays,
-        int pooledHeaderArraysCount,
         int dataSize,
-        Record[]? pooledRecordsArray = null,
         BatchArena? arena = null,
         Action<RecordMetadata, Exception?>?[]? callbacks = null,
         int callbackCount = 0,
@@ -5126,13 +4887,8 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         _recordBatch = recordBatch;
         _completionSourcesArray = completionSourcesArray;
         _completionSourcesCount = completionSourcesCount;
-        _pooledDataArrays = pooledDataArrays;
-        _pooledDataArraysCount = pooledDataArraysCount;
-        _pooledHeaderArrays = pooledHeaderArrays;
-        _pooledHeaderArraysCount = pooledHeaderArraysCount;
         DataSize = dataSize;
         EncodedSize = dataSize;
-        _pooledRecordsArray = pooledRecordsArray;
         _arena = arena;
         _callbacks = callbacks;
         _callbackCount = callbackCount;
@@ -5174,13 +4930,8 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         _recordBatch = null!;
         _completionSourcesArray = null;
         _completionSourcesCount = 0;
-        _pooledDataArrays = null;
-        _pooledDataArraysCount = 0;
-        _pooledHeaderArrays = null;
-        _pooledHeaderArraysCount = 0;
         DataSize = 0;
         EncodedSize = 0;
-        _pooledRecordsArray = null;
         _arena = null;
         _callbacks = null;
         _callbackCount = 0;
@@ -5422,57 +5173,24 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         if (Interlocked.Exchange(ref _cleanedUp, 1) != 0)
             return;
 
-        // Return pooled byte arrays (key/value data) - only for non-arena path.
-        // Uses ProducerDataPool (not ArrayPool<byte>.Shared) to match the rent path
-        // and prevent cross-thread TLS accumulation in multi-broker scenarios.
-        // Null check defensive against partially constructed batches.
-        if (_pooledDataArrays is not null)
-        {
-            for (var i = 0; i < _pooledDataArraysCount; i++)
-            {
-                ProducerDataPool.BytePool.Return(_pooledDataArrays[i], clearArray: false);
-            }
-        }
-
-        // Return pooled header arrays (large header counts)
-        // Uses dedicated pool to prevent TLS accumulation from cross-thread return.
-        // clearArray: false - header data is not sensitive
-        if (_pooledHeaderArrays is not null)
-        {
-            for (var i = 0; i < _pooledHeaderArraysCount; i++)
-            {
-                ProducerContainerPools.Headers.Return(_pooledHeaderArrays[i], clearArray: false);
-            }
-        }
-
-        // Return the working (container) arrays: either to the reuse queue for fast recycling
+        // Return the working (container) array: either to the reuse queue for fast recycling
         // back to PartitionBatch, or to ArrayPool as fallback.
-        // Note: PooledValueTaskSource instances auto-return to their pool when awaited.
-        if (_arrayReuseQueue is not null
-            && _pooledRecordsArray is not null
-            && _completionSourcesArray is not null
-            && _pooledDataArrays is not null
-            && _pooledHeaderArrays is not null)
+        // Safety: clearArray: false is intentional. Array slots past the used count may contain
+        // stale PooledValueTaskSource references, but these are never accessed because counters
+        // reset to 0 on reuse. PooledValueTaskSource instances auto-return to their pool via
+        // GetResult(), so stale references don't prevent pool recycling.
+        if (_completionSourcesArray is not null)
         {
-            // Enqueue all 4 working arrays for reuse by PartitionBatch.PrepareForPooling().
-            // Safety: clearArray: false is intentional. Array slots past _recordCount may contain stale
-            // PooledValueTaskSource references, but these are never accessed because counters reset to 0
-            // on reuse. PooledValueTaskSource instances auto-return to their pool via GetResult(),
-            // so stale references don't prevent pool recycling. This matches ArrayPool behavior.
-            _arrayReuseQueue.EnqueueOrReturn(_pooledRecordsArray, _completionSourcesArray, _pooledDataArrays, _pooledHeaderArrays);
-        }
-        else
-        {
-            // Fallback: return individually to dedicated pools (not ArrayPool<T>.Shared)
-            // to prevent TLS accumulation from cross-thread return on BrokerSender threads
-            if (_completionSourcesArray is not null)
+            if (_arrayReuseQueue is not null)
+            {
+                _arrayReuseQueue.EnqueueOrReturn(_completionSourcesArray);
+            }
+            else
+            {
+                // Fallback: return to the dedicated pool (not ArrayPool<T>.Shared) to prevent
+                // TLS accumulation from cross-thread return on BrokerSender threads
                 ProducerContainerPools.CompletionSources.Return(_completionSourcesArray, clearArray: false);
-            if (_pooledDataArrays is not null)
-                ProducerContainerPools.DataArrayRefs.Return(_pooledDataArrays, clearArray: false);
-            if (_pooledHeaderArrays is not null)
-                ProducerContainerPools.HeaderArrayRefs.Return(_pooledHeaderArrays, clearArray: false);
-            if (_pooledRecordsArray is not null)
-                ProducerContainerPools.Records.Return(_pooledRecordsArray, clearArray: false);
+            }
         }
 
         // Return arena to pool for reuse (arena-based path)
@@ -5497,66 +5215,5 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
             _recordBatch.DisposeRecordList();
             _recordBatch.ReturnToPool();
         }
-    }
-}
-
-/// <summary>
-/// Wrapper around a pooled Record array that implements IReadOnlyList.
-/// Used to present only the valid portion of a pooled array without copying.
-/// </summary>
-internal readonly struct RecordListWrapper : IReadOnlyList<Record>
-{
-    private readonly Record[] _array;
-    private readonly int _count;
-
-    public RecordListWrapper(Record[] array, int count)
-    {
-        _array = array;
-        _count = count;
-    }
-
-    public Record this[int index]
-    {
-        get
-        {
-            if (index < 0 || index >= _count)
-                throw new ArgumentOutOfRangeException(nameof(index));
-            return _array[index];
-        }
-    }
-
-    public int Count => _count;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ReadOnlySpan<Record> AsSpan() => _array.AsSpan(0, _count);
-
-    public Enumerator GetEnumerator() => new(_array, _count);
-
-    IEnumerator<Record> IEnumerable<Record>.GetEnumerator() => GetEnumerator();
-
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
-
-    public struct Enumerator : IEnumerator<Record>
-    {
-        private readonly Record[] _array;
-        private readonly int _count;
-        private int _index;
-
-        public Enumerator(Record[] array, int count)
-        {
-            _array = array;
-            _count = count;
-            _index = -1;
-        }
-
-        public Record Current => _array[_index];
-
-        object System.Collections.IEnumerator.Current => Current;
-
-        public bool MoveNext() => ++_index < _count;
-
-        public void Reset() => _index = -1;
-
-        public void Dispose() { }
     }
 }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -532,6 +532,7 @@ internal sealed class BatchArena
 
     private byte[] _buffer;
     private int _position;
+    private int _maxPooledCapacity;
 
     /// <summary>
     /// Creates a new arena with the specified capacity.
@@ -539,9 +540,15 @@ internal sealed class BatchArena
     /// </summary>
     /// <param name="capacity">Buffer size. Pinned on the POH permanently (not from ArrayPool) to avoid LOH fragmentation and Gen2 GC pressure.</param>
     public BatchArena(int capacity)
+        : this(capacity, capacity)
+    {
+    }
+
+    internal BatchArena(int capacity, int maxPooledCapacity)
     {
         _buffer = GC.AllocateUninitializedArray<byte>(capacity, pinned: true);
         _position = 0;
+        _maxPooledCapacity = maxPooledCapacity;
     }
 
     /// <summary>
@@ -549,25 +556,34 @@ internal sealed class BatchArena
     /// Pooled arenas retain their POH buffers for the pool's lifetime - no ArrayPool rent/return overhead.
     /// </summary>
     public static BatchArena RentOrCreate(int capacity)
+        => RentOrCreate(capacity, capacity);
+
+    public static BatchArena RentOrCreate(int capacity, int maxPooledCapacity)
     {
         var pool = Volatile.Read(ref s_pool);
         if (pool.TryPop(out var arena))
         {
-            arena.Reset(capacity);
+            arena.Reset(capacity, maxPooledCapacity);
             return arena;
         }
 
         Interlocked.Increment(ref s_misses);
-        return new BatchArena(capacity);
+        return new BatchArena(capacity, maxPooledCapacity);
     }
 
     /// <summary>
     /// Returns an arena to the pool for reuse, or drops the reference for GC collection if the pool is full.
     /// The POH buffer is never returned to ArrayPool.
     /// </summary>
-    public static void ReturnToPool(BatchArena arena)
+    public static bool ReturnToPool(BatchArena arena)
     {
         arena._position = 0;
+
+        if (arena._buffer.Length > arena._maxPooledCapacity)
+        {
+            arena._buffer = null!;
+            return false;
+        }
 
         var pool = Volatile.Read(ref s_pool);
         if (!pool.TryPush(arena))
@@ -575,15 +591,19 @@ internal sealed class BatchArena
             // Pool full — drop the reference so the GC can reclaim the POH segment
             // once all objects on it are dead. No ArrayPool return needed.
             arena._buffer = null!;
+            return false;
         }
+
+        return true;
     }
 
     /// <summary>
     /// Resets the arena for reuse. Keeps the existing buffer if it's large enough,
     /// otherwise allocates a new permanent buffer.
     /// </summary>
-    private void Reset(int capacity)
+    private void Reset(int capacity, int maxPooledCapacity)
     {
+        _maxPooledCapacity = maxPooledCapacity;
         if (_buffer is not null && _buffer.Length >= capacity)
         {
             // Skip clearing — _position reset to 0 means stale bytes are never read,
@@ -597,6 +617,8 @@ internal sealed class BatchArena
         _buffer = GC.AllocateUninitializedArray<byte>(capacity, pinned: true);
         _position = 0;
     }
+
+    internal int Capacity => _buffer.Length;
 
     /// <summary>
     /// Gets the current position in the arena (total bytes used).
@@ -1618,6 +1640,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         _compressionCodecs = compressionCodecs;
         _onBatchComplete = onBatchComplete;
 
+        ProducerOptions.ValidateArenaCapacity(options.BatchSize, options.ArenaCapacity);
+
         // Scale pool sizes with BufferMemory/BatchSize to prevent pool exhaustion.
         // Small batches (e.g., 16KB) create high batch churn (~6,250/sec at 100K msg/sec)
         // and need larger pools than the default 256 designed for 1MB batches.
@@ -1645,7 +1669,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var preWarmCount = Math.Min(poolSize / 8, 16);
         _readyBatchPool.PreWarm(Math.Min(poolSize, 32));
         _batchPool.PreWarm(preWarmCount);
-        BatchArena.PreWarm(preWarmCount, options.BatchSize);
+        BatchArena.PreWarm(preWarmCount,
+            ProducerOptions.GetEffectiveArenaCapacity(options.BatchSize, options.ArenaCapacity));
 
         // Create per-partition-affine append worker channels.
         // Each channel is SingleReader (one worker) but allows multiple writers (caller threads).
@@ -1783,18 +1808,29 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             {
                 workItem.CancellationToken.ThrowIfCancellationRequested();
 
-                if (!await AppendAsync(
-                    workItem.Topic,
-                    workItem.Partition,
-                    workItem.Timestamp,
-                    workItem.Key,
-                    workItem.Value,
-                    workItem.Headers,
-                    workItem.HeaderCount,
-                    workItem.Completion,
-                    null,
-                    workItem.CancellationToken,
-                    partitionCount: workItem.PartitionCount).ConfigureAwait(false))
+                ValueTask<bool> appendTask;
+                try
+                {
+                    appendTask = AppendAsync(
+                        workItem.Topic,
+                        workItem.Partition,
+                        workItem.Timestamp,
+                        workItem.Key,
+                        workItem.Value,
+                        workItem.Headers,
+                        workItem.HeaderCount,
+                        workItem.Completion,
+                        null,
+                        workItem.CancellationToken,
+                        partitionCount: workItem.PartitionCount);
+                }
+                catch
+                {
+                    CleanupWorkItemResources(in workItem);
+                    throw;
+                }
+
+                if (!await appendTask.ConfigureAwait(false))
                 {
                     CleanupWorkItemResources(in workItem);
                     workItem.Completion.TrySetException(new ObjectDisposedException(nameof(RecordAccumulator)));
@@ -1807,7 +1843,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             }
             catch (Exception ex)
             {
-                CleanupWorkItemResources(in workItem);
                 workItem.Completion.TrySetException(ex);
             }
         }
@@ -2389,7 +2424,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     if (pd.CurrentBatch is { } currentBatch)
                     {
                         if (TryAppendFromSpansToBatch(currentBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                            headers, headerCount, completionSource, callback, recordSize))
+                            headers, headerCount, completionSource, callback, recordSize, returnHeadersOnFailure))
                         {
                             if (completionSource is not null)
                                 QueueLingerPartition(pd, topicPartition);
@@ -2417,7 +2452,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
 
                         if (TryAppendFromSpansToBatch(newBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                            headers, headerCount, completionSource, callback, recordSize))
+                            headers, headerCount, completionSource, callback, recordSize, returnHeadersOnFailure))
                         {
                             ClearRotationInProgressUnderLock(pd);
                             ownsRotation = false;
@@ -2514,7 +2549,21 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Action<RecordMetadata, Exception?>? callback,
         int estimatedSize)
     {
-        var result = batch.TryAppend(timestamp, key, value, headers, headerCount, completionSource, callback);
+        RecordAppendResult result;
+        try
+        {
+            result = batch.TryAppend(timestamp, key, value, headers, headerCount, completionSource, callback);
+        }
+        catch
+        {
+            if (completionSource is not null)
+                Interlocked.Decrement(ref _pendingAwaitedProduceCount);
+            ReleaseMemory(estimatedSize);
+            key.Return();
+            value.Return();
+            ReturnPooledHeaders(headers);
+            throw;
+        }
 
         if (result.Success)
         {
@@ -2638,10 +2687,24 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int headerCount,
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
-        int estimatedSize)
+        int estimatedSize,
+        bool returnHeadersOnFailure)
     {
-        var result = batch.TryAppendFromSpans(timestamp, keyData, keyIsNull, valueData, valueIsNull,
-            headers, headerCount, completionSource, callback);
+        RecordAppendResult result;
+        try
+        {
+            result = batch.TryAppendFromSpans(timestamp, keyData, keyIsNull, valueData, valueIsNull,
+                headers, headerCount, completionSource, callback);
+        }
+        catch
+        {
+            if (completionSource is not null)
+                Interlocked.Decrement(ref _pendingAwaitedProduceCount);
+            ReleaseMemory(estimatedSize);
+            if (returnHeadersOnFailure)
+                ReturnPooledHeaders(headers);
+            throw;
+        }
 
         if (result.Success)
         {
@@ -4040,22 +4103,12 @@ internal sealed class PartitionBatch
     private bool _isTransactional;
 
     /// <summary>
-    /// Divisor for computing the arena headroom margin from BatchSize.
-    /// A divisor of 8 gives a 12.5% margin (BatchSize / 8) above BatchSize so a record
-    /// that lands near the batch-size boundary still fits in the arena.
-    /// </summary>
-    private const int ArenaOverflowMarginDivisor = 8;
-
-    /// <summary>
     /// Returns the effective arena capacity: BatchSize + 12.5% margin, or an explicit
-    /// ArenaCapacity when it is larger. Records encode directly into the arena, so a
-    /// capacity below BatchSize would silently cap batch fill — smaller values are ignored.
-    /// Uses long arithmetic to avoid integer overflow when BatchSize is large.
+    /// ArenaCapacity. Records encode directly into the arena, so explicit values below
+    /// the BatchSize-derived minimum are rejected during producer construction.
     /// </summary>
     private static int GetEffectiveArenaCapacity(ProducerOptions options) =>
-        Math.Max(
-            options.ArenaCapacity,
-            (int)Math.Min((long)options.BatchSize + options.BatchSize / ArenaOverflowMarginDivisor, int.MaxValue));
+        ProducerOptions.GetEffectiveArenaCapacity(options.BatchSize, options.ArenaCapacity);
 
     public PartitionBatch(TopicPartition topicPartition, ProducerOptions options)
     {
@@ -4405,13 +4458,14 @@ internal sealed class PartitionBatch
             return;
         }
 
-        var capacity = Math.Max(GetEffectiveArenaCapacity(_options), encodedRecordSize);
+        var normalCapacity = GetEffectiveArenaCapacity(_options);
+        var capacity = Math.Max(normalCapacity, encodedRecordSize);
         if (arena is not null)
         {
             BatchArena.ReturnToPool(arena);
         }
 
-        _arena = BatchArena.RentOrCreate(capacity);
+        _arena = BatchArena.RentOrCreate(capacity, normalCapacity);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4371,6 +4371,11 @@ internal sealed class PartitionBatch
             return new RecordAppendResult(false);
         }
 
+        if (recordIndex == 0)
+        {
+            EnsureArenaCanFitFirstRecord(encodedRecordSize);
+        }
+
         // Grow arrays if needed (rare - only happens if batch fills beyond initial capacity)
         if (_recordCount >= _records.Length)
         {
@@ -4439,6 +4444,23 @@ internal sealed class PartitionBatch
         _estimatedSize += encodedRecordSize;
 
         return new RecordAppendResult(Success: true, ActualSizeAdded: encodedRecordSize);
+    }
+
+    private void EnsureArenaCanFitFirstRecord(int encodedRecordSize)
+    {
+        var arena = _arena;
+        if (arena is not null && encodedRecordSize <= arena.RemainingCapacity)
+        {
+            return;
+        }
+
+        var capacity = Math.Max(GetEffectiveArenaCapacity(_options), encodedRecordSize);
+        if (arena is not null)
+        {
+            BatchArena.ReturnToPool(arena);
+        }
+
+        _arena = BatchArena.RentOrCreate(capacity);
     }
 
     [SkipLocalsInit]

--- a/src/Dekaf/Protocol/Records/Record.cs
+++ b/src/Dekaf/Protocol/Records/Record.cs
@@ -291,7 +291,16 @@ public readonly record struct Record
             }
         }
 
-        Debug.Assert(offset == destination.Length);
+        if (offset != destination.Length)
+            ThrowEncodedSizeMismatch(offset, destination.Length);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowEncodedSizeMismatch(int bytesWritten, int expectedBytes)
+    {
+        throw new InvalidOperationException(
+            $"Record.Encode wrote {bytesWritten} bytes but destination length is {expectedBytes}. " +
+            "Record.ComputeBodySize and Record.Encode are out of sync.");
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Protocol/Records/Record.cs
+++ b/src/Dekaf/Protocol/Records/Record.cs
@@ -1,5 +1,7 @@
 using System.Buffers;
+using System.Diagnostics;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using Dekaf.Serialization;
 
 namespace Dekaf.Protocol.Records;
@@ -230,6 +232,92 @@ public readonly record struct Record
         }
 
         return size;
+    }
+
+    /// <summary>
+    /// Encodes a record directly into a fixed-size destination span using the Kafka record
+    /// wire format (length varint + body). The destination length must equal
+    /// <c>VarIntSize(bodySize) + bodySize</c> where <paramref name="bodySize"/> was computed by
+    /// <see cref="ComputeBodySize"/> with the same arguments. Every byte written here must be
+    /// counted there — keep the two methods in sync.
+    /// </summary>
+    internal static void Encode(
+        Span<byte> destination,
+        int bodySize,
+        long timestampDelta,
+        int offsetDelta,
+        ReadOnlySpan<byte> keyData,
+        bool isKeyNull,
+        ReadOnlySpan<byte> valueData,
+        bool isValueNull,
+        Header[]? headers,
+        int headerCount)
+    {
+        var offset = 0;
+
+        WriteVarInt(destination, ref offset, bodySize);
+        destination[offset++] = 0; // record attributes
+        WriteVarLong(destination, ref offset, timestampDelta);
+        WriteVarInt(destination, ref offset, offsetDelta);
+
+        if (isKeyNull)
+        {
+            WriteVarInt(destination, ref offset, -1);
+        }
+        else
+        {
+            WriteVarInt(destination, ref offset, keyData.Length);
+            keyData.CopyTo(destination[offset..]);
+            offset += keyData.Length;
+        }
+
+        if (isValueNull)
+        {
+            WriteVarInt(destination, ref offset, -1);
+        }
+        else
+        {
+            WriteVarInt(destination, ref offset, valueData.Length);
+            valueData.CopyTo(destination[offset..]);
+            offset += valueData.Length;
+        }
+
+        WriteVarInt(destination, ref offset, headerCount);
+        if (headers is not null)
+        {
+            for (var i = 0; i < headerCount; i++)
+            {
+                headers[i].Encode(destination, ref offset);
+            }
+        }
+
+        Debug.Assert(offset == destination.Length);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void WriteVarInt(Span<byte> destination, ref int offset, int value)
+    {
+        var zigzag = (uint)((value << 1) ^ (value >> 31));
+        while (zigzag >= 0x80)
+        {
+            destination[offset++] = (byte)(zigzag | 0x80);
+            zigzag >>= 7;
+        }
+
+        destination[offset++] = (byte)zigzag;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void WriteVarLong(Span<byte> destination, ref int offset, long value)
+    {
+        var zigzag = (ulong)((value << 1) ^ (value >> 63));
+        while (zigzag >= 0x80)
+        {
+            destination[offset++] = (byte)(zigzag | 0x80);
+            zigzag >>= 7;
+        }
+
+        destination[offset++] = (byte)zigzag;
     }
 
     internal static int VarIntSize(int value)

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -446,6 +446,17 @@ public sealed class RecordBatch : IDisposable
 
     internal bool HasPreCompressedRecords => PreCompressedRecords is not null;
 
+    private ReadOnlyMemory<byte> _preEncodedRecords;
+    private bool _hasPreEncodedRecords;
+
+    internal bool HasPreEncodedRecords => _hasPreEncodedRecords;
+
+    internal void SetPreEncodedRecords(ReadOnlyMemory<byte> records)
+    {
+        _preEncodedRecords = records;
+        _hasPreEncodedRecords = true;
+    }
+
     /// <summary>
     /// Pre-serializes the records in this batch, compressing when a codec is configured.
     /// Producer send paths call this before request serialization so <see cref="Write"/>
@@ -453,13 +464,17 @@ public sealed class RecordBatch : IDisposable
     /// on the send-loop thread. The data is stored in a pooled array (a per-batch
     /// allocation, acceptable).
     /// </summary>
-    /// <param name="compression">The compression type to apply. <see cref="CompressionType.None"/>
-    /// stores the plain encoded records.</param>
+    /// <param name="compression">The compression type to apply.</param>
     /// <param name="codecs">The codec registry to use.</param>
     internal void PreCompress(CompressionType compression, CompressionCodecRegistry? codecs)
     {
         if (compression == CompressionType.None)
         {
+            if (_hasPreEncodedRecords)
+            {
+                return;
+            }
+
             var uncompressedRecords = Records;
             using var encodedBuffer = new DetachableBufferWriter(
                 ProducerDataPool.BytePool, GetEncodedRecordsLength(uncompressedRecords));
@@ -472,24 +487,31 @@ public sealed class RecordBatch : IDisposable
             return;
         }
 
+        var registry = codecs ?? CompressionCodecRegistry.Default;
+        var codec = registry.GetCodec(compression);
+        if (_hasPreEncodedRecords)
+        {
+            using var compressedBuffer = new DetachableBufferWriter(ProducerDataPool.BytePool, _preEncodedRecords.Length);
+            codec.Compress(new ReadOnlySequence<byte>(_preEncodedRecords), compressedBuffer);
+            PreCompressedRecords = compressedBuffer.DetachBuffer(out var compressedLength);
+            PreCompressedLength = compressedLength;
+            PreCompressedType = compression;
+            return;
+        }
+
         var cache = RentSerializationCache();
         try
         {
-            // Serialize records to pooled scratch buffer
+            // Compress directly into a detachable producer-pool buffer.
             var recordsBuffer = GetRecordsBuffer(cache);
             var recordsWriter = new KafkaProtocolWriter(recordsBuffer);
             var records = Records;
 
             WriteRecords(records, ref recordsWriter);
-
-            // Compress directly into a detachable producer-pool buffer.
-            var registry = codecs ?? CompressionCodecRegistry.Default;
-            var codec = registry.GetCodec(compression);
-            using var compressedBuffer = new DetachableBufferWriter(ProducerDataPool.BytePool, recordsBuffer.WrittenCount);
-            codec.Compress(new ReadOnlySequence<byte>(recordsBuffer.WrittenMemory), compressedBuffer);
-
-            PreCompressedRecords = compressedBuffer.DetachBuffer(out var compressedLength);
-            PreCompressedLength = compressedLength;
+            using var serializedCompressedBuffer = new DetachableBufferWriter(ProducerDataPool.BytePool, recordsBuffer.WrittenCount);
+            codec.Compress(new ReadOnlySequence<byte>(recordsBuffer.WrittenMemory), serializedCompressedBuffer);
+            PreCompressedRecords = serializedCompressedBuffer.DetachBuffer(out var serializedCompressedLength);
+            PreCompressedLength = serializedCompressedLength;
             PreCompressedType = compression;
         }
         finally
@@ -509,8 +531,19 @@ public sealed class RecordBatch : IDisposable
         {
             PreCompressedRecords = null;
             PreCompressedLength = 0;
+            PreCompressedType = CompressionType.None;
             Producer.ProducerDataPool.BytePool.Return(array, clearArray: false);
         }
+    }
+
+    internal void DisposeRecordList()
+    {
+        if (_records is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        _records = null!;
     }
 
     /// <summary>
@@ -525,10 +558,7 @@ public sealed class RecordBatch : IDisposable
 
         ReturnPreCompressedBuffer();
 
-        if (_records is IDisposable disposable)
-        {
-            disposable.Dispose();
-        }
+        DisposeRecordList();
 
         ReturnToPool();
     }
@@ -550,6 +580,8 @@ public sealed class RecordBatch : IDisposable
             item.PreCompressedRecords = null;
             item.PreCompressedLength = 0;
             item.PreCompressedType = CompressionType.None;
+            item._preEncodedRecords = default;
+            item._hasPreEncodedRecords = false;
 
             // Reset mutable state to defaults
             item.BaseOffset = 0;
@@ -622,6 +654,8 @@ public sealed class RecordBatch : IDisposable
         batch.ProducerEpoch = producerEpoch;
         batch.BaseSequence = baseSequence;
         batch.Records = Records;
+        batch._preEncodedRecords = _preEncodedRecords;
+        batch._hasPreEncodedRecords = _hasPreEncodedRecords;
 
         // Transfer pre-compressed data — records content is unchanged,
         // only header fields differ (CRC is recomputed in Write()).
@@ -671,6 +705,11 @@ public sealed class RecordBatch : IDisposable
                 // Pre-compressed at seal time — use the stored data directly
                 compressedRecords = PreCompressedRecords.AsSpan(0, PreCompressedLength);
                 effectiveCompression = PreCompressedType;
+            }
+            else if (_hasPreEncodedRecords)
+            {
+                compressedRecords = _preEncodedRecords.Span;
+                effectiveCompression = CompressionType.None;
             }
             else
             {
@@ -777,6 +816,9 @@ public sealed class RecordBatch : IDisposable
 
         if (compression != CompressionType.None)
             throw new InvalidOperationException("Compressed RecordBatch size requires pre-compressed records.");
+
+        if (_hasPreEncodedRecords)
+            return _preEncodedRecords.Length;
 
         return GetEncodedRecordsLength(Records);
     }

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -830,9 +830,6 @@ public sealed class RecordBatch : IDisposable
             case Record[] array:
                 WriteRecordSpan(array, ref writer);
                 return;
-            case RecordListWrapper wrapper:
-                WriteRecordSpan(wrapper.AsSpan(), ref writer);
-                return;
             case LazyRecordList lazyRecords:
                 lazyRecords.EnsureAllParsed();
                 var parsedRecords = lazyRecords.GetParsedArray();
@@ -868,7 +865,6 @@ public sealed class RecordBatch : IDisposable
         return records switch
         {
             Record[] array => GetEncodedRecordSpanLength(array),
-            RecordListWrapper wrapper => GetEncodedRecordSpanLength(wrapper.AsSpan()),
             LazyRecordList lazyRecords => GetEncodedLazyRecordListLength(lazyRecords),
             _ => GetEncodedRecordListLength(records)
         };

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -355,9 +355,50 @@ public readonly record struct Header
         return new Header(key, value, isNull: isValueNull);
     }
 
+    /// <summary>
+    /// Encodes the header into a fixed-size destination span at <paramref name="offset"/>,
+    /// advancing it past the bytes written. Must write exactly <see cref="CalculateSize"/>
+    /// bytes — keep the two methods in sync.
+    /// </summary>
+    [SkipLocalsInit]
+    internal void Encode(Span<byte> destination, ref int offset)
+    {
+        var key = Key;
+        if (key.Length <= 128)
+        {
+            // Single-pass encode for short keys (the common case): UTF-8 worst case is
+            // 3 bytes per char, so 128 chars always fit in the 512-byte scratch buffer.
+            Span<byte> buffer = stackalloc byte[512];
+            var keyByteCount = Encoding.UTF8.GetBytes(key, buffer);
+            Record.WriteVarInt(destination, ref offset, keyByteCount);
+            buffer[..keyByteCount].CopyTo(destination[offset..]);
+            offset += keyByteCount;
+        }
+        else
+        {
+            var keyByteCount = Encoding.UTF8.GetByteCount(key);
+            Record.WriteVarInt(destination, ref offset, keyByteCount);
+            Encoding.UTF8.GetBytes(key, destination[offset..]);
+            offset += keyByteCount;
+        }
+
+        if (IsValueNull)
+        {
+            Record.WriteVarInt(destination, ref offset, -1);
+        }
+        else
+        {
+            Record.WriteVarInt(destination, ref offset, Value.Length);
+            Value.Span.CopyTo(destination[offset..]);
+            offset += Value.Length;
+        }
+    }
+
     internal int CalculateSize()
     {
-        var keyBytes = Encoding.UTF8.GetByteCount(Key);
+        // ASCII keys (99%+ of cases): byte count == char count. Ascii.IsValid is
+        // SIMD-optimized and much cheaper than UTF8.GetByteCount for this case.
+        var keyBytes = Ascii.IsValid(Key) ? Key.Length : Encoding.UTF8.GetByteCount(Key);
         var size = Record.VarIntSize(keyBytes) + keyBytes;
 
         if (IsValueNull)

--- a/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
@@ -64,6 +64,21 @@ public class ProducerBuilderValidationTests
     }
 
     [Test]
+    public async Task Build_WithArenaCapacityBelowBatchMinimum_ThrowsInvalidOperationException()
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithBatchSize(1024)
+            .WithArenaCapacity(1024);
+
+        var act = () => builder.Build();
+
+        await Assert.That(act).Throws<InvalidOperationException>()
+            .And.HasMessageContaining("ArenaCapacity")
+            .And.HasMessageContaining("BatchSize");
+    }
+
+    [Test]
     public async Task BuildForTopic_WithNullTopic_ThrowsArgumentNullException()
     {
         var builder = Kafka.CreateProducer<string, string>()

--- a/tests/Dekaf.Tests.Unit/Concurrency/BatchArenaConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Concurrency/BatchArenaConcurrencyTests.cs
@@ -149,4 +149,16 @@ public class BatchArenaConcurrencyTests
         await Assert.That(success).IsTrue();
         BatchArena.ReturnToPool(finalArena);
     }
+
+    [Test]
+    public async Task ReturnToPool_OversizedArenaAbovePoolLimit_DropsBuffer()
+    {
+        var arena = new BatchArena(capacity: 4096, maxPooledCapacity: 1024);
+
+        await Assert.That(arena.Capacity).IsEqualTo(4096);
+
+        var pooled = BatchArena.ReturnToPool(arena);
+
+        await Assert.That(pooled).IsFalse();
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/BatchArrayReuseQueueTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BatchArrayReuseQueueTests.cs
@@ -1,37 +1,25 @@
 using System.Buffers;
 using Dekaf.Producer;
-using Dekaf.Protocol.Records;
-using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Producer;
 
 public class BatchArrayReuseQueueTests
 {
-    private static (Record[] Records, PooledValueTaskSource<RecordMetadata>[] CompletionSources, byte[][] DataArrays, Header[][] HeaderArrays) CreateTestArrays()
-    {
-        return (
-            ArrayPool<Record>.Shared.Rent(16),
-            ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(16),
-            ArrayPool<byte[]>.Shared.Rent(16),
-            ArrayPool<Header[]>.Shared.Rent(16)
-        );
-    }
+    private static PooledValueTaskSource<RecordMetadata>[] CreateTestArray()
+        => ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(16);
 
     [Test]
-    public async Task Enqueue_BelowCapacity_ThenDequeue_ReturnsArrays()
+    public async Task Enqueue_BelowCapacity_ThenDequeue_ReturnsArray()
     {
         var queue = new BatchArrayReuseQueue(maxSize: 4);
-        var arrays = CreateTestArrays();
+        var array = CreateTestArray();
 
-        queue.EnqueueOrReturn(arrays.Records, arrays.CompletionSources, arrays.DataArrays, arrays.HeaderArrays);
+        queue.EnqueueOrReturn(array);
 
         var success = queue.TryDequeue(out var reusable);
 
         await Assert.That(success).IsTrue();
-        await Assert.That(reusable!.Records).IsSameReferenceAs(arrays.Records);
-        await Assert.That(reusable.CompletionSources).IsSameReferenceAs(arrays.CompletionSources);
-        await Assert.That(reusable.DataArrays).IsSameReferenceAs(arrays.DataArrays);
-        await Assert.That(reusable.HeaderArrays).IsSameReferenceAs(arrays.HeaderArrays);
+        await Assert.That(reusable).IsSameReferenceAs(array);
     }
 
     [Test]
@@ -40,14 +28,11 @@ public class BatchArrayReuseQueueTests
         var queue = new BatchArrayReuseQueue(maxSize: 2);
 
         // Fill the queue to capacity
-        var arrays1 = CreateTestArrays();
-        var arrays2 = CreateTestArrays();
-        queue.EnqueueOrReturn(arrays1.Records, arrays1.CompletionSources, arrays1.DataArrays, arrays1.HeaderArrays);
-        queue.EnqueueOrReturn(arrays2.Records, arrays2.CompletionSources, arrays2.DataArrays, arrays2.HeaderArrays);
+        queue.EnqueueOrReturn(CreateTestArray());
+        queue.EnqueueOrReturn(CreateTestArray());
 
         // This one should be returned to ArrayPool (queue is full)
-        var overflow = CreateTestArrays();
-        queue.EnqueueOrReturn(overflow.Records, overflow.CompletionSources, overflow.DataArrays, overflow.HeaderArrays);
+        queue.EnqueueOrReturn(CreateTestArray());
 
         // Should only be able to dequeue the 2 that fit
         var success1 = queue.TryDequeue(out _);
@@ -88,8 +73,7 @@ public class BatchArrayReuseQueueTests
             {
                 for (var j = 0; j < operationsPerThread; j++)
                 {
-                    var arrays = CreateTestArrays();
-                    queue.EnqueueOrReturn(arrays.Records, arrays.CompletionSources, arrays.DataArrays, arrays.HeaderArrays);
+                    queue.EnqueueOrReturn(CreateTestArray());
                     Interlocked.Increment(ref enqueueCount);
                 }
             });
@@ -132,19 +116,19 @@ public class BatchArrayReuseQueueTests
         var queue = new BatchArrayReuseQueue(maxSize: 2);
 
         // First cycle
-        var arrays1 = CreateTestArrays();
-        queue.EnqueueOrReturn(arrays1.Records, arrays1.CompletionSources, arrays1.DataArrays, arrays1.HeaderArrays);
+        var array1 = CreateTestArray();
+        queue.EnqueueOrReturn(array1);
         var success1 = queue.TryDequeue(out var reusable1);
 
         await Assert.That(success1).IsTrue();
-        await Assert.That(reusable1!.Records).IsSameReferenceAs(arrays1.Records);
+        await Assert.That(reusable1).IsSameReferenceAs(array1);
 
         // Second cycle - queue should accept new items after draining
-        var arrays2 = CreateTestArrays();
-        queue.EnqueueOrReturn(arrays2.Records, arrays2.CompletionSources, arrays2.DataArrays, arrays2.HeaderArrays);
+        var array2 = CreateTestArray();
+        queue.EnqueueOrReturn(array2);
         var success2 = queue.TryDequeue(out var reusable2);
 
         await Assert.That(success2).IsTrue();
-        await Assert.That(reusable2!.Records).IsSameReferenceAs(arrays2.Records);
+        await Assert.That(reusable2).IsSameReferenceAs(array2);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -73,10 +73,6 @@ public sealed class BrokerSenderMuteOrderingTests
             new RecordBatch { Records = Array.Empty<Record>() },
             sources,
             messageCount,
-            pooledDataArrays: null,
-            pooledDataArraysCount: 0,
-            pooledHeaderArrays: null,
-            pooledHeaderArraysCount: 0,
             dataSize: 100);
 
         batch.TrySetMemoryReleased();

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -86,10 +86,6 @@ public sealed class BrokerSenderSendLoopTests
             new RecordBatch { Records = Array.Empty<Record>() },
             sources,
             messageCount,
-            pooledDataArrays: null,
-            pooledDataArraysCount: 0,
-            pooledHeaderArrays: null,
-            pooledHeaderArraysCount: 0,
             dataSize: 100);
 
         // Skip accumulator memory tracking in tests

--- a/tests/Dekaf.Tests.Unit/Producer/MemoryReleasedAtomicityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/MemoryReleasedAtomicityTests.cs
@@ -204,10 +204,6 @@ public class MemoryReleasedAtomicityTests
             new RecordBatch { Records = Array.Empty<Record>() },
             completionSourcesArray: null,
             completionSourcesCount: 0,
-            pooledDataArrays: null,
-            pooledDataArraysCount: 0,
-            pooledHeaderArrays: null,
-            pooledHeaderArraysCount: 0,
             dataSize: 50);
 
         // Second lifecycle — must succeed again
@@ -224,10 +220,6 @@ public class MemoryReleasedAtomicityTests
             new RecordBatch { Records = Array.Empty<Record>() },
             completionSourcesArray: null,
             completionSourcesCount: 0,
-            pooledDataArrays: null,
-            pooledDataArraysCount: 0,
-            pooledHeaderArrays: null,
-            pooledHeaderArraysCount: 0,
             dataSize: 100);
         return batch;
     }

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -840,10 +840,6 @@ public class PooledValueTaskSourceTests
             new RecordBatch { Records = Array.Empty<Record>() },
             completionSourcesArray: null,
             completionSourcesCount: 0,
-            pooledDataArrays: null,
-            pooledDataArraysCount: 0,
-            pooledHeaderArrays: null,
-            pooledHeaderArraysCount: 0,
             dataSize: 0);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -5,6 +5,7 @@ using Dekaf.Errors;
 using Dekaf.Producer;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Producer;
 
@@ -234,6 +235,115 @@ public class RecordAccumulatorTests
         await Assert.That(Encoding.UTF8.GetString(parsed.Records[0].Value.Span)).IsEqualTo(valueText);
 
         readyBatch.CompleteSend(baseOffset: 0, DateTimeOffset.FromUnixTimeMilliseconds(timestamp));
+    }
+
+    [Test]
+    public async Task AppendFromSpansAsync_ArenaFullBeforeBatchSize_RotatesAndPreservesRecords()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 1000,
+            LingerMs = 10_000
+        };
+
+        await using var accumulator = new RecordAccumulator(options);
+        var topicPartition = new TopicPartition("test-topic", 0);
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        var appended = await accumulator.AppendFromSpansAsync(
+            topicPartition.Topic,
+            topicPartition.Partition,
+            timestamp,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            new byte[] { 1 },
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(appended).IsTrue();
+
+        var currentBatch = GetCurrentPartitionBatch(accumulator, topicPartition);
+        var arena = currentBatch.Arena!;
+        var remaining = arena.RemainingCapacity;
+        await Assert.That(remaining).IsGreaterThan(0);
+        await Assert.That(arena.TryAllocate(remaining, out _, out _)).IsTrue();
+        await Assert.That(currentBatch.EstimatedSize).IsLessThan(options.BatchSize);
+
+        appended = await accumulator.AppendFromSpansAsync(
+            topicPartition.Topic,
+            topicPartition.Partition,
+            timestamp + 1,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            new byte[] { 2 },
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(appended).IsTrue();
+
+        await Assert.That(accumulator.TryDrainBatch(out var firstBatch)).IsTrue();
+        await Assert.That(firstBatch!.RecordBatch.Records[0].Value.Span[0]).IsEqualTo((byte)1);
+
+        var secondBatch = CompleteCurrentBatch(accumulator, topicPartition);
+        await Assert.That(secondBatch.RecordBatch.Records[0].Value.Span[0]).IsEqualTo((byte)2);
+
+        var now = DateTimeOffset.UtcNow;
+        firstBatch.CompleteSend(baseOffset: 0, now);
+        secondBatch.CompleteSend(baseOffset: 1, now);
+    }
+
+    [Test]
+    public async Task PartitionBatch_TryAppendFromSpans_WhenHeaderEncodingThrows_RewindsArenaAllocation()
+    {
+        var options = CreateTestOptions();
+        var batch = new PartitionBatch(new TopicPartition("test-topic", 0), options);
+        var headerValue = new ThrowingReadOnlyMemoryManager(length: 8);
+        var headers = new[] { new Header("bad-header", headerValue.ReadOnlyMemory, isNull: false) };
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        await Assert.That(() => batch.TryAppendFromSpans(
+                timestamp,
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                new byte[] { 1 },
+                valueIsNull: false,
+                headers,
+                headerCount: 1,
+                completionSource: null,
+                callback: null))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(batch.Arena!.Position).IsEqualTo(0);
+        await Assert.That(batch.RecordCount).IsEqualTo(0);
+
+        var result = batch.TryAppendFromSpans(
+            timestamp + 1,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            new byte[] { 2 },
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            completionSource: null,
+            callback: null);
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(batch.RecordCount).IsEqualTo(1);
+        await Assert.That(batch.Arena!.Position).IsEqualTo(result.ActualSizeAdded);
+
+        var readyBatch = batch.Complete();
+        readyBatch!.CompleteSend(baseOffset: 0, DateTimeOffset.UtcNow);
     }
 
     [Test]
@@ -2163,11 +2273,16 @@ public class RecordAccumulatorTests
 
     private static ReadyBatch CompleteCurrentBatch(RecordAccumulator accumulator, TopicPartition topicPartition)
     {
-        var partitionDeque = GetPartitionDeque(accumulator, topicPartition);
-        var currentBatchField = partitionDeque!.GetType().GetField("CurrentBatch");
-        var partitionBatch = currentBatchField!.GetValue(partitionDeque);
-        var completeMethod = partitionBatch!.GetType().GetMethod("Complete");
+        var partitionBatch = GetCurrentPartitionBatch(accumulator, topicPartition);
+        var completeMethod = partitionBatch.GetType().GetMethod("Complete");
         return (ReadyBatch)completeMethod!.Invoke(partitionBatch, null)!;
+    }
+
+    private static PartitionBatch GetCurrentPartitionBatch(RecordAccumulator accumulator, TopicPartition topicPartition)
+    {
+        var partitionDeque = GetPartitionDeque(accumulator, topicPartition);
+        var currentBatchField = partitionDeque.GetType().GetField("CurrentBatch");
+        return (PartitionBatch)currentBatchField!.GetValue(partitionDeque)!;
     }
 
     private static object GetPartitionDeque(RecordAccumulator accumulator, TopicPartition topicPartition)
@@ -2189,5 +2304,24 @@ public class RecordAccumulatorTests
     {
         var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
         return (T)field!.GetValue(instance)!;
+    }
+
+    private sealed class ThrowingReadOnlyMemoryManager(int length) : MemoryManager<byte>
+    {
+        public ReadOnlyMemory<byte> ReadOnlyMemory => CreateMemory(length);
+
+        public override Span<byte> GetSpan() =>
+            throw new InvalidOperationException("Header value span failed.");
+
+        public override MemoryHandle Pin(int elementIndex = 0) =>
+            throw new NotSupportedException();
+
+        public override void Unpin()
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+        }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1,7 +1,9 @@
 using System.Buffers;
 using System.Reflection;
+using System.Text;
 using Dekaf.Errors;
 using Dekaf.Producer;
+using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
 
 namespace Dekaf.Tests.Unit.Producer;
@@ -32,7 +34,7 @@ public class RecordAccumulatorTests
             BootstrapServers = new[] { "localhost:9092" },
             ClientId = "test-producer",
             BufferMemory = ulong.MaxValue,
-            BatchSize = 30,
+            BatchSize = 10,
             LingerMs = 10
         };
         var callbackCount = 0;
@@ -80,7 +82,7 @@ public class RecordAccumulatorTests
             BootstrapServers = new[] { "localhost:9092" },
             ClientId = "test-producer",
             BufferMemory = ulong.MaxValue,
-            BatchSize = 80,
+            BatchSize = 60,
             LingerMs = 10_000
         };
 
@@ -128,6 +130,63 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task AppendFromSpansAsync_SealedBatch_UsesPreEncodedArenaRecords()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 1000,
+            LingerMs = 10_000
+        };
+
+        await using var accumulator = new RecordAccumulator(options);
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var key = Encoding.UTF8.GetBytes("key-1");
+        var value = Encoding.UTF8.GetBytes("value-1");
+
+        var appended = await accumulator.AppendFromSpansAsync(
+            "test-topic",
+            partition: 0,
+            timestamp,
+            key,
+            keyIsNull: false,
+            value,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(appended).IsTrue();
+
+        var readyBatch = CompleteCurrentBatch(accumulator, new TopicPartition("test-topic", 0));
+        await Assert.That(readyBatch.RecordBatch.HasPreEncodedRecords).IsTrue();
+        await Assert.That(readyBatch.RecordBatch.HasPreCompressedRecords).IsFalse();
+        var encodedSize = readyBatch.RecordBatch.GetEncodedSize();
+        readyBatch.SetEncodedSize(encodedSize);
+        await Assert.That(readyBatch.EncodedSize).IsEqualTo(encodedSize);
+        await Assert.That(readyBatch.EncodedSize).IsEqualTo(readyBatch.DataSize + RecordBatch.TotalBatchHeaderSize);
+
+        var record = readyBatch.RecordBatch.Records[0];
+        await Assert.That(Encoding.UTF8.GetString(record.Key.Span)).IsEqualTo("key-1");
+        await Assert.That(Encoding.UTF8.GetString(record.Value.Span)).IsEqualTo("value-1");
+
+        var writer = new ArrayBufferWriter<byte>();
+        readyBatch.RecordBatch.Write(writer);
+        var reader = new KafkaProtocolReader(writer.WrittenMemory);
+        using var parsed = RecordBatch.Read(ref reader);
+
+        await Assert.That(parsed.Records.Count).IsEqualTo(1);
+        await Assert.That(Encoding.UTF8.GetString(parsed.Records[0].Key.Span)).IsEqualTo("key-1");
+        await Assert.That(Encoding.UTF8.GetString(parsed.Records[0].Value.Span)).IsEqualTo("value-1");
+
+        readyBatch.CompleteSend(baseOffset: 0, DateTimeOffset.FromUnixTimeMilliseconds(timestamp));
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_WithCallback_PreservesCallbackAfterRotation()
     {
         var options = new ProducerOptions
@@ -135,7 +194,7 @@ public class RecordAccumulatorTests
             BootstrapServers = new[] { "localhost:9092" },
             ClientId = "test-producer",
             BufferMemory = ulong.MaxValue,
-            BatchSize = 80,
+            BatchSize = 60,
             LingerMs = 10_000
         };
 
@@ -401,7 +460,7 @@ public class RecordAccumulatorTests
             BootstrapServers = ["localhost:9092"],
             ClientId = "test-producer",
             BufferMemory = ulong.MaxValue,
-            BatchSize = PartitionBatch.EstimateRecordSize(0, 16, null, 0) + 8,
+            BatchSize = 30,
             LingerMs = 10
         };
         var accumulator = new RecordAccumulator(options);
@@ -945,9 +1004,9 @@ public class RecordAccumulatorTests
     }
 
     [Test]
-    public async Task TryAppendFireAndForget_WithPooledMemory_TracksArraysForCleanup()
+    public async Task TryAppendFireAndForget_WithPooledMemory_ReturnsArraysAfterEncoding()
     {
-        // Verify that fire-and-forget correctly tracks pooled arrays for cleanup,
+        // Verify that fire-and-forget releases raw pooled arrays after append-time encoding,
         // even though it doesn't track completion sources.
 
         var options = CreateTestOptions();
@@ -977,7 +1036,7 @@ public class RecordAccumulatorTests
 
             await Assert.That(result).IsTrue();
 
-            // Get the batch and verify arrays are tracked
+            // Get the batch and verify raw arrays are not retained after append-time encoding.
             var dequesField = typeof(RecordAccumulator).GetField("_partitionDeques",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             var deques = dequesField!.GetValue(accumulator)!;
@@ -991,11 +1050,10 @@ public class RecordAccumulatorTests
             var currentBatchField = partitionDeque!.GetType().GetField("CurrentBatch");
             var partitionBatch = currentBatchField!.GetValue(partitionDeque);
 
-            // Verify pooled arrays are tracked (via reflection)
             var pooledArrayCountField = partitionBatch!.GetType().GetField("_pooledArrayCount",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             var pooledArrayCount = (int)pooledArrayCountField!.GetValue(partitionBatch)!;
-            await Assert.That(pooledArrayCount).IsEqualTo(2); // key + value arrays
+            await Assert.That(pooledArrayCount).IsEqualTo(0);
         }
         finally
         {
@@ -1312,7 +1370,7 @@ public class RecordAccumulatorTests
     }
 
     [Test]
-    public async Task Append_FireAndForget_WithPooledMemory_TracksArrays()
+    public async Task Append_FireAndForget_WithPooledMemory_ReturnsArraysAfterEncoding()
     {
         var options = new ProducerOptions
         {
@@ -1338,7 +1396,7 @@ public class RecordAccumulatorTests
 
             await Assert.That(result).IsTrue();
 
-            // Verify pooled arrays are tracked
+            // Verify raw arrays are not retained after append-time encoding.
             var dequesField = typeof(RecordAccumulator).GetField("_partitionDeques",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             var deques = dequesField!.GetValue(accumulator)!;
@@ -1354,7 +1412,7 @@ public class RecordAccumulatorTests
             var pooledArrayCountField = partitionBatch!.GetType().GetField("_pooledArrayCount",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             var pooledArrayCount = (int)pooledArrayCountField!.GetValue(partitionBatch)!;
-            await Assert.That(pooledArrayCount).IsEqualTo(2); // key + value
+            await Assert.That(pooledArrayCount).IsEqualTo(0);
         }
         finally
         {
@@ -2188,13 +2246,17 @@ public class RecordAccumulatorTests
             MaxBlockMs = 5000
         };
         var accumulator = new RecordAccumulator(options);
+        var syntheticReservation = 4096;
+        var remainingSyntheticReservation = syntheticReservation;
 
         try
         {
-            // Fill buffer via hot path
-            await FillBufferViaHotPath(accumulator, 100);
+            // Fill BufferMemory without creating batches. This keeps the test focused on
+            // PendingAppend drain behavior instead of disposal of synthetic hot-path batches.
+            await Assert.That(accumulator.TryReserveMemoryForTest(syntheticReservation)).IsTrue();
 
             var largeValue = new byte[2048];
+            var recordSize = PartitionBatch.EstimateRecordSize(0, largeValue.Length, null, 0);
 
             // Start an append that will block in the slow path
             var appendTask = Task.Run(async () =>
@@ -2205,19 +2267,15 @@ public class RecordAccumulatorTests
                     largeValue, valueIsNull: false,
                     null, 0, null, CancellationToken.None));
 
-            // Release enough memory to serve the pending append.
-            // Use a retry loop: if the background task hasn't enqueued yet,
-            // ReleaseMemory won't drain anything, but the task's own
-            // DrainPendingAppends call after Enqueue will pick it up.
-            // We retry to cover the case where memory was released before the enqueue.
-            while (!appendTask.IsCompleted)
-            {
-                var bufferedBytes = (int)accumulator.BufferedBytes;
-                if (bufferedBytes > 0)
-                    accumulator.ReleaseMemory(bufferedBytes);
-
+            while (accumulator.BufferPressureEvents == 0 && !appendTask.IsCompleted)
                 await Task.Yield();
-            }
+
+            await Assert.That(appendTask.IsCompleted).IsFalse();
+
+            // Release exactly the pending append's estimated reservation. DrainPendingAppends
+            // will reserve it, append it, then refund the estimate-vs-actual difference.
+            accumulator.ReleaseMemory(recordSize);
+            remainingSyntheticReservation -= recordSize;
 
             // The append should complete successfully
             var result = await appendTask.WaitAsync(TimeSpan.FromSeconds(5));
@@ -2225,6 +2283,11 @@ public class RecordAccumulatorTests
         }
         finally
         {
+            if (remainingSyntheticReservation > 0)
+            {
+                accumulator.ReleaseMemory(remainingSyntheticReservation);
+            }
+
             await accumulator.DisposeAsync();
         }
     }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -165,10 +165,11 @@ public class RecordAccumulatorTests
         var readyBatch = CompleteCurrentBatch(accumulator, new TopicPartition("test-topic", 0));
         await Assert.That(readyBatch.RecordBatch.HasPreEncodedRecords).IsTrue();
         await Assert.That(readyBatch.RecordBatch.HasPreCompressedRecords).IsFalse();
+
+        // The append-time accounting (DataSize) plus the fixed batch header must equal the
+        // full encoded size RecordBatch reports for MaxRequestSize drain accounting.
         var encodedSize = readyBatch.RecordBatch.GetEncodedSize();
-        readyBatch.SetEncodedSize(encodedSize);
-        await Assert.That(readyBatch.EncodedSize).IsEqualTo(encodedSize);
-        await Assert.That(readyBatch.EncodedSize).IsEqualTo(readyBatch.DataSize + RecordBatch.TotalBatchHeaderSize);
+        await Assert.That(encodedSize).IsEqualTo(readyBatch.DataSize + RecordBatch.TotalBatchHeaderSize);
 
         var record = readyBatch.RecordBatch.Records[0];
         await Assert.That(Encoding.UTF8.GetString(record.Key.Span)).IsEqualTo("key-1");
@@ -398,11 +399,9 @@ public class RecordAccumulatorTests
             await Assert.That(result).IsTrue();
 
             var readyBatch = CompleteCurrentBatch(accumulator, topicPartition);
-            var pooledDataArraysCount = GetPrivateField<int>(readyBatch, "_pooledDataArraysCount");
             var record = readyBatch.RecordBatch.Records[0];
 
             await Assert.That(readyBatch.CompletionSourcesCount).IsEqualTo(1);
-            await Assert.That(pooledDataArraysCount).IsEqualTo(0);
             await Assert.That(record.Key.ToArray()).IsEquivalentTo(key);
             await Assert.That(record.Value.ToArray()).IsEquivalentTo(value);
 
@@ -1053,10 +1052,11 @@ public class RecordAccumulatorTests
     }
 
     [Test]
-    public async Task TryAppendFireAndForget_WithPooledMemory_ReturnsArraysAfterEncoding()
+    public async Task TryAppendFireAndForget_WithPooledMemory_EncodesDataIntoBatch()
     {
-        // Verify that fire-and-forget releases raw pooled arrays after append-time encoding,
-        // even though it doesn't track completion sources.
+        // Fire-and-forget appends encode the pooled key/value into the batch arena at append
+        // time and return the raw arrays immediately, so the sealed batch must carry copies
+        // of the data (not references to the returned arrays).
 
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
@@ -1085,24 +1085,18 @@ public class RecordAccumulatorTests
 
             await Assert.That(result).IsTrue();
 
-            // Get the batch and verify raw arrays are not retained after append-time encoding.
-            var dequesField = typeof(RecordAccumulator).GetField("_partitionDeques",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            var deques = dequesField!.GetValue(accumulator)!;
+            // Clobber the (already returned) source arrays, then verify the sealed batch
+            // still round-trips the original data from its own encoded copy.
+            keyArray.AsSpan().Clear();
+            valueArray.AsSpan().Clear();
 
-            var topicPartition = new TopicPartition("test-topic", 0);
-            var tryGetValueMethod = deques.GetType().GetMethod("TryGetValue");
-            var parameters = new object[] { topicPartition, null! };
-            tryGetValueMethod!.Invoke(deques, parameters);
+            var readyBatch = CompleteCurrentBatch(accumulator, new TopicPartition("test-topic", 0));
+            await Assert.That(readyBatch.RecordBatch.HasPreEncodedRecords).IsTrue();
+            var record = readyBatch.RecordBatch.Records[0];
+            await Assert.That(record.Key.ToArray()).IsEquivalentTo(keyData);
+            await Assert.That(record.Value.ToArray()).IsEquivalentTo(valueData);
 
-            var partitionDeque = parameters[1];
-            var currentBatchField = partitionDeque!.GetType().GetField("CurrentBatch");
-            var partitionBatch = currentBatchField!.GetValue(partitionDeque);
-
-            var pooledArrayCountField = partitionBatch!.GetType().GetField("_pooledArrayCount",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            var pooledArrayCount = (int)pooledArrayCountField!.GetValue(partitionBatch)!;
-            await Assert.That(pooledArrayCount).IsEqualTo(0);
+            readyBatch.CompleteSend(baseOffset: 0, DateTimeOffset.UtcNow);
         }
         finally
         {
@@ -1278,7 +1272,7 @@ public class RecordAccumulatorTests
 
         // Call TryAppend with null completionSource and null callback (fire-and-forget)
         var tryAppendMethod = partitionBatchType.GetMethods()
-            .Single(m => m.Name == "TryAppend" && m.GetParameters().Length == 8);
+            .Single(m => m.Name == "TryAppend" && m.GetParameters().Length == 7);
         var pooledKey = new PooledMemory(null, 0, isNull: true);
         var pooledValue = new PooledMemory(null, 0, isNull: true);
 
@@ -1288,10 +1282,9 @@ public class RecordAccumulatorTests
             pooledKey,
             pooledValue,
             null,   // headers
-            null,   // pooledHeaderArray
+            null,   // headerCount (coerced to 0)
             null,   // completionSource
-            null,   // callback
-            20      // estimatedRecordSize: base overhead for empty record (key=null, value=null, no headers)
+            null    // callback
         });
 
         // Verify append succeeded
@@ -1418,174 +1411,7 @@ public class RecordAccumulatorTests
         await Assert.That(result).IsFalse();
     }
 
-    [Test]
-    public async Task Append_FireAndForget_WithPooledMemory_ReturnsArraysAfterEncoding()
-    {
-        var options = new ProducerOptions
-        {
-            BootstrapServers = new[] { "localhost:9092" },
-            ClientId = "test-producer",
-            BufferMemory = 100000,
-            BatchSize = 100000,
-            LingerMs = 10
-        };
-        var accumulator = new RecordAccumulator(options);
-
-        try
-        {
-            var keyArray = ArrayPool<byte>.Shared.Rent(10);
-            var valueArray = ArrayPool<byte>.Shared.Rent(20);
-
-            var result = await accumulator.AppendAsync(
-                "test-topic", 0,
-                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                new PooledMemory(keyArray, 10),
-                new PooledMemory(valueArray, 20),
-                null, 0, null, null, CancellationToken.None);
-
-            await Assert.That(result).IsTrue();
-
-            // Verify raw arrays are not retained after append-time encoding.
-            var dequesField = typeof(RecordAccumulator).GetField("_partitionDeques",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            var deques = dequesField!.GetValue(accumulator)!;
-
-            var topicPartition = new TopicPartition("test-topic", 0);
-            var tryGetValueMethod = deques.GetType().GetMethod("TryGetValue");
-            var parameters = new object[] { topicPartition, null! };
-            tryGetValueMethod!.Invoke(deques, parameters);
-
-            var partitionDeque = parameters[1];
-            var currentBatchField = partitionDeque!.GetType().GetField("CurrentBatch");
-            var partitionBatch = currentBatchField!.GetValue(partitionDeque);
-            var pooledArrayCountField = partitionBatch!.GetType().GetField("_pooledArrayCount",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            var pooledArrayCount = (int)pooledArrayCountField!.GetValue(partitionBatch)!;
-            await Assert.That(pooledArrayCount).IsEqualTo(0);
-        }
-        finally
-        {
-            await accumulator.DisposeAsync();
-        }
-    }
-
     #endregion
-
-    #region RecordListWrapper Tests
-
-    [Test]
-    public async Task RecordListWrapper_Count_ReturnsCorrectValue()
-    {
-        var records = new Record[10];
-        for (var i = 0; i < 10; i++)
-        {
-            records[i] = new Record { OffsetDelta = i };
-        }
-
-        var wrapper = new RecordListWrapper(records, 5); // Only 5 valid elements
-
-        await Assert.That(wrapper.Count).IsEqualTo(5);
-    }
-
-    [Test]
-    public async Task RecordListWrapper_Indexer_ReturnsCorrectElements()
-    {
-        var records = new Record[10];
-        for (var i = 0; i < 10; i++)
-        {
-            records[i] = new Record { OffsetDelta = i * 10 };
-        }
-
-        var wrapper = new RecordListWrapper(records, 5);
-
-        await Assert.That(wrapper[0].OffsetDelta).IsEqualTo(0);
-        await Assert.That(wrapper[2].OffsetDelta).IsEqualTo(20);
-        await Assert.That(wrapper[4].OffsetDelta).IsEqualTo(40);
-    }
-
-    [Test]
-    public async Task RecordListWrapper_Indexer_ThrowsOnOutOfRange()
-    {
-        var records = new Record[10];
-        var wrapper = new RecordListWrapper(records, 5);
-
-        await Assert.That(() => _ = wrapper[5]).Throws<ArgumentOutOfRangeException>();
-        await Assert.That(() => _ = wrapper[-1]).Throws<ArgumentOutOfRangeException>();
-        await Assert.That(() => _ = wrapper[10]).Throws<ArgumentOutOfRangeException>();
-    }
-
-    [Test]
-    public async Task RecordListWrapper_Enumerator_IteratesCorrectElements()
-    {
-        var records = new Record[10];
-        for (var i = 0; i < 10; i++)
-        {
-            records[i] = new Record { OffsetDelta = i };
-        }
-
-        var wrapper = new RecordListWrapper(records, 5);
-        var enumerated = new List<int>();
-
-        foreach (var record in wrapper)
-        {
-            enumerated.Add(record.OffsetDelta);
-        }
-
-        await Assert.That(enumerated).Count().IsEqualTo(5);
-        await Assert.That(enumerated[0]).IsEqualTo(0);
-        await Assert.That(enumerated[4]).IsEqualTo(4);
-    }
-
-    [Test]
-    public async Task RecordListWrapper_AsSpan_ExposesValidRecordsOnly()
-    {
-        var records = new Record[4];
-        records[0] = new Record { OffsetDelta = 10 };
-        records[1] = new Record { OffsetDelta = 20 };
-        records[2] = new Record { OffsetDelta = 30 };
-        records[3] = new Record { OffsetDelta = 40 };
-
-        var wrapper = new RecordListWrapper(records, 2);
-        var snapshot = ReadWrapperSpan(wrapper);
-
-        await Assert.That(snapshot.Length).IsEqualTo(2);
-        await Assert.That(snapshot.FirstOffset).IsEqualTo(10);
-        await Assert.That(snapshot.SecondOffset).IsEqualTo(20);
-    }
-
-    [Test]
-    public async Task RecordListWrapper_IndexBasedIteration_MatchesEnumerator()
-    {
-        var records = new Record[10];
-        for (var i = 0; i < 10; i++)
-        {
-            records[i] = new Record { OffsetDelta = i * 2 };
-        }
-
-        var wrapper = new RecordListWrapper(records, 7);
-        var fromEnumerator = new List<int>();
-        var fromIndexer = new List<int>();
-
-        foreach (var record in wrapper)
-        {
-            fromEnumerator.Add(record.OffsetDelta);
-        }
-
-        for (var i = 0; i < wrapper.Count; i++)
-        {
-            fromIndexer.Add(wrapper[i].OffsetDelta);
-        }
-
-        await Assert.That(fromIndexer).IsEquivalentTo(fromEnumerator);
-    }
-
-    #endregion
-
-    private static (int Length, int FirstOffset, int SecondOffset) ReadWrapperSpan(RecordListWrapper wrapper)
-    {
-        var span = wrapper.AsSpan();
-        return (span.Length, span[0].OffsetDelta, span[1].OffsetDelta);
-    }
 
     #region ReadyBatch.Reset Safety Net
 
@@ -1737,10 +1563,6 @@ public class RecordAccumulatorTests
             new RecordBatch { Records = Array.Empty<Record>() },
             sources,
             messageCount,
-            pooledDataArrays: null,
-            pooledDataArraysCount: 0,
-            pooledHeaderArrays: null,
-            pooledHeaderArraysCount: 0,
             dataSize: 100);
 
         return batch;
@@ -1878,10 +1700,6 @@ public class RecordAccumulatorTests
                 new RecordBatch { Records = Array.Empty<Record>() },
                 newSources,
                 completionSourcesCount: 1,
-                pooledDataArrays: null,
-                pooledDataArraysCount: 0,
-                pooledHeaderArrays: null,
-                pooledHeaderArraysCount: 0,
                 dataSize: 200);
 
             await Assert.That((int)cleanedUpField.GetValue(batch)!).IsEqualTo(0);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -187,6 +187,55 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task AppendFromSpansAsync_FirstRecordLargerThanBatchSize_UsesExpandedArena()
+    {
+        const int batchSize = 128;
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = batchSize,
+            LingerMs = 10_000
+        };
+
+        await using var accumulator = new RecordAccumulator(options);
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var valueText = new string('x', batchSize * 3);
+        var value = Encoding.UTF8.GetBytes(valueText);
+
+        var appended = await accumulator.AppendFromSpansAsync(
+            "test-topic",
+            partition: 0,
+            timestamp,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            value,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(appended).IsTrue();
+
+        var readyBatch = CompleteCurrentBatch(accumulator, new TopicPartition("test-topic", 0));
+        await Assert.That(readyBatch.RecordBatch.HasPreEncodedRecords).IsTrue();
+        await Assert.That(readyBatch.DataSize).IsGreaterThan(batchSize);
+
+        var writer = new ArrayBufferWriter<byte>();
+        readyBatch.RecordBatch.Write(writer);
+        var reader = new KafkaProtocolReader(writer.WrittenMemory);
+        using var parsed = RecordBatch.Read(ref reader);
+
+        await Assert.That(parsed.Records.Count).IsEqualTo(1);
+        await Assert.That(Encoding.UTF8.GetString(parsed.Records[0].Value.Span)).IsEqualTo(valueText);
+
+        readyBatch.CompleteSend(baseOffset: 0, DateTimeOffset.FromUnixTimeMilliseconds(timestamp));
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_WithCallback_PreservesCallbackAfterRotation()
     {
         var options = new ProducerOptions

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AccumulatorAppendBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AccumulatorAppendBenchmarks.cs
@@ -77,10 +77,10 @@ public class AccumulatorAppendBenchmarks
         var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         for (var i = 0; i < 100; i++)
         {
-            _accumulator.AppendFromSpansAsync(
+            AwaitSync(_accumulator.AppendFromSpansAsync(
                 "bench-topic", 0, ts,
                 _keyBytes, false, _valueBytes, false,
-                null, 0, null, CancellationToken.None).GetAwaiter().GetResult();
+                null, 0, null, CancellationToken.None));
         }
     }
 
@@ -94,11 +94,29 @@ public class AccumulatorAppendBenchmarks
         var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         for (var i = 0; i < 100; i++)
         {
-            _accumulator.AppendFromSpansAsync(
+            AwaitSync(_accumulator.AppendFromSpansAsync(
                 "bench-topic", i % 10, ts,
                 _keyBytes, false, _valueBytes, false,
-                null, 0, null, CancellationToken.None).GetAwaiter().GetResult();
+                null, 0, null, CancellationToken.None));
         }
+    }
+
+    /// <summary>
+    /// Blocks on an append ValueTask. On the hot path the task is already completed and this
+    /// is allocation-free. On the cold path (buffer full → pooled PendingAppend source) the
+    /// task is not yet completed — GetAwaiter().GetResult() on an incomplete IValueTaskSource
+    /// throws InvalidOperationException, so convert to a Task and block on that instead.
+    /// The cold path only engages when the drainer falls behind the append thread.
+    /// </summary>
+    private static void AwaitSync(ValueTask<bool> valueTask)
+    {
+        if (valueTask.IsCompleted)
+        {
+            valueTask.GetAwaiter().GetResult();
+            return;
+        }
+
+        valueTask.AsTask().GetAwaiter().GetResult();
     }
 
     private void FillAndDrain(int partition, int batchCount, int msgsPerBatch, long ts)
@@ -106,10 +124,10 @@ public class AccumulatorAppendBenchmarks
         var totalMessages = msgsPerBatch * batchCount;
         for (var i = 0; i < totalMessages; i++)
         {
-            _accumulator.AppendFromSpansAsync(
+            AwaitSync(_accumulator.AppendFromSpansAsync(
                 "bench-topic", partition, ts,
                 _keyBytes, false, _valueBytes, false,
-                null, 0, null, CancellationToken.None).GetAwaiter().GetResult();
+                null, 0, null, CancellationToken.None));
 
             // Drain periodically to release memory and return arenas/arrays to pools
             if (i % msgsPerBatch == msgsPerBatch - 1)


### PR DESCRIPTION
## Summary

Moves producer record wire encoding into the append path so sealed batches carry arena-backed encoded record bytes. `RecordBatch` can now write or compress those pre-encoded bytes directly, avoiding record re-encoding on the send path for `CompressionType.None` and compressing the existing encoded payload when compression is enabled.

## Root Cause

Producer batches previously retained logical record state and serialized it later during send preparation/write. That meant uncompressed sends still paid record encoding work on the send path, and compressed sends encoded records into scratch memory before compression.

## Changes

- Encode each appended record directly into the `BatchArena` using Kafka record wire format.
- Let sealed `RecordBatch` instances reference pre-encoded arena bytes and skip `PreCompress(None)` work.
- Compress pre-encoded arena bytes directly for compressed sends.
- Track exact encoded record bytes for batch sizing and expose full encoded batch size for `MaxRequestSize` drain accounting.
- Return raw pooled key/value/header inputs immediately after append-time encoding.
- Add/update producer tests for pre-encoded batches, pooling expectations, and slow-path memory accounting.

Closes #1136.

## Validation

- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj /p:RunAnalyzers=false`
- `tests\Dekaf.Tests.Unit\bin\Debug\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordAccumulatorTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Debug\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordBatchTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Debug\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ProduceRequestTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Debug\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordAccumulatorReadyTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Debug\net10.0\Dekaf.Tests.Unit.exe`