### PR TITLE
feat(networking): add reconnect backoff

### DIFF
--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -519,6 +519,10 @@ internal static class DekafConfigurationBinding
             builder.WithDeliveryTimeout(TimeSpan.FromMilliseconds(deliveryTimeoutMs));
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.RequestTimeoutMs), out var requestTimeoutMs))
             builder.WithRequestTimeout(TimeSpan.FromMilliseconds(requestTimeoutMs));
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.ReconnectBackoffMs), out var reconnectBackoffMs))
+            builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(reconnectBackoffMs));
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.ReconnectBackoffMaxMs), out var reconnectBackoffMaxMs))
+            builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(reconnectBackoffMaxMs));
         if (TryGetValue<bool>(configuration, nameof(ProducerOptions.EnableIdempotence), out var enableIdempotence))
             builder.WithIdempotence(enableIdempotence);
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.ConnectionsPerBroker), out var connectionsPerBroker))
@@ -615,6 +619,10 @@ internal static class DekafConfigurationBinding
             builder.WithIsolationLevel(isolationLevel);
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.RequestTimeoutMs), out var requestTimeoutMs))
             builder.WithRequestTimeout(TimeSpan.FromMilliseconds(requestTimeoutMs));
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.ReconnectBackoffMs), out var reconnectBackoffMs))
+            builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(reconnectBackoffMs));
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.ReconnectBackoffMaxMs), out var reconnectBackoffMaxMs))
+            builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(reconnectBackoffMaxMs));
         if (TryGetValue<bool>(configuration, nameof(ConsumerOptions.CheckCrcs), out var checkCrcs))
             builder.WithCheckCrcs(checkCrcs);
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
@@ -655,6 +663,10 @@ internal static class DekafConfigurationBinding
             builder.WithClientId(clientId);
         if (TryGetValue<int>(configuration, nameof(AdminClientOptions.RequestTimeoutMs), out var requestTimeoutMs))
             builder.WithRequestTimeout(TimeSpan.FromMilliseconds(requestTimeoutMs));
+        if (TryGetValue<int>(configuration, nameof(AdminClientOptions.ReconnectBackoffMs), out var reconnectBackoffMs))
+            builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(reconnectBackoffMs));
+        if (TryGetValue<int>(configuration, nameof(AdminClientOptions.ReconnectBackoffMaxMs), out var reconnectBackoffMaxMs))
+            builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(reconnectBackoffMaxMs));
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
         if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth))
             builder.WithSaslOptions(mechanism, username, password, gssapi, oauth);

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Dekaf;
+using Dekaf.Internal;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Producer;
@@ -44,6 +45,8 @@ public sealed class AdminClient : IAdminClient
                 UseTls = options.UseTls,
                 TlsConfig = options.TlsConfig,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
+                ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,
@@ -2473,6 +2476,8 @@ public sealed class AdminClientOptions
     public required IReadOnlyList<string> BootstrapServers { get; init; }
     public string? ClientId { get; init; } = "dekaf-admin";
     public int RequestTimeoutMs { get; init; } = 30000;
+    public int ReconnectBackoffMs { get; init; } = 50;
+    public int ReconnectBackoffMaxMs { get; init; } = 1000;
     public bool UseTls { get; init; }
     public TlsConfig? TlsConfig { get; init; }
     public SaslMechanism SaslMechanism { get; init; } = SaslMechanism.None;
@@ -2540,6 +2545,8 @@ public sealed class AdminClientBuilder
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
     private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
+    private int _reconnectBackoffMs = 50;
+    private int _reconnectBackoffMaxMs = 1000;
     private ILoggerFactory? _loggerFactory;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
@@ -2803,6 +2810,36 @@ public sealed class AdminClientBuilder
         return this;
     }
 
+    /// <summary>
+    /// Sets the initial delay before reconnecting to a broker after a connection failure.
+    /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to zero to disable the delay.
+    /// </summary>
+    /// <param name="backoff">The reconnect backoff. Cannot be negative.</param>
+    public AdminClientBuilder WithReconnectBackoff(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _reconnectBackoffMs = ReconnectBackoffValidation.ToMilliseconds(
+            backoff,
+            nameof(backoff),
+            "Reconnect backoff cannot be negative");
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum delay before reconnecting to a broker after repeated connection failures.
+    /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
+    /// </summary>
+    /// <param name="backoff">The maximum reconnect backoff. Cannot be negative.</param>
+    public AdminClientBuilder WithReconnectBackoffMax(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _reconnectBackoffMaxMs = ReconnectBackoffValidation.ToMilliseconds(
+            backoff,
+            nameof(backoff),
+            "Maximum reconnect backoff cannot be negative");
+        return this;
+    }
+
     internal AdminClientBuilder WithSaslOptions(
         SaslMechanism mechanism,
         string? username,
@@ -2824,12 +2861,15 @@ public sealed class AdminClientBuilder
     {
         if (_bootstrapServers.Count == 0)
             throw new InvalidOperationException("Bootstrap servers must be specified");
+        ReconnectBackoffValidation.ValidateMilliseconds(_reconnectBackoffMs, _reconnectBackoffMaxMs);
 
         var options = new AdminClientOptions
         {
             BootstrapServers = _bootstrapServers,
             ClientId = _clientId,
             RequestTimeoutMs = _requestTimeoutMs,
+            ReconnectBackoffMs = _reconnectBackoffMs,
+            ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
             SaslMechanism = _saslMechanism,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -65,6 +65,8 @@ public sealed class ProducerBuilder<TKey, TValue>
     private TimeSpan? _metadataMaxAge;
     private int? _deliveryTimeoutMs;
     private int? _requestTimeoutMs;
+    private int _reconnectBackoffMs = 50;
+    private int _reconnectBackoffMaxMs = 1000;
     private IRetryPolicy? _retryPolicy;
     private bool _enableAdaptiveConnections = true;
     private int _maxConnectionsPerBroker = 10;
@@ -669,6 +671,36 @@ public sealed class ProducerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Sets the initial delay before reconnecting to a broker after a connection failure.
+    /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to zero to disable the delay.
+    /// </summary>
+    /// <param name="backoff">The reconnect backoff. Cannot be negative.</param>
+    public ProducerBuilder<TKey, TValue> WithReconnectBackoff(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _reconnectBackoffMs = ReconnectBackoffValidation.ToMilliseconds(
+            backoff,
+            nameof(backoff),
+            "Reconnect backoff cannot be negative");
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum delay before reconnecting to a broker after repeated connection failures.
+    /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
+    /// </summary>
+    /// <param name="backoff">The maximum reconnect backoff. Cannot be negative.</param>
+    public ProducerBuilder<TKey, TValue> WithReconnectBackoffMax(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _reconnectBackoffMaxMs = ReconnectBackoffValidation.ToMilliseconds(
+            backoff,
+            nameof(backoff),
+            "Maximum reconnect backoff cannot be negative");
+        return this;
+    }
+
+    /// <summary>
     /// Sets the application-level retry policy for produce operations.
     /// When set, retriable exceptions from <see cref="IKafkaProducer{TKey,TValue}.ProduceAsync"/>
     /// will be retried according to this policy.
@@ -860,6 +892,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             throw new InvalidOperationException(
                 $"MaxConnectionsPerBroker ({_maxConnectionsPerBroker}) must be >= ConnectionsPerBroker ({_connectionsPerBroker}). " +
                 $"Adaptive scaling would be permanently disabled since the initial connection count already exceeds the maximum.");
+        ReconnectBackoffValidation.ValidateMilliseconds(_reconnectBackoffMs, _reconnectBackoffMaxMs);
 
         // Java Kafka client enforces acks=all when enable.idempotence=true.
         // With acks=leader, the leader acknowledges before ISR replication completes,
@@ -895,6 +928,8 @@ public sealed class ProducerBuilder<TKey, TValue>
             MaxBlockMs = _maxBlockMs ?? 60000, // 60 seconds default
             DeliveryTimeoutMs = _deliveryTimeoutMs ?? 120000,
             RequestTimeoutMs = _requestTimeoutMs ?? 30000,
+            ReconnectBackoffMs = _reconnectBackoffMs,
+            ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
             EnableIdempotence = _enableIdempotence,
             ConnectionsPerBroker = _connectionsPerBroker,
             TransactionalId = _transactionalId,
@@ -1070,6 +1105,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _connectionsPerBroker = 2;
     private bool _enableAdaptiveConnections = true;
     private int _maxConnectionsPerBroker = 4;
+    private int _reconnectBackoffMs = 50;
+    private int _reconnectBackoffMaxMs = 1000;
     private bool _enableAdaptiveFetchSizing;
     private AdaptiveFetchSizingOptions? _adaptiveFetchSizingOptions;
     private bool _enableFetchSessions = true;
@@ -1677,6 +1714,36 @@ public sealed class ConsumerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Sets the initial delay before reconnecting to a broker after a connection failure.
+    /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to zero to disable the delay.
+    /// </summary>
+    /// <param name="backoff">The reconnect backoff. Cannot be negative.</param>
+    public ConsumerBuilder<TKey, TValue> WithReconnectBackoff(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _reconnectBackoffMs = ReconnectBackoffValidation.ToMilliseconds(
+            backoff,
+            nameof(backoff),
+            "Reconnect backoff cannot be negative");
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum delay before reconnecting to a broker after repeated connection failures.
+    /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
+    /// </summary>
+    /// <param name="backoff">The maximum reconnect backoff. Cannot be negative.</param>
+    public ConsumerBuilder<TKey, TValue> WithReconnectBackoffMax(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _reconnectBackoffMaxMs = ReconnectBackoffValidation.ToMilliseconds(
+            backoff,
+            nameof(backoff),
+            "Maximum reconnect backoff cannot be negative");
+        return this;
+    }
+
+    /// <summary>
     /// Configures the consumer for high throughput scenarios.
     /// </summary>
     /// <remarks>
@@ -1913,6 +1980,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             throw new InvalidOperationException(
                 $"MaxConnectionsPerBroker ({_maxConnectionsPerBroker}) must be >= ConnectionsPerBroker ({_connectionsPerBroker}). " +
                 $"Adaptive scaling would be permanently disabled since the initial connection count already exceeds the maximum.");
+        ReconnectBackoffValidation.ValidateMilliseconds(_reconnectBackoffMs, _reconnectBackoffMaxMs);
 
         var memoryBudget = _clientInfrastructure?.MemoryBudget ?? DekafMemoryBudget.Global;
 
@@ -1938,6 +2006,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
             HeartbeatIntervalMs = _heartbeatIntervalMs ?? 3000,
             RebalanceTimeoutMs = _rebalanceTimeoutMs,
             RequestTimeoutMs = _requestTimeoutMs,
+            ReconnectBackoffMs = _reconnectBackoffMs,
+            ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
             CheckCrcs = _checkCrcs,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
@@ -2074,6 +2144,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private int _socketSendBufferBytes;
     private int _socketReceiveBufferBytes;
     private int _connectionsPerBroker = 2;
+    private int _reconnectBackoffMs = 50;
+    private int _reconnectBackoffMaxMs = 1000;
     private IRetryPolicy? _retryPolicy;
     private readonly List<string> _topicsToSubscribe = [];
 
@@ -2166,6 +2238,36 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     public ShareConsumerBuilder<TKey, TValue> WithRequestTimeoutMs(int requestTimeoutMs)
     {
         _requestTimeoutMs = requestTimeoutMs;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the initial delay before reconnecting to a broker after a connection failure.
+    /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to zero to disable the delay.
+    /// </summary>
+    /// <param name="backoff">The reconnect backoff. Cannot be negative.</param>
+    public ShareConsumerBuilder<TKey, TValue> WithReconnectBackoff(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _reconnectBackoffMs = ReconnectBackoffValidation.ToMilliseconds(
+            backoff,
+            nameof(backoff),
+            "Reconnect backoff cannot be negative");
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum delay before reconnecting to a broker after repeated connection failures.
+    /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
+    /// </summary>
+    /// <param name="backoff">The maximum reconnect backoff. Cannot be negative.</param>
+    public ShareConsumerBuilder<TKey, TValue> WithReconnectBackoffMax(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _reconnectBackoffMaxMs = ReconnectBackoffValidation.ToMilliseconds(
+            backoff,
+            nameof(backoff),
+            "Maximum reconnect backoff cannot be negative");
         return this;
     }
 
@@ -2337,6 +2439,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         if (_bootstrapServers.Count == 0)
             throw new InvalidOperationException("Bootstrap servers must be specified. Call WithBootstrapServers() before Build().");
         ArgumentNullException.ThrowIfNullOrEmpty(_groupId, nameof(_groupId));
+        ReconnectBackoffValidation.ValidateMilliseconds(_reconnectBackoffMs, _reconnectBackoffMaxMs);
 
         var keyDeserializer = _keyDeserializer ?? GetDefaultDeserializer<TKey>("key", "WithKeyDeserializer");
         var valueDeserializer = _valueDeserializer ?? GetDefaultDeserializer<TValue>("value", "WithValueDeserializer");
@@ -2355,6 +2458,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             SessionTimeoutMs = _sessionTimeoutMs,
             HeartbeatIntervalMs = _heartbeatIntervalMs,
             RequestTimeoutMs = _requestTimeoutMs,
+            ReconnectBackoffMs = _reconnectBackoffMs,
+            ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
             SaslMechanism = _saslMechanism,

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -140,6 +140,18 @@ public sealed class ConsumerOptions
     public int RequestTimeoutMs { get; init; } = 30000;
 
     /// <summary>
+    /// Initial delay in milliseconds before reconnecting to a broker after a connection failure.
+    /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to 0 to disable the delay.
+    /// </summary>
+    public int ReconnectBackoffMs { get; init; } = 50;
+
+    /// <summary>
+    /// Maximum delay in milliseconds before reconnecting to a broker after repeated failures.
+    /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
+    /// </summary>
+    public int ReconnectBackoffMaxMs { get; init; } = 1000;
+
+    /// <summary>
     /// Check CRCs.
     /// </summary>
     public bool CheckCrcs { get; init; }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -786,6 +786,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 UseTls = options.UseTls,
                 TlsConfig = options.TlsConfig,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
+                ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,

--- a/src/Dekaf/Internal/ReconnectBackoffValidation.cs
+++ b/src/Dekaf/Internal/ReconnectBackoffValidation.cs
@@ -1,0 +1,25 @@
+namespace Dekaf.Internal;
+
+internal static class ReconnectBackoffValidation
+{
+    public static int ToMilliseconds(TimeSpan value, string parameterName, string errorMessage)
+    {
+        if (value < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(parameterName, errorMessage);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(value.TotalMilliseconds, int.MaxValue, parameterName);
+
+        return (int)value.TotalMilliseconds;
+    }
+
+    public static void ValidateMilliseconds(int reconnectBackoffMs, int reconnectBackoffMaxMs)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(reconnectBackoffMs);
+        ArgumentOutOfRangeException.ThrowIfNegative(reconnectBackoffMaxMs);
+        if (reconnectBackoffMaxMs < reconnectBackoffMs)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(reconnectBackoffMaxMs),
+                "Maximum reconnect backoff must be greater than or equal to reconnect backoff");
+        }
+    }
+}

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -80,6 +80,8 @@ public sealed class KafkaClientBuilder
     private IReadOnlyList<string> _bootstrapServers = [];
     private string? _clientId;
     private int _requestTimeoutMs = 30000;
+    private int _reconnectBackoffMs = 50;
+    private int _reconnectBackoffMaxMs = 1000;
     private bool _useTls;
     private TlsConfig? _tlsConfig;
     private SaslMechanism _saslMechanism = SaslMechanism.None;
@@ -124,6 +126,34 @@ public sealed class KafkaClientBuilder
         ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
 
         _requestTimeoutMs = (int)timeout.TotalMilliseconds;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the initial delay before reconnecting to a broker after a connection failure.
+    /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to zero to disable the delay.
+    /// </summary>
+    /// <param name="backoff">The reconnect backoff. Cannot be negative.</param>
+    public KafkaClientBuilder WithReconnectBackoff(TimeSpan backoff)
+    {
+        _reconnectBackoffMs = ReconnectBackoffValidation.ToMilliseconds(
+            backoff,
+            nameof(backoff),
+            "Reconnect backoff cannot be negative");
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum delay before reconnecting to a broker after repeated connection failures.
+    /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
+    /// </summary>
+    /// <param name="backoff">The maximum reconnect backoff. Cannot be negative.</param>
+    public KafkaClientBuilder WithReconnectBackoffMax(TimeSpan backoff)
+    {
+        _reconnectBackoffMaxMs = ReconnectBackoffValidation.ToMilliseconds(
+            backoff,
+            nameof(backoff),
+            "Maximum reconnect backoff cannot be negative");
         return this;
     }
 
@@ -284,12 +314,15 @@ public sealed class KafkaClientBuilder
         if (_maxConnectionsPerBroker < _connectionsPerBroker)
             throw new InvalidOperationException(
                 $"MaxConnectionsPerBroker ({_maxConnectionsPerBroker}) must be >= ConnectionsPerBroker ({_connectionsPerBroker}).");
+        ReconnectBackoffValidation.ValidateMilliseconds(_reconnectBackoffMs, _reconnectBackoffMaxMs);
 
         var options = new KafkaClientOptions
         {
             BootstrapServers = _bootstrapServers,
             ClientId = _clientId,
             RequestTimeoutMs = _requestTimeoutMs,
+            ReconnectBackoffMs = _reconnectBackoffMs,
+            ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
             SaslMechanism = _saslMechanism,
@@ -318,6 +351,8 @@ internal sealed class KafkaClientOptions
     public required IReadOnlyList<string> BootstrapServers { get; init; }
     public string? ClientId { get; init; }
     public int RequestTimeoutMs { get; init; }
+    public int ReconnectBackoffMs { get; init; }
+    public int ReconnectBackoffMaxMs { get; init; }
     public bool UseTls { get; init; }
     public TlsConfig? TlsConfig { get; init; }
     public SaslMechanism SaslMechanism { get; init; }
@@ -386,6 +421,8 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
                 UseTls = options.UseTls,
                 TlsConfig = options.TlsConfig,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
+                ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Dekaf.Security.Sasl;
 using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
@@ -59,6 +60,7 @@ public sealed partial class ConnectionPool : IConnectionPool
     private readonly ConcurrentDictionary<int, IKafkaConnection> _connectionsById = new();
     // Per-endpoint semaphores to deduplicate concurrent single-connection creation
     private readonly ConcurrentDictionary<EndpointKey, SemaphoreSlim> _connectionCreationLocks = new();
+    private readonly ConcurrentDictionary<EndpointKey, ReconnectBackoffState> _reconnectBackoffs = new();
 
     // Multi-connection support: connection groups and round-robin index
     private readonly ConcurrentDictionary<int, IKafkaConnection[]> _connectionGroupsById = new();
@@ -99,6 +101,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         _connectionOptions = ConfigureSharedOAuthBearerProvider(
             connectionOptions ?? new ConnectionOptions(),
             out _sharedOAuthBearerTokenProvider);
+        ValidateReconnectBackoff(_connectionOptions);
         _loggerFactory = loggerFactory;
         _logger = loggerFactory?.CreateLogger<ConnectionPool>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ConnectionPool>.Instance;
         _connectionsPerBroker = Math.Max(1, connectionsPerBroker);
@@ -123,6 +126,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         _connectionOptions = ConfigureSharedOAuthBearerProvider(
             connectionOptions ?? new ConnectionOptions(),
             out _sharedOAuthBearerTokenProvider);
+        ValidateReconnectBackoff(_connectionOptions);
         _loggerFactory = null;
         _logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<ConnectionPool>.Instance;
         _connectionsPerBroker = Math.Max(1, connectionsPerBroker);
@@ -180,8 +184,30 @@ public sealed partial class ConnectionPool : IConnectionPool
             MinimumReadSize = options.MinimumReadSize,
             ConnectionTimeout = options.ConnectionTimeout,
             RequestTimeout = options.RequestTimeout,
+            ReconnectBackoff = options.ReconnectBackoff,
+            ReconnectBackoffMax = options.ReconnectBackoffMax,
             MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection
         };
+    }
+
+    private static void ValidateReconnectBackoff(ConnectionOptions options)
+    {
+        if (options.ReconnectBackoff < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(options), "Reconnect backoff cannot be negative");
+        if (options.ReconnectBackoffMax < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(options), "Maximum reconnect backoff cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            options.ReconnectBackoff.TotalMilliseconds,
+            int.MaxValue,
+            nameof(options));
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            options.ReconnectBackoffMax.TotalMilliseconds,
+            int.MaxValue,
+            nameof(options));
+        if (options.ReconnectBackoffMax < options.ReconnectBackoff)
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                "Maximum reconnect backoff must be greater than or equal to reconnect backoff");
     }
 
     /// <summary>
@@ -355,7 +381,13 @@ public sealed partial class ConnectionPool : IConnectionPool
             for (var i = 0; i < _connectionsPerBroker; i++)
             {
                 var index = i;
-                tasks[i] = CreateConnectionForGroupAsync(brokerId, brokerInfo.Host, brokerInfo.Port, index, token).AsTask();
+                tasks[i] = CreateConnectionForGroupAsync(
+                    brokerId,
+                    brokerInfo.Host,
+                    brokerInfo.Port,
+                    index,
+                    token,
+                    cancellationToken).AsTask();
             }
 
             // Add timeout to prevent indefinite hang if connection creation stalls
@@ -369,6 +401,7 @@ public sealed partial class ConnectionPool : IConnectionPool
 
             // Atomically set the connection group
             _connectionGroupsById[brokerId] = connections;
+            ResetReconnectBackoff(new EndpointKey(brokerInfo.Host, brokerInfo.Port), brokerId, brokerInfo.Host, brokerInfo.Port);
 
             LogCreatedConnectionGroup(_connectionsPerBroker, brokerId);
 
@@ -441,7 +474,13 @@ public sealed partial class ConnectionPool : IConnectionPool
             for (var i = 0; i < additionalCount; i++)
             {
                 var index = existingCount + i;
-                tasks[i] = CreateConnectionForGroupAsync(brokerId, brokerInfo.Host, brokerInfo.Port, index, linkedCts.Token).AsTask();
+                tasks[i] = CreateConnectionForGroupAsync(
+                    brokerId,
+                    brokerInfo.Host,
+                    brokerInfo.Port,
+                    index,
+                    linkedCts.Token,
+                    cancellationToken).AsTask();
             }
 
             try
@@ -464,6 +503,7 @@ public sealed partial class ConnectionPool : IConnectionPool
 
             // Atomically swap the connection group
             _connectionGroupsById[brokerId] = newGroup;
+            ResetReconnectBackoff(new EndpointKey(brokerInfo.Host, brokerInfo.Port), brokerId, brokerInfo.Host, brokerInfo.Port);
 
             LogScaledConnectionGroup(existingCount, newCount, brokerId);
             return newCount;
@@ -547,7 +587,13 @@ public sealed partial class ConnectionPool : IConnectionPool
                 return currentConnections[index];
             }
 
-            var connection = await CreateConnectionForGroupAsync(brokerId, brokerInfo.Host, brokerInfo.Port, index, token).ConfigureAwait(false);
+            var connection = await CreateConnectionForGroupAsync(
+                brokerId,
+                brokerInfo.Host,
+                brokerInfo.Port,
+                index,
+                token,
+                cancellationToken).ConfigureAwait(false);
 
             // Acquire _scaleLock to protect the array write against concurrent
             // ShrinkConnectionGroupAsync, which may have swapped the array reference.
@@ -595,6 +641,8 @@ public sealed partial class ConnectionPool : IConnectionPool
                     $"Connection slot {index} for broker {brokerId} was removed by a concurrent shrink");
             }
 
+            ResetReconnectBackoff(new EndpointKey(brokerInfo.Host, brokerInfo.Port), brokerId, brokerInfo.Host, brokerInfo.Port);
+
             return connection;
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
@@ -608,30 +656,70 @@ public sealed partial class ConnectionPool : IConnectionPool
         }
     }
 
-    private async ValueTask<IKafkaConnection> CreateConnectionForGroupAsync(int brokerId, string host, int port, int index, CancellationToken cancellationToken)
+    private async ValueTask<IKafkaConnection> CreateConnectionForGroupAsync(
+        int brokerId,
+        string host,
+        int port,
+        int index,
+        CancellationToken cancellationToken,
+        CancellationToken callerCancellationToken)
     {
-        if (_connectionFactory is not null)
+        var endpoint = new EndpointKey(host, port);
+        return await RunWithReconnectBackoffAsync(
+            endpoint,
+            brokerId,
+            host,
+            port,
+            () => CreateConnectionForGroupCoreAsync(
+                brokerId,
+                host,
+                port,
+                index,
+                cancellationToken,
+                callerCancellationToken),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask<IKafkaConnection> CreateConnectionForGroupCoreAsync(
+        int brokerId,
+        string host,
+        int port,
+        int index,
+        CancellationToken cancellationToken,
+        CancellationToken callerCancellationToken)
+    {
+        var endpoint = new EndpointKey(host, port);
+
+        try
         {
-            var factoryConnection = await _connectionFactory(brokerId, host, port, index, cancellationToken).ConfigureAwait(false);
+            if (_connectionFactory is not null)
+            {
+                var factoryConnection = await _connectionFactory(brokerId, host, port, index, cancellationToken).ConfigureAwait(false);
+                LogCreatedConnectionForGroup(index, brokerId, host, port);
+                return factoryConnection;
+            }
+
+            var connection = new KafkaConnection(
+                brokerId, host, port,
+                _clientId, _connectionOptions,
+                _loggerFactory?.CreateLogger<KafkaConnection>(),
+                DefaultBufferMemory, _connectionsPerBroker,
+                BrokerCount,
+                _responseBufferPool,
+                _sharedPipeMemoryPool,
+                _telemetryMetricCollector);
+
+            await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
+
             LogCreatedConnectionForGroup(index, brokerId, host, port);
-            return factoryConnection;
+
+            return connection;
         }
-
-        var connection = new KafkaConnection(
-            brokerId, host, port,
-            _clientId, _connectionOptions,
-            _loggerFactory?.CreateLogger<KafkaConnection>(),
-            DefaultBufferMemory, _connectionsPerBroker,
-            BrokerCount,
-            _responseBufferPool,
-            _sharedPipeMemoryPool,
-            _telemetryMetricCollector);
-
-        await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
-
-        LogCreatedConnectionForGroup(index, brokerId, host, port);
-
-        return connection;
+        catch (Exception) when (!callerCancellationToken.IsCancellationRequested)
+        {
+            RecordReconnectFailure(endpoint, brokerId, host, port);
+            throw;
+        }
     }
 
     public async ValueTask<IKafkaConnection> GetConnectionAsync(string host, int port, CancellationToken cancellationToken = default)
@@ -695,11 +783,12 @@ public sealed partial class ConnectionPool : IConnectionPool
                     catch { /* best-effort cleanup */ }
                 }
 
-                var connection = await CreateConnectionAsync(brokerId, host, port, token).ConfigureAwait(false);
+                var connection = await CreateConnectionAsync(brokerId, host, port, token, cancellationToken).ConfigureAwait(false);
 
                 // Verify connection is still valid
                 if (connection.IsConnected)
                 {
+                    ResetReconnectBackoff(endpoint, brokerId, host, port);
                     return connection;
                 }
 
@@ -710,6 +799,8 @@ public sealed partial class ConnectionPool : IConnectionPool
 
                 try { await connection.DisposeAsync().ConfigureAwait(false); }
                 catch { /* best-effort cleanup */ }
+
+                RecordReconnectFailure(endpoint, brokerId, host, port);
             }
 
             throw new InvalidOperationException($"Failed to create connection after {MaxRetries} retries");
@@ -729,34 +820,175 @@ public sealed partial class ConnectionPool : IConnectionPool
         int brokerId,
         string host,
         int port,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        CancellationToken callerCancellationToken)
+    {
+        var endpoint = new EndpointKey(host, port);
+        return await RunWithReconnectBackoffAsync(
+            endpoint,
+            brokerId,
+            host,
+            port,
+            () => CreateConnectionCoreAsync(
+                brokerId,
+                host,
+                port,
+                cancellationToken,
+                callerCancellationToken),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask<IKafkaConnection> CreateConnectionCoreAsync(
+        int brokerId,
+        string host,
+        int port,
+        CancellationToken cancellationToken,
+        CancellationToken callerCancellationToken)
     {
         var endpoint = new EndpointKey(host, port);
 
         // Note: Stale connection cleanup is handled by the caller (GetOrCreateConnectionAsync)
         // within the creation semaphore, so no duplicate cleanup is needed here.
 
-        var connection = new KafkaConnection(
-            brokerId, host, port,
-            _clientId, _connectionOptions,
-            _loggerFactory?.CreateLogger<KafkaConnection>(),
-            DefaultBufferMemory, _connectionsPerBroker,
-            BrokerCount,
-            _responseBufferPool,
-            _sharedPipeMemoryPool,
-            _telemetryMetricCollector);
-
-        await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
-
-        _connectionsByEndpoint[endpoint] = connection;
-        if (brokerId >= 0)
+        try
         {
-            _connectionsById[brokerId] = connection;
+            var connection = new KafkaConnection(
+                brokerId, host, port,
+                _clientId, _connectionOptions,
+                _loggerFactory?.CreateLogger<KafkaConnection>(),
+                DefaultBufferMemory, _connectionsPerBroker,
+                BrokerCount,
+                _responseBufferPool,
+                _sharedPipeMemoryPool,
+                _telemetryMetricCollector);
+
+            await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
+
+            _connectionsByEndpoint[endpoint] = connection;
+            if (brokerId >= 0)
+            {
+                _connectionsById[brokerId] = connection;
+            }
+
+            LogCreatedConnection(brokerId, host, port);
+
+            return connection;
+        }
+        catch (Exception) when (!callerCancellationToken.IsCancellationRequested)
+        {
+            RecordReconnectFailure(endpoint, brokerId, host, port);
+            throw;
+        }
+    }
+
+    private async ValueTask<IKafkaConnection> RunWithReconnectBackoffAsync(
+        EndpointKey endpoint,
+        int brokerId,
+        string host,
+        int port,
+        Func<ValueTask<IKafkaConnection>> createConnection,
+        CancellationToken cancellationToken)
+    {
+        if (_reconnectBackoffs.TryGetValue(endpoint, out var state))
+        {
+            await state.AttemptGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await WaitForReconnectBackoffAsync(endpoint, state, brokerId, host, port, cancellationToken).ConfigureAwait(false);
+                return await createConnection().ConfigureAwait(false);
+            }
+            finally
+            {
+                state.AttemptGate.Release();
+            }
         }
 
-        LogCreatedConnection(brokerId, host, port);
+        return await createConnection().ConfigureAwait(false);
+    }
 
-        return connection;
+    private async ValueTask WaitForReconnectBackoffAsync(
+        EndpointKey endpoint,
+        ReconnectBackoffState state,
+        int brokerId,
+        string host,
+        int port,
+        CancellationToken cancellationToken)
+    {
+        while (_reconnectBackoffs.TryGetValue(endpoint, out var currentState)
+               && ReferenceEquals(currentState, state))
+        {
+            TimeSpan delay;
+            int failureCount;
+            lock (state.Sync)
+            {
+                var retryAfterTicks = state.NextAttemptTimestamp - Stopwatch.GetTimestamp();
+                if (state.FailureCount == 0 || retryAfterTicks <= 0)
+                    return;
+
+                delay = TimeSpan.FromSeconds((double)retryAfterTicks / Stopwatch.Frequency);
+                failureCount = state.FailureCount;
+            }
+
+            LogReconnectBackoffDelay(delay.TotalMilliseconds, brokerId, host, port, failureCount);
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private void RecordReconnectFailure(EndpointKey endpoint, int brokerId, string host, int port)
+    {
+        var state = _reconnectBackoffs.GetOrAdd(endpoint, static _ => new ReconnectBackoffState());
+
+        TimeSpan delay;
+        int failureCount;
+        lock (state.Sync)
+        {
+            state.FailureCount = Math.Min(state.FailureCount + 1, 30);
+            failureCount = state.FailureCount;
+            delay = CalculateReconnectBackoffDelay(failureCount);
+            state.NextAttemptTimestamp = Stopwatch.GetTimestamp() + ToStopwatchTicks(delay);
+        }
+
+        LogReconnectBackoffScheduled(delay.TotalMilliseconds, brokerId, host, port, failureCount);
+    }
+
+    private void ResetReconnectBackoff(EndpointKey endpoint, int brokerId, string host, int port)
+    {
+        if (!_reconnectBackoffs.TryRemove(endpoint, out var state))
+            return;
+
+        lock (state.Sync)
+        {
+            state.FailureCount = 0;
+            state.NextAttemptTimestamp = 0;
+        }
+
+        LogReconnectBackoffReset(brokerId, host, port);
+    }
+
+    private TimeSpan CalculateReconnectBackoffDelay(int failureCount)
+    {
+        var minMs = _connectionOptions.ReconnectBackoff.TotalMilliseconds;
+        var maxMs = _connectionOptions.ReconnectBackoffMax.TotalMilliseconds;
+        if (minMs <= 0 || maxMs <= 0)
+            return TimeSpan.Zero;
+
+        var exponent = Math.Min(failureCount - 1, 30);
+        var baseMs = Math.Min(maxMs, minMs * Math.Pow(2, exponent));
+        if (baseMs < maxMs)
+        {
+            var jitterMaxMs = Math.Max(1, (int)Math.Ceiling(baseMs * 0.2));
+            baseMs = Math.Min(maxMs, baseMs + Random.Shared.Next(jitterMaxMs + 1));
+        }
+
+        return TimeSpan.FromMilliseconds(baseMs);
+    }
+
+    private static long ToStopwatchTicks(TimeSpan delay)
+    {
+        if (delay <= TimeSpan.Zero)
+            return 0;
+
+        return (long)(delay.TotalSeconds * Stopwatch.Frequency);
     }
 
     public async ValueTask RemoveConnectionAsync(int brokerId)
@@ -855,6 +1087,7 @@ public sealed partial class ConnectionPool : IConnectionPool
             _connectionsByEndpoint.Clear();
             _connectionsById.Clear();
             _connectionGroupsById.Clear();
+            _reconnectBackoffs.Clear();
 
             if (Volatile.Read(ref _disposed) != 0)
             {
@@ -942,7 +1175,24 @@ public sealed partial class ConnectionPool : IConnectionPool
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to dispose replaced connection for broker {BrokerId} index {Index}")]
     private static partial void LogOldConnectionDisposalFailed(ILogger logger, int brokerId, int index, Exception ex);
 
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Waiting {DelayMs}ms before reconnecting to broker {BrokerId} at {Host}:{Port} after {FailureCount} failed attempt(s)")]
+    private partial void LogReconnectBackoffDelay(double delayMs, int brokerId, string host, int port, int failureCount);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Scheduled reconnect backoff of {DelayMs}ms for broker {BrokerId} at {Host}:{Port} after {FailureCount} failed attempt(s)")]
+    private partial void LogReconnectBackoffScheduled(double delayMs, int brokerId, string host, int port, int failureCount);
+
+    [LoggerMessage(Level = LogLevel.Trace, Message = "Reset reconnect backoff for broker {BrokerId} at {Host}:{Port}")]
+    private partial void LogReconnectBackoffReset(int brokerId, string host, int port);
+
     #endregion
+
+    private sealed class ReconnectBackoffState
+    {
+        public readonly object Sync = new();
+        public readonly SemaphoreSlim AttemptGate = new(1, 1);
+        public int FailureCount;
+        public long NextAttemptTimestamp;
+    }
 
     private readonly record struct EndpointKey(string Host, int Port);
     private readonly record struct BrokerInfo(int BrokerId, string Host, int Port);

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -2678,6 +2678,18 @@ public sealed class ConnectionOptions
     public TimeSpan RequestTimeout { get; init; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
+    /// Initial delay before reconnecting to a broker after a connection failure.
+    /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to zero to disable the delay.
+    /// </summary>
+    public TimeSpan ReconnectBackoff { get; init; } = TimeSpan.FromMilliseconds(50);
+
+    /// <summary>
+    /// Maximum delay before reconnecting to a broker after repeated connection failures.
+    /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
+    /// </summary>
+    public TimeSpan ReconnectBackoffMax { get; init; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
     /// Maximum in-flight requests per connection. Used internally to derive pool sizes.
     /// </summary>
     internal int MaxInFlightRequestsPerConnection { get; init; } = 5;

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -221,6 +221,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 UseTls = options.UseTls,
                 TlsConfig = options.TlsConfig,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
+                ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -34,6 +34,18 @@ public sealed class ProducerOptions
     public int RequestTimeoutMs { get; init; } = 30000;
 
     /// <summary>
+    /// Initial delay in milliseconds before reconnecting to a broker after a connection failure.
+    /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to 0 to disable the delay.
+    /// </summary>
+    public int ReconnectBackoffMs { get; init; } = 50;
+
+    /// <summary>
+    /// Maximum delay in milliseconds before reconnecting to a broker after repeated failures.
+    /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
+    /// </summary>
+    public int ReconnectBackoffMaxMs { get; init; } = 1000;
+
+    /// <summary>
     /// Linger time in milliseconds before sending a batch.
     /// Default is 0 (immediate send), matching the Java Kafka producer default.
     /// Use <see cref="ProducerBuilder{TKey,TValue}.ForHighThroughput"/> to set 100ms

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -68,6 +68,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 UseTls = options.UseTls,
                 TlsConfig = options.TlsConfig,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
+                ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -72,6 +72,18 @@ public sealed class ShareConsumerOptions
     public int RequestTimeoutMs { get; init; } = 30000;
 
     /// <summary>
+    /// Initial delay in milliseconds before reconnecting to a broker after a connection failure.
+    /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to 0 to disable the delay.
+    /// </summary>
+    public int ReconnectBackoffMs { get; init; } = 50;
+
+    /// <summary>
+    /// Maximum delay in milliseconds before reconnecting to a broker after repeated failures.
+    /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
+    /// </summary>
+    public int ReconnectBackoffMaxMs { get; init; } = 1000;
+
+    /// <summary>
     /// Whether to use TLS for broker connections.
     /// </summary>
     public bool UseTls { get; init; }

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -82,6 +82,8 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithMetadataMaxAge(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
+            .Throws<InvalidOperationException>();
 
         await Assert.That(() => client.CreateConsumer<string, string>().UseTls())
             .Throws<InvalidOperationException>();
@@ -95,6 +97,8 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithMetadataMaxAge(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
+            .Throws<InvalidOperationException>();
 
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithTls())
             .Throws<InvalidOperationException>();
@@ -103,6 +107,8 @@ public sealed class KafkaClientBuilderTests
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithSocketReceiveBufferBytes(4096))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithConnectionsPerBroker(2))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
             .Throws<InvalidOperationException>();
 
         await Assert.That(() => client.CreateAdminClient().UseTls())
@@ -115,6 +121,22 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateAdminClient().WithMetadataMaxAge(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task RootClient_WithReconnectBackoff_ConfiguresSharedConnectionPool()
+    {
+        await using var client = Kafka.Connect("localhost:9092", builder => builder
+            .WithReconnectBackoff(TimeSpan.FromMilliseconds(123))
+            .WithReconnectBackoffMax(TimeSpan.FromMilliseconds(456)));
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var pool = GetField<ConnectionPool>(producer, "_connectionPool");
+
+        await Assert.That(pool.EffectiveConnectionOptions.ReconnectBackoff).IsEqualTo(TimeSpan.FromMilliseconds(123));
+        await Assert.That(pool.EffectiveConnectionOptions.ReconnectBackoffMax).IsEqualTo(TimeSpan.FromMilliseconds(456));
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
@@ -145,6 +145,20 @@ public class ConsumerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task ReconnectBackoffMs_DefaultsTo_50()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.ReconnectBackoffMs).IsEqualTo(50);
+    }
+
+    [Test]
+    public async Task ReconnectBackoffMaxMs_DefaultsTo_1000()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(1000);
+    }
+
+    [Test]
     public async Task CheckCrcs_DefaultsTo_False()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -344,6 +344,8 @@ public class DependencyInjectionTests
             ["Kafka:Producers:Orders:MaxBlockMs"] = "1000",
             ["Kafka:Producers:Orders:DeliveryTimeoutMs"] = "2000",
             ["Kafka:Producers:Orders:RequestTimeoutMs"] = "3000",
+            ["Kafka:Producers:Orders:ReconnectBackoffMs"] = "75",
+            ["Kafka:Producers:Orders:ReconnectBackoffMaxMs"] = "750",
             ["Kafka:Producers:Orders:EnableIdempotence"] = "false",
             ["Kafka:Producers:Orders:ConnectionsPerBroker"] = "3",
             ["Kafka:Producers:Orders:MaxConnectionsPerBroker"] = "6",
@@ -388,6 +390,8 @@ public class DependencyInjectionTests
         await Assert.That(options.MaxBlockMs).IsEqualTo(1000);
         await Assert.That(options.DeliveryTimeoutMs).IsEqualTo(2000);
         await Assert.That(options.RequestTimeoutMs).IsEqualTo(3000);
+        await Assert.That(options.ReconnectBackoffMs).IsEqualTo(75);
+        await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(750);
         await Assert.That(options.EnableIdempotence).IsFalse();
         await Assert.That(options.ConnectionsPerBroker).IsEqualTo(3);
         await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(6);
@@ -463,6 +467,8 @@ public class DependencyInjectionTests
             ["Kafka:Consumers:Orders:RebalanceTimeoutMs"] = "45000",
             ["Kafka:Consumers:Orders:IsolationLevel"] = "ReadCommitted",
             ["Kafka:Consumers:Orders:RequestTimeoutMs"] = "15000",
+            ["Kafka:Consumers:Orders:ReconnectBackoffMs"] = "80",
+            ["Kafka:Consumers:Orders:ReconnectBackoffMaxMs"] = "800",
             ["Kafka:Consumers:Orders:CheckCrcs"] = "true",
             ["Kafka:Consumers:Orders:UseTls"] = "true",
             ["Kafka:Consumers:Orders:SaslMechanism"] = "Plain",
@@ -516,6 +522,8 @@ public class DependencyInjectionTests
         await Assert.That(options.RebalanceTimeoutMs).IsEqualTo(45000);
         await Assert.That(options.IsolationLevel).IsEqualTo(IsolationLevel.ReadCommitted);
         await Assert.That(options.RequestTimeoutMs).IsEqualTo(15000);
+        await Assert.That(options.ReconnectBackoffMs).IsEqualTo(80);
+        await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(800);
         await Assert.That(options.CheckCrcs).IsTrue();
         await Assert.That(options.UseTls).IsTrue();
         await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.Plain);
@@ -614,6 +622,8 @@ public class DependencyInjectionTests
             ["Kafka:Admin:BootstrapServers"] = "broker1:9092",
             ["Kafka:Admin:ClientId"] = "admin-client",
             ["Kafka:Admin:RequestTimeoutMs"] = "45000",
+            ["Kafka:Admin:ReconnectBackoffMs"] = "90",
+            ["Kafka:Admin:ReconnectBackoffMaxMs"] = "900",
             ["Kafka:Admin:UseTls"] = "true",
             ["Kafka:Admin:SaslMechanism"] = "Plain",
             ["Kafka:Admin:SaslUsername"] = "admin",
@@ -635,6 +645,8 @@ public class DependencyInjectionTests
         await Assert.That(options.BootstrapServers[0]).IsEqualTo("broker1:9092");
         await Assert.That(options.ClientId).IsEqualTo("admin-client");
         await Assert.That(options.RequestTimeoutMs).IsEqualTo(45000);
+        await Assert.That(options.ReconnectBackoffMs).IsEqualTo(90);
+        await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(900);
         await Assert.That(options.UseTls).IsTrue();
         await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.Plain);
         await Assert.That(options.SaslUsername).IsEqualTo("admin");

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataRecoveryStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataRecoveryStrategyTests.cs
@@ -161,6 +161,28 @@ public sealed class MetadataRecoveryStrategyTests
         await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(300000);
     }
 
+    [Test]
+    public async Task AdminClientOptions_ReconnectBackoffMs_DefaultsTo50()
+    {
+        var options = new Dekaf.Admin.AdminClientOptions
+        {
+            BootstrapServers = ["localhost:9092"]
+        };
+
+        await Assert.That(options.ReconnectBackoffMs).IsEqualTo(50);
+    }
+
+    [Test]
+    public async Task AdminClientOptions_ReconnectBackoffMaxMs_DefaultsTo1000()
+    {
+        var options = new Dekaf.Admin.AdminClientOptions
+        {
+            BootstrapServers = ["localhost:9092"]
+        };
+
+        await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(1000);
+    }
+
     #endregion
 
     #region MetadataOptions Defaults

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1,7 +1,10 @@
 using System.Buffers;
+using System.Diagnostics;
 using System.Reflection;
+using Dekaf.Errors;
 using Dekaf.Networking;
 using Dekaf.Security.Sasl;
+using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Networking;
 
@@ -356,6 +359,98 @@ public sealed class ConnectionPoolTests
         await Assert.That(result).IsNull();
     }
 
+    [Test]
+    [NotInParallel]
+    public async Task CreateConnectionGroup_AfterConnectionFailure_WaitsForReconnectBackoff()
+    {
+        const int connectionsPerBroker = 2;
+        var attempts = 0;
+        var options = new ConnectionOptions
+        {
+            ConnectionTimeout = TimeSpan.FromSeconds(30),
+            ReconnectBackoff = TimeSpan.FromMilliseconds(40),
+            ReconnectBackoffMax = TimeSpan.FromMilliseconds(40)
+        };
+
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: options,
+            connectionsPerBroker: connectionsPerBroker,
+            connectionFactory: (brokerId, host, port, _, _) =>
+            {
+                if (Interlocked.Increment(ref attempts) <= connectionsPerBroker)
+                    return new ValueTask<IKafkaConnection>(Task.FromException<IKafkaConnection>(
+                        new InvalidOperationException("broker down")));
+
+                return new ValueTask<IKafkaConnection>(CreateConnectedConnection(brokerId, host, port));
+            });
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+
+            Func<Task> firstAttempt = () => pool.GetConnectionAsync(1).AsTask();
+            await Assert.That(firstAttempt).Throws<InvalidOperationException>();
+
+            var stopwatch = Stopwatch.StartNew();
+            var connection = await pool.GetConnectionAsync(1);
+            stopwatch.Stop();
+
+            await Assert.That(connection.IsConnected).IsTrue();
+            await Assert.That(stopwatch.Elapsed).IsGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(25));
+            await Assert.That(attempts).IsEqualTo(4);
+        }
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ReplaceConnectionInGroup_DuringReconnectBackoff_RespectsConnectionTimeout()
+    {
+        const int connectionsPerBroker = 2;
+        var initialCreationDone = 0;
+        var replacementAttempts = 0;
+        var options = new ConnectionOptions
+        {
+            ConnectionTimeout = TimeSpan.FromMilliseconds(100),
+            ReconnectBackoff = TimeSpan.FromSeconds(1),
+            ReconnectBackoffMax = TimeSpan.FromSeconds(1)
+        };
+
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: options,
+            connectionsPerBroker: connectionsPerBroker,
+            connectionFactory: (brokerId, host, port, _, _) =>
+            {
+                if (Volatile.Read(ref initialCreationDone) != 0
+                    && Interlocked.Increment(ref replacementAttempts) == 1)
+                {
+                    return new ValueTask<IKafkaConnection>(Task.FromException<IKafkaConnection>(
+                        new InvalidOperationException("broker down")));
+                }
+
+                return new ValueTask<IKafkaConnection>(CreateConnectedConnection(brokerId, host, port));
+            });
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+
+            await pool.GetConnectionAsync(1);
+            Volatile.Write(ref initialCreationDone, 1);
+
+            var oldConnection = await pool.GetConnectionByIndexAsync(1, 0);
+            oldConnection.IsConnected.Returns(false);
+
+            Func<Task> failedReplacement = () => pool.GetConnectionByIndexAsync(1, 0).AsTask();
+            await Assert.That(failedReplacement).Throws<InvalidOperationException>();
+
+            Func<Task> timedOutReplacement = () => pool.GetConnectionByIndexAsync(1, 0).AsTask();
+            await Assert.That(timedOutReplacement).Throws<KafkaException>()
+                .WithMessageContaining("Connection replacement timeout");
+        }
+    }
+
     private static OAuthBearerConfig CreateOAuthBearerConfig() => new()
     {
         TokenEndpointUrl = "https://auth.example.invalid/token",
@@ -377,5 +472,15 @@ public sealed class ConnectionPoolTests
             BindingFlags.NonPublic | BindingFlags.Instance);
 
         return (MemoryPool<byte>)field!.GetValue(pool)!;
+    }
+
+    private static IKafkaConnection CreateConnectedConnection(int brokerId, string host, int port)
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.IsConnected.Returns(true);
+        connection.BrokerId.Returns(brokerId);
+        connection.Host.Returns(host);
+        connection.Port.Returns(port);
+        return connection;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
@@ -33,6 +33,20 @@ public class ProducerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task ReconnectBackoffMs_DefaultsTo_50()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.ReconnectBackoffMs).IsEqualTo(50);
+    }
+
+    [Test]
+    public async Task ReconnectBackoffMaxMs_DefaultsTo_1000()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(1000);
+    }
+
+    [Test]
     public async Task LingerMs_DefaultsTo_0()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerOptionsDefaultsTests.cs
@@ -1,0 +1,26 @@
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed class ShareConsumerOptionsDefaultsTests
+{
+    private static ShareConsumerOptions CreateOptions() => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        GroupId = "share-group"
+    };
+
+    [Test]
+    public async Task ReconnectBackoffMs_DefaultsTo_50()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.ReconnectBackoffMs).IsEqualTo(50);
+    }
+
+    [Test]
+    public async Task ReconnectBackoffMaxMs_DefaultsTo_1000()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(1000);
+    }
+}


### PR DESCRIPTION
## Summary
- add per-endpoint reconnect backoff state in ConnectionPool with exponential delay, jitter, and success reset
- expose reconnect backoff options on ConnectionOptions and producer/consumer/share/admin/root builders
- bind DI configuration and cover defaults plus timeout/backoff behavior in unit tests

Closes #1152

## Tests
- dotnet build tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj -c Release
- tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe --no-progress --disable-logo