### PR TITLE
fix(ci): stop stress-test results being lost to artifact filename collisions

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -298,7 +298,12 @@ jobs:
         with:
           pattern: results-*
           path: ./all-results
-          merge-multiple: true
+          # NOT merge-multiple: matrix jobs for the same client+scenario can emit
+          # identically named result files (runs starting in the same second), and
+          # merging would silently overwrite one — dropping rows from the published
+          # tables. Per-artifact subdirectories keep every result; the recursive
+          # glob below finds them all.
+          merge-multiple: false
 
       - name: List Downloaded Results
         run: |

--- a/docs/docs/stress-tests.md
+++ b/docs/docs/stress-tests.md
@@ -6,7 +6,7 @@ sidebar_position: 14
 
 Long-running stress tests comparing sustained performance between Dekaf and Confluent.Kafka under real-world load.
 
-**Last Updated:** 2026-07-03 20:28 UTC
+**Last Updated:** 2026-07-03 20:58 UTC
 
 :::info
 These tests run weekly (Sunday 2 AM UTC) and can be manually triggered. 
@@ -19,8 +19,13 @@ They measure sustained performance over 15+ minutes with real Kafka instances.
 |--------|--------------|--------|----------------|--------|------------|------------|
 | Dekaf (3conn) | 1,527,361 | 1456.60 | 1,527,361 | 0 | 0.92 | 1.40 |
 | Dekaf | 1,373,405 | 1309.78 | 1,373,405 | 0 | 0.91 | 1.25 |
+| Confluent | 1,148,284 | 1095.09 | 1,148,284 | 0 | 1.46 | 1.67 |
 
 *Messages/sec counts broker-confirmed deliveries (end-offset delta). Accepted msg/s is the client-side append rate — a large gap means messages were buffered or dropped without ever reaching the broker.*
+
+:::tip
+**Dekaf is 1.20x faster** than Confluent.Kafka for producer (fire-and-forget) throughput!
+:::
 
 ## Producer (Fire-and-Forget), 3 Brokers Throughput (15 minutes, 1000B messages)
 
@@ -54,8 +59,13 @@ They measure sustained performance over 15+ minutes with real Kafka instances.
 | Client | Messages/sec | MB/sec | Accepted msg/s | Errors | CPU μs/msg | Cores Used |
 |--------|--------------|--------|----------------|--------|------------|------------|
 | Dekaf | 1,066,122 | 1016.73 | 1,066,122 | 0 | 1.05 | 1.12 |
+| Confluent | 758,594 | 723.45 | 758,594 | 0 | 2.05 | 1.55 |
 
 *Messages/sec counts broker-confirmed deliveries (end-offset delta). Accepted msg/s is the client-side append rate — a large gap means messages were buffered or dropped without ever reaching the broker.*
+
+:::tip
+**Dekaf is 1.41x faster** than Confluent.Kafka for producer (producer-acks-all), 3 brokers throughput!
+:::
 
 ## Producer (Fire-and-Forget, Idempotent) Throughput (15 minutes, 1000B messages)
 
@@ -101,8 +111,10 @@ Dekaf and Confluent.Kafka have similar producer (fire-and-forget, idempotent) pe
 | Client | Scenario | Gen0 | Gen1 | Gen2 | Total Allocated |
 |--------|----------|------|------|------|-----------------|
 | Confluent | Consumer | 44589 | 0 | 0 | 213.85 GB |
+| Confluent | Producer (Fire-and-Forget) | 263590 | 1 | 1 | 1240.19 GB |
 | Confluent | Producer (Fire-and-Forget), 3 Brokers | 196618 | 0 | 0 | 920.65 GB |
 | Confluent | producer-acks-all | 208335 | 1 | 1 | 1003.56 GB |
+| Confluent | producer-acks-all, 3 Brokers | 172974 | 1 | 0 | 819.32 GB |
 | Confluent | Producer (Fire-and-Forget, Idempotent) | 319429 | 1 | 1 | 1511.49 GB |
 | Confluent | Producer (Fire-and-Forget, Idempotent), 3 Brokers | 175970 | 2 | 2 | 822.91 GB |
 | Dekaf | Consumer | 81248 | 48075 | 2350 | 4026.25 GB |

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -174,8 +174,13 @@ public static class Program
             Directory.CreateDirectory(outputDir);
         }
 
+        // Broker/connection counts are part of the name so runs of the same
+        // client+scenario (e.g. 1-broker vs 3-broker CI matrix jobs, which can start
+        // within the same second) never produce identically named files — flattening
+        // their outputs into one directory would silently overwrite one.
+        var connSuffix = options.ConnectionsPerBroker > 1 ? $"-{options.ConnectionsPerBroker}conn" : "";
         var fileSuffix = options.Scenario != "all" || options.Client != "all"
-            ? $"-{options.Client}-{options.Scenario}-{runStartedAt:yyyyMMdd-HHmmss}"
+            ? $"-{options.Client}-{options.Scenario}-{options.Brokers}brokers{connSuffix}-{runStartedAt:yyyyMMdd-HHmmss}"
             : $"-{runStartedAt:yyyyMMdd-HHmmss}";
         var jsonPath = Path.Combine(outputDir, $"stress-test-results{fileSuffix}.json");
         var mdPath = Path.Combine(outputDir, $"stress-test-results{fileSuffix}.md");


### PR DESCRIPTION
## Problem

The published stress-test docs (https://thomhurst.github.io/Dekaf/docs/stress-tests/) were missing Confluent rows for two scenarios:

- **Producer (Fire-and-Forget), 1 broker** — Confluent row missing
- **Producer (acks-all), 3 brokers** — Confluent row missing
- Same two entries missing from the Memory & GC table

## Root cause

Result files are named `stress-test-results-{client}-{scenario}-{yyyyMMdd-HHmmss}.json` — no broker/connection count. Matrix jobs for the same client+scenario but different broker counts start within the same second, so both wrote **identical filenames**. In run 28681380102:

- `results-confluent-producer-1brokers` and `results-confluent-producer-3brokers` both contained `stress-test-results-confluent-producer-20260703-201104.json`
- both acks-all artifacts contained `...-confluent-producer-acks-all-20260703-201107.json`

The `generate-summary` job downloads with `merge-multiple: true`, which flattens all artifacts into one directory — one file of each colliding pair was silently overwritten. The merged results contained 16 of 18 results, and the docs published without the two rows. The `needs.stress-test.result == ''success''` gate could not catch this: every job succeeded; data was lost after upload.

## Fix

1. **`stress-tests.yml`**: download with `merge-multiple: false` so each artifact extracts into its own subdirectory. Uniqueness now derives from the already-unique artifact names; the existing recursive glob picks up every file. This is the structural fix — no filename convention can cause data loss.
2. **`Program.cs`**: include `{brokers}brokers[-Nconn]` in the result filename as defense in depth and to make local artifacts self-describing.
3. **`docs/docs/stress-tests.md`**: regenerated from the complete 18-result set of run 28681380102 (recovered from the per-job artifacts), restoring the two dropped rows and their comparison callouts.

The benchmarks workflow was checked for the same hazard: its jobs already write to distinct subdirectories (`Unit/`, `Client/`, `ClientNative/`), so its `merge-multiple: true` is safe.