### PR TITLE
Add Dekaf.Testing in-memory clients

### DIFF
--- a/Dekaf.sln
+++ b/Dekaf.sln
@@ -44,7 +44,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.OpenTelemetry", "src\Dekaf.OpenTelemetry\Dekaf.OpenTelemetry.csproj", "{B9AC6ECC-9F52-4F17-AF8A-4072AF3CBC69}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Compression.Brotli", "src\Dekaf.Compression.Brotli\Dekaf.Compression.Brotli.csproj", "{94F26971-45A8-47CF-9E0F-8FF20CDF9131}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Extensions.HealthChecks", "src\Dekaf.Extensions.HealthChecks\Dekaf.Extensions.HealthChecks.csproj", "{5C982DF4-7AC3-42E6-A20D-ED3CDF73067D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Testing", "src\Dekaf.Testing\Dekaf.Testing.csproj", "{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -272,6 +275,18 @@ Global
 		{5C982DF4-7AC3-42E6-A20D-ED3CDF73067D}.Release|x64.Build.0 = Release|Any CPU
 		{5C982DF4-7AC3-42E6-A20D-ED3CDF73067D}.Release|x86.ActiveCfg = Release|Any CPU
 		{5C982DF4-7AC3-42E6-A20D-ED3CDF73067D}.Release|x86.Build.0 = Release|Any CPU
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}.Debug|x64.Build.0 = Debug|Any CPU
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}.Debug|x86.Build.0 = Debug|Any CPU
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}.Release|x64.ActiveCfg = Release|Any CPU
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}.Release|x64.Build.0 = Release|Any CPU
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}.Release|x86.ActiveCfg = Release|Any CPU
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -295,5 +310,6 @@ Global
 		{B9AC6ECC-9F52-4F17-AF8A-4072AF3CBC69} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{94F26971-45A8-47CF-9E0F-8FF20CDF9131} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{5C982DF4-7AC3-42E6-A20D-ED3CDF73067D} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 EndGlobal

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1,0 +1,66 @@
+---
+sidebar_position: 12
+---
+
+# Testing
+
+`Dekaf.Testing` provides in-memory implementations of the main Dekaf client interfaces for fast application unit tests:
+
+- `InMemoryKafkaCluster`
+- `InMemoryProducer<TKey, TValue>`
+- `InMemoryConsumer<TKey, TValue>`
+- `InMemoryShareConsumer<TKey, TValue>`
+- `InMemoryAdminClient`
+
+The cluster stores serialized bytes, not typed values, so custom serializers and deserializers still run during tests.
+
+## Direct use
+
+```csharp
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Testing;
+
+var cluster = new InMemoryKafkaCluster();
+cluster.CreateTopic("orders", partitionCount: 3);
+
+var producer = new InMemoryProducer<string, string>(cluster);
+var consumer = new InMemoryConsumer<string, string>(
+    cluster,
+    new InMemoryConsumerOptions
+    {
+        GroupId = "orders-service",
+        AutoOffsetReset = AutoOffsetReset.Earliest
+    });
+
+await producer.ProduceAsync(new ProducerMessage<string, string>
+{
+    Topic = "orders",
+    Key = "order-1",
+    Value = "created"
+});
+
+consumer.Subscribe("orders");
+var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+```
+
+## Dependency Injection
+
+Use `AddDekafInMemory()` to replace producer, consumer, share consumer, and admin client registrations with in-memory doubles backed by one shared cluster:
+
+```csharp
+using Dekaf.Testing;
+
+services.AddDekafInMemory(options =>
+{
+    options.DefaultPartitionCount = 3;
+});
+```
+
+Register `ISerializer<T>` and `IDeserializer<T>` in DI when your application uses custom payload types. Built-in Dekaf serializers are used automatically for common primitive types.
+
+## Admin and offsets
+
+`InMemoryAdminClient` supports common unit-test operations such as creating, deleting, listing, and describing topics, altering/listing group offsets, deleting records, creating partitions, and listing offsets. Broker-only APIs such as ACL, SCRAM, and config mutation are accepted as no-ops or return empty results.
+
+Use Testcontainers or another real broker for protocol compatibility and integration coverage.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -57,6 +57,7 @@ const sidebars = {
     },
     'compression',
     'dependency-injection',
+    'testing',
     'performance',
     'benchmarks',
     'stress-tests',

--- a/src/Dekaf.Testing/Dekaf.Testing.csproj
+++ b/src/Dekaf.Testing/Dekaf.Testing.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Dekaf.Testing</PackageId>
+    <Description>First-party in-memory test doubles for Dekaf Kafka clients</Description>
+    <PackageTags>kafka;testing;in-memory;test-doubles;unit-testing</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+  </ItemGroup>
+
+</Project>

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -1,0 +1,509 @@
+using Dekaf.Admin;
+using Dekaf.Metadata;
+using Dekaf.Protocol;
+using Dekaf.Telemetry;
+
+namespace Dekaf.Testing;
+
+/// <summary>
+/// In-memory <see cref="IAdminClient"/> for common topic and group-offset test operations.
+/// </summary>
+public sealed class InMemoryAdminClient : IAdminClient
+{
+    private readonly InMemoryKafkaCluster _cluster;
+    private bool _disposed;
+
+    public InMemoryAdminClient(InMemoryKafkaCluster cluster)
+    {
+        _cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));
+    }
+
+    public ClusterMetadata Metadata { get; } = new();
+
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        ArgumentNullException.ThrowIfNull(metric);
+        ThrowIfDisposed();
+    }
+
+    public void UnregisterMetricFromSubscription(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ThrowIfDisposed();
+    }
+
+    public ValueTask CreateTopicsAsync(
+        IEnumerable<NewTopic> topics,
+        CreateTopicsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(topics);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        if (options?.ValidateOnly == true)
+            return ValueTask.CompletedTask;
+
+        foreach (var topic in topics)
+            _cluster.CreateTopic(topic.Name, topic.NumPartitions, topic.Configs);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DeleteTopicsAsync(
+        IEnumerable<string> topicNames,
+        DeleteTopicsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(topicNames);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        foreach (var topicName in topicNames)
+            _cluster.DeleteTopic(topicName);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<IReadOnlyList<TopicListing>> ListTopicsAsync(
+        ListTopicsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.FromResult(_cluster.TopicListings(options?.ListInternal == true));
+    }
+
+    public ValueTask<IReadOnlyDictionary<string, TopicDescription>> DescribeTopicsAsync(
+        IEnumerable<string> topicNames,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(topicNames);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.FromResult(_cluster.DescribeTopics(topicNames));
+    }
+
+    public ValueTask<IReadOnlyDictionary<string, TopicDescription>> DescribeTopicPartitionsAsync(
+        IEnumerable<string> topicNames,
+        DescribeTopicPartitionsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return DescribeTopicsAsync(topicNames, cancellationToken);
+    }
+
+    public ValueTask<DescribeTopicPartitionsPage> DescribeTopicPartitionsPageAsync(
+        IEnumerable<string> topicNames,
+        DescribeTopicPartitionsPageOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(topicNames);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        return ValueTask.FromResult(new DescribeTopicPartitionsPage
+        {
+            Topics = _cluster.DescribeTopics(topicNames),
+            NextCursor = null
+        });
+    }
+
+    public ValueTask<ClusterDescription> DescribeClusterAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        return ValueTask.FromResult(new ClusterDescription
+        {
+            ClusterId = _cluster.Options.ClusterId,
+            ControllerId = 0,
+            Nodes =
+            [
+                new BrokerNode
+                {
+                    NodeId = 0,
+                    Host = "in-memory",
+                    Port = 0
+                }
+            ]
+        });
+    }
+
+    public ValueTask<IReadOnlyDictionary<string, GroupDescription>> DescribeConsumerGroupsAsync(
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(groupIds);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var result = groupIds.ToDictionary(
+            groupId => groupId,
+            groupId => new GroupDescription
+            {
+                GroupId = groupId,
+                ProtocolType = "consumer",
+                State = "Stable",
+                Members = []
+            },
+            StringComparer.Ordinal);
+
+        return ValueTask.FromResult<IReadOnlyDictionary<string, GroupDescription>>(result);
+    }
+
+    public ValueTask<IReadOnlyList<GroupListing>> ListConsumerGroupsAsync(
+        ListConsumerGroupsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        IReadOnlyList<GroupListing> result = _cluster.ListGroups()
+            .Select(groupId => new GroupListing
+            {
+                GroupId = groupId,
+                ProtocolType = "consumer",
+                State = "Stable"
+            })
+            .ToArray();
+
+        return ValueTask.FromResult(result);
+    }
+
+    public ValueTask DeleteConsumerGroupsAsync(
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(groupIds);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        foreach (var groupId in groupIds)
+            _cluster.DeleteGroup(groupId);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<IReadOnlyDictionary<TopicPartition, long>> ListConsumerGroupOffsetsAsync(
+        string groupId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.FromResult(_cluster.GetGroupOffsets(groupId));
+    }
+
+    public ValueTask AlterConsumerGroupOffsetsAsync(
+        string groupId,
+        IEnumerable<TopicPartitionOffset> offsets,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        ArgumentNullException.ThrowIfNull(offsets);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        _cluster.CommitOffsets(groupId, offsets);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<IReadOnlyDictionary<TopicPartition, long>> DeleteRecordsAsync(
+        IReadOnlyDictionary<TopicPartition, long> offsets,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(offsets);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.FromResult(_cluster.DeleteRecords(offsets));
+    }
+
+    public ValueTask CreatePartitionsAsync(
+        IReadOnlyDictionary<string, int> newPartitionCounts,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(newPartitionCounts);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        foreach (var (topicName, partitionCount) in newPartitionCounts)
+            _cluster.CreatePartitions(topicName, partitionCount);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<IReadOnlyDictionary<string, IReadOnlyList<ScramCredentialInfo>>> DescribeUserScramCredentialsAsync(
+        IEnumerable<string>? users = null,
+        DescribeUserScramCredentialsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var result = (users ?? []).ToDictionary(
+            user => user,
+            _ => (IReadOnlyList<ScramCredentialInfo>)Array.Empty<ScramCredentialInfo>(),
+            StringComparer.Ordinal);
+
+        return ValueTask.FromResult<IReadOnlyDictionary<string, IReadOnlyList<ScramCredentialInfo>>>(result);
+    }
+
+    public ValueTask AlterUserScramCredentialsAsync(
+        IEnumerable<UserScramCredentialAlteration> alterations,
+        AlterUserScramCredentialsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(alterations);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        _ = alterations.Count();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<IReadOnlyDictionary<ConfigResource, IReadOnlyList<ConfigEntry>>> DescribeConfigsAsync(
+        IEnumerable<ConfigResource> resources,
+        DescribeConfigsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resources);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var result = resources.ToDictionary(
+            resource => resource,
+            _ => (IReadOnlyList<ConfigEntry>)Array.Empty<ConfigEntry>());
+
+        return ValueTask.FromResult<IReadOnlyDictionary<ConfigResource, IReadOnlyList<ConfigEntry>>>(result);
+    }
+
+    public ValueTask AlterConfigsAsync(
+        IReadOnlyDictionary<ConfigResource, IReadOnlyList<ConfigEntry>> configs,
+        AlterConfigsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(configs);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask IncrementalAlterConfigsAsync(
+        IReadOnlyDictionary<ConfigResource, IReadOnlyList<ConfigAlter>> configs,
+        IncrementalAlterConfigsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(configs);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask CreateAclsAsync(
+        IEnumerable<AclBinding> aclBindings,
+        CreateAclsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(aclBindings);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<IReadOnlyList<AclBinding>> DeleteAclsAsync(
+        IEnumerable<AclBindingFilter> filters,
+        DeleteAclsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(filters);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.FromResult<IReadOnlyList<AclBinding>>(Array.Empty<AclBinding>());
+    }
+
+    public ValueTask<IReadOnlyList<AclBinding>> DescribeAclsAsync(
+        AclBindingFilter filter,
+        DescribeAclsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.FromResult<IReadOnlyList<AclBinding>>(Array.Empty<AclBinding>());
+    }
+
+    public ValueTask DeleteConsumerGroupOffsetsAsync(
+        string groupId,
+        IEnumerable<TopicPartition> partitions,
+        DeleteConsumerGroupOffsetsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        ArgumentNullException.ThrowIfNull(partitions);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        _cluster.DeleteGroupOffsets(groupId, partitions);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<IReadOnlyDictionary<TopicPartition, ListOffsetsResultInfo>> ListOffsetsAsync(
+        IEnumerable<TopicPartitionOffsetSpec> specs,
+        ListOffsetsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(specs);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var result = specs.ToDictionary(
+            spec => spec.TopicPartition,
+            spec =>
+            {
+                var offset = spec.Spec switch
+                {
+                    OffsetSpec.Earliest => _cluster.GetWatermarks(spec.TopicPartition).Low,
+                    OffsetSpec.Latest or OffsetSpec.MaxTimestamp => _cluster.GetWatermarks(spec.TopicPartition).High,
+                    OffsetSpec.Timestamp => _cluster.GetOffsetForTimestamp(spec.TopicPartition, spec.Timestamp ?? 0),
+                    _ => -1
+                };
+
+                return new ListOffsetsResultInfo
+                {
+                    Offset = offset,
+                    Timestamp = spec.Spec == OffsetSpec.Timestamp ? spec.Timestamp ?? -1 : -1,
+                    LeaderEpoch = 0
+                };
+            });
+
+        return ValueTask.FromResult<IReadOnlyDictionary<TopicPartition, ListOffsetsResultInfo>>(result);
+    }
+
+    public ValueTask<IReadOnlyDictionary<TopicPartition, ElectLeadersResultInfo>> ElectLeadersAsync(
+        ElectionType electionType,
+        IEnumerable<TopicPartition>? partitions = null,
+        ElectLeadersOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var result = (partitions ?? []).ToDictionary(
+            partition => partition,
+            partition => new ElectLeadersResultInfo
+            {
+                TopicPartition = partition,
+                ErrorCode = ErrorCode.None
+            });
+
+        return ValueTask.FromResult<IReadOnlyDictionary<TopicPartition, ElectLeadersResultInfo>>(result);
+    }
+
+    public ValueTask<IReadOnlyDictionary<string, ShareGroupDescription>> DescribeShareGroupsAsync(
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(groupIds);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var result = groupIds.ToDictionary(
+            groupId => groupId,
+            groupId => new ShareGroupDescription
+            {
+                GroupId = groupId,
+                GroupState = "Stable",
+                Members = []
+            },
+            StringComparer.Ordinal);
+
+        return ValueTask.FromResult<IReadOnlyDictionary<string, ShareGroupDescription>>(result);
+    }
+
+    public ValueTask<IReadOnlyList<GroupListing>> ListShareGroupsAsync(
+        ListShareGroupsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return ListConsumerGroupsAsync(null, cancellationToken);
+    }
+
+    public ValueTask<IReadOnlyList<ShareGroupOffsetDescription>> DescribeShareGroupOffsetsAsync(
+        string groupId,
+        IEnumerable<TopicPartition>? partitions = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var groupOffsets = _cluster.GetGroupOffsets(groupId);
+        var targetPartitions = partitions?.ToArray() ?? groupOffsets.Keys.ToArray();
+        var result = targetPartitions
+            .Select(partition =>
+            {
+                var offset = groupOffsets.GetValueOrDefault(partition);
+                var high = _cluster.GetWatermarks(partition).High;
+                return new ShareGroupOffsetDescription
+                {
+                    TopicPartition = partition,
+                    StartOffset = offset,
+                    LeaderEpoch = 0,
+                    Lag = Math.Max(0, high - offset),
+                    ErrorCode = ErrorCode.None
+                };
+            })
+            .ToArray();
+
+        return ValueTask.FromResult<IReadOnlyList<ShareGroupOffsetDescription>>(result);
+    }
+
+    public ValueTask AlterShareGroupOffsetsAsync(
+        string groupId,
+        IEnumerable<ShareGroupOffsetAlteration> offsets,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        ArgumentNullException.ThrowIfNull(offsets);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        _cluster.CommitOffsets(
+            groupId,
+            offsets.Select(offset => new TopicPartitionOffset(
+                offset.TopicPartition.Topic,
+                offset.TopicPartition.Partition,
+                offset.StartOffset)));
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DeleteShareGroupOffsetsAsync(
+        string groupId,
+        IEnumerable<string> topics,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        ArgumentNullException.ThrowIfNull(topics);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var topicSet = topics.ToHashSet(StringComparer.Ordinal);
+        var partitions = _cluster.GetGroupOffsets(groupId)
+            .Keys
+            .Where(partition => topicSet.Contains(partition.Topic))
+            .ToArray();
+
+        _cluster.DeleteGroupOffsets(groupId, partitions);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _disposed = true;
+        return ValueTask.CompletedTask;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+}

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -82,7 +82,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         get
         {
             lock (_gate)
-                return _assignment.ToHashSet();
+                return GetCurrentAssignmentUnderLock().ToHashSet();
         }
     }
 
@@ -141,6 +141,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 _subscription.Add(topic);
 
             ReplaceAssignment(topicPartitions);
+            RegisterConsumerGroupMemberUnderLock();
         }
     }
 
@@ -166,6 +167,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _assignment.Clear();
             _paused.Clear();
             _positions.Clear();
+            UnregisterConsumerGroupMemberUnderLock();
         }
     }
 
@@ -280,14 +282,28 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     public ValueTask CloseAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        _disposed = true;
+
+        if (_disposed)
+            return ValueTask.CompletedTask;
+
+        lock (_gate)
+        {
+            if (_disposed)
+                return ValueTask.CompletedTask;
+
+            if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
+                CommitCurrentOffsets();
+
+            UnregisterConsumerGroupMemberUnderLock();
+            _disposed = true;
+        }
+
         return ValueTask.CompletedTask;
     }
 
     public ValueTask DisposeAsync()
     {
-        _disposed = true;
-        return ValueTask.CompletedTask;
+        return CloseAsync();
     }
 
     public ValueTask<long?> GetCommittedOffsetAsync(
@@ -309,7 +325,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         ThrowIfDisposed();
 
         lock (_gate)
-            return _positions.GetValueOrDefault(partition);
+            return _positions.TryGetValue(partition, out var position) ? position : null;
     }
 
     public void Seek(TopicPartitionOffset offset)
@@ -353,6 +369,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         {
             _subscription.Clear();
             ReplaceAssignment(partitions);
+            RegisterConsumerGroupMemberUnderLock();
         }
     }
 
@@ -365,6 +382,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _assignment.Clear();
             _paused.Clear();
             _positions.Clear();
+            UnregisterConsumerGroupMemberUnderLock();
         }
     }
 
@@ -378,9 +396,12 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             foreach (var offset in partitions)
             {
                 var partition = new TopicPartition(offset.Topic, offset.Partition);
+                var position = offset.Offset >= 0 ? offset.Offset : GetStartOffset(partition);
                 _assignment.Add(partition);
-                _positions[partition] = offset.Offset >= 0 ? offset.Offset : GetStartOffset(partition);
+                _positions[partition] = position;
             }
+
+            RegisterConsumerGroupMemberUnderLock();
         }
     }
 
@@ -397,6 +418,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 _paused.Remove(partition);
                 _positions.Remove(partition);
             }
+
+            RegisterConsumerGroupMemberUnderLock();
         }
     }
 
@@ -461,12 +484,14 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
-            foreach (var partition in _assignment.OrderBy(item => item.Topic, StringComparer.Ordinal).ThenBy(item => item.Partition))
+            foreach (var partition in GetCurrentAssignmentUnderLock().OrderBy(item => item.Topic, StringComparer.Ordinal).ThenBy(item => item.Partition))
             {
                 if (_paused.Contains(partition))
                     continue;
 
-                var position = _positions.GetValueOrDefault(partition);
+                if (!_positions.TryGetValue(partition, out var position))
+                    continue;
+
                 if (!_cluster.TryRead(partition, position, out var record))
                     continue;
 
@@ -509,14 +534,18 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     private void ReplaceAssignment(IEnumerable<TopicPartition> partitions)
     {
+        var nextPositions = new Dictionary<TopicPartition, long>();
+        foreach (var partition in partitions.Distinct())
+            nextPositions[partition] = GetStartOffset(partition);
+
         _assignment.Clear();
         _paused.Clear();
         _positions.Clear();
 
-        foreach (var partition in partitions.Distinct())
+        foreach (var (partition, position) in nextPositions)
         {
             _assignment.Add(partition);
-            _positions[partition] = GetStartOffset(partition);
+            _positions[partition] = position;
         }
     }
 
@@ -550,12 +579,42 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         if (_options.GroupId is null)
             return;
 
-        var offsets = _positions.Select(item => new TopicPartitionOffset(
-            item.Key.Topic,
-            item.Key.Partition,
-            item.Value));
+        var assignment = GetCurrentAssignmentUnderLock();
+        var offsets = _positions
+            .Where(item => assignment.Contains(item.Key))
+            .Select(item => new TopicPartitionOffset(
+                item.Key.Topic,
+                item.Key.Partition,
+                item.Value))
+            .ToArray();
 
-        _cluster.CommitOffsets(_options.GroupId, offsets);
+        if (offsets.Length > 0)
+            _cluster.CommitOffsets(_options.GroupId, offsets);
+    }
+
+    private IReadOnlySet<TopicPartition> GetCurrentAssignmentUnderLock()
+    {
+        if (_options.GroupId is null || _memberId is null)
+            return _assignment;
+
+        var owned = _cluster.GetConsumerGroupAssignment(_options.GroupId, _memberId);
+        return owned.Where(_assignment.Contains).ToHashSet();
+    }
+
+    private void RegisterConsumerGroupMemberUnderLock()
+    {
+        if (_options.GroupId is null || _memberId is null)
+            return;
+
+        _cluster.RegisterConsumerGroupMember(_options.GroupId, _memberId, _assignment);
+    }
+
+    private void UnregisterConsumerGroupMemberUnderLock()
+    {
+        if (_options.GroupId is null || _memberId is null)
+            return;
+
+        _cluster.UnregisterConsumerGroupMember(_options.GroupId, _memberId);
     }
 
     private void ThrowIfDisposed()

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -1,0 +1,565 @@
+using System.Runtime.CompilerServices;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+using Dekaf.Telemetry;
+
+namespace Dekaf.Testing;
+
+/// <summary>
+/// In-memory <see cref="IKafkaConsumer{TKey,TValue}"/> backed by an <see cref="InMemoryKafkaCluster"/>.
+/// </summary>
+public sealed class InMemoryConsumer<TKey, TValue> :
+    IKafkaConsumer<TKey, TValue>,
+    IConsumerPositions,
+    IConsumerPartitions,
+    IConsumerOffsets
+{
+    private readonly object _gate = new();
+    private readonly InMemoryKafkaCluster _cluster;
+    private readonly IDeserializer<TKey> _keyDeserializer;
+    private readonly IDeserializer<TValue> _valueDeserializer;
+    private readonly InMemoryConsumerOptions _options;
+    private readonly HashSet<string> _subscription = new(StringComparer.Ordinal);
+    private readonly HashSet<TopicPartition> _assignment = [];
+    private readonly HashSet<TopicPartition> _paused = [];
+    private readonly Dictionary<TopicPartition, long> _positions = [];
+    private readonly string? _memberId;
+    private bool _disposed;
+
+    public InMemoryConsumer(InMemoryKafkaCluster cluster)
+        : this(
+            cluster,
+            InMemorySerdeResolver.Deserializer<TKey>(),
+            InMemorySerdeResolver.Deserializer<TValue>(),
+            new InMemoryConsumerOptions())
+    {
+    }
+
+    public InMemoryConsumer(
+        InMemoryKafkaCluster cluster,
+        InMemoryConsumerOptions options)
+        : this(
+            cluster,
+            InMemorySerdeResolver.Deserializer<TKey>(),
+            InMemorySerdeResolver.Deserializer<TValue>(),
+            options)
+    {
+    }
+
+    public InMemoryConsumer(
+        InMemoryKafkaCluster cluster,
+        IDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer)
+        : this(cluster, keyDeserializer, valueDeserializer, new InMemoryConsumerOptions())
+    {
+    }
+
+    public InMemoryConsumer(
+        InMemoryKafkaCluster cluster,
+        IDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer,
+        InMemoryConsumerOptions options)
+    {
+        _cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));
+        _keyDeserializer = keyDeserializer ?? throw new ArgumentNullException(nameof(keyDeserializer));
+        _valueDeserializer = valueDeserializer ?? throw new ArgumentNullException(nameof(valueDeserializer));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _memberId = options.GroupId is null ? null : options.MemberId ?? Guid.NewGuid().ToString("N");
+    }
+
+    public IReadOnlySet<string> Subscription
+    {
+        get
+        {
+            lock (_gate)
+                return _subscription.ToHashSet(StringComparer.Ordinal);
+        }
+    }
+
+    public IReadOnlySet<TopicPartition> Assignment
+    {
+        get
+        {
+            lock (_gate)
+                return _assignment.ToHashSet();
+        }
+    }
+
+    public IReadOnlySet<TopicPartition> Paused
+    {
+        get
+        {
+            lock (_gate)
+                return _paused.ToHashSet();
+        }
+    }
+
+    public string? MemberId => _memberId;
+
+    public ConsumerGroupMetadata? ConsumerGroupMetadata => _options.GroupId is null || _memberId is null
+        ? null
+        : new ConsumerGroupMetadata
+        {
+            GroupId = _options.GroupId,
+            GenerationId = 1,
+            MemberId = _memberId
+        };
+
+    public IConsumerPositions Positions => this;
+
+    public IConsumerPartitions Partitions => this;
+
+    public IConsumerOffsets Offsets => this;
+
+    IReadOnlySet<TopicPartition> IConsumerPartitions.Assignment => Assignment;
+
+    IReadOnlySet<TopicPartition> IConsumerPartitions.Paused => Paused;
+
+    public ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.CompletedTask;
+    }
+
+    public void Subscribe(params string[] topics)
+    {
+        ArgumentNullException.ThrowIfNull(topics);
+        ThrowIfDisposed();
+
+        var topicPartitions = topics
+            .Where(topic => !string.IsNullOrWhiteSpace(topic))
+            .Distinct(StringComparer.Ordinal)
+            .SelectMany(topic => _cluster.GetTopicPartitions(topic))
+            .ToArray();
+
+        lock (_gate)
+        {
+            _subscription.Clear();
+            foreach (var topic in topics.Where(topic => !string.IsNullOrWhiteSpace(topic)).Distinct(StringComparer.Ordinal))
+                _subscription.Add(topic);
+
+            ReplaceAssignment(topicPartitions);
+        }
+    }
+
+    public void Subscribe(Func<string, bool> topicFilter)
+    {
+        ArgumentNullException.ThrowIfNull(topicFilter);
+        ThrowIfDisposed();
+
+        var topics = _cluster.ListTopics()
+            .Where(topicFilter)
+            .ToArray();
+
+        Subscribe(topics);
+    }
+
+    public void Unsubscribe()
+    {
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            _subscription.Clear();
+            _assignment.Clear();
+            _paused.Clear();
+            _positions.Clear();
+        }
+    }
+
+    public async IAsyncEnumerable<ConsumeResult<TKey, TValue>> ConsumeAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var result = await ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            if (result.HasValue)
+                yield return result.Value;
+        }
+    }
+
+    public async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+            throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        var deadline = timeout == Timeout.InfiniteTimeSpan ? (DateTimeOffset?)null : DateTimeOffset.UtcNow + timeout;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (TryConsumeOne(out var result))
+                return result;
+
+            if (deadline is null)
+            {
+                await _cluster.WaitForRecordsAsync(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            var remaining = deadline.Value - DateTimeOffset.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+                return null;
+
+            try
+            {
+                await _cluster.WaitForRecordsAsync(remaining, cancellationToken).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                return null;
+            }
+        }
+    }
+
+    public async IAsyncEnumerable<ConsumeBatch<TKey, TValue>> ConsumeBatchAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await Task.CompletedTask.ConfigureAwait(false);
+        throw new NotSupportedException("In-memory consumer does not support batch fetch wrappers. Use ConsumeAsync or ConsumeOneAsync.");
+#pragma warning disable CS0162
+        yield break;
+#pragma warning restore CS0162
+    }
+
+    public async IAsyncEnumerable<ConsumeRawBatch> ConsumeRawBatchAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await Task.CompletedTask.ConfigureAwait(false);
+        throw new NotSupportedException("In-memory consumer does not support raw batch fetch wrappers. Use InMemoryKafkaCluster.ReadRecords for raw records.");
+#pragma warning disable CS0162
+        yield break;
+#pragma warning restore CS0162
+    }
+
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        ArgumentNullException.ThrowIfNull(metric);
+        ThrowIfDisposed();
+    }
+
+    public void UnregisterMetricFromSubscription(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ThrowIfDisposed();
+    }
+
+    public ValueTask CommitAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        lock (_gate)
+            CommitCurrentOffsets();
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask CommitAsync(
+        IEnumerable<TopicPartitionOffset> offsets,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(offsets);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        if (_options.GroupId is not null)
+            _cluster.CommitOffsets(_options.GroupId, offsets);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask CloseAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _disposed = true;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _disposed = true;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<long?> GetCommittedOffsetAsync(
+        TopicPartition partition,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var offset = _options.GroupId is null
+            ? null
+            : _cluster.GetCommittedOffset(_options.GroupId, partition);
+
+        return ValueTask.FromResult(offset);
+    }
+
+    public long? GetPosition(TopicPartition partition)
+    {
+        ThrowIfDisposed();
+
+        lock (_gate)
+            return _positions.GetValueOrDefault(partition);
+    }
+
+    public void Seek(TopicPartitionOffset offset)
+    {
+        ThrowIfDisposed();
+
+        lock (_gate)
+            _positions[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
+    }
+
+    public void SeekToBeginning(params TopicPartition[] partitions)
+    {
+        ArgumentNullException.ThrowIfNull(partitions);
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            foreach (var partition in SelectTargetPartitions(partitions))
+                _positions[partition] = _cluster.GetWatermarks(partition).Low;
+        }
+    }
+
+    public void SeekToEnd(params TopicPartition[] partitions)
+    {
+        ArgumentNullException.ThrowIfNull(partitions);
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            foreach (var partition in SelectTargetPartitions(partitions))
+                _positions[partition] = _cluster.GetWatermarks(partition).High;
+        }
+    }
+
+    public void Assign(params TopicPartition[] partitions)
+    {
+        ArgumentNullException.ThrowIfNull(partitions);
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            _subscription.Clear();
+            ReplaceAssignment(partitions);
+        }
+    }
+
+    public void Unassign()
+    {
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            _assignment.Clear();
+            _paused.Clear();
+            _positions.Clear();
+        }
+    }
+
+    public void IncrementalAssign(IEnumerable<TopicPartitionOffset> partitions)
+    {
+        ArgumentNullException.ThrowIfNull(partitions);
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            foreach (var offset in partitions)
+            {
+                var partition = new TopicPartition(offset.Topic, offset.Partition);
+                _assignment.Add(partition);
+                _positions[partition] = offset.Offset >= 0 ? offset.Offset : GetStartOffset(partition);
+            }
+        }
+    }
+
+    public void IncrementalUnassign(IEnumerable<TopicPartition> partitions)
+    {
+        ArgumentNullException.ThrowIfNull(partitions);
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            foreach (var partition in partitions)
+            {
+                _assignment.Remove(partition);
+                _paused.Remove(partition);
+                _positions.Remove(partition);
+            }
+        }
+    }
+
+    public void Pause(params TopicPartition[] partitions)
+    {
+        ArgumentNullException.ThrowIfNull(partitions);
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            foreach (var partition in partitions)
+                _paused.Add(partition);
+        }
+    }
+
+    public void Resume(params TopicPartition[] partitions)
+    {
+        ArgumentNullException.ThrowIfNull(partitions);
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            foreach (var partition in partitions)
+                _paused.Remove(partition);
+        }
+    }
+
+    public ValueTask<IReadOnlyDictionary<TopicPartition, long>> GetOffsetsForTimesAsync(
+        IEnumerable<TopicPartitionTimestamp> timestampsToSearch,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(timestampsToSearch);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var result = timestampsToSearch.ToDictionary(
+            item => item.TopicPartition,
+            item => _cluster.GetOffsetForTimestamp(item.TopicPartition, item.Timestamp));
+
+        return ValueTask.FromResult<IReadOnlyDictionary<TopicPartition, long>>(result);
+    }
+
+    public WatermarkOffsets? GetWatermarkOffsets(TopicPartition topicPartition)
+    {
+        ThrowIfDisposed();
+        return _cluster.GetWatermarks(topicPartition);
+    }
+
+    public ValueTask<WatermarkOffsets> QueryWatermarkOffsetsAsync(
+        TopicPartition topicPartition,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.FromResult(_cluster.GetWatermarks(topicPartition));
+    }
+
+    private bool TryConsumeOne(out ConsumeResult<TKey, TValue> result)
+    {
+        InMemoryRecord? selected = null;
+        TopicPartition selectedPartition = default;
+
+        lock (_gate)
+        {
+            foreach (var partition in _assignment.OrderBy(item => item.Topic, StringComparer.Ordinal).ThenBy(item => item.Partition))
+            {
+                if (_paused.Contains(partition))
+                    continue;
+
+                var position = _positions.GetValueOrDefault(partition);
+                if (!_cluster.TryRead(partition, position, out var record))
+                    continue;
+
+                selected = record;
+                selectedPartition = partition;
+                _positions[partition] = record.Offset + 1;
+                if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
+                    CommitCurrentOffsets();
+                break;
+            }
+        }
+
+        if (selected is null)
+        {
+            result = default;
+            return false;
+        }
+
+        result = ToConsumeResult(selectedPartition, selected);
+        return true;
+    }
+
+    private ConsumeResult<TKey, TValue> ToConsumeResult(TopicPartition topicPartition, InMemoryRecord record)
+    {
+        return new ConsumeResult<TKey, TValue>(
+            topic: topicPartition.Topic,
+            partition: topicPartition.Partition,
+            offset: record.Offset,
+            keyData: record.Key,
+            isKeyNull: record.IsKeyNull,
+            valueData: record.Value,
+            isValueNull: record.IsValueNull,
+            headers: record.Headers,
+            timestampMs: record.TimestampMs,
+            timestampType: TimestampType.CreateTime,
+            leaderEpoch: null,
+            keyDeserializer: _keyDeserializer,
+            valueDeserializer: _valueDeserializer);
+    }
+
+    private void ReplaceAssignment(IEnumerable<TopicPartition> partitions)
+    {
+        _assignment.Clear();
+        _paused.Clear();
+        _positions.Clear();
+
+        foreach (var partition in partitions.Distinct())
+        {
+            _assignment.Add(partition);
+            _positions[partition] = GetStartOffset(partition);
+        }
+    }
+
+    private long GetStartOffset(TopicPartition partition)
+    {
+        if (_options.GroupId is not null &&
+            _cluster.GetCommittedOffset(_options.GroupId, partition) is { } committed)
+        {
+            return committed;
+        }
+
+        return _options.AutoOffsetReset switch
+        {
+            AutoOffsetReset.Earliest => _cluster.GetWatermarks(partition).Low,
+            AutoOffsetReset.Latest => _cluster.GetWatermarks(partition).High,
+            AutoOffsetReset.ByDuration => _cluster.GetOffsetForTimestamp(
+                partition,
+                DateTimeOffset.UtcNow.Subtract(_options.AutoOffsetResetDuration ?? TimeSpan.Zero).ToUnixTimeMilliseconds()),
+            AutoOffsetReset.None => throw new InvalidOperationException($"No committed offset exists for {partition}."),
+            _ => _cluster.GetWatermarks(partition).High
+        };
+    }
+
+    private IEnumerable<TopicPartition> SelectTargetPartitions(TopicPartition[] partitions)
+    {
+        return partitions.Length == 0 ? _assignment.ToArray() : partitions;
+    }
+
+    private void CommitCurrentOffsets()
+    {
+        if (_options.GroupId is null)
+            return;
+
+        var offsets = _positions.Select(item => new TopicPartitionOffset(
+            item.Key.Topic,
+            item.Key.Partition,
+            item.Value));
+
+        _cluster.CommitOffsets(_options.GroupId, offsets);
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+}

--- a/src/Dekaf.Testing/InMemoryConsumerOptions.cs
+++ b/src/Dekaf.Testing/InMemoryConsumerOptions.cs
@@ -10,25 +10,25 @@ public sealed class InMemoryConsumerOptions
     /// <summary>
     /// Consumer group ID used for committed offsets.
     /// </summary>
-    public string? GroupId { get; set; }
+    public string? GroupId { get; init; }
 
     /// <summary>
     /// Offset reset behavior when no committed offset exists.
     /// </summary>
-    public AutoOffsetReset AutoOffsetReset { get; set; } = AutoOffsetReset.Latest;
+    public AutoOffsetReset AutoOffsetReset { get; init; } = AutoOffsetReset.Latest;
 
     /// <summary>
     /// Duration used when <see cref="AutoOffsetReset"/> is <see cref="AutoOffsetReset.ByDuration"/>.
     /// </summary>
-    public TimeSpan? AutoOffsetResetDuration { get; set; }
+    public TimeSpan? AutoOffsetResetDuration { get; init; }
 
     /// <summary>
     /// Commit consumed offsets automatically.
     /// </summary>
-    public OffsetCommitMode OffsetCommitMode { get; set; } = OffsetCommitMode.Auto;
+    public OffsetCommitMode OffsetCommitMode { get; init; } = OffsetCommitMode.Auto;
 
     /// <summary>
     /// Member ID reported by the fake consumer.
     /// </summary>
-    public string? MemberId { get; set; }
+    public string? MemberId { get; init; }
 }

--- a/src/Dekaf.Testing/InMemoryConsumerOptions.cs
+++ b/src/Dekaf.Testing/InMemoryConsumerOptions.cs
@@ -1,0 +1,34 @@
+using Dekaf.Consumer;
+
+namespace Dekaf.Testing;
+
+/// <summary>
+/// Options for <see cref="InMemoryConsumer{TKey,TValue}"/>.
+/// </summary>
+public sealed class InMemoryConsumerOptions
+{
+    /// <summary>
+    /// Consumer group ID used for committed offsets.
+    /// </summary>
+    public string? GroupId { get; set; }
+
+    /// <summary>
+    /// Offset reset behavior when no committed offset exists.
+    /// </summary>
+    public AutoOffsetReset AutoOffsetReset { get; set; } = AutoOffsetReset.Latest;
+
+    /// <summary>
+    /// Duration used when <see cref="AutoOffsetReset"/> is <see cref="AutoOffsetReset.ByDuration"/>.
+    /// </summary>
+    public TimeSpan? AutoOffsetResetDuration { get; set; }
+
+    /// <summary>
+    /// Commit consumed offsets automatically.
+    /// </summary>
+    public OffsetCommitMode OffsetCommitMode { get; set; } = OffsetCommitMode.Auto;
+
+    /// <summary>
+    /// Member ID reported by the fake consumer.
+    /// </summary>
+    public string? MemberId { get; set; }
+}

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -173,7 +173,6 @@ public sealed class InMemoryKafkaCluster
             };
 
             signal = _recordsChanged;
-            _recordsChanged = NewRecordsChangedSource();
         }
 
         signal.TrySetResult();
@@ -210,7 +209,11 @@ public sealed class InMemoryKafkaCluster
     {
         Task task;
         lock (_gate)
+        {
             task = _recordsChanged.Task;
+            if (task.IsCompleted)
+                _recordsChanged = NewRecordsChangedSource();
+        }
 
         if (timeout == Timeout.InfiniteTimeSpan)
         {

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -14,6 +14,9 @@ public sealed class InMemoryKafkaCluster
     private readonly object _gate = new();
     private readonly Dictionary<string, TopicState> _topics = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Dictionary<TopicPartition, long>> _consumerGroupOffsets = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<string, HashSet<TopicPartition>>> _consumerGroupMembers = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, ShareLeaseState>>> _shareLeases = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<TopicPartition, Dictionary<long, int>>> _shareDeliveryCounts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Exception> _produceFailures = new(StringComparer.Ordinal);
     private readonly InMemoryKafkaClusterOptions _options;
     private TaskCompletionSource _recordsChanged = NewRecordsChangedSource();
@@ -100,6 +103,59 @@ public sealed class InMemoryKafkaCluster
         }
     }
 
+    internal void RegisterConsumerGroupMember(
+        string groupId,
+        string memberId,
+        IEnumerable<TopicPartition> subscribedPartitions)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
+        ArgumentNullException.ThrowIfNull(subscribedPartitions);
+
+        var partitions = subscribedPartitions.Distinct().ToHashSet();
+
+        lock (_gate)
+        {
+            if (!_consumerGroupMembers.TryGetValue(groupId, out var members))
+            {
+                members = new Dictionary<string, HashSet<TopicPartition>>(StringComparer.Ordinal);
+                _consumerGroupMembers[groupId] = members;
+            }
+
+            members[memberId] = partitions;
+        }
+    }
+
+    internal void UnregisterConsumerGroupMember(string groupId, string memberId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
+
+        lock (_gate)
+        {
+            if (!_consumerGroupMembers.TryGetValue(groupId, out var members))
+                return;
+
+            members.Remove(memberId);
+            if (members.Count == 0)
+                _consumerGroupMembers.Remove(groupId);
+        }
+    }
+
+    internal IReadOnlySet<TopicPartition> GetConsumerGroupAssignment(string groupId, string memberId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
+
+        lock (_gate)
+        {
+            var assignments = BuildConsumerGroupAssignments(groupId);
+            return assignments.TryGetValue(memberId, out var partitions)
+                ? partitions.ToHashSet()
+                : new HashSet<TopicPartition>();
+        }
+    }
+
     public IReadOnlyList<InMemoryRecord> ReadRecords(string topic, int partition = 0)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(topic);
@@ -183,26 +239,101 @@ public sealed class InMemoryKafkaCluster
     {
         lock (_gate)
         {
-            if (!_topics.TryGetValue(topicPartition.Topic, out var topic) ||
-                (uint)topicPartition.Partition >= (uint)topic.Partitions.Count)
+            if (!TryReadRecordUnderLock(topicPartition, offset, out var candidate))
             {
                 record = null!;
                 return false;
             }
 
-            var partition = topic.Partitions[topicPartition.Partition];
-            foreach (var candidate in partition.Records)
+            record = CloneRecord(candidate);
+            return true;
+        }
+    }
+
+    internal bool TryAcquireShareRecord(
+        string groupId,
+        string memberId,
+        TopicPartition topicPartition,
+        long offset,
+        out InMemoryRecord record,
+        out int deliveryCount)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
+
+        lock (_gate)
+        {
+            if (!TryReadRecordUnderLock(topicPartition, offset, out var candidate))
             {
-                if (candidate.Offset >= offset)
-                {
-                    record = CloneRecord(candidate);
-                    return true;
-                }
+                record = null!;
+                deliveryCount = 0;
+                return false;
             }
 
-            record = null!;
-            return false;
+            var partitionLeases = GetShareLeasePartition(groupId, topicPartition, create: true)!;
+            if (partitionLeases.TryGetValue(candidate.Offset, out var lease) &&
+                !StringComparer.Ordinal.Equals(lease.MemberId, memberId))
+            {
+                record = null!;
+                deliveryCount = 0;
+                return false;
+            }
+
+            var partitionDeliveryCounts = GetShareDeliveryCountPartition(groupId, topicPartition, create: true)!;
+            if (!partitionLeases.ContainsKey(candidate.Offset))
+            {
+                partitionDeliveryCounts.TryGetValue(candidate.Offset, out deliveryCount);
+                deliveryCount++;
+                partitionDeliveryCounts[candidate.Offset] = deliveryCount;
+                partitionLeases[candidate.Offset] = new ShareLeaseState(memberId);
+            }
+            else
+            {
+                deliveryCount = partitionDeliveryCounts.GetValueOrDefault(candidate.Offset, 1);
+            }
+
+            record = CloneRecord(candidate);
+            return true;
         }
+    }
+
+    internal void CompleteShareRecords(
+        string groupId,
+        string memberId,
+        IEnumerable<TopicPartitionOffset> completedRecords,
+        IEnumerable<TopicPartitionOffset> commitOffsets)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
+        ArgumentNullException.ThrowIfNull(completedRecords);
+        ArgumentNullException.ThrowIfNull(commitOffsets);
+
+        var completed = completedRecords.ToArray();
+        var commits = commitOffsets.ToArray();
+
+        lock (_gate)
+        {
+            ReleaseShareLeasesUnderLock(groupId, memberId, completed);
+            if (commits.Length > 0)
+            {
+                CommitOffsetsUnderLock(groupId, commits);
+                foreach (var commitOffset in commits)
+                    RemoveCommittedShareDeliveryCountsUnderLock(groupId, commitOffset);
+            }
+        }
+    }
+
+    internal void ReleaseShareRecords(
+        string groupId,
+        string memberId,
+        IEnumerable<TopicPartitionOffset> records)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(memberId);
+        ArgumentNullException.ThrowIfNull(records);
+
+        lock (_gate)
+            ReleaseShareLeasesUnderLock(groupId, memberId, records);
     }
 
     internal async Task WaitForRecordsAsync(TimeSpan timeout, CancellationToken cancellationToken)
@@ -279,16 +410,7 @@ public sealed class InMemoryKafkaCluster
     internal void CommitOffsets(string groupId, IEnumerable<TopicPartitionOffset> offsets)
     {
         lock (_gate)
-        {
-            if (!_consumerGroupOffsets.TryGetValue(groupId, out var groupOffsets))
-            {
-                groupOffsets = [];
-                _consumerGroupOffsets[groupId] = groupOffsets;
-            }
-
-            foreach (var offset in offsets)
-                groupOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
-        }
+            CommitOffsetsUnderLock(groupId, offsets);
     }
 
     internal IReadOnlyDictionary<TopicPartition, long> GetGroupOffsets(string groupId)
@@ -415,6 +537,175 @@ public sealed class InMemoryKafkaCluster
             throw new InvalidOperationException($"Topic '{name}' does not exist.");
 
         return EnsureTopic(name, _options.DefaultPartitionCount, configs: null);
+    }
+
+    private bool TryReadRecordUnderLock(TopicPartition topicPartition, long offset, out InMemoryRecord record)
+    {
+        if (!_topics.TryGetValue(topicPartition.Topic, out var topic) ||
+            (uint)topicPartition.Partition >= (uint)topic.Partitions.Count)
+        {
+            record = null!;
+            return false;
+        }
+
+        var partition = topic.Partitions[topicPartition.Partition];
+        foreach (var candidate in partition.Records)
+        {
+            if (candidate.Offset >= offset)
+            {
+                record = candidate;
+                return true;
+            }
+        }
+
+        record = null!;
+        return false;
+    }
+
+    private Dictionary<string, HashSet<TopicPartition>> BuildConsumerGroupAssignments(string groupId)
+    {
+        var result = new Dictionary<string, HashSet<TopicPartition>>(StringComparer.Ordinal);
+        if (!_consumerGroupMembers.TryGetValue(groupId, out var members))
+            return result;
+
+        foreach (var memberId in members.Keys)
+            result[memberId] = [];
+
+        var partitions = members
+            .Values
+            .SelectMany(static item => item)
+            .Distinct()
+            .OrderBy(static item => item.Topic, StringComparer.Ordinal)
+            .ThenBy(static item => item.Partition)
+            .ToArray();
+
+        for (var i = 0; i < partitions.Length; i++)
+        {
+            var partition = partitions[i];
+            var eligibleMembers = members
+                .Where(member => member.Value.Contains(partition))
+                .Select(static member => member.Key)
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+
+            if (eligibleMembers.Length == 0)
+                continue;
+
+            var owner = eligibleMembers[i % eligibleMembers.Length];
+            result[owner].Add(partition);
+        }
+
+        return result;
+    }
+
+    private void CommitOffsetsUnderLock(string groupId, IEnumerable<TopicPartitionOffset> offsets)
+    {
+        if (!_consumerGroupOffsets.TryGetValue(groupId, out var groupOffsets))
+        {
+            groupOffsets = [];
+            _consumerGroupOffsets[groupId] = groupOffsets;
+        }
+
+        foreach (var offset in offsets)
+            groupOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
+    }
+
+    private Dictionary<long, ShareLeaseState>? GetShareLeasePartition(
+        string groupId,
+        TopicPartition topicPartition,
+        bool create)
+    {
+        if (!_shareLeases.TryGetValue(groupId, out var groupLeases))
+        {
+            if (!create)
+                return null;
+
+            groupLeases = [];
+            _shareLeases[groupId] = groupLeases;
+        }
+
+        if (!groupLeases.TryGetValue(topicPartition, out var partitionLeases))
+        {
+            if (!create)
+                return null;
+
+            partitionLeases = [];
+            groupLeases[topicPartition] = partitionLeases;
+        }
+
+        return partitionLeases;
+    }
+
+    private Dictionary<long, int>? GetShareDeliveryCountPartition(
+        string groupId,
+        TopicPartition topicPartition,
+        bool create)
+    {
+        if (!_shareDeliveryCounts.TryGetValue(groupId, out var groupCounts))
+        {
+            if (!create)
+                return null;
+
+            groupCounts = [];
+            _shareDeliveryCounts[groupId] = groupCounts;
+        }
+
+        if (!groupCounts.TryGetValue(topicPartition, out var partitionCounts))
+        {
+            if (!create)
+                return null;
+
+            partitionCounts = [];
+            groupCounts[topicPartition] = partitionCounts;
+        }
+
+        return partitionCounts;
+    }
+
+    private void ReleaseShareLeasesUnderLock(
+        string groupId,
+        string memberId,
+        IEnumerable<TopicPartitionOffset> records)
+    {
+        if (!_shareLeases.TryGetValue(groupId, out var groupLeases))
+            return;
+
+        foreach (var record in records)
+        {
+            var topicPartition = new TopicPartition(record.Topic, record.Partition);
+            if (!groupLeases.TryGetValue(topicPartition, out var partitionLeases) ||
+                !partitionLeases.TryGetValue(record.Offset, out var lease) ||
+                !StringComparer.Ordinal.Equals(lease.MemberId, memberId))
+            {
+                continue;
+            }
+
+            partitionLeases.Remove(record.Offset);
+            if (partitionLeases.Count == 0)
+                groupLeases.Remove(topicPartition);
+        }
+
+        if (groupLeases.Count == 0)
+            _shareLeases.Remove(groupId);
+    }
+
+    private void RemoveCommittedShareDeliveryCountsUnderLock(string groupId, TopicPartitionOffset commitOffset)
+    {
+        var topicPartition = new TopicPartition(commitOffset.Topic, commitOffset.Partition);
+        var partitionCounts = GetShareDeliveryCountPartition(groupId, topicPartition, create: false);
+        if (partitionCounts is null)
+            return;
+
+        foreach (var offset in partitionCounts.Keys.Where(offset => offset < commitOffset.Offset).ToArray())
+            partitionCounts.Remove(offset);
+
+        if (partitionCounts.Count == 0 &&
+            _shareDeliveryCounts.TryGetValue(groupId, out var groupCounts))
+        {
+            groupCounts.Remove(topicPartition);
+            if (groupCounts.Count == 0)
+                _shareDeliveryCounts.Remove(groupId);
+        }
     }
 
     private TopicState GetTopicForRead(string name)
@@ -558,5 +849,15 @@ public sealed class InMemoryKafkaCluster
         public List<InMemoryRecord> Records { get; } = [];
         public long LogStartOffset { get; set; }
         public long HighWatermark => Records.Count == 0 ? LogStartOffset : Records[^1].Offset + 1;
+    }
+
+    private sealed class ShareLeaseState
+    {
+        public ShareLeaseState(string memberId)
+        {
+            MemberId = memberId;
+        }
+
+        public string MemberId { get; }
     }
 }

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -1,0 +1,559 @@
+using Dekaf.Admin;
+using Dekaf.Metadata;
+using Dekaf.Protocol;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Testing;
+
+/// <summary>
+/// Shared in-memory topic, partition, offset, and group-offset store.
+/// </summary>
+public sealed class InMemoryKafkaCluster
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, TopicState> _topics = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<TopicPartition, long>> _consumerGroupOffsets = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Exception> _produceFailures = new(StringComparer.Ordinal);
+    private readonly InMemoryKafkaClusterOptions _options;
+    private TaskCompletionSource _recordsChanged = NewRecordsChangedSource();
+    private TimeSpan _produceLatency;
+
+    public InMemoryKafkaCluster()
+        : this(new InMemoryKafkaClusterOptions())
+    {
+    }
+
+    public InMemoryKafkaCluster(InMemoryKafkaClusterOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.DefaultPartitionCount, 1);
+        _options = options;
+    }
+
+    public InMemoryKafkaClusterOptions Options => _options;
+
+    public TimeSpan ProduceLatency
+    {
+        get
+        {
+            lock (_gate)
+                return _produceLatency;
+        }
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, TimeSpan.Zero);
+            lock (_gate)
+                _produceLatency = value;
+        }
+    }
+
+    public void FailProduces(string topic, Exception exception)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        ArgumentNullException.ThrowIfNull(exception);
+
+        lock (_gate)
+            _produceFailures[topic] = exception;
+    }
+
+    public bool ClearProduceFailure(string topic)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        lock (_gate)
+            return _produceFailures.Remove(topic);
+    }
+
+    public void CreateTopic(string name, int partitionCount = 1, IReadOnlyDictionary<string, string>? configs = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentOutOfRangeException.ThrowIfLessThan(partitionCount, 1);
+
+        lock (_gate)
+            EnsureTopic(name, partitionCount, configs);
+    }
+
+    public bool DeleteTopic(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        lock (_gate)
+            return _topics.Remove(name);
+    }
+
+    public IReadOnlyList<string> ListTopics()
+    {
+        lock (_gate)
+            return _topics.Keys.Order(StringComparer.Ordinal).ToArray();
+    }
+
+    public IReadOnlyList<TopicPartition> GetTopicPartitions(string topic)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+
+        lock (_gate)
+        {
+            var state = GetTopicForRead(topic);
+            return Enumerable.Range(0, state.Partitions.Count)
+                .Select(partition => new TopicPartition(topic, partition))
+                .ToArray();
+        }
+    }
+
+    public IReadOnlyList<InMemoryRecord> ReadRecords(string topic, int partition = 0)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        ArgumentOutOfRangeException.ThrowIfLessThan(partition, 0);
+
+        lock (_gate)
+        {
+            var state = GetTopicForRead(topic);
+            var partitionState = GetPartitionForRead(state, partition);
+            return partitionState.Records.Select(CloneRecord).ToArray();
+        }
+    }
+
+    internal async ValueTask<RecordMetadata> AppendAsync(
+        string topic,
+        int? partition,
+        byte[] key,
+        bool isKeyNull,
+        byte[] value,
+        bool isValueNull,
+        IReadOnlyList<Header>? headers,
+        DateTimeOffset timestamp,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        var latency = GetProduceLatency(topic, out var failure);
+        if (latency > TimeSpan.Zero)
+            await Task.Delay(latency, cancellationToken).ConfigureAwait(false);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (failure is not null)
+            throw failure;
+
+        TaskCompletionSource signal;
+        RecordMetadata metadata;
+        lock (_gate)
+        {
+            var state = GetOrAutoCreateTopic(topic);
+            var selectedPartition = SelectPartition(state, partition, key, isKeyNull);
+            var partitionState = state.Partitions[selectedPartition];
+            var offset = partitionState.HighWatermark;
+            var timestampMs = timestamp.ToUnixTimeMilliseconds();
+
+            var record = new InMemoryRecord
+            {
+                Topic = topic,
+                Partition = selectedPartition,
+                Offset = offset,
+                Key = key,
+                IsKeyNull = isKeyNull,
+                Value = value,
+                IsValueNull = isValueNull,
+                Headers = CopyHeaders(headers),
+                TimestampMs = timestampMs
+            };
+
+            partitionState.Records.Add(record);
+
+            metadata = new RecordMetadata
+            {
+                Topic = topic,
+                Partition = selectedPartition,
+                Offset = offset,
+                Timestamp = timestamp,
+                KeySize = isKeyNull ? 0 : key.Length,
+                ValueSize = isValueNull ? 0 : value.Length
+            };
+
+            signal = _recordsChanged;
+            _recordsChanged = NewRecordsChangedSource();
+        }
+
+        signal.TrySetResult();
+        return metadata;
+    }
+
+    internal bool TryRead(TopicPartition topicPartition, long offset, out InMemoryRecord record)
+    {
+        lock (_gate)
+        {
+            if (!_topics.TryGetValue(topicPartition.Topic, out var topic) ||
+                (uint)topicPartition.Partition >= (uint)topic.Partitions.Count)
+            {
+                record = null!;
+                return false;
+            }
+
+            var partition = topic.Partitions[topicPartition.Partition];
+            foreach (var candidate in partition.Records)
+            {
+                if (candidate.Offset >= offset)
+                {
+                    record = CloneRecord(candidate);
+                    return true;
+                }
+            }
+
+            record = null!;
+            return false;
+        }
+    }
+
+    internal async Task WaitForRecordsAsync(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        Task task;
+        lock (_gate)
+            task = _recordsChanged.Task;
+
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await task.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal WatermarkOffsets GetWatermarks(TopicPartition topicPartition)
+    {
+        lock (_gate)
+        {
+            if (!_topics.TryGetValue(topicPartition.Topic, out var topic) ||
+                (uint)topicPartition.Partition >= (uint)topic.Partitions.Count)
+            {
+                return new WatermarkOffsets(0, 0);
+            }
+
+            var partition = topic.Partitions[topicPartition.Partition];
+            return new WatermarkOffsets(partition.LogStartOffset, partition.HighWatermark);
+        }
+    }
+
+    internal long GetOffsetForTimestamp(TopicPartition topicPartition, long timestamp)
+    {
+        lock (_gate)
+        {
+            if (!_topics.TryGetValue(topicPartition.Topic, out var topic) ||
+                (uint)topicPartition.Partition >= (uint)topic.Partitions.Count)
+            {
+                return -1;
+            }
+
+            var partition = topic.Partitions[topicPartition.Partition];
+            if (timestamp == TopicPartitionTimestamp.Earliest)
+                return partition.LogStartOffset;
+            if (timestamp == TopicPartitionTimestamp.Latest)
+                return partition.HighWatermark;
+
+            foreach (var record in partition.Records)
+            {
+                if (record.TimestampMs >= timestamp)
+                    return record.Offset;
+            }
+
+            return -1;
+        }
+    }
+
+    internal long? GetCommittedOffset(string groupId, TopicPartition topicPartition)
+    {
+        lock (_gate)
+        {
+            return _consumerGroupOffsets.TryGetValue(groupId, out var offsets) &&
+                   offsets.TryGetValue(topicPartition, out var offset)
+                ? offset
+                : null;
+        }
+    }
+
+    internal void CommitOffsets(string groupId, IEnumerable<TopicPartitionOffset> offsets)
+    {
+        lock (_gate)
+        {
+            if (!_consumerGroupOffsets.TryGetValue(groupId, out var groupOffsets))
+            {
+                groupOffsets = [];
+                _consumerGroupOffsets[groupId] = groupOffsets;
+            }
+
+            foreach (var offset in offsets)
+                groupOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
+        }
+    }
+
+    internal IReadOnlyDictionary<TopicPartition, long> GetGroupOffsets(string groupId)
+    {
+        lock (_gate)
+        {
+            return _consumerGroupOffsets.TryGetValue(groupId, out var offsets)
+                ? new Dictionary<TopicPartition, long>(offsets)
+                : new Dictionary<TopicPartition, long>();
+        }
+    }
+
+    internal IReadOnlyList<string> ListGroups()
+    {
+        lock (_gate)
+            return _consumerGroupOffsets.Keys.Order(StringComparer.Ordinal).ToArray();
+    }
+
+    internal void DeleteGroup(string groupId)
+    {
+        lock (_gate)
+            _consumerGroupOffsets.Remove(groupId);
+    }
+
+    internal void DeleteGroupOffsets(string groupId, IEnumerable<TopicPartition> partitions)
+    {
+        lock (_gate)
+        {
+            if (!_consumerGroupOffsets.TryGetValue(groupId, out var offsets))
+                return;
+
+            foreach (var partition in partitions)
+                offsets.Remove(partition);
+        }
+    }
+
+    internal IReadOnlyDictionary<TopicPartition, long> DeleteRecords(IReadOnlyDictionary<TopicPartition, long> offsets)
+    {
+        lock (_gate)
+        {
+            var result = new Dictionary<TopicPartition, long>();
+            foreach (var (topicPartition, offset) in offsets)
+            {
+                if (!_topics.TryGetValue(topicPartition.Topic, out var topic) ||
+                    (uint)topicPartition.Partition >= (uint)topic.Partitions.Count)
+                {
+                    result[topicPartition] = -1;
+                    continue;
+                }
+
+                var partition = topic.Partitions[topicPartition.Partition];
+                var target = Math.Clamp(offset, partition.LogStartOffset, partition.HighWatermark);
+                partition.Records.RemoveAll(record => record.Offset < target);
+                partition.LogStartOffset = target;
+                result[topicPartition] = target;
+            }
+
+            return result;
+        }
+    }
+
+    internal void CreatePartitions(string topicName, int newPartitionCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(newPartitionCount, 1);
+
+        lock (_gate)
+        {
+            var topic = GetTopicForRead(topicName);
+            if (newPartitionCount <= topic.Partitions.Count)
+                return;
+
+            while (topic.Partitions.Count < newPartitionCount)
+                topic.Partitions.Add(new PartitionState());
+        }
+    }
+
+    internal IReadOnlyDictionary<string, TopicDescription> DescribeTopics(IEnumerable<string> topicNames)
+    {
+        lock (_gate)
+        {
+            var result = new Dictionary<string, TopicDescription>(StringComparer.Ordinal);
+            foreach (var name in topicNames)
+            {
+                var topic = GetTopicForRead(name);
+                result[name] = DescribeTopic(topic);
+            }
+
+            return result;
+        }
+    }
+
+    internal IReadOnlyList<TopicListing> TopicListings(bool includeInternal)
+    {
+        lock (_gate)
+        {
+            return _topics.Values
+                .Where(topic => includeInternal || !topic.IsInternal)
+                .OrderBy(topic => topic.Name, StringComparer.Ordinal)
+                .Select(topic => new TopicListing
+                {
+                    Name = topic.Name,
+                    TopicId = topic.TopicId,
+                    IsInternal = topic.IsInternal
+                })
+                .ToArray();
+        }
+    }
+
+    private TimeSpan GetProduceLatency(string topic, out Exception? failure)
+    {
+        lock (_gate)
+        {
+            failure = _produceFailures.GetValueOrDefault(topic);
+            return _produceLatency;
+        }
+    }
+
+    private TopicState GetOrAutoCreateTopic(string name)
+    {
+        if (_topics.TryGetValue(name, out var state))
+            return state;
+
+        if (!_options.AutoCreateTopics)
+            throw new InvalidOperationException($"Topic '{name}' does not exist.");
+
+        return EnsureTopic(name, _options.DefaultPartitionCount, configs: null);
+    }
+
+    private TopicState GetTopicForRead(string name)
+    {
+        if (_topics.TryGetValue(name, out var state))
+            return state;
+
+        if (!_options.AutoCreateTopics)
+            throw new InvalidOperationException($"Topic '{name}' does not exist.");
+
+        return EnsureTopic(name, _options.DefaultPartitionCount, configs: null);
+    }
+
+    private TopicState EnsureTopic(string name, int partitionCount, IReadOnlyDictionary<string, string>? configs)
+    {
+        if (_topics.TryGetValue(name, out var existing))
+            return existing;
+
+        var state = new TopicState(name, partitionCount, configs);
+        _topics[name] = state;
+        return state;
+    }
+
+    private static PartitionState GetPartitionForRead(TopicState topic, int partition)
+    {
+        if ((uint)partition >= (uint)topic.Partitions.Count)
+            throw new ArgumentOutOfRangeException(nameof(partition), $"Topic '{topic.Name}' has {topic.Partitions.Count} partitions.");
+
+        return topic.Partitions[partition];
+    }
+
+    private static int SelectPartition(TopicState topic, int? requestedPartition, byte[] key, bool isKeyNull)
+    {
+        if (requestedPartition is { } partition)
+        {
+            if ((uint)partition >= (uint)topic.Partitions.Count)
+                throw new ArgumentOutOfRangeException(nameof(requestedPartition), $"Topic '{topic.Name}' has {topic.Partitions.Count} partitions.");
+
+            return partition;
+        }
+
+        if (!isKeyNull && key.Length > 0)
+            return (int)(Fnv1A(key) % (uint)topic.Partitions.Count);
+
+        var selected = topic.NextPartition;
+        topic.NextPartition = (topic.NextPartition + 1) % topic.Partitions.Count;
+        return selected;
+    }
+
+    private static uint Fnv1A(ReadOnlySpan<byte> bytes)
+    {
+        const uint offset = 2166136261;
+        const uint prime = 16777619;
+
+        var hash = offset;
+        foreach (var value in bytes)
+        {
+            hash ^= value;
+            hash *= prime;
+        }
+
+        return hash;
+    }
+
+    private static IReadOnlyList<Header>? CopyHeaders(IReadOnlyList<Header>? headers)
+    {
+        if (headers is null || headers.Count == 0)
+            return null;
+
+        var copy = new Header[headers.Count];
+        for (var i = 0; i < headers.Count; i++)
+        {
+            var header = headers[i];
+            copy[i] = new Header(header.Key, header.IsValueNull ? null : header.Value.ToArray());
+        }
+
+        return copy;
+    }
+
+    private static InMemoryRecord CloneRecord(InMemoryRecord record)
+    {
+        return record with
+        {
+            Key = record.Key.ToArray(),
+            Value = record.Value.ToArray(),
+            Headers = CopyHeaders(record.Headers)
+        };
+    }
+
+    private static TopicDescription DescribeTopic(TopicState topic)
+    {
+        var partitions = topic.Partitions
+            .Select((_, index) => new PartitionInfo
+            {
+                PartitionIndex = index,
+                LeaderId = 0,
+                LeaderEpoch = 0,
+                ReplicaNodes = [0],
+                IsrNodes = [0],
+                OfflineReplicas = [],
+                ErrorCode = ErrorCode.None
+            })
+            .ToArray();
+
+        return new TopicDescription
+        {
+            Name = topic.Name,
+            TopicId = topic.TopicId,
+            IsInternal = topic.IsInternal,
+            Partitions = partitions,
+            ErrorCode = ErrorCode.None
+        };
+    }
+
+    private static TaskCompletionSource NewRecordsChangedSource() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private sealed class TopicState
+    {
+        public TopicState(string name, int partitionCount, IReadOnlyDictionary<string, string>? configs)
+        {
+            Name = name;
+            Configs = configs is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : new Dictionary<string, string>(configs, StringComparer.Ordinal);
+
+            for (var i = 0; i < partitionCount; i++)
+                Partitions.Add(new PartitionState());
+        }
+
+        public string Name { get; }
+        public Guid TopicId { get; } = Guid.NewGuid();
+        public bool IsInternal => Name.StartsWith("__", StringComparison.Ordinal);
+        public Dictionary<string, string> Configs { get; }
+        public List<PartitionState> Partitions { get; } = [];
+        public int NextPartition { get; set; }
+    }
+
+    private sealed class PartitionState
+    {
+        public List<InMemoryRecord> Records { get; } = [];
+        public long LogStartOffset { get; set; }
+        public long HighWatermark => Records.Count == 0 ? LogStartOffset : Records[^1].Offset + 1;
+    }
+}

--- a/src/Dekaf.Testing/InMemoryKafkaClusterOptions.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaClusterOptions.cs
@@ -1,0 +1,22 @@
+namespace Dekaf.Testing;
+
+/// <summary>
+/// Options for an <see cref="InMemoryKafkaCluster"/>.
+/// </summary>
+public sealed class InMemoryKafkaClusterOptions
+{
+    /// <summary>
+    /// Number of partitions created for auto-created topics.
+    /// </summary>
+    public int DefaultPartitionCount { get; set; } = 1;
+
+    /// <summary>
+    /// Whether producers and consumers may create missing topics on first use.
+    /// </summary>
+    public bool AutoCreateTopics { get; set; } = true;
+
+    /// <summary>
+    /// Cluster ID surfaced by admin operations.
+    /// </summary>
+    public string ClusterId { get; set; } = "dekaf-in-memory";
+}

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -67,14 +67,24 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         return ProduceCoreAsync(topic, partition: null, key, value, headers: null, DateTimeOffset.UtcNow, cancellationToken);
     }
 
-    public async ValueTask FireAsync(ProducerMessage<TKey, TValue> message)
+    public ValueTask FireAsync(ProducerMessage<TKey, TValue> message)
     {
-        await ProduceAsync(message).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(message);
+        ThrowIfDisposed();
+
+        return FireAndForgetCoreAsync(
+            message.Topic,
+            message.Partition,
+            message.Key,
+            message.Value,
+            message.Headers,
+            message.Timestamp ?? DateTimeOffset.UtcNow);
     }
 
-    public async ValueTask FireAsync(string topic, TKey? key, TValue value)
+    public ValueTask FireAsync(string topic, TKey? key, TValue value)
     {
-        await ProduceAsync(topic, key, value).ConfigureAwait(false);
+        ThrowIfDisposed();
+        return FireAndForgetCoreAsync(topic, partition: null, key, value, headers: null, DateTimeOffset.UtcNow);
     }
 
     public async ValueTask FireAsync(
@@ -191,6 +201,25 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
             headers?.ToList(),
             timestamp,
             cancellationToken);
+    }
+
+    private async ValueTask FireAndForgetCoreAsync(
+        string topic,
+        int? partition,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        DateTimeOffset timestamp)
+    {
+        try
+        {
+            await ProduceCoreAsync(topic, partition, key, value, headers, timestamp, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            // Matches IKafkaProducer fire-and-forget delivery semantics: failures are not surfaced.
+        }
     }
 
     private static byte[] Serialize<T>(

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -1,0 +1,353 @@
+using System.Buffers;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+using Dekaf.Telemetry;
+
+namespace Dekaf.Testing;
+
+/// <summary>
+/// In-memory <see cref="IKafkaProducer{TKey,TValue}"/> backed by an <see cref="InMemoryKafkaCluster"/>.
+/// </summary>
+public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue>
+{
+    private readonly InMemoryKafkaCluster _cluster;
+    private readonly ISerializer<TKey> _keySerializer;
+    private readonly ISerializer<TValue> _valueSerializer;
+    private bool _disposed;
+
+    public InMemoryProducer(InMemoryKafkaCluster cluster)
+        : this(
+            cluster,
+            InMemorySerdeResolver.Serializer<TKey>(),
+            InMemorySerdeResolver.Serializer<TValue>())
+    {
+    }
+
+    public InMemoryProducer(
+        InMemoryKafkaCluster cluster,
+        ISerializer<TKey> keySerializer,
+        ISerializer<TValue> valueSerializer)
+    {
+        _cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));
+        _keySerializer = keySerializer ?? throw new ArgumentNullException(nameof(keySerializer));
+        _valueSerializer = valueSerializer ?? throw new ArgumentNullException(nameof(valueSerializer));
+    }
+
+    public ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<RecordMetadata> ProduceAsync(
+        ProducerMessage<TKey, TValue> message,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ThrowIfDisposed();
+
+        return ProduceCoreAsync(
+            message.Topic,
+            message.Partition,
+            message.Key,
+            message.Value,
+            message.Headers,
+            message.Timestamp ?? DateTimeOffset.UtcNow,
+            cancellationToken);
+    }
+
+    public ValueTask<RecordMetadata> ProduceAsync(
+        string topic,
+        TKey? key,
+        TValue value,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        return ProduceCoreAsync(topic, partition: null, key, value, headers: null, DateTimeOffset.UtcNow, cancellationToken);
+    }
+
+    public async ValueTask FireAsync(ProducerMessage<TKey, TValue> message)
+    {
+        await ProduceAsync(message).ConfigureAwait(false);
+    }
+
+    public async ValueTask FireAsync(string topic, TKey? key, TValue value)
+    {
+        await ProduceAsync(topic, key, value).ConfigureAwait(false);
+    }
+
+    public async ValueTask FireAsync(
+        ProducerMessage<TKey, TValue> message,
+        Action<RecordMetadata, Exception?> deliveryHandler)
+    {
+        ArgumentNullException.ThrowIfNull(deliveryHandler);
+
+        try
+        {
+            var metadata = await ProduceAsync(message).ConfigureAwait(false);
+            deliveryHandler(metadata, null);
+        }
+        catch (Exception ex)
+        {
+            deliveryHandler(default, ex);
+        }
+    }
+
+    public async Task<RecordMetadata[]> ProduceAllAsync(
+        IEnumerable<ProducerMessage<TKey, TValue>> messages,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+
+        var result = new List<RecordMetadata>();
+        foreach (var message in messages)
+            result.Add(await ProduceAsync(message, cancellationToken).ConfigureAwait(false));
+
+        return result.ToArray();
+    }
+
+    public async Task<RecordMetadata[]> ProduceAllAsync(
+        string topic,
+        IEnumerable<(TKey? Key, TValue Value)> messages,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        ArgumentNullException.ThrowIfNull(messages);
+
+        var result = new List<RecordMetadata>();
+        foreach (var (key, value) in messages)
+            result.Add(await ProduceAsync(topic, key, value, cancellationToken).ConfigureAwait(false));
+
+        return result.ToArray();
+    }
+
+    public ValueTask FlushAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.CompletedTask;
+    }
+
+    public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+    {
+        ArgumentNullException.ThrowIfNull(metric);
+        ThrowIfDisposed();
+    }
+
+    public void UnregisterMetricFromSubscription(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ThrowIfDisposed();
+    }
+
+    public ITransaction<TKey, TValue> BeginTransaction()
+    {
+        ThrowIfDisposed();
+        throw new NotSupportedException("In-memory producer transactions are not supported.");
+    }
+
+    public ValueTask InitTransactionsAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.CompletedTask;
+    }
+
+    public ITopicProducer<TKey, TValue> ForTopic(string topic)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        ThrowIfDisposed();
+        return new InMemoryTopicProducer(this, topic);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _disposed = true;
+        return ValueTask.CompletedTask;
+    }
+
+    private ValueTask<RecordMetadata> ProduceCoreAsync(
+        string topic,
+        int? partition,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        DateTimeOffset timestamp,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+
+        var keyBytes = Serialize(_keySerializer, key, topic, SerializationComponent.Key, headers, out var isKeyNull);
+        var valueBytes = Serialize(_valueSerializer, value, topic, SerializationComponent.Value, headers, out var isValueNull);
+
+        return _cluster.AppendAsync(
+            topic,
+            partition,
+            keyBytes,
+            isKeyNull,
+            valueBytes,
+            isValueNull,
+            headers?.ToList(),
+            timestamp,
+            cancellationToken);
+    }
+
+    private static byte[] Serialize<T>(
+        ISerializer<T> serializer,
+        T? value,
+        string topic,
+        SerializationComponent component,
+        Headers? headers,
+        out bool isNull)
+    {
+        if (value is null)
+        {
+            isNull = true;
+            return [];
+        }
+
+        var writer = new ArrayBufferWriter<byte>();
+        var context = new SerializationContext
+        {
+            Topic = topic,
+            Component = component,
+            Headers = headers,
+            IsNull = false
+        };
+
+        serializer.Serialize(value, ref writer, context);
+        isNull = false;
+        return writer.WrittenSpan.ToArray();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    private sealed class InMemoryTopicProducer : ITopicProducer<TKey, TValue>
+    {
+        private readonly InMemoryProducer<TKey, TValue> _producer;
+
+        public InMemoryTopicProducer(InMemoryProducer<TKey, TValue> producer, string topic)
+        {
+            _producer = producer;
+            Topic = topic;
+        }
+
+        public string Topic { get; }
+
+        public ValueTask InitializeAsync(CancellationToken cancellationToken = default) =>
+            _producer.InitializeAsync(cancellationToken);
+
+        public ValueTask<RecordMetadata> ProduceAsync(
+            TKey? key,
+            TValue value,
+            CancellationToken cancellationToken = default) =>
+            _producer.ProduceAsync(Topic, key, value, cancellationToken);
+
+        public ValueTask<RecordMetadata> ProduceAsync(
+            TKey? key,
+            TValue value,
+            Headers headers,
+            CancellationToken cancellationToken = default) =>
+            _producer.ProduceAsync(
+                new ProducerMessage<TKey, TValue>
+                {
+                    Topic = Topic,
+                    Key = key,
+                    Value = value,
+                    Headers = headers
+                },
+                cancellationToken);
+
+        public ValueTask<RecordMetadata> ProduceAsync(
+            int partition,
+            TKey? key,
+            TValue value,
+            CancellationToken cancellationToken = default) =>
+            _producer.ProduceAsync(
+                new ProducerMessage<TKey, TValue>
+                {
+                    Topic = Topic,
+                    Partition = partition,
+                    Key = key,
+                    Value = value
+                },
+                cancellationToken);
+
+        public ValueTask<RecordMetadata> ProduceAsync(
+            TopicProducerMessage<TKey, TValue> message,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return _producer.ProduceAsync(
+                new ProducerMessage<TKey, TValue>
+                {
+                    Topic = Topic,
+                    Partition = message.Partition,
+                    Key = message.Key,
+                    Value = message.Value,
+                    Headers = message.Headers,
+                    Timestamp = message.Timestamp
+                },
+                cancellationToken);
+        }
+
+        public ValueTask FireAsync(TKey? key, TValue value) =>
+            _producer.FireAsync(Topic, key, value);
+
+        public ValueTask FireAsync(TKey? key, TValue value, Headers headers) =>
+            _producer.FireAsync(
+                new ProducerMessage<TKey, TValue>
+                {
+                    Topic = Topic,
+                    Key = key,
+                    Value = value,
+                    Headers = headers
+                });
+
+        public ValueTask FireAsync(
+            TKey? key,
+            TValue value,
+            Action<RecordMetadata, Exception?> deliveryHandler) =>
+            _producer.FireAsync(
+                new ProducerMessage<TKey, TValue>
+                {
+                    Topic = Topic,
+                    Key = key,
+                    Value = value
+                },
+                deliveryHandler);
+
+        public Task<RecordMetadata[]> ProduceAllAsync(
+            IEnumerable<(TKey? Key, TValue Value)> messages,
+            CancellationToken cancellationToken = default) =>
+            _producer.ProduceAllAsync(Topic, messages, cancellationToken);
+
+        public Task<RecordMetadata[]> ProduceAllAsync(
+            IEnumerable<TopicProducerMessage<TKey, TValue>> messages,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(messages);
+
+            var producerMessages = messages.Select(message => new ProducerMessage<TKey, TValue>
+            {
+                Topic = Topic,
+                Partition = message.Partition,
+                Key = message.Key,
+                Value = message.Value,
+                Headers = message.Headers,
+                Timestamp = message.Timestamp
+            });
+
+            return _producer.ProduceAllAsync(producerMessages, cancellationToken);
+        }
+
+        public ValueTask FlushAsync(CancellationToken cancellationToken = default) =>
+            _producer.FlushAsync(cancellationToken);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/src/Dekaf.Testing/InMemoryRecord.cs
+++ b/src/Dekaf.Testing/InMemoryRecord.cs
@@ -1,0 +1,20 @@
+using Dekaf.Serialization;
+
+namespace Dekaf.Testing;
+
+/// <summary>
+/// Raw record stored by <see cref="InMemoryKafkaCluster"/>.
+/// </summary>
+public sealed record InMemoryRecord
+{
+    public required string Topic { get; init; }
+    public required int Partition { get; init; }
+    public required long Offset { get; init; }
+    public required byte[] Key { get; init; }
+    public required bool IsKeyNull { get; init; }
+    public required byte[] Value { get; init; }
+    public required bool IsValueNull { get; init; }
+    public IReadOnlyList<Header>? Headers { get; init; }
+    public required long TimestampMs { get; init; }
+    public DateTimeOffset Timestamp => DateTimeOffset.FromUnixTimeMilliseconds(TimestampMs);
+}

--- a/src/Dekaf.Testing/InMemorySerdeResolver.cs
+++ b/src/Dekaf.Testing/InMemorySerdeResolver.cs
@@ -1,0 +1,49 @@
+using Dekaf.Serialization;
+
+namespace Dekaf.Testing;
+
+internal static class InMemorySerdeResolver
+{
+    public static ISerializer<T> Serializer<T>()
+    {
+        return Serde<T>();
+    }
+
+    public static IDeserializer<T> Deserializer<T>()
+    {
+        return Serde<T>();
+    }
+
+    private static ISerde<T> Serde<T>()
+    {
+        var type = typeof(T);
+
+        if (type == typeof(string))
+            return (ISerde<T>)Serializers.String;
+        if (type == typeof(byte[]))
+            return (ISerde<T>)Serializers.ByteArray;
+        if (type == typeof(ReadOnlyMemory<byte>))
+            return (ISerde<T>)Serializers.RawBytes;
+        if (type == typeof(int))
+            return (ISerde<T>)Serializers.Int32;
+        if (type == typeof(long))
+            return (ISerde<T>)Serializers.Int64;
+        if (type == typeof(Guid))
+            return (ISerde<T>)Serializers.Guid;
+        if (type == typeof(double))
+            return (ISerde<T>)Serializers.Double;
+        if (type == typeof(float))
+            return (ISerde<T>)Serializers.Float;
+        if (type == typeof(DateTime))
+            return (ISerde<T>)Serializers.DateTime;
+        if (type == typeof(DateTimeOffset))
+            return (ISerde<T>)Serializers.DateTimeOffset;
+        if (type == typeof(TimeSpan))
+            return (ISerde<T>)Serializers.TimeSpan;
+        if (type == typeof(Ignore))
+            return (ISerde<T>)Serializers.Ignore;
+
+        throw new InvalidOperationException(
+            $"No built-in Dekaf serializer is available for {type.FullName}. Register ISerializer<{type.Name}>/IDeserializer<{type.Name}> or pass one to the in-memory client constructor.");
+    }
+}

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -171,14 +171,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             if (_pending.Count == 0)
                 return ValueTask.CompletedTask;
 
-            var offsets = _pending.Values
-                .Where(record => record.AcknowledgeType is AcknowledgeType.Accept or AcknowledgeType.Reject)
-                .GroupBy(record => record.TopicPartition)
-                .Select(group => new TopicPartitionOffset(
-                    group.Key.Topic,
-                    group.Key.Partition,
-                    group.Max(record => record.NextOffset)))
-                .ToArray();
+            var offsets = BuildCommitOffsets(_pending.Values);
 
             if (offsets.Length > 0)
                 _cluster.CommitOffsets(_options.GroupId, offsets);
@@ -282,6 +275,41 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             TimestampMs = record.TimestampMs,
             DeliveryCount = 1
         };
+    }
+
+    private static TopicPartitionOffset[] BuildCommitOffsets(IEnumerable<PendingShareRecord> records)
+    {
+        var offsets = new List<TopicPartitionOffset>();
+
+        foreach (var group in records.GroupBy(record => record.TopicPartition))
+        {
+            var ordered = group.OrderBy(record => record.NextOffset).ToArray();
+            if (ordered.Length == 0)
+                continue;
+
+            var commitOffset = ordered[0].NextOffset - 1;
+            foreach (var record in ordered)
+            {
+                var recordOffset = record.NextOffset - 1;
+                if (recordOffset != commitOffset)
+                    break;
+
+                if (record.AcknowledgeType is not (AcknowledgeType.Accept or AcknowledgeType.Reject))
+                    break;
+
+                commitOffset = record.NextOffset;
+            }
+
+            if (commitOffset > ordered[0].NextOffset - 1)
+            {
+                offsets.Add(new TopicPartitionOffset(
+                    group.Key.Topic,
+                    group.Key.Partition,
+                    commitOffset));
+            }
+        }
+
+        return offsets.ToArray();
     }
 
     private static SerializationContext Context(

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -104,6 +104,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
 
         lock (_gate)
         {
+            ReleasePendingUnderLock();
             _subscription.Clear();
             foreach (var topic in topics.Where(topic => !string.IsNullOrWhiteSpace(topic)).Distinct(StringComparer.Ordinal))
                 _subscription.Add(topic);
@@ -111,8 +112,6 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             _assignment.Clear();
             foreach (var topicPartition in topicPartitions)
                 _assignment.Add(topicPartition);
-
-            _pending.Clear();
         }
 
         return this;
@@ -124,9 +123,9 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
 
         lock (_gate)
         {
+            ReleasePendingUnderLock();
             _subscription.Clear();
             _assignment.Clear();
-            _pending.Clear();
         }
 
         return this;
@@ -137,10 +136,13 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
     {
         await CommitAsync(cancellationToken).ConfigureAwait(false);
 
-        var records = TakeAvailableRecords();
-        foreach (var record in records)
+        for (var i = 0; i < _options.MaxPollRecords; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            var record = TryTakeAvailableRecord();
+            if (record is null)
+                yield break;
+
             yield return record;
         }
     }
@@ -171,11 +173,11 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             if (_pending.Count == 0)
                 return ValueTask.CompletedTask;
 
-            var offsets = BuildCommitOffsets(_pending.Values);
+            var pending = _pending.Values.ToArray();
+            var offsets = BuildCommitOffsets(pending);
+            var completedRecords = BuildCompletedRecords(pending);
 
-            if (offsets.Length > 0)
-                _cluster.CommitOffsets(_options.GroupId, offsets);
-
+            _cluster.CompleteShareRecords(_options.GroupId, _memberId, completedRecords, offsets);
             _pending.Clear();
         }
 
@@ -199,10 +201,8 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
         await CloseAsync().ConfigureAwait(false);
     }
 
-    private IReadOnlyList<ShareConsumeResult<TKey, TValue>> TakeAvailableRecords()
+    private ShareConsumeResult<TKey, TValue>? TryTakeAvailableRecord()
     {
-        var results = new List<ShareConsumeResult<TKey, TValue>>();
-        Dictionary<TopicPartition, long> nextOffsets;
         TopicPartition[] assignment;
 
         lock (_gate)
@@ -213,42 +213,36 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
                 .ToArray();
         }
 
-        nextOffsets = assignment.ToDictionary(
-            partition => partition,
-            partition => _cluster.GetCommittedOffset(_options.GroupId, partition) ??
-                         _cluster.GetWatermarks(partition).Low);
-
-        while (results.Count < _options.MaxPollRecords)
+        foreach (var partition in assignment)
         {
-            var madeProgress = false;
-            foreach (var partition in assignment)
+            long offset;
+            lock (_gate)
+                offset = GetNextOffsetUnderLock(partition);
+
+            if (!_cluster.TryAcquireShareRecord(
+                    _options.GroupId,
+                    _memberId,
+                    partition,
+                    offset,
+                    out var record,
+                    out var deliveryCount))
             {
-                if (results.Count >= _options.MaxPollRecords)
-                    break;
-
-                var offset = nextOffsets[partition];
-                if (!_cluster.TryRead(partition, offset, out var record))
-                    continue;
-
-                var result = ToShareResult(record);
-                var pending = new PendingShareRecord(partition, record.Offset + 1);
-
-                lock (_gate)
-                    _pending[result] = pending;
-
-                results.Add(result);
-                nextOffsets[partition] = record.Offset + 1;
-                madeProgress = true;
+                continue;
             }
 
-            if (!madeProgress)
-                break;
+            var result = ToShareResult(record, deliveryCount);
+            var pending = new PendingShareRecord(partition, record.Offset, record.Offset + 1);
+
+            lock (_gate)
+                _pending[result] = pending;
+
+            return result;
         }
 
-        return results;
+        return null;
     }
 
-    private ShareConsumeResult<TKey, TValue> ToShareResult(InMemoryRecord record)
+    private ShareConsumeResult<TKey, TValue> ToShareResult(InMemoryRecord record, int deliveryCount)
     {
         var key = record.IsKeyNull
             ? default
@@ -273,8 +267,31 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             Value = value,
             Headers = record.Headers,
             TimestampMs = record.TimestampMs,
-            DeliveryCount = 1
+            DeliveryCount = deliveryCount
         };
+    }
+
+    private long GetNextOffsetUnderLock(TopicPartition partition)
+    {
+        var offset = _cluster.GetCommittedOffset(_options.GroupId, partition) ??
+                     _cluster.GetWatermarks(partition).Low;
+
+        foreach (var pending in _pending.Values)
+        {
+            if (pending.TopicPartition == partition && pending.NextOffset > offset)
+                offset = pending.NextOffset;
+        }
+
+        return offset;
+    }
+
+    private void ReleasePendingUnderLock()
+    {
+        if (_pending.Count == 0)
+            return;
+
+        _cluster.ReleaseShareRecords(_options.GroupId, _memberId, BuildCompletedRecords(_pending.Values));
+        _pending.Clear();
     }
 
     private static TopicPartitionOffset[] BuildCommitOffsets(IEnumerable<PendingShareRecord> records)
@@ -312,6 +329,16 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
         return offsets.ToArray();
     }
 
+    private static TopicPartitionOffset[] BuildCompletedRecords(IEnumerable<PendingShareRecord> records)
+    {
+        return records
+            .Select(record => new TopicPartitionOffset(
+                record.TopicPartition.Topic,
+                record.TopicPartition.Partition,
+                record.Offset))
+            .ToArray();
+    }
+
     private static SerializationContext Context(
         string topic,
         SerializationComponent component,
@@ -332,13 +359,15 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
 
     private sealed class PendingShareRecord
     {
-        public PendingShareRecord(TopicPartition topicPartition, long nextOffset)
+        public PendingShareRecord(TopicPartition topicPartition, long offset, long nextOffset)
         {
             TopicPartition = topicPartition;
+            Offset = offset;
             NextOffset = nextOffset;
         }
 
         public TopicPartition TopicPartition { get; }
+        public long Offset { get; }
         public long NextOffset { get; }
         public AcknowledgeType AcknowledgeType { get; set; } = AcknowledgeType.Accept;
     }

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -1,0 +1,317 @@
+using System.Runtime.CompilerServices;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Testing;
+
+/// <summary>
+/// In-memory <see cref="IKafkaShareConsumer{TKey,TValue}"/> backed by an <see cref="InMemoryKafkaCluster"/>.
+/// </summary>
+public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TKey, TValue>
+{
+    private readonly object _gate = new();
+    private readonly InMemoryKafkaCluster _cluster;
+    private readonly IDeserializer<TKey> _keyDeserializer;
+    private readonly IDeserializer<TValue> _valueDeserializer;
+    private readonly InMemoryShareConsumerOptions _options;
+    private readonly HashSet<string> _subscription = new(StringComparer.Ordinal);
+    private readonly HashSet<TopicPartition> _assignment = [];
+    private readonly Dictionary<ShareConsumeResult<TKey, TValue>, PendingShareRecord> _pending = [];
+    private readonly string _memberId;
+    private bool _disposed;
+
+    public InMemoryShareConsumer(InMemoryKafkaCluster cluster)
+        : this(
+            cluster,
+            InMemorySerdeResolver.Deserializer<TKey>(),
+            InMemorySerdeResolver.Deserializer<TValue>(),
+            new InMemoryShareConsumerOptions())
+    {
+    }
+
+    public InMemoryShareConsumer(
+        InMemoryKafkaCluster cluster,
+        InMemoryShareConsumerOptions options)
+        : this(
+            cluster,
+            InMemorySerdeResolver.Deserializer<TKey>(),
+            InMemorySerdeResolver.Deserializer<TValue>(),
+            options)
+    {
+    }
+
+    public InMemoryShareConsumer(
+        InMemoryKafkaCluster cluster,
+        IDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer)
+        : this(cluster, keyDeserializer, valueDeserializer, new InMemoryShareConsumerOptions())
+    {
+    }
+
+    public InMemoryShareConsumer(
+        InMemoryKafkaCluster cluster,
+        IDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer,
+        InMemoryShareConsumerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.GroupId);
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxPollRecords, 1);
+        _cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));
+        _keyDeserializer = keyDeserializer ?? throw new ArgumentNullException(nameof(keyDeserializer));
+        _valueDeserializer = valueDeserializer ?? throw new ArgumentNullException(nameof(valueDeserializer));
+        _options = options;
+        _memberId = _options.MemberId ?? Guid.NewGuid().ToString("N");
+    }
+
+    public IReadOnlySet<string> Subscription
+    {
+        get
+        {
+            lock (_gate)
+                return _subscription.ToHashSet(StringComparer.Ordinal);
+        }
+    }
+
+    public IReadOnlySet<TopicPartition> Assignment
+    {
+        get
+        {
+            lock (_gate)
+                return _assignment.ToHashSet();
+        }
+    }
+
+    public string? MemberId => _memberId;
+
+    public ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.CompletedTask;
+    }
+
+    public IKafkaShareConsumer<TKey, TValue> Subscribe(params string[] topics)
+    {
+        ArgumentNullException.ThrowIfNull(topics);
+        ThrowIfDisposed();
+
+        var topicPartitions = topics
+            .Where(topic => !string.IsNullOrWhiteSpace(topic))
+            .Distinct(StringComparer.Ordinal)
+            .SelectMany(topic => _cluster.GetTopicPartitions(topic))
+            .ToArray();
+
+        lock (_gate)
+        {
+            _subscription.Clear();
+            foreach (var topic in topics.Where(topic => !string.IsNullOrWhiteSpace(topic)).Distinct(StringComparer.Ordinal))
+                _subscription.Add(topic);
+
+            _assignment.Clear();
+            foreach (var topicPartition in topicPartitions)
+                _assignment.Add(topicPartition);
+
+            _pending.Clear();
+        }
+
+        return this;
+    }
+
+    public IKafkaShareConsumer<TKey, TValue> Unsubscribe()
+    {
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            _subscription.Clear();
+            _assignment.Clear();
+            _pending.Clear();
+        }
+
+        return this;
+    }
+
+    public async IAsyncEnumerable<ShareConsumeResult<TKey, TValue>> PollAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await CommitAsync(cancellationToken).ConfigureAwait(false);
+
+        var records = TakeAvailableRecords();
+        foreach (var record in records)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return record;
+        }
+    }
+
+    public void Acknowledge(
+        ShareConsumeResult<TKey, TValue> record,
+        AcknowledgeType type = AcknowledgeType.Accept)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            if (!_pending.TryGetValue(record, out var pending))
+                throw new InvalidOperationException("Record was not returned by the current poll.");
+
+            pending.AcknowledgeType = type;
+        }
+    }
+
+    public ValueTask CommitAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        lock (_gate)
+        {
+            if (_pending.Count == 0)
+                return ValueTask.CompletedTask;
+
+            var offsets = _pending.Values
+                .Where(record => record.AcknowledgeType is AcknowledgeType.Accept or AcknowledgeType.Reject)
+                .GroupBy(record => record.TopicPartition)
+                .Select(group => new TopicPartitionOffset(
+                    group.Key.Topic,
+                    group.Key.Partition,
+                    group.Max(record => record.NextOffset)))
+                .ToArray();
+
+            if (offsets.Length > 0)
+                _cluster.CommitOffsets(_options.GroupId, offsets);
+
+            _pending.Clear();
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask CloseAsync(CancellationToken cancellationToken = default)
+    {
+        if (_disposed)
+            return;
+
+        await CommitAsync(cancellationToken).ConfigureAwait(false);
+        _disposed = true;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        await CloseAsync().ConfigureAwait(false);
+    }
+
+    private IReadOnlyList<ShareConsumeResult<TKey, TValue>> TakeAvailableRecords()
+    {
+        var results = new List<ShareConsumeResult<TKey, TValue>>();
+        Dictionary<TopicPartition, long> nextOffsets;
+        TopicPartition[] assignment;
+
+        lock (_gate)
+        {
+            assignment = _assignment
+                .OrderBy(item => item.Topic, StringComparer.Ordinal)
+                .ThenBy(item => item.Partition)
+                .ToArray();
+        }
+
+        nextOffsets = assignment.ToDictionary(
+            partition => partition,
+            partition => _cluster.GetCommittedOffset(_options.GroupId, partition) ??
+                         _cluster.GetWatermarks(partition).Low);
+
+        while (results.Count < _options.MaxPollRecords)
+        {
+            var madeProgress = false;
+            foreach (var partition in assignment)
+            {
+                if (results.Count >= _options.MaxPollRecords)
+                    break;
+
+                var offset = nextOffsets[partition];
+                if (!_cluster.TryRead(partition, offset, out var record))
+                    continue;
+
+                var result = ToShareResult(record);
+                var pending = new PendingShareRecord(partition, record.Offset + 1);
+
+                lock (_gate)
+                    _pending[result] = pending;
+
+                results.Add(result);
+                nextOffsets[partition] = record.Offset + 1;
+                madeProgress = true;
+            }
+
+            if (!madeProgress)
+                break;
+        }
+
+        return results;
+    }
+
+    private ShareConsumeResult<TKey, TValue> ToShareResult(InMemoryRecord record)
+    {
+        var key = record.IsKeyNull
+            ? default
+            : _keyDeserializer.Deserialize(
+                record.Key,
+                Context(record.Topic, SerializationComponent.Key, record.Headers, isNull: false));
+
+        var value = record.IsValueNull
+            ? _valueDeserializer.Deserialize(
+                ReadOnlyMemory<byte>.Empty,
+                Context(record.Topic, SerializationComponent.Value, record.Headers, isNull: true))
+            : _valueDeserializer.Deserialize(
+                record.Value,
+                Context(record.Topic, SerializationComponent.Value, record.Headers, isNull: false));
+
+        return new ShareConsumeResult<TKey, TValue>
+        {
+            Topic = record.Topic,
+            Partition = record.Partition,
+            Offset = record.Offset,
+            Key = key,
+            Value = value,
+            Headers = record.Headers,
+            TimestampMs = record.TimestampMs,
+            DeliveryCount = 1
+        };
+    }
+
+    private static SerializationContext Context(
+        string topic,
+        SerializationComponent component,
+        IReadOnlyList<Header>? headers,
+        bool isNull) =>
+        new()
+        {
+            Topic = topic,
+            Component = component,
+            Headers = headers is null ? null : new Headers(headers),
+            IsNull = isNull
+        };
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    private sealed class PendingShareRecord
+    {
+        public PendingShareRecord(TopicPartition topicPartition, long nextOffset)
+        {
+            TopicPartition = topicPartition;
+            NextOffset = nextOffset;
+        }
+
+        public TopicPartition TopicPartition { get; }
+        public long NextOffset { get; }
+        public AcknowledgeType AcknowledgeType { get; set; } = AcknowledgeType.Accept;
+    }
+}

--- a/src/Dekaf.Testing/InMemoryShareConsumerOptions.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumerOptions.cs
@@ -1,0 +1,22 @@
+namespace Dekaf.Testing;
+
+/// <summary>
+/// Options for <see cref="InMemoryShareConsumer{TKey,TValue}"/>.
+/// </summary>
+public sealed class InMemoryShareConsumerOptions
+{
+    /// <summary>
+    /// Share group ID used for accepted offsets.
+    /// </summary>
+    public string GroupId { get; set; } = "dekaf-in-memory-share";
+
+    /// <summary>
+    /// Maximum records returned by each poll.
+    /// </summary>
+    public int MaxPollRecords { get; set; } = 500;
+
+    /// <summary>
+    /// Member ID reported by the fake share consumer.
+    /// </summary>
+    public string? MemberId { get; set; }
+}

--- a/src/Dekaf.Testing/InMemoryShareConsumerOptions.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumerOptions.cs
@@ -8,15 +8,15 @@ public sealed class InMemoryShareConsumerOptions
     /// <summary>
     /// Share group ID used for accepted offsets.
     /// </summary>
-    public string GroupId { get; set; } = "dekaf-in-memory-share";
+    public string GroupId { get; init; } = "dekaf-in-memory-share";
 
     /// <summary>
     /// Maximum records returned by each poll.
     /// </summary>
-    public int MaxPollRecords { get; set; } = 500;
+    public int MaxPollRecords { get; init; } = 500;
 
     /// <summary>
     /// Member ID reported by the fake share consumer.
     /// </summary>
-    public string? MemberId { get; set; }
+    public string? MemberId { get; init; }
 }

--- a/src/Dekaf.Testing/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Testing/ServiceCollectionExtensions.cs
@@ -1,0 +1,43 @@
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.ShareConsumer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Dekaf.Testing;
+
+/// <summary>
+/// Dependency injection helpers for in-memory Dekaf test doubles.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Replaces Dekaf client registrations with in-memory test doubles backed by one shared cluster.
+    /// </summary>
+    public static IServiceCollection AddDekafInMemory(
+        this IServiceCollection services,
+        Action<InMemoryKafkaClusterOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var options = new InMemoryKafkaClusterOptions();
+        configure?.Invoke(options);
+
+        services.RemoveAll(typeof(IKafkaProducer<,>));
+        services.RemoveAll(typeof(IKafkaConsumer<,>));
+        services.RemoveAll(typeof(IKafkaShareConsumer<,>));
+        services.RemoveAll<IAdminClient>();
+
+        services.AddSingleton(options);
+        services.TryAddSingleton(new InMemoryConsumerOptions());
+        services.TryAddSingleton(new InMemoryShareConsumerOptions());
+        services.AddSingleton<InMemoryKafkaCluster>();
+        services.AddTransient(typeof(IKafkaProducer<,>), typeof(InMemoryProducer<,>));
+        services.AddTransient(typeof(IKafkaConsumer<,>), typeof(InMemoryConsumer<,>));
+        services.AddTransient(typeof(IKafkaShareConsumer<,>), typeof(InMemoryShareConsumer<,>));
+        services.AddSingleton<IAdminClient, InMemoryAdminClient>();
+
+        return services;
+    }
+}

--- a/src/Dekaf.Testing/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Testing/ServiceCollectionExtensions.cs
@@ -24,10 +24,7 @@ public static class ServiceCollectionExtensions
         var options = new InMemoryKafkaClusterOptions();
         configure?.Invoke(options);
 
-        services.RemoveAll(typeof(IKafkaProducer<,>));
-        services.RemoveAll(typeof(IKafkaConsumer<,>));
-        services.RemoveAll(typeof(IKafkaShareConsumer<,>));
-        services.RemoveAll<IAdminClient>();
+        RemoveDekafClientRegistrations(services);
 
         services.AddSingleton(options);
         services.TryAddSingleton(new InMemoryConsumerOptions());
@@ -39,5 +36,31 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAdminClient, InMemoryAdminClient>();
 
         return services;
+    }
+
+    private static void RemoveDekafClientRegistrations(IServiceCollection services)
+    {
+        for (var i = services.Count - 1; i >= 0; i--)
+        {
+            if (IsDekafClientServiceType(services[i].ServiceType))
+                services.RemoveAt(i);
+        }
+    }
+
+    private static bool IsDekafClientServiceType(Type serviceType)
+    {
+        if (serviceType == typeof(IAdminClient) ||
+            serviceType == typeof(IInitializableKafkaClient))
+        {
+            return true;
+        }
+
+        if (!serviceType.IsGenericType)
+            return false;
+
+        var definition = serviceType.GetGenericTypeDefinition();
+        return definition == typeof(IKafkaProducer<,>) ||
+               definition == typeof(IKafkaConsumer<,>) ||
+               definition == typeof(IKafkaShareConsumer<,>);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\src\Dekaf.Compression.Brotli\Dekaf.Compression.Brotli.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Serialization.Json\Dekaf.Serialization.Json.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Testing\Dekaf.Testing.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Extensions.DependencyInjection\Dekaf.Extensions.DependencyInjection.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Extensions.Hosting\Dekaf.Extensions.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.OpenTelemetry\Dekaf.OpenTelemetry.csproj" />

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -163,6 +163,140 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task ShareConsumer_PartialPollOnlyCommitsYieldedRecords()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var shareConsumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions
+            {
+                GroupId = "share-partial",
+                MaxPollRecords = 2
+            });
+
+        for (var i = 0; i < 2; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = "shared",
+                Partition = 0,
+                Key = $"k-{i}",
+                Value = $"v-{i}"
+            });
+        }
+
+        shareConsumer.Subscribe("shared");
+        var first = await shareConsumer.PollAsync().FirstAsync();
+        await shareConsumer.CommitAsync();
+        var second = await shareConsumer.PollAsync().FirstAsync();
+
+        await Assert.That(first.Offset).IsEqualTo(0);
+        await Assert.That(second.Offset).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ShareConsumer_LeasesRecordsAcrossMembersUntilRelease()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var firstConsumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "share-leases", MemberId = "a" });
+        var secondConsumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "share-leases", MemberId = "b" });
+
+        await producer.ProduceAsync("leased", "k", "v");
+        firstConsumer.Subscribe("leased");
+        secondConsumer.Subscribe("leased");
+
+        var first = await firstConsumer.PollAsync().FirstAsync();
+        var blocked = new List<ShareConsumeResult<string, string>>();
+        await foreach (var record in secondConsumer.PollAsync())
+            blocked.Add(record);
+
+        firstConsumer.Acknowledge(first, AcknowledgeType.Release);
+        await firstConsumer.CommitAsync();
+        var redelivered = await secondConsumer.PollAsync().FirstAsync();
+
+        await Assert.That(blocked).IsEmpty();
+        await Assert.That(redelivered.Offset).IsEqualTo(0);
+        await Assert.That(redelivered.DeliveryCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ConsumerGroupMembersSplitAssignedPartitions()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("balanced", partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var firstConsumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "balanced-group",
+                MemberId = "a",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        var secondConsumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "balanced-group",
+                MemberId = "b",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "balanced",
+            Partition = 0,
+            Key = "k-0",
+            Value = "v-0"
+        });
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "balanced",
+            Partition = 1,
+            Key = "k-1",
+            Value = "v-1"
+        });
+
+        firstConsumer.Subscribe("balanced");
+        secondConsumer.Subscribe("balanced");
+
+        var firstAssignment = firstConsumer.Assignment;
+        var secondAssignment = secondConsumer.Assignment;
+        var first = await firstConsumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(50));
+        var second = await secondConsumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(50));
+
+        await Assert.That(firstAssignment.Intersect(secondAssignment).ToArray()).IsEmpty();
+        await Assert.That(firstAssignment.Concat(secondAssignment).Select(item => item.Partition).ToArray())
+            .IsEquivalentTo([0, 1]);
+        await Assert.That(new[] { first!.Value.Partition, second!.Value.Partition })
+            .IsEquivalentTo([0, 1]);
+    }
+
+    [Test]
+    public async Task Consumer_AssignFailureDoesNotLeavePartialState()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("strict");
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { AutoOffsetReset = AutoOffsetReset.None });
+        var partition = new TopicPartition("strict", 0);
+
+        await Assert.That(() => consumer.Assign(partition)).Throws<InvalidOperationException>();
+        await Assert.That(() => consumer.IncrementalAssign([new TopicPartitionOffset("strict", 0, -1)]))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(consumer.Assignment).IsEmpty();
+        await Assert.That(consumer.GetPosition(partition)).IsNull();
+    }
+
+    [Test]
     public async Task WaitForRecordsAsync_ReturnsWhenRecordWasAppendedBeforeWait()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -206,6 +340,16 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task FireAsync_DoesNotThrowDeliveryFailure()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        cluster.FailProduces("fire", new InvalidOperationException("produce failed"));
+
+        await producer.FireAsync("fire", "k", "v");
+    }
+
+    [Test]
     public async Task AddDekafInMemory_RegistersClientDoubles()
     {
         var services = new ServiceCollection();
@@ -226,6 +370,31 @@ public sealed class InMemoryKafkaClusterTests
         await Assert.That(consumer).IsTypeOf<InMemoryConsumer<string, string>>();
         await Assert.That(admin).IsTypeOf<InMemoryAdminClient>();
         await Assert.That(shareConsumer).IsTypeOf<InMemoryShareConsumer<string, string>>();
+    }
+
+    [Test]
+    public async Task AddDekafInMemory_ReplacesClosedClientRegistrations()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IKafkaProducer<string, string>>(_ => throw new InvalidOperationException("real producer"));
+        services.AddSingleton<IKafkaConsumer<string, string>>(_ => throw new InvalidOperationException("real consumer"));
+        services.AddSingleton<IKafkaShareConsumer<string, string>>(_ => throw new InvalidOperationException("real share consumer"));
+        services.AddSingleton<IAdminClient>(_ => throw new InvalidOperationException("real admin"));
+        services.AddSingleton<IInitializableKafkaClient>(_ => throw new InvalidOperationException("real initializer"));
+
+        services.AddDekafInMemory();
+
+        await using var provider = services.BuildServiceProvider();
+        var producer = provider.GetRequiredService<IKafkaProducer<string, string>>();
+        var consumer = provider.GetRequiredService<IKafkaConsumer<string, string>>();
+        var shareConsumer = provider.GetRequiredService<IKafkaShareConsumer<string, string>>();
+        var admin = provider.GetRequiredService<IAdminClient>();
+
+        await Assert.That(producer).IsTypeOf<InMemoryProducer<string, string>>();
+        await Assert.That(consumer).IsTypeOf<InMemoryConsumer<string, string>>();
+        await Assert.That(shareConsumer).IsTypeOf<InMemoryShareConsumer<string, string>>();
+        await Assert.That(admin).IsTypeOf<InMemoryAdminClient>();
+        await Assert.That(provider.GetServices<IInitializableKafkaClient>().ToArray()).IsEmpty();
     }
 
     private static Task InvokeWaitForRecordsAsync(

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
@@ -123,6 +124,88 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task ShareConsumer_ReleaseGapStopsContiguousCommit()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var shareConsumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "share-gap" });
+
+        for (var i = 0; i < 3; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = "shared",
+                Partition = 0,
+                Key = $"k-{i}",
+                Value = $"v-{i}"
+            });
+        }
+
+        shareConsumer.Subscribe("shared");
+        var records = new List<ShareConsumeResult<string, string>>();
+        await foreach (var record in shareConsumer.PollAsync())
+            records.Add(record);
+
+        shareConsumer.Acknowledge(records[0], AcknowledgeType.Accept);
+        shareConsumer.Acknowledge(records[1], AcknowledgeType.Release);
+        shareConsumer.Acknowledge(records[2], AcknowledgeType.Accept);
+        await shareConsumer.CommitAsync();
+
+        var redelivered = await shareConsumer.PollAsync().FirstAsync();
+        var admin = new InMemoryAdminClient(cluster);
+        var offsets = await admin.ListConsumerGroupOffsetsAsync("share-gap");
+
+        await Assert.That(records.Select(record => record.Offset).ToArray()).IsEquivalentTo([0L, 1L, 2L]);
+        await Assert.That(offsets[new TopicPartition("shared", 0)]).IsEqualTo(1);
+        await Assert.That(redelivered.Offset).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task WaitForRecordsAsync_ReturnsWhenRecordWasAppendedBeforeWait()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+
+        await producer.ProduceAsync("wakeups", "k", "v");
+
+        await InvokeWaitForRecordsAsync(cluster, TimeSpan.FromMilliseconds(50), CancellationToken.None);
+    }
+
+    [Test]
+    public async Task ProduceLatency_ObservesCancellation()
+    {
+        var cluster = new InMemoryKafkaCluster
+        {
+            ProduceLatency = TimeSpan.FromSeconds(10)
+        };
+        var producer = new InMemoryProducer<string, string>(cluster);
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(25));
+
+        await Assert.That(async () => await producer.ProduceAsync("slow", "k", "v", cts.Token))
+            .Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task ProduceFailure_CanBeConfiguredAndCleared()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+
+        cluster.FailProduces("failures", new InvalidOperationException("produce failed"));
+
+        await Assert.That(async () => await producer.ProduceAsync("failures", "k", "v"))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(cluster.ClearProduceFailure("failures")).IsTrue();
+        var metadata = await producer.ProduceAsync("failures", "k", "v");
+
+        await Assert.That(metadata.Topic).IsEqualTo("failures");
+        await Assert.That(cluster.ClearProduceFailure("failures")).IsFalse();
+    }
+
+    [Test]
     public async Task AddDekafInMemory_RegistersClientDoubles()
     {
         var services = new ServiceCollection();
@@ -143,5 +226,17 @@ public sealed class InMemoryKafkaClusterTests
         await Assert.That(consumer).IsTypeOf<InMemoryConsumer<string, string>>();
         await Assert.That(admin).IsTypeOf<InMemoryAdminClient>();
         await Assert.That(shareConsumer).IsTypeOf<InMemoryShareConsumer<string, string>>();
+    }
+
+    private static Task InvokeWaitForRecordsAsync(
+        InMemoryKafkaCluster cluster,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(InMemoryKafkaCluster).GetMethod(
+            "WaitForRecordsAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        return (Task)method.Invoke(cluster, [timeout, cancellationToken])!;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -1,0 +1,147 @@
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+using Dekaf.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+public sealed class InMemoryKafkaClusterTests
+{
+    [Test]
+    public async Task ProducerConsumer_RoundTripsThroughSerializers()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders", partitionCount: 2);
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "orders-service",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        var headers = Headers.Create("trace-id", "abc");
+
+        var metadata = await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "orders",
+            Partition = 1,
+            Key = "order-1",
+            Value = "created",
+            Headers = headers,
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(1234)
+        });
+        consumer.Subscribe("orders");
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+
+        await Assert.That(metadata.Topic).IsEqualTo("orders");
+        await Assert.That(metadata.Partition).IsEqualTo(1);
+        await Assert.That(metadata.Offset).IsEqualTo(0);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Topic).IsEqualTo("orders");
+        await Assert.That(result.Value.Partition).IsEqualTo(1);
+        await Assert.That(result.Value.Offset).IsEqualTo(0);
+        await Assert.That(result.Value.Key).IsEqualTo("order-1");
+        await Assert.That(result.Value.Value).IsEqualTo("created");
+        await Assert.That(result.Value.Headers!.Single().GetValueAsString()).IsEqualTo("abc");
+        await Assert.That(result.Value.TimestampMs).IsEqualTo(1234);
+    }
+
+    [Test]
+    public async Task Consumer_ManualCommit_PersistsGroupOffsets()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Manual
+            });
+        var admin = new InMemoryAdminClient(cluster);
+
+        await producer.ProduceAsync("jobs", "a", "one");
+        consumer.Subscribe("jobs");
+        _ = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+        await consumer.CommitAsync();
+
+        var offsets = await admin.ListConsumerGroupOffsetsAsync("workers");
+
+        await Assert.That(offsets[new TopicPartition("jobs", 0)]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Admin_CreatesDescribesAndDeletesTopics()
+    {
+        var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions { AutoCreateTopics = false });
+        var admin = new InMemoryAdminClient(cluster);
+
+        await admin.CreateTopicsAsync(
+        [
+            new NewTopic { Name = "events", NumPartitions = 3 }
+        ]);
+        var listings = await admin.ListTopicsAsync();
+        var descriptions = await admin.DescribeTopicsAsync(["events"]);
+        await admin.DeleteTopicsAsync(["events"]);
+        var afterDelete = await admin.ListTopicsAsync();
+
+        await Assert.That(listings.Single().Name).IsEqualTo("events");
+        await Assert.That(descriptions["events"].Partitions.Count).IsEqualTo(3);
+        await Assert.That(afterDelete).IsEmpty();
+    }
+
+    [Test]
+    public async Task ShareConsumer_ReleaseDoesNotAdvanceOffset_AcceptDoes()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var shareConsumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "share-workers" });
+
+        await producer.ProduceAsync("shared", "k", "v");
+        shareConsumer.Subscribe("shared");
+
+        var first = await shareConsumer.PollAsync().FirstAsync();
+        shareConsumer.Acknowledge(first, AcknowledgeType.Release);
+        await shareConsumer.CommitAsync();
+        var second = await shareConsumer.PollAsync().FirstAsync();
+        shareConsumer.Acknowledge(second);
+        await shareConsumer.CommitAsync();
+        var admin = new InMemoryAdminClient(cluster);
+        var offsets = await admin.ListConsumerGroupOffsetsAsync("share-workers");
+
+        await Assert.That(first.Offset).IsEqualTo(0);
+        await Assert.That(second.Offset).IsEqualTo(0);
+        await Assert.That(offsets[new TopicPartition("shared", 0)]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task AddDekafInMemory_RegistersClientDoubles()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDekafInMemory(options => options.DefaultPartitionCount = 2);
+
+        await using var provider = services.BuildServiceProvider();
+        var cluster = provider.GetRequiredService<InMemoryKafkaCluster>();
+        var producer = provider.GetRequiredService<IKafkaProducer<string, string>>();
+        var consumer = provider.GetRequiredService<IKafkaConsumer<string, string>>();
+        var admin = provider.GetRequiredService<IAdminClient>();
+        var shareConsumer = provider.GetRequiredService<IKafkaShareConsumer<string, string>>();
+
+        var metadata = await producer.ProduceAsync("di-topic", "k", "v");
+
+        await Assert.That(cluster.Options.DefaultPartitionCount).IsEqualTo(2);
+        await Assert.That(metadata.Topic).IsEqualTo("di-topic");
+        await Assert.That(consumer).IsTypeOf<InMemoryConsumer<string, string>>();
+        await Assert.That(admin).IsTypeOf<InMemoryAdminClient>();
+        await Assert.That(shareConsumer).IsTypeOf<InMemoryShareConsumer<string, string>>();
+    }
+}

--- a/tools/Dekaf.Pipeline/Modules/PackModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/PackModule.cs
@@ -27,7 +27,8 @@ public class PackModule : Module<List<PackedProject>>
         "Dekaf.SchemaRegistry",
         "Dekaf.SchemaRegistry.Avro",
         "Dekaf.SchemaRegistry.Protobuf",
-        "Dekaf.Serialization.Json"
+        "Dekaf.Serialization.Json",
+        "Dekaf.Testing"
     ];
 
     protected override async Task<List<PackedProject>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- add `Dekaf.Testing` package with `InMemoryKafkaCluster`, producer, consumer, share consumer, and admin client test doubles
- store serialized bytes so real serializers/deserializers run in unit tests; support offsets, headers, timestamps, topic admin, group offsets, release/accept share semantics, latency/failure injection hooks
- add `services.AddDekafInMemory()` DI swap helper plus docs and unit coverage

## Tests
- `dotnet build src\Dekaf.Testing\Dekaf.Testing.csproj --configuration Release --no-restore`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter "/*/Dekaf.Tests.Unit.Testing/InMemoryKafkaClusterTests/*" --no-ansi --disable-logo` (5 passed)
- `dotnet build --configuration Release --no-restore`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --no-ansi --disable-logo` (3850 passed)

Closes #1156