### PR TITLE
fix(stress-tests): bound the HW-stall window that defeats broker retention

### DIFF
--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -40,6 +40,20 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
     // reclaim); a client-side throughput gain of ~15% was enough to fill two of three
     // 6 GB tmpfs mounts in ~40s under the previous 128 MB / 1s / 1s settings, so the
     // margins here are deliberately generous.
+    //
+    // The 5s replica lag window bounds a stall none of the above can fix: retention
+    // only deletes segments below the high watermark, and the high watermark cannot
+    // advance past a lagging in-sync follower. On CPU-starved CI brokers (three
+    // brokers sharing six cores, each moving the full client byte rate) a follower
+    // can lag for the whole replica.lag.time.max.ms window (default 30s) before the
+    // ISR sheds it, freezing the deletable set while the leader ingests at full
+    // rate — observed as a broker going from 60% to a full 6 GB tmpfs within one
+    // 15s disk sample despite 500ms retention sweeps. 5s caps the frozen window at
+    // ~1 GB of overshoot. The ISR churn this invites is acceptable: producer
+    // scenarios measure client throughput at acks=Leader, not replication durability.
+    //
+    // Not only log.* retention keys: any broker knob whose job is keeping the log-dir
+    // tmpfs bounded belongs here, so both container paths pick it up uniformly.
     private static readonly Dictionary<string, string> RetentionConfig = new()
     {
         ["KAFKA_LOG_RETENTION_MS"] = "300000",
@@ -49,6 +63,7 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
         ["KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS"] = "500",
         ["KAFKA_LOG_INITIAL_TASK_DELAY_MS"] = "1000",
         ["KAFKA_LOG_CLEANUP_POLICY"] = "delete",
+        ["KAFKA_REPLICA_LAG_TIME_MAX_MS"] = "5000",
     };
 
     // The image default (1 GB) is undersized for sustained ~1 GB/s ingestion; give the
@@ -378,12 +393,23 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
     /// </summary>
     private static async Task DumpBrokerDiagnosticsAsync(IContainer container, string name)
     {
+        // df exec requires a running container and throws for one that died mid-run —
+        // exactly the case these diagnostics exist for. Non-fatal so the log fetch
+        // below (which works on stopped containers) still captures the broker's
+        // dying words, e.g. "No space left on device".
         try
         {
             var df = await container.ExecAsync(["df", "-h", KafkaLogDir]).ConfigureAwait(false);
             Console.WriteLine($"[{name}] log-dir usage:");
             Console.WriteLine(df.Stdout.TrimEnd());
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[{name}] log-dir usage unavailable (container dead?): {ex.Message}");
+        }
 
+        try
+        {
             var (stdout, stderr) = await container.GetLogsAsync(timestampsEnabled: false).ConfigureAwait(false);
 
             // Bounded scan instead of concat+Split: broker logs can be tens of MB after


### PR DESCRIPTION
## Problem

The plain (acks=Leader) 3-broker producer stress jobs — `Dekaf Producer (3 Brokers)` and `(3conn, 3 Brokers)` — still kill brokers by filling the 6 GB tmpfs, even on b0f704f (#1193) which already applied the most aggressive retention settings (64 MB `retention.bytes`, 16 MB segments, 0 ms delete delay, 500 ms check interval). Failing runs: [28674440851](https://github.com/thomhurst/Dekaf/actions/runs/28674440851), [28676582938](https://github.com/thomhurst/Dekaf/actions/runs/28676582938), [28678706480](https://github.com/thomhurst/Dekaf/actions/runs/28678706480).

The broker-disk monitor from run 28678706480 shows retention is not slow — it gets **blocked**:

- t+15s: disks at 55–68%, then a sweep reclaims to ~10% — tuning works initially
- t+75s: kafka-1 jumps from 3.7 G (61%) to a full 6 G **within one 15 s sample** and dies, despite 500 ms retention sweeps
- t+90s: kafka-3 follows (92% → full)
- the survivor then plateaus at exactly 5.0 G for 14 minutes, never shrinking despite `retention.ms=5min`

## Root cause

Kafka only deletes segments **below the high watermark**. On CPU-starved CI brokers (three brokers sharing six cores, each moving the full client byte rate at RF=3), a replica fetcher can lag for the entire `replica.lag.time.max.ms` window (default **30 s**) before the ISR sheds it. While it lags, the high watermark — and therefore the deletable set — is frozen, and the leader keeps ingesting at ~1.2 GB/s. 30 s of frozen deletion is far more than the tmpfs can absorb.

The survivor's frozen 5.0 G plateau is the same mechanism in its terminal form: with two of three combined-mode KRaft nodes dead there is no controller quorum, so AlterPartition fails, the ISR can never shrink, the HW never advances, and deletion stays blocked forever.

## Fix

- Set `replica.lag.time.max.ms=5000` in the shared broker config so a stalled follower is dropped from the ISR in seconds, capping the frozen-deletion overshoot at roughly 1 GB. ISR churn is acceptable here: producer scenarios measure client throughput at acks=Leader, not replication durability.
- Fix `DumpBrokerDiagnosticsAsync` for dead containers: the `df` exec throws for a container that is not running, and the shared catch then skipped the log fetch entirely — which is why the dying brokers' logs (expected: "No space left on device") have never appeared in CI output. `GetLogsAsync` works on stopped containers, so it now runs regardless of the `df` outcome. If this fix's theory is wrong, the next failure will now say so.

## If this doesn't hold

Retention-config tuning is exhausted; remaining levers are raising replica fetcher parallelism (`num.replica.fetchers`, `replica.fetch.max.bytes`), RF=2 for the plain jobs, or more broker cores. The improved diagnostics will show the actual dying-broker error to steer that choice.

## Testing

- `dotnet build tools/Dekaf.StressTests -c Release` clean.
- Real validation requires a stress-tests workflow dispatch on this branch (Docker + ubicloud runner).