### PR TITLE
feat(consumer): add server-side regex subscription

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -240,6 +240,18 @@ Subscribe to topics during build:
 .SubscribeTo("orders", "payments", "notifications")
 ```
 
+### SubscribeToPattern
+
+Subscribe with a broker-side topic name pattern:
+
+```csharp
+.SubscribeToPattern("orders-.*")
+```
+
+Kafka evaluates the pattern on the broker using RE2/J-compatible syntax. Dekaf sends the pattern as-is; .NET regular expression syntax is not translated.
+
+Server-side pattern subscription requires Kafka 4.1+ brokers with `ConsumerGroupHeartbeat` v1. Use `Subscribe(Func<string, bool>)` on `IKafkaConsumer` when you need arbitrary .NET predicates or compatibility with older brokers. That overload remains client-side and refreshes metadata to find matching topics.
+
 ## Rebalancing
 
 ### WithRebalanceListener
@@ -350,6 +362,7 @@ For transactional reads:
 | `WithSessionTimeout` | 45000ms | Session timeout |
 | `WithHeartbeatInterval` | 3000ms | Group heartbeat interval |
 | `SubscribeTo` | (none) | Topics to subscribe |
+| `SubscribeToPattern` | (none) | Broker-side topic regex subscription; Kafka 4.1+ |
 | `WithRebalanceListener` | null | Rebalance callbacks |
 | `WithPartitionEof` | false | EOF notifications |
 | `WithQueuedMinMessages` | 100000 | Prefetch target count |

--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -50,6 +50,22 @@ var consumer2 = await Kafka.CreateConsumer<string, string>()
     .BuildAsync();
 ```
 
+## Server-side Pattern Subscriptions
+
+Kafka 4.1+ brokers can evaluate topic name patterns during group coordination:
+
+```csharp
+var consumer = await Kafka.CreateConsumer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithGroupId("order-processors")
+    .SubscribeToPattern("orders-.*")
+    .BuildAsync();
+```
+
+The pattern is sent through `ConsumerGroupHeartbeat` v1 as `SubscribedTopicRegex`. Kafka evaluates it with RE2/J-compatible syntax, and Dekaf does not translate .NET regex syntax.
+
+For arbitrary .NET predicates, use `consumer.Subscribe(Func<string, bool>)` after building the consumer. That mode is client-side and polls metadata for matching topics, so it works with older brokers but does not use broker-side regex subscription.
+
 ## Rebalancing
 
 When the group membership changes, Kafka rebalances partitions:

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -460,8 +460,7 @@ public sealed class InMemoryAdminClient : IAdminClient
         var result = new Dictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>(replicaAssignments.Count);
         foreach (var (replica, logDir) in replicaAssignments)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(replica.Topic);
-            ArgumentOutOfRangeException.ThrowIfNegative(replica.Partition);
+            ValidateTopicPartition(replica.TopicPartition);
             ArgumentOutOfRangeException.ThrowIfNegative(replica.BrokerId);
             ArgumentException.ThrowIfNullOrWhiteSpace(logDir);
 

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.Serialization;
@@ -25,6 +26,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private readonly HashSet<TopicPartition> _paused = [];
     private readonly Dictionary<TopicPartition, long> _positions = [];
     private readonly string? _memberId;
+    private string? _subscriptionPattern;
     private bool _disposed;
 
     public InMemoryConsumer(InMemoryKafkaCluster cluster)
@@ -74,6 +76,15 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         {
             lock (_gate)
                 return _subscription.ToHashSet(StringComparer.Ordinal);
+        }
+    }
+
+    public string? SubscriptionPattern
+    {
+        get
+        {
+            lock (_gate)
+                return _subscriptionPattern;
         }
     }
 
@@ -136,6 +147,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            _subscriptionPattern = null;
             _subscription.Clear();
             foreach (var topic in topics.Where(topic => !string.IsNullOrWhiteSpace(topic)).Distinct(StringComparer.Ordinal))
                 _subscription.Add(topic);
@@ -157,12 +169,39 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         Subscribe(topics);
     }
 
+    public void SubscribePattern(string pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        if (string.IsNullOrWhiteSpace(pattern))
+            throw new ArgumentException("Subscription pattern must be specified.", nameof(pattern));
+
+        if (string.IsNullOrWhiteSpace(_options.GroupId))
+            throw new InvalidOperationException("Server-side regex subscriptions require a consumer group ID.");
+
+        ThrowIfDisposed();
+
+        var regex = new Regex(pattern, RegexOptions.CultureInvariant);
+        var topicPartitions = _cluster.ListTopics()
+            .Where(topic => IsFullMatch(regex, topic))
+            .SelectMany(topic => _cluster.GetTopicPartitions(topic))
+            .ToArray();
+
+        lock (_gate)
+        {
+            _subscriptionPattern = pattern;
+            _subscription.Clear();
+            ReplaceAssignment(topicPartitions);
+            RegisterConsumerGroupMemberUnderLock();
+        }
+    }
+
     public void Unsubscribe()
     {
         ThrowIfDisposed();
 
         lock (_gate)
         {
+            _subscriptionPattern = null;
             _subscription.Clear();
             _assignment.Clear();
             _paused.Clear();
@@ -367,6 +406,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            _subscriptionPattern = null;
             _subscription.Clear();
             ReplaceAssignment(partitions);
             RegisterConsumerGroupMemberUnderLock();
@@ -572,6 +612,12 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private IEnumerable<TopicPartition> SelectTargetPartitions(TopicPartition[] partitions)
     {
         return partitions.Length == 0 ? _assignment.ToArray() : partitions;
+    }
+
+    private static bool IsFullMatch(Regex regex, string topic)
+    {
+        var match = regex.Match(topic);
+        return match.Success && match.Index == 0 && match.Length == topic.Length;
     }
 
     private void CommitCurrentOffsets()

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -139,6 +139,13 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         return ValueTask.CompletedTask;
     }
 
+    public ValueTask PurgeAsync(PurgeOptions options, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.CompletedTask;
+    }
+
     public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
     {
         ArgumentNullException.ThrowIfNull(metric);

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -2085,6 +2085,9 @@ public sealed class ConsumerBuilder<TKey, TValue>
         if (_bootstrapServers.Count == 0)
             throw new InvalidOperationException("Bootstrap servers must be specified. Call WithBootstrapServers() before Build().");
 
+        if (_topicPatternToSubscribe is not null && string.IsNullOrWhiteSpace(_groupId))
+            throw new InvalidOperationException("SubscribeToPattern requires WithGroupId(...) to be called before Build().");
+
         var keyDeserializer = _keyDeserializer ?? GetDefaultDeserializer<TKey>("key", "WithKeyDeserializer");
         var valueDeserializer = _valueDeserializer ?? GetDefaultDeserializer<TValue>("value", "WithValueDeserializer");
 

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1149,6 +1149,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
     private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
     private readonly List<string> _topicsToSubscribe = [];
+    private string? _topicPatternToSubscribe;
     private TimeSpan? _metadataMaxAge;
     private IsolationLevel _isolationLevel = IsolationLevel.ReadUncommitted;
     private IRetryPolicy? _retryPolicy;
@@ -1240,6 +1241,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="topic">The topic to subscribe to.</param>
     public ConsumerBuilder<TKey, TValue> SubscribeTo(string topic)
     {
+        _topicPatternToSubscribe = null;
         _topicsToSubscribe.Add(topic);
         return this;
     }
@@ -1251,7 +1253,29 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="topics">The topics to subscribe to.</param>
     public ConsumerBuilder<TKey, TValue> SubscribeTo(params string[] topics)
     {
+        _topicPatternToSubscribe = null;
         _topicsToSubscribe.AddRange(topics);
+        return this;
+    }
+
+    /// <summary>
+    /// Subscribes the consumer to topics matching a broker-side RE2/J regular expression when built.
+    /// </summary>
+    /// <remarks>
+    /// The pattern is sent to Kafka as-is. .NET regular expression syntax is not translated to RE2/J.
+    /// Requires ConsumerGroupHeartbeat v1, available on Kafka 4.1+ brokers.
+    /// </remarks>
+    /// <param name="pattern">The RE2/J topic regex pattern.</param>
+    public ConsumerBuilder<TKey, TValue> SubscribeToPattern(string pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            throw new ArgumentException("Subscription pattern must be specified.", nameof(pattern));
+        }
+
+        _topicsToSubscribe.Clear();
+        _topicPatternToSubscribe = pattern;
         return this;
     }
 
@@ -2172,7 +2196,11 @@ public sealed class ConsumerBuilder<TKey, TValue>
         else
             memoryBudget.ReserveExplicit((ulong)_queuedMaxMessagesKbytes!.Value * 1024);
 
-        if (_topicsToSubscribe.Count > 0)
+        if (_topicPatternToSubscribe is not null)
+        {
+            consumer.SubscribePattern(_topicPatternToSubscribe);
+        }
+        else if (_topicsToSubscribe.Count > 0)
         {
             consumer.Subscribe(_topicsToSubscribe.ToArray());
         }

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -49,6 +49,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private volatile int _heartbeatIntervalMs;
     private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
     private volatile IReadOnlySet<string>? _subscribedTopics;
+    private volatile string? _subscribedTopicRegex;
 
     internal static int GetCoordinationConnectionIndex(int connectionsPerBroker)
         => connectionsPerBroker - 1;
@@ -112,8 +113,14 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// <summary>
     /// Ensures the consumer has joined the group.
     /// </summary>
+    public ValueTask EnsureActiveGroupAsync(
+        IReadOnlySet<string> topics,
+        CancellationToken cancellationToken)
+        => EnsureActiveGroupAsync(topics, null, cancellationToken);
+
     public async ValueTask EnsureActiveGroupAsync(
         IReadOnlySet<string> topics,
+        string? subscribedTopicRegex,
         CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _disposed) != 0)
@@ -122,10 +129,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (string.IsNullOrEmpty(_options.GroupId))
             return;
 
-        if (_state == CoordinatorState.Stable)
-            return;
-
-        await EnsureActiveGroupConsumerProtocolAsync(topics, cancellationToken).ConfigureAwait(false);
+        await EnsureActiveGroupConsumerProtocolAsync(topics, subscribedTopicRegex, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -144,6 +148,33 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         errorCode is ErrorCode.NotCoordinator
             or ErrorCode.CoordinatorNotAvailable
             or ErrorCode.CoordinatorLoadInProgress;
+
+    private static bool SetEquals(IReadOnlySet<string>? current, IReadOnlySet<string> next)
+    {
+        if (current is null || current.Count != next.Count)
+            return false;
+
+        foreach (var topic in next)
+        {
+            if (!current.Contains(topic))
+                return false;
+        }
+
+        return true;
+    }
+
+    private void UpdateSubscription(IReadOnlySet<string> topics, string? subscribedTopicRegex)
+    {
+        if (string.Equals(_subscribedTopicRegex, subscribedTopicRegex, StringComparison.Ordinal) &&
+            SetEquals(_subscribedTopics, topics))
+        {
+            return;
+        }
+
+        _subscribedTopics = topics;
+        _subscribedTopicRegex = subscribedTopicRegex;
+        Interlocked.Exchange(ref _subscriptionChanged, 1);
+    }
 
     private async ValueTask FindCoordinatorAsync(CancellationToken cancellationToken)
     {
@@ -649,7 +680,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         // Always send topics on initial/re-join — KIP-848 requires SubscribedTopicNames to be
         // non-null when joining. The flag must still be cleared to avoid a stale re-send later.
         var subscriptionChanged = Interlocked.Exchange(ref _subscriptionChanged, 0) == 1;
-        var subscribedTopics = (isInitial || subscriptionChanged) ? _subscribedTopics?.ToList() : null;
+        var subscribedTopicRegex = (isInitial || subscriptionChanged) ? _subscribedTopicRegex : null;
+        var subscribedTopics = (isInitial || subscriptionChanged) && subscribedTopicRegex is null
+            ? _subscribedTopics?.ToList()
+            : null;
 
         var request = new ConsumerGroupHeartbeatRequest
         {
@@ -660,6 +694,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             RebalanceTimeoutMs = isInitial ? _options.RebalanceTimeoutMs : -1,
             RackId = isInitial ? _options.ClientRack : null,
             SubscribedTopicNames = subscribedTopics,
+            SubscribedTopicRegex = subscribedTopicRegex,
             ServerAssignor = isInitial ? _options.GroupRemoteAssignor : null,
             TopicPartitions = ownedTopicPartitions
         };
@@ -714,6 +749,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
             ErrorCode.UnsupportedAssignor => new GroupException(response.ErrorCode,
                 $"ConsumerGroupHeartbeat: unsupported assignor '{_options.GroupRemoteAssignor}': {response.ErrorMessage}")
+            { GroupId = _options.GroupId },
+
+            ErrorCode.InvalidRegularExpression => new GroupException(response.ErrorCode,
+                $"ConsumerGroupHeartbeat: invalid subscription regex '{_subscribedTopicRegex}': {response.ErrorMessage}")
             { GroupId = _options.GroupId },
 
             _ => new GroupException(response.ErrorCode,
@@ -824,6 +863,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// </summary>
     private async ValueTask EnsureActiveGroupConsumerProtocolAsync(
         IReadOnlySet<string> topics,
+        string? subscribedTopicRegex,
         CancellationToken cancellationToken)
     {
         if (!_metadataManager.HasApiKey(ApiKey.ConsumerGroupHeartbeat))
@@ -833,8 +873,15 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 "(KIP-848, introduced in Kafka 4.0). Dekaf's consumer requires Kafka 4.0 or later.");
         }
 
-        _subscribedTopics = topics;
-        Interlocked.Exchange(ref _subscriptionChanged, 1);
+        if (subscribedTopicRegex is not null &&
+            !_metadataManager.SupportsApiVersion(ApiKey.ConsumerGroupHeartbeat, 1))
+        {
+            throw new BrokerVersionException(
+                "Server-side regex subscriptions require ConsumerGroupHeartbeat v1 " +
+                "(Kafka 4.1 or later). Use Subscribe(Func<string, bool>) for client-side filtering on older brokers.");
+        }
+
+        UpdateSubscription(topics, subscribedTopicRegex);
 
         ConsumerHeartbeatResult heartbeatResult = default;
 
@@ -995,6 +1042,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                         case ErrorCode.UnreleasedInstanceId:
                         case ErrorCode.UnsupportedAssignor:
+                        case ErrorCode.InvalidRegularExpression:
                             _state = CoordinatorState.Unjoined;
                             break;
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -129,6 +129,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (string.IsNullOrEmpty(_options.GroupId))
             return;
 
+        if (_state == CoordinatorState.Stable && SubscriptionMatches(topics, subscribedTopicRegex))
+            return;
+
         await EnsureActiveGroupConsumerProtocolAsync(topics, subscribedTopicRegex, cancellationToken).ConfigureAwait(false);
     }
 
@@ -163,13 +166,14 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         return true;
     }
 
+    private bool SubscriptionMatches(IReadOnlySet<string> topics, string? subscribedTopicRegex)
+        => string.Equals(_subscribedTopicRegex, subscribedTopicRegex, StringComparison.Ordinal) &&
+           SetEquals(_subscribedTopics, topics);
+
     private void UpdateSubscription(IReadOnlySet<string> topics, string? subscribedTopicRegex)
     {
-        if (string.Equals(_subscribedTopicRegex, subscribedTopicRegex, StringComparison.Ordinal) &&
-            SetEquals(_subscribedTopics, topics))
-        {
+        if (SubscriptionMatches(topics, subscribedTopicRegex))
             return;
-        }
 
         _subscribedTopics = topics;
         _subscribedTopicRegex = subscribedTopicRegex;

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -154,6 +154,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     private static bool SetEquals(IReadOnlySet<string>? current, IReadOnlySet<string> next)
     {
+        if (ReferenceEquals(current, next))
+            return true;
+
         if (current is null || current.Count != next.Count)
             return false;
 
@@ -684,9 +687,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         // Always send topics on initial/re-join — KIP-848 requires SubscribedTopicNames to be
         // non-null when joining. The flag must still be cleared to avoid a stale re-send later.
         var subscriptionChanged = Interlocked.Exchange(ref _subscriptionChanged, 0) == 1;
-        var subscribedTopicRegex = (isInitial || subscriptionChanged) ? _subscribedTopicRegex : null;
-        var subscribedTopics = (isInitial || subscriptionChanged) && subscribedTopicRegex is null
-            ? _subscribedTopics?.ToList()
+        var subscriptionShouldBeSent = isInitial || subscriptionChanged;
+        var currentSubscribedTopicRegex = _subscribedTopicRegex;
+        var subscribedTopics = subscriptionShouldBeSent ? _subscribedTopics?.ToList() : null;
+        var subscribedTopicRegex = subscriptionShouldBeSent && version >= 1
+            ? currentSubscribedTopicRegex ?? (isInitial ? null : string.Empty)
             : null;
 
         var request = new ConsumerGroupHeartbeatRequest
@@ -708,7 +713,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         if (response.ErrorCode != ErrorCode.None)
         {
-            HandleConsumerGroupHeartbeatError(response);
+            HandleConsumerGroupHeartbeatError(response, subscribedTopicRegex);
         }
 
         if (response.MemberId is not null)
@@ -735,7 +740,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// Throws an appropriate exception for ConsumerGroupHeartbeat error codes.
     /// Does NOT mutate coordinator state — callers own state transitions.
     /// </summary>
-    private void HandleConsumerGroupHeartbeatError(ConsumerGroupHeartbeatResponse response)
+    private void HandleConsumerGroupHeartbeatError(
+        ConsumerGroupHeartbeatResponse response,
+        string? subscribedTopicRegex)
     {
         throw response.ErrorCode switch
         {
@@ -756,7 +763,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             { GroupId = _options.GroupId },
 
             ErrorCode.InvalidRegularExpression => new GroupException(response.ErrorCode,
-                $"ConsumerGroupHeartbeat: invalid subscription regex '{_subscribedTopicRegex}': {response.ErrorMessage}")
+                $"ConsumerGroupHeartbeat: invalid subscription regex '{subscribedTopicRegex}': {response.ErrorMessage}")
             { GroupId = _options.GroupId },
 
             _ => new GroupException(response.ErrorCode,

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -17,6 +17,11 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     IReadOnlySet<string> Subscription { get; }
 
     /// <summary>
+    /// Gets the current server-side topic regex subscription, if any.
+    /// </summary>
+    string? SubscriptionPattern { get; }
+
+    /// <summary>
     /// Gets the current assignment.
     /// </summary>
     IReadOnlySet<TopicPartition> Assignment { get; }
@@ -61,6 +66,16 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Subscribes to topics matching a pattern.
     /// </summary>
     void Subscribe(Func<string, bool> topicFilter);
+
+    /// <summary>
+    /// Subscribes to topics matching a broker-side RE2/J regular expression.
+    /// </summary>
+    /// <remarks>
+    /// The pattern is sent to Kafka as-is. .NET regular expression syntax is not translated to RE2/J.
+    /// Requires ConsumerGroupHeartbeat v1, available on Kafka 4.1+ brokers.
+    /// </remarks>
+    /// <param name="pattern">The RE2/J topic regex pattern.</param>
+    void SubscribePattern(string pattern);
 
     /// <summary>
     /// Unsubscribes from all topics.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -605,6 +605,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     // Pattern subscription support
     private volatile Func<string, bool>? _topicFilter;
+    private volatile string? _topicPattern;
     private long _lastFilterRefreshTicks;
 
     // Thread-safety notes:
@@ -928,6 +929,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     public IReadOnlySet<string> Subscription => _subscriptionSnapshot;
+    public string? SubscriptionPattern => _topicPattern;
     public IReadOnlySet<TopicPartition> Assignment => _assignmentSnapshot;
     public string? MemberId => _coordinator?.MemberId;
     public IReadOnlySet<TopicPartition> Paused => _pausedSnapshot;
@@ -992,6 +994,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     public void Subscribe(params string[] topics)
     {
         _topicFilter = null;
+        _topicPattern = null;
         _subscription.Clear();
         foreach (var topic in topics)
         {
@@ -1025,6 +1028,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         ArgumentNullException.ThrowIfNull(topicFilter);
 
         _topicFilter = topicFilter;
+        _topicPattern = null;
         _subscription.Clear();
         PublishSubscriptionSnapshot();
         SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
@@ -1046,9 +1050,44 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         InvalidateFetchRequestCache();
     }
 
+    public void SubscribePattern(string pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            throw new ArgumentException("Subscription pattern must be specified.", nameof(pattern));
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.GroupId))
+        {
+            throw new InvalidOperationException("Server-side regex subscriptions require a consumer group ID.");
+        }
+
+        _topicFilter = null;
+        _topicPattern = pattern;
+        _subscription.Clear();
+        PublishSubscriptionSnapshot();
+        SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
+        try
+        {
+            _assignment.Clear();
+            PublishAssignmentSnapshot();
+        }
+        finally
+        {
+            SemaphoreHelper.ReleaseSafely(_assignmentLock);
+        }
+
+        ClearFetchBuffer();
+
+        InvalidatePartitionCache();
+        InvalidateFetchRequestCache();
+    }
+
     public void Unsubscribe()
     {
         _topicFilter = null;
+        _topicPattern = null;
         _subscription.Clear();
         PublishSubscriptionSnapshot();
         SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
@@ -1071,6 +1110,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     public void Assign(params TopicPartition[] partitions)
     {
+        _topicFilter = null;
+        _topicPattern = null;
         _subscription.Clear();
         PublishSubscriptionSnapshot();
         SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
@@ -1122,6 +1163,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     public void IncrementalAssign(IEnumerable<TopicPartitionOffset> partitions)
     {
         // Clear subscription since we're doing manual assignment
+        _topicFilter = null;
+        _topicPattern = null;
         _subscription.Clear();
         PublishSubscriptionSnapshot();
 
@@ -3304,10 +3347,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         var subscriptionSnapshot = _subscriptionSnapshot;
+        var topicPattern = _topicPattern;
         var coordinator = _coordinator;
-        if (subscriptionSnapshot.Count != 0 && coordinator is not null)
+        if ((subscriptionSnapshot.Count != 0 || topicPattern is not null) && coordinator is not null)
         {
-            await coordinator.EnsureActiveGroupAsync(subscriptionSnapshot, cancellationToken).ConfigureAwait(false);
+            await coordinator.EnsureActiveGroupAsync(subscriptionSnapshot, topicPattern, cancellationToken).ConfigureAwait(false);
 
             var coordinatorAssignmentVersion = coordinator.AssignmentVersion;
             if (Volatile.Read(ref _lastCoordinatorAssignmentVersion) == coordinatorAssignmentVersion)
@@ -3326,7 +3370,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         try
         {
             coordinator = _coordinator;
-            if (!_subscription.IsEmpty && coordinator is not null)
+            if ((!_subscription.IsEmpty || topicPattern is not null) && coordinator is not null)
             {
                 var coordinatorAssignmentVersion = coordinator.AssignmentVersion;
                 var coordinatorAssignment = coordinator.Assignment;
@@ -3428,7 +3472,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private bool IsManualAssignmentEnsureCurrent()
     {
-        if (_topicFilter is not null || !_subscription.IsEmpty)
+        if (_topicFilter is not null || _topicPattern is not null || !_subscription.IsEmpty)
             return false;
 
         var assignmentEnsureVersion = Volatile.Read(ref _assignmentEnsureVersion);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1000,6 +1000,51 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             _subscription.TryAdd(topic, 0);
         }
+
+        PublishSubscriptionAndClearAssignment(invalidatePartitionCache: false);
+    }
+
+    public void Subscribe(Func<string, bool> topicFilter)
+    {
+        ArgumentNullException.ThrowIfNull(topicFilter);
+
+        _topicFilter = topicFilter;
+        _topicPattern = null;
+        _subscription.Clear();
+        _lastFilterRefreshTicks = 0; // Force immediate refresh on next EnsureAssignment
+        PublishSubscriptionAndClearAssignment(invalidatePartitionCache: true);
+    }
+
+    public void SubscribePattern(string pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            throw new ArgumentException("Subscription pattern must be specified.", nameof(pattern));
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.GroupId))
+        {
+            throw new InvalidOperationException("Server-side regex subscriptions require a consumer group ID.");
+        }
+
+        _topicFilter = null;
+        _topicPattern = pattern;
+        _subscription.Clear();
+
+        PublishSubscriptionAndClearAssignment(invalidatePartitionCache: true);
+    }
+
+    public void Unsubscribe()
+    {
+        _topicFilter = null;
+        _topicPattern = null;
+        _subscription.Clear();
+        PublishSubscriptionAndClearAssignment(invalidatePartitionCache: true);
+    }
+
+    private void PublishSubscriptionAndClearAssignment(bool invalidatePartitionCache)
+    {
         PublishSubscriptionSnapshot();
         SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
         try
@@ -1020,91 +1065,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // one-time latency cost for the discarded prefetch.
         ClearFetchBuffer();
 
-        InvalidateFetchRequestCache();
-    }
+        if (invalidatePartitionCache)
+            InvalidatePartitionCache();
 
-    public void Subscribe(Func<string, bool> topicFilter)
-    {
-        ArgumentNullException.ThrowIfNull(topicFilter);
-
-        _topicFilter = topicFilter;
-        _topicPattern = null;
-        _subscription.Clear();
-        PublishSubscriptionSnapshot();
-        SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
-        try
-        {
-            _assignment.Clear();
-            PublishAssignmentSnapshot();
-        }
-        finally
-        {
-            SemaphoreHelper.ReleaseSafely(_assignmentLock);
-        }
-
-        // Clear stale fetched data (same rationale as Assign).
-        ClearFetchBuffer();
-
-        _lastFilterRefreshTicks = 0; // Force immediate refresh on next EnsureAssignment
-        InvalidatePartitionCache();
-        InvalidateFetchRequestCache();
-    }
-
-    public void SubscribePattern(string pattern)
-    {
-        ArgumentNullException.ThrowIfNull(pattern);
-        if (string.IsNullOrWhiteSpace(pattern))
-        {
-            throw new ArgumentException("Subscription pattern must be specified.", nameof(pattern));
-        }
-
-        if (string.IsNullOrWhiteSpace(_options.GroupId))
-        {
-            throw new InvalidOperationException("Server-side regex subscriptions require a consumer group ID.");
-        }
-
-        _topicFilter = null;
-        _topicPattern = pattern;
-        _subscription.Clear();
-        PublishSubscriptionSnapshot();
-        SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
-        try
-        {
-            _assignment.Clear();
-            PublishAssignmentSnapshot();
-        }
-        finally
-        {
-            SemaphoreHelper.ReleaseSafely(_assignmentLock);
-        }
-
-        ClearFetchBuffer();
-
-        InvalidatePartitionCache();
-        InvalidateFetchRequestCache();
-    }
-
-    public void Unsubscribe()
-    {
-        _topicFilter = null;
-        _topicPattern = null;
-        _subscription.Clear();
-        PublishSubscriptionSnapshot();
-        SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
-        try
-        {
-            _assignment.Clear();
-            PublishAssignmentSnapshot();
-        }
-        finally
-        {
-            SemaphoreHelper.ReleaseSafely(_assignmentLock);
-        }
-
-        // Clear stale fetched data (same rationale as Assign).
-        ClearFetchBuffer();
-
-        InvalidatePartitionCache();
         InvalidateFetchRequestCache();
     }
 

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -147,6 +147,11 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// </summary>
     public bool HasApiKey(ApiKey apiKey) => _brokerApiVersions.ContainsKey(apiKey);
 
+    internal bool SupportsApiVersion(ApiKey apiKey, short version) =>
+        _brokerApiVersions.TryGetValue(apiKey, out var versions) &&
+        versions.MinVersion <= version &&
+        versions.MaxVersion >= version;
+
     /// <summary>
     /// Seeds a broker API version entry. Internal — used by unit tests to bypass negotiation.
     /// </summary>

--- a/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatRequest.cs
@@ -51,7 +51,7 @@ public sealed class ConsumerGroupHeartbeatRequest : IKafkaRequest<ConsumerGroupH
 
     /// <summary>
     /// The subscribed topic regex pattern for regex-based subscriptions (v1+ only).
-    /// Null if not used or unchanged since the last heartbeat.
+    /// Null if unchanged since the last heartbeat. Empty string clears a previous regex subscription.
     /// </summary>
     public string? SubscribedTopicRegex { get; init; }
 

--- a/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatRequest.cs
@@ -82,7 +82,7 @@ public sealed class ConsumerGroupHeartbeatRequest : IKafkaRequest<ConsumerGroupH
                 w.WriteCompactString(topic);
             });
 
-        // v1+ adds SubscribedTopicRegex as a positional field (KIP-1082).
+        // v1+ adds SubscribedTopicRegex as a positional field.
         if (version >= 1)
         {
             writer.WriteCompactNullableString(SubscribedTopicRegex);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerBuilderTests.cs
@@ -139,6 +139,33 @@ public sealed class ConsumerBuilderTests
     }
 
     [Test]
+    public async Task SubscribeToPattern_BuildsWithSubscriptionPattern()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("test-group")
+            .SubscribeToPattern("orders-.*")
+            .Build();
+
+        await Assert.That(consumer.Subscription).IsEmpty();
+        await Assert.That(consumer.SubscriptionPattern).IsEqualTo("orders-.*");
+    }
+
+    [Test]
+    public async Task SubscribeToPattern_ClearsConfiguredTopics()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("test-group")
+            .SubscribeTo("topic-a")
+            .SubscribeToPattern("orders-.*")
+            .Build();
+
+        await Assert.That(consumer.Subscription).IsEmpty();
+        await Assert.That(consumer.SubscriptionPattern).IsEqualTo("orders-.*");
+    }
+
+    [Test]
     public async Task WithConnectionsPerBroker_ValidValues_ReturnsBuilder()
     {
         var builder = Kafka.CreateConsumer<string, string>()

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Metadata;
@@ -151,6 +152,17 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     {
         SetupFindCoordinator();
         SetupConsumerGroupHeartbeat(memberId, memberEpoch, assignment: assignment);
+    }
+
+    private static async ValueTask InvokeSteadyConsumerGroupHeartbeatAsync(ConsumerCoordinator coordinator)
+    {
+        var method = typeof(ConsumerCoordinator).GetMethod(
+            "SendConsumerGroupHeartbeatAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        var result = method!.Invoke(coordinator, [false, CancellationToken.None])!;
+        var task = (Task)result.GetType().GetMethod("AsTask")!.Invoke(result, null)!;
+        await task;
     }
 
     private static ConsumerGroupHeartbeatAssignment CreateAssignment(
@@ -370,6 +382,51 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             Arg.Any<ConsumerGroupHeartbeatRequest>(),
             Arg.Any<short>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_WhenStableAndTopicsChange_NextHeartbeatSendsUpdatedTopics()
+    {
+        SetupFindCoordinator();
+
+        var requests = new List<ConsumerGroupHeartbeatRequest>();
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var request = ci.Arg<ConsumerGroupHeartbeatRequest>();
+                requests.Add(request);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = request.MemberId.Length == 0 ? "member-1" : request.MemberId,
+                    MemberEpoch = request.MemberEpoch == 0 ? 1 : request.MemberEpoch,
+                    HeartbeatIntervalMs = 60000
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        requests.Clear();
+
+        await coordinator.EnsureActiveGroupAsync(
+            new HashSet<string> { "test-topic", "orders" },
+            CancellationToken.None);
+
+        await Assert.That(requests).IsEmpty();
+
+        await InvokeSteadyConsumerGroupHeartbeatAsync(coordinator);
+
+        await Assert.That(requests).Count().IsEqualTo(1);
+        await Assert.That(requests[0].SubscribedTopicNames).IsNotNull();
+        await Assert.That(requests[0].SubscribedTopicNames!).Contains("test-topic");
+        await Assert.That(requests[0].SubscribedTopicNames!).Contains("orders");
+        await Assert.That(requests[0].SubscribedTopicRegex).IsNull();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -944,6 +944,82 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
     #endregion
 
+    #region Server-side Regex Subscription Tests
+
+    [Test]
+    public async Task ConsumerProtocol_ServerSideRegex_SendsRegexInsteadOfTopicNames()
+    {
+        _metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 1);
+        SetupFindCoordinator();
+
+        ConsumerGroupHeartbeatRequest? capturedRequest = null;
+        short capturedVersion = -1;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                capturedRequest = ci.Arg<ConsumerGroupHeartbeatRequest>();
+                capturedVersion = ci.ArgAt<short>(1);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = capturedRequest.MemberId,
+                    MemberEpoch = 1,
+                    HeartbeatIntervalMs = 5000
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string>(), "orders-.*", CancellationToken.None);
+
+        await Assert.That(capturedVersion).IsEqualTo((short)1);
+        await Assert.That(capturedRequest).IsNotNull();
+        await Assert.That(capturedRequest!.SubscribedTopicNames).IsNull();
+        await Assert.That(capturedRequest.SubscribedTopicRegex).IsEqualTo("orders-.*");
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_ServerSideRegex_BrokerWithoutV1_ThrowsBrokerVersionException()
+    {
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await Assert.That(async () =>
+                await coordinator.EnsureActiveGroupAsync(new HashSet<string>(), "orders-.*", CancellationToken.None))
+            .Throws<BrokerVersionException>()
+            .WithMessageContaining("Kafka 4.1");
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_InvalidRegularExpression_ThrowsGroupException()
+    {
+        _metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 1);
+        SetupFindCoordinator();
+        SetupConsumerGroupHeartbeat(errorCode: ErrorCode.InvalidRegularExpression);
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        GroupException? caught = null;
+        try
+        {
+            await coordinator.EnsureActiveGroupAsync(new HashSet<string>(), "orders-(", CancellationToken.None);
+        }
+        catch (GroupException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.ErrorCode).IsEqualTo(ErrorCode.InvalidRegularExpression);
+    }
+
+    #endregion
+
     #region KIP-1082 Client-Generated Member ID Tests
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1035,8 +1035,93 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
         await Assert.That(capturedVersion).IsEqualTo((short)1);
         await Assert.That(capturedRequest).IsNotNull();
-        await Assert.That(capturedRequest!.SubscribedTopicNames).IsNull();
+        await Assert.That(capturedRequest!.SubscribedTopicNames).IsNotNull();
+        await Assert.That(capturedRequest.SubscribedTopicNames!).IsEmpty();
         await Assert.That(capturedRequest.SubscribedTopicRegex).IsEqualTo("orders-.*");
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_SwitchFromRegexToTopics_ClearsRegex()
+    {
+        _metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 1);
+        SetupFindCoordinator();
+
+        var requests = new List<ConsumerGroupHeartbeatRequest>();
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var request = ci.Arg<ConsumerGroupHeartbeatRequest>();
+                requests.Add(request);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = request.MemberId,
+                    MemberEpoch = request.MemberEpoch == 0 ? 1 : request.MemberEpoch,
+                    HeartbeatIntervalMs = 60000
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string>(), "orders-.*", CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        requests.Clear();
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, null, CancellationToken.None);
+        await Assert.That(requests).IsEmpty();
+
+        await InvokeSteadyConsumerGroupHeartbeatAsync(coordinator);
+
+        await Assert.That(requests).Count().IsEqualTo(1);
+        await Assert.That(requests[0].SubscribedTopicNames).IsNotNull();
+        await Assert.That(requests[0].SubscribedTopicNames!).Contains("test-topic");
+        await Assert.That(requests[0].SubscribedTopicRegex).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_SwitchFromTopicsToRegex_ClearsTopics()
+    {
+        _metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 1);
+        SetupFindCoordinator();
+
+        var requests = new List<ConsumerGroupHeartbeatRequest>();
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var request = ci.Arg<ConsumerGroupHeartbeatRequest>();
+                requests.Add(request);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = request.MemberId,
+                    MemberEpoch = request.MemberEpoch == 0 ? 1 : request.MemberEpoch,
+                    HeartbeatIntervalMs = 60000
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        requests.Clear();
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string>(), "orders-.*", CancellationToken.None);
+        await Assert.That(requests).IsEmpty();
+
+        await InvokeSteadyConsumerGroupHeartbeatAsync(coordinator);
+
+        await Assert.That(requests).Count().IsEqualTo(1);
+        await Assert.That(requests[0].SubscribedTopicNames).IsNotNull();
+        await Assert.That(requests[0].SubscribedTopicNames!).IsEmpty();
+        await Assert.That(requests[0].SubscribedTopicRegex).IsEqualTo("orders-.*");
     }
 
     [Test]
@@ -1073,6 +1158,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
         await Assert.That(caught).IsNotNull();
         await Assert.That(caught!.ErrorCode).IsEqualTo(ErrorCode.InvalidRegularExpression);
+        await Assert.That(caught.Message).Contains("orders-(");
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerBudgetTests.cs
@@ -82,4 +82,35 @@ public class KafkaConsumerBudgetTests
 
         DekafMemoryBudget.ResetForTesting();
     }
+
+    [Test]
+    public async Task SubscribeToPatternWithoutGroupId_DoesNotRegisterLeakedConsumer()
+    {
+        DekafMemoryBudget.ResetForTesting();
+        DekafMemoryBudget.SetBudget(TestBudget);
+
+        try
+        {
+            var act = () => Kafka.CreateConsumer<string, string>()
+                .WithBootstrapServers("localhost:9092")
+                .SubscribeToPattern("orders-.*")
+                .Build();
+
+            await Assert.That(act)
+                .Throws<InvalidOperationException>()
+                .WithMessageContaining("WithGroupId");
+
+            await using var consumer = Kafka.CreateConsumer<string, string>()
+                .WithBootstrapServers("localhost:9092")
+                .WithGroupId("test")
+                .Build();
+
+            var limit = ((KafkaConsumer<string, string>)consumer).CurrentQueuedMaxBytes;
+            await Assert.That(limit).IsEqualTo(TestBudget);
+        }
+        finally
+        {
+            DekafMemoryBudget.ResetForTesting();
+        }
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/PatternSubscriptionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PatternSubscriptionTests.cs
@@ -18,6 +18,41 @@ public sealed class PatternSubscriptionTests
     }
 
     [Test]
+    public async Task SubscribePattern_WithNullPattern_ThrowsArgumentNullException()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("test-group")
+            .Build();
+
+        var act = () => consumer.SubscribePattern(null!);
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task SubscribePattern_WithEmptyPattern_ThrowsArgumentException()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("test-group")
+            .Build();
+
+        var act = () => consumer.SubscribePattern(" ");
+        await Assert.That(act).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task SubscribePattern_WithoutGroupId_ThrowsInvalidOperationException()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+
+        var act = () => consumer.SubscribePattern("orders-.*");
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task Subscribe_WithFilter_ClearsExistingSubscription()
     {
         await using var consumer = Kafka.CreateConsumer<string, string>()
@@ -30,6 +65,54 @@ public sealed class PatternSubscriptionTests
 
         // Subscribe with filter - should clear explicit subscription
         consumer.Subscribe(topic => topic.StartsWith("prefix-", StringComparison.Ordinal));
+        await Assert.That(consumer.Subscription.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SubscribePattern_ClearsExistingSubscription()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("test-group")
+            .Build();
+
+        consumer.Subscribe("topic-a", "topic-b");
+
+        consumer.SubscribePattern("orders-.*");
+
+        await Assert.That(consumer.Subscription.Count).IsEqualTo(0);
+        await Assert.That(consumer.SubscriptionPattern).IsEqualTo("orders-.*");
+    }
+
+    [Test]
+    public async Task Subscribe_WithTopics_ClearsServerSidePattern()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("test-group")
+            .Build();
+
+        consumer.SubscribePattern("orders-.*");
+
+        consumer.Subscribe("topic-a");
+
+        await Assert.That(consumer.SubscriptionPattern).IsNull();
+        await Assert.That(consumer.Subscription).Contains("topic-a");
+    }
+
+    [Test]
+    public async Task Subscribe_WithFilter_ClearsServerSidePattern()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("test-group")
+            .Build();
+
+        consumer.SubscribePattern("orders-.*");
+
+        consumer.Subscribe(topic => topic.StartsWith("prefix-", StringComparison.Ordinal));
+
+        await Assert.That(consumer.SubscriptionPattern).IsNull();
         await Assert.That(consumer.Subscription.Count).IsEqualTo(0);
     }
 
@@ -62,6 +145,7 @@ public sealed class PatternSubscriptionTests
         // Unsubscribe - should clear everything including the filter
         consumer.Unsubscribe();
         await Assert.That(consumer.Subscription.Count).IsEqualTo(0);
+        await Assert.That(consumer.SubscriptionPattern).IsNull();
         await Assert.That(consumer.Assignment.Count).IsEqualTo(0);
     }
 

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -99,6 +99,33 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task Consumer_SubscribePattern_AssignsMatchingInMemoryTopics()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders-created");
+        cluster.CreateTopic("payments-created");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "orders-service",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+
+        await producer.ProduceAsync("orders-created", "order-1", "created");
+        await producer.ProduceAsync("payments-created", "payment-1", "created");
+        consumer.SubscribePattern("orders-.*");
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+
+        await Assert.That(consumer.Subscription).IsEmpty();
+        await Assert.That(consumer.SubscriptionPattern).IsEqualTo("orders-.*");
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Topic).IsEqualTo("orders-created");
+    }
+
+    [Test]
     public async Task Admin_DescribeLogDirs_ReturnsInMemoryReplicaInfo()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -138,6 +165,16 @@ public sealed class InMemoryKafkaClusterTests
 
         await Assert.That(result[replica].TopicPartitionReplica).IsEqualTo(replica);
         await Assert.That(result[replica].ErrorCode).IsEqualTo(ErrorCode.None);
+    }
+
+    [Test]
+    public async Task Producer_PurgeAsync_IsNoOpForInMemoryProducer()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+
+        await producer.PurgeAsync(PurgeOptions.None);
+        await producer.PurgeAsync(PurgeOptions.All);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add SubscribePattern/SubscribeToPattern for broker-side topic regex while keeping single-string topic subscriptions unchanged
- send SubscribedTopicRegex through ConsumerGroupHeartbeat v1 with Kafka 4.1+ gating and InvalidRegularExpression mapping
- document RE2/J syntax, no .NET regex translation, and the client-side predicate trade-off

## Test plan
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PatternSubscriptionTests/*"
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumerBuilderTests/*"
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumerCoordinatorKip848Tests/*"
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe
- dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release
- npm ci && npm run build (docs)
- git diff --check

Closes #1157