### PR TITLE
feat(admin): add log dir APIs

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1932,6 +1932,246 @@ public sealed class AdminClient : IAdminClient
         }, cancellationToken).ConfigureAwait(false);
     }
 
+    public async ValueTask<IReadOnlyDictionary<int, IReadOnlyDictionary<string, LogDirDescription>>> DescribeLogDirsAsync(
+        IEnumerable<int> brokerIds,
+        IEnumerable<TopicPartition>? partitions = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(brokerIds);
+
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var brokerIdList = brokerIds.Distinct().ToArray();
+        foreach (var brokerId in brokerIdList)
+        {
+            if (brokerId < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(brokerIds), brokerId, "Broker ID must be non-negative.");
+            }
+        }
+
+        var topicFilters = BuildDescribeLogDirsTopics(partitions);
+        if (brokerIdList.Length == 0)
+        {
+            return new Dictionary<int, IReadOnlyDictionary<string, LogDirDescription>>();
+        }
+
+        return await WithRetryAsync<IReadOnlyDictionary<int, IReadOnlyDictionary<string, LogDirDescription>>>(async () =>
+        {
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.DescribeLogDirs,
+                DescribeLogDirsRequest.LowestSupportedVersion,
+                DescribeLogDirsRequest.HighestSupportedVersion);
+
+            var results = new Dictionary<int, IReadOnlyDictionary<string, LogDirDescription>>();
+            foreach (var brokerId in brokerIdList)
+            {
+                var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
+                var response = await connection.SendAsync<DescribeLogDirsRequest, DescribeLogDirsResponse>(
+                    new DescribeLogDirsRequest { Topics = topicFilters },
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (response.ErrorCode != Protocol.ErrorCode.None)
+                {
+                    throw new KafkaException(response.ErrorCode,
+                        $"DescribeLogDirs failed for broker {brokerId}: {response.ErrorCode}");
+                }
+
+                var brokerResult = new Dictionary<string, LogDirDescription>();
+                foreach (var dir in response.Results)
+                {
+                    var replicas = new Dictionary<TopicPartition, ReplicaLogDirInfo>();
+                    foreach (var topic in dir.Topics)
+                    {
+                        foreach (var partition in topic.Partitions)
+                        {
+                            var topicPartition = new TopicPartition(topic.Name, partition.PartitionIndex);
+                            replicas[topicPartition] = new ReplicaLogDirInfo
+                            {
+                                Size = partition.PartitionSize,
+                                OffsetLag = partition.OffsetLag,
+                                IsFuture = partition.IsFutureKey
+                            };
+                        }
+                    }
+
+                    brokerResult[dir.LogDir] = new LogDirDescription
+                    {
+                        ErrorCode = dir.ErrorCode,
+                        ReplicaInfos = replicas,
+                        TotalBytes = dir.TotalBytes,
+                        UsableBytes = dir.UsableBytes,
+                        IsCordoned = dir.IsCordoned
+                    };
+                }
+
+                results[brokerId] = brokerResult;
+            }
+
+            return results;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<IReadOnlyDictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>> AlterReplicaLogDirsAsync(
+        IReadOnlyDictionary<TopicPartitionReplica, string> replicaAssignments,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(replicaAssignments);
+
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var assignments = new List<ReplicaLogDirAssignment>(replicaAssignments.Count);
+        foreach (var (replica, logDir) in replicaAssignments)
+        {
+            ValidateTopicPartitionReplica(replica, nameof(replicaAssignments));
+            if (string.IsNullOrWhiteSpace(logDir))
+            {
+                throw new ArgumentException("Log directory path must be specified.", nameof(replicaAssignments));
+            }
+
+            assignments.Add(new ReplicaLogDirAssignment(replica, logDir));
+        }
+
+        if (assignments.Count == 0)
+        {
+            return new Dictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>();
+        }
+
+        var assignmentsByBroker = assignments.GroupBy(static a => a.Replica.BrokerId).ToArray();
+
+        return await WithRetryAsync<IReadOnlyDictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>>(async () =>
+        {
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.AlterReplicaLogDirs,
+                AlterReplicaLogDirsRequest.LowestSupportedVersion,
+                AlterReplicaLogDirsRequest.HighestSupportedVersion);
+
+            var results = new Dictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>();
+            foreach (var brokerAssignments in assignmentsByBroker)
+            {
+                var brokerId = brokerAssignments.Key;
+                var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
+                var request = new AlterReplicaLogDirsRequest
+                {
+                    Dirs = BuildAlterReplicaLogDirsRequestDirs(brokerAssignments)
+                };
+
+                var response = await connection.SendAsync<AlterReplicaLogDirsRequest, AlterReplicaLogDirsResponse>(
+                    request,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+
+                foreach (var topic in response.Results)
+                {
+                    foreach (var partition in topic.Partitions)
+                    {
+                        var replica = new TopicPartitionReplica(topic.TopicName, partition.PartitionIndex, brokerId);
+                        results[replica] = new AlterReplicaLogDirResultInfo
+                        {
+                            TopicPartitionReplica = replica,
+                            ErrorCode = partition.ErrorCode
+                        };
+                    }
+                }
+            }
+
+            return results;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static IReadOnlyList<DescribeLogDirsRequestTopic>? BuildDescribeLogDirsTopics(IEnumerable<TopicPartition>? partitions)
+    {
+        if (partitions is null)
+        {
+            return null;
+        }
+
+        var topics = new Dictionary<string, List<int>>();
+        foreach (var topicPartition in partitions)
+        {
+            ValidateTopicPartition(topicPartition, nameof(partitions));
+            if (!topics.TryGetValue(topicPartition.Topic, out var topicPartitions))
+            {
+                topicPartitions = [];
+                topics[topicPartition.Topic] = topicPartitions;
+            }
+
+            if (!topicPartitions.Contains(topicPartition.Partition))
+            {
+                topicPartitions.Add(topicPartition.Partition);
+            }
+        }
+
+        return topics
+            .Select(static kvp => new DescribeLogDirsRequestTopic
+            {
+                Topic = kvp.Key,
+                Partitions = kvp.Value
+            })
+            .ToList();
+    }
+
+    private static IReadOnlyList<AlterReplicaLogDirsRequestDir> BuildAlterReplicaLogDirsRequestDirs(
+        IEnumerable<ReplicaLogDirAssignment> assignments)
+    {
+        var dirs = new Dictionary<string, Dictionary<string, List<int>>>();
+        foreach (var assignment in assignments)
+        {
+            if (!dirs.TryGetValue(assignment.LogDir, out var topics))
+            {
+                topics = [];
+                dirs[assignment.LogDir] = topics;
+            }
+
+            if (!topics.TryGetValue(assignment.Replica.Topic, out var partitions))
+            {
+                partitions = [];
+                topics[assignment.Replica.Topic] = partitions;
+            }
+
+            partitions.Add(assignment.Replica.Partition);
+        }
+
+        return dirs
+            .Select(static dir => new AlterReplicaLogDirsRequestDir
+            {
+                Path = dir.Key,
+                Topics = dir.Value
+                    .Select(static topic => new AlterReplicaLogDirsRequestTopic
+                    {
+                        Name = topic.Key,
+                        Partitions = topic.Value
+                    })
+                    .ToList()
+            })
+            .ToList();
+    }
+
+    private static void ValidateTopicPartition(TopicPartition topicPartition, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(topicPartition.Topic))
+        {
+            throw new ArgumentException("Topic name must be specified.", paramName);
+        }
+
+        if (topicPartition.Partition < 0)
+        {
+            throw new ArgumentOutOfRangeException(paramName, topicPartition.Partition, "Partition must be non-negative.");
+        }
+    }
+
+    private static void ValidateTopicPartitionReplica(TopicPartitionReplica replica, string paramName)
+    {
+        ValidateTopicPartition(replica.TopicPartition, paramName);
+        if (replica.BrokerId < 0)
+        {
+            throw new ArgumentOutOfRangeException(paramName, replica.BrokerId, "Broker ID must be non-negative.");
+        }
+    }
+
+    private readonly record struct ReplicaLogDirAssignment(TopicPartitionReplica Replica, string LogDir);
+
     public async ValueTask<IReadOnlyDictionary<string, ShareGroupDescription>> DescribeShareGroupsAsync(
         IEnumerable<string> groupIds,
         CancellationToken cancellationToken = default)

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1963,8 +1963,8 @@ public sealed class AdminClient : IAdminClient
                 DescribeLogDirsRequest.LowestSupportedVersion,
                 DescribeLogDirsRequest.HighestSupportedVersion);
 
-            var results = new Dictionary<int, IReadOnlyDictionary<string, LogDirDescription>>();
-            foreach (var brokerId in brokerIdList)
+            // Fan out to all requested brokers in parallel.
+            var brokerResults = await Task.WhenAll(brokerIdList.Select(async brokerId =>
             {
                 var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
                 var response = await connection.SendAsync<DescribeLogDirsRequest, DescribeLogDirsResponse>(
@@ -2006,7 +2006,13 @@ public sealed class AdminClient : IAdminClient
                     };
                 }
 
-                results[brokerId] = brokerResult;
+                return (BrokerId: brokerId, Result: brokerResult);
+            })).ConfigureAwait(false);
+
+            var results = new Dictionary<int, IReadOnlyDictionary<string, LogDirDescription>>(brokerResults.Length);
+            foreach (var brokerResult in brokerResults)
+            {
+                results[brokerResult.BrokerId] = brokerResult.Result;
             }
 
             return results;
@@ -2047,8 +2053,8 @@ public sealed class AdminClient : IAdminClient
                 AlterReplicaLogDirsRequest.LowestSupportedVersion,
                 AlterReplicaLogDirsRequest.HighestSupportedVersion);
 
-            var results = new Dictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>();
-            foreach (var brokerAssignments in assignmentsByBroker)
+            // Fan out to all target brokers in parallel.
+            var brokerResults = await Task.WhenAll(assignmentsByBroker.Select(async brokerAssignments =>
             {
                 var brokerId = brokerAssignments.Key;
                 var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
@@ -2062,17 +2068,29 @@ public sealed class AdminClient : IAdminClient
                     apiVersion,
                     cancellationToken).ConfigureAwait(false);
 
+                var brokerResult = new Dictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>();
                 foreach (var topic in response.Results)
                 {
                     foreach (var partition in topic.Partitions)
                     {
                         var replica = new TopicPartitionReplica(topic.TopicName, partition.PartitionIndex, brokerId);
-                        results[replica] = new AlterReplicaLogDirResultInfo
+                        brokerResult[replica] = new AlterReplicaLogDirResultInfo
                         {
                             TopicPartitionReplica = replica,
                             ErrorCode = partition.ErrorCode
                         };
                     }
+                }
+
+                return brokerResult;
+            })).ConfigureAwait(false);
+
+            var results = new Dictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>(replicaAssignments.Count);
+            foreach (var brokerResult in brokerResults)
+            {
+                foreach (var (replica, result) in brokerResult)
+                {
+                    results[replica] = result;
                 }
             }
 

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -235,6 +235,28 @@ public interface IAdminClient : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Describes log directories on the specified brokers.
+    /// </summary>
+    /// <param name="brokerIds">The broker IDs to query.</param>
+    /// <param name="partitions">Optional partition filter, or null to describe all replicas on each broker.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A dictionary mapping broker ID to log directory path to directory description.</returns>
+    ValueTask<IReadOnlyDictionary<int, IReadOnlyDictionary<string, LogDirDescription>>> DescribeLogDirsAsync(
+        IEnumerable<int> brokerIds,
+        IEnumerable<TopicPartition>? partitions = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Alters replica log directories on their assigned brokers.
+    /// </summary>
+    /// <param name="replicaAssignments">Replica-to-log-directory assignments.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Results for each requested replica.</returns>
+    ValueTask<IReadOnlyDictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>> AlterReplicaLogDirsAsync(
+        IReadOnlyDictionary<TopicPartitionReplica, string> replicaAssignments,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Describes share groups.
     /// </summary>
     ValueTask<IReadOnlyDictionary<string, ShareGroupDescription>> DescribeShareGroupsAsync(
@@ -608,4 +630,83 @@ public sealed class ElectLeadersResultInfo
     /// Error message, if any.
     /// </summary>
     public string? ErrorMessage { get; init; }
+}
+
+/// <summary>
+/// Identifies a replica of a topic partition on a specific broker.
+/// </summary>
+public readonly record struct TopicPartitionReplica(string Topic, int Partition, int BrokerId)
+{
+    /// <summary>
+    /// The topic partition for this replica.
+    /// </summary>
+    public TopicPartition TopicPartition => new(Topic, Partition);
+}
+
+/// <summary>
+/// Description of a broker log directory.
+/// </summary>
+public sealed class LogDirDescription
+{
+    /// <summary>
+    /// Directory-level error code, or None if the directory was described successfully.
+    /// </summary>
+    public Protocol.ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// Replica information keyed by topic partition.
+    /// </summary>
+    public required IReadOnlyDictionary<TopicPartition, ReplicaLogDirInfo> ReplicaInfos { get; init; }
+
+    /// <summary>
+    /// Total size in bytes of the volume containing the log directory, when returned by the broker.
+    /// </summary>
+    public long? TotalBytes { get; init; }
+
+    /// <summary>
+    /// Usable size in bytes of the volume containing the log directory, when returned by the broker.
+    /// </summary>
+    public long? UsableBytes { get; init; }
+
+    /// <summary>
+    /// True when the broker reports the log directory is cordoned.
+    /// </summary>
+    public bool? IsCordoned { get; init; }
+}
+
+/// <summary>
+/// Replica placement and size information inside a log directory.
+/// </summary>
+public sealed class ReplicaLogDirInfo
+{
+    /// <summary>
+    /// Size of the log segments for this replica in bytes.
+    /// </summary>
+    public required long Size { get; init; }
+
+    /// <summary>
+    /// Offset lag of this log relative to the current replica high watermark or log end offset.
+    /// </summary>
+    public required long OffsetLag { get; init; }
+
+    /// <summary>
+    /// True when this is a future log created by AlterReplicaLogDirs.
+    /// </summary>
+    public required bool IsFuture { get; init; }
+}
+
+/// <summary>
+/// Result of altering a replica log directory.
+/// </summary>
+public sealed class AlterReplicaLogDirResultInfo
+{
+    /// <summary>
+    /// The replica the result applies to.
+    /// </summary>
+    public required TopicPartitionReplica TopicPartitionReplica { get; init; }
+
+    /// <summary>
+    /// Per-replica error code, or None if the assignment succeeded.
+    /// </summary>
+    public Protocol.ErrorCode ErrorCode { get; init; }
 }

--- a/src/Dekaf/Protocol/Messages/AlterReplicaLogDirsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/AlterReplicaLogDirsRequest.cs
@@ -1,0 +1,104 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// AlterReplicaLogDirs request (API key 34).
+/// Moves replicas to the requested log directories on a broker.
+/// </summary>
+public sealed class AlterReplicaLogDirsRequest : IKafkaRequest<AlterReplicaLogDirsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.AlterReplicaLogDirs;
+    public static short LowestSupportedVersion => 1;
+    public static short HighestSupportedVersion => 2;
+
+    /// <summary>
+    /// The directory assignments to apply.
+    /// </summary>
+    public required IReadOnlyList<AlterReplicaLogDirsRequestDir> Dirs { get; init; }
+
+    public static bool IsFlexibleVersion(short version) => version >= 2;
+
+    public static short GetRequestHeaderVersion(short version) => version >= 2 ? (short)2 : (short)1;
+
+    public static short GetResponseHeaderVersion(short version) => version >= 2 ? (short)1 : (short)0;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        if (version >= 2)
+        {
+            writer.WriteCompactArray(
+                Dirs,
+                static (ref KafkaProtocolWriter w, AlterReplicaLogDirsRequestDir d, short v) => d.Write(ref w, v),
+                version);
+            writer.WriteEmptyTaggedFields();
+            return;
+        }
+
+        writer.WriteArray(
+            Dirs,
+            static (ref KafkaProtocolWriter w, AlterReplicaLogDirsRequestDir d, short v) => d.Write(ref w, v),
+            version);
+    }
+}
+
+/// <summary>
+/// Target log directory and replicas for AlterReplicaLogDirs.
+/// </summary>
+public sealed class AlterReplicaLogDirsRequestDir
+{
+    /// <summary>
+    /// Absolute log directory path.
+    /// </summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    /// Topics to add to this directory.
+    /// </summary>
+    public required IReadOnlyList<AlterReplicaLogDirsRequestTopic> Topics { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        if (version >= 2)
+        {
+            writer.WriteCompactString(Path);
+            writer.WriteCompactArray(
+                Topics,
+                static (ref KafkaProtocolWriter w, AlterReplicaLogDirsRequestTopic t, short v) => t.Write(ref w, v),
+                version);
+            writer.WriteEmptyTaggedFields();
+            return;
+        }
+
+        writer.WriteString(Path);
+        writer.WriteArray(
+            Topics,
+            static (ref KafkaProtocolWriter w, AlterReplicaLogDirsRequestTopic t, short v) => t.Write(ref w, v),
+            version);
+    }
+}
+
+/// <summary>
+/// Topic in an AlterReplicaLogDirs request.
+/// </summary>
+public sealed class AlterReplicaLogDirsRequestTopic
+{
+    public required string Name { get; init; }
+    public required IReadOnlyList<int> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        if (version >= 2)
+        {
+            writer.WriteCompactString(Name);
+            writer.WriteCompactArray(
+                Partitions,
+                static (ref KafkaProtocolWriter w, int p) => w.WriteInt32(p));
+            writer.WriteEmptyTaggedFields();
+            return;
+        }
+
+        writer.WriteString(Name);
+        writer.WriteArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, int p) => w.WriteInt32(p));
+    }
+}

--- a/src/Dekaf/Protocol/Messages/AlterReplicaLogDirsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/AlterReplicaLogDirsResponse.cs
@@ -1,0 +1,105 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// AlterReplicaLogDirs response (API key 34).
+/// </summary>
+public sealed class AlterReplicaLogDirsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.AlterReplicaLogDirs;
+    public static short LowestSupportedVersion => 1;
+    public static short HighestSupportedVersion => 2;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// Results for each topic.
+    /// </summary>
+    public required IReadOnlyList<AlterReplicaLogDirsResponseTopic> Results { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var results = version >= 2
+            ? reader.ReadCompactArray(
+                static (ref KafkaProtocolReader r, short v) => AlterReplicaLogDirsResponseTopic.Read(ref r, v),
+                version)
+            : reader.ReadArray(
+                static (ref KafkaProtocolReader r, short v) => AlterReplicaLogDirsResponseTopic.Read(ref r, v),
+                version);
+
+        if (version >= 2)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new AlterReplicaLogDirsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            Results = results
+        };
+    }
+}
+
+/// <summary>
+/// Topic result in an AlterReplicaLogDirs response.
+/// </summary>
+public sealed class AlterReplicaLogDirsResponseTopic
+{
+    public required string TopicName { get; init; }
+    public required IReadOnlyList<AlterReplicaLogDirsResponsePartition> Partitions { get; init; }
+
+    public static AlterReplicaLogDirsResponseTopic Read(ref KafkaProtocolReader reader, short version)
+    {
+        var topicName = version >= 2
+            ? reader.ReadCompactString() ?? string.Empty
+            : reader.ReadString() ?? string.Empty;
+
+        var partitions = version >= 2
+            ? reader.ReadCompactArray(
+                static (ref KafkaProtocolReader r, short v) => AlterReplicaLogDirsResponsePartition.Read(ref r, v),
+                version)
+            : reader.ReadArray(
+                static (ref KafkaProtocolReader r, short v) => AlterReplicaLogDirsResponsePartition.Read(ref r, v),
+                version);
+
+        if (version >= 2)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new AlterReplicaLogDirsResponseTopic
+        {
+            TopicName = topicName,
+            Partitions = partitions
+        };
+    }
+}
+
+/// <summary>
+/// Partition result in an AlterReplicaLogDirs response.
+/// </summary>
+public sealed class AlterReplicaLogDirsResponsePartition
+{
+    public required int PartitionIndex { get; init; }
+    public required ErrorCode ErrorCode { get; init; }
+
+    public static AlterReplicaLogDirsResponsePartition Read(ref KafkaProtocolReader reader, short version)
+    {
+        var partitionIndex = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        if (version >= 2)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new AlterReplicaLogDirsResponsePartition
+        {
+            PartitionIndex = partitionIndex,
+            ErrorCode = errorCode
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DescribeLogDirsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeLogDirsRequest.cs
@@ -1,0 +1,68 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DescribeLogDirs request (API key 35).
+/// Describes replica placement and size by log directory on a broker.
+/// </summary>
+public sealed class DescribeLogDirsRequest : IKafkaRequest<DescribeLogDirsResponse>
+{
+    public static ApiKey ApiKey => ApiKey.DescribeLogDirs;
+    public static short LowestSupportedVersion => 1;
+    public static short HighestSupportedVersion => 5;
+
+    /// <summary>
+    /// Topics to describe, or null for all topics.
+    /// </summary>
+    public IReadOnlyList<DescribeLogDirsRequestTopic>? Topics { get; init; }
+
+    public static bool IsFlexibleVersion(short version) => version >= 2;
+
+    public static short GetRequestHeaderVersion(short version) => version >= 2 ? (short)2 : (short)1;
+
+    public static short GetResponseHeaderVersion(short version) => version >= 2 ? (short)1 : (short)0;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        if (version >= 2)
+        {
+            writer.WriteCompactNullableArray(
+                Topics,
+                static (ref KafkaProtocolWriter w, DescribeLogDirsRequestTopic t, short v) => t.Write(ref w, v),
+                version);
+            writer.WriteEmptyTaggedFields();
+            return;
+        }
+
+        writer.WriteNullableArray(
+            Topics,
+            static (ref KafkaProtocolWriter w, DescribeLogDirsRequestTopic t, short v) => t.Write(ref w, v),
+            version);
+    }
+}
+
+/// <summary>
+/// Topic filter in a DescribeLogDirs request.
+/// </summary>
+public sealed class DescribeLogDirsRequestTopic
+{
+    public required string Topic { get; init; }
+    public required IReadOnlyList<int> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        if (version >= 2)
+        {
+            writer.WriteCompactString(Topic);
+            writer.WriteCompactArray(
+                Partitions,
+                static (ref KafkaProtocolWriter w, int p) => w.WriteInt32(p));
+            writer.WriteEmptyTaggedFields();
+            return;
+        }
+
+        writer.WriteString(Topic);
+        writer.WriteArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, int p) => w.WriteInt32(p));
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DescribeLogDirsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeLogDirsResponse.cs
@@ -1,0 +1,178 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DescribeLogDirs response (API key 35).
+/// </summary>
+public sealed class DescribeLogDirsResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.DescribeLogDirs;
+    public static short LowestSupportedVersion => 1;
+    public static short HighestSupportedVersion => 5;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation.
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// Top-level error code for v3+ responses.
+    /// </summary>
+    public ErrorCode ErrorCode { get; init; }
+
+    /// <summary>
+    /// The log directories reported by the broker.
+    /// </summary>
+    public required IReadOnlyList<DescribeLogDirsResponseDir> Results { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = version >= 3 ? (ErrorCode)reader.ReadInt16() : ErrorCode.None;
+
+        var results = version >= 2
+            ? reader.ReadCompactArray(
+                static (ref KafkaProtocolReader r, short v) => DescribeLogDirsResponseDir.Read(ref r, v),
+                version)
+            : reader.ReadArray(
+                static (ref KafkaProtocolReader r, short v) => DescribeLogDirsResponseDir.Read(ref r, v),
+                version);
+
+        if (version >= 2)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DescribeLogDirsResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            Results = results
+        };
+    }
+}
+
+/// <summary>
+/// Log directory result in a DescribeLogDirs response.
+/// </summary>
+public sealed class DescribeLogDirsResponseDir
+{
+    public required ErrorCode ErrorCode { get; init; }
+    public required string LogDir { get; init; }
+    public required IReadOnlyList<DescribeLogDirsResponseTopic> Topics { get; init; }
+    public long? TotalBytes { get; init; }
+    public long? UsableBytes { get; init; }
+    public bool? IsCordoned { get; init; }
+
+    public static DescribeLogDirsResponseDir Read(ref KafkaProtocolReader reader, short version)
+    {
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var logDir = version >= 2
+            ? reader.ReadCompactString() ?? string.Empty
+            : reader.ReadString() ?? string.Empty;
+
+        var topics = version >= 2
+            ? reader.ReadCompactArray(
+                static (ref KafkaProtocolReader r, short v) => DescribeLogDirsResponseTopic.Read(ref r, v),
+                version)
+            : reader.ReadArray(
+                static (ref KafkaProtocolReader r, short v) => DescribeLogDirsResponseTopic.Read(ref r, v),
+                version);
+
+        long? totalBytes = null;
+        long? usableBytes = null;
+        bool? isCordoned = null;
+
+        if (version >= 4)
+        {
+            totalBytes = reader.ReadInt64();
+            usableBytes = reader.ReadInt64();
+        }
+
+        if (version >= 5)
+        {
+            isCordoned = reader.ReadBoolean();
+        }
+
+        if (version >= 2)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DescribeLogDirsResponseDir
+        {
+            ErrorCode = errorCode,
+            LogDir = logDir,
+            Topics = topics,
+            TotalBytes = totalBytes,
+            UsableBytes = usableBytes,
+            IsCordoned = isCordoned
+        };
+    }
+}
+
+/// <summary>
+/// Topic in a DescribeLogDirs response.
+/// </summary>
+public sealed class DescribeLogDirsResponseTopic
+{
+    public required string Name { get; init; }
+    public required IReadOnlyList<DescribeLogDirsResponsePartition> Partitions { get; init; }
+
+    public static DescribeLogDirsResponseTopic Read(ref KafkaProtocolReader reader, short version)
+    {
+        var name = version >= 2
+            ? reader.ReadCompactString() ?? string.Empty
+            : reader.ReadString() ?? string.Empty;
+
+        var partitions = version >= 2
+            ? reader.ReadCompactArray(
+                static (ref KafkaProtocolReader r, short v) => DescribeLogDirsResponsePartition.Read(ref r, v),
+                version)
+            : reader.ReadArray(
+                static (ref KafkaProtocolReader r, short v) => DescribeLogDirsResponsePartition.Read(ref r, v),
+                version);
+
+        if (version >= 2)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DescribeLogDirsResponseTopic
+        {
+            Name = name,
+            Partitions = partitions
+        };
+    }
+}
+
+/// <summary>
+/// Partition information in a DescribeLogDirs response.
+/// </summary>
+public sealed class DescribeLogDirsResponsePartition
+{
+    public required int PartitionIndex { get; init; }
+    public required long PartitionSize { get; init; }
+    public required long OffsetLag { get; init; }
+    public required bool IsFutureKey { get; init; }
+
+    public static DescribeLogDirsResponsePartition Read(ref KafkaProtocolReader reader, short version)
+    {
+        var partitionIndex = reader.ReadInt32();
+        var partitionSize = reader.ReadInt64();
+        var offsetLag = reader.ReadInt64();
+        var isFutureKey = reader.ReadBoolean();
+
+        if (version >= 2)
+        {
+            reader.SkipTaggedFields();
+        }
+
+        return new DescribeLogDirsResponsePartition
+        {
+            PartitionIndex = partitionIndex,
+            PartitionSize = partitionSize,
+            OffsetLag = offsetLag,
+            IsFutureKey = isFutureKey
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Integration/AdminClientTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminClientTests.cs
@@ -107,6 +107,49 @@ public class AdminClientTests(KafkaTestContainer kafka) : KafkaIntegrationTest(k
 
     #endregion
 
+    #region LogDir Tests
+
+    [Test]
+    public async Task DescribeLogDirsAsync_ReturnsReplicaInfoForTopicPartition()
+    {
+        // Arrange
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1).ConfigureAwait(false);
+        var topicPartition = new TopicPartition(topic, 0);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-log-dirs-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key",
+            Value = "value"
+        }).ConfigureAwait(false);
+
+        await using var admin = CreateAdminClient();
+        var cluster = await admin.DescribeClusterAsync().ConfigureAwait(false);
+        var brokerIds = cluster.Nodes.Select(static n => n.NodeId).ToArray();
+
+        // Act
+        var logDirs = await WaitForConditionAsync(
+            async () => await admin.DescribeLogDirsAsync(brokerIds, [topicPartition]).ConfigureAwait(false),
+            result => FindReplicaInfo(result, topicPartition) is not null,
+            maxRetries: 8).ConfigureAwait(false);
+
+        // Assert
+        await Assert.That(brokerIds.Length).IsGreaterThan(0);
+        var replicaInfo = FindReplicaInfo(logDirs, topicPartition);
+        await Assert.That(replicaInfo).IsNotNull();
+        await Assert.That(replicaInfo!.Size).IsGreaterThanOrEqualTo(0);
+        await Assert.That(replicaInfo.OffsetLag).IsGreaterThanOrEqualTo(0);
+        await Assert.That(replicaInfo.IsFuture).IsFalse();
+    }
+
+    #endregion
+
     #region AlterConfigs Tests
 
     [Test]
@@ -874,4 +917,22 @@ public class AdminClientTests(KafkaTestContainer kafka) : KafkaIntegrationTest(k
     }
 
     #endregion
+
+    private static ReplicaLogDirInfo? FindReplicaInfo(
+        IReadOnlyDictionary<int, IReadOnlyDictionary<string, LogDirDescription>> logDirs,
+        TopicPartition topicPartition)
+    {
+        foreach (var brokerDirs in logDirs.Values)
+        {
+            foreach (var dir in brokerDirs.Values)
+            {
+                if (dir.ReplicaInfos.TryGetValue(topicPartition, out var info))
+                {
+                    return info;
+                }
+            }
+        }
+
+        return null;
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Admin/AdminLogDirsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminLogDirsTests.cs
@@ -68,6 +68,74 @@ public sealed class AdminLogDirsTests
         await Assert.That(result[brokerTwo].ErrorCode).IsEqualTo(ErrorCode.None);
     }
 
+    [Test]
+    public async Task DescribeLogDirsAsync_NullBrokerIds_ThrowsArgumentNullException()
+    {
+        await using var context = new AdminTestContext();
+
+        async Task Act() => await context.Client.DescribeLogDirsAsync(null!);
+
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task DescribeLogDirsAsync_NegativeBrokerId_ThrowsArgumentOutOfRangeException()
+    {
+        await using var context = new AdminTestContext();
+
+        async Task Act() => await context.Client.DescribeLogDirsAsync([-1]);
+
+        await Assert.That(Act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task DescribeLogDirsAsync_NegativePartition_ThrowsArgumentOutOfRangeException()
+    {
+        await using var context = new AdminTestContext();
+
+        async Task Act() => await context.Client.DescribeLogDirsAsync(
+            [1],
+            [new TopicPartition("topic-a", -1)]);
+
+        await Assert.That(Act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task AlterReplicaLogDirsAsync_NullAssignments_ThrowsArgumentNullException()
+    {
+        await using var context = new AdminTestContext();
+
+        async Task Act() => await context.Client.AlterReplicaLogDirsAsync(null!);
+
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task AlterReplicaLogDirsAsync_NegativeBrokerId_ThrowsArgumentOutOfRangeException()
+    {
+        await using var context = new AdminTestContext();
+
+        async Task Act() => await context.Client.AlterReplicaLogDirsAsync(new Dictionary<TopicPartitionReplica, string>
+        {
+            [new TopicPartitionReplica("topic-a", 0, -1)] = "/data-1"
+        });
+
+        await Assert.That(Act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task AlterReplicaLogDirsAsync_EmptyLogDir_ThrowsArgumentException()
+    {
+        await using var context = new AdminTestContext();
+
+        async Task Act() => await context.Client.AlterReplicaLogDirsAsync(new Dictionary<TopicPartitionReplica, string>
+        {
+            [new TopicPartitionReplica("topic-a", 0, 1)] = " "
+        });
+
+        await Assert.That(Act).Throws<ArgumentException>();
+    }
+
     private static DescribeLogDirsResponse DescribeResponse(
         string logDir,
         string topicName,

--- a/tests/Dekaf.Tests.Unit/Admin/AdminLogDirsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminLogDirsTests.cs
@@ -1,0 +1,236 @@
+using Dekaf.Admin;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public sealed class AdminLogDirsTests
+{
+    [Test]
+    public async Task DescribeLogDirsAsync_FansOutToBrokersAndMapsResults()
+    {
+        await using var context = new AdminTestContext();
+        context.EnqueueDescribe(DescribeResponse("/data-1", "topic-a", partition: 0, size: 100, offsetLag: 2, isFuture: false));
+        context.EnqueueDescribe(DescribeResponse("/data-2", "topic-a", partition: 1, size: 200, offsetLag: 3, isFuture: true));
+
+        var result = await context.Client.DescribeLogDirsAsync(
+            [1, 2],
+            [new TopicPartition("topic-a", 0)]);
+
+        var requests = context.RequestsOfType<DescribeLogDirsRequest>();
+        var brokerOneReplica = result[1]["/data-1"].ReplicaInfos[new TopicPartition("topic-a", 0)];
+        var brokerTwoReplica = result[2]["/data-2"].ReplicaInfos[new TopicPartition("topic-a", 1)];
+        var topics = requests[0].Topics!;
+
+        await Assert.That(requests.Count).IsEqualTo(2);
+        await Assert.That(requests[0].Topics).IsNotNull();
+        await Assert.That(topics[0].Topic).IsEqualTo("topic-a");
+        await Assert.That(topics[0].Partitions).IsEquivalentTo([0]);
+        await Assert.That(brokerOneReplica.Size).IsEqualTo(100);
+        await Assert.That(brokerOneReplica.OffsetLag).IsEqualTo(2);
+        await Assert.That(brokerOneReplica.IsFuture).IsFalse();
+        await Assert.That(brokerTwoReplica.Size).IsEqualTo(200);
+        await Assert.That(brokerTwoReplica.OffsetLag).IsEqualTo(3);
+        await Assert.That(brokerTwoReplica.IsFuture).IsTrue();
+    }
+
+    [Test]
+    public async Task AlterReplicaLogDirsAsync_GroupsAssignmentsByBrokerAndDirectory()
+    {
+        await using var context = new AdminTestContext();
+        context.EnqueueAlter(AlterResponse("topic-a", (0, ErrorCode.None), (1, ErrorCode.KafkaStorageError)));
+        context.EnqueueAlter(AlterResponse("topic-b", (0, ErrorCode.None)));
+
+        var brokerOneFirst = new TopicPartitionReplica("topic-a", 0, 1);
+        var brokerOneSecond = new TopicPartitionReplica("topic-a", 1, 1);
+        var brokerTwo = new TopicPartitionReplica("topic-b", 0, 2);
+
+        var result = await context.Client.AlterReplicaLogDirsAsync(new Dictionary<TopicPartitionReplica, string>
+        {
+            [brokerOneFirst] = "/data-1",
+            [brokerOneSecond] = "/data-2",
+            [brokerTwo] = "/data-3"
+        });
+
+        var requests = context.RequestsOfType<AlterReplicaLogDirsRequest>();
+        var brokerOneDirs = requests[0].Dirs.ToDictionary(static d => d.Path);
+
+        await Assert.That(requests.Count).IsEqualTo(2);
+        await Assert.That(brokerOneDirs.Keys).IsEquivalentTo(["/data-1", "/data-2"]);
+        await Assert.That(brokerOneDirs["/data-1"].Topics[0].Name).IsEqualTo("topic-a");
+        await Assert.That(brokerOneDirs["/data-1"].Topics[0].Partitions).IsEquivalentTo([0]);
+        await Assert.That(brokerOneDirs["/data-2"].Topics[0].Partitions).IsEquivalentTo([1]);
+        await Assert.That(result[brokerOneFirst].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(result[brokerOneSecond].ErrorCode).IsEqualTo(ErrorCode.KafkaStorageError);
+        await Assert.That(result[brokerTwo].ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    private static DescribeLogDirsResponse DescribeResponse(
+        string logDir,
+        string topicName,
+        int partition,
+        long size,
+        long offsetLag,
+        bool isFuture) => new()
+        {
+            ThrottleTimeMs = 0,
+            ErrorCode = ErrorCode.None,
+            Results =
+            [
+                new DescribeLogDirsResponseDir
+                {
+                    ErrorCode = ErrorCode.None,
+                    LogDir = logDir,
+                    TotalBytes = 10000,
+                    UsableBytes = 9000,
+                    IsCordoned = false,
+                    Topics =
+                    [
+                        new DescribeLogDirsResponseTopic
+                        {
+                            Name = topicName,
+                            Partitions =
+                            [
+                                new DescribeLogDirsResponsePartition
+                                {
+                                    PartitionIndex = partition,
+                                    PartitionSize = size,
+                                    OffsetLag = offsetLag,
+                                    IsFutureKey = isFuture
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+    private static AlterReplicaLogDirsResponse AlterResponse(
+        string topicName,
+        params (int Partition, ErrorCode ErrorCode)[] partitions) => new()
+        {
+            ThrottleTimeMs = 0,
+            Results =
+            [
+                new AlterReplicaLogDirsResponseTopic
+                {
+                    TopicName = topicName,
+                    Partitions = partitions
+                        .Select(static p => new AlterReplicaLogDirsResponsePartition
+                        {
+                            PartitionIndex = p.Partition,
+                            ErrorCode = p.ErrorCode
+                        })
+                        .ToList()
+                }
+            ]
+        };
+
+    private sealed class AdminTestContext : IAsyncDisposable
+    {
+        private readonly IConnectionPool _pool;
+        private readonly IKafkaConnection _connection;
+        private readonly MetadataManager _metadataManager;
+        private readonly Queue<DescribeLogDirsResponse> _describeResponses = new();
+        private readonly Queue<AlterReplicaLogDirsResponse> _alterResponses = new();
+        private readonly List<object> _requests = [];
+
+        public AdminTestContext()
+        {
+            _connection = Substitute.For<IKafkaConnection>();
+            _connection.BrokerId.Returns(1);
+            _connection.Host.Returns("localhost");
+            _connection.Port.Returns(9092);
+            _connection.IsConnected.Returns(true);
+            _connection
+                .SendAsync<DescribeLogDirsRequest, DescribeLogDirsResponse>(
+                    Arg.Any<DescribeLogDirsRequest>(),
+                    Arg.Any<short>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    _requests.Add(callInfo.ArgAt<DescribeLogDirsRequest>(0));
+                    if (!_describeResponses.TryDequeue(out var response))
+                    {
+                        throw new InvalidOperationException($"No queued response for {nameof(DescribeLogDirsRequest)}.");
+                    }
+
+                    return new ValueTask<DescribeLogDirsResponse>(response);
+                });
+            _connection
+                .SendAsync<AlterReplicaLogDirsRequest, AlterReplicaLogDirsResponse>(
+                    Arg.Any<AlterReplicaLogDirsRequest>(),
+                    Arg.Any<short>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    _requests.Add(callInfo.ArgAt<AlterReplicaLogDirsRequest>(0));
+                    if (!_alterResponses.TryDequeue(out var response))
+                    {
+                        throw new InvalidOperationException($"No queued response for {nameof(AlterReplicaLogDirsRequest)}.");
+                    }
+
+                    return new ValueTask<AlterReplicaLogDirsResponse>(response);
+                });
+
+            _pool = Substitute.For<IConnectionPool>();
+            _pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<IKafkaConnection>(_connection));
+            _pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<IKafkaConnection>(_connection));
+            _pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<IKafkaConnection>(_connection));
+
+            _metadataManager = new MetadataManager(_pool, ["localhost:9092"]);
+            _metadataManager.SetApiVersion(ApiKey.DescribeLogDirs, 1, 5);
+            _metadataManager.SetApiVersion(ApiKey.AlterReplicaLogDirs, 1, 2);
+            _metadataManager.Metadata.Update(new MetadataResponse
+            {
+                Brokers =
+                [
+                    new BrokerMetadata
+                    {
+                        NodeId = 1,
+                        Host = "localhost",
+                        Port = 9092
+                    },
+                    new BrokerMetadata
+                    {
+                        NodeId = 2,
+                        Host = "localhost",
+                        Port = 9093
+                    }
+                ],
+                ClusterId = "test-cluster",
+                ControllerId = 1,
+                Topics = []
+            });
+
+            Client = new AdminClient(
+                new AdminClientOptions
+                {
+                    BootstrapServers = ["localhost:9092"]
+                },
+                _pool,
+                _metadataManager);
+        }
+
+        public AdminClient Client { get; }
+
+        public void EnqueueDescribe(DescribeLogDirsResponse response) => _describeResponses.Enqueue(response);
+
+        public void EnqueueAlter(AlterReplicaLogDirsResponse response) => _alterResponses.Enqueue(response);
+
+        public IReadOnlyList<T> RequestsOfType<T>() => _requests.OfType<T>().ToArray();
+
+        public async ValueTask DisposeAsync()
+        {
+            await Client.DisposeAsync().ConfigureAwait(false);
+            await _metadataManager.DisposeAsync().ConfigureAwait(false);
+            await _pool.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminTypesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminTypesTests.cs
@@ -169,6 +169,65 @@ public class AdminTypesTests
 
     #endregion
 
+    #region LogDir Admin Types Tests
+
+    [Test]
+    public async Task TopicPartitionReplica_ExposesTopicPartition()
+    {
+        var replica = new TopicPartitionReplica("test-topic", 2, 3);
+
+        await Assert.That(replica.Topic).IsEqualTo("test-topic");
+        await Assert.That(replica.Partition).IsEqualTo(2);
+        await Assert.That(replica.BrokerId).IsEqualTo(3);
+        await Assert.That(replica.TopicPartition).IsEqualTo(new TopicPartition("test-topic", 2));
+    }
+
+    [Test]
+    public async Task LogDirDescription_CanBeCreated()
+    {
+        var topicPartition = new TopicPartition("test-topic", 0);
+        var description = new LogDirDescription
+        {
+            ErrorCode = ErrorCode.None,
+            TotalBytes = 10000,
+            UsableBytes = 7500,
+            IsCordoned = true,
+            ReplicaInfos = new Dictionary<TopicPartition, ReplicaLogDirInfo>
+            {
+                [topicPartition] = new()
+                {
+                    Size = 1234,
+                    OffsetLag = 5,
+                    IsFuture = false
+                }
+            }
+        };
+
+        await Assert.That(description.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(description.TotalBytes).IsEqualTo(10000);
+        await Assert.That(description.UsableBytes).IsEqualTo(7500);
+        await Assert.That(description.IsCordoned).IsTrue();
+        await Assert.That(description.ReplicaInfos[topicPartition].Size).IsEqualTo(1234);
+        await Assert.That(description.ReplicaInfos[topicPartition].OffsetLag).IsEqualTo(5);
+        await Assert.That(description.ReplicaInfos[topicPartition].IsFuture).IsFalse();
+    }
+
+    [Test]
+    public async Task AlterReplicaLogDirResultInfo_CanBeCreated()
+    {
+        var replica = new TopicPartitionReplica("test-topic", 0, 1);
+        var result = new AlterReplicaLogDirResultInfo
+        {
+            TopicPartitionReplica = replica,
+            ErrorCode = ErrorCode.KafkaStorageError
+        };
+
+        await Assert.That(result.TopicPartitionReplica).IsEqualTo(replica);
+        await Assert.That(result.ErrorCode).IsEqualTo(ErrorCode.KafkaStorageError);
+    }
+
+    #endregion
+
     #region ElectionType Tests
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Protocol/LogDirMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/LogDirMessageTests.cs
@@ -1,0 +1,140 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class LogDirMessageTests
+{
+    [Test]
+    public async Task AlterReplicaLogDirsRequest_V2_Flexible_EncodedCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new AlterReplicaLogDirsRequest
+        {
+            Dirs =
+            [
+                new AlterReplicaLogDirsRequestDir
+                {
+                    Path = "/data-1",
+                    Topics =
+                    [
+                        new AlterReplicaLogDirsRequestTopic
+                        {
+                            Name = "topic-a",
+                            Partitions = [0, 1]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        request.Write(ref writer, version: 2);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var dirCount = reader.ReadUnsignedVarInt() - 1;
+        var path = reader.ReadCompactString();
+        var topicCount = reader.ReadUnsignedVarInt() - 1;
+        var topic = reader.ReadCompactString();
+        var partitionCount = reader.ReadUnsignedVarInt() - 1;
+        var firstPartition = reader.ReadInt32();
+        var secondPartition = reader.ReadInt32();
+        reader.SkipTaggedFields();
+        reader.SkipTaggedFields();
+        reader.SkipTaggedFields();
+
+        await Assert.That(dirCount).IsEqualTo(1);
+        await Assert.That(path).IsEqualTo("/data-1");
+        await Assert.That(topicCount).IsEqualTo(1);
+        await Assert.That(topic).IsEqualTo("topic-a");
+        await Assert.That(partitionCount).IsEqualTo(2);
+        await Assert.That(firstPartition).IsEqualTo(0);
+        await Assert.That(secondPartition).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task DescribeLogDirsRequest_V1_UsesLegacyHeadersAndNullArray()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new DescribeLogDirsRequest { Topics = null };
+        request.Write(ref writer, version: 1);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var topicArrayLength = reader.ReadInt32();
+
+        await Assert.That(DescribeLogDirsRequest.GetRequestHeaderVersion(1)).IsEqualTo((short)1);
+        await Assert.That(DescribeLogDirsRequest.GetResponseHeaderVersion(1)).IsEqualTo((short)0);
+        await Assert.That(DescribeLogDirsRequest.GetRequestHeaderVersion(2)).IsEqualTo((short)2);
+        await Assert.That(DescribeLogDirsRequest.GetResponseHeaderVersion(2)).IsEqualTo((short)1);
+        await Assert.That(topicArrayLength).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task AlterReplicaLogDirsResponse_V2_Flexible_CanBeParsed()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(25);
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteCompactString("topic-a");
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (AlterReplicaLogDirsResponse)AlterReplicaLogDirsResponse.Read(ref reader, version: 2);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(25);
+        await Assert.That(response.Results.Count).IsEqualTo(1);
+        await Assert.That(response.Results[0].TopicName).IsEqualTo("topic-a");
+        await Assert.That(response.Results[0].Partitions[0].ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
+    public async Task DescribeLogDirsResponse_V5_Flexible_CanBeParsed()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(100);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactString("/data-1");
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteCompactString("topic-a");
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteInt32(0);
+        writer.WriteInt64(1234);
+        writer.WriteInt64(7);
+        writer.WriteBoolean(true);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+        writer.WriteInt64(10000);
+        writer.WriteInt64(9000);
+        writer.WriteBoolean(false);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (DescribeLogDirsResponse)DescribeLogDirsResponse.Read(ref reader, version: 5);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(100);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.Results[0].LogDir).IsEqualTo("/data-1");
+        await Assert.That(response.Results[0].TotalBytes).IsEqualTo(10000);
+        await Assert.That(response.Results[0].UsableBytes).IsEqualTo(9000);
+        await Assert.That(response.Results[0].IsCordoned).IsFalse();
+        await Assert.That(response.Results[0].Topics[0].Partitions[0].PartitionSize).IsEqualTo(1234);
+        await Assert.That(response.Results[0].Topics[0].Partitions[0].OffsetLag).IsEqualTo(7);
+        await Assert.That(response.Results[0].Topics[0].Partitions[0].IsFutureKey).IsTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- add AlterReplicaLogDirs and DescribeLogDirs protocol messages from the Kafka protocol docs
- expose broker-routed `DescribeLogDirsAsync` and `AlterReplicaLogDirsAsync` on `IAdminClient`
- add public log-dir result models plus unit and integration coverage

## Tests
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe` (3918 passed)
- `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj --configuration Release --no-restore`
- `./tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration.exe --treenode-filter "/*/*/AdminClientTests/DescribeLogDirsAsync_ReturnsReplicaInfoForTopicPartition"` (3 passed)
- `git diff --check`

Protocol reference: https://kafka.apache.org/43/design/protocol/#protocol_messages

Closes #1159