### PR TITLE
feat(producer): add purge API

### DIFF
--- a/src/Dekaf/Errors/KafkaException.cs
+++ b/src/Dekaf/Errors/KafkaException.cs
@@ -228,6 +228,22 @@ public sealed class ProduceException : KafkaException
     {
     }
 
+    public ProduceException(ProduceErrorKind kind, string message) : base(message)
+    {
+        Kind = kind;
+    }
+
+    public ProduceException(ProduceErrorKind kind, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Kind = kind;
+    }
+
+    /// <summary>
+    /// The local producer failure kind, when the failure was not represented by a Kafka protocol error code.
+    /// </summary>
+    public ProduceErrorKind Kind { get; init; }
+
     /// <summary>
     /// The topic the produce was for.
     /// </summary>
@@ -237,6 +253,22 @@ public sealed class ProduceException : KafkaException
     /// The partition the produce was for.
     /// </summary>
     public int? Partition { get; init; }
+}
+
+/// <summary>
+/// Identifies local producer failure kinds that do not have Kafka protocol error codes.
+/// </summary>
+public enum ProduceErrorKind
+{
+    /// <summary>
+    /// No local failure kind was specified.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The produce was failed because the application purged it.
+    /// </summary>
+    Purged
 }
 
 /// <summary>

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -162,6 +162,17 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     ValueTask FlushAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Purges queued and/or in-flight messages from the producer.
+    /// </summary>
+    /// <remarks>
+    /// Queued messages are dropped before they are sent. In-flight messages may already have
+    /// reached the broker; purging them only fails local delivery tasks and callbacks.
+    /// </remarks>
+    /// <param name="options">The messages to purge.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask PurgeAsync(PurgeOptions options, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Registers or replaces an application metric for broker telemetry subscriptions.
     /// </summary>
     /// <param name="metric">The application metric to register.</param>
@@ -197,6 +208,38 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <param name="topic">The topic to bind the producer to.</param>
     /// <returns>A producer bound to the specified topic.</returns>
     ITopicProducer<TKey, TValue> ForTopic(string topic);
+}
+
+/// <summary>
+/// Flags controlling which producer messages are purged.
+/// </summary>
+[Flags]
+public enum PurgeOptions
+{
+    /// <summary>
+    /// Do not purge any messages.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Purge messages buffered locally that have not been sent.
+    /// </summary>
+    Queue = 1,
+
+    /// <summary>
+    /// Purge messages that were sent and are awaiting acknowledgement.
+    /// </summary>
+    InFlight = 2,
+
+    /// <summary>
+    /// Return after local purge state is updated.
+    /// </summary>
+    NonBlocking = 4,
+
+    /// <summary>
+    /// Purge queued and in-flight messages.
+    /// </summary>
+    All = Queue | InFlight
 }
 
 /// <summary>

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -167,6 +167,7 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <remarks>
     /// Queued messages are dropped before they are sent. In-flight messages may already have
     /// reached the broker; purging them only fails local delivery tasks and callbacks.
+    /// Transactional producers cannot purge while a transaction is active; commit or abort first.
     /// </remarks>
     /// <param name="options">The messages to purge.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -230,11 +231,6 @@ public enum PurgeOptions
     /// Purge messages that were sent and are awaiting acknowledgement.
     /// </summary>
     InFlight = 2,
-
-    /// <summary>
-    /// Return after local purge state is updated.
-    /// </summary>
-    NonBlocking = 4,
 
     /// <summary>
     /// Purge queued and in-flight messages.

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1439,12 +1439,30 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         if ((options & PurgeOptions.All) == PurgeOptions.None)
             return ValueTask.CompletedTask;
 
+        ThrowIfPurgeCannotRun();
+
         var exception = new ProduceException(
             ProduceErrorKind.Purged,
             "Produce operation was purged before delivery completed.");
 
         _accumulator.Purge(options, exception, CompleteInflightEntry);
         return ValueTask.CompletedTask;
+    }
+
+    private void ThrowIfPurgeCannotRun()
+    {
+        if (_options.TransactionalId is null)
+            return;
+
+        var transactionState = _transactionState;
+        if (transactionState is TransactionState.InTransaction
+            or TransactionState.CommittingTransaction
+            or TransactionState.AbortingTransaction
+            or TransactionState.AbortableError)
+        {
+            throw new InvalidOperationException(
+                "PurgeAsync cannot be called while a transaction is active. Commit or abort the transaction before purging buffered records.");
+        }
     }
 
     /// <inheritdoc />

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1427,6 +1427,26 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         return _accumulator.FlushAsync(cancellationToken);
     }
 
+    public ValueTask PurgeAsync(PurgeOptions options, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>));
+
+        ThrowIfNotInitialized();
+
+        if ((options & PurgeOptions.All) == PurgeOptions.None)
+            return ValueTask.CompletedTask;
+
+        var exception = new ProduceException(
+            ProduceErrorKind.Purged,
+            "Produce operation was purged before delivery completed.");
+
+        _accumulator.Purge(options, exception, CompleteInflightEntry);
+        return ValueTask.CompletedTask;
+    }
+
     /// <inheritdoc />
     public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
     {

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3679,6 +3679,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// <summary>
     /// Purges queued and/or in-flight batches with a caller-provided exception.
     /// </summary>
+    /// <returns>
+    /// Diagnostic count of purged work. Queued purge counts pending append operations plus
+    /// current/ready batches; in-flight purge counts batches.
+    /// </returns>
     internal int Purge(PurgeOptions options, Exception exception, Action<ReadyBatch>? onPurgingBatch = null)
     {
         ArgumentNullException.ThrowIfNull(exception);

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3677,6 +3677,180 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
+    /// Purges queued and/or in-flight batches with a caller-provided exception.
+    /// </summary>
+    internal int Purge(PurgeOptions options, Exception exception, Action<ReadyBatch>? onPurgingBatch = null)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        var purgedCount = 0;
+
+        if ((options & PurgeOptions.Queue) != 0)
+            purgedCount += PurgeQueuedBatches(exception, onPurgingBatch);
+
+        if ((options & PurgeOptions.InFlight) != 0)
+            purgedCount += PurgeInFlightBatches(exception, onPurgingBatch);
+
+        if (purgedCount > 0)
+            SignalWakeup();
+
+        return purgedCount;
+    }
+
+    private int PurgeQueuedBatches(Exception exception, Action<ReadyBatch>? onPurgingBatch)
+    {
+        var purgedCount = FailPendingAppendsForPurge(exception);
+        List<PartitionBatch>? currentBatches = null;
+        List<ReadyBatch>? readyBatches = null;
+
+        foreach (var kvp in _partitionDeques)
+        {
+            var pd = kvp.Value;
+            using var guard = new SpinLockGuard(ref pd.Lock);
+
+            if (pd.CurrentBatch is { } currentBatch)
+            {
+                pd.CurrentBatch = null;
+                MarkLingerPartitionDequeued(pd);
+                Interlocked.Decrement(ref _unsealedBatchCount);
+
+                currentBatches ??= new List<PartitionBatch>();
+                currentBatches.Add(currentBatch);
+            }
+
+            while (pd.Count > 0)
+            {
+                readyBatches ??= new List<ReadyBatch>();
+                readyBatches.Add(pd.PollFirst()!);
+            }
+        }
+
+        if (currentBatches is not null)
+        {
+            foreach (var currentBatch in currentBatches)
+            {
+                var readyBatch = CompleteDetachedBatch(currentBatch);
+                if (readyBatch is not null)
+                {
+                    readyBatches ??= new List<ReadyBatch>();
+                    readyBatches.Add(readyBatch);
+                }
+            }
+        }
+
+        if (readyBatches is null)
+            return purgedCount;
+
+        foreach (var batch in readyBatches)
+        {
+            FailPurgedBatch(
+                batch,
+                exception,
+                onPurgingBatch,
+                removeFromPipeline: true,
+                returnToPool: true);
+            purgedCount++;
+        }
+
+        return purgedCount;
+    }
+
+    private int FailPendingAppendsForPurge(Exception exception)
+    {
+        if (_pendingAppends.IsEmpty)
+            return 0;
+
+        var spinWait = new SpinWait();
+        while (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
+            spinWait.SpinOnce();
+
+        var failedCount = 0;
+        try
+        {
+            while (_pendingAppends.TryDequeue(out var op))
+            {
+                if (op.TryFail(exception))
+                    failedCount++;
+            }
+        }
+        finally
+        {
+            Volatile.Write(ref _draining, 0);
+        }
+
+        return failedCount;
+    }
+
+    private int PurgeInFlightBatches(Exception exception, Action<ReadyBatch>? onPurgingBatch)
+    {
+        if (Volatile.Read(ref _inFlightBatchCount) <= 0)
+            return 0;
+
+        var snapshot = new List<ReadyBatch>();
+        InFlightBatchListSnapshot(snapshot);
+
+        var purgedCount = 0;
+        foreach (var batch in snapshot)
+        {
+            if (IsBatchStillQueued(batch))
+                continue;
+
+            if (!OnBatchExitsPipeline(batch))
+                continue;
+
+            FailPurgedBatch(
+                batch,
+                exception,
+                onPurgingBatch,
+                removeFromPipeline: false,
+                returnToPool: false);
+            purgedCount++;
+        }
+
+        return purgedCount;
+    }
+
+    private bool IsBatchStillQueued(ReadyBatch batch)
+    {
+        if (!_partitionDeques.TryGetValue(batch.TopicPartition, out var pd))
+            return false;
+
+        using var guard = new SpinLockGuard(ref pd.Lock);
+        return pd.Contains(batch);
+    }
+
+    private void FailPurgedBatch(
+        ReadyBatch batch,
+        Exception exception,
+        Action<ReadyBatch>? onPurgingBatch,
+        bool removeFromPipeline,
+        bool returnToPool)
+    {
+        try { onPurgingBatch?.Invoke(batch); }
+        catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx); }
+        try { batch.Fail(exception); }
+        catch (Exception failEx) { LogBatchCleanupStepFailed(failEx); }
+        try
+        {
+            if (batch.TrySetMemoryReleased())
+            {
+                ReleaseMemory(batch.DataSize);
+            }
+        }
+        catch (Exception memEx) { LogBatchCleanupStepFailed(memEx); }
+        if (removeFromPipeline)
+        {
+            try { OnBatchExitsPipeline(batch); }
+            catch (Exception exitEx) { LogBatchCleanupStepFailed(exitEx); }
+        }
+        if (returnToPool)
+        {
+            try { ReturnReadyBatch(batch); }
+            catch (Exception returnEx) { LogBatchCleanupStepFailed(returnEx); }
+        }
+    }
+
+    /// <summary>
     /// Fails a batch and releases its memory. Does NOT return the batch to the pool.
     /// For sweep: BrokerSender still holds a reference in _pendingResponses — returning
     /// to pool would cause use-after-free when the response arrives and BrokerSender

--- a/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
@@ -91,6 +91,8 @@ internal sealed class FastPathProducerSpy<TKey, TValue> : IKafkaProducer<TKey, T
 
     public ValueTask FlushAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
+    public ValueTask PurgeAsync(PurgeOptions options, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
     public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
     {
     }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerErrorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerErrorTests.cs
@@ -60,6 +60,16 @@ public class ProducerErrorTests
         await Assert.That(ex.IsRetriable).IsFalse();
     }
 
+    [Test]
+    public async Task ProduceException_PurgedKind_IsNonRetriableWithoutErrorCode()
+    {
+        var ex = new ProduceException(ProduceErrorKind.Purged, "purged");
+
+        await Assert.That(ex.Kind).IsEqualTo(ProduceErrorKind.Purged);
+        await Assert.That(ex.ErrorCode).IsNull();
+        await Assert.That(ex.IsRetriable).IsFalse();
+    }
+
     public static IEnumerable<ErrorCode> RetriableProducerErrorCodes()
     {
         yield return ErrorCode.NotLeaderOrFollower;

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerInitializationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerInitializationTests.cs
@@ -99,6 +99,19 @@ public sealed class ProducerInitializationTests
     }
 
     [Test]
+    public async Task PurgeAsync_WithoutInitialize_ThrowsInvalidOperationException()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+
+        await Assert.That(async () =>
+        {
+            await producer.PurgeAsync(PurgeOptions.All);
+        }).Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task InitializeAsync_AfterDispose_ThrowsObjectDisposedException()
     {
         var producer = Kafka.CreateProducer<string, string>()
@@ -110,6 +123,21 @@ public sealed class ProducerInitializationTests
         await Assert.That(async () =>
         {
             await producer.InitializeAsync();
+        }).Throws<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task PurgeAsync_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+
+        await producer.DisposeAsync();
+
+        await Assert.That(async () =>
+        {
+            await producer.PurgeAsync(PurgeOptions.All);
         }).Throws<ObjectDisposedException>();
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -273,6 +273,86 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task Purge_InFlight_IdempotentNextQueuedBatchKeepsContiguousSequence()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 1000,
+            LingerMs = 0,
+            EnableIdempotence = true
+        };
+        var accumulator = new RecordAccumulator(options);
+        var topicPartition = new TopicPartition("test-topic", 0);
+        ReadyBatch? inFlightBatch = null;
+        ReadyBatch? nextBatch = null;
+
+        try
+        {
+            accumulator.ProducerId = 123;
+            accumulator.ProducerEpoch = 0;
+
+            await accumulator.AppendAsync(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                new PooledMemory(null, 0, isNull: true),
+                new PooledMemory(null, 0, isNull: true),
+                null,
+                0,
+                completionSource: null,
+                callback: null,
+                CancellationToken.None);
+            await accumulator.ExpireLingerAsync(CancellationToken.None);
+            await Assert.That(accumulator.TryDrainBatch(out inFlightBatch)).IsTrue();
+
+            var inFlightRecordCount = inFlightBatch!.RecordBatch.Records.Count;
+            var inFlightSequence = accumulator.GetAndIncrementSequence(topicPartition, inFlightRecordCount);
+            inFlightBatch.RecordBatch.BaseSequence = inFlightSequence;
+
+            await accumulator.AppendAsync(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                new PooledMemory(null, 0, isNull: true),
+                new PooledMemory(null, 0, isNull: true),
+                null,
+                0,
+                completionSource: null,
+                callback: null,
+                CancellationToken.None);
+            await accumulator.ExpireLingerAsync(CancellationToken.None);
+
+            var purged = accumulator.Purge(PurgeOptions.InFlight, CreatePurgedException());
+            await Assert.That(purged).IsEqualTo(1);
+            await Assert.That(accumulator.TryDrainBatch(out nextBatch)).IsTrue();
+
+            var nextSequence = accumulator.GetAndIncrementSequence(
+                topicPartition,
+                nextBatch!.RecordBatch.Records.Count);
+
+            await Assert.That(inFlightSequence).IsEqualTo(0);
+            await Assert.That(nextSequence).IsEqualTo(inFlightRecordCount);
+        }
+        finally
+        {
+            if (inFlightBatch is not null)
+                accumulator.ReturnReadyBatch(inFlightBatch);
+
+            if (nextBatch is not null)
+            {
+                accumulator.OnBatchExitsPipeline(nextBatch);
+                nextBatch.CompleteSend(baseOffset: 1, timestamp: DateTimeOffset.UtcNow);
+                accumulator.ReturnReadyBatch(nextBatch);
+            }
+
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task Purge_Queue_FailsPendingAppendBlockedOnBufferMemory()
     {
         var options = new ProducerOptions

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -131,6 +131,199 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task Purge_Queue_FailsCurrentBatchWithPurgedProduceException()
+    {
+        var options = CreateTestOptions();
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var topicPartition = new TopicPartition("test-topic", 0);
+
+        try
+        {
+            var completion = pool.Rent();
+            var completionTask = completion.Task;
+
+            var appended = accumulator.TryAppendWithCompletion(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                new PooledMemory(null, 0, isNull: true),
+                new PooledMemory(null, 0, isNull: true),
+                null,
+                0,
+                completion);
+
+            await Assert.That(appended).IsTrue();
+
+            var purged = accumulator.Purge(PurgeOptions.Queue, CreatePurgedException());
+
+            await Assert.That(purged).IsEqualTo(1);
+            var ex = await Assert.ThrowsAsync<ProduceException>(async () => await completionTask);
+            await Assert.That(ex!.Kind).IsEqualTo(ProduceErrorKind.Purged);
+            await Assert.That(ex.IsRetriable).IsFalse();
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Purge_Queue_FailsSealedQueuedBatch()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 1000,
+            LingerMs = 0
+        };
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var topicPartition = new TopicPartition("test-topic", 0);
+
+        try
+        {
+            var completion = pool.Rent();
+            var completionTask = completion.Task;
+
+            await accumulator.AppendAsync(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                new PooledMemory(null, 0, isNull: true),
+                new PooledMemory(null, 0, isNull: true),
+                null,
+                0,
+                completion,
+                callback: null,
+                CancellationToken.None);
+
+            await accumulator.ExpireLingerAsync(CancellationToken.None);
+
+            var purged = accumulator.Purge(PurgeOptions.Queue, CreatePurgedException());
+
+            await Assert.That(purged).IsEqualTo(1);
+            var ex = await Assert.ThrowsAsync<ProduceException>(async () => await completionTask);
+            await Assert.That(ex!.Kind).IsEqualTo(ProduceErrorKind.Purged);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Purge_InFlight_FailsDrainedBatchWithoutReturningToPool()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 1000,
+            LingerMs = 0
+        };
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var topicPartition = new TopicPartition("test-topic", 0);
+        ReadyBatch? readyBatch = null;
+
+        try
+        {
+            var completion = pool.Rent();
+            var completionTask = completion.Task;
+
+            await accumulator.AppendAsync(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                new PooledMemory(null, 0, isNull: true),
+                new PooledMemory(null, 0, isNull: true),
+                null,
+                0,
+                completion,
+                callback: null,
+                CancellationToken.None);
+
+            await accumulator.ExpireLingerAsync(CancellationToken.None);
+            await Assert.That(accumulator.TryDrainBatch(out readyBatch)).IsTrue();
+
+            var purged = accumulator.Purge(PurgeOptions.InFlight, CreatePurgedException());
+
+            await Assert.That(purged).IsEqualTo(1);
+            var ex = await Assert.ThrowsAsync<ProduceException>(async () => await completionTask);
+            await Assert.That(ex!.Kind).IsEqualTo(ProduceErrorKind.Purged);
+            await Assert.That(readyBatch!.IsReturnedToPool).IsFalse();
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            if (readyBatch is not null)
+                accumulator.ReturnReadyBatch(readyBatch);
+
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Purge_Queue_FailsPendingAppendBlockedOnBufferMemory()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = 4096,
+            BatchSize = 4096,
+            LingerMs = 10,
+            MaxBlockMs = 30000
+        };
+        var accumulator = new RecordAccumulator(options);
+        var syntheticReservation = 4096;
+        var releaseSyntheticReservation = false;
+
+        try
+        {
+            await Assert.That(accumulator.TryReserveMemoryForTest(syntheticReservation)).IsTrue();
+            releaseSyntheticReservation = true;
+
+            var largeValue = new byte[2048];
+            var appendTask = Task.Run(async () =>
+                await accumulator.AppendFromSpansAsync(
+                    "test-topic", 0,
+                    DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                    largeValue, valueIsNull: false,
+                    null, 0, null, CancellationToken.None));
+
+            while (accumulator.BufferPressureEvents == 0 && !appendTask.IsCompleted)
+                await Task.Yield();
+
+            await Assert.That(appendTask.IsCompleted).IsFalse();
+
+            var purged = accumulator.Purge(PurgeOptions.Queue, CreatePurgedException());
+
+            await Assert.That(purged).IsEqualTo(1);
+            var ex = await Assert.ThrowsAsync<ProduceException>(async () =>
+                await appendTask.WaitAsync(TimeSpan.FromSeconds(5)));
+            await Assert.That(ex!.Kind).IsEqualTo(ProduceErrorKind.Purged);
+        }
+        finally
+        {
+            if (releaseSyntheticReservation)
+                accumulator.ReleaseMemory(syntheticReservation);
+
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_SealedBatch_UsesPreEncodedArenaRecords()
     {
         var options = new ProducerOptions
@@ -2277,6 +2470,9 @@ public class RecordAccumulatorTests
         var completeMethod = partitionBatch.GetType().GetMethod("Complete");
         return (ReadyBatch)completeMethod!.Invoke(partitionBatch, null)!;
     }
+
+    private static ProduceException CreatePurgedException()
+        => new(ProduceErrorKind.Purged, "purged");
 
     private static PartitionBatch GetCurrentPartitionBatch(RecordAccumulator accumulator, TopicPartition topicPartition)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Producer;
 
 namespace Dekaf.Tests.Unit.Producer;
@@ -72,6 +73,24 @@ public sealed class TransactionTests
 
         var act = () => producer.InitTransactionsAsync().AsTask();
         await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task PurgeAsync_InTransaction_ThrowsInvalidOperationException()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTransactionalId("test-txn-id")
+            .Build();
+
+        var kafkaProducer = (KafkaProducer<string, string>)producer;
+        SetInstanceField(kafkaProducer, "_initialized", true);
+        kafkaProducer._transactionState = TransactionState.InTransaction;
+
+        await Assert.That(async () =>
+        {
+            await producer.PurgeAsync(PurgeOptions.All);
+        }).Throws<InvalidOperationException>();
     }
 
     [Test]
@@ -199,5 +218,13 @@ public sealed class TransactionTests
 
         await Assert.That(tpo1).IsEqualTo(tpo2);
         await Assert.That(tpo1).IsNotEqualTo(tpo3);
+    }
+
+    private static void SetInstanceField<T>(object target, string name, T value)
+    {
+        const BindingFlags instanceFieldFlags =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        var field = target.GetType().GetField(name, instanceFieldFlags);
+        field!.SetValue(target, value);
     }
 }


### PR DESCRIPTION
Closes #1151

## Summary
- add producer PurgeAsync flags for queued and in-flight messages
- fail purged delivery tasks/callbacks with ProduceErrorKind.Purged
- release buffer memory and pending appends during queue purge

## Tests
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordAccumulatorTests/*|/*/*/ProducerErrorTests/*"
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe
- dotnet build Dekaf.sln --configuration Release --no-restore