### PR TITLE
fix(networking): clean reconnect backoff state

### DIFF
--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -907,22 +907,24 @@ public sealed partial class ConnectionPool : IConnectionPool
         Func<ValueTask<IKafkaConnection>> createConnection,
         CancellationToken cancellationToken)
     {
-        if (_reconnectBackoffs.TryGetValue(endpoint, out var state) && state.TryAddUser())
+        if (_reconnectBackoffs.TryGetValue(endpoint, out var state) && state.TryAddRef())
         {
-            var gateAcquired = false;
             try
             {
                 await state.AttemptGate.WaitAsync(cancellationToken).ConfigureAwait(false);
-                gateAcquired = true;
-
-                await WaitForReconnectBackoffAsync(endpoint, state, brokerId, host, port, cancellationToken).ConfigureAwait(false);
-                return await createConnection().ConfigureAwait(false);
+                try
+                {
+                    await WaitForReconnectBackoffAsync(endpoint, state, brokerId, host, port, cancellationToken).ConfigureAwait(false);
+                    return await createConnection().ConfigureAwait(false);
+                }
+                finally
+                {
+                    state.AttemptGate.Release();
+                }
             }
             finally
             {
-                if (gateAcquired)
-                    state.AttemptGate.Release();
-                state.ReleaseUser();
+                state.ReleaseRef();
             }
         }
 
@@ -984,8 +986,7 @@ public sealed partial class ConnectionPool : IConnectionPool
             state.FailureCount = 0;
             state.NextAttemptTimestamp = 0;
         }
-        state.RequestDispose();
-
+        state.MarkRemoved();
         LogReconnectBackoffReset(brokerId, host, port);
     }
 
@@ -1308,9 +1309,7 @@ public sealed partial class ConnectionPool : IConnectionPool
                 }
             }
 
-            _connectionsByEndpoint.Clear();
-            _connectionsById.Clear();
-            _connectionGroupsById.Clear();
+            foreach (var state in _reconnectBackoffs.Values) state.MarkRemoved();
 
             if (Volatile.Read(ref _disposed) != 0)
             {
@@ -1318,12 +1317,14 @@ public sealed partial class ConnectionPool : IConnectionPool
                 foreach (var sem in _connectionCreationLocks.Values) sem.Dispose();
                 foreach (var sem in _connectionReplacementLocks.Values) sem.Dispose();
                 foreach (var sem in _groupCreationLocks.Values) sem.Dispose();
-                foreach (var state in _reconnectBackoffs.Values) state.RequestDispose();
             }
+            _connectionsByEndpoint.Clear();
+            _connectionsById.Clear();
+            _connectionGroupsById.Clear();
+            _reconnectBackoffs.Clear();
             _connectionCreationLocks.Clear();
             _connectionReplacementLocks.Clear();
             _groupCreationLocks.Clear();
-            _reconnectBackoffs.Clear();
 
             LogAllConnectionsClosed();
         }
@@ -1432,58 +1433,47 @@ public sealed partial class ConnectionPool : IConnectionPool
         public int FailureCount;
         public long NextAttemptTimestamp;
         private int _activeUsers;
-        private bool _disposeRequested;
-        private bool _disposed;
+        private int _removed;
+        private int _disposed;
 
-        public bool TryAddUser()
+        public bool TryAddRef()
         {
-            lock (Sync)
+            while (true)
             {
-                if (_disposeRequested || _disposed)
+                if (Volatile.Read(ref _removed) != 0)
                     return false;
 
-                _activeUsers++;
-                return true;
+                var activeUsers = Volatile.Read(ref _activeUsers);
+                if (Interlocked.CompareExchange(ref _activeUsers, activeUsers + 1, activeUsers) != activeUsers)
+                    continue;
+
+                if (Volatile.Read(ref _removed) == 0)
+                    return true;
+
+                ReleaseRef();
+                return false;
             }
         }
 
-        public void ReleaseUser()
+        public void ReleaseRef()
         {
-            var shouldDispose = false;
-            lock (Sync)
-            {
-                _activeUsers--;
-                shouldDispose = _disposeRequested && _activeUsers == 0;
-            }
-
-            if (shouldDispose)
-                Dispose();
+            Interlocked.Decrement(ref _activeUsers);
+            TryDispose();
         }
 
-        public void RequestDispose()
+        public void MarkRemoved()
         {
-            var shouldDispose = false;
-            lock (Sync)
-            {
-                _disposeRequested = true;
-                shouldDispose = _activeUsers == 0;
-            }
-
-            if (shouldDispose)
-                Dispose();
+            Volatile.Write(ref _removed, 1);
+            TryDispose();
         }
 
-        private void Dispose()
+        private void TryDispose()
         {
-            lock (Sync)
-            {
-                if (_disposed)
-                    return;
+            if (Volatile.Read(ref _removed) == 0 || Volatile.Read(ref _activeUsers) != 0)
+                return;
 
-                _disposed = true;
-            }
-
-            AttemptGate.Dispose();
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                AttemptGate.Dispose();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -594,6 +594,69 @@ public sealed class ConnectionPoolTests
         }
     }
 
+    [Test]
+    [NotInParallel]
+    public async Task GetConnectionAsync_AfterReconnectBackoffReset_DisposesAttemptGate()
+    {
+        var attempts = 0;
+        var options = new ConnectionOptions
+        {
+            ReconnectBackoff = TimeSpan.FromMilliseconds(1),
+            ReconnectBackoffMax = TimeSpan.FromMilliseconds(1)
+        };
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: options,
+            connectionsPerBroker: 2,
+            connectionFactory: (brokerId, host, port, _, _) =>
+            {
+                if (Interlocked.Increment(ref attempts) <= 2)
+                    return new ValueTask<IKafkaConnection>(Task.FromException<IKafkaConnection>(
+                        new InvalidOperationException("broker down")));
+
+                return new ValueTask<IKafkaConnection>(CreateConnectedConnection(brokerId, host, port));
+            });
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+
+            Func<Task> firstAttempt = () => pool.GetConnectionAsync(1).AsTask();
+            await Assert.That(firstAttempt).Throws<InvalidOperationException>();
+            var gate = await AssertSingleReconnectBackoffGate(pool);
+
+            var connection = await pool.GetConnectionAsync(1);
+
+            await Assert.That(connection.IsConnected).IsTrue();
+            await Assert.That(() => gate.Wait(0)).Throws<ObjectDisposedException>();
+        }
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task CloseAllAsync_DisposesReconnectBackoffAttemptGates()
+    {
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 2,
+            connectionFactory: (_, _, _, _, _) => new ValueTask<IKafkaConnection>(Task.FromException<IKafkaConnection>(
+                new InvalidOperationException("broker down"))));
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+
+            Func<Task> failedConnection = () => pool.GetConnectionAsync(1).AsTask();
+            await Assert.That(failedConnection).Throws<InvalidOperationException>();
+            var gate = await AssertSingleReconnectBackoffGate(pool);
+
+            await pool.CloseAllAsync();
+
+            await Assert.That(() => gate.Wait(0)).Throws<ObjectDisposedException>();
+        }
+    }
+
     private static OAuthBearerConfig CreateOAuthBearerConfig() => new()
     {
         TokenEndpointUrl = "https://auth.example.invalid/token",
@@ -618,6 +681,25 @@ public sealed class ConnectionPoolTests
     }
 
     private static long StaleIdleTimestamp() => Environment.TickCount64 - IdleThresholdMs - 1;
+
+    private static async Task<SemaphoreSlim> AssertSingleReconnectBackoffGate(ConnectionPool pool)
+    {
+        var field = typeof(ConnectionPool).GetField(
+            "_reconnectBackoffs",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        var backoffs = field!.GetValue(pool)!;
+        var values = (System.Collections.IEnumerable)backoffs.GetType().GetProperty("Values")!.GetValue(backoffs)!;
+        var gates = new List<SemaphoreSlim>();
+
+        foreach (var state in values)
+        {
+            var gateField = state.GetType().GetField("AttemptGate")!;
+            gates.Add((SemaphoreSlim)gateField.GetValue(state)!);
+        }
+
+        await Assert.That(gates).Count().IsEqualTo(1);
+        return gates[0];
+    }
 
     private static IKafkaConnection CreateConnectedConnection(int brokerId, string host, int port)
     {


### PR DESCRIPTION
## Summary
- reuse the shared reconnect-backoff validation helper in `ConnectionPool`
- mark reconnect backoff states removed and dispose their `AttemptGate` after active users drain
- add tests for gate disposal after successful reset and `CloseAllAsync`

## Test plan
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release /p:RunAnalyzers=false`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConnectionPoolTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe`
- `git diff --check`

Closes #1178
