### PR TITLE
feat(networking): reap idle connections

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -96,6 +96,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithQueuedMinMessages(...)` | `QueuedMinMessages` | Integer |
 | `WithQueuedMaxMessagesKbytes(...)` | `QueuedMaxMessagesKbytes` | KiB; omit to keep auto-tuning |
 | `WithPrefetchPipelineDepth(...)` | `PrefetchPipelineDepth` | Integer |
+| `WithConnectionsMaxIdle(...)` | `ConnectionsMaxIdleMs` | Milliseconds; `-1` disables |
 | `WithConnectionsPerBroker(...)` | `ConnectionsPerBroker` | Integer |
 | `WithAdaptiveConnections(...)` | `EnableAdaptiveConnections`, `MaxConnectionsPerBroker` | Set `EnableAdaptiveConnections` to `false` to disable |
 | `WithAdaptiveFetchSizing(...)` | `EnableAdaptiveFetchSizing`, `AdaptiveFetchSizingOptions` | Bind nested adaptive sizing fields |
@@ -248,6 +249,19 @@ Get notified of partition changes:
 .WithRebalanceListener(new MyRebalanceListener())
 ```
 
+## Networking
+
+### WithConnectionsMaxIdle
+
+Maximum time an unused broker connection stays open before the client closes it:
+
+```csharp
+.WithConnectionsMaxIdle(TimeSpan.FromMinutes(9)) // Default: 540000ms
+.WithConnectionsMaxIdle(Timeout.InfiniteTimeSpan) // Disable idle reaping
+```
+
+The default is 9 minutes, slightly below Kafka's broker-side `connections.max.idle.ms` default of 10 minutes. Connections with in-flight requests are not reaped.
+
 ## Security
 
 ### UseTls
@@ -339,6 +353,7 @@ For transactional reads:
 | `WithQueuedMinMessages` | 100000 | Prefetch target count |
 | `WithQueuedMaxMessagesKbytes` | auto-tuned | Prefetch memory limit |
 | `WithPrefetchPipelineDepth` | 3 | Overlapping prefetch operations |
+| `WithConnectionsMaxIdle` | 540000ms | Close unused broker connections; `Timeout.InfiniteTimeSpan` disables |
 | `WithConnectionsPerBroker` | 2 | TCP connections per broker |
 | `WithAdaptiveConnections` | enabled (max 4) | Auto-scale connections under load |
 | `UseTls` | false | Enable TLS |

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -78,6 +78,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithDeliveryTimeout(...)` | `DeliveryTimeoutMs` | Milliseconds |
 | `WithRequestTimeout(...)` | `RequestTimeoutMs` | Milliseconds |
 | `WithIdempotence(...)` | `EnableIdempotence` | Boolean |
+| `WithConnectionsMaxIdle(...)` | `ConnectionsMaxIdleMs` | Milliseconds; `-1` disables |
 | `WithConnectionsPerBroker(...)` | `ConnectionsPerBroker` | Integer |
 | `WithAdaptiveConnections(...)` | `EnableAdaptiveConnections`, `MaxConnectionsPerBroker` | Set `EnableAdaptiveConnections` to `false` to disable |
 | `WithTransactionalId(...)` | `TransactionalId` | String |
@@ -257,6 +258,17 @@ Number of TCP connections to each broker:
 
 Default: 1. Must be 1 for idempotent producers (partition affinity requires a fixed connection).
 
+### WithConnectionsMaxIdle
+
+Maximum time an unused broker connection stays open before the client closes it:
+
+```csharp
+.WithConnectionsMaxIdle(TimeSpan.FromMinutes(9)) // Default: 540000ms
+.WithConnectionsMaxIdle(Timeout.InfiniteTimeSpan) // Disable idle reaping
+```
+
+The default is 9 minutes, slightly below Kafka's broker-side `connections.max.idle.ms` default of 10 minutes. This lets Dekaf close unused connections first and avoid a request racing a broker idle close.
+
 ### WithAdaptiveConnections
 
 Configure adaptive connection scaling. When sustained buffer backpressure is detected, the producer automatically adds connections per broker to increase drain throughput:
@@ -329,6 +341,7 @@ Enable logging:
 | `WithCompressionLevel` | null | Codec-specific compression level |
 | `WithPartitioner` | Default | Partition strategy |
 | `WithConnectionsPerBroker` | 1 | TCP connections per broker |
+| `WithConnectionsMaxIdle` | 540000ms | Close unused broker connections; `Timeout.InfiniteTimeSpan` disables |
 | `WithAdaptiveConnections` | enabled (max 10) | Auto-scale connections under load |
 | `WithoutAdaptiveConnections` | - | Disable adaptive scaling |
 | `WithBufferMemory` | auto-tuned | Max buffer for unsent messages |

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -47,6 +47,7 @@ public sealed class AdminClient : IAdminClient
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
                 ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
+                ConnectionsMaxIdleMs = options.ConnectionsMaxIdleMs,
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,
@@ -2478,6 +2479,14 @@ public sealed class AdminClientOptions
     public int RequestTimeoutMs { get; init; } = 30000;
     public int ReconnectBackoffMs { get; init; } = 50;
     public int ReconnectBackoffMaxMs { get; init; } = 1000;
+
+    /// <summary>
+    /// Maximum idle time in milliseconds before unused broker connections are closed.
+    /// Default is 9 minutes, below Kafka's default broker-side 10 minute idle timeout.
+    /// Set to -1 to disable client-side idle connection reaping.
+    /// </summary>
+    public int ConnectionsMaxIdleMs { get; init; } = ConnectionOptions.DefaultConnectionsMaxIdleMs;
+
     public bool UseTls { get; init; }
     public TlsConfig? TlsConfig { get; init; }
     public SaslMechanism SaslMechanism { get; init; } = SaslMechanism.None;
@@ -2547,6 +2556,7 @@ public sealed class AdminClientBuilder
     private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
+    private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private ILoggerFactory? _loggerFactory;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
@@ -2840,6 +2850,18 @@ public sealed class AdminClientBuilder
         return this;
     }
 
+    /// <summary>
+    /// Sets the maximum idle time before unused broker connections are closed.
+    /// Equivalent to Kafka's <c>connections.max.idle.ms</c>. Use <see cref="Timeout.InfiniteTimeSpan"/> to disable.
+    /// </summary>
+    /// <param name="idle">The maximum idle time. Must be non-negative, or <see cref="Timeout.InfiniteTimeSpan"/>.</param>
+    public AdminClientBuilder WithConnectionsMaxIdle(TimeSpan idle)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _connectionsMaxIdleMs = ConnectionOptions.ToConnectionsMaxIdleMs(idle, nameof(idle));
+        return this;
+    }
+
     internal AdminClientBuilder WithSaslOptions(
         SaslMechanism mechanism,
         string? username,
@@ -2872,6 +2894,7 @@ public sealed class AdminClientBuilder
             RequestTimeoutMs = _requestTimeoutMs,
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
+            ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
             SaslMechanism = _saslMechanism,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography.X509Certificates;
 using Dekaf.Consumer;
 using Dekaf.Internal;
 using Dekaf.Metadata;
+using Dekaf.Networking;
 using Dekaf.Producer;
 using Dekaf.Retry;
 using Dekaf.Security;
@@ -67,6 +68,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private int? _requestTimeoutMs;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
+    private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private IRetryPolicy? _retryPolicy;
     private bool _enableAdaptiveConnections = true;
     private int _maxConnectionsPerBroker = 10;
@@ -701,6 +703,18 @@ public sealed class ProducerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Sets the maximum idle time before unused broker connections are closed.
+    /// Equivalent to Kafka's <c>connections.max.idle.ms</c>. Use <see cref="Timeout.InfiniteTimeSpan"/> to disable.
+    /// </summary>
+    /// <param name="idle">The maximum idle time. Must be non-negative, or <see cref="Timeout.InfiniteTimeSpan"/>.</param>
+    public ProducerBuilder<TKey, TValue> WithConnectionsMaxIdle(TimeSpan idle)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _connectionsMaxIdleMs = ConnectionOptions.ToConnectionsMaxIdleMs(idle, nameof(idle));
+        return this;
+    }
+
+    /// <summary>
     /// Sets the application-level retry policy for produce operations.
     /// When set, retriable exceptions from <see cref="IKafkaProducer{TKey,TValue}.ProduceAsync"/>
     /// will be retried according to this policy.
@@ -934,6 +948,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             RequestTimeoutMs = _requestTimeoutMs ?? 30000,
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
+            ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             EnableIdempotence = _enableIdempotence,
             ConnectionsPerBroker = _connectionsPerBroker,
             TransactionalId = _transactionalId,
@@ -1111,6 +1126,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _maxConnectionsPerBroker = 4;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
+    private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private bool _enableAdaptiveFetchSizing;
     private AdaptiveFetchSizingOptions? _adaptiveFetchSizingOptions;
     private bool _enableFetchSessions = true;
@@ -1748,6 +1764,18 @@ public sealed class ConsumerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Sets the maximum idle time before unused broker connections are closed.
+    /// Equivalent to Kafka's <c>connections.max.idle.ms</c>. Use <see cref="Timeout.InfiniteTimeSpan"/> to disable.
+    /// </summary>
+    /// <param name="idle">The maximum idle time. Must be non-negative, or <see cref="Timeout.InfiniteTimeSpan"/>.</param>
+    public ConsumerBuilder<TKey, TValue> WithConnectionsMaxIdle(TimeSpan idle)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _connectionsMaxIdleMs = ConnectionOptions.ToConnectionsMaxIdleMs(idle, nameof(idle));
+        return this;
+    }
+
+    /// <summary>
     /// Configures the consumer for high throughput scenarios.
     /// </summary>
     /// <remarks>
@@ -2014,6 +2042,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             RequestTimeoutMs = _requestTimeoutMs,
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
+            ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             CheckCrcs = _checkCrcs,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
@@ -2152,6 +2181,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private int _connectionsPerBroker = 2;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
+    private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private IRetryPolicy? _retryPolicy;
     private readonly List<string> _topicsToSubscribe = [];
 
@@ -2274,6 +2304,18 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             backoff,
             nameof(backoff),
             "Maximum reconnect backoff cannot be negative");
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum idle time before unused broker connections are closed.
+    /// Equivalent to Kafka's <c>connections.max.idle.ms</c>. Use <see cref="Timeout.InfiniteTimeSpan"/> to disable.
+    /// </summary>
+    /// <param name="idle">The maximum idle time. Must be non-negative, or <see cref="Timeout.InfiniteTimeSpan"/>.</param>
+    public ShareConsumerBuilder<TKey, TValue> WithConnectionsMaxIdle(TimeSpan idle)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _connectionsMaxIdleMs = ConnectionOptions.ToConnectionsMaxIdleMs(idle, nameof(idle));
         return this;
     }
 
@@ -2468,6 +2510,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             RequestTimeoutMs = _requestTimeoutMs,
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
+            ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
             SaslMechanism = _saslMechanism,

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -1,4 +1,5 @@
 using Dekaf.Metadata;
+using Dekaf.Networking;
 using Dekaf.Protocol.Messages;
 using Dekaf.Retry;
 using Dekaf.Security;
@@ -150,6 +151,13 @@ public sealed class ConsumerOptions
     /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
     /// </summary>
     public int ReconnectBackoffMaxMs { get; init; } = 1000;
+
+    /// <summary>
+    /// Maximum idle time in milliseconds before unused broker connections are closed.
+    /// Default is 9 minutes, below Kafka's default broker-side 10 minute idle timeout.
+    /// Set to -1 to disable client-side idle connection reaping.
+    /// </summary>
+    public int ConnectionsMaxIdleMs { get; init; } = ConnectionOptions.DefaultConnectionsMaxIdleMs;
 
     /// <summary>
     /// Check CRCs.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -788,6 +788,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
                 ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
+                ConnectionsMaxIdleMs = options.ConnectionsMaxIdleMs,
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -95,6 +95,7 @@ public sealed class KafkaClientBuilder
     private int _connectionsPerBroker = 1;
     private int _maxInFlightRequestsPerConnection = 5;
     private int _maxConnectionsPerBroker = 10;
+    private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan? _metadataMaxAge;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
@@ -272,6 +273,17 @@ public sealed class KafkaClientBuilder
         return this;
     }
 
+    /// <summary>
+    /// Sets the maximum idle time before unused broker connections are closed.
+    /// Equivalent to Kafka's <c>connections.max.idle.ms</c>. Use <see cref="Timeout.InfiniteTimeSpan"/> to disable.
+    /// </summary>
+    /// <param name="idle">The maximum idle time. Must be non-negative, or <see cref="Timeout.InfiniteTimeSpan"/>.</param>
+    public KafkaClientBuilder WithConnectionsMaxIdle(TimeSpan idle)
+    {
+        _connectionsMaxIdleMs = ConnectionOptions.ToConnectionsMaxIdleMs(idle, nameof(idle));
+        return this;
+    }
+
     public KafkaClientBuilder WithMetadataMaxAge(TimeSpan interval)
     {
         if (interval <= TimeSpan.Zero)
@@ -338,6 +350,7 @@ public sealed class KafkaClientBuilder
             ConnectionsPerBroker = _connectionsPerBroker,
             MaxInFlightRequestsPerConnection = _maxInFlightRequestsPerConnection,
             MaxConnectionsPerBroker = _maxConnectionsPerBroker,
+            ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             MetadataMaxAge = _metadataMaxAge,
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
@@ -368,6 +381,7 @@ internal sealed class KafkaClientOptions
     public int ConnectionsPerBroker { get; init; }
     public int MaxInFlightRequestsPerConnection { get; init; }
     public int MaxConnectionsPerBroker { get; init; }
+    public int ConnectionsMaxIdleMs { get; init; }
     public TimeSpan? MetadataMaxAge { get; init; }
     public MetadataRecoveryStrategy MetadataRecoveryStrategy { get; init; }
     public int MetadataRecoveryRebootstrapTriggerMs { get; init; }
@@ -425,6 +439,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
                 ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
+                ConnectionsMaxIdleMs = options.ConnectionsMaxIdleMs,
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -20,6 +20,8 @@ public sealed partial class ConnectionPool : IConnectionPool
     private readonly ResponseBufferPool _responseBufferPool;
     private readonly ClientTelemetryMetricCollector? _telemetryMetricCollector;
     private readonly OAuthBearerTokenProvider? _sharedOAuthBearerTokenProvider;
+    private CancellationTokenSource? _idleReaperCts;
+    private Task? _idleReaperTask;
 
     /// <summary>
     /// Shared memory pool for all connections. Bounds total retained memory to one set of
@@ -110,6 +112,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         var bucketCapacity = pipeMemoryBucketCapacity ?? ScaledBucketCapacity(_connectionsPerBroker);
         _sharedPipeMemoryPool = new PipeMemoryPool(maxArraysPerBucket: bucketCapacity);
         _currentPipeMemoryBucketCapacity = bucketCapacity;
+        StartIdleConnectionReaper();
     }
 
     /// <summary>
@@ -133,6 +136,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         _responseBufferPool = ResponseBufferPool.Default;
         _connectionFactory = connectionFactory;
         // No shared pool needed: factory-created connections manage their own pools.
+        StartIdleConnectionReaper();
     }
 
     /// <summary>
@@ -186,6 +190,7 @@ public sealed partial class ConnectionPool : IConnectionPool
             RequestTimeout = options.RequestTimeout,
             ReconnectBackoff = options.ReconnectBackoff,
             ReconnectBackoffMax = options.ReconnectBackoffMax,
+            ConnectionsMaxIdleMs = options.ConnectionsMaxIdleMs,
             MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection
         };
     }
@@ -256,7 +261,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         if (_connectionsById.TryGetValue(brokerId, out var existing) && existing.IsConnected)
         {
             LogConnectionAcquired(brokerId);
-            return existing;
+            return MarkConnectionAcquired(existing);
         }
 
         // Get broker info
@@ -265,8 +270,9 @@ public sealed partial class ConnectionPool : IConnectionPool
             throw new InvalidOperationException($"Unknown broker ID: {brokerId}");
         }
 
-        return await GetOrCreateConnectionAsync(brokerId, brokerInfo.Host, brokerInfo.Port, cancellationToken)
+        var connection = await GetOrCreateConnectionAsync(brokerId, brokerInfo.Host, brokerInfo.Port, cancellationToken)
             .ConfigureAwait(false);
+        return MarkConnectionAcquired(connection);
     }
 
     private async ValueTask<IKafkaConnection> GetConnectionFromGroupAsync(int brokerId, CancellationToken cancellationToken)
@@ -286,16 +292,18 @@ public sealed partial class ConnectionPool : IConnectionPool
 
             if (connection is not null && connection.IsConnected)
             {
-                return connection;
+                return MarkConnectionAcquired(connection);
             }
 
             // Connection at this index is invalid, try to replace it
             LogConnectionReplacement(brokerId, (int)index);
-            return await ReplaceConnectionInGroupAsync(brokerId, brokerInfo, (int)index, cancellationToken).ConfigureAwait(false);
+            var replacement = await ReplaceConnectionInGroupAsync(brokerId, brokerInfo, (int)index, cancellationToken).ConfigureAwait(false);
+            return MarkConnectionAcquired(replacement);
         }
 
         // Need to create new connection group
-        return await CreateConnectionGroupAsync(brokerId, brokerInfo, cancellationToken).ConfigureAwait(false);
+        var created = await CreateConnectionGroupAsync(brokerId, brokerInfo, cancellationToken).ConfigureAwait(false);
+        return MarkConnectionAcquired(created);
     }
 
     public async ValueTask<IKafkaConnection> GetConnectionByIndexAsync(int brokerId, int index, CancellationToken cancellationToken = default)
@@ -331,10 +339,11 @@ public sealed partial class ConnectionPool : IConnectionPool
 
         if (connection is not null && connection.IsConnected)
         {
-            return connection;
+            return MarkConnectionAcquired(connection);
         }
 
-        return await ReplaceConnectionInGroupAsync(brokerId, brokerInfo, effectiveIndex, cancellationToken).ConfigureAwait(false);
+        var replacement = await ReplaceConnectionInGroupAsync(brokerId, brokerInfo, effectiveIndex, cancellationToken).ConfigureAwait(false);
+        return MarkConnectionAcquired(replacement);
     }
 
     private async ValueTask<IKafkaConnection> CreateConnectionGroupAsync(int brokerId, BrokerInfo brokerInfo, CancellationToken cancellationToken)
@@ -732,10 +741,11 @@ public sealed partial class ConnectionPool : IConnectionPool
         // Try to get existing connection
         if (_connectionsByEndpoint.TryGetValue(endpoint, out var existing) && existing.IsConnected)
         {
-            return existing;
+            return MarkConnectionAcquired(existing);
         }
 
-        return await GetOrCreateConnectionAsync(-1, host, port, cancellationToken).ConfigureAwait(false);
+        var connection = await GetOrCreateConnectionAsync(-1, host, port, cancellationToken).ConfigureAwait(false);
+        return MarkConnectionAcquired(connection);
     }
 
     private async ValueTask<IKafkaConnection> GetOrCreateConnectionAsync(
@@ -852,6 +862,19 @@ public sealed partial class ConnectionPool : IConnectionPool
 
         try
         {
+            if (_connectionFactory is not null)
+            {
+                var factoryConnection = await _connectionFactory(brokerId, host, port, 0, cancellationToken).ConfigureAwait(false);
+                _connectionsByEndpoint[endpoint] = factoryConnection;
+                if (brokerId >= 0)
+                {
+                    _connectionsById[brokerId] = factoryConnection;
+                }
+
+                LogCreatedConnection(brokerId, host, port);
+                return factoryConnection;
+            }
+
             var connection = new KafkaConnection(
                 brokerId, host, port,
                 _clientId, _connectionOptions,
@@ -991,6 +1014,206 @@ public sealed partial class ConnectionPool : IConnectionPool
         return (long)(delay.TotalSeconds * Stopwatch.Frequency);
     }
 
+    internal async ValueTask<int> ReapIdleConnectionsAsync()
+    {
+        if (_connectionOptions.ConnectionsMaxIdleMs < 0 || Volatile.Read(ref _disposed) != 0)
+            return 0;
+
+        await _disposeLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+                return 0;
+
+            var now = Environment.TickCount64;
+            var reaped = 0;
+
+            foreach (var (endpoint, connection) in _connectionsByEndpoint.ToArray())
+            {
+                if (await TryReapEndpointConnectionAsync(endpoint, connection, now).ConfigureAwait(false))
+                    reaped++;
+            }
+
+            foreach (var (_, group) in _connectionGroupsById.ToArray())
+            {
+                var connectedCount = CountConnected(group);
+                for (var i = 0; i < group.Length; i++)
+                {
+                    var connection = group[i];
+                    if (connection is not null
+                        && await TryReapGroupConnectionAsync(group, i, connection, connectedCount, now).ConfigureAwait(false))
+                    {
+                        connectedCount--;
+                        reaped++;
+                    }
+                }
+            }
+
+            return reaped;
+        }
+        finally
+        {
+            _disposeLock.Release();
+        }
+    }
+
+    private async ValueTask<bool> TryReapEndpointConnectionAsync(EndpointKey endpoint, IKafkaConnection connection, long now)
+    {
+        if (!IsIdleReapable(connection, now))
+            return false;
+
+        if (!TryRemoveExact(_connectionsByEndpoint, endpoint, connection))
+            return false;
+
+        var removedByBrokerId = connection.BrokerId >= 0
+            && TryRemoveExact(_connectionsById, connection.BrokerId, connection);
+
+        var disposed = await DisposeIdleConnectionAsync(connection, now).ConfigureAwait(false);
+        if (!disposed)
+        {
+            if (connection.IsConnected)
+            {
+                _connectionsByEndpoint.TryAdd(endpoint, connection);
+                if (removedByBrokerId)
+                {
+                    _connectionsById.TryAdd(connection.BrokerId, connection);
+                }
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private async ValueTask<bool> TryReapGroupConnectionAsync(
+        IKafkaConnection[] group,
+        int index,
+        IKafkaConnection connection,
+        int connectedCount,
+        long now)
+    {
+        if (!IsIdleReapable(connection, now))
+            return false;
+
+        if (connectedCount <= 1 && HasPendingRequests(group))
+            return false;
+
+        if (Interlocked.CompareExchange(ref group[index], null!, connection) != connection)
+            return false;
+
+        var disposed = await DisposeIdleConnectionAsync(connection, now).ConfigureAwait(false);
+        if (!disposed && connection.IsConnected)
+            Interlocked.CompareExchange(ref group[index], connection, null!);
+
+        return disposed;
+    }
+
+    private bool IsIdleReapable(IKafkaConnection connection, long now)
+    {
+        if (!connection.IsConnected || connection is not IIdleTrackedKafkaConnection idleState)
+            return false;
+
+        if (idleState.PendingRequestCount != 0)
+            return false;
+
+        return now - idleState.LastUsedTimestampMs >= _connectionOptions.ConnectionsMaxIdleMs;
+    }
+
+    private async ValueTask<bool> DisposeIdleConnectionAsync(IKafkaConnection connection, long now)
+    {
+        if (!IsIdleReapable(connection, now))
+            return false;
+
+        try
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+            if (connection is IIdleTrackedKafkaConnection idleState)
+            {
+                LogReapedIdleConnection(
+                    connection.BrokerId,
+                    connection.Host,
+                    connection.Port,
+                    now - idleState.LastUsedTimestampMs);
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            LogIdleConnectionDisposalFailed(ex, connection.BrokerId, connection.Host, connection.Port);
+            return false;
+        }
+    }
+
+    private static int CountConnected(IKafkaConnection[] group)
+    {
+        var count = 0;
+        foreach (var connection in group)
+        {
+            if (connection is not null && connection.IsConnected)
+                count++;
+        }
+
+        return count;
+    }
+
+    private static bool HasPendingRequests(IKafkaConnection[] group)
+    {
+        foreach (var connection in group)
+        {
+            if (connection is IIdleTrackedKafkaConnection { PendingRequestCount: > 0 })
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryRemoveExact<TKey, TValue>(
+        ConcurrentDictionary<TKey, TValue> dictionary,
+        TKey key,
+        TValue value)
+        where TKey : notnull
+        => ((ICollection<KeyValuePair<TKey, TValue>>)dictionary).Remove(new KeyValuePair<TKey, TValue>(key, value));
+
+    private static IKafkaConnection MarkConnectionAcquired(IKafkaConnection connection)
+    {
+        if (connection is IIdleTrackedKafkaConnection idleState)
+            idleState.Touch();
+
+        return connection;
+    }
+
+    private void StartIdleConnectionReaper()
+    {
+        if (_connectionOptions.ConnectionsMaxIdleMs < 0)
+            return;
+
+        _idleReaperCts = new CancellationTokenSource();
+        _idleReaperTask = RunIdleConnectionReaperAsync(_idleReaperCts.Token);
+    }
+
+    private async Task RunIdleConnectionReaperAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var timer = new PeriodicTimer(GetIdleReaperInterval(_connectionOptions.ConnectionsMaxIdleMs));
+            while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+            {
+                await ReapIdleConnectionsAsync().ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            LogIdleConnectionReaperFailed(ex);
+        }
+    }
+
+    private static TimeSpan GetIdleReaperInterval(int connectionsMaxIdleMs)
+        => TimeSpan.FromMilliseconds(Math.Clamp(connectionsMaxIdleMs / 2, 1000, 60000));
+
     public async ValueTask RemoveConnectionAsync(int brokerId)
     {
         if (_connectionsById.TryRemove(brokerId, out var connection))
@@ -1113,6 +1336,11 @@ public sealed partial class ConnectionPool : IConnectionPool
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
+        _idleReaperCts?.Cancel();
+        if (_idleReaperTask is not null)
+            await _idleReaperTask.ConfigureAwait(false);
+        _idleReaperCts?.Dispose();
+
         await CloseAllAsync().ConfigureAwait(false);
 
         // Dispose the shared memory pool only when the pool itself is disposed.
@@ -1183,6 +1411,15 @@ public sealed partial class ConnectionPool : IConnectionPool
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Reset reconnect backoff for broker {BrokerId} at {Host}:{Port}")]
     private partial void LogReconnectBackoffReset(int brokerId, string host, int port);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Reaped idle connection to broker {BrokerId} at {Host}:{Port} after {IdleMs}ms")]
+    private partial void LogReapedIdleConnection(int brokerId, string host, int port, long idleMs);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Idle connection reaper failed")]
+    private partial void LogIdleConnectionReaperFailed(Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to dispose idle connection to broker {BrokerId} at {Host}:{Port}")]
+    private partial void LogIdleConnectionDisposalFailed(Exception ex, int brokerId, string host, int port);
 
     #endregion
 

--- a/src/Dekaf/Networking/IIdleTrackedKafkaConnection.cs
+++ b/src/Dekaf/Networking/IIdleTrackedKafkaConnection.cs
@@ -1,0 +1,10 @@
+namespace Dekaf.Networking;
+
+internal interface IIdleTrackedKafkaConnection
+{
+    long LastUsedTimestampMs { get; }
+
+    int PendingRequestCount { get; }
+
+    void Touch();
+}

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -130,7 +130,7 @@ internal static class ConnectionHelper
 /// <summary>
 /// A multiplexed connection to a Kafka broker using System.IO.Pipelines.
 /// </summary>
-public sealed partial class KafkaConnection : IKafkaConnection
+public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafkaConnection
 {
     private readonly string _host;
     private readonly int _port;
@@ -189,6 +189,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
     private OAuthBearerTokenProvider? _ownedTokenProvider;
     private int _disposed;
     private int _connected;
+    private long _lastUsedTimestampMs = Environment.TickCount64;
     private readonly SemaphoreSlim _connectLock = new(1, 1);
 
     // SASL re-authentication (KIP-368)
@@ -205,6 +206,12 @@ public sealed partial class KafkaConnection : IKafkaConnection
     public string Host => _host;
     public int Port => _port;
     public bool IsConnected => Volatile.Read(ref _disposed) == 0 && Volatile.Read(ref _connected) != 0 && (_socket?.Connected ?? false);
+
+    long IIdleTrackedKafkaConnection.LastUsedTimestampMs => Volatile.Read(ref _lastUsedTimestampMs);
+
+    int IIdleTrackedKafkaConnection.PendingRequestCount => GetPendingRequestCount();
+
+    void IIdleTrackedKafkaConnection.Touch() => Touch();
 
     /// <summary>
     /// Gets the current SASL session state, if SASL authentication was performed.
@@ -468,6 +475,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
         _receiveCts = new CancellationTokenSource();
         _receiveTask = ReceiveLoopAsync(_receiveCts.Token);
+        Touch();
         Volatile.Write(ref _connected, 1);
         _telemetryMetricCollector?.RecordConnectionCreated();
 
@@ -487,6 +495,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         if (!IsConnected)
             throw new InvalidOperationException("Not connected");
 
+        Touch();
         var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
         var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
         var responseHeaderVersion = TRequest.GetResponseHeaderVersion(apiVersion);
@@ -522,6 +531,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
             // Response phase: await response with timeout and parse
             var response = await AwaitAndParseResponseAsync<TRequest, TResponse>(
                 pending, correlationId, apiVersion, callerOwnsTimeout: false, cancellationToken).ConfigureAwait(false);
+            Touch();
             _telemetryMetricCollector?.RecordRequestLatency(BrokerId, telemetryStartTimestamp);
             return response;
         }
@@ -580,6 +590,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         if (!IsConnected)
             throw new InvalidOperationException("Not connected");
 
+        Touch();
         var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
         var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
 
@@ -590,6 +601,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken, callerOwnsTimeout)
             .ConfigureAwait(false);
 
+        Touch();
         LogFireAndForgetRequestSent(correlationId);
     }
 
@@ -634,6 +646,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
         if (!IsConnected)
             throw new InvalidOperationException("Not connected");
 
+        Touch();
         var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
         var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
         var responseHeaderVersion = TRequest.GetResponseHeaderVersion(apiVersion);
@@ -664,6 +677,7 @@ public sealed partial class KafkaConnection : IKafkaConnection
             // Response phase: await response with timeout, then parse
             var response = await AwaitAndParseResponseAsync<TRequest, TResponse>(
                 pending, correlationId, apiVersion, callerOwnsTimeout, cancellationToken).ConfigureAwait(false);
+            Touch();
             _telemetryMetricCollector?.RecordRequestLatency(BrokerId, telemetryStartTimestamp);
             return response;
         }
@@ -1349,6 +1363,8 @@ public sealed partial class KafkaConnection : IKafkaConnection
 
         return count;
     }
+
+    private void Touch() => Volatile.Write(ref _lastUsedTimestampMs, Environment.TickCount64);
 
     private bool TryReadResponse(
         ref ReadOnlySequence<byte> buffer,
@@ -2690,9 +2706,44 @@ public sealed class ConnectionOptions
     public TimeSpan ReconnectBackoffMax { get; init; } = TimeSpan.FromSeconds(1);
 
     /// <summary>
+    /// Maximum idle time before an unused connection is closed. Set to -1 to disable.
+    /// </summary>
+    public int ConnectionsMaxIdleMs
+    {
+        get => _connectionsMaxIdleMs;
+        init => _connectionsMaxIdleMs = ValidateConnectionsMaxIdleMs(value, nameof(ConnectionsMaxIdleMs));
+    }
+
+    /// <summary>
     /// Maximum in-flight requests per connection. Used internally to derive pool sizes.
     /// </summary>
     internal int MaxInFlightRequestsPerConnection { get; init; } = 5;
+
+    internal const int DefaultConnectionsMaxIdleMs = 540000;
+
+    internal static int ValidateConnectionsMaxIdleMs(int value, string paramName)
+    {
+        if (value < -1)
+            throw new ArgumentOutOfRangeException(paramName, "ConnectionsMaxIdleMs must be -1 or greater.");
+
+        return value;
+    }
+
+    internal static int ToConnectionsMaxIdleMs(TimeSpan value, string paramName)
+    {
+        if (value == Timeout.InfiniteTimeSpan)
+            return -1;
+
+        if (value < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                "Connections max idle must be non-negative, or Timeout.InfiniteTimeSpan to disable.");
+
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(value.TotalMilliseconds, int.MaxValue, paramName);
+        return (int)value.TotalMilliseconds;
+    }
+
+    private readonly int _connectionsMaxIdleMs = DefaultConnectionsMaxIdleMs;
 }
 
 /// <summary>

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -223,6 +223,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
                 ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
+                ConnectionsMaxIdleMs = options.ConnectionsMaxIdleMs,
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Dekaf.Metadata;
+using Dekaf.Networking;
 using Dekaf.Protocol.Records;
 using Dekaf.Retry;
 using Dekaf.Security;
@@ -44,6 +45,13 @@ public sealed class ProducerOptions
     /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
     /// </summary>
     public int ReconnectBackoffMaxMs { get; init; } = 1000;
+
+    /// <summary>
+    /// Maximum idle time in milliseconds before unused broker connections are closed.
+    /// Default is 9 minutes, below Kafka's default broker-side 10 minute idle timeout.
+    /// Set to -1 to disable client-side idle connection reaping.
+    /// </summary>
+    public int ConnectionsMaxIdleMs { get; init; } = ConnectionOptions.DefaultConnectionsMaxIdleMs;
 
     /// <summary>
     /// Linger time in milliseconds before sending a batch.

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -70,6 +70,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
                 ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
+                ConnectionsMaxIdleMs = options.ConnectionsMaxIdleMs,
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -1,3 +1,4 @@
+using Dekaf.Networking;
 using Dekaf.Retry;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
@@ -82,6 +83,13 @@ public sealed class ShareConsumerOptions
     /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
     /// </summary>
     public int ReconnectBackoffMaxMs { get; init; } = 1000;
+
+    /// <summary>
+    /// Maximum idle time in milliseconds before unused broker connections are closed.
+    /// Default is 9 minutes, below Kafka's default broker-side 10 minute idle timeout.
+    /// Set to -1 to disable client-side idle connection reaping.
+    /// </summary>
+    public int ConnectionsMaxIdleMs { get; init; } = ConnectionOptions.DefaultConnectionsMaxIdleMs;
 
     /// <summary>
     /// Whether to use TLS for broker connections.

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -84,6 +84,8 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
+            .Throws<InvalidOperationException>();
 
         await Assert.That(() => client.CreateConsumer<string, string>().UseTls())
             .Throws<InvalidOperationException>();
@@ -99,6 +101,8 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
+            .Throws<InvalidOperationException>();
 
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithTls())
             .Throws<InvalidOperationException>();
@@ -109,6 +113,8 @@ public sealed class KafkaClientBuilderTests
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithConnectionsPerBroker(2))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
 
         await Assert.That(() => client.CreateAdminClient().UseTls())
@@ -122,6 +128,8 @@ public sealed class KafkaClientBuilderTests
         await Assert.That(() => client.CreateAdminClient().WithMetadataMaxAge(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateAdminClient().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
     }
 
@@ -137,6 +145,18 @@ public sealed class KafkaClientBuilderTests
 
         await Assert.That(pool.EffectiveConnectionOptions.ReconnectBackoff).IsEqualTo(TimeSpan.FromMilliseconds(123));
         await Assert.That(pool.EffectiveConnectionOptions.ReconnectBackoffMax).IsEqualTo(TimeSpan.FromMilliseconds(456));
+    }
+
+    [Test]
+    public async Task RootClient_WithConnectionsMaxIdle_ConfiguresSharedConnectionPool()
+    {
+        await using var client = Kafka.Connect("localhost:9092", builder => builder
+            .WithConnectionsMaxIdle(TimeSpan.FromMilliseconds(1234)));
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var pool = GetField<ConnectionPool>(producer, "_connectionPool");
+
+        await Assert.That(pool.EffectiveConnectionOptions.ConnectionsMaxIdleMs).IsEqualTo(1234);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Consumer;
+using Dekaf.Networking;
 using Dekaf.Protocol.Messages;
 using Dekaf.Security.Sasl;
 
@@ -156,6 +157,13 @@ public class ConsumerOptionsDefaultsTests
     {
         var options = CreateOptions();
         await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(1000);
+    }
+
+    [Test]
+    public async Task ConnectionsMaxIdleMs_DefaultsTo_540000()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.ConnectionsMaxIdleMs).IsEqualTo(ConnectionOptions.DefaultConnectionsMaxIdleMs);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataRecoveryStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataRecoveryStrategyTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Dekaf.Metadata;
+using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 
@@ -181,6 +182,17 @@ public sealed class MetadataRecoveryStrategyTests
         };
 
         await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(1000);
+    }
+
+    [Test]
+    public async Task AdminClientOptions_ConnectionsMaxIdleMs_DefaultsTo540000()
+    {
+        var options = new Dekaf.Admin.AdminClientOptions
+        {
+            BootstrapServers = ["localhost:9092"]
+        };
+
+        await Assert.That(options.ConnectionsMaxIdleMs).IsEqualTo(ConnectionOptions.DefaultConnectionsMaxIdleMs);
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Reflection;
 using Dekaf.Errors;
 using Dekaf.Networking;
+using Dekaf.Protocol;
 using Dekaf.Security.Sasl;
 using NSubstitute;
 
@@ -14,6 +15,8 @@ namespace Dekaf.Tests.Unit.Networking;
 /// </summary>
 public sealed class ConnectionPoolTests
 {
+    private const int IdleThresholdMs = 60000;
+
     [Test]
     public async Task GetConnectionAsync_DisposedPool_ThrowsObjectDisposedException()
     {
@@ -360,6 +363,146 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ConnectionOptions_ConnectionsMaxIdleMs_DefaultsToNineMinutes()
+    {
+        var options = new ConnectionOptions();
+
+        await Assert.That(options.ConnectionsMaxIdleMs).IsEqualTo(ConnectionOptions.DefaultConnectionsMaxIdleMs);
+    }
+
+    [Test]
+    public async Task ConnectionOptions_ConnectionsMaxIdleMs_RejectsValuesBelowDisabled()
+    {
+        await Assert.That(() => new ConnectionOptions { ConnectionsMaxIdleMs = -2 })
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task ConnectionOptions_ToConnectionsMaxIdleMs_MapsInfiniteTimeSpanToDisabled()
+    {
+        var value = ConnectionOptions.ToConnectionsMaxIdleMs(Timeout.InfiniteTimeSpan, "idle");
+
+        await Assert.That(value).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task ReapIdleConnectionsAsync_Disabled_DoesNotDisposeIdleConnection()
+    {
+        var connection = new TestIdleConnection(1, "localhost", 9092);
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = -1 },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => new ValueTask<IKafkaConnection>(connection));
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+
+            await pool.GetConnectionAsync(1);
+            connection.LastUsedTimestampMs = StaleIdleTimestamp();
+            var reaped = await pool.ReapIdleConnectionsAsync();
+
+            await Assert.That(reaped).IsEqualTo(0);
+            await Assert.That(connection.DisposeCount).IsEqualTo(0);
+            await Assert.That(connection.IsConnected).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task ReapIdleConnectionsAsync_IdleSingleConnection_DisposesAndRecreates()
+    {
+        var created = new List<TestIdleConnection>();
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = IdleThresholdMs },
+            connectionsPerBroker: 1,
+            connectionFactory: (brokerId, host, port, _, _) =>
+            {
+                var connection = new TestIdleConnection(brokerId, host, port);
+                created.Add(connection);
+                return new ValueTask<IKafkaConnection>(connection);
+            });
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+
+            var first = await pool.GetConnectionAsync(1);
+            created[0].LastUsedTimestampMs = StaleIdleTimestamp();
+            var reaped = await pool.ReapIdleConnectionsAsync();
+            var second = await pool.GetConnectionAsync(1);
+
+            await Assert.That(reaped).IsEqualTo(1);
+            await Assert.That(created.Count).IsEqualTo(2);
+            await Assert.That(created[0].DisposeCount).IsEqualTo(1);
+            await Assert.That(first).IsNotSameReferenceAs(second);
+        }
+    }
+
+    [Test]
+    public async Task ReapIdleConnectionsAsync_PendingRequest_DoesNotDisposeConnection()
+    {
+        var connection = new TestIdleConnection(1, "localhost", 9092)
+        {
+            PendingRequestCount = 1
+        };
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = IdleThresholdMs },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => new ValueTask<IKafkaConnection>(connection));
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+
+            await pool.GetConnectionAsync(1);
+            connection.LastUsedTimestampMs = StaleIdleTimestamp();
+            var reapedWithPendingRequest = await pool.ReapIdleConnectionsAsync();
+            connection.PendingRequestCount = 0;
+            var reapedAfterRequestCompletes = await pool.ReapIdleConnectionsAsync();
+
+            await Assert.That(reapedWithPendingRequest).IsEqualTo(0);
+            await Assert.That(reapedAfterRequestCompletes).IsEqualTo(1);
+            await Assert.That(connection.DisposeCount).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task ReapIdleConnectionsAsync_Group_ReapsOnlyConnectionsWithoutPendingRequests()
+    {
+        var created = new TestIdleConnection[2];
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = IdleThresholdMs },
+            connectionsPerBroker: 2,
+            connectionFactory: (brokerId, host, port, index, _) =>
+            {
+                var connection = new TestIdleConnection(brokerId, host, port)
+                {
+                    PendingRequestCount = index == 0 ? 1 : 0
+                };
+                created[index] = connection;
+                return new ValueTask<IKafkaConnection>(connection);
+            });
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+
+            await pool.GetConnectionAsync(1);
+            created[0].LastUsedTimestampMs = StaleIdleTimestamp();
+            created[1].LastUsedTimestampMs = StaleIdleTimestamp();
+            var reaped = await pool.ReapIdleConnectionsAsync();
+
+            await Assert.That(reaped).IsEqualTo(1);
+            await Assert.That(created[0].DisposeCount).IsEqualTo(0);
+            await Assert.That(created[1].DisposeCount).IsEqualTo(1);
+        }
+    }
+
+    [Test]
     [NotInParallel]
     public async Task CreateConnectionGroup_AfterConnectionFailure_WaitsForReconnectBackoff()
     {
@@ -474,6 +617,8 @@ public sealed class ConnectionPoolTests
         return (MemoryPool<byte>)field!.GetValue(pool)!;
     }
 
+    private static long StaleIdleTimestamp() => Environment.TickCount64 - IdleThresholdMs - 1;
+
     private static IKafkaConnection CreateConnectedConnection(int brokerId, string host, int port)
     {
         var connection = Substitute.For<IKafkaConnection>();
@@ -482,5 +627,86 @@ public sealed class ConnectionPoolTests
         connection.Host.Returns(host);
         connection.Port.Returns(port);
         return connection;
+    }
+
+    private sealed class TestIdleConnection(int brokerId, string host, int port) : IKafkaConnection, IIdleTrackedKafkaConnection
+    {
+        private int _connected = 1;
+        private long _lastUsedTimestampMs = Environment.TickCount64;
+        private int _pendingRequestCount;
+        private int _disposeCount;
+
+        public int BrokerId { get; } = brokerId;
+        public string Host { get; } = host;
+        public int Port { get; } = port;
+        public bool IsConnected => Volatile.Read(ref _connected) != 0;
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
+
+        public long LastUsedTimestampMs
+        {
+            get => Volatile.Read(ref _lastUsedTimestampMs);
+            set => Volatile.Write(ref _lastUsedTimestampMs, value);
+        }
+
+        public int PendingRequestCount
+        {
+            get => Volatile.Read(ref _pendingRequestCount);
+            set => Volatile.Write(ref _pendingRequestCount, value);
+        }
+
+        long IIdleTrackedKafkaConnection.LastUsedTimestampMs => LastUsedTimestampMs;
+
+        int IIdleTrackedKafkaConnection.PendingRequestCount => PendingRequestCount;
+
+        void IIdleTrackedKafkaConnection.Touch() => LastUsedTimestampMs = Environment.TickCount64;
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => ValueTask.FromException<TResponse>(new NotSupportedException());
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => ValueTask.FromException(new NotSupportedException());
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => Task.FromException<TResponse>(new NotSupportedException());
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => ValueTask.FromException(new NotSupportedException());
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => Task.FromException<TResponse>(new NotSupportedException());
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref _disposeCount);
+            Volatile.Write(ref _connected, 0);
+            return ValueTask.CompletedTask;
+        }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Producer;
+using Dekaf.Networking;
 using Dekaf.Protocol.Records;
 using Dekaf.Security.Sasl;
 
@@ -44,6 +45,13 @@ public class ProducerOptionsDefaultsTests
     {
         var options = CreateOptions();
         await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(1000);
+    }
+
+    [Test]
+    public async Task ConnectionsMaxIdleMs_DefaultsTo_540000()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.ConnectionsMaxIdleMs).IsEqualTo(ConnectionOptions.DefaultConnectionsMaxIdleMs);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerOptionsDefaultsTests.cs
@@ -1,3 +1,4 @@
+using Dekaf.Networking;
 using Dekaf.ShareConsumer;
 
 namespace Dekaf.Tests.Unit.ShareConsumer;
@@ -22,5 +23,12 @@ public sealed class ShareConsumerOptionsDefaultsTests
     {
         var options = CreateOptions();
         await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(1000);
+    }
+
+    [Test]
+    public async Task ConnectionsMaxIdleMs_DefaultsTo_540000()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.ConnectionsMaxIdleMs).IsEqualTo(ConnectionOptions.DefaultConnectionsMaxIdleMs);
     }
 }


### PR DESCRIPTION
## Summary
- add `ConnectionsMaxIdleMs` and `WithConnectionsMaxIdle(...)` across root, producer, consumer, share-consumer, and admin configuration
- track last-used time and pending request count on broker connections
- add a connection-pool idle reaper that closes idle, request-free connections before broker-side idle timeout
- document the option in producer and consumer configuration docs

## Test plan
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release /p:RunAnalyzers=false`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConnectionPoolTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --diagnostic --diagnostic-synchronous-write --diagnostic-verbosity Information --output Detailed --no-progress` (3900/3900)
- `npm run build --prefix docs`
- `git diff --check HEAD~1 HEAD`

Closes #1153
