### PR TITLE
fix(stress-tests): tighten multi-broker retention to survive faster producer bursts

### DIFF
--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -18,11 +18,11 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
     // 1. Original 5s retention was too aggressive — caused constant "offset out of range" resets
     // 2. Long time-based retention (e.g. 30 min) would retain ~360 GB at high throughput,
     //    exhausting disk/memory on CI runners
-    // Solution: byte-based retention (128 MB/partition × 6 partitions ≈ 768 MB max disk) is
+    // Solution: byte-based retention (64 MB/partition × 6 partitions ≈ 384 MB max disk) is
     // the primary bound. Time-based retention (5 min) is a secondary backstop. Small 16 MB
     // segments let Kafka reclaim space incrementally as the consumer keeps up.
     //
-    // The 1s check interval is load-bearing: producers push ~1 GB/s, so disk usage can
+    // The 500ms check interval is load-bearing: producers push ~1 GB/s, so disk usage can
     // overshoot the retention caps by roughly (produce rate × check interval) between
     // sweeps. A 10s interval meant ~10 GB overshoot windows — more than the broker tmpfs —
     // which filled the log dir and halted ingestion seconds into producer runs.
@@ -32,13 +32,21 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
     // 30s; Kafka 3.8+). At ~1 GB/s a 6 GB tmpfs fills in ~5s, so with the default
     // delay the broker died of "No space left on device" before retention ever ran —
     // none of the settings above mattered.
+    //
+    // The 0ms segment delete delay matters at replication factor 3: every broker ingests
+    // the full client byte rate (leader writes + replica fetches), and a nonzero delay
+    // leaves already-deleted segments on disk for (produce rate × delay) — ~1.2 GB of
+    // dead data per broker at 1s. Retention must win the NET fill race (ingest minus
+    // reclaim); a client-side throughput gain of ~15% was enough to fill two of three
+    // 6 GB tmpfs mounts in ~40s under the previous 128 MB / 1s / 1s settings, so the
+    // margins here are deliberately generous.
     private static readonly Dictionary<string, string> RetentionConfig = new()
     {
         ["KAFKA_LOG_RETENTION_MS"] = "300000",
-        ["KAFKA_LOG_RETENTION_BYTES"] = "134217728",
+        ["KAFKA_LOG_RETENTION_BYTES"] = "67108864",
         ["KAFKA_LOG_SEGMENT_BYTES"] = "16777216",
-        ["KAFKA_LOG_SEGMENT_DELETE_DELAY_MS"] = "1000",
-        ["KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS"] = "1000",
+        ["KAFKA_LOG_SEGMENT_DELETE_DELAY_MS"] = "0",
+        ["KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS"] = "500",
         ["KAFKA_LOG_INITIAL_TASK_DELAY_MS"] = "1000",
         ["KAFKA_LOG_CLEANUP_POLICY"] = "delete",
     };


### PR DESCRIPTION
## Problem

`Dekaf Producer (3 Brokers)` and `Dekaf Producer (3conn, 3 Brokers)` fail since the producer perf improvements #1139 / #1143 landed (runs [28674440851](https://github.com/thomhurst/Dekaf/actions/runs/28674440851), [28676582938](https://github.com/thomhurst/Dekaf/actions/runs/28676582938)).

kafka-1 and kafka-2 fill their 6 GB tmpfs log dirs within ~40s of test start and die; the run then crawls against the surviving broker, flush times out, and the end-offset query fails against the dead cluster — so the #1131 guard correctly fails the scenario.

## Root cause

Net-fill race, not a sleeping retention task this time:

- With replication factor 3, **every** broker ingests the full client byte rate (~1.2 GB/s) — leader writes plus replica fetches.
- Retention *was* running and deleting (replica-fetch snapshots at broker death show `logStartOffset` advanced ~2M records/partition ≈ 12 GB reclaimed per broker in under a minute), but reclaim lagged ingest.
- The last passing run burst at ~0.98–1.05M msg/s and disks oscillated at 2–3.5 GB of 6 GB. After #1139/#1143 the burst is ~1.14–1.21M msg/s (+10–16%) and disk growth went monotonic to full. The old settings were knife-edge.
- Only the plain acks=Leader fire-and-forget 3-broker variants fail; acks=all / idempotent / single-broker jobs are slower or un-replicated and pass.

## Fix

Widen the reclaim margin in `KafkaEnvironment.RetentionConfig` (multi-broker clusters + local runs):

| Setting | Before | After |
|---|---|---|
| `log.segment.delete.delay.ms` | 1000 | **0** |
| `log.retention.bytes` | 128 MB | **64 MB** |
| `log.retention.check.interval.ms` | 1000 | **500** |

The delete-delay change is the big one: a 1s delay kept ~1.2 GB of already-deleted segment files on disk per broker at full ingest rate.

Growing tmpfs instead is not viable: 3×6 GB tmpfs + 3×~3 GB broker JVM already ≈ the runner's 31.3 GB RAM.

The workflow-managed single broker in `stress-tests.yml` is tuned separately (100ms delete delay, 10s retention.ms), its jobs pass, and it is untouched.

## Verification

Config-only harness change; validated by the Stress Tests workflow on this branch/next scheduled run.