### PR TITLE
fix(admin): harden delegation token APIs

### DIFF
--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -776,6 +776,11 @@ internal static class DekafConfigurationBinding
                 mechanism = SaslMechanism.None;
         }
 
+        if (saslScramTokenAuth && mechanism is not (SaslMechanism.ScramSha256 or SaslMechanism.ScramSha512))
+        {
+            throw new InvalidOperationException("SaslScramTokenAuth requires SaslMechanism ScramSha256 or ScramSha512.");
+        }
+
         return hasMechanism || hasUsername || hasPassword || hasSaslScramTokenAuth || hasGssapi || hasOAuth || hasAwsMskIam;
     }
 

--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -1,4 +1,5 @@
 using Dekaf.Admin;
+using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Protocol;
 using Dekaf.Telemetry;
@@ -808,7 +809,9 @@ public sealed class InMemoryAdminClient : IAdminClient
         lock (_delegationTokenGate)
         {
             if (!_delegationTokens.TryGetValue(key, out var token))
-                throw new InvalidOperationException("Delegation token was not found.");
+                throw KafkaException.FromErrorCode(
+                    ErrorCode.DelegationTokenNotFound,
+                    "Delegation token was not found.");
 
             var expiry = DateTimeOffset.UtcNow + period;
             if (expiry > token.MaxTimestamp)

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1736,38 +1736,36 @@ public sealed class AdminClient : IAdminClient
         var ownerPrincipal = owner is { } value ? ToProtocolPrincipal(value) : null;
         var maxLifetimeMs = ToKafkaMilliseconds(maxLifetime, nameof(maxLifetime));
 
-        return await WithRetryAsync<DelegationToken>(async () =>
+        // CreateDelegationToken has no client idempotency key; do not auto-retry after the broker may have minted a token.
+        var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+        var request = new CreateDelegationTokenRequest
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
-            var request = new CreateDelegationTokenRequest
-            {
-                Owner = ownerPrincipal,
-                Renewers = protocolRenewers,
-                MaxLifetimeMs = maxLifetimeMs
-            };
+            Owner = ownerPrincipal,
+            Renewers = protocolRenewers,
+            MaxLifetimeMs = maxLifetimeMs
+        };
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.CreateDelegationToken,
-                CreateDelegationTokenRequest.LowestSupportedVersion,
-                CreateDelegationTokenRequest.HighestSupportedVersion);
+        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            Protocol.ApiKey.CreateDelegationToken,
+            CreateDelegationTokenRequest.LowestSupportedVersion,
+            CreateDelegationTokenRequest.HighestSupportedVersion);
 
-            if (ownerPrincipal is not null && apiVersion < 3)
-            {
-                throw new NotSupportedException("CreateDelegationToken owner override requires CreateDelegationToken API v3 or later.");
-            }
+        if (ownerPrincipal is not null && apiVersion < 3)
+        {
+            throw new NotSupportedException("CreateDelegationToken owner override requires CreateDelegationToken API v3 or later.");
+        }
 
-            var response = await controller.SendAsync<CreateDelegationTokenRequest, CreateDelegationTokenResponse>(
-                request,
-                apiVersion,
-                cancellationToken).ConfigureAwait(false);
+        var response = await controller.SendAsync<CreateDelegationTokenRequest, CreateDelegationTokenResponse>(
+            request,
+            apiVersion,
+            cancellationToken).ConfigureAwait(false);
 
-            if (response.ErrorCode != Protocol.ErrorCode.None)
-            {
-                throw KafkaException.FromErrorCode(response.ErrorCode, $"CreateDelegationToken failed: {response.ErrorCode}");
-            }
+        if (response.ErrorCode != Protocol.ErrorCode.None)
+        {
+            throw KafkaException.FromErrorCode(response.ErrorCode, $"CreateDelegationToken failed: {response.ErrorCode}");
+        }
 
-            return MapDelegationToken(response, renewerList);
-        }, cancellationToken).ConfigureAwait(false);
+        return MapDelegationToken(response, renewerList);
     }
 
     public async ValueTask<DateTimeOffset> RenewDelegationTokenAsync(

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -2532,6 +2532,9 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         return this;
     }
 
+    public ShareConsumerBuilder<TKey, TValue> WithSaslScramSha256DelegationToken(string tokenId, string tokenHmac)
+        => WithSaslScram256DelegationToken(tokenId, tokenHmac);
+
     public ShareConsumerBuilder<TKey, TValue> WithSaslScram256DelegationToken(string tokenId, string tokenHmac)
     {
         ThrowIfClientOwnedConnectionSettings();
@@ -2541,6 +2544,9 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         _saslScramTokenAuth = true;
         return this;
     }
+
+    public ShareConsumerBuilder<TKey, TValue> WithSaslScramSha512DelegationToken(string tokenId, string tokenHmac)
+        => WithSaslScram512DelegationToken(tokenId, tokenHmac);
 
     public ShareConsumerBuilder<TKey, TValue> WithSaslScram512DelegationToken(string tokenId, string tokenHmac)
     {

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientDelegationTokenTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientDelegationTokenTests.cs
@@ -65,6 +65,29 @@ public sealed class AdminClientDelegationTokenTests
     }
 
     [Test]
+    public async Task CreateDelegationTokenAsync_RetriableResponseError_DoesNotRetryNonIdempotentCreate()
+    {
+        await using var context = new AdminTestContext();
+        context.EnqueueCreate(new CreateDelegationTokenResponse
+        {
+            ErrorCode = ErrorCode.RequestTimedOut,
+            PrincipalType = "User",
+            PrincipalName = "owner",
+            TokenId = "token-id",
+            Hmac = []
+        });
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await context.Client.CreateDelegationTokenAsync());
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
+        await context.Connection.Received(1).SendAsync<CreateDelegationTokenRequest, CreateDelegationTokenResponse>(
+            Arg.Any<CreateDelegationTokenRequest>(),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task CreateDelegationTokenAsync_WithOwnerAndV2_ThrowsNotSupported()
     {
         await using var context = new AdminTestContext(createDelegationTokenMaxVersion: 2);

--- a/tests/Dekaf.Tests.Unit/Builder/AwsMskIamBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/AwsMskIamBuilderTests.cs
@@ -48,6 +48,34 @@ public sealed class AwsMskIamBuilderTests
     }
 
     [Test]
+    public async Task ShareConsumer_WithSaslScramSha256DelegationToken_SetsTokenAuth()
+    {
+        var builder = Kafka.CreateShareConsumer<string, string>();
+
+        var result = builder.WithSaslScramSha256DelegationToken("token-id", "token-hmac");
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(GetSaslMechanism(builder)).IsEqualTo(SaslMechanism.ScramSha256);
+        await Assert.That(GetSaslUsername(builder)).IsEqualTo("token-id");
+        await Assert.That(GetSaslPassword(builder)).IsEqualTo("token-hmac");
+        await Assert.That(GetSaslScramTokenAuth(builder)).IsTrue();
+    }
+
+    [Test]
+    public async Task ShareConsumer_WithSaslScramSha512DelegationToken_SetsTokenAuth()
+    {
+        var builder = Kafka.CreateShareConsumer<string, string>();
+
+        var result = builder.WithSaslScramSha512DelegationToken("token-id", "token-hmac");
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(GetSaslMechanism(builder)).IsEqualTo(SaslMechanism.ScramSha512);
+        await Assert.That(GetSaslUsername(builder)).IsEqualTo("token-id");
+        await Assert.That(GetSaslPassword(builder)).IsEqualTo("token-hmac");
+        await Assert.That(GetSaslScramTokenAuth(builder)).IsTrue();
+    }
+
+    [Test]
     public async Task AdminClient_WithAwsMskIam_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateAdminClient()
@@ -115,6 +143,12 @@ public sealed class AwsMskIamBuilderTests
 
     private static AwsMskIamConfig? GetAwsMskIamConfig(object builder)
         => GetField<AwsMskIamConfig?>(builder, "_awsMskIamConfig");
+
+    private static string? GetSaslUsername(object builder)
+        => GetField<string?>(builder, "_saslUsername");
+
+    private static string? GetSaslPassword(object builder)
+        => GetField<string?>(builder, "_saslPassword");
 
     private static bool GetSaslScramTokenAuth(object builder)
         => GetField<bool>(builder, "_saslScramTokenAuth");

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -444,6 +444,28 @@ public class DependencyInjectionTests
     }
 
     [Test]
+    public async Task AddProducer_WithSaslScramTokenAuthAndNonScramMechanism_ThrowsInvalidOperationException()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:BootstrapServers"] = "broker1:9092",
+            ["Kafka:SaslMechanism"] = "Plain",
+            ["Kafka:SaslUsername"] = "user",
+            ["Kafka:SaslPassword"] = "password",
+            ["Kafka:SaslScramTokenAuth"] = "true"
+        });
+
+        void Act() => services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>(configuration.GetSection("Kafka"));
+        });
+
+        await Assert.That(Act).Throws<InvalidOperationException>()
+            .WithMessageContaining("SaslScramTokenAuth requires SaslMechanism ScramSha256 or ScramSha512");
+    }
+
+    [Test]
     public async Task AddProducer_WithConfigurationSection_FluentConfigurationOverridesBoundValues()
     {
         var services = new ServiceCollection();
@@ -503,7 +525,7 @@ public class DependencyInjectionTests
             ["Kafka:Consumers:Orders:ReconnectBackoffMaxMs"] = "800",
             ["Kafka:Consumers:Orders:CheckCrcs"] = "true",
             ["Kafka:Consumers:Orders:UseTls"] = "true",
-            ["Kafka:Consumers:Orders:SaslMechanism"] = "Plain",
+            ["Kafka:Consumers:Orders:SaslMechanism"] = "ScramSha256",
             ["Kafka:Consumers:Orders:SaslUsername"] = "user",
             ["Kafka:Consumers:Orders:SaslPassword"] = "password",
             ["Kafka:Consumers:Orders:SaslScramTokenAuth"] = "true",
@@ -560,7 +582,7 @@ public class DependencyInjectionTests
         await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(800);
         await Assert.That(options.CheckCrcs).IsTrue();
         await Assert.That(options.UseTls).IsTrue();
-        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.Plain);
+        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha256);
         await Assert.That(options.SaslUsername).IsEqualTo("user");
         await Assert.That(options.SaslPassword).IsEqualTo("password");
         await Assert.That(options.SaslScramTokenAuth).IsTrue();
@@ -661,7 +683,7 @@ public class DependencyInjectionTests
             ["Kafka:Admin:ReconnectBackoffMs"] = "90",
             ["Kafka:Admin:ReconnectBackoffMaxMs"] = "900",
             ["Kafka:Admin:UseTls"] = "true",
-            ["Kafka:Admin:SaslMechanism"] = "Plain",
+            ["Kafka:Admin:SaslMechanism"] = "ScramSha512",
             ["Kafka:Admin:SaslUsername"] = "admin",
             ["Kafka:Admin:SaslPassword"] = "secret",
             ["Kafka:Admin:SaslScramTokenAuth"] = "true",
@@ -686,7 +708,7 @@ public class DependencyInjectionTests
         await Assert.That(options.ReconnectBackoffMs).IsEqualTo(90);
         await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(900);
         await Assert.That(options.UseTls).IsTrue();
-        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.Plain);
+        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha512);
         await Assert.That(options.SaslUsername).IsEqualTo("admin");
         await Assert.That(options.SaslPassword).IsEqualTo("secret");
         await Assert.That(options.SaslScramTokenAuth).IsTrue();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Dekaf.Admin;
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Producer;
 using Dekaf.Protocol;
 using Dekaf.Serialization;
@@ -122,6 +123,18 @@ public sealed class InMemoryKafkaClusterTests
         await Assert.That(filtered).IsEmpty();
         await Assert.That(renewed <= token.MaxTimestamp).IsTrue();
         await Assert.That(afterExpire.Single().ExpiryTimestamp).IsEqualTo(expired);
+    }
+
+    [Test]
+    public async Task Admin_DelegationTokenRenewMissing_ThrowsKafkaException()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var admin = new InMemoryAdminClient(cluster);
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await admin.RenewDelegationTokenAsync([1, 2, 3]));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.DelegationTokenNotFound);
     }
 
     [Test]


### PR DESCRIPTION
Follow-up to #1189. That PR was merged before the latest review-fix branch head was attached to the PR, so this carries only the hardening changes from that review.

Changes:
- Do not auto-retry `CreateDelegationTokenAsync`; a retriable broker error is surfaced instead of risking duplicate orphaned tokens.
- Validate DI config so `SaslScramTokenAuth=true` requires `SaslMechanism` `ScramSha256` or `ScramSha512`.
- Make `InMemoryAdminClient` missing delegation tokens throw `KafkaException` with `DelegationTokenNotFound`.
- Add `ShareConsumerBuilder.WithSaslScramSha256/512DelegationToken` aliases while preserving existing names.

Validation:
- `dotnet build Dekaf.sln --configuration Release`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/AdminClientDelegationTokenTests/*"`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/DependencyInjectionTests/*"`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/AwsMskIamBuilderTests/*"`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/InMemoryKafkaClusterTests/*DelegationToken*"`
- `Dekaf.Tests.Unit.exe` (4070 passed)
- `Dekaf.Tests.Integration.exe --treenode-filter "/*/*/SaslAuthenticationTests/*DelegationToken*"` (3 passed)