### PR TITLE
test(producer): deflake pending purge test

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2915,6 +2915,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     internal long BufferPressureEvents => Volatile.Read(ref _bufferPressureEvents);
 
+    internal int PendingAppendCountForTest => _pendingAppends.Count;
+
     /// <summary>
     /// Gets the current buffer utilization as a ratio (0.0 to 1.0+).
     /// Used by adaptive connection scaling to confirm buffer is actually full.

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -385,6 +385,9 @@ public class RecordAccumulatorTests
             while (accumulator.BufferPressureEvents == 0 && !appendTask.IsCompleted)
                 await Task.Yield();
 
+            while (accumulator.PendingAppendCountForTest == 0 && !appendTask.IsCompleted)
+                await Task.Yield();
+
             await Assert.That(appendTask.IsCompleted).IsFalse();
 
             var purged = accumulator.Purge(PurgeOptions.Queue, CreatePurgedException());


### PR DESCRIPTION
## Problem

`main` CI has been red since b0f704f. The compile break (`CS0535`: `InMemoryProducer` missing interface members merged in #1183/#1185) was already fixed by #1190's merge — but the pending-purge test race it was masking is still on `main`.

## Race

`RecordAccumulator.BeginReservationWait` increments `_bufferPressureEvents` **before** the pending op is enqueued to `_pendingAppends` (`AppendWithReservationAsync`). The test spins only on `BufferPressureEvents != 0`, so `Purge(PurgeOptions.Queue)` can run in the window between the counter increment and the enqueue, drain an empty queue, and fail the assertions.

## Fix

Add a second deterministic spin-wait on the actual observable state (`PendingAppendCountForTest > 0`) before purging — no timing dependency, per the project's deflaking policy.

Cherry-picked from work another session had parked on the #1196 branch (originally `8f575bb`), rebased onto current `main`.

## Testing

`RecordAccumulatorTests` full class: 6 consecutive runs, 52/52 pass each (Release, net10.0).