### PR TITLE
feat(consumer): add rack-aware fetching

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1027,6 +1027,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private string? _groupId;
     private string? _groupInstanceId;
     private string? _groupRemoteAssignor;
+    private string? _clientRack;
     private OffsetCommitMode _offsetCommitMode = OffsetCommitMode.Auto;
     private int _autoCommitIntervalMs = 5000;
     private AutoOffsetReset _autoOffsetReset = AutoOffsetReset.Latest;
@@ -1117,6 +1118,16 @@ public sealed class ConsumerBuilder<TKey, TValue>
     public ConsumerBuilder<TKey, TValue> WithGroupInstanceId(string groupInstanceId)
     {
         _groupInstanceId = groupInstanceId;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the consumer rack ID used for rack-aware assignment and preferred read-replica fetching.
+    /// </summary>
+    /// <param name="clientRack">The logical rack ID for this consumer.</param>
+    public ConsumerBuilder<TKey, TValue> WithClientRack(string clientRack)
+    {
+        _clientRack = clientRack ?? throw new ArgumentNullException(nameof(clientRack));
         return this;
     }
 
@@ -1923,6 +1934,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             GroupId = _groupId,
             GroupInstanceId = _groupInstanceId,
             GroupRemoteAssignor = _groupRemoteAssignor,
+            ClientRack = _clientRack,
             OffsetCommitMode = _offsetCommitMode,
             AutoCommitIntervalMs = _autoCommitIntervalMs,
             AutoOffsetReset = _autoOffsetReset,

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -658,6 +658,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             MemberEpoch = memberEpoch,
             InstanceId = _options.GroupInstanceId,
             RebalanceTimeoutMs = isInitial ? _options.RebalanceTimeoutMs : -1,
+            RackId = isInitial ? _options.ClientRack : null,
             SubscribedTopicNames = subscribedTopics,
             ServerAssignor = isInitial ? _options.GroupRemoteAssignor : null,
             TopicPartitions = ownedTopicPartitions

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -59,6 +59,12 @@ public sealed class ConsumerOptions
     public string? GroupRemoteAssignor { get; init; }
 
     /// <summary>
+    /// Logical rack ID of this consumer. Brokers use this for rack-aware assignment and
+    /// preferred read-replica selection when the cluster has rack metadata configured.
+    /// </summary>
+    public string? ClientRack { get; init; }
+
+    /// <summary>
     /// Offset commit mode controlling how offsets are stored and committed.
     /// Default is <see cref="OffsetCommitMode.Auto"/>.
     /// </summary>

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -709,7 +709,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private bool ShouldUseFetchSessions => _options.EnableFetchSessions && !_options.EnablePartitionEof;
 
     // Cached partition grouping by broker to avoid allocations on every fetch
-    // Invalidated whenever _assignment or _paused changes
+    // Invalidated whenever _assignment, _paused, or preferred read replicas change.
     // Access to _cachedPartitionsByBroker must be synchronized via _partitionCacheLock
     private Dictionary<int, List<TopicPartition>>? _cachedPartitionsByBroker;
     private readonly object _partitionCacheLock = new();
@@ -720,11 +720,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly object _fetchCacheLock = new();
     private Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>>? _cachedTopicPartitions;
     private List<TopicPartition>? _cachedPartitionsList;
+    private readonly ConcurrentDictionary<TopicPartition, PreferredReadReplicaState> _preferredReadReplicas = new();
     private readonly object _leaderRefreshTasksLock = new();
     private readonly ConcurrentDictionary<string, Task> _pendingLeaderRefreshTasks = new();
     private int _assignmentEnsureVersion;
     private int _lastManualAssignmentEnsureVersion = -1;
     private int _lastCoordinatorAssignmentVersion = -1;
+
+    private static readonly long s_preferredReadReplicaMaxAgeTimestampDelta =
+        (long)(TimeSpan.FromMinutes(5).TotalSeconds * Stopwatch.Frequency);
+
+    private readonly record struct PreferredReadReplicaState(
+        int ReplicaId,
+        DateTimeOffset MetadataLastRefreshed,
+        long ExpiresAtTimestamp);
 
     public KafkaConsumer(
         ConsumerOptions options,
@@ -1935,6 +1944,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             // Transient errors (connection timeouts, broker unavailable, etc.) — log and
             // suppress. The pipeline retries on the next cycle, and in multi-broker setups
             // other brokers may still succeed in this cycle.
+            ClearPreferredReadReplicasForBroker(brokerId, partitions, partitionStartIndex, partitionCount);
             LogPrefetchFromBrokerError(ex, brokerId);
         }
     }
@@ -2032,6 +2042,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             request.MinBytes = _options.FetchMinBytes;
             request.MaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes;
             request.IsolationLevel = _options.IsolationLevel;
+            request.RackId = _options.ClientRack;
             request.Topics = fetchSessionBuild?.Topics ?? topicData;
             request.ForgottenTopicsData = fetchSessionBuild?.ForgottenTopicsData;
             request.SessionId = fetchSessionBuild?.SessionId ?? 0;
@@ -2067,6 +2078,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (response.ErrorCode != ErrorCode.None)
             {
                 fetchSessionHandler?.HandleResponse(response);
+                ClearPreferredReadReplicasForBroker(brokerId, partitions, partitionStartIndex, partitionCount);
                 LogFetchSessionError(brokerId, response.ErrorCode);
                 response.ReturnToPool();
                 memoryOwner?.Dispose();
@@ -2097,6 +2109,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         // Update watermark cache from fetch response (even on errors, watermarks may be valid)
                         UpdateWatermarksFromFetchResponse(topic, partitionResponse);
+                        UpdatePreferredReadReplica(topic, partitionResponse);
 
                         if (partitionResponse.DivergingEpoch is not null)
                         {
@@ -3733,6 +3746,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
         catch (Exception ex)
         {
+            ClearPreferredReadReplicasForBroker(brokerId, partitions);
             LogFetchFromBrokerError(ex, brokerId);
             return null;
         }
@@ -3791,7 +3805,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         lock (_partitionCacheLock)
         {
-            if (_cachedPartitionsByBroker is not null)
+            if (_cachedPartitionsByBroker is not null && _preferredReadReplicas.IsEmpty)
             {
                 return _cachedPartitionsByBroker;
             }
@@ -3813,17 +3827,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
         }
 
-        // Build the cache outside the lock - allocate once per assignment change
-        // Resolve all partition leaders in parallel for maximum throughput
-        var leaderTasks = ArrayPool<Task<(TopicPartition Partition, BrokerNode? Leader)>>.Shared.Rent(assignmentCount);
+        // Build the cache outside the lock - allocate once per assignment change.
+        // Resolve all partition fetch brokers in parallel for maximum throughput.
+        var brokerTasks = ArrayPool<Task<(TopicPartition Partition, BrokerNode? Broker)>>.Shared.Rent(assignmentCount);
         try
         {
             for (var i = 0; i < assignmentCount; i++)
             {
-                leaderTasks[i] = ResolvePartitionLeaderAsync(assignmentArray[i], cancellationToken);
+                brokerTasks[i] = ResolvePartitionFetchBrokerAsync(assignmentArray[i], cancellationToken);
             }
 
-            await Task.WhenAll(new ReadOnlySpan<Task<(TopicPartition Partition, BrokerNode? Leader)>>(leaderTasks, 0, assignmentCount)).ConfigureAwait(false);
+            await Task.WhenAll(new ReadOnlySpan<Task<(TopicPartition Partition, BrokerNode? Broker)>>(brokerTasks, 0, assignmentCount)).ConfigureAwait(false);
         }
         finally
         {
@@ -3834,21 +3848,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var result = new Dictionary<int, List<TopicPartition>>();
         for (var i = 0; i < assignmentCount; i++)
         {
-            var (partition, leader) = leaderTasks[i].Result;
-            if (leader is null)
+            var (partition, broker) = brokerTasks[i].Result;
+            if (broker is null)
                 continue;
 
-            if (!result.TryGetValue(leader.NodeId, out var list))
+            if (!result.TryGetValue(broker.NodeId, out var list))
             {
                 list = [];
-                result[leader.NodeId] = list;
+                result[broker.NodeId] = list;
             }
 
             list.Add(partition);
         }
 
         // Return pooled array after extracting results
-        ArrayPool<Task<(TopicPartition Partition, BrokerNode? Leader)>>.Shared.Return(leaderTasks, clearArray: true);
+        ArrayPool<Task<(TopicPartition Partition, BrokerNode? Broker)>>.Shared.Return(brokerTasks, clearArray: true);
 
         // Cache the result - will be reused until assignment/paused changes.
         // Don't cache empty results: an empty dictionary means partition leaders
@@ -3858,6 +3872,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         lock (_partitionCacheLock)
         {
             if (result.Count > 0 && _cachedPartitionsByBroker is null
+                && _preferredReadReplicas.IsEmpty
                 && Volatile.Read(ref _assignmentVersion) == capturedVersion)
             {
                 _cachedPartitionsByBroker = result;
@@ -3866,13 +3881,44 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
-    private async Task<(TopicPartition Partition, BrokerNode? Leader)> ResolvePartitionLeaderAsync(
+    private async Task<(TopicPartition Partition, BrokerNode? Broker)> ResolvePartitionFetchBrokerAsync(
         TopicPartition partition,
         CancellationToken cancellationToken)
     {
         var leader = await _metadataManager.GetPartitionLeaderAsync(
             partition.Topic, partition.Partition, cancellationToken).ConfigureAwait(false);
-        return (partition, leader);
+        if (leader is null)
+            return (partition, null);
+
+        return (partition, GetPreferredReadReplicaBrokerOrLeader(partition, leader));
+    }
+
+    private BrokerNode GetPreferredReadReplicaBrokerOrLeader(TopicPartition partition, BrokerNode leader)
+    {
+        if (string.IsNullOrEmpty(_options.ClientRack)
+            || !_preferredReadReplicas.TryGetValue(partition, out var preferred))
+        {
+            return leader;
+        }
+
+        var now = Stopwatch.GetTimestamp();
+        var metadata = _metadataManager.Metadata;
+        if (preferred.ExpiresAtTimestamp <= now
+            || preferred.MetadataLastRefreshed != metadata.LastRefreshed)
+        {
+            ClearPreferredReadReplica(partition);
+            return leader;
+        }
+
+        var preferredBroker = metadata.GetBroker(preferred.ReplicaId);
+        if (preferredBroker is null)
+        {
+            ClearPreferredReadReplica(partition);
+            return leader;
+        }
+
+        LogUsingPreferredReadReplica(partition.Topic, partition.Partition, preferred.ReplicaId, leader.NodeId);
+        return preferredBroker;
     }
 
     private async ValueTask<List<PendingFetchData>?> FetchFromBrokerAsync(int brokerId, List<TopicPartition> partitions, CancellationToken cancellationToken)
@@ -3909,6 +3955,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         request.MinBytes = _options.FetchMinBytes;
         request.MaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes;
         request.IsolationLevel = _options.IsolationLevel;
+        request.RackId = _options.ClientRack;
         request.Topics = fetchSessionBuild?.Topics ?? topicData;
         request.ForgottenTopicsData = fetchSessionBuild?.ForgottenTopicsData;
         request.SessionId = fetchSessionBuild?.SessionId ?? 0;
@@ -3944,6 +3991,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (response.ErrorCode != ErrorCode.None)
         {
             fetchSessionHandler?.HandleResponse(response);
+            ClearPreferredReadReplicasForBroker(brokerId, partitions);
             LogFetchSessionError(brokerId, response.ErrorCode);
             response.ReturnToPool();
             memoryOwner?.Dispose();
@@ -3969,6 +4017,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                     // Update watermark cache from fetch response (even on errors, watermarks may be valid)
                     UpdateWatermarksFromFetchResponse(topic, partitionResponse);
+                    UpdatePreferredReadReplica(topic, partitionResponse);
 
                     if (partitionResponse.DivergingEpoch is not null)
                     {
@@ -4226,6 +4275,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         FetchResponsePartition partitionResponse,
         IReadOnlyList<NodeEndpoint> nodeEndpoints)
     {
+        ClearPreferredReadReplica(new TopicPartition(topic, partitionResponse.PartitionIndex));
+
         var currentLeader = partitionResponse.CurrentLeader;
         var endpoint = currentLeader is null
             ? null
@@ -4254,6 +4305,84 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         IReadOnlyList<NodeEndpoint> nodeEndpoints)
     {
         return HandleLeaderEpochRefreshAsync(topic, partitionResponse, nodeEndpoints);
+    }
+
+    private void UpdatePreferredReadReplica(string topic, FetchResponsePartition partitionResponse)
+    {
+        var partition = new TopicPartition(topic, partitionResponse.PartitionIndex);
+
+        if (partitionResponse.ErrorCode != ErrorCode.None)
+        {
+            ClearPreferredReadReplica(partition);
+            return;
+        }
+
+        if (string.IsNullOrEmpty(_options.ClientRack)
+            || partitionResponse.PreferredReadReplica < 0)
+        {
+            ClearPreferredReadReplica(partition);
+            return;
+        }
+
+        var metadata = _metadataManager.Metadata;
+        var partitionInfo = metadata.GetPartitionInfo(topic, partitionResponse.PartitionIndex);
+        if (partitionInfo is not null && partitionResponse.PreferredReadReplica == partitionInfo.LeaderId)
+        {
+            ClearPreferredReadReplica(partition);
+            return;
+        }
+
+        if (metadata.GetBroker(partitionResponse.PreferredReadReplica) is null)
+        {
+            ClearPreferredReadReplica(partition);
+            return;
+        }
+
+        var state = new PreferredReadReplicaState(
+            partitionResponse.PreferredReadReplica,
+            metadata.LastRefreshed,
+            Stopwatch.GetTimestamp() + s_preferredReadReplicaMaxAgeTimestampDelta);
+
+        var changed = !_preferredReadReplicas.TryGetValue(partition, out var existing)
+            || existing.ReplicaId != state.ReplicaId;
+
+        _preferredReadReplicas[partition] = state;
+
+        if (changed)
+        {
+            InvalidatePartitionCache();
+            LogPreferredReadReplicaSelected(topic, partitionResponse.PartitionIndex, state.ReplicaId);
+        }
+    }
+
+    private void ClearPreferredReadReplica(TopicPartition partition)
+    {
+        if (_preferredReadReplicas.TryRemove(partition, out var existing))
+        {
+            InvalidatePartitionCache();
+            LogPreferredReadReplicaCleared(partition.Topic, partition.Partition, existing.ReplicaId);
+        }
+    }
+
+    private void ClearPreferredReadReplicasForBroker(int brokerId, IReadOnlyList<TopicPartition> partitions)
+        => ClearPreferredReadReplicasForBroker(brokerId, partitions, 0, partitions.Count);
+
+    private void ClearPreferredReadReplicasForBroker(
+        int brokerId,
+        IReadOnlyList<TopicPartition> partitions,
+        int startIndex,
+        int count)
+    {
+        var endIndex = startIndex + count;
+        for (var i = startIndex; i < endIndex; i++)
+        {
+            var partition = partitions[i];
+            if (_preferredReadReplicas.TryGetValue(partition, out var existing)
+                && existing.ReplicaId == brokerId)
+            {
+                ClearPreferredReadReplica(partition);
+            }
+        }
     }
 
     private void ScheduleLeaderRefresh(string topic)
@@ -5033,6 +5162,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "{Error} for {Topic}-{Partition}, refreshing leader metadata")]
     private partial void LogLeaderEpochRefresh(string topic, int partition, ErrorCode error);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Preferred read replica {ReplicaId} selected for {Topic}-{Partition}")]
+    private partial void LogPreferredReadReplicaSelected(string topic, int partition, int replicaId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Preferred read replica {ReplicaId} cleared for {Topic}-{Partition}")]
+    private partial void LogPreferredReadReplicaCleared(string topic, int partition, int replicaId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Fetching {Topic}-{Partition} from preferred read replica {ReplicaId} instead of leader {LeaderId}")]
+    private partial void LogUsingPreferredReadReplica(string topic, int partition, int replicaId, int leaderId);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Prefetch error for {Topic}-{Partition}: {Error}")]
     private partial void LogPrefetchError(string topic, int partition, ErrorCode error);

--- a/tests/Dekaf.Tests.Integration/ConsumerRackAwarenessIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerRackAwarenessIntegrationTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Concurrent;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Consumer")]
+[ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ConsumerRackAwarenessIntegrationTests(RackAwareKafkaContainer kafka)
+{
+    [Test]
+    public async Task Consumer_WithClientRack_FetchesFromPreferredReadReplica()
+    {
+        var topic = await kafka.CreateTopicWithRemoteLeaderAndLocalFollowerAsync().ConfigureAwait(false);
+
+        await ProduceAsync(kafka.BootstrapServers, topic, key: "first", value: "first").ConfigureAwait(false);
+
+        using var logs = new CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Debug);
+            builder.AddProvider(logs);
+        });
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"rack-aware-consumer-{Guid.NewGuid():N}")
+            .WithClientRack("rack-a")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithLoggerFactory(loggerFactory)
+            .BuildAsync()
+            .ConfigureAwait(false);
+
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var first = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token).ConfigureAwait(false);
+        await Assert.That(first).IsNotNull();
+        await Assert.That(first!.Value.Value).IsEqualTo("first");
+
+        await ProduceAsync(kafka.BootstrapServers, topic, key: "second", value: "second").ConfigureAwait(false);
+
+        var second = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token).ConfigureAwait(false);
+        await Assert.That(second).IsNotNull();
+        await Assert.That(second!.Value.Value).IsEqualTo("second");
+
+        await WaitForPreferredReadReplicaLogAsync(logs, topic).ConfigureAwait(false);
+    }
+
+    private static async Task ProduceAsync(string bootstrapServers, string topic, string key, string value)
+    {
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(bootstrapServers)
+            .WithClientId($"rack-aware-producer-{Guid.NewGuid():N}")
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync()
+            .ConfigureAwait(false);
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Partition = 0,
+            Key = key,
+            Value = value
+        }, CancellationToken.None).ConfigureAwait(false);
+
+        await producer.FlushWithTimeoutAsync().ConfigureAwait(false);
+    }
+
+    private static async Task WaitForPreferredReadReplicaLogAsync(
+        CapturingLoggerProvider logs,
+        string topic)
+    {
+        for (var attempt = 0; attempt < 50; attempt++)
+        {
+            if (logs.Messages.Any(message =>
+                message.Contains($"Fetching {topic}-0 from preferred read replica 2 instead of leader 1",
+                    StringComparison.Ordinal)))
+            {
+                return;
+            }
+
+            await Task.Delay(100).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException("Consumer did not fetch from preferred read replica 2.");
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<string> _messages = new();
+
+        public IReadOnlyCollection<string> Messages => _messages;
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(_messages);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class CapturingLogger(ConcurrentQueue<string> messages) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+                return;
+
+            messages.Enqueue(formatter(state, exception));
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -1,0 +1,201 @@
+using System.Net;
+using System.Net.Sockets;
+using Dekaf.Admin;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using TUnit.Core.Interfaces;
+
+namespace Dekaf.Tests.Integration;
+
+public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposable
+{
+    private const string Image = "apache/kafka:4.2.0";
+    private const int InternalBrokerPort = 9092;
+    private const int ControllerPort = 9093;
+    private const int ExternalBrokerPort = 19092;
+
+    private readonly string _resourceSuffix = Guid.NewGuid().ToString("N")[..12];
+    private readonly int[] _hostPorts = GetFreeTcpPorts(3);
+    private readonly IContainer[] _brokers = new IContainer[3];
+    private INetwork? _network;
+
+    public string BootstrapServers => string.Join(",", _hostPorts.Select(port => $"127.0.0.1:{port}"));
+
+    public async Task InitializeAsync()
+    {
+        _network = new NetworkBuilder()
+            .WithName($"dekaf-rack-{_resourceSuffix}")
+            .Build();
+
+        await _network.CreateAsync().ConfigureAwait(false);
+
+        _brokers[0] = CreateBroker(nodeId: 1, rack: "rack-b", externalPort: _hostPorts[0]);
+        _brokers[1] = CreateBroker(nodeId: 2, rack: "rack-a", externalPort: _hostPorts[1]);
+        _brokers[2] = CreateBroker(nodeId: 3, rack: "rack-a", externalPort: _hostPorts[2]);
+
+        await Task.WhenAll(_brokers.Select(broker => broker.StartAsync())).ConfigureAwait(false);
+        await WaitForClusterAsync().ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var broker in _brokers.Reverse())
+        {
+            if (broker is not null)
+                await broker.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (_network is not null)
+            await _network.DisposeAsync().ConfigureAwait(false);
+    }
+
+    public IAdminClient CreateAdminClient()
+    {
+        return Kafka.CreateAdminClient()
+            .WithBootstrapServers(BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .Build();
+    }
+
+    public async Task<string> CreateTopicWithRemoteLeaderAndLocalFollowerAsync()
+    {
+        var topic = $"rack-aware-{Guid.NewGuid():N}";
+        await using var admin = CreateAdminClient();
+
+        await admin.CreateTopicsAsync([
+            new NewTopic
+            {
+                Name = topic,
+                NumPartitions = -1,
+                ReplicationFactor = -1,
+                ReplicaAssignments = new Dictionary<int, IReadOnlyList<int>>
+                {
+                    [0] = [1, 2]
+                },
+                Configs = new Dictionary<string, string>
+                {
+                    ["min.insync.replicas"] = "1"
+                }
+            }
+        ]).ConfigureAwait(false);
+
+        await WaitForTopicAssignmentAsync(admin, topic).ConfigureAwait(false);
+        return topic;
+    }
+
+    private IContainer CreateBroker(int nodeId, string rack, int externalPort)
+    {
+        var brokerAlias = BrokerAlias(nodeId);
+
+        return new ContainerBuilder(Image)
+            .WithName($"dekaf-rack-{_resourceSuffix}-{brokerAlias}")
+            .WithHostname(brokerAlias)
+            .WithNetwork(_network!)
+            .WithNetworkAliases(brokerAlias)
+            .WithPortBinding(externalPort, ExternalBrokerPort)
+            .WithEnvironment(CreateBrokerEnvironment(nodeId, rack, externalPort))
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(ExternalBrokerPort))
+            .Build();
+    }
+
+    private static IReadOnlyDictionary<string, string> CreateBrokerEnvironment(int nodeId, string rack, int externalPort)
+    {
+        return new Dictionary<string, string>
+        {
+            ["KAFKA_CLUSTER_ID"] = "MkU3OEVBNTcwNTJENDM2Qk",
+            ["KAFKA_NODE_ID"] = nodeId.ToString(),
+            ["KAFKA_PROCESS_ROLES"] = "broker,controller",
+            ["KAFKA_CONTROLLER_QUORUM_VOTERS"] = string.Join(",", Enumerable.Range(1, 3)
+                .Select(id => $"{id}@{BrokerAlias(id)}:{ControllerPort}")),
+            ["KAFKA_LISTENERS"] =
+                $"PLAINTEXT://0.0.0.0:{InternalBrokerPort},CONTROLLER://0.0.0.0:{ControllerPort},EXTERNAL://0.0.0.0:{ExternalBrokerPort}",
+            ["KAFKA_ADVERTISED_LISTENERS"] =
+                $"PLAINTEXT://{BrokerAlias(nodeId)}:{InternalBrokerPort},EXTERNAL://127.0.0.1:{externalPort}",
+            ["KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"] = "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT",
+            ["KAFKA_INTER_BROKER_LISTENER_NAME"] = "PLAINTEXT",
+            ["KAFKA_CONTROLLER_LISTENER_NAMES"] = "CONTROLLER",
+            ["KAFKA_BROKER_RACK"] = rack,
+            ["KAFKA_REPLICA_SELECTOR_CLASS"] = "org.apache.kafka.common.replica.RackAwareReplicaSelector",
+            ["KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR"] = "3",
+            ["KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS"] = "3",
+            ["KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR"] = "3",
+            ["KAFKA_TRANSACTION_STATE_LOG_MIN_ISR"] = "2",
+            ["KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS"] = "0",
+            ["KAFKA_AUTO_CREATE_TOPICS_ENABLE"] = "false",
+            ["KAFKA_LOG_RETENTION_MS"] = "30000",
+            ["KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS"] = "10000",
+            ["KAFKA_LOG_SEGMENT_BYTES"] = "1048576",
+            ["KAFKA_LOG_CLEANUP_POLICY"] = "delete",
+            ["KAFKA_HEAP_OPTS"] = "-Xmx384m -Xms384m"
+        };
+    }
+
+    private async Task WaitForClusterAsync()
+    {
+        Exception? lastError = null;
+        for (var attempt = 0; attempt < 90; attempt++)
+        {
+            try
+            {
+                await using var admin = CreateAdminClient();
+                var cluster = await admin.DescribeClusterAsync().ConfigureAwait(false);
+                if (cluster.Nodes.Count == 3)
+                    return;
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+            }
+
+            await Task.Delay(1000).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException(
+            $"Rack-aware Kafka cluster was not ready after 90s. Last error: {lastError?.Message}");
+    }
+
+    private static async Task WaitForTopicAssignmentAsync(IAdminClient admin, string topic)
+    {
+        for (var attempt = 0; attempt < 60; attempt++)
+        {
+            var descriptions = await admin.DescribeTopicsAsync([topic]).ConfigureAwait(false);
+            var partition = descriptions[topic].Partitions.Single();
+
+            if (partition.LeaderId == 1
+                && partition.ReplicaNodes.SequenceEqual([1, 2])
+                && partition.IsrNodes.Contains(2))
+            {
+                return;
+            }
+
+            await Task.Delay(500).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException($"Topic '{topic}' did not get expected rack-aware assignment.");
+    }
+
+    private static int[] GetFreeTcpPorts(int count)
+    {
+        var listeners = new TcpListener[count];
+        try
+        {
+            for (var i = 0; i < count; i++)
+            {
+                listeners[i] = new TcpListener(IPAddress.Loopback, 0);
+                listeners[i].Start();
+            }
+
+            return listeners
+                .Select(listener => ((IPEndPoint)listener.LocalEndpoint).Port)
+                .ToArray();
+        }
+        finally
+        {
+            foreach (var listener in listeners)
+                listener?.Stop();
+        }
+    }
+
+    private static string BrokerAlias(int nodeId) => $"broker-{nodeId}";
+}

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -97,6 +97,26 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task WithClientRack_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+        var result = builder.WithClientRack("rack-a");
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithClientRack_SetsOptions()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithClientRack("rack-a")
+            .Build();
+
+        var options = GetConsumerOptions(consumer);
+        await Assert.That(options.ClientRack).IsEqualTo("rack-a");
+    }
+
+    [Test]
     public async Task SubscribeTo_Single_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateConsumer<string, string>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -87,6 +87,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         IRebalanceListener? rebalanceListener = null,
         string? groupInstanceId = null,
         string? groupRemoteAssignor = null,
+        string? clientRack = null,
         int heartbeatIntervalMs = 3000,
         int rebalanceTimeoutMs = 30000) => new()
         {
@@ -94,6 +95,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             GroupId = groupId,
             GroupRemoteAssignor = groupRemoteAssignor,
             GroupInstanceId = groupInstanceId,
+            ClientRack = clientRack,
             RebalanceListener = rebalanceListener,
             HeartbeatIntervalMs = heartbeatIntervalMs,
             RebalanceTimeoutMs = rebalanceTimeoutMs
@@ -921,6 +923,21 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
         await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
             Arg.Is<ConsumerGroupHeartbeatRequest>(r => r.InstanceId == "static-instance-1"),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_InitialJoin_SendsClientRack()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(clientRack: "rack-a");
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(r => r.RackId == "rack-a"),
             Arg.Any<short>(),
             Arg.Any<CancellationToken>());
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerRackAwarenessTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerRackAwarenessTests.cs
@@ -1,0 +1,364 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerRackAwarenessTests
+{
+    private const string Topic = "rack-aware-topic";
+    private static readonly TopicPartition Partition = new(Topic, 0);
+
+    [Test]
+    public async Task FetchRequest_WithClientRack_SendsRackId()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        string? capturedRackId = null;
+
+        connection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedRackId = callInfo.Arg<FetchRequest>().RackId;
+                return ValueTask.FromResult(CreateFetchResponse(preferredReadReplica: -1));
+            });
+
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager, clientRack: "rack-a");
+
+        await InvokeFetchFromBrokerAsync(consumer, brokerId: 1, [Partition]);
+
+        await Assert.That(capturedRackId).IsEqualTo("rack-a");
+    }
+
+    [Test]
+    public async Task PreferredReadReplica_RoutesNextFetchToPreferredBroker()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+
+        connection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateFetchResponse(preferredReadReplica: 2)));
+
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager, clientRack: "rack-a");
+        consumer.Assign(Partition);
+
+        var initialGroups = await InvokeGroupPartitionsByBrokerAsync(consumer);
+        await Assert.That(initialGroups).ContainsKey(1);
+
+        await InvokeFetchFromBrokerAsync(consumer, brokerId: 1, [Partition]);
+
+        var preferredGroups = await InvokeGroupPartitionsByBrokerAsync(consumer);
+        await Assert.That(preferredGroups).ContainsKey(2);
+        await Assert.That(preferredGroups).DoesNotContainKey(1);
+    }
+
+    [Test]
+    public async Task PreferredReadReplica_FetchErrorFallsBackToLeader()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var leaderConnection = Substitute.For<IKafkaConnection>();
+        var preferredConnection = Substitute.For<IKafkaConnection>();
+
+        leaderConnection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateFetchResponse(preferredReadReplica: 2)));
+
+        preferredConnection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateFetchResponse(
+                preferredReadReplica: -1,
+                errorCode: ErrorCode.UnknownServerError)));
+
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(leaderConnection));
+        pool.GetConnectionByIndexAsync(2, 0, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(preferredConnection));
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager, clientRack: "rack-a");
+        consumer.Assign(Partition);
+
+        await InvokeFetchFromBrokerAsync(consumer, brokerId: 1, [Partition]);
+        var preferredGroups = await InvokeGroupPartitionsByBrokerAsync(consumer);
+        await Assert.That(preferredGroups).ContainsKey(2);
+
+        await InvokeFetchFromBrokerAsync(consumer, brokerId: 2, [Partition]);
+
+        var fallbackGroups = await InvokeGroupPartitionsByBrokerAsync(consumer);
+        await Assert.That(fallbackGroups).ContainsKey(1);
+        await Assert.That(fallbackGroups).DoesNotContainKey(2);
+    }
+
+    [Test]
+    public async Task PreferredReadReplica_BrokerFailureFallsBackToLeader()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var leaderConnection = Substitute.For<IKafkaConnection>();
+        var preferredConnection = Substitute.For<IKafkaConnection>();
+
+        leaderConnection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateFetchResponse(preferredReadReplica: 2)));
+
+        preferredConnection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromException<FetchResponse>(new InvalidOperationException("preferred broker unavailable")));
+
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(leaderConnection));
+        pool.GetConnectionByIndexAsync(2, 0, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(preferredConnection));
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager, clientRack: "rack-a");
+        consumer.Assign(Partition);
+
+        await InvokeFetchFromBrokerAsync(consumer, brokerId: 1, [Partition]);
+        var preferredGroups = await InvokeGroupPartitionsByBrokerAsync(consumer);
+        await Assert.That(preferredGroups).ContainsKey(2);
+
+        await InvokeFetchFromBrokerWithErrorHandlingAsync(consumer, brokerId: 2, [Partition]);
+
+        var fallbackGroups = await InvokeGroupPartitionsByBrokerAsync(consumer);
+        await Assert.That(fallbackGroups).ContainsKey(1);
+        await Assert.That(fallbackGroups).DoesNotContainKey(2);
+    }
+
+    [Test]
+    public async Task PreferredReadReplica_TopLevelFetchErrorFallsBackToLeader()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var leaderConnection = Substitute.For<IKafkaConnection>();
+        var preferredConnection = Substitute.For<IKafkaConnection>();
+
+        leaderConnection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateFetchResponse(preferredReadReplica: 2)));
+
+        preferredConnection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateFetchResponse(
+                preferredReadReplica: -1,
+                responseErrorCode: ErrorCode.UnknownServerError)));
+
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(leaderConnection));
+        pool.GetConnectionByIndexAsync(2, 0, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(preferredConnection));
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager, clientRack: "rack-a");
+        consumer.Assign(Partition);
+
+        await InvokeFetchFromBrokerAsync(consumer, brokerId: 1, [Partition]);
+        var preferredGroups = await InvokeGroupPartitionsByBrokerAsync(consumer);
+        await Assert.That(preferredGroups).ContainsKey(2);
+
+        await InvokeFetchFromBrokerAsync(consumer, brokerId: 2, [Partition]);
+
+        var fallbackGroups = await InvokeGroupPartitionsByBrokerAsync(consumer);
+        await Assert.That(fallbackGroups).ContainsKey(1);
+        await Assert.That(fallbackGroups).DoesNotContainKey(2);
+    }
+
+    [Test]
+    public async Task PreferredReadReplica_WithoutClientRack_UsesLeader()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+
+        connection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateFetchResponse(preferredReadReplica: 2)));
+
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager, clientRack: null);
+        consumer.Assign(Partition);
+
+        await InvokeFetchFromBrokerAsync(consumer, brokerId: 1, [Partition]);
+
+        var groups = await InvokeGroupPartitionsByBrokerAsync(consumer);
+        await Assert.That(groups).ContainsKey(1);
+        await Assert.That(groups).DoesNotContainKey(2);
+    }
+
+    private static MetadataManager CreateMetadataManager(IConnectionPool pool)
+    {
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.SetApiVersion(ApiKey.Fetch, FetchRequest.LowestSupportedVersion, FetchRequest.HighestSupportedVersion);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            ClusterId = "test-cluster",
+            ControllerId = 1,
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9093, Rack = "rack-b" },
+                new BrokerMetadata { NodeId = 2, Host = "broker-2", Port = 9094, Rack = "rack-a" }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = Topic,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 1,
+                            LeaderEpoch = 5,
+                            ReplicaNodes = [1, 2],
+                            IsrNodes = [1, 2]
+                        }
+                    ]
+                }
+            ]
+        });
+        return metadataManager;
+    }
+
+    private static KafkaConsumer<string, string> CreateConsumer(
+        IConnectionPool pool,
+        MetadataManager metadataManager,
+        string? clientRack)
+        => new(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "test-consumer",
+                ClientRack = clientRack,
+                EnableFetchSessions = false
+            },
+            Serializers.String,
+            Serializers.String,
+            pool,
+            metadataManager);
+
+    private static FetchResponse CreateFetchResponse(
+        int preferredReadReplica,
+        ErrorCode errorCode = ErrorCode.None,
+        ErrorCode responseErrorCode = ErrorCode.None)
+        => new()
+        {
+            ErrorCode = responseErrorCode,
+            Responses =
+            [
+                new FetchResponseTopic
+                {
+                    Topic = Topic,
+                    Partitions =
+                    [
+                        new FetchResponsePartition
+                        {
+                            PartitionIndex = 0,
+                            ErrorCode = errorCode,
+                            HighWatermark = 0,
+                            PreferredReadReplica = preferredReadReplica
+                        }
+                    ]
+                }
+            ]
+        };
+
+    private static async ValueTask InvokeFetchFromBrokerAsync(
+        KafkaConsumer<string, string> consumer,
+        int brokerId,
+        List<TopicPartition> partitions)
+    {
+        var method = typeof(KafkaConsumer<string, string>)
+            .GetMethod("FetchFromBrokerAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("FetchFromBrokerAsync method not found");
+
+        var result = method.Invoke(consumer, [brokerId, partitions, CancellationToken.None]);
+        if (result is not ValueTask<List<PendingFetchData>?> valueTask)
+            throw new InvalidOperationException("FetchFromBrokerAsync returned unexpected type");
+
+        var pendingItems = await valueTask.ConfigureAwait(false);
+        DisposeAndReturn(pendingItems);
+    }
+
+    private static async ValueTask InvokeFetchFromBrokerWithErrorHandlingAsync(
+        KafkaConsumer<string, string> consumer,
+        int brokerId,
+        List<TopicPartition> partitions)
+    {
+        var method = typeof(KafkaConsumer<string, string>)
+            .GetMethod("FetchFromBrokerWithErrorHandlingAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("FetchFromBrokerWithErrorHandlingAsync method not found");
+
+        var result = method.Invoke(consumer, [brokerId, partitions, CancellationToken.None, CancellationToken.None]);
+        if (result is not Task<List<PendingFetchData>?> task)
+            throw new InvalidOperationException("FetchFromBrokerWithErrorHandlingAsync returned unexpected type");
+
+        var pendingItems = await task.ConfigureAwait(false);
+        DisposeAndReturn(pendingItems);
+    }
+
+    private static void DisposeAndReturn(List<PendingFetchData>? pendingItems)
+    {
+        if (pendingItems is null)
+            return;
+
+        try
+        {
+            foreach (var pending in pendingItems)
+                pending.Dispose();
+        }
+        finally
+        {
+            ConsumerFetchPools.ReturnPendingFetchDataList(pendingItems);
+        }
+    }
+
+    private static async ValueTask<Dictionary<int, List<TopicPartition>>> InvokeGroupPartitionsByBrokerAsync(
+        KafkaConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaConsumer<string, string>)
+            .GetMethod("GroupPartitionsByBrokerAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("GroupPartitionsByBrokerAsync method not found");
+
+        var result = method.Invoke(consumer, [CancellationToken.None]);
+        if (result is not ValueTask<Dictionary<int, List<TopicPartition>>> valueTask)
+            throw new InvalidOperationException("GroupPartitionsByBrokerAsync returned unexpected type");
+
+        return await valueTask.ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ConsumerOptions.ClientRack` and `WithClientRack`
- send rack id on consumer fetches and KIP-848 initial heartbeats
- route fetches to `PreferredReadReplica` with fallback on partition, top-level, broker, metadata, and expiry cases
- add unit coverage plus a 3-broker rack-aware integration test using `RackAwareReplicaSelector`

## Tests
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release /p:RunAnalyzers=false`
- `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj --configuration Release /p:RunAnalyzers=false`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumerRackAwarenessTests/*"`
- `tests\Dekaf.Tests.Integration\bin\Release\net10.0\Dekaf.Tests.Integration.exe --treenode-filter "/*/*/ConsumerRackAwarenessIntegrationTests/*"`

Closes #1149