### PR TITLE
Track consumer leader epochs

### DIFF
--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -125,7 +125,7 @@ namespace Dekaf.Consumer
                     headerOwner: pending,
                     timestampMs: timestampMs,
                     timestampType: timestampType,
-                    leaderEpoch: null,
+                    leaderEpoch: pending.CurrentPartitionLeaderEpoch >= 0 ? pending.CurrentPartitionLeaderEpoch : null,
                     keyDeserializer: _batch._keyDeserializer,
                     valueDeserializer: _batch._valueDeserializer);
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -328,7 +328,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     partitions.Add(new OffsetCommitRequestPartition
                     {
                         PartitionIndex = offset.Partition,
-                        CommittedOffset = offset.Offset
+                        CommittedOffset = offset.Offset,
+                        CommittedLeaderEpoch = offset.LeaderEpoch
                     });
                 }
 
@@ -390,16 +391,16 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// <summary>
     /// Fetches committed offsets for the group.
     /// </summary>
-    public async ValueTask<IReadOnlyDictionary<TopicPartition, long>> FetchOffsetsAsync(
+    public async ValueTask<IReadOnlyDictionary<TopicPartition, TopicPartitionOffset>> FetchOffsetsAsync(
         IEnumerable<TopicPartition> partitions,
         CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(_options.GroupId))
-            return new Dictionary<TopicPartition, long>();
+            return new Dictionary<TopicPartition, TopicPartitionOffset>();
 
         // If coordinator hasn't been discovered yet, return empty (no committed offsets known)
         if (_coordinatorId < 0)
-            return new Dictionary<TopicPartition, long>();
+            return new Dictionary<TopicPartition, TopicPartitionOffset>();
 
         // Lock is intentionally held across retries to protect the shared _fetchTopicGroups dictionary,
         // which is reused across calls to avoid allocations. With up to 3 retries x ~600ms each,
@@ -468,7 +469,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     };
                 }
 
-                var result = new Dictionary<TopicPartition, long>();
+                var result = new Dictionary<TopicPartition, TopicPartitionOffset>();
 
                 // v6-v7: Topics field
                 if (response.Topics is not null)
@@ -492,7 +493,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                             if (partition.CommittedOffset >= 0)
                             {
-                                result[new TopicPartition(topic.Name, partition.PartitionIndex)] = partition.CommittedOffset;
+                                result[new TopicPartition(topic.Name, partition.PartitionIndex)] =
+                                    new TopicPartitionOffset(
+                                        topic.Name,
+                                        partition.PartitionIndex,
+                                        partition.CommittedOffset,
+                                        partition.CommittedLeaderEpoch);
                             }
                         }
                     }
@@ -535,7 +541,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                                 if (partition.CommittedOffset >= 0)
                                 {
-                                    result[new TopicPartition(topic.Name, partition.PartitionIndex)] = partition.CommittedOffset;
+                                    result[new TopicPartition(topic.Name, partition.PartitionIndex)] =
+                                        new TopicPartitionOffset(
+                                            topic.Name,
+                                            partition.PartitionIndex,
+                                            partition.CommittedOffset,
+                                            partition.CommittedLeaderEpoch);
                                 }
                             }
                         }

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -549,7 +549,7 @@ public readonly struct ConsumeResult<TKey, TValue>
     /// <summary>
     /// Gets the topic-partition-offset.
     /// </summary>
-    public TopicPartitionOffset TopicPartitionOffset => new(Topic, Partition, Offset);
+    public TopicPartitionOffset TopicPartitionOffset => new(Topic, Partition, Offset, LeaderEpoch ?? -1);
 
 }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -109,6 +109,7 @@ internal sealed class PendingFetchData : IDisposable
     /// consumer poll loop thread. Each instance handles one partition's fetch response.
     /// </remarks>
     public long LastYieldedOffset { get; private set; } = -1;
+    public int LastYieldedLeaderEpoch { get; private set; } = -1;
 
     /// <summary>
     /// Tracks total bytes consumed in this pending fetch.
@@ -220,6 +221,7 @@ internal sealed class PendingFetchData : IDisposable
     /// Updated only on batch transitions to avoid per-message property access overhead.
     /// </summary>
     internal long CurrentBaseOffset { get; private set; }
+    internal int CurrentPartitionLeaderEpoch { get; private set; } = -1;
     internal long CurrentBaseTimestamp { get; private set; }
     /// <summary>
     /// Cached timestamp type for the current batch.
@@ -235,6 +237,7 @@ internal sealed class PendingFetchData : IDisposable
     public void TrackConsumed(long offset, int messageBytes)
     {
         LastYieldedOffset = offset;
+        LastYieldedLeaderEpoch = CurrentPartitionLeaderEpoch;
         TotalBytesConsumed += messageBytes;
         MessageCount++;
     }
@@ -298,6 +301,7 @@ internal sealed class PendingFetchData : IDisposable
             : null;
 
         CurrentBaseOffset = batch.BaseOffset;
+        CurrentPartitionLeaderEpoch = batch.PartitionLeaderEpoch;
         CurrentBaseTimestamp = batch.BaseTimestamp;
         var attrs = batch.Attributes;
         CurrentTimestampType = (attrs & RecordBatchAttributes.TimestampTypeLogAppendTime) != 0
@@ -444,9 +448,11 @@ internal sealed class PendingFetchData : IDisposable
                 _headerGeneration = 1;
         }
         CurrentBaseOffset = 0;
+        CurrentPartitionLeaderEpoch = -1;
         CurrentBaseTimestamp = 0;
         CurrentTimestampType = default;
         LastYieldedOffset = -1;
+        LastYieldedLeaderEpoch = -1;
         TotalBytesConsumed = 0;
         MessageCount = 0;
         _emittedMessageCount = 0;
@@ -612,6 +618,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly ConcurrentDictionary<TopicPartition, long> _positions = new();      // Consumed position (what app has seen)
     private readonly ConcurrentDictionary<TopicPartition, long> _dirtyPositions = new(); // Positions changed since last successful commit
     private readonly ConcurrentDictionary<TopicPartition, long> _fetchPositions = new(); // Fetch position (what to fetch next)
+    // Last consumed record-batch leader epoch, sent as FetchRequest.LastFetchedEpoch.
+    private readonly ConcurrentDictionary<TopicPartition, int> _lastConsumedLeaderEpochs = new();
     private readonly ConcurrentDictionary<TopicPartition, long> _committed = new();
     private readonly ConcurrentDictionary<TopicPartition, WatermarkOffsets> _watermarks = new(); // Cached watermark offsets from fetch responses
 
@@ -623,6 +631,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     // Pending fetch responses for lazy record iteration
     private readonly Queue<PendingFetchData> _pendingFetches = new();
+    private readonly ConcurrentQueue<Exception> _pendingFetchExceptions = new();
 
     // Incremented whenever queued fetch data is disposed (Seek/Assign clear the buffer).
     // ConsumeAsync iterates the front of _pendingFetches while it is still queued, and
@@ -1114,6 +1123,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 if (tpo.Offset >= 0)
                 {
                     SetPosition(tp, tpo.Offset, dirty: false);
+                    if (tpo.LeaderEpoch >= 0)
+                        SetLastConsumedLeaderEpoch(tp, tpo.LeaderEpoch);
+                    else
+                        ClearLastConsumedLeaderEpoch(tp);
                     _fetchPositions[tp] = tpo.Offset;
                 }
                 // Otherwise, positions will be initialized lazily based on auto.offset.reset
@@ -1186,6 +1199,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
+            ThrowPendingFetchException();
+
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
 
             if (_assignmentSnapshot.Count == 0)
@@ -1248,6 +1263,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Direct fetch (no prefetching)
                     await FetchRecordsAsync(cancellationToken).ConfigureAwait(false);
                 }
+
+                ThrowPendingFetchException();
             }
 
             // Yield records lazily from pending fetches
@@ -1339,7 +1356,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 headerOwner: pending,
                                 timestampMs: timestampMs,
                                 timestampType: timestampType,
-                                leaderEpoch: null,
+                                leaderEpoch: pending.CurrentPartitionLeaderEpoch >= 0 ? pending.CurrentPartitionLeaderEpoch : null,
                                 keyDeserializer: _keyDeserializer,
                                 valueDeserializer: _valueDeserializer);
 
@@ -1471,6 +1488,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
+            ThrowPendingFetchException();
+
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
 
             if (_assignmentSnapshot.Count == 0)
@@ -1528,6 +1547,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Direct fetch (no prefetching)
                     await FetchRecordsAsync(cancellationToken).ConfigureAwait(false);
                 }
+
+                ThrowPendingFetchException();
             }
 
             // Yield batches from pending fetches
@@ -1606,6 +1627,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
+            ThrowPendingFetchException();
+
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
 
             if (_assignmentSnapshot.Count == 0)
@@ -1663,6 +1686,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Direct fetch (no prefetching)
                     await FetchRecordsAsync(cancellationToken).ConfigureAwait(false);
                 }
+
+                ThrowPendingFetchException();
             }
 
             // Yield raw batches from pending fetches
@@ -2073,6 +2098,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         // Update watermark cache from fetch response (even on errors, watermarks may be valid)
                         UpdateWatermarksFromFetchResponse(topic, partitionResponse);
 
+                        if (partitionResponse.DivergingEpoch is not null)
+                        {
+                            ResetToDivergingEpoch(topic, partitionResponse);
+                            continue;
+                        }
+
                         if (partitionResponse.ErrorCode != ErrorCode.None)
                         {
                             if (partitionResponse.ErrorCode == ErrorCode.OffsetOutOfRange)
@@ -2084,19 +2115,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 {
                                     _fetchPositions[tp] = resetTimestamp;
                                     SetPosition(tp, resetTimestamp, dirty: false);
+                                    ClearLastConsumedLeaderEpoch(tp);
                                 }
                                 else
                                 {
                                     var resetOffset = await ResolveAutoResetOffsetAsync(tp, resetTimestamp, cancellationToken).ConfigureAwait(false);
                                     _fetchPositions[tp] = resetOffset;
                                     SetPosition(tp, resetOffset, dirty: false);
+                                    ClearLastConsumedLeaderEpoch(tp);
                                 }
 
                                 LogOffsetOutOfRangeReset(topic, partitionResponse.PartitionIndex, GetAutoOffsetResetName());
                             }
-                            else if (partitionResponse.ErrorCode == ErrorCode.NotLeaderOrFollower)
+                            else if (IsLeaderEpochRefreshError(partitionResponse.ErrorCode))
                             {
-                                await HandleNotLeaderOrFollowerAsync(
+                                await HandleLeaderEpochRefreshAsync(
                                     topic,
                                     partitionResponse,
                                     response.NodeEndpoints).ConfigureAwait(false);
@@ -2192,10 +2225,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// </summary>
     private void FlushConsumedPositions(PendingFetchData pending)
     {
-        if (!TryGetConsumedPosition(pending, out var tp, out var nextOffset))
+        if (!TryGetConsumedPosition(pending, out var tp, out var nextOffset, out var leaderEpoch))
             return;
 
         SetPosition(tp, nextOffset, dirty: true);
+        SetLastConsumedLeaderEpoch(tp, leaderEpoch);
 
         if (!_prefetchEnabled)
         {
@@ -2209,39 +2243,50 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             return;
 
         var pending = _pendingFetches.Peek();
-        if (TryGetConsumedPosition(pending, out var tp, out var nextOffset))
+        if (TryGetConsumedPosition(pending, out var tp, out var nextOffset, out var leaderEpoch))
+        {
             SetPosition(tp, nextOffset, dirty: true);
+            SetLastConsumedLeaderEpoch(tp, leaderEpoch);
+        }
     }
 
-    private bool TryGetActiveConsumedPosition(TopicPartition partition, out long position)
+    private bool TryGetActiveConsumedPosition(TopicPartition partition, out long position, out int leaderEpoch)
     {
         if (_pendingFetches.Count == 0)
         {
             position = 0;
+            leaderEpoch = -1;
             return false;
         }
 
         var pending = _pendingFetches.Peek();
-        if (!TryGetConsumedPosition(pending, out var tp, out position) || !tp.Equals(partition))
+        if (!TryGetConsumedPosition(pending, out var tp, out position, out leaderEpoch) || !tp.Equals(partition))
         {
             position = 0;
+            leaderEpoch = -1;
             return false;
         }
 
         return true;
     }
 
-    private static bool TryGetConsumedPosition(PendingFetchData pending, out TopicPartition partition, out long nextOffset)
+    private static bool TryGetConsumedPosition(
+        PendingFetchData pending,
+        out TopicPartition partition,
+        out long nextOffset,
+        out int leaderEpoch)
     {
         if (pending.LastYieldedOffset < 0)
         {
             partition = default;
             nextOffset = 0;
+            leaderEpoch = -1;
             return false;
         }
 
         partition = pending.TopicPartition;
         nextOffset = pending.LastYieldedOffset + 1;
+        leaderEpoch = pending.LastYieldedLeaderEpoch;
         return true;
     }
 
@@ -2252,6 +2297,22 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _dirtyPositions[partition] = position;
         else
             _dirtyPositions.TryRemove(partition, out _);
+    }
+
+    private void SetLastConsumedLeaderEpoch(TopicPartition partition, int leaderEpoch)
+    {
+        if (leaderEpoch >= 0)
+        {
+            _lastConsumedLeaderEpochs[partition] = leaderEpoch;
+            return;
+        }
+
+        ClearLastConsumedLeaderEpoch(partition);
+    }
+
+    private void ClearLastConsumedLeaderEpoch(TopicPartition partition)
+    {
+        _lastConsumedLeaderEpochs.TryRemove(partition, out _);
     }
 
     private void ClearDirtyPositionIfCommitted(TopicPartition partition, long committedOffset)
@@ -2433,6 +2494,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
+            ThrowPendingFetchException();
+
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
 
             if (_assignmentSnapshot.Count == 0)
@@ -2448,6 +2511,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 {
                     return null;
                 }
+
+                ThrowPendingFetchException();
             }
 
             if (TryConsumeOneFromPendingFetches(out var result))
@@ -2569,7 +2634,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             headerOwner: pending,
                             timestampMs: timestampMs,
                             timestampType: timestampType,
-                            leaderEpoch: null,
+                            leaderEpoch: pending.CurrentPartitionLeaderEpoch >= 0 ? pending.CurrentPartitionLeaderEpoch : null,
                             keyDeserializer: _keyDeserializer,
                             valueDeserializer: _valueDeserializer);
 
@@ -2646,7 +2711,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 int index = 0;
                 foreach (var kvp in dirtyPositionsSnapshot)
                 {
-                    offsetsArray[index++] = new TopicPartitionOffset(kvp.Key.Topic, kvp.Key.Partition, kvp.Value);
+                    offsetsArray[index++] = new TopicPartitionOffset(
+                        kvp.Key.Topic,
+                        kvp.Key.Partition,
+                        kvp.Value,
+                        GetLastConsumedLeaderEpoch(kvp.Key));
                 }
 
                 // Create array segment to pass only the used portion
@@ -2699,9 +2768,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (_coordinator is not null)
         {
             var offsets = await _coordinator.FetchOffsetsAsync([partition], cancellationToken).ConfigureAwait(false);
-            if (offsets.TryGetValue(partition, out offset))
+            if (offsets.TryGetValue(partition, out var committedOffset))
             {
+                offset = committedOffset.Offset;
                 _committed[partition] = offset;
+                if (committedOffset.LeaderEpoch >= 0)
+                    SetLastConsumedLeaderEpoch(partition, committedOffset.LeaderEpoch);
+                else
+                    ClearLastConsumedLeaderEpoch(partition);
                 return offset;
             }
         }
@@ -2712,9 +2786,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     public long? GetPosition(TopicPartition partition)
     {
         if (_options.OffsetCommitMode == OffsetCommitMode.Manual
-            && TryGetActiveConsumedPosition(partition, out var activePosition))
+            && TryGetActiveConsumedPosition(partition, out var activePosition, out var leaderEpoch))
         {
             SetPosition(partition, activePosition, dirty: true);
+            SetLastConsumedLeaderEpoch(partition, leaderEpoch);
             return activePosition;
         }
 
@@ -2757,6 +2832,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var tp = new TopicPartition(offset.Topic, offset.Partition);
         // Update positions (thread-safe with ConcurrentDictionary)
         SetPosition(tp, offset.Offset, dirty: true);
+        if (offset.LeaderEpoch >= 0)
+            SetLastConsumedLeaderEpoch(tp, offset.LeaderEpoch);
+        else
+            ClearLastConsumedLeaderEpoch(tp);
         _fetchPositions[tp] = offset.Offset;
 
         // Reset EOF state for this partition so it can fire again
@@ -2770,6 +2849,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         foreach (var partition in partitions)
         {
             SetPosition(partition, 0, dirty: true);
+            ClearLastConsumedLeaderEpoch(partition);
             _fetchPositions[partition] = 0;
         }
 
@@ -2787,6 +2867,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         foreach (var partition in partitions)
         {
             SetPosition(partition, -1, dirty: true); // Special value meaning end
+            ClearLastConsumedLeaderEpoch(partition);
             _fetchPositions[partition] = -1; // Special value meaning end
         }
 
@@ -2810,6 +2891,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _positions.TryRemove(partition, out _);
             _dirtyPositions.TryRemove(partition, out _);
             _fetchPositions.TryRemove(partition, out _);
+            _lastConsumedLeaderEpochs.TryRemove(partition, out _);
             _committed.TryRemove(partition, out _);
             _highWatermarks.TryRemove(partition, out _);
             _watermarks.TryRemove(partition, out _);
@@ -2974,7 +3056,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private static ListOffsetsRequest CreateWatermarkListOffsetsRequest(
         TopicPartition topicPartition,
         IsolationLevel isolationLevel,
-        long timestamp) => new()
+        long timestamp,
+        int currentLeaderEpoch) => new()
         {
             ReplicaId = -1,
             IsolationLevel = isolationLevel,
@@ -2989,7 +3072,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         {
                             PartitionIndex = topicPartition.Partition,
                             Timestamp = timestamp,
-                            CurrentLeaderEpoch = -1
+                            CurrentLeaderEpoch = currentLeaderEpoch
                         }
                     ]
                 }
@@ -3037,8 +3120,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 ListOffsetsRequest.LowestSupportedVersion,
                 ListOffsetsRequest.HighestSupportedVersion);
 
-            var earliestRequest = CreateWatermarkListOffsetsRequest(topicPartition, _options.IsolationLevel, EarliestOffsetTimestamp);
-            var latestRequest = CreateWatermarkListOffsetsRequest(topicPartition, _options.IsolationLevel, LatestOffsetTimestamp);
+            var currentLeaderEpoch = GetCurrentLeaderEpoch(topicPartition);
+            var earliestRequest = CreateWatermarkListOffsetsRequest(
+                topicPartition,
+                _options.IsolationLevel,
+                EarliestOffsetTimestamp,
+                currentLeaderEpoch);
+            var latestRequest = CreateWatermarkListOffsetsRequest(
+                topicPartition,
+                _options.IsolationLevel,
+                LatestOffsetTimestamp,
+                currentLeaderEpoch);
 
             var earliestResponseTask = connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
                 earliestRequest,
@@ -3349,6 +3441,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             var offset = await GetResetOffsetAsync(partition, cancellationToken).ConfigureAwait(false);
             SetPosition(partition, offset, dirty: false);
+            ClearLastConsumedLeaderEpoch(partition);
             _fetchPositions[partition] = offset;
         }
     }
@@ -3360,18 +3453,23 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         foreach (var partition in partitions)
         {
-            if (committedOffsets.TryGetValue(partition, out var committedOffset) && committedOffset >= 0)
+            if (committedOffsets.TryGetValue(partition, out var committedOffset) && committedOffset.Offset >= 0)
             {
                 // Use committed offset
-                SetPosition(partition, committedOffset, dirty: false);
-                _fetchPositions[partition] = committedOffset;
-                _committed[partition] = committedOffset;
+                SetPosition(partition, committedOffset.Offset, dirty: false);
+                if (committedOffset.LeaderEpoch >= 0)
+                    SetLastConsumedLeaderEpoch(partition, committedOffset.LeaderEpoch);
+                else
+                    ClearLastConsumedLeaderEpoch(partition);
+                _fetchPositions[partition] = committedOffset.Offset;
+                _committed[partition] = committedOffset.Offset;
             }
             else
             {
                 // No committed offset, use auto offset reset
                 var offset = await GetResetOffsetAsync(partition, cancellationToken).ConfigureAwait(false);
                 SetPosition(partition, offset, dirty: false);
+                ClearLastConsumedLeaderEpoch(partition);
                 _fetchPositions[partition] = offset;
             }
         }
@@ -3419,6 +3517,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 var resolvedOffset = await ResolveOffsetAsync(partition, fetchPosition, cancellationToken).ConfigureAwait(false);
                 _fetchPositions[partition] = resolvedOffset;
                 SetPosition(partition, resolvedOffset, dirty: false);
+                ClearLastConsumedLeaderEpoch(partition);
             }
         }
     }
@@ -3451,7 +3550,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             {
                                 PartitionIndex = partition.Partition,
                                 Timestamp = timestamp,
-                                CurrentLeaderEpoch = -1
+                                CurrentLeaderEpoch = GetCurrentLeaderEpoch(partition)
                             }
                         ]
                     }
@@ -3871,11 +3970,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Update watermark cache from fetch response (even on errors, watermarks may be valid)
                     UpdateWatermarksFromFetchResponse(topic, partitionResponse);
 
+                    if (partitionResponse.DivergingEpoch is not null)
+                    {
+                        ResetToDivergingEpoch(topic, partitionResponse);
+                        continue;
+                    }
+
                     if (partitionResponse.ErrorCode != ErrorCode.None)
                     {
-                        if (partitionResponse.ErrorCode == ErrorCode.NotLeaderOrFollower)
+                        if (IsLeaderEpochRefreshError(partitionResponse.ErrorCode))
                         {
-                            await HandleNotLeaderOrFollowerAsync(
+                            await HandleLeaderEpochRefreshAsync(
                                 topic,
                                 partitionResponse,
                                 response.NodeEndpoints).ConfigureAwait(false);
@@ -4082,7 +4187,41 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
-    private ValueTask HandleNotLeaderOrFollowerAsync(
+    private int GetCurrentLeaderEpoch(TopicPartition partition) =>
+        _metadataManager.Metadata.GetPartitionInfo(partition.Topic, partition.Partition)?.LeaderEpoch ?? -1;
+
+    private int GetLastConsumedLeaderEpoch(TopicPartition partition) =>
+        _lastConsumedLeaderEpochs.GetValueOrDefault(partition, -1);
+
+    private void ThrowPendingFetchException()
+    {
+        if (_pendingFetchExceptions.TryDequeue(out var exception))
+            throw exception;
+    }
+
+    private void QueueFetchException(Exception exception)
+    {
+        _pendingFetchExceptions.Enqueue(exception);
+    }
+
+    private void ResetToDivergingEpoch(string topic, FetchResponsePartition partitionResponse)
+    {
+        if (partitionResponse.DivergingEpoch is not { } divergingEpoch)
+            return;
+
+        var partition = new TopicPartition(topic, partitionResponse.PartitionIndex);
+        _fetchPositions[partition] = divergingEpoch.EndOffset;
+        SetPosition(partition, divergingEpoch.EndOffset, dirty: false);
+        SetLastConsumedLeaderEpoch(partition, divergingEpoch.Epoch);
+        QueueFetchException(new Errors.ConsumeException(
+            ErrorCode.OffsetOutOfRange,
+            $"Log truncation detected for {topic}-{partitionResponse.PartitionIndex}; reset fetch position to offset {divergingEpoch.EndOffset} at leader epoch {divergingEpoch.Epoch}."));
+    }
+
+    private static bool IsLeaderEpochRefreshError(ErrorCode errorCode) =>
+        errorCode is ErrorCode.NotLeaderOrFollower or ErrorCode.FencedLeaderEpoch or ErrorCode.UnknownLeaderEpoch;
+
+    private ValueTask HandleLeaderEpochRefreshAsync(
         string topic,
         FetchResponsePartition partitionResponse,
         IReadOnlyList<NodeEndpoint> nodeEndpoints)
@@ -4101,12 +4240,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 endpoint);
 
         InvalidatePartitionCache();
-        LogNotLeaderOrFollower(topic, partitionResponse.PartitionIndex);
+        LogLeaderEpochRefresh(topic, partitionResponse.PartitionIndex, partitionResponse.ErrorCode);
 
         if (!updated)
             ScheduleLeaderRefresh(topic);
 
         return ValueTask.CompletedTask;
+    }
+
+    private ValueTask HandleNotLeaderOrFollowerAsync(
+        string topic,
+        FetchResponsePartition partitionResponse,
+        IReadOnlyList<NodeEndpoint> nodeEndpoints)
+    {
+        return HandleLeaderEpochRefreshAsync(topic, partitionResponse, nodeEndpoints);
     }
 
     private void ScheduleLeaderRefresh(string topic)
@@ -4223,7 +4370,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             // Each broker task gets its own FetchRequestPartition objects so that
             // concurrent calls cannot mutate offsets visible to another task.
             // This allocates per fetch cycle (per-batch), not per-message.
-            return BuildFetchResult(cachedDict, _fetchPositions, _adaptiveFetchSizer?.CurrentPartitionFetchBytes, _metadataManager.Metadata);
+            return BuildFetchResult(
+                cachedDict,
+                _fetchPositions,
+                _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
+                _metadataManager.Metadata,
+                _lastConsumedLeaderEpochs);
         }
 
         // Cache miss (or subrange): build fresh structure with TopicPartition stored alongside
@@ -4253,7 +4405,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Build result with fresh copies so the caller owns its own FetchRequestPartition
         // instances. The cached dict stores templates; each caller gets independent copies
         // to prevent any shared-state issues with concurrent PrefetchFromBrokerAsync calls.
-        var result = BuildFetchResult(topicPartitions, _fetchPositions, _adaptiveFetchSizer?.CurrentPartitionFetchBytes, _metadataManager.Metadata);
+        var result = BuildFetchResult(
+            topicPartitions,
+            _fetchPositions,
+            _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
+            _metadataManager.Metadata,
+            _lastConsumedLeaderEpochs);
 
         // Update cache (first writer wins to avoid overwriting fresher data) — only for full-list case
         if (isFullList)
@@ -4301,7 +4458,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>> templateDict,
         ConcurrentDictionary<TopicPartition, long> fetchPositions,
         int? adaptivePartitionMaxBytes = null,
-        ClusterMetadata? clusterMetadata = null)
+        ClusterMetadata? clusterMetadata = null,
+        ConcurrentDictionary<TopicPartition, int>? lastConsumedLeaderEpochs = null)
     {
         var result = ConsumerFetchPools.RentFetchRequestTopicList(templateDict.Count);
 
@@ -4312,12 +4470,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             foreach (var (template, tp) in cachedPartitions)
             {
+                var currentLeaderEpoch = clusterMetadata?.GetPartitionInfo(tp.Topic, tp.Partition)?.LeaderEpoch ?? -1;
                 partitionList.Add(new FetchRequestPartition
                 {
                     Partition = template.Partition,
                     FetchOffset = fetchPositions.GetValueOrDefault(tp, 0),
-                    CurrentLeaderEpoch = template.CurrentLeaderEpoch,
-                    LastFetchedEpoch = template.LastFetchedEpoch,
+                    CurrentLeaderEpoch = currentLeaderEpoch,
+                    LastFetchedEpoch = lastConsumedLeaderEpochs?.GetValueOrDefault(tp, -1) ?? -1,
                     LogStartOffset = template.LogStartOffset,
                     PartitionMaxBytes = adaptivePartitionMaxBytes ?? template.PartitionMaxBytes
                 });
@@ -4674,7 +4833,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 PartitionIndex = tpt.Partition,
                 Timestamp = tpt.Timestamp,
-                CurrentLeaderEpoch = -1
+                CurrentLeaderEpoch = GetCurrentLeaderEpoch(tpt.TopicPartition)
             });
         }
 
@@ -4872,8 +5031,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     [LoggerMessage(Level = LogLevel.Warning, Message = "OffsetOutOfRange for {Topic}-{Partition}, resetting to {Reset}")]
     private partial void LogOffsetOutOfRangeReset(string topic, int partition, string reset);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "NotLeaderOrFollower for {Topic}-{Partition}, updating leader metadata")]
-    private partial void LogNotLeaderOrFollower(string topic, int partition);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "{Error} for {Topic}-{Partition}, refreshing leader metadata")]
+    private partial void LogLeaderEpochRefresh(string topic, int partition, ErrorCode error);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Prefetch error for {Topic}-{Partition}: {Error}")]
     private partial void LogPrefetchError(string topic, int partition, ErrorCode error);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2016,7 +2016,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 list.Add(new TxnOffsetCommitRequestPartition
                 {
                     PartitionIndex = offset.Partition,
-                    CommittedOffset = offset.Offset
+                    CommittedOffset = offset.Offset,
+                    CommittedLeaderEpoch = offset.LeaderEpoch
                 });
             }
 

--- a/src/Dekaf/TopicPartition.cs
+++ b/src/Dekaf/TopicPartition.cs
@@ -8,7 +8,19 @@ public readonly record struct TopicPartition(string Topic, int Partition);
 /// <summary>
 /// Represents a topic, partition, and offset.
 /// </summary>
-public readonly record struct TopicPartitionOffset(string Topic, int Partition, long Offset);
+public readonly record struct TopicPartitionOffset(string Topic, int Partition, long Offset)
+{
+    public TopicPartitionOffset(string topic, int partition, long offset, int leaderEpoch)
+        : this(topic, partition, offset)
+    {
+        LeaderEpoch = leaderEpoch;
+    }
+
+    /// <summary>
+    /// Leader epoch associated with the offset, or -1 when unknown.
+    /// </summary>
+    public int LeaderEpoch { get; init; } = -1;
+}
 
 /// <summary>
 /// Represents a topic, partition, and timestamp for offset lookup.

--- a/tests/Dekaf.Tests.Unit/Consumer/BuildFetchResultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/BuildFetchResultTests.cs
@@ -30,7 +30,7 @@ public class BuildFetchResultTests
         return (dict, tp);
     }
 
-    private static ClusterMetadata CreateClusterMetadata(string topic, Guid topicId)
+    private static ClusterMetadata CreateClusterMetadata(string topic, Guid topicId, int leaderEpoch = -1)
     {
         var clusterMetadata = new ClusterMetadata();
         clusterMetadata.Update(new MetadataResponse
@@ -43,7 +43,18 @@ public class BuildFetchResultTests
                     Name = topic,
                     TopicId = topicId,
                     ErrorCode = ErrorCode.None,
-                    Partitions = [new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] }]
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 1,
+                            LeaderEpoch = leaderEpoch,
+                            ReplicaNodes = [1],
+                            IsrNodes = [1]
+                        }
+                    ]
                 }
             ]
         });
@@ -150,6 +161,26 @@ public class BuildFetchResultTests
         var result = KafkaConsumer<string, string>.BuildFetchResult(templateDict, fetchPositions, clusterMetadata: clusterMetadata);
 
         await Assert.That(result[0].TopicId).IsEqualTo(topicId);
+    }
+
+    [Test]
+    public async Task BuildFetchResult_WithLeaderEpochState_PopulatesFetchEpochs()
+    {
+        var topicId = Guid.NewGuid();
+        var (templateDict, tp0) = CreateSinglePartitionTemplate();
+        var fetchPositions = new ConcurrentDictionary<TopicPartition, long> { [tp0] = 42 };
+        var lastConsumedLeaderEpochs = new ConcurrentDictionary<TopicPartition, int> { [tp0] = 8 };
+        var clusterMetadata = CreateClusterMetadata("topic-a", topicId, leaderEpoch: 6);
+
+        var result = KafkaConsumer<string, string>.BuildFetchResult(
+            templateDict,
+            fetchPositions,
+            clusterMetadata: clusterMetadata,
+            lastConsumedLeaderEpochs: lastConsumedLeaderEpochs);
+
+        var partition = result[0].Partitions[0];
+        await Assert.That(partition.CurrentLeaderEpoch).IsEqualTo(6);
+        await Assert.That(partition.LastFetchedEpoch).IsEqualTo(8);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeResultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeResultTests.cs
@@ -133,6 +133,28 @@ public class ConsumeResultTests
     }
 
     [Test]
+    public async Task TopicPartitionOffset_IncludesLeaderEpoch()
+    {
+        var result = new ConsumeResult<string, string>(
+            topic: "test-topic",
+            partition: 0,
+            offset: 42,
+            keyData: default,
+            isKeyNull: true,
+            valueData: default,
+            isValueNull: true,
+            headers: null,
+            timestampMs: 0,
+            timestampType: TimestampType.CreateTime,
+            leaderEpoch: 7,
+            keyDeserializer: null,
+            valueDeserializer: null);
+
+        await Assert.That(result.TopicPartitionOffset)
+            .IsEqualTo(new TopicPartitionOffset("test-topic", 0, 42, 7));
+    }
+
+    [Test]
     public async Task LazyConsumeHeaders_CountDoesNotMaterialize()
     {
         var pooledHeaders = new[]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -95,6 +95,20 @@ public sealed class ConsumerDirtyCommitTests
         await Assert.That(requests).IsEmpty();
     }
 
+    [Test]
+    public async Task CommitAsync_ExplicitLeaderEpoch_SendsCommittedLeaderEpoch()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(requests, ErrorCode.None);
+
+        await consumer.CommitAsync(
+            [new TopicPartitionOffset("topic-a", 0, 42, leaderEpoch: 7)],
+            CancellationToken.None);
+
+        var partition = requests.Single().Topics.Single().Partitions.Single();
+        await Assert.That(partition.CommittedLeaderEpoch).IsEqualTo(7);
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer(
         List<OffsetCommitRequest> requests,
         ErrorCode responseError)
@@ -171,7 +185,8 @@ public sealed class ConsumerDirtyCommitTests
                         .Select(static partition => new OffsetCommitRequestPartition
                         {
                             PartitionIndex = partition.PartitionIndex,
-                            CommittedOffset = partition.CommittedOffset
+                            CommittedOffset = partition.CommittedOffset,
+                            CommittedLeaderEpoch = partition.CommittedLeaderEpoch
                         })
                         .ToArray()
                 })
@@ -203,7 +218,11 @@ public sealed class ConsumerDirtyCommitTests
     {
         return request.Topics
             .SelectMany(static topic => topic.Partitions.Select(partition =>
-                new TopicPartitionOffset(topic.Name, partition.PartitionIndex, partition.CommittedOffset)))
+                new TopicPartitionOffset(
+                    topic.Name,
+                    partition.PartitionIndex,
+                    partition.CommittedOffset,
+                    partition.CommittedLeaderEpoch)))
             .OrderBy(static offset => offset.Topic, StringComparer.Ordinal)
             .ThenBy(static offset => offset.Partition)
             .ThenBy(static offset => offset.Offset)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
@@ -164,6 +165,31 @@ public sealed class ConsumerLeaderDiscoveryTests
 
         refreshResponse.SetResult(CreateMetadataResponse());
         await WaitForLeaderRefreshToDrainAsync(consumer);
+    }
+
+    [Test]
+    public async Task ResetToDivergingEpoch_RepositionsAndQueuesConsumeException()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+
+        var partitionResponse = new FetchResponsePartition
+        {
+            PartitionIndex = 0,
+            DivergingEpoch = new EpochEndOffset
+            {
+                Epoch = 7,
+                EndOffset = 42
+            }
+        };
+
+        InvokeResetToDivergingEpoch(consumer, partitionResponse);
+
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(42);
+        var exception = DrainPendingFetchException(consumer);
+        await Assert.That(exception).IsTypeOf<ConsumeException>();
+        await Assert.That(((ConsumeException)exception!).ErrorCode).IsEqualTo(ErrorCode.OffsetOutOfRange);
     }
 
     [Test]
@@ -334,5 +360,33 @@ public sealed class ConsumerLeaderDiscoveryTests
             throw new InvalidOperationException("HandleNotLeaderOrFollowerAsync did not return ValueTask");
 
         await valueTask.ConfigureAwait(false);
+    }
+
+    private static void InvokeResetToDivergingEpoch(
+        KafkaConsumer<string, string> consumer,
+        FetchResponsePartition partitionResponse)
+    {
+        var method = typeof(KafkaConsumer<string, string>)
+            .GetMethod("ResetToDivergingEpoch", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ResetToDivergingEpoch method not found");
+
+        method.Invoke(consumer, [Topic, partitionResponse]);
+    }
+
+    private static Exception? DrainPendingFetchException(KafkaConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaConsumer<string, string>)
+            .GetMethod("ThrowPendingFetchException", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ThrowPendingFetchException method not found");
+
+        try
+        {
+            method.Invoke(consumer, []);
+            return null;
+        }
+        catch (TargetInvocationException ex)
+        {
+            return ex.InnerException;
+        }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsTests.cs
@@ -52,6 +52,10 @@ public sealed class QueryWatermarkOffsetsTests
             {
                 var request = ci.Arg<ListOffsetsRequest>();
                 var timestamp = request.Topics[0].Partitions[0].Timestamp;
+                var currentLeaderEpoch = request.Topics[0].Partitions[0].CurrentLeaderEpoch;
+
+                if (currentLeaderEpoch != 3)
+                    throw new InvalidOperationException($"Unexpected CurrentLeaderEpoch {currentLeaderEpoch}");
 
                 if (timestamp == EarliestOffsetTimestamp)
                     earliestStarted.TrySetResult();
@@ -133,6 +137,7 @@ public sealed class QueryWatermarkOffsetsTests
                     {
                         PartitionIndex = Partition,
                         LeaderId = 0,
+                        LeaderEpoch = 3,
                         ErrorCode = ErrorCode.None,
                         ReplicaNodes = [0],
                         IsrNodes = [0]

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -345,6 +345,7 @@ public class MetadataManagerTests
     [Test]
     public async Task DisposeAsync_CancelsBackgroundRefreshCtsCreatedWhileInitializationDrains()
     {
+        var timeout = TimeSpan.FromSeconds(15);
         var manager = new MetadataManager(
             Substitute.For<IConnectionPool>(),
             ["localhost:9092"],
@@ -359,14 +360,14 @@ public class MetadataManagerTests
         SetInstanceField(manager, "_backgroundRefreshCts", firstCts);
 
         var disposeTask = manager.DisposeAsync().AsTask();
-        await firstCancelObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await firstCancelObserved.Task.WaitAsync(timeout);
         await Assert.That(disposeTask.IsCompleted).IsFalse();
 
         var racedCts = new CancellationTokenSource();
         SetInstanceField(manager, "_backgroundRefreshCts", racedCts);
         initializeLock.Release();
 
-        await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await disposeTask.WaitAsync(timeout);
 
         await Assert.That(racedCts.IsCancellationRequested).IsTrue();
     }


### PR DESCRIPTION
## Summary
- track current and last-fetched leader epochs on consumer fetch and ListOffsets requests
- surface fetch diverging epochs as consumer-visible truncation errors while repositioning to the broker-provided end offset
- carry leader epochs through consumed results, offset commits, offset fetches, and transactional offset commits

## Test plan
- [x] dotnet build --configuration Release
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit (3845 passed)
- [x] ./tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration --treenode-filter /*/*/ConsumerTests/* (87 passed)
- [ ] Full integration suite attempted; timed out after 10 minutes before producing a final summary. Testcontainers from that run were cleaned up.

Closes #1150
