### PR TITLE
fix(consumer): recover truncation fetches

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2123,24 +2123,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         {
                             if (partitionResponse.ErrorCode == ErrorCode.OffsetOutOfRange)
                             {
-                                // CRITICAL: Reset fetch position based on auto.offset.reset policy
-                                // Without this, we would retry with the same invalid offset forever
-                                var resetTimestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow, tp);
-                                if (resetTimestamp == -1 || resetTimestamp == -2)
-                                {
-                                    _fetchPositions[tp] = resetTimestamp;
-                                    SetPosition(tp, resetTimestamp, dirty: false);
-                                    ClearLastConsumedLeaderEpoch(tp);
-                                }
-                                else
-                                {
-                                    var resetOffset = await ResolveAutoResetOffsetAsync(tp, resetTimestamp, cancellationToken).ConfigureAwait(false);
-                                    _fetchPositions[tp] = resetOffset;
-                                    SetPosition(tp, resetOffset, dirty: false);
-                                    ClearLastConsumedLeaderEpoch(tp);
-                                }
-
-                                LogOffsetOutOfRangeReset(topic, partitionResponse.PartitionIndex, GetAutoOffsetResetName());
+                                await ResetOffsetOutOfRangeAsync(tp, cancellationToken).ConfigureAwait(false);
                             }
                             else if (IsLeaderEpochRefreshError(partitionResponse.ErrorCode))
                             {
@@ -4029,7 +4012,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                     if (partitionResponse.ErrorCode != ErrorCode.None)
                     {
-                        if (IsLeaderEpochRefreshError(partitionResponse.ErrorCode))
+                        if (partitionResponse.ErrorCode == ErrorCode.OffsetOutOfRange)
+                        {
+                            await ResetOffsetOutOfRangeAsync(tp, cancellationToken).ConfigureAwait(false);
+                        }
+                        else if (IsLeaderEpochRefreshError(partitionResponse.ErrorCode))
                         {
                             await HandleLeaderEpochRefreshAsync(
                                 topic,
@@ -4266,7 +4253,32 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         SetLastConsumedLeaderEpoch(partition, divergingEpoch.Epoch);
         QueueFetchException(new Errors.ConsumeException(
             ErrorCode.OffsetOutOfRange,
-            $"Log truncation detected for {topic}-{partitionResponse.PartitionIndex}; reset fetch position to offset {divergingEpoch.EndOffset} at leader epoch {divergingEpoch.Epoch}."));
+            $"Log truncation detected for {topic}-{partitionResponse.PartitionIndex}; reset fetch position to offset {divergingEpoch.EndOffset} at leader epoch {divergingEpoch.Epoch}.",
+            isRetriable: true));
+    }
+
+    private async ValueTask ResetOffsetOutOfRangeAsync(
+        TopicPartition partition,
+        CancellationToken cancellationToken)
+    {
+        // Reset fetch position based on auto.offset.reset policy. Without this, the
+        // consumer would retry the same invalid offset forever.
+        var resetTimestamp = AutoOffsetResetStrategy.GetListOffsetsTimestamp(_options, DateTimeOffset.UtcNow, partition);
+        if (resetTimestamp == LatestOffsetTimestamp || resetTimestamp == EarliestOffsetTimestamp)
+        {
+            _fetchPositions[partition] = resetTimestamp;
+            SetPosition(partition, resetTimestamp, dirty: false);
+            ClearLastConsumedLeaderEpoch(partition);
+        }
+        else
+        {
+            var resetOffset = await ResolveAutoResetOffsetAsync(partition, resetTimestamp, cancellationToken).ConfigureAwait(false);
+            _fetchPositions[partition] = resetOffset;
+            SetPosition(partition, resetOffset, dirty: false);
+            ClearLastConsumedLeaderEpoch(partition);
+        }
+
+        LogOffsetOutOfRangeReset(partition.Topic, partition.Partition, GetAutoOffsetResetName());
     }
 
     private static bool IsLeaderEpochRefreshError(ErrorCode errorCode) =>
@@ -4299,14 +4311,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             ScheduleLeaderRefresh(topic);
 
         return ValueTask.CompletedTask;
-    }
-
-    private ValueTask HandleNotLeaderOrFollowerAsync(
-        string topic,
-        FetchResponsePartition partitionResponse,
-        IReadOnlyList<NodeEndpoint> nodeEndpoints)
-    {
-        return HandleLeaderEpochRefreshAsync(topic, partitionResponse, nodeEndpoints);
     }
 
     private void UpdatePreferredReadReplica(string topic, FetchResponsePartition partitionResponse)

--- a/src/Dekaf/Errors/KafkaException.cs
+++ b/src/Dekaf/Errors/KafkaException.cs
@@ -8,6 +8,8 @@ namespace Dekaf.Errors;
 /// </summary>
 public class KafkaException : Exception
 {
+    private readonly bool? _isRetriableOverride;
+
     /// <summary>
     /// Creates a new KafkaException.
     /// </summary>
@@ -28,6 +30,12 @@ public class KafkaException : Exception
     public KafkaException(ErrorCode errorCode, string message) : base(message)
     {
         ErrorCode = errorCode;
+    }
+
+    internal KafkaException(ErrorCode errorCode, string message, bool isRetriable) : base(message)
+    {
+        ErrorCode = errorCode;
+        _isRetriableOverride = isRetriable;
     }
 
     /// <summary>
@@ -54,7 +62,7 @@ public class KafkaException : Exception
     /// <summary>
     /// Whether this exception is retriable.
     /// </summary>
-    public bool IsRetriable => ErrorCode?.IsRetriable() ?? false;
+    public bool IsRetriable => _isRetriableOverride ?? ErrorCode?.IsRetriable() ?? false;
 
     /// <summary>
     /// Creates the most specific exception type for a Kafka error code:
@@ -253,6 +261,10 @@ public sealed class ConsumeException : KafkaException
     }
 
     public ConsumeException(ErrorCode errorCode, string message) : base(errorCode, message)
+    {
+    }
+
+    internal ConsumeException(ErrorCode errorCode, string message, bool isRetriable) : base(errorCode, message, isRetriable)
     {
     }
 

--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -1201,6 +1201,51 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
     }
 
     [Test]
+    public async Task Consumer_StaleLeaderEpochOffsetOutOfRange_ConsumeAsyncResetsToBeginning()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key-0",
+            Value = "value-0"
+        }, CancellationToken.None);
+        await producer.FlushAsync(CancellationToken.None);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-consumer")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithQueuedMinMessages(1)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var tp = new TopicPartition(topic, 0);
+        consumer.Assign(tp);
+        consumer.Seek(new TopicPartitionOffset(topic, 0, 999999, leaderEpoch: int.MaxValue));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        ConsumeResult<string, string>? recovered = null;
+
+        await foreach (var msg in consumer.ConsumeAsync(cts.Token))
+        {
+            recovered = msg;
+            break;
+        }
+
+        await Assert.That(recovered).IsNotNull();
+        await Assert.That(recovered!.Value.Offset).IsEqualTo(0);
+        await Assert.That(recovered.Value.Value).IsEqualTo("value-0");
+    }
+
+    [Test]
     public async Task Consumer_OffsetOutOfRange_WithLatest_ResetsToEnd()
     {
         // This tests that when AutoOffsetReset.Latest is configured and OffsetOutOfRange occurs,

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -16,7 +16,7 @@ public sealed class ConsumerLeaderDiscoveryTests
     private const string Topic = "test-topic";
 
     [Test]
-    public async Task HandleNotLeaderOrFollower_WithInlineLeader_UpdatesMetadataWithoutRefresh()
+    public async Task HandleLeaderEpochRefresh_WithInlineLeader_UpdatesMetadataWithoutRefresh()
     {
         var pool = Substitute.For<IConnectionPool>();
         await using var metadataManager = CreateMetadataManager(pool);
@@ -35,7 +35,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             }
         };
 
-        await InvokeHandleNotLeaderOrFollowerAsync(
+        await InvokeHandleLeaderEpochRefreshAsync(
             consumer,
             partitionResponse,
             [new NodeEndpoint { NodeId = 2, Host = "broker-2", Port = 9094 }]);
@@ -49,7 +49,7 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
-    public async Task HandleNotLeaderOrFollower_WithoutInlineLeader_DeduplicatesRefreshPerTopic()
+    public async Task HandleLeaderEpochRefresh_WithoutInlineLeader_DeduplicatesRefreshPerTopic()
     {
         var pool = Substitute.For<IConnectionPool>();
         var connectionRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -71,12 +71,12 @@ public sealed class ConsumerLeaderDiscoveryTests
             ErrorCode = ErrorCode.NotLeaderOrFollower
         };
 
-        await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
+        await InvokeHandleLeaderEpochRefreshAsync(consumer, partitionResponse, []);
         // The background refresh signals connectionRequested when it calls GetConnectionAsync.
         // Await it directly: a 5s cap raced that continuation under CI thread-pool starvation.
         await connectionRequested.Task;
 
-        await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
+        await InvokeHandleLeaderEpochRefreshAsync(consumer, partitionResponse, []);
 
         _ = pool.Received(1).GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>());
 
@@ -85,7 +85,7 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
-    public async Task HandleNotLeaderOrFollower_WithoutInlineLeader_UsesDedicatedRefreshToken()
+    public async Task HandleLeaderEpochRefresh_WithoutInlineLeader_UsesDedicatedRefreshToken()
     {
         var pool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
@@ -114,7 +114,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             ErrorCode = ErrorCode.NotLeaderOrFollower
         };
 
-        await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
+        await InvokeHandleLeaderEpochRefreshAsync(consumer, partitionResponse, []);
 
         // The background refresh signals refreshTokenCaptured when it calls SendAsync.
         // Await directly: a 5s cap raced that continuation under CI thread-pool starvation.
@@ -126,7 +126,7 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
-    public async Task HandleNotLeaderOrFollower_WithoutInlineLeader_SchedulesRefreshWithoutFetchCycleToken()
+    public async Task HandleLeaderEpochRefresh_WithoutInlineLeader_SchedulesRefreshWithoutFetchCycleToken()
     {
         var pool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
@@ -155,7 +155,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             ErrorCode = ErrorCode.NotLeaderOrFollower
         };
 
-        await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
+        await InvokeHandleLeaderEpochRefreshAsync(consumer, partitionResponse, []);
 
         // The background refresh signals refreshTokenCaptured when it calls SendAsync.
         // Await directly: a 5s cap raced that continuation under CI thread-pool starvation.
@@ -189,7 +189,9 @@ public sealed class ConsumerLeaderDiscoveryTests
         await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(42);
         var exception = DrainPendingFetchException(consumer);
         await Assert.That(exception).IsTypeOf<ConsumeException>();
-        await Assert.That(((ConsumeException)exception!).ErrorCode).IsEqualTo(ErrorCode.OffsetOutOfRange);
+        var consumeException = (ConsumeException)exception!;
+        await Assert.That(consumeException.ErrorCode).IsEqualTo(ErrorCode.OffsetOutOfRange);
+        await Assert.That(consumeException.IsRetriable).IsTrue();
     }
 
     [Test]
@@ -239,7 +241,7 @@ public sealed class ConsumerLeaderDiscoveryTests
                 ErrorCode = ErrorCode.NotLeaderOrFollower
             };
 
-            await InvokeHandleNotLeaderOrFollowerAsync(consumer, partitionResponse, []);
+            await InvokeHandleLeaderEpochRefreshAsync(consumer, partitionResponse, []);
             // Each step below is gated by a deterministic signal (the mock's SendAsync, the
             // refresh cancellation callback, and the dispose completing after the refresh
             // response is set). The previous 5s caps raced those continuations under CI
@@ -346,18 +348,18 @@ public sealed class ConsumerLeaderDiscoveryTests
         }
     }
 
-    private static async ValueTask InvokeHandleNotLeaderOrFollowerAsync(
+    private static async ValueTask InvokeHandleLeaderEpochRefreshAsync(
         KafkaConsumer<string, string> consumer,
         FetchResponsePartition partitionResponse,
         IReadOnlyList<NodeEndpoint> nodeEndpoints)
     {
         var method = typeof(KafkaConsumer<string, string>)
-            .GetMethod("HandleNotLeaderOrFollowerAsync", BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("HandleNotLeaderOrFollowerAsync method not found");
+            .GetMethod("HandleLeaderEpochRefreshAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("HandleLeaderEpochRefreshAsync method not found");
 
         var result = method.Invoke(consumer, [Topic, partitionResponse, nodeEndpoints]);
         if (result is not ValueTask valueTask)
-            throw new InvalidOperationException("HandleNotLeaderOrFollowerAsync did not return ValueTask");
+            throw new InvalidOperationException("HandleLeaderEpochRefreshAsync did not return ValueTask");
 
         await valueTask.ConfigureAwait(false);
     }


### PR DESCRIPTION
## Summary
- mark diverging-epoch truncation recovery `ConsumeException` instances as retriable
- share `OffsetOutOfRange` reset handling across prefetch and non-prefetch fetch paths
- remove the dead `HandleNotLeaderOrFollowerAsync` wrapper and point tests at `HandleLeaderEpochRefreshAsync`
- add a Testcontainers `ConsumeAsync` recovery test with a stale leader epoch

## Tests
- `dotnet build --configuration Release`
- `tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe --disable-logo --no-progress --treenode-filter "/*/*/ConsumerLeaderDiscoveryTests/*"`
- `tests\\Dekaf.Tests.Integration\\bin\\Release\\net10.0\\Dekaf.Tests.Integration.exe --disable-logo --no-progress --treenode-filter "/*/*/ConsumerTests/Consumer_StaleLeaderEpochOffsetOutOfRange_ConsumeAsyncResetsToBeginning" --output Normal --no-ansi`
- `tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe --disable-logo --no-progress --output Normal` (passed on rerun; first run hit unrelated `ConnectionPoolConcurrencyTests.ReplaceAndShrink_ConcurrentExecution_DisposesOrphanedConnection` flake)

Closes #1176