### PR TITLE
Add AWS MSK IAM SASL support

### DIFF
--- a/docs/docs/security/oauth.md
+++ b/docs/docs/security/oauth.md
@@ -110,7 +110,19 @@ var producer = await Kafka.CreateProducer<string, string>()
 
 ## AWS MSK IAM
 
-For AWS MSK with IAM authentication:
+For Amazon MSK IAM access control, prefer the native AWS_MSK_IAM mechanism:
+
+```csharp
+using Dekaf;
+
+var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("b-1.example.c2.kafka.us-east-1.amazonaws.com:9098")
+    .UseTls()
+    .WithAwsMskIam()
+    .BuildAsync();
+```
+
+You can still use OAUTHBEARER for MSK clusters configured for that mechanism:
 
 ```csharp
 using Dekaf;

--- a/docs/docs/security/sasl.md
+++ b/docs/docs/security/sasl.md
@@ -72,6 +72,63 @@ var producer = await Kafka.CreateProducer<string, string>()
     .BuildAsync();
 ```
 
+## AWS_MSK_IAM (Amazon MSK IAM)
+
+Use the native AWS_MSK_IAM mechanism for Amazon MSK clusters with IAM access control:
+
+```csharp
+using Dekaf;
+
+var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("b-1.example.c2.kafka.us-east-1.amazonaws.com:9098")
+    .UseTls()
+    .WithAwsMskIam()
+    .BuildAsync();
+```
+
+Dekaf signs the SASL payload with SigV4 using the default AWS credential chain:
+environment variables, web identity, shared AWS profiles, ECS credentials, then EC2 instance metadata.
+The AWS region is inferred from standard MSK broker hostnames; set it explicitly when using a custom DNS name:
+
+```csharp
+using Dekaf;
+using Dekaf.Security.Sasl;
+
+var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("kafka.internal.example.com:9098")
+    .UseTls()
+    .WithAwsMskIam(new AwsMskIamConfig
+    {
+        Region = "us-east-1",
+        ProfileName = "msk-prod"
+    })
+    .BuildAsync();
+```
+
+For non-standard credential sources, provide a custom credentials provider without adding the AWS SDK to Dekaf:
+
+```csharp
+using Dekaf;
+using Dekaf.Security.Sasl;
+
+var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("b-1.example.c2.kafka.us-east-1.amazonaws.com:9098")
+    .UseTls()
+    .WithAwsMskIam(new AwsMskIamConfig
+    {
+        CredentialsProviderFunc = async ct =>
+        {
+            var credentials = await LoadCredentialsAsync(ct);
+            return new AwsCredentials(
+                credentials.AccessKeyId,
+                credentials.SecretAccessKey,
+                credentials.SessionToken,
+                credentials.ExpiresAt);
+        }
+    })
+    .BuildAsync();
+```
+
 ## Consumer Configuration
 
 Same methods work for consumers:

--- a/docs/docs/security/tls.md
+++ b/docs/docs/security/tls.md
@@ -105,7 +105,7 @@ using Dekaf;
 var producer = await Kafka.CreateProducer<string, string>()
     .WithBootstrapServers("broker1.msk.us-east-1.amazonaws.com:9098")
     .UseTls()
-    .WithOAuthBearer(GetAwsMskTokenAsync)
+    .WithAwsMskIam()
     .BuildAsync();
 ```
 

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -549,8 +549,8 @@ internal static class DekafConfigurationBinding
         if (TryGetValue<PartitionerType>(configuration, nameof(ProducerOptions.Partitioner), out var partitioner))
             builder.WithPartitioner(partitioner);
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
-        if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth))
-            builder.WithSaslOptions(mechanism, username, password, gssapi, oauth);
+        if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth, out var awsMskIam))
+            builder.WithSaslOptions(mechanism, username, password, gssapi, oauth, awsMskIam);
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.SocketSendBufferBytes), out var sendBuffer))
             builder.WithSocketSendBufferBytes(sendBuffer);
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.SocketReceiveBufferBytes), out var receiveBuffer))
@@ -635,8 +635,8 @@ internal static class DekafConfigurationBinding
         if (TryGetValue<bool>(configuration, nameof(ConsumerOptions.CheckCrcs), out var checkCrcs))
             builder.WithCheckCrcs(checkCrcs);
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
-        if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth))
-            builder.WithSaslOptions(mechanism, username, password, gssapi, oauth);
+        if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth, out var awsMskIam))
+            builder.WithSaslOptions(mechanism, username, password, gssapi, oauth, awsMskIam);
         if (TryGetValue<bool>(configuration, nameof(ConsumerOptions.EnablePartitionEof), out var enablePartitionEof))
             builder.WithPartitionEof(enablePartitionEof);
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.SocketSendBufferBytes), out var sendBuffer))
@@ -679,8 +679,8 @@ internal static class DekafConfigurationBinding
         if (TryGetValue<int>(configuration, nameof(AdminClientOptions.ReconnectBackoffMaxMs), out var reconnectBackoffMaxMs))
             builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(reconnectBackoffMaxMs));
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
-        if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth))
-            builder.WithSaslOptions(mechanism, username, password, gssapi, oauth);
+        if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth, out var awsMskIam))
+            builder.WithSaslOptions(mechanism, username, password, gssapi, oauth, awsMskIam);
         if (TryGetValue<MetadataRecoveryStrategy>(configuration, nameof(AdminClientOptions.MetadataRecoveryStrategy), out var metadataRecoveryStrategy))
             builder.WithMetadataRecoveryStrategy(metadataRecoveryStrategy);
         if (TryGetValue<int>(configuration, nameof(AdminClientOptions.MetadataRecoveryRebootstrapTriggerMs), out var rebootstrapMs))
@@ -750,26 +750,31 @@ internal static class DekafConfigurationBinding
         out string? username,
         out string? password,
         out GssapiConfig? gssapiConfig,
-        out OAuthBearerConfig? oauthConfig)
+        out OAuthBearerConfig? oauthConfig,
+        out AwsMskIamConfig? awsMskIamConfig)
     {
         var hasMechanism = TryGetValue<SaslMechanism>(configuration, nameof(ProducerOptions.SaslMechanism), out mechanism);
         var hasUsername = TryGetValue<string>(configuration, nameof(ProducerOptions.SaslUsername), out username);
         var hasPassword = TryGetValue<string>(configuration, nameof(ProducerOptions.SaslPassword), out password);
         var hasGssapi = TryGetValue<GssapiConfig>(configuration, nameof(ProducerOptions.GssapiConfig), out gssapiConfig);
         var hasOAuth = TryGetValue<OAuthBearerConfig>(configuration, nameof(ProducerOptions.OAuthBearerConfig), out oauthConfig);
+        var hasAwsMskIam = TryGetValue<AwsMskIamConfig>(configuration, nameof(ProducerOptions.AwsMskIamConfig), out awsMskIamConfig);
 
         if (!hasMechanism)
         {
-            mechanism = oauthConfig is not null
-                ? SaslMechanism.OAuthBearer
-                : gssapiConfig is not null
-                    ? SaslMechanism.Gssapi
-                    : hasUsername || hasPassword
-                        ? SaslMechanism.Plain
-                        : SaslMechanism.None;
+            if (awsMskIamConfig is not null)
+                mechanism = SaslMechanism.AwsMskIam;
+            else if (oauthConfig is not null)
+                mechanism = SaslMechanism.OAuthBearer;
+            else if (gssapiConfig is not null)
+                mechanism = SaslMechanism.Gssapi;
+            else if (hasUsername || hasPassword)
+                mechanism = SaslMechanism.Plain;
+            else
+                mechanism = SaslMechanism.None;
         }
 
-        return hasMechanism || hasUsername || hasPassword || hasGssapi || hasOAuth;
+        return hasMechanism || hasUsername || hasPassword || hasGssapi || hasOAuth || hasAwsMskIam;
     }
 
     private static bool TryGetBootstrapServers(IConfiguration configuration, out string[] servers)

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -398,6 +398,83 @@ public sealed class InMemoryAdminClient : IAdminClient
         return ValueTask.FromResult<IReadOnlyDictionary<TopicPartition, ElectLeadersResultInfo>>(result);
     }
 
+    public ValueTask<IReadOnlyDictionary<int, IReadOnlyDictionary<string, LogDirDescription>>> DescribeLogDirsAsync(
+        IEnumerable<int> brokerIds,
+        IEnumerable<TopicPartition>? partitions = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(brokerIds);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var targetPartitions = partitions?.Distinct().ToArray() ??
+            _cluster.ListTopics().SelectMany(_cluster.GetTopicPartitions).ToArray();
+        foreach (var partition in targetPartitions)
+            ValidateTopicPartition(partition);
+
+        var result = new Dictionary<int, IReadOnlyDictionary<string, LogDirDescription>>();
+        foreach (var brokerId in brokerIds.Distinct().Order())
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(brokerId);
+
+            if (brokerId != 0)
+            {
+                result[brokerId] = new Dictionary<string, LogDirDescription>();
+                continue;
+            }
+
+            var replicas = targetPartitions.ToDictionary(
+                partition => partition,
+                partition =>
+                {
+                    var watermarks = _cluster.GetWatermarks(partition);
+                    return new ReplicaLogDirInfo
+                    {
+                        Size = Math.Max(0, watermarks.High - watermarks.Low),
+                        OffsetLag = 0,
+                        IsFuture = false
+                    };
+                });
+
+            result[brokerId] = new Dictionary<string, LogDirDescription>(StringComparer.Ordinal)
+            {
+                ["in-memory"] = new()
+                {
+                    ErrorCode = ErrorCode.None,
+                    ReplicaInfos = replicas
+                }
+            };
+        }
+
+        return ValueTask.FromResult<IReadOnlyDictionary<int, IReadOnlyDictionary<string, LogDirDescription>>>(result);
+    }
+
+    public ValueTask<IReadOnlyDictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>> AlterReplicaLogDirsAsync(
+        IReadOnlyDictionary<TopicPartitionReplica, string> replicaAssignments,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(replicaAssignments);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var result = new Dictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>(replicaAssignments.Count);
+        foreach (var (replica, logDir) in replicaAssignments)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(replica.Topic);
+            ArgumentOutOfRangeException.ThrowIfNegative(replica.Partition);
+            ArgumentOutOfRangeException.ThrowIfNegative(replica.BrokerId);
+            ArgumentException.ThrowIfNullOrWhiteSpace(logDir);
+
+            result[replica] = new AlterReplicaLogDirResultInfo
+            {
+                TopicPartitionReplica = replica,
+                ErrorCode = ErrorCode.None
+            };
+        }
+
+        return ValueTask.FromResult<IReadOnlyDictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>>(result);
+    }
+
     public ValueTask<IReadOnlyDictionary<string, ShareGroupDescription>> DescribeShareGroupsAsync(
         IEnumerable<string> groupIds,
         CancellationToken cancellationToken = default)
@@ -505,5 +582,11 @@ public sealed class InMemoryAdminClient : IAdminClient
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    private static void ValidateTopicPartition(TopicPartition topicPartition)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topicPartition.Topic);
+        ArgumentOutOfRangeException.ThrowIfNegative(topicPartition.Partition);
     }
 }

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -55,7 +55,8 @@ public sealed class AdminClient : IAdminClient
                 OAuthBearerConfig = options.OAuthBearerConfig,
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
                 OAuthBearerToken = options.OAuthBearerToken,
-                ClientDnsLookup = options.ClientDnsLookup
+                ClientDnsLookup = options.ClientDnsLookup,
+                AwsMskIamConfig = options.AwsMskIamConfig
             },
             loggerFactory);
 
@@ -2777,6 +2778,11 @@ public sealed class AdminClientOptions
     public OAuthBearerToken? OAuthBearerToken { get; init; }
 
     /// <summary>
+    /// AWS_MSK_IAM configuration.
+    /// </summary>
+    public AwsMskIamConfig? AwsMskIamConfig { get; init; }
+
+    /// <summary>
     /// Strategy for recovering cluster metadata when all known brokers become unavailable.
     /// Default is <see cref="MetadataRecoveryStrategy.Rebootstrap"/>.
     /// </summary>
@@ -2821,6 +2827,7 @@ public sealed class AdminClientBuilder
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
+    private AwsMskIamConfig? _awsMskIamConfig;
     private ILoggerFactory? _loggerFactory;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
@@ -3004,6 +3011,18 @@ public sealed class AdminClientBuilder
         return this;
     }
 
+    /// <summary>
+    /// Configures Amazon MSK IAM authentication using the AWS_MSK_IAM SASL mechanism.
+    /// </summary>
+    /// <param name="config">Optional AWS_MSK_IAM configuration. Defaults to the AWS credential chain and broker-derived region.</param>
+    public AdminClientBuilder WithAwsMskIam(AwsMskIamConfig? config = null)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.AwsMskIam;
+        _awsMskIamConfig = config ?? new AwsMskIamConfig();
+        return this;
+    }
+
     public AdminClientBuilder WithLoggerFactory(ILoggerFactory loggerFactory)
     {
         _loggerFactory = loggerFactory;
@@ -3142,7 +3161,8 @@ public sealed class AdminClientBuilder
         string? username,
         string? password,
         GssapiConfig? gssapiConfig,
-        OAuthBearerConfig? oauthConfig)
+        OAuthBearerConfig? oauthConfig,
+        AwsMskIamConfig? awsMskIamConfig = null)
     {
         ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = mechanism;
@@ -3150,6 +3170,7 @@ public sealed class AdminClientBuilder
         _saslPassword = password;
         _gssapiConfig = gssapiConfig;
         _oauthConfig = oauthConfig;
+        _awsMskIamConfig = awsMskIamConfig ?? (mechanism == SaslMechanism.AwsMskIam ? new AwsMskIamConfig() : null);
         _oauthTokenProvider = null;
         return this;
     }
@@ -3178,6 +3199,7 @@ public sealed class AdminClientBuilder
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
             OAuthBearerTokenProvider = _oauthTokenProvider,
+            AwsMskIamConfig = _awsMskIamConfig,
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -51,6 +51,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
     private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
+    private AwsMskIamConfig? _awsMskIamConfig;
     private ISerializer<TKey>? _keySerializer;
     private ISerializer<TValue>? _valueSerializer;
     private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
@@ -494,6 +495,18 @@ public sealed class ProducerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>
+    /// Configures Amazon MSK IAM authentication using the AWS_MSK_IAM SASL mechanism.
+    /// </summary>
+    /// <param name="config">Optional AWS_MSK_IAM configuration. Defaults to the AWS credential chain and broker-derived region.</param>
+    public ProducerBuilder<TKey, TValue> WithAwsMskIam(AwsMskIamConfig? config = null)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.AwsMskIam;
+        _awsMskIamConfig = config ?? new AwsMskIamConfig();
+        return this;
+    }
+
     public ProducerBuilder<TKey, TValue> WithKeySerializer(ISerializer<TKey> serializer)
     {
         _keySerializer = serializer;
@@ -839,7 +852,8 @@ public sealed class ProducerBuilder<TKey, TValue>
         string? username,
         string? password,
         GssapiConfig? gssapiConfig,
-        OAuthBearerConfig? oauthConfig)
+        OAuthBearerConfig? oauthConfig,
+        AwsMskIamConfig? awsMskIamConfig = null)
     {
         ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = mechanism;
@@ -847,6 +861,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         _saslPassword = password;
         _gssapiConfig = gssapiConfig;
         _oauthConfig = oauthConfig;
+        _awsMskIamConfig = awsMskIamConfig ?? (mechanism == SaslMechanism.AwsMskIam ? new AwsMskIamConfig() : null);
         _oauthTokenProvider = null;
         return this;
     }
@@ -978,6 +993,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
             OAuthBearerTokenProvider = _oauthTokenProvider,
+            AwsMskIamConfig = _awsMskIamConfig,
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
@@ -1119,6 +1135,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
     private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
+    private AwsMskIamConfig? _awsMskIamConfig;
     private IDeserializer<TKey>? _keyDeserializer;
     private IDeserializer<TValue>? _valueDeserializer;
     private IRebalanceListener? _rebalanceListener;
@@ -1578,6 +1595,18 @@ public sealed class ConsumerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>
+    /// Configures Amazon MSK IAM authentication using the AWS_MSK_IAM SASL mechanism.
+    /// </summary>
+    /// <param name="config">Optional AWS_MSK_IAM configuration. Defaults to the AWS credential chain and broker-derived region.</param>
+    public ConsumerBuilder<TKey, TValue> WithAwsMskIam(AwsMskIamConfig? config = null)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.AwsMskIam;
+        _awsMskIamConfig = config ?? new AwsMskIamConfig();
+        return this;
+    }
+
     public ConsumerBuilder<TKey, TValue> WithKeyDeserializer(IDeserializer<TKey> deserializer)
     {
         _keyDeserializer = deserializer;
@@ -1991,7 +2020,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
         string? username,
         string? password,
         GssapiConfig? gssapiConfig,
-        OAuthBearerConfig? oauthConfig)
+        OAuthBearerConfig? oauthConfig,
+        AwsMskIamConfig? awsMskIamConfig = null)
     {
         ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = mechanism;
@@ -1999,6 +2029,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _saslPassword = password;
         _gssapiConfig = gssapiConfig;
         _oauthConfig = oauthConfig;
+        _awsMskIamConfig = awsMskIamConfig ?? (mechanism == SaslMechanism.AwsMskIam ? new AwsMskIamConfig() : null);
         _oauthTokenProvider = null;
         return this;
     }
@@ -2088,6 +2119,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
             OAuthBearerTokenProvider = _oauthTokenProvider,
+            AwsMskIamConfig = _awsMskIamConfig,
             RebalanceListener = _rebalanceListener,
             EnablePartitionEof = _enablePartitionEof,
             SocketSendBufferBytes = _socketSendBufferBytes,
@@ -2211,6 +2243,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
     private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
+    private AwsMskIamConfig? _awsMskIamConfig;
     private IDeserializer<TKey>? _keyDeserializer;
     private IDeserializer<TValue>? _valueDeserializer;
     private ILoggerFactory? _loggerFactory;
@@ -2438,7 +2471,20 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerTokenProvider(Func<CancellationToken, ValueTask<OAuthBearerToken>> provider)
     {
         ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthTokenProvider = provider;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures Amazon MSK IAM authentication using the AWS_MSK_IAM SASL mechanism.
+    /// </summary>
+    /// <param name="config">Optional AWS_MSK_IAM configuration. Defaults to the AWS credential chain and broker-derived region.</param>
+    public ShareConsumerBuilder<TKey, TValue> WithAwsMskIam(AwsMskIamConfig? config = null)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.AwsMskIam;
+        _awsMskIamConfig = config ?? new AwsMskIamConfig();
         return this;
     }
 
@@ -2568,6 +2614,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
             OAuthBearerTokenProvider = _oauthTokenProvider,
+            AwsMskIamConfig = _awsMskIamConfig,
             SocketSendBufferBytes = _socketSendBufferBytes,
             SocketReceiveBufferBytes = _socketReceiveBufferBytes,
             ConnectionsPerBroker = _connectionsPerBroker,

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -213,6 +213,11 @@ public sealed class ConsumerOptions
     public Func<CancellationToken, ValueTask<OAuthBearerToken>>? OAuthBearerTokenProvider { get; init; }
 
     /// <summary>
+    /// AWS_MSK_IAM configuration.
+    /// </summary>
+    public AwsMskIamConfig? AwsMskIamConfig { get; init; }
+
+    /// <summary>
     /// Rebalance listener.
     /// </summary>
     public IRebalanceListener? RebalanceListener { get; init; }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -804,6 +804,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
+                AwsMskIamConfig = options.AwsMskIamConfig,
                 SendBufferSize = options.SocketSendBufferBytes,
                 ReceiveBufferSize = options.SocketReceiveBufferBytes,
                 ClientDnsLookup = options.ClientDnsLookup

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -90,6 +90,7 @@ public sealed class KafkaClientBuilder
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
     private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
+    private AwsMskIamConfig? _awsMskIamConfig;
     private int _socketSendBufferBytes;
     private int _socketReceiveBufferBytes;
     private int _connectionsPerBroker = 1;
@@ -237,6 +238,17 @@ public sealed class KafkaClientBuilder
         return this;
     }
 
+    /// <summary>
+    /// Configures Amazon MSK IAM authentication using the AWS_MSK_IAM SASL mechanism.
+    /// </summary>
+    /// <param name="config">Optional AWS_MSK_IAM configuration. Defaults to the AWS credential chain and broker-derived region.</param>
+    public KafkaClientBuilder WithAwsMskIam(AwsMskIamConfig? config = null)
+    {
+        _saslMechanism = SaslMechanism.AwsMskIam;
+        _awsMskIamConfig = config ?? new AwsMskIamConfig();
+        return this;
+    }
+
     public KafkaClientBuilder WithSocketSendBufferBytes(int bytes)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(bytes);
@@ -355,6 +367,7 @@ public sealed class KafkaClientBuilder
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
             OAuthBearerTokenProvider = _oauthTokenProvider,
+            AwsMskIamConfig = _awsMskIamConfig,
             SocketSendBufferBytes = _socketSendBufferBytes,
             SocketReceiveBufferBytes = _socketReceiveBufferBytes,
             ConnectionsPerBroker = _connectionsPerBroker,
@@ -387,6 +400,7 @@ internal sealed class KafkaClientOptions
     public GssapiConfig? GssapiConfig { get; init; }
     public OAuthBearerConfig? OAuthBearerConfig { get; init; }
     public Func<CancellationToken, ValueTask<OAuthBearerToken>>? OAuthBearerTokenProvider { get; init; }
+    public AwsMskIamConfig? AwsMskIamConfig { get; init; }
     public int SocketSendBufferBytes { get; init; }
     public int SocketReceiveBufferBytes { get; init; }
     public int ConnectionsPerBroker { get; init; }
@@ -458,6 +472,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
+                AwsMskIamConfig = options.AwsMskIamConfig,
                 SendBufferSize = options.SocketSendBufferBytes,
                 ReceiveBufferSize = options.SocketReceiveBufferBytes,
                 MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -178,6 +178,7 @@ public sealed partial class ConnectionPool : IConnectionPool
             GssapiConfig = options.GssapiConfig,
             OAuthBearerTokenProvider = sharedProvider.GetTokenAsync,
             OAuthBearerToken = options.OAuthBearerToken,
+            AwsMskIamConfig = options.AwsMskIamConfig,
             SaslReauthenticationConfig = options.SaslReauthenticationConfig,
             SendBufferSize = options.SendBufferSize,
             ReceiveBufferSize = options.ReceiveBufferSize,

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1901,11 +1901,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             LogSaslHandshakeSuccessful();
 
             // Step 2: Perform authentication exchanges
-            // For OAUTHBEARER, ensure token is fetched before getting initial response
-            if (authenticator is OAuthBearerAuthenticator oauthAuthenticator)
-            {
-                await oauthAuthenticator.GetTokenAsync(cancellationToken).ConfigureAwait(false);
-            }
+            await PrepareSaslAuthenticatorAsync(authenticator, cancellationToken).ConfigureAwait(false);
 
             var authBytes = authenticator.GetInitialResponse();
 
@@ -1977,6 +1973,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             _options.GssapiConfig ?? throw new InvalidOperationException("GSSAPI configuration not provided"),
             _resolvedTargetHost ?? _host),
         SaslMechanism.OAuthBearer => CreateOAuthBearerAuthenticator(),
+        SaslMechanism.AwsMskIam => new AwsMskIamAuthenticator(_options.AwsMskIamConfig, _host),
         _ => throw new InvalidOperationException($"Unsupported SASL mechanism: {_options.SaslMechanism}")
     };
 
@@ -2124,11 +2121,8 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                     $"Supported mechanisms: {string.Join(", ", handshakeResponse.Mechanisms)}");
             }
 
-            // Step 2: For OAUTHBEARER, fetch fresh token
-            if (authenticator is OAuthBearerAuthenticator oauthAuthenticator)
-            {
-                await oauthAuthenticator.GetTokenAsync(cancellationToken).ConfigureAwait(false);
-            }
+            // Step 2: Fetch any credentials needed before creating the synchronous initial response.
+            await PrepareSaslAuthenticatorAsync(authenticator, cancellationToken).ConfigureAwait(false);
 
             var authBytes = authenticator.GetInitialResponse();
 
@@ -2201,6 +2195,21 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         throw new InvalidOperationException(
             "OAUTHBEARER authentication requires either OAuthBearerToken, OAuthBearerTokenProvider, or OAuthBearerConfig to be configured");
+    }
+
+    private static async ValueTask PrepareSaslAuthenticatorAsync(
+        ISaslAuthenticator authenticator,
+        CancellationToken cancellationToken)
+    {
+        switch (authenticator)
+        {
+            case OAuthBearerAuthenticator oauthAuthenticator:
+                await oauthAuthenticator.GetTokenAsync(cancellationToken).ConfigureAwait(false);
+                break;
+            case AwsMskIamAuthenticator awsMskIamAuthenticator:
+                await awsMskIamAuthenticator.GetCredentialsAsync(cancellationToken).ConfigureAwait(false);
+                break;
+        }
     }
 
     private async ValueTask<TResponse> SendSaslMessageAsync<TRequest, TResponse>(
@@ -2685,6 +2694,11 @@ public sealed class ConnectionOptions
     /// Use this for pre-obtained tokens; for dynamic token retrieval, use OAuthBearerTokenProvider instead.
     /// </summary>
     public OAuthBearerToken? OAuthBearerToken { get; init; }
+
+    /// <summary>
+    /// AWS_MSK_IAM configuration.
+    /// </summary>
+    public AwsMskIamConfig? AwsMskIamConfig { get; init; }
 
     /// <summary>
     /// SASL re-authentication configuration (KIP-368).

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -230,6 +230,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
+                AwsMskIamConfig = options.AwsMskIamConfig,
                 SendBufferSize = options.SocketSendBufferBytes,
                 ReceiveBufferSize = options.SocketReceiveBufferBytes,
                 MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection,

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -317,6 +317,11 @@ public sealed class ProducerOptions
     public Func<CancellationToken, ValueTask<OAuthBearerToken>>? OAuthBearerTokenProvider { get; init; }
 
     /// <summary>
+    /// AWS_MSK_IAM configuration.
+    /// </summary>
+    public AwsMskIamConfig? AwsMskIamConfig { get; init; }
+
+    /// <summary>
     /// Socket send buffer size in bytes. Set to 0 to use system default.
     /// Larger buffers can improve throughput for high-volume producers.
     /// </summary>

--- a/src/Dekaf/Security/Sasl/AwsCredentials.cs
+++ b/src/Dekaf/Security/Sasl/AwsCredentials.cs
@@ -1,0 +1,92 @@
+namespace Dekaf.Security.Sasl;
+
+/// <summary>
+/// AWS credentials used to sign AWS_MSK_IAM authentication payloads.
+/// </summary>
+public sealed class AwsCredentials
+{
+    /// <summary>
+    /// Creates AWS credentials.
+    /// </summary>
+    public AwsCredentials(
+        string accessKeyId,
+        string secretAccessKey,
+        string? sessionToken = null,
+        DateTimeOffset? expiration = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessKeyId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(secretAccessKey);
+
+        AccessKeyId = accessKeyId;
+        SecretAccessKey = secretAccessKey;
+        SessionToken = string.IsNullOrWhiteSpace(sessionToken) ? null : sessionToken;
+        Expiration = expiration;
+    }
+
+    /// <summary>
+    /// AWS access key ID.
+    /// </summary>
+    public string AccessKeyId { get; }
+
+    /// <summary>
+    /// AWS secret access key.
+    /// </summary>
+    public string SecretAccessKey { get; }
+
+    /// <summary>
+    /// Optional AWS session token for temporary credentials.
+    /// </summary>
+    public string? SessionToken { get; }
+
+    /// <summary>
+    /// Optional expiration time for temporary credentials.
+    /// </summary>
+    public DateTimeOffset? Expiration { get; }
+
+    internal bool IsExpired(DateTimeOffset now, TimeSpan refreshBuffer)
+        => Expiration is { } expiration && expiration <= now.Add(refreshBuffer);
+}
+
+/// <summary>
+/// Provides AWS credentials for AWS_MSK_IAM authentication.
+/// </summary>
+public interface IAwsCredentialsProvider
+{
+    /// <summary>
+    /// Gets AWS credentials.
+    /// </summary>
+    ValueTask<AwsCredentials> GetCredentialsAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// AWS credentials provider backed by a fixed credential set.
+/// </summary>
+public sealed class StaticAwsCredentialsProvider : IAwsCredentialsProvider
+{
+    private readonly AwsCredentials _credentials;
+
+    /// <summary>
+    /// Creates a static AWS credentials provider.
+    /// </summary>
+    public StaticAwsCredentialsProvider(AwsCredentials credentials)
+    {
+        _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+    }
+
+    /// <inheritdoc />
+    public ValueTask<AwsCredentials> GetCredentialsAsync(CancellationToken cancellationToken = default)
+        => new(_credentials);
+}
+
+internal sealed class DelegateAwsCredentialsProvider : IAwsCredentialsProvider
+{
+    private readonly Func<CancellationToken, ValueTask<AwsCredentials>> _provider;
+
+    public DelegateAwsCredentialsProvider(Func<CancellationToken, ValueTask<AwsCredentials>> provider)
+    {
+        _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+    }
+
+    public ValueTask<AwsCredentials> GetCredentialsAsync(CancellationToken cancellationToken = default)
+        => _provider(cancellationToken);
+}

--- a/src/Dekaf/Security/Sasl/AwsMskIamAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamAuthenticator.cs
@@ -1,0 +1,131 @@
+using System.Text;
+using System.Text.Json;
+using Dekaf.Errors;
+
+namespace Dekaf.Security.Sasl;
+
+/// <summary>
+/// AWS_MSK_IAM SASL mechanism authenticator.
+/// </summary>
+public sealed class AwsMskIamAuthenticator : ISaslAuthenticator
+{
+    private static readonly AwsMskIamConfig DefaultConfig = new();
+
+    private readonly AwsMskIamConfig _config;
+    private readonly string _host;
+    private readonly IAwsCredentialsProvider _credentialsProvider;
+    private AwsCredentials? _credentials;
+    private bool _initialResponseSent;
+    private bool _complete;
+
+    /// <summary>
+    /// Creates an AWS_MSK_IAM authenticator.
+    /// </summary>
+    public AwsMskIamAuthenticator(AwsMskIamConfig? config, string host)
+    {
+        _config = config ?? DefaultConfig;
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        _host = host;
+        _credentialsProvider = _config.CreateCredentialsProvider();
+    }
+
+    /// <inheritdoc />
+    public string MechanismName => "AWS_MSK_IAM";
+
+    /// <inheritdoc />
+    public bool IsComplete => _complete;
+
+    /// <summary>
+    /// Fetches AWS credentials before the synchronous initial SASL response is created.
+    /// </summary>
+    public async ValueTask<AwsCredentials> GetCredentialsAsync(CancellationToken cancellationToken = default)
+    {
+        _credentials = await _credentialsProvider.GetCredentialsAsync(cancellationToken).ConfigureAwait(false);
+        return _credentials;
+    }
+
+    /// <inheritdoc />
+    public byte[] GetInitialResponse()
+    {
+        if (_initialResponseSent)
+            throw new InvalidOperationException("GetInitialResponse can only be called once");
+
+        var credentials = _credentials
+            ?? throw new InvalidOperationException("AWS credentials are not available. Call GetCredentialsAsync before authentication.");
+
+        var region = ResolveRegion();
+        var payload = AwsMskIamSignedPayload.Create(
+            credentials,
+            _host,
+            region,
+            string.IsNullOrWhiteSpace(_config.UserAgent) ? "dekaf" : _config.UserAgent,
+            DateTimeOffset.UtcNow,
+            _config.AuthenticationPayloadExpiration);
+
+        _initialResponseSent = true;
+        return Encoding.UTF8.GetBytes(payload);
+    }
+
+    /// <inheritdoc />
+    public byte[]? EvaluateChallenge(byte[] challenge)
+    {
+        if (challenge.Length == 0)
+            throw new AuthenticationException("AWS_MSK_IAM authentication failed: broker returned an empty response");
+
+        var response = Encoding.UTF8.GetString(challenge);
+        try
+        {
+            using var document = JsonDocument.Parse(response);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+                throw new AuthenticationException("AWS_MSK_IAM authentication failed: broker response was not a JSON object");
+        }
+        catch (JsonException ex)
+        {
+            throw new AuthenticationException("AWS_MSK_IAM authentication failed: broker response was not valid JSON", ex);
+        }
+
+        _complete = true;
+        return null;
+    }
+
+    private string ResolveRegion()
+    {
+        var region =
+            _config.Region ??
+            AwsMskIamRegionResolver.TryResolveFromHost(_host) ??
+            Environment.GetEnvironmentVariable("AWS_REGION") ??
+            Environment.GetEnvironmentVariable("AWS_DEFAULT_REGION");
+
+        if (string.IsNullOrWhiteSpace(region))
+            throw new InvalidOperationException(
+                "AWS_MSK_IAM authentication requires an AWS region. Set AwsMskIamConfig.Region or use an MSK broker hostname containing the region.");
+
+        return region;
+    }
+}
+
+internal static class AwsMskIamRegionResolver
+{
+    public static string? TryResolveFromHost(string host)
+    {
+        foreach (var label in host.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (LooksLikeRegion(label))
+                return label;
+        }
+
+        return null;
+    }
+
+    private static bool LooksLikeRegion(string value)
+    {
+        var parts = value.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 3)
+            return false;
+
+        return parts[0].Length == 2 &&
+               parts[^1].Length == 1 &&
+               char.IsDigit(parts[^1][0]) &&
+               parts.All(part => part.All(char.IsLetterOrDigit));
+    }
+}

--- a/src/Dekaf/Security/Sasl/AwsMskIamAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamAuthenticator.cs
@@ -116,12 +116,16 @@ internal static class AwsMskIamRegionResolver
 
             var serviceLabel = labels[i - 2];
             var region = labels[i - 1];
-            if (string.Equals(serviceLabel, "kafka", StringComparison.OrdinalIgnoreCase) && LooksLikeRegion(region))
+            if (IsKafkaServiceLabel(serviceLabel) && LooksLikeRegion(region))
                 return region;
         }
 
         return null;
     }
+
+    private static bool IsKafkaServiceLabel(string label)
+        => string.Equals(label, "kafka", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(label, "kafka-serverless", StringComparison.OrdinalIgnoreCase);
 
     private static bool IsAmazonAwsSuffix(string[] labels, int index)
     {

--- a/src/Dekaf/Security/Sasl/AwsMskIamAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamAuthenticator.cs
@@ -100,7 +100,7 @@ public sealed class AwsMskIamAuthenticator : ISaslAuthenticator
             throw new InvalidOperationException(
                 "AWS_MSK_IAM authentication requires an AWS region. Set AwsMskIamConfig.Region or use an MSK broker hostname containing the region.");
 
-        return region;
+        return AwsMskIamRegionResolver.ValidateRegion(region);
     }
 }
 
@@ -108,13 +108,44 @@ internal static class AwsMskIamRegionResolver
 {
     public static string? TryResolveFromHost(string host)
     {
-        foreach (var label in host.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        var labels = host.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var i = 0; i < labels.Length; i++)
         {
-            if (LooksLikeRegion(label))
-                return label;
+            if (!IsAmazonAwsSuffix(labels, i) || i < 2)
+                continue;
+
+            var serviceLabel = labels[i - 2];
+            var region = labels[i - 1];
+            if (string.Equals(serviceLabel, "kafka", StringComparison.OrdinalIgnoreCase) && LooksLikeRegion(region))
+                return region;
         }
 
         return null;
+    }
+
+    private static bool IsAmazonAwsSuffix(string[] labels, int index)
+    {
+        if (!string.Equals(labels[index], "amazonaws", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return (index == labels.Length - 2 &&
+                string.Equals(labels[index + 1], "com", StringComparison.OrdinalIgnoreCase)) ||
+               (index == labels.Length - 3 &&
+                string.Equals(labels[index + 1], "com", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(labels[index + 2], "cn", StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static string ValidateRegion(string region)
+    {
+        if (string.IsNullOrWhiteSpace(region))
+            throw new InvalidOperationException("AWS_MSK_IAM region cannot be empty.");
+
+        var value = region.Trim();
+        if (value.Any(static c => !IsRegionCharacter(c)))
+            throw new InvalidOperationException(
+                $"AWS_MSK_IAM region '{region}' is invalid. Region names may only contain lowercase letters, digits, and hyphens.");
+
+        return value;
     }
 
     private static bool LooksLikeRegion(string value)
@@ -128,4 +159,7 @@ internal static class AwsMskIamRegionResolver
                char.IsDigit(parts[^1][0]) &&
                parts.All(part => part.All(char.IsLetterOrDigit));
     }
+
+    private static bool IsRegionCharacter(char value)
+        => value is >= 'a' and <= 'z' or >= '0' and <= '9' or '-';
 }

--- a/src/Dekaf/Security/Sasl/AwsMskIamConfig.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamConfig.cs
@@ -1,0 +1,57 @@
+namespace Dekaf.Security.Sasl;
+
+/// <summary>
+/// Configuration for AWS_MSK_IAM SASL authentication.
+/// </summary>
+public sealed class AwsMskIamConfig
+{
+    private IAwsCredentialsProvider? _resolvedCredentialsProvider;
+
+    /// <summary>
+    /// AWS region for the MSK broker. When null, Dekaf tries the broker hostname and AWS region environment variables.
+    /// </summary>
+    public string? Region { get; init; }
+
+    /// <summary>
+    /// AWS profile name to use from shared AWS credentials/config files.
+    /// When null, AWS_PROFILE or the default profile is used.
+    /// </summary>
+    public string? ProfileName { get; init; }
+
+    /// <summary>
+    /// User agent value embedded in the AWS_MSK_IAM payload.
+    /// </summary>
+    public string? UserAgent { get; init; }
+
+    /// <summary>
+    /// Validity period, in seconds, for the SigV4 presigned authentication payload.
+    /// Amazon MSK recommends 15 minutes.
+    /// </summary>
+    public TimeSpan AuthenticationPayloadExpiration { get; init; } = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Custom AWS credentials provider. Takes precedence over the default credential chain.
+    /// </summary>
+    public IAwsCredentialsProvider? CredentialsProvider { get; init; }
+
+    /// <summary>
+    /// Custom AWS credentials provider callback. Used only when <see cref="CredentialsProvider"/> is null.
+    /// </summary>
+    public Func<CancellationToken, ValueTask<AwsCredentials>>? CredentialsProviderFunc { get; init; }
+
+    internal IAwsCredentialsProvider CreateCredentialsProvider()
+    {
+        if (CredentialsProvider is not null)
+            return CredentialsProvider;
+
+        var provider = _resolvedCredentialsProvider;
+        if (provider is not null)
+            return provider;
+
+        provider = CredentialsProviderFunc is not null
+            ? new DelegateAwsCredentialsProvider(CredentialsProviderFunc)
+            : new AwsMskIamDefaultCredentialsProvider(ProfileName, Region);
+
+        return Interlocked.CompareExchange(ref _resolvedCredentialsProvider, provider, null) ?? provider;
+    }
+}

--- a/src/Dekaf/Security/Sasl/AwsMskIamDefaultCredentialsProvider.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamDefaultCredentialsProvider.cs
@@ -1,0 +1,371 @@
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace Dekaf.Security.Sasl;
+
+/// <summary>
+/// Default AWS credentials provider for AWS_MSK_IAM authentication.
+/// </summary>
+public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvider
+{
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(2)
+    };
+
+    private readonly string? _profileName;
+    private readonly string? _region;
+    private readonly string _webIdentitySessionName = "dekaf-" + Guid.NewGuid().ToString("N");
+    private readonly SemaphoreSlim _refreshLock = new(1, 1);
+    private AwsCredentials? _cachedCredentials;
+
+    /// <summary>
+    /// Creates the default AWS credentials provider.
+    /// </summary>
+    public AwsMskIamDefaultCredentialsProvider(string? profileName = null, string? region = null)
+    {
+        _profileName = profileName;
+        _region = region;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<AwsCredentials> GetCredentialsAsync(CancellationToken cancellationToken = default)
+    {
+        var cached = _cachedCredentials;
+        if (cached is not null && !cached.IsExpired(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(5)))
+            return cached;
+
+        await _refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            cached = _cachedCredentials;
+            if (cached is not null && !cached.IsExpired(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(5)))
+                return cached;
+
+            var credentials =
+                TryGetEnvironmentCredentials() ??
+                await TryGetWebIdentityCredentialsAsync(cancellationToken).ConfigureAwait(false) ??
+                TryGetProfileCredentials() ??
+                await TryGetContainerCredentialsAsync(cancellationToken).ConfigureAwait(false) ??
+                await TryGetInstanceMetadataCredentialsAsync(cancellationToken).ConfigureAwait(false);
+
+            if (credentials is null)
+            {
+                throw new InvalidOperationException(
+                    "Unable to resolve AWS credentials for AWS_MSK_IAM. Checked environment variables, web identity, shared AWS profiles, ECS credentials, and EC2 instance metadata.");
+            }
+
+            _cachedCredentials = credentials;
+            return credentials;
+        }
+        finally
+        {
+            _refreshLock.Release();
+        }
+    }
+
+    private static AwsCredentials? TryGetEnvironmentCredentials()
+    {
+        var accessKeyId = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY_ID");
+        var secretAccessKey = Environment.GetEnvironmentVariable("AWS_SECRET_ACCESS_KEY");
+
+        if (string.IsNullOrWhiteSpace(accessKeyId) || string.IsNullOrWhiteSpace(secretAccessKey))
+            return null;
+
+        return new AwsCredentials(
+            accessKeyId,
+            secretAccessKey,
+            Environment.GetEnvironmentVariable("AWS_SESSION_TOKEN"));
+    }
+
+    private async Task<AwsCredentials?> TryGetWebIdentityCredentialsAsync(CancellationToken cancellationToken)
+    {
+        var roleArn = Environment.GetEnvironmentVariable("AWS_ROLE_ARN");
+        var tokenFile = Environment.GetEnvironmentVariable("AWS_WEB_IDENTITY_TOKEN_FILE");
+
+        if (string.IsNullOrWhiteSpace(roleArn) || string.IsNullOrWhiteSpace(tokenFile) || !File.Exists(tokenFile))
+            return null;
+
+        var webIdentityToken = await File.ReadAllTextAsync(tokenFile, cancellationToken).ConfigureAwait(false);
+        var sessionName = Environment.GetEnvironmentVariable("AWS_ROLE_SESSION_NAME") ?? _webIdentitySessionName;
+        var endpoint = BuildStsEndpoint(ResolveStsRegion());
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["Action"] = "AssumeRoleWithWebIdentity",
+                ["Version"] = "2011-06-15",
+                ["RoleArn"] = roleArn,
+                ["RoleSessionName"] = sessionName,
+                ["WebIdentityToken"] = webIdentityToken,
+                ["DurationSeconds"] = "3600"
+            })
+        };
+
+        using var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var xml = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        var document = XDocument.Parse(xml);
+        var credentials = document.Descendants().FirstOrDefault(element => element.Name.LocalName == "Credentials");
+        if (credentials is null)
+            throw new InvalidOperationException("STS AssumeRoleWithWebIdentity response did not contain credentials");
+
+        return new AwsCredentials(
+            RequiredElement(credentials, "AccessKeyId"),
+            RequiredElement(credentials, "SecretAccessKey"),
+            RequiredElement(credentials, "SessionToken"),
+            DateTimeOffset.Parse(RequiredElement(credentials, "Expiration"), null, System.Globalization.DateTimeStyles.AssumeUniversal));
+    }
+
+    private AwsCredentials? TryGetProfileCredentials()
+    {
+        var profileName = _profileName ?? Environment.GetEnvironmentVariable("AWS_PROFILE") ?? "default";
+
+        foreach (var path in GetProfilePaths())
+        {
+            if (!File.Exists(path))
+                continue;
+
+            var profiles = ReadProfileFile(path);
+            if (TryGetProfile(profiles, profileName, out var profile) &&
+                profile.TryGetValue("aws_access_key_id", out var accessKeyId) &&
+                profile.TryGetValue("aws_secret_access_key", out var secretAccessKey))
+            {
+                profile.TryGetValue("aws_session_token", out var sessionToken);
+                return new AwsCredentials(accessKeyId, secretAccessKey, sessionToken);
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryGetProfile(
+        Dictionary<string, Dictionary<string, string>> profiles,
+        string profileName,
+        out Dictionary<string, string> profile)
+    {
+        if (profiles.TryGetValue(profileName, out profile!))
+            return true;
+
+        return profiles.TryGetValue("profile " + profileName, out profile!);
+    }
+
+    private static async Task<AwsCredentials?> TryGetContainerCredentialsAsync(CancellationToken cancellationToken)
+    {
+        var fullUri = Environment.GetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_FULL_URI");
+        var relativeUri = Environment.GetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI");
+
+        Uri? endpoint = null;
+        if (!string.IsNullOrWhiteSpace(fullUri) && Uri.TryCreate(fullUri, UriKind.Absolute, out var parsedFullUri))
+        {
+            endpoint = parsedFullUri;
+        }
+        else if (!string.IsNullOrWhiteSpace(relativeUri))
+        {
+            endpoint = new Uri("http://169.254.170.2" + relativeUri);
+        }
+
+        if (endpoint is null)
+            return null;
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+            ApplyContainerAuthorization(request);
+
+            using var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            return ParseJsonCredentials(json);
+        }
+        catch (HttpRequestException)
+        {
+            return null;
+        }
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
+    }
+
+    private static async Task<AwsCredentials?> TryGetInstanceMetadataCredentialsAsync(CancellationToken cancellationToken)
+    {
+        if (string.Equals(
+            Environment.GetEnvironmentVariable("AWS_EC2_METADATA_DISABLED"),
+            "true",
+            StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        try
+        {
+            var token = await TryGetImdsTokenAsync(cancellationToken).ConfigureAwait(false);
+            var roleName = await GetImdsStringAsync("http://169.254.169.254/latest/meta-data/iam/security-credentials/", token, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (string.IsNullOrWhiteSpace(roleName))
+                return null;
+
+            roleName = roleName.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)[0];
+            var json = await GetImdsStringAsync(
+                "http://169.254.169.254/latest/meta-data/iam/security-credentials/" + Uri.EscapeDataString(roleName),
+                token,
+                cancellationToken).ConfigureAwait(false);
+
+            return string.IsNullOrWhiteSpace(json) ? null : ParseJsonCredentials(json);
+        }
+        catch (HttpRequestException)
+        {
+            return null;
+        }
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
+    }
+
+    private static async Task<string?> TryGetImdsTokenAsync(CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Put, "http://169.254.169.254/latest/api/token");
+        request.Headers.Add("X-aws-ec2-metadata-token-ttl-seconds", "21600");
+
+        try
+        {
+            using var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            return response.IsSuccessStatusCode
+                ? await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false)
+                : null;
+        }
+        catch (HttpRequestException)
+        {
+            return null;
+        }
+    }
+
+    private static async Task<string?> GetImdsStringAsync(
+        string endpoint,
+        string? token,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+        if (!string.IsNullOrWhiteSpace(token))
+            request.Headers.Add("X-aws-ec2-metadata-token", token);
+
+        using var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        return response.IsSuccessStatusCode
+            ? await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false)
+            : null;
+    }
+
+    private static void ApplyContainerAuthorization(HttpRequestMessage request)
+    {
+        var token = Environment.GetEnvironmentVariable("AWS_CONTAINER_AUTHORIZATION_TOKEN");
+        var tokenFile = Environment.GetEnvironmentVariable("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE");
+
+        if (string.IsNullOrWhiteSpace(token) && !string.IsNullOrWhiteSpace(tokenFile) && File.Exists(tokenFile))
+            token = File.ReadAllText(tokenFile).Trim();
+
+        if (!string.IsNullOrWhiteSpace(token))
+            request.Headers.TryAddWithoutValidation("Authorization", token);
+    }
+
+    private string ResolveStsRegion()
+        => _region ??
+           Environment.GetEnvironmentVariable("AWS_REGION") ??
+           Environment.GetEnvironmentVariable("AWS_DEFAULT_REGION") ??
+           "us-east-1";
+
+    private static Uri BuildStsEndpoint(string region)
+        => region.StartsWith("cn-", StringComparison.Ordinal)
+            ? new Uri($"https://sts.{region}.amazonaws.com.cn/")
+            : new Uri($"https://sts.{region}.amazonaws.com/");
+
+    private static string RequiredElement(XElement parent, string localName)
+        => parent.Elements().First(element => element.Name.LocalName == localName).Value;
+
+    private static IEnumerable<string> GetProfilePaths()
+    {
+        var sharedCredentialsFile = Environment.GetEnvironmentVariable("AWS_SHARED_CREDENTIALS_FILE");
+        if (!string.IsNullOrWhiteSpace(sharedCredentialsFile))
+            yield return sharedCredentialsFile;
+
+        var configFile = Environment.GetEnvironmentVariable("AWS_CONFIG_FILE");
+        if (!string.IsNullOrWhiteSpace(configFile))
+            yield return configFile;
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(home))
+        {
+            yield return Path.Combine(home, ".aws", "credentials");
+            yield return Path.Combine(home, ".aws", "config");
+        }
+    }
+
+    private static Dictionary<string, Dictionary<string, string>> ReadProfileFile(string path)
+    {
+        var profiles = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal);
+        Dictionary<string, string>? currentProfile = null;
+
+        foreach (var rawLine in File.ReadLines(path))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line[0] is '#' or ';')
+                continue;
+
+            if (line[0] == '[' && line[^1] == ']')
+            {
+                var section = line[1..^1].Trim();
+                currentProfile = profiles.GetValueOrDefault(section);
+                if (currentProfile is null)
+                {
+                    currentProfile = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    profiles[section] = currentProfile;
+                }
+                continue;
+            }
+
+            if (currentProfile is null)
+                continue;
+
+            var equalsIndex = line.IndexOf('=');
+            if (equalsIndex <= 0)
+                continue;
+
+            currentProfile[line[..equalsIndex].Trim()] = line[(equalsIndex + 1)..].Trim();
+        }
+
+        return profiles;
+    }
+
+    private static AwsCredentials ParseJsonCredentials(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        return new AwsCredentials(
+            RequiredProperty(root, "AccessKeyId"),
+            RequiredProperty(root, "SecretAccessKey"),
+            TryGetProperty(root, "Token"),
+            TryParseExpiration(TryGetProperty(root, "Expiration")));
+    }
+
+    private static string RequiredProperty(JsonElement root, string name)
+        => root.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()!
+            : throw new InvalidOperationException($"AWS credentials response did not contain {name}");
+
+    private static string? TryGetProperty(JsonElement root, string name)
+        => root.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static DateTimeOffset? TryParseExpiration(string? value)
+        => DateTimeOffset.TryParse(value, null, System.Globalization.DateTimeStyles.AssumeUniversal, out var expiration)
+            ? expiration
+            : null;
+}

--- a/src/Dekaf/Security/Sasl/AwsMskIamDefaultCredentialsProvider.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamDefaultCredentialsProvider.cs
@@ -8,11 +8,12 @@ namespace Dekaf.Security.Sasl;
 /// </summary>
 public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvider
 {
-    private static readonly HttpClient HttpClient = new()
+    private static readonly HttpClient SharedHttpClient = new()
     {
         Timeout = TimeSpan.FromSeconds(2)
     };
 
+    private readonly HttpClient _httpClient;
     private readonly string? _profileName;
     private readonly string? _region;
     private readonly string _webIdentitySessionName = "dekaf-" + Guid.NewGuid().ToString("N");
@@ -23,7 +24,15 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
     /// Creates the default AWS credentials provider.
     /// </summary>
     public AwsMskIamDefaultCredentialsProvider(string? profileName = null, string? region = null)
+        : this(SharedHttpClient, profileName, region)
     {
+    }
+
+    internal AwsMskIamDefaultCredentialsProvider(HttpClient httpClient, string? profileName = null, string? region = null)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+
+        _httpClient = httpClient;
         _profileName = profileName;
         _region = region;
     }
@@ -103,20 +112,31 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
             })
         };
 
-        using var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+        try
+        {
+            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
 
-        var xml = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        var document = XDocument.Parse(xml);
-        var credentials = document.Descendants().FirstOrDefault(element => element.Name.LocalName == "Credentials");
-        if (credentials is null)
-            throw new InvalidOperationException("STS AssumeRoleWithWebIdentity response did not contain credentials");
+            var xml = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var document = XDocument.Parse(xml);
+            var credentials = document.Descendants().FirstOrDefault(element => element.Name.LocalName == "Credentials");
+            if (credentials is null)
+                throw new InvalidOperationException("STS AssumeRoleWithWebIdentity response did not contain credentials");
 
-        return new AwsCredentials(
-            RequiredElement(credentials, "AccessKeyId"),
-            RequiredElement(credentials, "SecretAccessKey"),
-            RequiredElement(credentials, "SessionToken"),
-            DateTimeOffset.Parse(RequiredElement(credentials, "Expiration"), null, System.Globalization.DateTimeStyles.AssumeUniversal));
+            return new AwsCredentials(
+                RequiredElement(credentials, "AccessKeyId"),
+                RequiredElement(credentials, "SecretAccessKey"),
+                RequiredElement(credentials, "SessionToken"),
+                DateTimeOffset.Parse(RequiredElement(credentials, "Expiration"), null, System.Globalization.DateTimeStyles.AssumeUniversal));
+        }
+        catch (HttpRequestException)
+        {
+            return null;
+        }
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
     }
 
     private AwsCredentials? TryGetProfileCredentials()
@@ -152,7 +172,7 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
         return profiles.TryGetValue("profile " + profileName, out profile!);
     }
 
-    private static async Task<AwsCredentials?> TryGetContainerCredentialsAsync(CancellationToken cancellationToken)
+    private async Task<AwsCredentials?> TryGetContainerCredentialsAsync(CancellationToken cancellationToken)
     {
         var fullUri = Environment.GetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_FULL_URI");
         var relativeUri = Environment.GetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI");
@@ -175,7 +195,7 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
             using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
             ApplyContainerAuthorization(request);
 
-            using var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
                 return null;
 
@@ -205,7 +225,7 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
                string.Equals(uri.DnsSafeHost, "fd00:ec2::23", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static async Task<AwsCredentials?> TryGetInstanceMetadataCredentialsAsync(CancellationToken cancellationToken)
+    private async Task<AwsCredentials?> TryGetInstanceMetadataCredentialsAsync(CancellationToken cancellationToken)
     {
         if (string.Equals(
             Environment.GetEnvironmentVariable("AWS_EC2_METADATA_DISABLED"),
@@ -218,6 +238,9 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
         try
         {
             var token = await TryGetImdsTokenAsync(cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(token))
+                return null;
+
             var roleName = await GetImdsStringAsync("http://169.254.169.254/latest/meta-data/iam/security-credentials/", token, cancellationToken)
                 .ConfigureAwait(false);
 
@@ -242,14 +265,14 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
         }
     }
 
-    private static async Task<string?> TryGetImdsTokenAsync(CancellationToken cancellationToken)
+    private async Task<string?> TryGetImdsTokenAsync(CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Put, "http://169.254.169.254/latest/api/token");
         request.Headers.Add("X-aws-ec2-metadata-token-ttl-seconds", "21600");
 
         try
         {
-            using var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
             return response.IsSuccessStatusCode
                 ? await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false)
                 : null;
@@ -260,7 +283,7 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
         }
     }
 
-    private static async Task<string?> GetImdsStringAsync(
+    private async Task<string?> GetImdsStringAsync(
         string endpoint,
         string? token,
         CancellationToken cancellationToken)
@@ -269,7 +292,7 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
         if (!string.IsNullOrWhiteSpace(token))
             request.Headers.Add("X-aws-ec2-metadata-token", token);
 
-        using var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         return response.IsSuccessStatusCode
             ? await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false)
             : null;

--- a/src/Dekaf/Security/Sasl/AwsMskIamDefaultCredentialsProvider.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamDefaultCredentialsProvider.cs
@@ -160,7 +160,7 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
         Uri? endpoint = null;
         if (!string.IsNullOrWhiteSpace(fullUri) && Uri.TryCreate(fullUri, UriKind.Absolute, out var parsedFullUri))
         {
-            endpoint = parsedFullUri;
+            endpoint = IsTrustedContainerCredentialsFullUri(parsedFullUri) ? parsedFullUri : null;
         }
         else if (!string.IsNullOrWhiteSpace(relativeUri))
         {
@@ -190,6 +190,19 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
         {
             return null;
         }
+    }
+
+    internal static bool IsTrustedContainerCredentialsFullUri(Uri uri)
+    {
+        if (uri.Scheme == Uri.UriSchemeHttps)
+            return true;
+
+        if (uri.Scheme != Uri.UriSchemeHttp)
+            return false;
+
+        return string.Equals(uri.DnsSafeHost, "169.254.170.2", StringComparison.Ordinal) ||
+               string.Equals(uri.DnsSafeHost, "169.254.170.23", StringComparison.Ordinal) ||
+               string.Equals(uri.DnsSafeHost, "fd00:ec2::23", StringComparison.OrdinalIgnoreCase);
     }
 
     private static async Task<AwsCredentials?> TryGetInstanceMetadataCredentialsAsync(CancellationToken cancellationToken)
@@ -275,15 +288,19 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
     }
 
     private string ResolveStsRegion()
-        => _region ??
-           Environment.GetEnvironmentVariable("AWS_REGION") ??
-           Environment.GetEnvironmentVariable("AWS_DEFAULT_REGION") ??
-           "us-east-1";
+        => AwsMskIamRegionResolver.ValidateRegion(
+            _region ??
+            Environment.GetEnvironmentVariable("AWS_REGION") ??
+            Environment.GetEnvironmentVariable("AWS_DEFAULT_REGION") ??
+            "us-east-1");
 
-    private static Uri BuildStsEndpoint(string region)
-        => region.StartsWith("cn-", StringComparison.Ordinal)
+    internal static Uri BuildStsEndpoint(string region)
+    {
+        region = AwsMskIamRegionResolver.ValidateRegion(region);
+        return region.StartsWith("cn-", StringComparison.Ordinal)
             ? new Uri($"https://sts.{region}.amazonaws.com.cn/")
             : new Uri($"https://sts.{region}.amazonaws.com/");
+    }
 
     private static string RequiredElement(XElement parent, string localName)
         => parent.Elements().First(element => element.Name.LocalName == localName).Value;

--- a/src/Dekaf/Security/Sasl/AwsMskIamSignedPayload.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamSignedPayload.cs
@@ -1,0 +1,149 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Dekaf.Security.Sasl;
+
+internal static class AwsMskIamSignedPayload
+{
+    private const string Action = "kafka-cluster:Connect";
+    private const string Algorithm = "AWS4-HMAC-SHA256";
+    private const string Service = "kafka-cluster";
+    private const string Version = "2020_10_22";
+    private const string SignedHeaders = "host";
+    private static readonly byte[] EmptyPayloadHash = SHA256.HashData([]);
+
+    public static string Create(
+        AwsCredentials credentials,
+        string host,
+        string region,
+        string userAgent,
+        DateTimeOffset now,
+        TimeSpan expiration)
+    {
+        ArgumentNullException.ThrowIfNull(credentials);
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentException.ThrowIfNullOrWhiteSpace(region);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userAgent);
+
+        if (expiration <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(expiration), "Expiration must be positive");
+        if (expiration.TotalSeconds > int.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(expiration), "Expiration is too large");
+
+        var utc = now.ToUniversalTime();
+        var dateStamp = utc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+        var amzDate = utc.ToString("yyyyMMdd'T'HHmmss'Z'", CultureInfo.InvariantCulture);
+        var expires = ((int)expiration.TotalSeconds).ToString(CultureInfo.InvariantCulture);
+        var credentialScope = $"{dateStamp}/{region}/{Service}/aws4_request";
+        var credential = $"{credentials.AccessKeyId}/{credentialScope}";
+
+        var queryParameters = new SortedDictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["Action"] = Action,
+            ["X-Amz-Algorithm"] = Algorithm,
+            ["X-Amz-Credential"] = credential,
+            ["X-Amz-Date"] = amzDate,
+            ["X-Amz-Expires"] = expires,
+            ["X-Amz-SignedHeaders"] = SignedHeaders
+        };
+
+        if (credentials.SessionToken is not null)
+            queryParameters["X-Amz-Security-Token"] = credentials.SessionToken;
+
+        var canonicalRequest = CreateCanonicalRequest(queryParameters, host);
+        var stringToSign = string.Join(
+            '\n',
+            Algorithm,
+            amzDate,
+            credentialScope,
+            Hex(SHA256.HashData(Encoding.UTF8.GetBytes(canonicalRequest))));
+
+        var signature = CalculateSignature(credentials.SecretAccessKey, dateStamp, region, stringToSign);
+
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("version", Version);
+            writer.WriteString("host", host);
+            writer.WriteString("user-agent", userAgent);
+            writer.WriteString("action", Action);
+            writer.WriteString("x-amz-algorithm", Algorithm);
+            writer.WriteString("x-amz-credential", credential);
+            writer.WriteString("x-amz-date", amzDate);
+            if (credentials.SessionToken is not null)
+                writer.WriteString("x-amz-security-token", credentials.SessionToken);
+            writer.WriteString("x-amz-signedheaders", SignedHeaders);
+            writer.WriteString("x-amz-expires", expires);
+            writer.WriteString("x-amz-signature", signature);
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    private static string CreateCanonicalRequest(
+        SortedDictionary<string, string> queryParameters,
+        string host)
+    {
+        var canonicalQuery = string.Join(
+            '&',
+            queryParameters.Select(pair => $"{UriEncode(pair.Key)}={UriEncode(pair.Value)}"));
+
+        return string.Join(
+            '\n',
+            "GET",
+            "/",
+            canonicalQuery,
+            $"host:{host}\n",
+            SignedHeaders,
+            Hex(EmptyPayloadHash));
+    }
+
+    private static string CalculateSignature(
+        string secretAccessKey,
+        string dateStamp,
+        string region,
+        string stringToSign)
+    {
+        var dateKey = Hmac(Encoding.UTF8.GetBytes("AWS4" + secretAccessKey), dateStamp);
+        var dateRegionKey = Hmac(dateKey, region);
+        var dateRegionServiceKey = Hmac(dateRegionKey, Service);
+        var signingKey = Hmac(dateRegionServiceKey, "aws4_request");
+        return Hex(Hmac(signingKey, stringToSign));
+    }
+
+    private static byte[] Hmac(byte[] key, string message)
+        => HMACSHA256.HashData(key, Encoding.UTF8.GetBytes(message));
+
+    private static string Hex(ReadOnlySpan<byte> bytes)
+    {
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    private static string UriEncode(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        var builder = new StringBuilder(bytes.Length);
+
+        foreach (var b in bytes)
+        {
+            if ((b >= 'A' && b <= 'Z') ||
+                (b >= 'a' && b <= 'z') ||
+                (b >= '0' && b <= '9') ||
+                b is (byte)'-' or (byte)'_' or (byte)'.' or (byte)'~')
+            {
+                builder.Append((char)b);
+            }
+            else
+            {
+                builder.Append('%');
+                builder.Append(b.ToString("X2", CultureInfo.InvariantCulture));
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Dekaf/Security/Sasl/SaslMechanism.cs
+++ b/src/Dekaf/Security/Sasl/SaslMechanism.cs
@@ -38,7 +38,12 @@ public enum SaslMechanism
     /// SASL OAUTHBEARER mechanism. OAuth 2.0 / OpenID Connect authentication
     /// using bearer tokens. Supports both static tokens and dynamic token providers.
     /// </summary>
-    OAuthBearer
+    OAuthBearer,
+
+    /// <summary>
+    /// Amazon MSK IAM mechanism. Sends a SigV4-signed AWS_MSK_IAM payload.
+    /// </summary>
+    AwsMskIam
 }
 
 /// <summary>
@@ -56,6 +61,7 @@ public static class SaslMechanismExtensions
         SaslMechanism.ScramSha512 => "SCRAM-SHA-512",
         SaslMechanism.Gssapi => "GSSAPI",
         SaslMechanism.OAuthBearer => "OAUTHBEARER",
+        SaslMechanism.AwsMskIam => "AWS_MSK_IAM",
         _ => throw new ArgumentOutOfRangeException(nameof(mechanism), mechanism, "Unsupported SASL mechanism")
     };
 }

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -77,6 +77,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
+                AwsMskIamConfig = options.AwsMskIamConfig,
                 SendBufferSize = options.SocketSendBufferBytes,
                 ReceiveBufferSize = options.SocketReceiveBufferBytes,
                 ClientDnsLookup = options.ClientDnsLookup

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -132,6 +132,11 @@ public sealed class ShareConsumerOptions
     public Func<CancellationToken, ValueTask<OAuthBearerToken>>? OAuthBearerTokenProvider { get; init; }
 
     /// <summary>
+    /// AWS_MSK_IAM configuration.
+    /// </summary>
+    public AwsMskIamConfig? AwsMskIamConfig { get; init; }
+
+    /// <summary>
     /// TCP socket send buffer size in bytes. 0 uses the system default.
     /// </summary>
     public int SocketSendBufferBytes { get; init; }

--- a/tests/Dekaf.Tests.Unit/Builder/AwsMskIamBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/AwsMskIamBuilderTests.cs
@@ -1,0 +1,117 @@
+using System.Reflection;
+using Dekaf.Producer;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.Builder;
+
+public sealed class AwsMskIamBuilderTests
+{
+    [Test]
+    public async Task Producer_WithAwsMskIam_SetsMechanismAndConfig()
+    {
+        var config = CreateConfig();
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var result = builder.WithAwsMskIam(config);
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(GetSaslMechanism(builder)).IsEqualTo(SaslMechanism.AwsMskIam);
+        await Assert.That(GetAwsMskIamConfig(builder)).IsSameReferenceAs(config);
+    }
+
+    [Test]
+    public async Task Consumer_WithAwsMskIam_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var result = builder.WithAwsMskIam(CreateConfig());
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(GetSaslMechanism(builder)).IsEqualTo(SaslMechanism.AwsMskIam);
+    }
+
+    [Test]
+    public async Task ShareConsumer_WithAwsMskIam_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateShareConsumer<string, string>();
+
+        var result = builder.WithAwsMskIam(CreateConfig());
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(GetSaslMechanism(builder)).IsEqualTo(SaslMechanism.AwsMskIam);
+    }
+
+    [Test]
+    public async Task AdminClient_WithAwsMskIam_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateAdminClient();
+
+        var result = builder.WithAwsMskIam(CreateConfig());
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(GetSaslMechanism(builder)).IsEqualTo(SaslMechanism.AwsMskIam);
+    }
+
+    [Test]
+    public async Task KafkaClient_WithAwsMskIam_ReturnsSameBuilder()
+    {
+        var builder = Kafka.Connect();
+
+        var result = builder.WithAwsMskIam(CreateConfig());
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(GetSaslMechanism(builder)).IsEqualTo(SaslMechanism.AwsMskIam);
+    }
+
+    [Test]
+    public async Task Producer_Build_WithAwsMskIam_PreservesConfig()
+    {
+        var config = CreateConfig();
+
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithAwsMskIam(config)
+            .Build();
+
+        var options = GetField<ProducerOptions>(producer, "_options");
+
+        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.AwsMskIam);
+        await Assert.That(options.AwsMskIamConfig).IsSameReferenceAs(config);
+    }
+
+    [Test]
+    public async Task KafkaClient_CreatedBuilders_RejectAwsMskIamOverrides()
+    {
+        await using var client = Kafka.Connect("localhost:9092");
+
+        await Assert.That(() => client.CreateProducer<string, string>().WithAwsMskIam())
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithAwsMskIam())
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithAwsMskIam())
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithAwsMskIam())
+            .Throws<InvalidOperationException>();
+    }
+
+    private static AwsMskIamConfig CreateConfig() => new()
+    {
+        Region = "us-east-1",
+        CredentialsProvider = new StaticAwsCredentialsProvider(new AwsCredentials("access", "secret"))
+    };
+
+    private static SaslMechanism GetSaslMechanism(object builder)
+        => GetField<SaslMechanism>(builder, "_saslMechanism");
+
+    private static AwsMskIamConfig? GetAwsMskIamConfig(object builder)
+        => GetField<AwsMskIamConfig?>(builder, "_awsMskIamConfig");
+
+    private static T GetField<T>(object instance, string name)
+    {
+        var field = instance.GetType()
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{name} field not found");
+
+        return (T)field.GetValue(instance)!;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -415,6 +415,33 @@ public class DependencyInjectionTests
     }
 
     [Test]
+    public async Task AddProducer_WithAwsMskIamConfig_InferSaslMechanism()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:BootstrapServers"] = "broker1:9098",
+            ["Kafka:UseTls"] = "true",
+            ["Kafka:AwsMskIamConfig:Region"] = "us-east-1",
+            ["Kafka:AwsMskIamConfig:ProfileName"] = "msk-prod"
+        });
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>(configuration.GetSection("Kafka"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var producer = provider.GetRequiredService<IKafkaProducer<string, string>>();
+        var options = GetProducerOptions(producer);
+
+        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.AwsMskIam);
+        await Assert.That(options.AwsMskIamConfig).IsNotNull();
+        await Assert.That(options.AwsMskIamConfig!.Region).IsEqualTo("us-east-1");
+        await Assert.That(options.AwsMskIamConfig.ProfileName).IsEqualTo("msk-prod");
+    }
+
+    [Test]
     public async Task AddProducer_WithConfigurationSection_FluentConfigurationOverridesBoundValues()
     {
         var services = new ServiceCollection();

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamAuthenticatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamAuthenticatorTests.cs
@@ -112,6 +112,15 @@ public sealed class AwsMskIamAuthenticatorTests
     }
 
     [Test]
+    public async Task TryResolveFromHost_ReturnsMskServerlessRegion()
+    {
+        var region = AwsMskIamRegionResolver.TryResolveFromHost(
+            "boot-abcdefghij.c1.kafka-serverless.us-west-2.amazonaws.com");
+
+        await Assert.That(region).IsEqualTo("us-west-2");
+    }
+
+    [Test]
     public async Task TryResolveFromHost_IgnoresClusterNameThatLooksLikeRegion()
     {
         var region = AwsMskIamRegionResolver.TryResolveFromHost(

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamAuthenticatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamAuthenticatorTests.cs
@@ -1,0 +1,102 @@
+using System.Text;
+using System.Text.Json;
+using Dekaf.Errors;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.Security.Sasl;
+
+public sealed class AwsMskIamAuthenticatorTests
+{
+    private const string Host = "b-1.test.c2.kafka.us-east-1.amazonaws.com";
+
+    [Test]
+    public async Task CreatePayload_ProducesExpectedSigV4Fields()
+    {
+        var credentials = new AwsCredentials(
+            "AKIDEXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY");
+        var now = new DateTimeOffset(2015, 8, 30, 12, 36, 0, TimeSpan.Zero);
+
+        var payload = AwsMskIamSignedPayload.Create(
+            credentials,
+            Host,
+            "us-east-1",
+            "dekaf-test",
+            now,
+            TimeSpan.FromMinutes(15));
+
+        using var document = JsonDocument.Parse(payload);
+        var root = document.RootElement;
+
+        await Assert.That(root.GetProperty("version").GetString()).IsEqualTo("2020_10_22");
+        await Assert.That(root.GetProperty("host").GetString()).IsEqualTo(Host);
+        await Assert.That(root.GetProperty("user-agent").GetString()).IsEqualTo("dekaf-test");
+        await Assert.That(root.GetProperty("action").GetString()).IsEqualTo("kafka-cluster:Connect");
+        await Assert.That(root.GetProperty("x-amz-algorithm").GetString()).IsEqualTo("AWS4-HMAC-SHA256");
+        await Assert.That(root.GetProperty("x-amz-credential").GetString())
+            .IsEqualTo("AKIDEXAMPLE/20150830/us-east-1/kafka-cluster/aws4_request");
+        await Assert.That(root.GetProperty("x-amz-date").GetString()).IsEqualTo("20150830T123600Z");
+        await Assert.That(root.GetProperty("x-amz-expires").GetString()).IsEqualTo("900");
+        await Assert.That(root.GetProperty("x-amz-signedheaders").GetString()).IsEqualTo("host");
+        await Assert.That(root.TryGetProperty("x-amz-security-token", out _)).IsFalse();
+        await Assert.That(root.GetProperty("x-amz-signature").GetString())
+            .IsEqualTo("166d06165f73bde1f7f584d772d7a23bf5548f63444ca4e970fbec0a17baeb15");
+    }
+
+    [Test]
+    public async Task CreatePayload_IncludesSessionTokenWhenPresent()
+    {
+        var credentials = new AwsCredentials("access", "secret", "session-token");
+
+        var payload = AwsMskIamSignedPayload.Create(
+            credentials,
+            Host,
+            "us-east-1",
+            "dekaf-test",
+            DateTimeOffset.FromUnixTimeSeconds(1_700_000_000),
+            TimeSpan.FromMinutes(15));
+
+        using var document = JsonDocument.Parse(payload);
+
+        await Assert.That(document.RootElement.GetProperty("x-amz-security-token").GetString())
+            .IsEqualTo("session-token");
+    }
+
+    [Test]
+    public async Task GetInitialResponse_UsesCredentialProviderAndCompletesAfterBrokerResponse()
+    {
+        var authenticator = new AwsMskIamAuthenticator(
+            new AwsMskIamConfig
+            {
+                Region = "us-east-1",
+                UserAgent = "dekaf-test",
+                CredentialsProvider = new StaticAwsCredentialsProvider(new AwsCredentials("access", "secret"))
+            },
+            Host);
+
+        await authenticator.GetCredentialsAsync();
+
+        var response = Encoding.UTF8.GetString(authenticator.GetInitialResponse());
+
+        await Assert.That(response).Contains("\"host\":\"" + Host + "\"");
+        await Assert.That(authenticator.IsComplete).IsFalse();
+        await Assert.That(authenticator.EvaluateChallenge("""{"version":"2020_10_22","request-id":"req"}"""u8.ToArray()))
+            .IsNull();
+        await Assert.That(authenticator.IsComplete).IsTrue();
+    }
+
+    [Test]
+    public async Task EvaluateChallenge_EmptyResponse_ThrowsAuthenticationException()
+    {
+        var authenticator = new AwsMskIamAuthenticator(
+            new AwsMskIamConfig
+            {
+                Region = "us-east-1",
+                CredentialsProvider = new StaticAwsCredentialsProvider(new AwsCredentials("access", "secret"))
+            },
+            Host);
+
+        await Assert.That(() => authenticator.EvaluateChallenge([]))
+            .Throws<AuthenticationException>();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamAuthenticatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamAuthenticatorTests.cs
@@ -86,6 +86,58 @@ public sealed class AwsMskIamAuthenticatorTests
     }
 
     [Test]
+    public async Task GetInitialResponse_InvalidConfiguredRegion_Throws()
+    {
+        var authenticator = new AwsMskIamAuthenticator(
+            new AwsMskIamConfig
+            {
+                Region = "evil.com/",
+                CredentialsProvider = new StaticAwsCredentialsProvider(new AwsCredentials("access", "secret"))
+            },
+            Host);
+
+        await authenticator.GetCredentialsAsync();
+
+        var exception = await Assert.That(() => authenticator.GetInitialResponse())
+            .Throws<InvalidOperationException>();
+        await Assert.That(exception!.Message).Contains("region");
+    }
+
+    [Test]
+    public async Task TryResolveFromHost_ReturnsMskRegion()
+    {
+        var region = AwsMskIamRegionResolver.TryResolveFromHost(Host);
+
+        await Assert.That(region).IsEqualTo("us-east-1");
+    }
+
+    [Test]
+    public async Task TryResolveFromHost_IgnoresClusterNameThatLooksLikeRegion()
+    {
+        var region = AwsMskIamRegionResolver.TryResolveFromHost(
+            "b-1.my-cluster-2.abcdef.c2.kafka.us-east-1.amazonaws.com");
+
+        await Assert.That(region).IsEqualTo("us-east-1");
+    }
+
+    [Test]
+    public async Task TryResolveFromHost_ReturnsNullWhenHostIsNotMskShape()
+    {
+        var region = AwsMskIamRegionResolver.TryResolveFromHost("b-1.test.c2.us-east-1.amazonaws.com");
+
+        await Assert.That(region).IsNull();
+    }
+
+    [Test]
+    public async Task TryResolveFromHost_ReturnsNullWhenAmazonAwsIsNotSuffix()
+    {
+        var region = AwsMskIamRegionResolver.TryResolveFromHost(
+            "b-1.test.c2.kafka.us-east-1.amazonaws.com.example.com");
+
+        await Assert.That(region).IsNull();
+    }
+
+    [Test]
     public async Task EvaluateChallenge_EmptyResponse_ThrowsAuthenticationException()
     {
         var authenticator = new AwsMskIamAuthenticator(

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamDefaultCredentialsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamDefaultCredentialsProviderTests.cs
@@ -90,6 +90,52 @@ public sealed class AwsMskIamDefaultCredentialsProviderTests
         }
     }
 
+    [Test]
+    public async Task IsTrustedContainerCredentialsFullUri_RejectsHttpNonMetadataHost()
+    {
+        var trusted = AwsMskIamDefaultCredentialsProvider.IsTrustedContainerCredentialsFullUri(
+            new Uri("http://example.com/credentials"));
+
+        await Assert.That(trusted).IsFalse();
+    }
+
+    [Test]
+    public async Task IsTrustedContainerCredentialsFullUri_AllowsHttpsNonMetadataHost()
+    {
+        var trusted = AwsMskIamDefaultCredentialsProvider.IsTrustedContainerCredentialsFullUri(
+            new Uri("https://example.com/credentials"));
+
+        await Assert.That(trusted).IsTrue();
+    }
+
+    [Arguments("http://169.254.170.2/credentials")]
+    [Arguments("http://169.254.170.23/credentials")]
+    [Arguments("http://[fd00:ec2::23]/credentials")]
+    [Test]
+    public async Task IsTrustedContainerCredentialsFullUri_AllowsTrustedMetadataHosts(string uri)
+    {
+        var trusted = AwsMskIamDefaultCredentialsProvider.IsTrustedContainerCredentialsFullUri(new Uri(uri));
+
+        await Assert.That(trusted).IsTrue();
+    }
+
+    [Test]
+    public async Task BuildStsEndpoint_InvalidRegion_Throws()
+    {
+        var exception = await Assert.That(() => AwsMskIamDefaultCredentialsProvider.BuildStsEndpoint("evil.com/"))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(exception!.Message).Contains("region");
+    }
+
+    [Test]
+    public async Task BuildStsEndpoint_ChinaRegion_UsesChinaSuffix()
+    {
+        var endpoint = AwsMskIamDefaultCredentialsProvider.BuildStsEndpoint("cn-north-1");
+
+        await Assert.That(endpoint).IsEqualTo(new Uri("https://sts.cn-north-1.amazonaws.com.cn/"));
+    }
+
     private sealed class EnvironmentSnapshot
     {
         private readonly Dictionary<string, string?> _values;

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamDefaultCredentialsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamDefaultCredentialsProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Dekaf.Security.Sasl;
 
 namespace Dekaf.Tests.Unit.Security.Sasl;
@@ -135,6 +136,146 @@ public sealed class AwsMskIamDefaultCredentialsProviderTests
 
         await Assert.That(endpoint).IsEqualTo(new Uri("https://sts.cn-north-1.amazonaws.com.cn/"));
     }
+
+    [Test]
+    public async Task GetCredentialsAsync_WebIdentityHttpFailureFallsBackToProfile()
+    {
+        var snapshot = EnvironmentSnapshot.Capture(
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_ROLE_ARN",
+            "AWS_ROLE_SESSION_NAME",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+            "AWS_REGION",
+            "AWS_DEFAULT_REGION",
+            "AWS_SHARED_CREDENTIALS_FILE",
+            "AWS_CONFIG_FILE",
+            "AWS_PROFILE",
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "AWS_EC2_METADATA_DISABLED");
+        var tokenFile = Path.GetTempFileName();
+        var credentialsFile = Path.GetTempFileName();
+
+        try
+        {
+            Environment.SetEnvironmentVariable("AWS_ACCESS_KEY_ID", null);
+            Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", null);
+            Environment.SetEnvironmentVariable("AWS_SESSION_TOKEN", null);
+            Environment.SetEnvironmentVariable("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/msk-client");
+            Environment.SetEnvironmentVariable("AWS_ROLE_SESSION_NAME", "dekaf-test");
+            Environment.SetEnvironmentVariable("AWS_WEB_IDENTITY_TOKEN_FILE", tokenFile);
+            Environment.SetEnvironmentVariable("AWS_REGION", "us-east-1");
+            Environment.SetEnvironmentVariable("AWS_DEFAULT_REGION", null);
+            Environment.SetEnvironmentVariable("AWS_SHARED_CREDENTIALS_FILE", credentialsFile);
+            Environment.SetEnvironmentVariable("AWS_CONFIG_FILE", null);
+            Environment.SetEnvironmentVariable("AWS_PROFILE", "fallback");
+            Environment.SetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_FULL_URI", null);
+            Environment.SetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", null);
+            Environment.SetEnvironmentVariable("AWS_EC2_METADATA_DISABLED", "true");
+
+            await File.WriteAllTextAsync(tokenFile, "web-token");
+            await File.WriteAllTextAsync(
+                credentialsFile,
+                """
+                [fallback]
+                aws_access_key_id = profile-access
+                aws_secret_access_key = profile-secret
+                aws_session_token = profile-token
+                """);
+
+            var handler = new CapturingHttpMessageHandler(_ => throw new HttpRequestException("STS unavailable"));
+            using var httpClient = new HttpClient(handler);
+            var provider = new AwsMskIamDefaultCredentialsProvider(httpClient);
+
+            var credentials = await provider.GetCredentialsAsync();
+
+            await Assert.That(credentials.AccessKeyId).IsEqualTo("profile-access");
+            await Assert.That(credentials.SecretAccessKey).IsEqualTo("profile-secret");
+            await Assert.That(credentials.SessionToken).IsEqualTo("profile-token");
+            await Assert.That(handler.Requests.Count).IsEqualTo(1);
+            await Assert.That(handler.Requests[0].Method).IsEqualTo(HttpMethod.Post);
+            await Assert.That(handler.Requests[0].RequestUri!.Host).IsEqualTo("sts.us-east-1.amazonaws.com");
+        }
+        finally
+        {
+            File.Delete(tokenFile);
+            File.Delete(credentialsFile);
+            snapshot.Restore();
+        }
+    }
+
+    [Test]
+    public async Task GetCredentialsAsync_ImdsTokenFailureDoesNotFallbackToUnauthenticatedMetadata()
+    {
+        var snapshot = EnvironmentSnapshot.Capture(
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_ROLE_ARN",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+            "AWS_SHARED_CREDENTIALS_FILE",
+            "AWS_CONFIG_FILE",
+            "AWS_PROFILE",
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "AWS_EC2_METADATA_DISABLED");
+        var credentialsFile = Path.GetTempFileName();
+        var configFile = Path.GetTempFileName();
+
+        try
+        {
+            Environment.SetEnvironmentVariable("AWS_ACCESS_KEY_ID", null);
+            Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", null);
+            Environment.SetEnvironmentVariable("AWS_SESSION_TOKEN", null);
+            Environment.SetEnvironmentVariable("AWS_ROLE_ARN", null);
+            Environment.SetEnvironmentVariable("AWS_WEB_IDENTITY_TOKEN_FILE", null);
+            Environment.SetEnvironmentVariable("AWS_SHARED_CREDENTIALS_FILE", credentialsFile);
+            Environment.SetEnvironmentVariable("AWS_CONFIG_FILE", configFile);
+            Environment.SetEnvironmentVariable("AWS_PROFILE", "dekaf-missing-" + Guid.NewGuid().ToString("N"));
+            Environment.SetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_FULL_URI", null);
+            Environment.SetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", null);
+            Environment.SetEnvironmentVariable("AWS_EC2_METADATA_DISABLED", null);
+
+            var handler = new CapturingHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.Forbidden));
+            using var httpClient = new HttpClient(handler);
+            var provider = new AwsMskIamDefaultCredentialsProvider(httpClient);
+
+            await Assert.That(async () => await provider.GetCredentialsAsync()).Throws<InvalidOperationException>();
+            await Assert.That(handler.Requests.Count).IsEqualTo(1);
+            await Assert.That(handler.Requests[0].Method).IsEqualTo(HttpMethod.Put);
+            await Assert.That(handler.Requests[0].RequestUri!.AbsolutePath).IsEqualTo("/latest/api/token");
+        }
+        finally
+        {
+            File.Delete(credentialsFile);
+            File.Delete(configFile);
+            snapshot.Restore();
+        }
+    }
+
+    private sealed class CapturingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responseFactory;
+
+        public CapturingHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        {
+            _responseFactory = responseFactory;
+        }
+
+        public List<CapturedRequest> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(new CapturedRequest(request.Method, request.RequestUri));
+            return Task.FromResult(_responseFactory(request));
+        }
+    }
+
+    private sealed record CapturedRequest(HttpMethod Method, Uri? RequestUri);
 
     private sealed class EnvironmentSnapshot
     {

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamDefaultCredentialsProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/AwsMskIamDefaultCredentialsProviderTests.cs
@@ -1,0 +1,116 @@
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.Security.Sasl;
+
+[NotInParallel("AwsEnvironment")]
+public sealed class AwsMskIamDefaultCredentialsProviderTests
+{
+    [Test]
+    public async Task GetCredentialsAsync_UsesEnvironmentCredentials()
+    {
+        var snapshot = EnvironmentSnapshot.Capture(
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("AWS_ACCESS_KEY_ID", "env-access");
+            Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", "env-secret");
+            Environment.SetEnvironmentVariable("AWS_SESSION_TOKEN", "env-token");
+
+            var provider = new AwsMskIamDefaultCredentialsProvider();
+
+            var credentials = await provider.GetCredentialsAsync();
+
+            await Assert.That(credentials.AccessKeyId).IsEqualTo("env-access");
+            await Assert.That(credentials.SecretAccessKey).IsEqualTo("env-secret");
+            await Assert.That(credentials.SessionToken).IsEqualTo("env-token");
+        }
+        finally
+        {
+            snapshot.Restore();
+        }
+    }
+
+    [Test]
+    public async Task GetCredentialsAsync_UsesConfiguredSharedCredentialsProfile()
+    {
+        var snapshot = EnvironmentSnapshot.Capture(
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_SHARED_CREDENTIALS_FILE",
+            "AWS_PROFILE",
+            "AWS_ROLE_ARN",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "AWS_EC2_METADATA_DISABLED");
+        var credentialsFile = Path.GetTempFileName();
+
+        try
+        {
+            Environment.SetEnvironmentVariable("AWS_ACCESS_KEY_ID", null);
+            Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", null);
+            Environment.SetEnvironmentVariable("AWS_SESSION_TOKEN", null);
+            Environment.SetEnvironmentVariable("AWS_ROLE_ARN", null);
+            Environment.SetEnvironmentVariable("AWS_WEB_IDENTITY_TOKEN_FILE", null);
+            Environment.SetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_FULL_URI", null);
+            Environment.SetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", null);
+            Environment.SetEnvironmentVariable("AWS_EC2_METADATA_DISABLED", "true");
+            Environment.SetEnvironmentVariable("AWS_SHARED_CREDENTIALS_FILE", credentialsFile);
+            Environment.SetEnvironmentVariable("AWS_PROFILE", "msk-prod");
+
+            await File.WriteAllTextAsync(
+                credentialsFile,
+                """
+                [default]
+                aws_access_key_id = default-access
+                aws_secret_access_key = default-secret
+
+                [msk-prod]
+                aws_access_key_id = profile-access
+                aws_secret_access_key = profile-secret
+                aws_session_token = profile-token
+                """);
+
+            var provider = new AwsMskIamDefaultCredentialsProvider();
+
+            var credentials = await provider.GetCredentialsAsync();
+
+            await Assert.That(credentials.AccessKeyId).IsEqualTo("profile-access");
+            await Assert.That(credentials.SecretAccessKey).IsEqualTo("profile-secret");
+            await Assert.That(credentials.SessionToken).IsEqualTo("profile-token");
+        }
+        finally
+        {
+            File.Delete(credentialsFile);
+            snapshot.Restore();
+        }
+    }
+
+    private sealed class EnvironmentSnapshot
+    {
+        private readonly Dictionary<string, string?> _values;
+
+        private EnvironmentSnapshot(Dictionary<string, string?> values)
+        {
+            _values = values;
+        }
+
+        public static EnvironmentSnapshot Capture(params string[] names)
+        {
+            var values = new Dictionary<string, string?>(StringComparer.Ordinal);
+            foreach (var name in names)
+                values[name] = Environment.GetEnvironmentVariable(name);
+            return new EnvironmentSnapshot(values);
+        }
+
+        public void Restore()
+        {
+            foreach (var (name, value) in _values)
+                Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/SaslMechanismTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/SaslMechanismTests.cs
@@ -29,6 +29,12 @@ public class SaslMechanismTests
     }
 
     [Test]
+    public async Task ToProtocolName_AwsMskIam_ReturnsAWSMSKIAM()
+    {
+        await Assert.That(SaslMechanism.AwsMskIam.ToProtocolName()).IsEqualTo("AWS_MSK_IAM");
+    }
+
+    [Test]
     public async Task ToProtocolName_None_ThrowsArgumentOutOfRangeException()
     {
         await Assert.That(() => SaslMechanism.None.ToProtocolName())

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
+using Dekaf.Protocol;
 using Dekaf.Serialization;
 using Dekaf.ShareConsumer;
 using Dekaf.Testing;
@@ -95,6 +96,48 @@ public sealed class InMemoryKafkaClusterTests
         await Assert.That(listings.Single().Name).IsEqualTo("events");
         await Assert.That(descriptions["events"].Partitions.Count).IsEqualTo(3);
         await Assert.That(afterDelete).IsEmpty();
+    }
+
+    [Test]
+    public async Task Admin_DescribeLogDirs_ReturnsInMemoryReplicaInfo()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("events", partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var admin = new InMemoryAdminClient(cluster);
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "events",
+            Partition = 1,
+            Key = "k",
+            Value = "v"
+        });
+
+        var result = await admin.DescribeLogDirsAsync([0], [new TopicPartition("events", 1)]);
+
+        await Assert.That(result.Keys).IsEquivalentTo([0]);
+        await Assert.That(result[0].Keys).IsEquivalentTo(["in-memory"]);
+        var replica = result[0]["in-memory"].ReplicaInfos[new TopicPartition("events", 1)];
+        await Assert.That(replica.Size).IsEqualTo(1);
+        await Assert.That(replica.OffsetLag).IsEqualTo(0);
+        await Assert.That(replica.IsFuture).IsFalse();
+    }
+
+    [Test]
+    public async Task Admin_AlterReplicaLogDirs_ReturnsSuccessPerReplica()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var admin = new InMemoryAdminClient(cluster);
+        var replica = new TopicPartitionReplica("events", 0, 0);
+
+        var result = await admin.AlterReplicaLogDirsAsync(new Dictionary<TopicPartitionReplica, string>
+        {
+            [replica] = "in-memory"
+        });
+
+        await Assert.That(result[replica].TopicPartitionReplica).IsEqualTo(replica);
+        await Assert.That(result[replica].ErrorCode).IsEqualTo(ErrorCode.None);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add native AWS_MSK_IAM SASL mechanism with SigV4 payload generation and broker response handling
- add default no-SDK AWS credential chain plus explicit credential provider hooks
- wire producer/consumer/share/admin/root builders, DI config, KIP-368 reauth, and docs

## Sources
- AWS MSK IAM client config: https://docs.aws.amazon.com/msk/latest/developerguide/configure-clients-for-iam-access-control.html
- AWS_MSK_IAM SigV4 payload/message exchange: https://github.com/aws/aws-msk-iam-auth#details

## Tests
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit` (3856 passed; reran and passed after unrelated timing flake)
- `dotnet build --configuration Release --no-restore`

Closes #1148