### PR TITLE
Add client DNS lookup support

### DIFF
--- a/docs/docs/configuration/client-dns-lookup.md
+++ b/docs/docs/configuration/client-dns-lookup.md
@@ -1,0 +1,50 @@
+---
+sidebar_position: 4
+---
+
+# Client DNS Lookup
+
+Dekaf resolves broker hostnames before opening TCP connections. By default it tries every A or AAAA record returned by DNS until one connects, then remembers the last successful address and tries it first on the next reconnect.
+
+```csharp
+var producer = new ProducerBuilder<string, string>()
+    .WithBootstrapServers("kafka.example.com:9092")
+    .WithClientDnsLookup(ClientDnsLookup.UseAllDnsIps)
+    .Build();
+```
+
+Use `ResolveCanonicalBootstrapServersOnly` when a bootstrap alias must be canonicalized before TLS or SASL/GSSAPI authentication:
+
+```csharp
+var consumer = new ConsumerBuilder<string, string>()
+    .WithBootstrapServers("bootstrap.kafka.example.com:9093")
+    .WithClientDnsLookup(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly)
+    .UseTls()
+    .Build();
+```
+
+## Modes
+
+| Mode | Behavior |
+|------|----------|
+| `UseAllDnsIps` | Resolves all IP addresses for the broker hostname and tries each address until a connection succeeds. This is the default. |
+| `ResolveCanonicalBootstrapServersOnly` | Resolves the canonical hostname and uses that name as the TLS/SASL target host while still trying the returned IP addresses. |
+
+DNS is resolved on every reconnect, so changes in broker DNS records are picked up without recreating the client.
+
+## Configuration
+
+`ClientDnsLookup` can be configured on root clients, producers, consumers, share consumers, and admin clients. It also binds from `appsettings.json` by enum name:
+
+```json
+{
+  "Kafka": {
+    "Producers": {
+      "Orders": {
+        "BootstrapServers": "kafka.example.com:9092",
+        "ClientDnsLookup": "UseAllDnsIps"
+      }
+    }
+  }
+}
+```

--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -76,6 +76,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 |------------|------------|-------|
 | `WithBootstrapServers(...)` | `BootstrapServers` | Server list (prefer `params string[]` in code; comma-separated string and JSON arrays are also supported) |
 | `WithClientId(...)` | `ClientId` | String |
+| `WithClientDnsLookup(...)` | `ClientDnsLookup` | `UseAllDnsIps` or `ResolveCanonicalBootstrapServersOnly` |
 | `WithGroupId(...)` | `GroupId` | String |
 | `WithGroupInstanceId(...)` | `GroupInstanceId` | String |
 | `WithGroupRemoteAssignor(...)` | `GroupRemoteAssignor` | Common values: `uniform`, `range` |
@@ -334,6 +335,7 @@ For transactional reads:
 |--------|---------|-------------|
 | `WithBootstrapServers` | (required) | Broker addresses |
 | `WithClientId` | "dekaf-consumer" | Client identifier |
+| `WithClientDnsLookup` | UseAllDnsIps | DNS lookup mode |
 | `WithGroupId` | null | Consumer group ID |
 | `WithGroupInstanceId` | null | Static membership ID |
 | `WithOffsetCommitMode` | Auto | Offset management mode |

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -70,6 +70,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 |------------|------------|-------|
 | `WithBootstrapServers(...)` | `BootstrapServers` | Server list (prefer `params string[]` in code; comma-separated string and JSON arrays are also supported) |
 | `WithClientId(...)` | `ClientId` | String |
+| `WithClientDnsLookup(...)` | `ClientDnsLookup` | `UseAllDnsIps` or `ResolveCanonicalBootstrapServersOnly` |
 | `WithAcks(...)` | `Acks` | `None`, `Leader`, `All` |
 | `WithLinger(...)` | `LingerMs` | Milliseconds |
 | `WithBatchSize(...)` | `BatchSize` | Bytes |
@@ -331,6 +332,7 @@ Enable logging:
 |--------|---------|-------------|
 | `WithBootstrapServers` | (required) | Broker addresses |
 | `WithClientId` | "dekaf-producer" | Client identifier |
+| `WithClientDnsLookup` | UseAllDnsIps | DNS lookup mode |
 | `WithAcks` | All | Acknowledgment mode |
 | `WithLinger` | 0ms | Batch wait time |
 | `WithBatchSize` | 1048576 | Max batch size in bytes |

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -34,6 +34,7 @@ const sidebars = {
         'configuration/presets',
         'configuration/producer-options',
         'configuration/consumer-options',
+        'configuration/client-dns-lookup',
       ],
     },
     {

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Consumer.DeadLetter;
 using Dekaf.Metadata;
+using Dekaf.Networking;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
 using Dekaf.Producer;
@@ -459,6 +460,12 @@ public sealed class AdminClientServiceBuilder
         return this;
     }
 
+    public AdminClientServiceBuilder WithClientDnsLookup(ClientDnsLookup lookup)
+    {
+        _builder.WithClientDnsLookup(lookup);
+        return this;
+    }
+
     public AdminClientServiceBuilder RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
     {
         _builder.RegisterMetricForSubscription(metric);
@@ -558,6 +565,8 @@ internal static class DekafConfigurationBinding
             builder.WithMetadataRecoveryStrategy(metadataRecoveryStrategy);
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.MetadataRecoveryRebootstrapTriggerMs), out var rebootstrapMs))
             builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(rebootstrapMs));
+        if (TryGetValue<ClientDnsLookup>(configuration, nameof(ProducerOptions.ClientDnsLookup), out var clientDnsLookup))
+            builder.WithClientDnsLookup(clientDnsLookup);
         ApplyAdaptiveConnections(
             configuration,
             nameof(ProducerOptions.EnableAdaptiveConnections),
@@ -642,6 +651,8 @@ internal static class DekafConfigurationBinding
             builder.WithMetadataRecoveryStrategy(metadataRecoveryStrategy);
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.MetadataRecoveryRebootstrapTriggerMs), out var rebootstrapMs))
             builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(rebootstrapMs));
+        if (TryGetValue<ClientDnsLookup>(configuration, nameof(ConsumerOptions.ClientDnsLookup), out var clientDnsLookup))
+            builder.WithClientDnsLookup(clientDnsLookup);
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.PrefetchPipelineDepth), out var prefetchPipelineDepth))
             builder.WithPrefetchPipelineDepth(prefetchPipelineDepth);
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.ConnectionsPerBroker), out var connectionsPerBroker))
@@ -674,6 +685,8 @@ internal static class DekafConfigurationBinding
             builder.WithMetadataRecoveryStrategy(metadataRecoveryStrategy);
         if (TryGetValue<int>(configuration, nameof(AdminClientOptions.MetadataRecoveryRebootstrapTriggerMs), out var rebootstrapMs))
             builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(rebootstrapMs));
+        if (TryGetValue<ClientDnsLookup>(configuration, nameof(AdminClientOptions.ClientDnsLookup), out var clientDnsLookup))
+            builder.WithClientDnsLookup(clientDnsLookup);
     }
 
     private static void ApplyTls<TBuilder>(

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -54,7 +54,8 @@ public sealed class AdminClient : IAdminClient
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
-                OAuthBearerToken = options.OAuthBearerToken
+                OAuthBearerToken = options.OAuthBearerToken,
+                ClientDnsLookup = options.ClientDnsLookup
             },
             loggerFactory);
 
@@ -2532,6 +2533,11 @@ public sealed class AdminClientOptions
     public int MetadataRecoveryRebootstrapTriggerMs { get; init; } = 300000;
 
     /// <summary>
+    /// Controls how broker hostnames are resolved before connecting.
+    /// </summary>
+    public ClientDnsLookup ClientDnsLookup { get; init; } = ClientDnsLookup.UseAllDnsIps;
+
+    /// <summary>
     /// Application metrics registered for broker telemetry subscriptions.
     /// </summary>
     public IReadOnlyList<ApplicationTelemetryMetric> ApplicationMetrics { get; init; } = [];
@@ -2560,6 +2566,7 @@ public sealed class AdminClientBuilder
     private ILoggerFactory? _loggerFactory;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
+    private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
     private TimeSpan? _metadataMaxAge;
     private readonly Dictionary<string, ApplicationTelemetryMetric> _applicationMetrics = new(StringComparer.Ordinal);
 
@@ -2793,6 +2800,16 @@ public sealed class AdminClientBuilder
     }
 
     /// <summary>
+    /// Sets how broker DNS names are resolved before connecting.
+    /// </summary>
+    public AdminClientBuilder WithClientDnsLookup(ClientDnsLookup lookup)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _clientDnsLookup = lookup;
+        return this;
+    }
+
+    /// <summary>
     /// Sets the maximum age of metadata before it is refreshed.
     /// This controls how frequently the client refreshes its view of the cluster topology.
     /// Equivalent to Kafka's <c>metadata.max.age.ms</c> configuration.
@@ -2905,6 +2922,7 @@ public sealed class AdminClientBuilder
             OAuthBearerTokenProvider = _oauthTokenProvider,
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
+            ClientDnsLookup = _clientDnsLookup,
             ApplicationMetrics = _applicationMetrics.Count > 0 ? _applicationMetrics.Values.ToArray() : []
         };
 
@@ -2912,7 +2930,8 @@ public sealed class AdminClientBuilder
         {
             MetadataRefreshInterval = _metadataMaxAge ?? TimeSpan.FromMinutes(15),
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
-            MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs
+            MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
+            ClientDnsLookup = _clientDnsLookup
         };
 
         return _clientInfrastructure is null

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -58,6 +58,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private int? _maxBlockMs;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
+    private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
     private bool _enableIdempotence = true;
     private int _connectionsPerBroker = 1;
     private int _socketSendBufferBytes;
@@ -536,6 +537,16 @@ public sealed class ProducerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Sets how broker DNS names are resolved before connecting.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithClientDnsLookup(ClientDnsLookup lookup)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _clientDnsLookup = lookup;
+        return this;
+    }
+
+    /// <summary>
     /// Sets the maximum age of metadata before it is refreshed.
     /// This controls how frequently the client refreshes its view of the cluster topology.
     /// Equivalent to Kafka's <c>metadata.max.age.ms</c> configuration.
@@ -969,6 +980,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             OAuthBearerTokenProvider = _oauthTokenProvider,
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
+            ClientDnsLookup = _clientDnsLookup,
             SocketSendBufferBytes = _socketSendBufferBytes,
             SocketReceiveBufferBytes = _socketReceiveBufferBytes,
             ValueTaskSourcePoolSize = _valueTaskSourcePoolSize,
@@ -985,7 +997,8 @@ public sealed class ProducerBuilder<TKey, TValue>
         {
             MetadataRefreshInterval = _metadataMaxAge ?? TimeSpan.FromMinutes(15),
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
-            MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs
+            MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
+            ClientDnsLookup = _clientDnsLookup
         };
 
         var producer = _clientInfrastructure is null
@@ -1117,6 +1130,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int? _queuedMaxMessagesKbytes;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
+    private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
     private readonly List<string> _topicsToSubscribe = [];
     private TimeSpan? _metadataMaxAge;
     private IsolationLevel _isolationLevel = IsolationLevel.ReadUncommitted;
@@ -1727,6 +1741,16 @@ public sealed class ConsumerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Sets how broker DNS names are resolved before connecting.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithClientDnsLookup(ClientDnsLookup lookup)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _clientDnsLookup = lookup;
+        return this;
+    }
+
+    /// <summary>
     /// Sets the maximum age of metadata before it is refreshed.
     /// This controls how frequently the client refreshes its view of the cluster topology.
     /// Equivalent to Kafka's <c>metadata.max.age.ms</c> configuration.
@@ -2075,6 +2099,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             IsolationLevel = _isolationLevel,
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
+            ClientDnsLookup = _clientDnsLookup,
             Interceptors = _interceptors?.Count > 0 ? _interceptors.ToArray() : null,
             RetryPolicy = _retryPolicy,
             PrefetchPipelineDepth = _prefetchPipelineDepth,
@@ -2090,7 +2115,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
         {
             MetadataRefreshInterval = _metadataMaxAge ?? TimeSpan.FromMinutes(15),
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
-            MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs
+            MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
+            ClientDnsLookup = _clientDnsLookup
         };
 
         var consumer = _clientInfrastructure is null
@@ -2194,6 +2220,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
+    private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
     private IRetryPolicy? _retryPolicy;
     private readonly List<string> _topicsToSubscribe = [];
 
@@ -2454,6 +2481,16 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>
+    /// Sets how broker DNS names are resolved before connecting.
+    /// </summary>
+    public ShareConsumerBuilder<TKey, TValue> WithClientDnsLookup(ClientDnsLookup lookup)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _clientDnsLookup = lookup;
+        return this;
+    }
+
     public ShareConsumerBuilder<TKey, TValue> WithRetryPolicy(IRetryPolicy retryPolicy)
     {
         _retryPolicy = retryPolicy;
@@ -2534,6 +2571,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             SocketSendBufferBytes = _socketSendBufferBytes,
             SocketReceiveBufferBytes = _socketReceiveBufferBytes,
             ConnectionsPerBroker = _connectionsPerBroker,
+            ClientDnsLookup = _clientDnsLookup,
             RetryPolicy = _retryPolicy
         };
 

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -307,6 +307,11 @@ public sealed class ConsumerOptions
     public int MetadataRecoveryRebootstrapTriggerMs { get; init; } = 300000;
 
     /// <summary>
+    /// Controls how broker hostnames are resolved before connecting.
+    /// </summary>
+    public ClientDnsLookup ClientDnsLookup { get; init; } = ClientDnsLookup.UseAllDnsIps;
+
+    /// <summary>
     /// Application-level retry policy for message processing in hosted consumer services.
     /// When set, the consumer service will use this policy to determine delays between retries.
     /// When <c>null</c>, existing retry behavior is unchanged.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -805,7 +805,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 OAuthBearerConfig = options.OAuthBearerConfig,
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
                 SendBufferSize = options.SocketSendBufferBytes,
-                ReceiveBufferSize = options.SocketReceiveBufferBytes
+                ReceiveBufferSize = options.SocketReceiveBufferBytes,
+                ClientDnsLookup = options.ClientDnsLookup
             },
             loggerFactory,
             connectionsPerBroker: options.ConnectionsPerBroker,

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -99,6 +99,7 @@ public sealed class KafkaClientBuilder
     private TimeSpan? _metadataMaxAge;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
+    private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
     private ulong? _memoryBudgetBytes;
     private ILoggerFactory? _loggerFactory;
 
@@ -306,6 +307,15 @@ public sealed class KafkaClientBuilder
         return this;
     }
 
+    /// <summary>
+    /// Sets how broker DNS names are resolved before connecting.
+    /// </summary>
+    public KafkaClientBuilder WithClientDnsLookup(ClientDnsLookup lookup)
+    {
+        _clientDnsLookup = lookup;
+        return this;
+    }
+
     public KafkaClientBuilder WithMemoryBudget(ulong bytes)
     {
         ArgumentOutOfRangeException.ThrowIfZero(bytes);
@@ -354,6 +364,7 @@ public sealed class KafkaClientBuilder
             MetadataMaxAge = _metadataMaxAge,
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
+            ClientDnsLookup = _clientDnsLookup,
             MemoryBudgetBytes = _memoryBudgetBytes,
             LoggerFactory = _loggerFactory
         };
@@ -385,6 +396,7 @@ internal sealed class KafkaClientOptions
     public TimeSpan? MetadataMaxAge { get; init; }
     public MetadataRecoveryStrategy MetadataRecoveryStrategy { get; init; }
     public int MetadataRecoveryRebootstrapTriggerMs { get; init; }
+    public ClientDnsLookup ClientDnsLookup { get; init; }
     public ulong? MemoryBudgetBytes { get; init; }
     public ILoggerFactory? LoggerFactory { get; init; }
 }
@@ -448,7 +460,8 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
                 SendBufferSize = options.SocketSendBufferBytes,
                 ReceiveBufferSize = options.SocketReceiveBufferBytes,
-                MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection
+                MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection,
+                ClientDnsLookup = options.ClientDnsLookup
             },
             options.LoggerFactory,
             options.ConnectionsPerBroker,
@@ -459,7 +472,8 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         {
             MetadataRefreshInterval = options.MetadataMaxAge ?? TimeSpan.FromMinutes(15),
             MetadataRecoveryStrategy = options.MetadataRecoveryStrategy,
-            MetadataRecoveryRebootstrapTriggerMs = options.MetadataRecoveryRebootstrapTriggerMs
+            MetadataRecoveryRebootstrapTriggerMs = options.MetadataRecoveryRebootstrapTriggerMs,
+            ClientDnsLookup = options.ClientDnsLookup
         };
 
         var metadataManager = new MetadataManager(

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -787,16 +787,31 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 // Apply a per-host timeout to prevent DNS hangs from blocking rebootstrap
                 using var dnsCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 dnsCts.CancelAfter(TimeSpan.FromSeconds(5));
-                var addresses = await Dns.GetHostAddressesAsync(host, dnsCts.Token).ConfigureAwait(false);
-                foreach (var address in addresses)
+                IPAddress[] addresses;
+                if (_options.ClientDnsLookup == ClientDnsLookup.ResolveCanonicalBootstrapServersOnly)
                 {
-                    var endpoint = (address.ToString(), port);
-                    // Add both the resolved IP and the original hostname
-                    // The original hostname is important because the broker may expect
-                    // connections using the hostname (e.g., for TLS SNI)
-                    if (seen.Add(endpoint))
+                    var entry = await Dns.GetHostEntryAsync(host, dnsCts.Token).ConfigureAwait(false);
+                    addresses = entry.AddressList;
+                    var canonicalHost = string.IsNullOrWhiteSpace(entry.HostName) ? host : entry.HostName;
+                    var canonicalEndpoint = (canonicalHost, port);
+                    if (seen.Add(canonicalEndpoint))
                     {
-                        resolved.Add(endpoint);
+                        resolved.Add(canonicalEndpoint);
+                    }
+                }
+                else
+                {
+                    addresses = await Dns.GetHostAddressesAsync(host, dnsCts.Token).ConfigureAwait(false);
+                    foreach (var address in addresses)
+                    {
+                        var endpoint = (address.ToString(), port);
+                        // Add resolved IP endpoints for rebootstrap fan-out. The original
+                        // hostname fallback below preserves TLS/SASL target names when direct
+                        // IP endpoints are unsuitable.
+                        if (seen.Add(endpoint))
+                        {
+                            resolved.Add(endpoint);
+                        }
                     }
                 }
 
@@ -1173,6 +1188,11 @@ public sealed class MetadataOptions
     /// Default is 300000 (5 minutes).
     /// </summary>
     public int MetadataRecoveryRebootstrapTriggerMs { get; init; } = 300000;
+
+    /// <summary>
+    /// Controls how bootstrap and broker hostnames are resolved before connecting.
+    /// </summary>
+    public ClientDnsLookup ClientDnsLookup { get; init; } = ClientDnsLookup.UseAllDnsIps;
 
     /// <summary>
     /// Initial retry backoff in milliseconds for metadata initialization.

--- a/src/Dekaf/Networking/ClientDnsEndpointResolver.cs
+++ b/src/Dekaf/Networking/ClientDnsEndpointResolver.cs
@@ -1,0 +1,103 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Dekaf.Networking;
+
+internal sealed class ClientDnsEndpointResolver
+{
+    public static ClientDnsEndpointResolver Default { get; } = new(new SystemDnsLookup());
+
+    private readonly IDnsLookup _dnsLookup;
+    private readonly ConcurrentDictionary<EndpointCacheKey, IPAddress> _lastSuccessfulAddresses = new();
+
+    public ClientDnsEndpointResolver(IDnsLookup dnsLookup)
+    {
+        _dnsLookup = dnsLookup;
+    }
+
+    public async ValueTask<IReadOnlyList<ClientDnsEndpoint>> ResolveAsync(
+        string host,
+        int port,
+        ClientDnsLookup lookup,
+        CancellationToken cancellationToken)
+    {
+        if (IPAddress.TryParse(host, out var address))
+            return [new ClientDnsEndpoint(address, port, host)];
+
+        var targetHost = host;
+        IPAddress[] addresses;
+
+        if (lookup == ClientDnsLookup.ResolveCanonicalBootstrapServersOnly)
+        {
+            var entry = await _dnsLookup.GetHostEntryAsync(host, cancellationToken).ConfigureAwait(false);
+            targetHost = string.IsNullOrWhiteSpace(entry.HostName) ? host : entry.HostName;
+            addresses = entry.AddressList;
+        }
+        else
+        {
+            addresses = await _dnsLookup.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
+        }
+
+        var endpoints = addresses
+            .Where(IsSupportedAddress)
+            .Distinct()
+            .Select(ipAddress => new ClientDnsEndpoint(ipAddress, port, targetHost))
+            .ToArray();
+
+        if (endpoints.Length == 0)
+            return [];
+
+        var key = new EndpointCacheKey(host, port, lookup);
+        if (_lastSuccessfulAddresses.TryGetValue(key, out var lastSuccessful))
+            MoveAddressToFront(endpoints, lastSuccessful);
+
+        return endpoints;
+    }
+
+    public void MarkSuccessful(string host, int port, ClientDnsLookup lookup, IPAddress address)
+    {
+        _lastSuccessfulAddresses[new EndpointCacheKey(host, port, lookup)] = address;
+    }
+
+    private static bool IsSupportedAddress(IPAddress address)
+    {
+        return address.AddressFamily is AddressFamily.InterNetwork
+            or AddressFamily.InterNetworkV6;
+    }
+
+    private static void MoveAddressToFront(ClientDnsEndpoint[] endpoints, IPAddress address)
+    {
+        var index = Array.FindIndex(endpoints, endpoint => endpoint.Address.Equals(address));
+        if (index <= 0)
+            return;
+
+        var selected = endpoints[index];
+        Array.Copy(endpoints, 0, endpoints, 1, index);
+        endpoints[0] = selected;
+    }
+
+    private readonly record struct EndpointCacheKey(string Host, int Port, ClientDnsLookup Lookup);
+}
+
+internal readonly record struct ClientDnsEndpoint(IPAddress Address, int Port, string TargetHost);
+
+internal interface IDnsLookup
+{
+    ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken);
+
+    ValueTask<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken);
+}
+
+internal sealed class SystemDnsLookup : IDnsLookup
+{
+    public async ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken)
+    {
+        return await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken)
+    {
+        return await Dns.GetHostEntryAsync(host, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Dekaf/Networking/ClientDnsLookup.cs
+++ b/src/Dekaf/Networking/ClientDnsLookup.cs
@@ -1,0 +1,17 @@
+namespace Dekaf.Networking;
+
+/// <summary>
+/// Controls how broker hostnames are resolved before connecting.
+/// </summary>
+public enum ClientDnsLookup
+{
+    /// <summary>
+    /// Resolve all IP addresses for a hostname and try them in order until one connects.
+    /// </summary>
+    UseAllDnsIps,
+
+    /// <summary>
+    /// Resolve hostnames to their canonical DNS name before connecting.
+    /// </summary>
+    ResolveCanonicalBootstrapServersOnly
+}

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -192,7 +192,9 @@ public sealed partial class ConnectionPool : IConnectionPool
             ReconnectBackoff = options.ReconnectBackoff,
             ReconnectBackoffMax = options.ReconnectBackoffMax,
             ConnectionsMaxIdleMs = options.ConnectionsMaxIdleMs,
-            MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection
+            MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection,
+            ClientDnsLookup = options.ClientDnsLookup,
+            DnsResolver = options.DnsResolver
         };
     }
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks.Sources;
 using Dekaf.Errors;
@@ -143,6 +144,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
     private readonly ResponseBufferPool _responseBufferPool;
 
     private Socket? _socket;
+    private string? _resolvedTargetHost;
     private Stream? _stream;
     private PipeReader? _reader;
     private SocketPipe? _socketPipe;
@@ -365,26 +367,18 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
     {
         LogConnecting(_host, _port);
 
-        _socket = new Socket(SocketType.Stream, ProtocolType.Tcp)
-        {
-            NoDelay = true
-        };
-
-        if (_options.SendBufferSize > 0)
-            _socket.SendBufferSize = _options.SendBufferSize;
-        if (_options.ReceiveBufferSize > 0)
-            _socket.ReceiveBufferSize = _options.ReceiveBufferSize;
-        ConfigureTcpKeepAlive(_socket);
-
-        var endpoint = new DnsEndPoint(_host, _port);
-        await _socket.ConnectAsync(endpoint, cancellationToken).ConfigureAwait(false);
+        using var connectTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        connectTimeoutCts.CancelAfter(_options.ConnectionTimeout);
+        var (socket, targetHost) = await ConnectSocketAsync(connectTimeoutCts.Token).ConfigureAwait(false);
+        _socket = socket;
+        _resolvedTargetHost = targetHost;
 
         Stream networkStream = new NetworkStream(_socket, ownsSocket: false);
 
         if (_options.UseTls || _options.TlsConfig is not null)
         {
             var sslStream = new SslStream(networkStream, leaveInnerStreamOpen: false);
-            var sslOptions = BuildSslClientAuthenticationOptions();
+            var sslOptions = BuildSslClientAuthenticationOptions(targetHost);
             try
             {
                 await sslStream.AuthenticateAsClientAsync(sslOptions, cancellationToken).ConfigureAwait(false);
@@ -480,6 +474,63 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         _telemetryMetricCollector?.RecordConnectionCreated();
 
         LogConnected(_host, _port);
+    }
+
+    private async ValueTask<(Socket Socket, string TargetHost)> ConnectSocketAsync(CancellationToken cancellationToken)
+    {
+        var endpoints = await _options.DnsResolver
+            .ResolveAsync(_host, _port, _options.ClientDnsLookup, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (endpoints.Count == 0)
+            throw new SocketException((int)SocketError.HostNotFound);
+
+        Exception? lastException = null;
+        foreach (var endpoint in endpoints)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var socket = CreateSocket(endpoint.Address.AddressFamily);
+            try
+            {
+                await socket.ConnectAsync(new IPEndPoint(endpoint.Address, endpoint.Port), cancellationToken)
+                    .ConfigureAwait(false);
+
+                _options.DnsResolver.MarkSuccessful(_host, _port, _options.ClientDnsLookup, endpoint.Address);
+                return (socket, endpoint.TargetHost);
+            }
+            catch (OperationCanceledException)
+            {
+                socket.Dispose();
+                throw;
+            }
+            catch (Exception ex)
+            {
+                socket.Dispose();
+                lastException = ex;
+            }
+        }
+
+        if (lastException is not null)
+            ExceptionDispatchInfo.Capture(lastException).Throw();
+
+        throw new SocketException((int)SocketError.HostNotFound);
+    }
+
+    private Socket CreateSocket(AddressFamily addressFamily)
+    {
+        var socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp)
+        {
+            NoDelay = true
+        };
+
+        if (_options.SendBufferSize > 0)
+            socket.SendBufferSize = _options.SendBufferSize;
+        if (_options.ReceiveBufferSize > 0)
+            socket.ReceiveBufferSize = _options.ReceiveBufferSize;
+        ConfigureTcpKeepAlive(socket);
+
+        return socket;
     }
 
     public async ValueTask<TResponse> SendAsync<TRequest, TResponse>(
@@ -1539,12 +1590,12 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         ReleasePendingRequestSlots(releasedSlots);
     }
 
-    private SslClientAuthenticationOptions BuildSslClientAuthenticationOptions()
+    private SslClientAuthenticationOptions BuildSslClientAuthenticationOptions(string targetHost)
     {
         var tlsConfig = _options.TlsConfig;
         var options = new SslClientAuthenticationOptions
         {
-            TargetHost = tlsConfig?.TargetHost ?? _host,
+            TargetHost = tlsConfig?.TargetHost ?? targetHost,
             RemoteCertificateValidationCallback = _options.RemoteCertificateValidationCallback
         };
 
@@ -1924,7 +1975,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             _options.SaslPassword ?? throw new InvalidOperationException("SASL password not configured")),
         SaslMechanism.Gssapi => new GssapiAuthenticator(
             _options.GssapiConfig ?? throw new InvalidOperationException("GSSAPI configuration not provided"),
-            _host),
+            _resolvedTargetHost ?? _host),
         SaslMechanism.OAuthBearer => CreateOAuthBearerAuthenticator(),
         _ => throw new InvalidOperationException($"Unsupported SASL mechanism: {_options.SaslMechanism}")
     };
@@ -2718,6 +2769,16 @@ public sealed class ConnectionOptions
     /// Maximum in-flight requests per connection. Used internally to derive pool sizes.
     /// </summary>
     internal int MaxInFlightRequestsPerConnection { get; init; } = 5;
+
+    /// <summary>
+    /// Controls how broker hostnames are resolved before connecting.
+    /// </summary>
+    public ClientDnsLookup ClientDnsLookup { get; init; } = ClientDnsLookup.UseAllDnsIps;
+
+    /// <summary>
+    /// DNS resolver used by connections. Internal for deterministic tests.
+    /// </summary>
+    internal ClientDnsEndpointResolver DnsResolver { get; init; } = ClientDnsEndpointResolver.Default;
 
     internal const int DefaultConnectionsMaxIdleMs = 540000;
 

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -232,7 +232,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
                 SendBufferSize = options.SocketSendBufferBytes,
                 ReceiveBufferSize = options.SocketReceiveBufferBytes,
-                MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection
+                MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection,
+                ClientDnsLookup = options.ClientDnsLookup
             },
             loggerFactory,
             options.ConnectionsPerBroker,

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -398,6 +398,11 @@ public sealed class ProducerOptions
     public int MetadataRecoveryRebootstrapTriggerMs { get; init; } = 300000;
 
     /// <summary>
+    /// Controls how broker hostnames are resolved before connecting.
+    /// </summary>
+    public ClientDnsLookup ClientDnsLookup { get; init; } = ClientDnsLookup.UseAllDnsIps;
+
+    /// <summary>
     /// Application-level retry policy for <see cref="KafkaProducer{TKey,TValue}.ProduceAsync"/>.
     /// When set, retriable exceptions that escape the internal protocol-level retries will be
     /// retried according to this policy. When <c>null</c>, no application-level retries occur.

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -78,7 +78,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 OAuthBearerConfig = options.OAuthBearerConfig,
                 OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
                 SendBufferSize = options.SocketSendBufferBytes,
-                ReceiveBufferSize = options.SocketReceiveBufferBytes
+                ReceiveBufferSize = options.SocketReceiveBufferBytes,
+                ClientDnsLookup = options.ClientDnsLookup
             },
             loggerFactory,
             connectionsPerBroker: options.ConnectionsPerBroker);

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -147,6 +147,11 @@ public sealed class ShareConsumerOptions
     public int ConnectionsPerBroker { get; init; } = 2;
 
     /// <summary>
+    /// Controls how broker hostnames are resolved before connecting.
+    /// </summary>
+    public ClientDnsLookup ClientDnsLookup { get; init; } = ClientDnsLookup.UseAllDnsIps;
+
+    /// <summary>
     /// Custom retry policy for transient errors.
     /// </summary>
     public IRetryPolicy? RetryPolicy { get; init; }

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -86,6 +86,8 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithClientDnsLookup(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly))
+            .Throws<InvalidOperationException>();
 
         await Assert.That(() => client.CreateConsumer<string, string>().UseTls())
             .Throws<InvalidOperationException>();
@@ -103,6 +105,8 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithClientDnsLookup(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly))
+            .Throws<InvalidOperationException>();
 
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithTls())
             .Throws<InvalidOperationException>();
@@ -115,6 +119,8 @@ public sealed class KafkaClientBuilderTests
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithClientDnsLookup(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly))
             .Throws<InvalidOperationException>();
 
         await Assert.That(() => client.CreateAdminClient().UseTls())
@@ -131,6 +137,8 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateAdminClient().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithClientDnsLookup(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly))
+            .Throws<InvalidOperationException>();
     }
 
     [Test]
@@ -139,6 +147,7 @@ public sealed class KafkaClientBuilderTests
         await using var client = Kafka.Connect("localhost:9092", builder => builder
             .WithReconnectBackoff(TimeSpan.FromMilliseconds(123))
             .WithReconnectBackoffMax(TimeSpan.FromMilliseconds(456)));
+
         await using var producer = client.CreateProducer<string, string>().Build();
 
         var pool = GetField<ConnectionPool>(producer, "_connectionPool");
@@ -152,11 +161,25 @@ public sealed class KafkaClientBuilderTests
     {
         await using var client = Kafka.Connect("localhost:9092", builder => builder
             .WithConnectionsMaxIdle(TimeSpan.FromMilliseconds(1234)));
+
         await using var producer = client.CreateProducer<string, string>().Build();
 
         var pool = GetField<ConnectionPool>(producer, "_connectionPool");
 
         await Assert.That(pool.EffectiveConnectionOptions.ConnectionsMaxIdleMs).IsEqualTo(1234);
+    }
+
+    [Test]
+    public async Task RootClient_WithClientDnsLookup_ConfiguresSharedConnectionPool()
+    {
+        await using var client = Kafka.Connect("localhost:9092", builder => builder
+            .WithClientDnsLookup(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly));
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var pool = GetField<ConnectionPool>(producer, "_connectionPool");
+
+        await Assert.That(pool.EffectiveConnectionOptions.ClientDnsLookup)
+            .IsEqualTo(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -5,6 +5,7 @@ using Dekaf.Consumer;
 using Dekaf.Consumer.DeadLetter;
 using Dekaf.Extensions.DependencyInjection;
 using Dekaf.Metadata;
+using Dekaf.Networking;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
 using Dekaf.Producer;
@@ -362,7 +363,8 @@ public class DependencyInjectionTests
             ["Kafka:Producers:Orders:ArenaCapacity"] = "131072",
             ["Kafka:Producers:Orders:InitialBatchRecordCapacity"] = "32",
             ["Kafka:Producers:Orders:MetadataRecoveryStrategy"] = "None",
-            ["Kafka:Producers:Orders:MetadataRecoveryRebootstrapTriggerMs"] = "60000"
+            ["Kafka:Producers:Orders:MetadataRecoveryRebootstrapTriggerMs"] = "60000",
+            ["Kafka:Producers:Orders:ClientDnsLookup"] = "ResolveCanonicalBootstrapServersOnly"
         });
 
         services.AddDekaf(builder =>
@@ -409,6 +411,7 @@ public class DependencyInjectionTests
         await Assert.That(options.InitialBatchRecordCapacity).IsEqualTo(32);
         await Assert.That(options.MetadataRecoveryStrategy).IsEqualTo(MetadataRecoveryStrategy.None);
         await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(60000);
+        await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly);
     }
 
     [Test]
@@ -481,6 +484,7 @@ public class DependencyInjectionTests
             ["Kafka:Consumers:Orders:QueuedMaxMessagesKbytes"] = "32768",
             ["Kafka:Consumers:Orders:MetadataRecoveryStrategy"] = "None",
             ["Kafka:Consumers:Orders:MetadataRecoveryRebootstrapTriggerMs"] = "90000",
+            ["Kafka:Consumers:Orders:ClientDnsLookup"] = "ResolveCanonicalBootstrapServersOnly",
             ["Kafka:Consumers:Orders:PrefetchPipelineDepth"] = "4",
             ["Kafka:Consumers:Orders:ConnectionsPerBroker"] = "2",
             ["Kafka:Consumers:Orders:EnableAdaptiveConnections"] = "false",
@@ -537,6 +541,7 @@ public class DependencyInjectionTests
         await Assert.That(options.IsAutoTuned).IsFalse();
         await Assert.That(options.MetadataRecoveryStrategy).IsEqualTo(MetadataRecoveryStrategy.None);
         await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(90000);
+        await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly);
         await Assert.That(options.PrefetchPipelineDepth).IsEqualTo(4);
         await Assert.That(options.ConnectionsPerBroker).IsEqualTo(2);
         await Assert.That(options.EnableAdaptiveConnections).IsFalse();
@@ -629,7 +634,8 @@ public class DependencyInjectionTests
             ["Kafka:Admin:SaslUsername"] = "admin",
             ["Kafka:Admin:SaslPassword"] = "secret",
             ["Kafka:Admin:MetadataRecoveryStrategy"] = "None",
-            ["Kafka:Admin:MetadataRecoveryRebootstrapTriggerMs"] = "120000"
+            ["Kafka:Admin:MetadataRecoveryRebootstrapTriggerMs"] = "120000",
+            ["Kafka:Admin:ClientDnsLookup"] = "ResolveCanonicalBootstrapServersOnly"
         });
 
         services.AddDekaf(builder =>
@@ -653,6 +659,7 @@ public class DependencyInjectionTests
         await Assert.That(options.SaslPassword).IsEqualTo("secret");
         await Assert.That(options.MetadataRecoveryStrategy).IsEqualTo(MetadataRecoveryStrategy.None);
         await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(120000);
+        await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly);
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataRecoveryStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataRecoveryStrategyTests.cs
@@ -63,6 +63,17 @@ public sealed class MetadataRecoveryStrategyTests
     }
 
     [Test]
+    public async Task ProducerOptions_ClientDnsLookup_DefaultsToUseAllDnsIps()
+    {
+        var options = new Dekaf.Producer.ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"]
+        };
+
+        await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.UseAllDnsIps);
+    }
+
+    [Test]
     public async Task ProducerOptions_MetadataRecoveryStrategy_CanBeSetToNone()
     {
         var options = new Dekaf.Producer.ProducerOptions
@@ -110,6 +121,17 @@ public sealed class MetadataRecoveryStrategyTests
         };
 
         await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(300000);
+    }
+
+    [Test]
+    public async Task ConsumerOptions_ClientDnsLookup_DefaultsToUseAllDnsIps()
+    {
+        var options = new Dekaf.Consumer.ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"]
+        };
+
+        await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.UseAllDnsIps);
     }
 
     [Test]
@@ -195,6 +217,17 @@ public sealed class MetadataRecoveryStrategyTests
         await Assert.That(options.ConnectionsMaxIdleMs).IsEqualTo(ConnectionOptions.DefaultConnectionsMaxIdleMs);
     }
 
+    [Test]
+    public async Task AdminClientOptions_ClientDnsLookup_DefaultsToUseAllDnsIps()
+    {
+        var options = new Dekaf.Admin.AdminClientOptions
+        {
+            BootstrapServers = ["localhost:9092"]
+        };
+
+        await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.UseAllDnsIps);
+    }
+
     #endregion
 
     #region MetadataOptions Defaults
@@ -213,6 +246,14 @@ public sealed class MetadataRecoveryStrategyTests
         var options = new MetadataOptions();
 
         await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(300000);
+    }
+
+    [Test]
+    public async Task MetadataOptions_ClientDnsLookup_DefaultsToUseAllDnsIps()
+    {
+        var options = new MetadataOptions();
+
+        await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.UseAllDnsIps);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/ClientDnsLookupTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ClientDnsLookupTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Net.Sockets;
+using Dekaf.Networking;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public sealed class ClientDnsLookupTests
+{
+    [Test]
+    public async Task ResolveAsync_UseAllDnsIps_ReturnsAllAddresses()
+    {
+        var resolver = new ClientDnsEndpointResolver(new StubDnsLookup(
+            addresses: [IPAddress.Parse("192.0.2.10"), IPAddress.Parse("192.0.2.11")]));
+
+        var endpoints = await resolver.ResolveAsync(
+            "broker.example",
+            9092,
+            ClientDnsLookup.UseAllDnsIps,
+            CancellationToken.None);
+
+        await Assert.That(endpoints.Select(endpoint => endpoint.Address.ToString()).ToArray())
+            .IsEquivalentTo(["192.0.2.10", "192.0.2.11"]);
+        await Assert.That(endpoints.All(endpoint => endpoint.TargetHost == "broker.example")).IsTrue();
+    }
+
+    [Test]
+    public async Task ResolveAsync_SuccessfulAddress_IsTriedFirstNextTime()
+    {
+        var secondAddress = IPAddress.Parse("192.0.2.11");
+        var resolver = new ClientDnsEndpointResolver(new StubDnsLookup(
+            addresses: [IPAddress.Parse("192.0.2.10"), secondAddress]));
+
+        resolver.MarkSuccessful("broker.example", 9092, ClientDnsLookup.UseAllDnsIps, secondAddress);
+
+        var endpoints = await resolver.ResolveAsync(
+            "broker.example",
+            9092,
+            ClientDnsLookup.UseAllDnsIps,
+            CancellationToken.None);
+
+        await Assert.That(endpoints[0].Address).IsEqualTo(secondAddress);
+    }
+
+    [Test]
+    public async Task ResolveAsync_CanonicalMode_UsesCanonicalTargetHost()
+    {
+        var resolver = new ClientDnsEndpointResolver(new StubDnsLookup(
+            hostEntry: new IPHostEntry
+            {
+                HostName = "canonical.example",
+                AddressList = [IPAddress.Parse("192.0.2.10")]
+            }));
+
+        var endpoints = await resolver.ResolveAsync(
+            "alias.example",
+            9092,
+            ClientDnsLookup.ResolveCanonicalBootstrapServersOnly,
+            CancellationToken.None);
+
+        await Assert.That(endpoints.Single().TargetHost).IsEqualTo("canonical.example");
+    }
+
+    [Test]
+    public async Task KafkaConnection_ConnectAsync_TriesAllResolvedAddresses()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var acceptTask = listener.AcceptSocketAsync();
+        var resolver = new ClientDnsEndpointResolver(new StubDnsLookup(
+            addresses: [IPAddress.Parse("127.0.0.2"), IPAddress.Loopback]));
+
+        await using var connection = new KafkaConnection(
+            "multi.example",
+            port,
+            options: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromSeconds(5),
+                DnsResolver = resolver
+            });
+
+        await connection.ConnectAsync();
+        using var accepted = await acceptTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var endpoints = await resolver.ResolveAsync(
+            "multi.example",
+            port,
+            ClientDnsLookup.UseAllDnsIps,
+            CancellationToken.None);
+
+        await Assert.That(connection.IsConnected).IsTrue();
+        await Assert.That(endpoints[0].Address).IsEqualTo(IPAddress.Loopback);
+    }
+
+    private sealed class StubDnsLookup : IDnsLookup
+    {
+        private readonly IPAddress[] _addresses;
+        private readonly IPHostEntry _hostEntry;
+
+        public StubDnsLookup(IPAddress[]? addresses = null, IPHostEntry? hostEntry = null)
+        {
+            _addresses = addresses ?? hostEntry?.AddressList ?? [];
+            _hostEntry = hostEntry ?? new IPHostEntry
+            {
+                HostName = "broker.example",
+                AddressList = _addresses
+            };
+        }
+
+        public ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(_addresses);
+        }
+
+        public ValueTask<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(_hostEntry);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerOptionsDefaultsTests.cs
@@ -31,4 +31,11 @@ public sealed class ShareConsumerOptionsDefaultsTests
         var options = CreateOptions();
         await Assert.That(options.ConnectionsMaxIdleMs).IsEqualTo(ConnectionOptions.DefaultConnectionsMaxIdleMs);
     }
+
+    [Test]
+    public async Task ClientDnsLookup_DefaultsTo_UseAllDnsIps()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.UseAllDnsIps);
+    }
 }


### PR DESCRIPTION
Closes #1154

## Summary
- add `ClientDnsLookup` and a DNS resolver that tries all A/AAAA records with last-good prioritization
- thread DNS lookup mode through root, producer, consumer, share consumer, admin, DI config, metadata, and connection pool options
- document client DNS lookup modes

## Tests
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release`
- focused unit filters for `ClientDnsLookupTests`, `KafkaClientBuilderTests/*ClientDnsLookup*`, DI configuration binding, metadata defaults, and share consumer defaults
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-progress --disable-logo`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj -c Release /p:RunAnalyzers=false`