### PR TITLE
Honor GSSAPI principal and keytab config

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -2825,6 +2825,8 @@ public sealed class AdminClientBuilder
         if (_bootstrapServers.Count == 0)
             throw new InvalidOperationException("Bootstrap servers must be specified");
 
+        GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
+
         var options = new AdminClientOptions
         {
             BootstrapServers = _bootstrapServers,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -874,6 +874,8 @@ public sealed class ProducerBuilder<TKey, TValue>
             _acks = Acks.All;
         }
 
+        GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
+
         var keySerializer = _keySerializer ?? GetDefaultSerializer<TKey>("key", "WithKeySerializer");
         var valueSerializer = _valueSerializer ?? GetDefaultSerializer<TValue>("value", "WithValueSerializer");
 
@@ -1914,6 +1916,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
                 $"MaxConnectionsPerBroker ({_maxConnectionsPerBroker}) must be >= ConnectionsPerBroker ({_connectionsPerBroker}). " +
                 $"Adaptive scaling would be permanently disabled since the initial connection count already exceeds the maximum.");
 
+        GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
+
         var memoryBudget = _clientInfrastructure?.MemoryBudget ?? DekafMemoryBudget.Global;
 
         var options = new ConsumerOptions
@@ -2215,7 +2219,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     {
         ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = SaslMechanism.Gssapi;
-        _gssapiConfig = config;
+        _gssapiConfig = config ?? throw new ArgumentNullException(nameof(config));
         return this;
     }
 
@@ -2337,6 +2341,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         if (_bootstrapServers.Count == 0)
             throw new InvalidOperationException("Bootstrap servers must be specified. Call WithBootstrapServers() before Build().");
         ArgumentNullException.ThrowIfNullOrEmpty(_groupId, nameof(_groupId));
+
+        GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
 
         var keyDeserializer = _keyDeserializer ?? GetDefaultDeserializer<TKey>("key", "WithKeyDeserializer");
         var valueDeserializer = _valueDeserializer ?? GetDefaultDeserializer<TValue>("value", "WithValueDeserializer");

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -285,6 +285,8 @@ public sealed class KafkaClientBuilder
             throw new InvalidOperationException(
                 $"MaxConnectionsPerBroker ({_maxConnectionsPerBroker}) must be >= ConnectionsPerBroker ({_connectionsPerBroker}).");
 
+        GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
+
         var options = new KafkaClientOptions
         {
             BootstrapServers = _bootstrapServers,

--- a/src/Dekaf/Security/Sasl/GssapiAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/GssapiAuthenticator.cs
@@ -43,6 +43,7 @@ public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
     {
         _config = config ?? throw new ArgumentNullException(nameof(config));
         _targetHost = targetHost ?? throw new ArgumentNullException(nameof(targetHost));
+        _config.Validate();
     }
 
     /// <inheritdoc />
@@ -62,29 +63,10 @@ public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
         // Mark state early to prevent re-entry even if authentication fails
         _state = GssapiState.TokenExchange;
 
-        // Build the Service Principal Name (SPN)
-        // Format: serviceName/hostname[@realm]
-        var spn = BuildSpn();
+        _config.ApplyKeytabEnvironment();
 
-        // Create the NegotiateAuthentication client
-        // NegotiateAuthentication automatically uses GSSAPI on Unix and SSPI on Windows
-        var clientOptions = new NegotiateAuthenticationClientOptions
-        {
-            Package = "Kerberos",
-            TargetName = spn,
-            RequiredProtectionLevel = ProtectionLevel.None, // Kafka uses authentication only, not integrity/encryption
-            AllowedImpersonationLevel = System.Security.Principal.TokenImpersonationLevel.Identification
-        };
-
-        // Note: NegotiateAuthentication always uses the credentials from the system credential cache.
-        // The Principal and KeytabPath configuration properties are provided for documentation purposes
-        // and to match librdkafka's configuration options, but they do not directly affect credential
-        // selection. To use specific credentials:
-        // - On Linux: Use kinit with the desired principal, or set KRB5_CLIENT_KTNAME for keytab-based auth
-        // - On Windows: Log in as the desired user or use runas
-        // - On macOS: Use kinit with the desired principal
-
-        _auth = new NegotiateAuthentication(clientOptions);
+        // NegotiateAuthentication automatically uses GSSAPI on Unix and SSPI on Windows.
+        _auth = new(_config.CreateClientOptions(_targetHost));
 
         // Get the initial token
         var outgoingBlob = _auth.GetOutgoingBlob(ReadOnlySpan<byte>.Empty, out var statusCode);
@@ -131,20 +113,6 @@ public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
         }
 
         throw new AuthenticationException($"GSSAPI authentication failed: {statusCode}");
-    }
-
-    private string BuildSpn()
-    {
-        // SPN format: serviceName/hostname[@REALM]
-        // Kafka brokers typically expect: kafka/broker-hostname@REALM
-        var spn = $"{_config.ServiceName}/{_targetHost}";
-
-        if (_config.Realm is not null)
-        {
-            spn = $"{spn}@{_config.Realm}";
-        }
-
-        return spn;
     }
 
     /// <inheritdoc />

--- a/src/Dekaf/Security/Sasl/GssapiConfig.cs
+++ b/src/Dekaf/Security/Sasl/GssapiConfig.cs
@@ -1,3 +1,7 @@
+using System.Net;
+using System.Net.Security;
+using System.Security.Principal;
+
 namespace Dekaf.Security.Sasl;
 
 /// <summary>
@@ -5,6 +9,11 @@ namespace Dekaf.Security.Sasl;
 /// </summary>
 public sealed class GssapiConfig
 {
+    internal const string ClientKeytabEnvironmentVariable = "KRB5_CLIENT_KTNAME";
+
+    private static readonly object s_keytabEnvironmentLock = new();
+    private static string? s_configuredKeytabEnvironmentValue;
+
     /// <summary>
     /// The Kerberos service principal name. Defaults to "kafka".
     /// The full SPN will be: {ServiceName}/{hostname}@{Realm}
@@ -15,12 +24,10 @@ public sealed class GssapiConfig
     /// The client principal name (e.g., "user@REALM.COM").
     /// </summary>
     /// <remarks>
-    /// Note: This property is provided for configuration compatibility with librdkafka,
-    /// but it does not directly affect credential selection in .NET. The NegotiateAuthentication
-    /// API always uses the system's default credentials from the Kerberos credential cache.
-    /// To authenticate as a specific principal:
-    /// - On Linux/macOS: Run <c>kinit principal@REALM</c> before starting the application
-    /// - On Windows: Log in as the desired user or use <c>runas /user:principal</c>
+    /// When set, Dekaf passes this value to <see cref="NegotiateAuthenticationClientOptions.Credential"/>
+    /// as the client identity. The underlying platform must still be able to satisfy that
+    /// identity from its credential cache or configured client keytab; Dekaf does not store a
+    /// Kerberos password.
     /// </remarks>
     public string? Principal { get; init; }
 
@@ -28,13 +35,10 @@ public sealed class GssapiConfig
     /// Path to the keytab file for service authentication.
     /// </summary>
     /// <remarks>
-    /// Note: This property is provided for configuration compatibility with librdkafka,
-    /// but it does not directly affect credential selection in .NET. The NegotiateAuthentication
-    /// API always uses the system's Kerberos configuration for keytab-based authentication.
-    /// To use a specific keytab:
-    /// - On Linux: Set the <c>KRB5_CLIENT_KTNAME</c> environment variable to the keytab path
-    /// - On macOS: Set the <c>KRB5_CLIENT_KTNAME</c> environment variable to the keytab path
-    /// - On Windows: Configure the keytab through the system Kerberos configuration
+    /// On Unix-like platforms, Dekaf sets <c>KRB5_CLIENT_KTNAME</c> before the first
+    /// authentication attempt. MIT/Heimdal Kerberos treat this as a process-wide setting, so
+    /// different keytabs in the same process are rejected. Windows keytab selection is not
+    /// supported by <see cref="NegotiateAuthentication"/> and fails during build/initialization.
     /// </remarks>
     public string? KeytabPath { get; init; }
 
@@ -42,4 +46,158 @@ public sealed class GssapiConfig
     /// The Kerberos realm. If not specified, uses the default realm from the system configuration.
     /// </summary>
     public string? Realm { get; init; }
+
+    internal static void ValidateForBuild(SaslMechanism mechanism, GssapiConfig? config)
+    {
+        if (mechanism != SaslMechanism.Gssapi)
+        {
+            return;
+        }
+
+        if (config is null)
+        {
+            throw new InvalidOperationException("GSSAPI configuration must be provided when SaslMechanism is Gssapi.");
+        }
+
+        config.Validate();
+    }
+
+    internal void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ServiceName);
+
+        if (Principal is not null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(Principal);
+        }
+
+        if (Realm is not null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(Realm);
+        }
+
+        if (KeytabPath is not null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(KeytabPath);
+            if (OperatingSystem.IsWindows())
+            {
+                throw new NotSupportedException(
+                    "GSSAPI KeytabPath is not supported on Windows by .NET NegotiateAuthentication. " +
+                    "Use the Windows credential store, run the process as the desired identity, or omit KeytabPath.");
+            }
+
+            var localPath = GetLocalKeytabPath(NormalizeKeytabEnvironmentValue(KeytabPath));
+            if (localPath is not null && !File.Exists(localPath))
+            {
+                throw new FileNotFoundException("GSSAPI keytab file was not found.", localPath);
+            }
+        }
+    }
+
+    internal NegotiateAuthenticationClientOptions CreateClientOptions(string targetHost)
+    {
+        Validate();
+
+        var options = new NegotiateAuthenticationClientOptions
+        {
+            Package = "Kerberos",
+            TargetName = BuildSpn(targetHost),
+            RequiredProtectionLevel = ProtectionLevel.None,
+            AllowedImpersonationLevel = TokenImpersonationLevel.Identification
+        };
+
+        var credential = CreateCredential();
+        if (credential is not null)
+        {
+            options.Credential = credential;
+        }
+
+        return options;
+    }
+
+    internal void ApplyKeytabEnvironment()
+    {
+        if (KeytabPath is null)
+        {
+            return;
+        }
+
+        Validate();
+
+        var environmentValue = NormalizeKeytabEnvironmentValue(KeytabPath);
+        lock (s_keytabEnvironmentLock)
+        {
+            var existing = Environment.GetEnvironmentVariable(ClientKeytabEnvironmentVariable);
+            if (!string.IsNullOrEmpty(existing) && !string.Equals(existing, environmentValue, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot use GSSAPI KeytabPath '{KeytabPath}' because process-wide " +
+                    $"{ClientKeytabEnvironmentVariable} is already set to '{existing}'. " +
+                    "Use one client keytab per process or configure Kerberos credentials externally.");
+            }
+
+            if (s_configuredKeytabEnvironmentValue is not null &&
+                !string.Equals(s_configuredKeytabEnvironmentValue, environmentValue, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot use GSSAPI KeytabPath '{KeytabPath}' because this process already configured " +
+                    $"{ClientKeytabEnvironmentVariable} as '{s_configuredKeytabEnvironmentValue}'. " +
+                    "Use one client keytab per process or configure Kerberos credentials externally.");
+            }
+
+            Environment.SetEnvironmentVariable(ClientKeytabEnvironmentVariable, environmentValue);
+            s_configuredKeytabEnvironmentValue = environmentValue;
+        }
+    }
+
+    internal string BuildSpn(string targetHost)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetHost);
+
+        var spn = $"{ServiceName}/{targetHost}";
+        return Realm is null ? spn : $"{spn}@{Realm}";
+    }
+
+    internal NetworkCredential? CreateCredential()
+    {
+        if (Principal is null)
+        {
+            return null;
+        }
+
+        var principal = Principal.Trim();
+        if (principal.Contains('@', StringComparison.Ordinal) || Realm is null)
+        {
+            return new NetworkCredential(principal, string.Empty);
+        }
+
+        return new NetworkCredential(principal, string.Empty, Realm);
+    }
+
+    internal static string NormalizeKeytabEnvironmentValue(string keytabPath)
+    {
+        var trimmed = keytabPath.Trim();
+        const string filePrefix = "FILE:";
+        if (trimmed.StartsWith(filePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return filePrefix + Path.GetFullPath(trimmed[filePrefix.Length..]);
+        }
+
+        return trimmed.Contains(':', StringComparison.Ordinal)
+            ? trimmed
+            : Path.GetFullPath(trimmed);
+    }
+
+    private static string? GetLocalKeytabPath(string environmentValue)
+    {
+        const string filePrefix = "FILE:";
+        if (environmentValue.StartsWith(filePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return environmentValue[filePrefix.Length..];
+        }
+
+        return environmentValue.Contains(':', StringComparison.Ordinal)
+            ? null
+            : environmentValue;
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Security/GssapiAuthenticatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/GssapiAuthenticatorTests.cs
@@ -183,4 +183,122 @@ public class GssapiConfigTests
 
         await Assert.That(config.Realm).IsEqualTo("EXAMPLE.COM");
     }
+
+    [Test]
+    public async Task BuildSpn_IncludesRealmWhenConfigured()
+    {
+        var config = new GssapiConfig { Realm = "EXAMPLE.COM" };
+
+        await Assert.That(config.BuildSpn("broker.example.com")).IsEqualTo("kafka/broker.example.com@EXAMPLE.COM");
+    }
+
+    [Test]
+    public async Task CreateClientOptions_DefaultsToKafkaAuthOnly()
+    {
+        var config = new GssapiConfig();
+
+        var options = config.CreateClientOptions("broker.example.com");
+
+        await Assert.That(options.Package).IsEqualTo("Kerberos");
+        await Assert.That(options.TargetName).IsEqualTo("kafka/broker.example.com");
+        await Assert.That(options.RequiredProtectionLevel).IsEqualTo(System.Net.Security.ProtectionLevel.None);
+        await Assert.That(options.Credential).IsNotNull();
+    }
+
+    [Test]
+    public async Task CreateClientOptions_WithPrincipal_SetsExplicitCredential()
+    {
+        var config = new GssapiConfig { Principal = "user@REALM.COM" };
+
+        var options = config.CreateClientOptions("broker.example.com");
+
+        await Assert.That(options.Credential.UserName).IsEqualTo("user@REALM.COM");
+        await Assert.That(options.Credential.Password).IsEqualTo(string.Empty);
+        await Assert.That(options.Credential.Domain).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task CreateClientOptions_WithPrincipalAndRealm_SetsCredentialDomain()
+    {
+        var config = new GssapiConfig
+        {
+            Principal = "user",
+            Realm = "REALM.COM"
+        };
+
+        var options = config.CreateClientOptions("broker.example.com");
+
+        await Assert.That(options.Credential.UserName).IsEqualTo("user");
+        await Assert.That(options.Credential.Domain).IsEqualTo("REALM.COM");
+        await Assert.That(options.TargetName).IsEqualTo("kafka/broker.example.com@REALM.COM");
+    }
+
+    [Test]
+    public async Task ValidateForBuild_GssapiWithoutConfig_Throws()
+    {
+        var exception = await Assert.That(() => GssapiConfig.ValidateForBuild(SaslMechanism.Gssapi, null))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(exception!.Message).Contains("GSSAPI configuration must be provided");
+    }
+
+    [Test]
+    public async Task Validate_KeytabPath_FailsFastWhenCannotBeHonored()
+    {
+        var keytabPath = Path.Combine(Path.GetTempPath(), $"dekaf-missing-{Guid.NewGuid():N}.keytab");
+        var config = new GssapiConfig { KeytabPath = keytabPath };
+
+        if (OperatingSystem.IsWindows())
+        {
+            var exception = await Assert.That(() => config.Validate()).Throws<NotSupportedException>();
+
+            await Assert.That(exception!.Message).Contains("KeytabPath is not supported on Windows");
+            return;
+        }
+
+        var missing = await Assert.That(() => config.Validate()).Throws<FileNotFoundException>();
+
+        await Assert.That(missing!.FileName).IsEqualTo(keytabPath);
+    }
+
+    [Test]
+    public async Task ProducerBuild_WithUnsupportedKeytab_FailsFast()
+    {
+        var keytabPath = Path.Combine(Path.GetTempPath(), $"dekaf-missing-{Guid.NewGuid():N}.keytab");
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGssapi(new GssapiConfig { KeytabPath = keytabPath });
+
+        if (OperatingSystem.IsWindows())
+        {
+            await Assert.That(() => builder.Build()).Throws<NotSupportedException>();
+            return;
+        }
+
+        var exception = await Assert.That(() => builder.Build()).Throws<FileNotFoundException>();
+
+        await Assert.That(exception!.FileName).IsEqualTo(keytabPath);
+    }
+
+    [Test]
+    public async Task Validate_KeytabPath_ExistingFileAllowedOnUnix()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var keytabPath = Path.Combine(Path.GetTempPath(), $"dekaf-{Guid.NewGuid():N}.keytab");
+        try
+        {
+            await File.WriteAllBytesAsync(keytabPath, [0]);
+            var config = new GssapiConfig { KeytabPath = keytabPath };
+
+            await Assert.That(() => config.Validate()).ThrowsNothing();
+        }
+        finally
+        {
+            File.Delete(keytabPath);
+        }
+    }
 }


### PR DESCRIPTION
Closes #1155.

## Summary
- pass `GssapiConfig.Principal` into `NegotiateAuthenticationClientOptions.Credential`
- honor Unix client keytabs by configuring `KRB5_CLIENT_KTNAME` before GSSAPI auth
- fail fast for unsupported/missing keytab settings and process-global keytab conflicts
- validate GSSAPI config from producer, consumer, share consumer, admin, and `KafkaClient` builders

## Validation
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/Gssapi*/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe`