### PR TITLE
test(stress): match Confluent consumer fetch config to Dekaf's ForHighThroughput()

### DIFF
--- a/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
@@ -20,7 +20,17 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
             ClientId = "stress-consumer-confluent",
             GroupId = $"stress-group-confluent-{Guid.NewGuid():N}",
             AutoOffsetReset = ConfluentKafka.AutoOffsetReset.Earliest,
-            EnableAutoCommit = true
+            EnableAutoCommit = true,
+            // Match Dekaf's ForHighThroughput() consumer preset so both clients fetch and prefetch
+            // with the same bounds. Otherwise Confluent runs on librdkafka's smaller defaults and
+            // the "consumer" throughput comparison measures the config gap, not the client — the
+            // producer scenarios already match buffers this way. See ConfluentStressTestHelpers.
+            FetchMinBytes = ConfluentStressTestHelpers.FetchMinBytes,
+            FetchWaitMaxMs = ConfluentStressTestHelpers.FetchMaxWaitMs,
+            MaxPartitionFetchBytes = ConfluentStressTestHelpers.MaxPartitionFetchBytes,
+            FetchMaxBytes = ConfluentStressTestHelpers.FetchMaxBytes,
+            QueuedMaxMessagesKbytes = ConfluentStressTestHelpers.QueuedMaxMessagesKbytes,
+            QueuedMinMessages = ConfluentStressTestHelpers.QueuedMinMessages
         };
 
         // The topic is pre-seeded by Program.SeedConsumerTopicAsync. The consumer re-reads

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
@@ -20,6 +20,40 @@ internal static class ConfluentStressTestHelpers
     /// </summary>
     internal const int QueueBufferingMaxMessages = 10_000_000;
 
+    // --- Consumer fetch sizing -------------------------------------------------------------
+    // Mirrors Dekaf's ConsumerBuilder.ForHighThroughput() preset (src/Dekaf/Builders.cs) so the
+    // Confluent consumer stress test fetches with the same bounds instead of librdkafka's much
+    // smaller defaults (max.partition.fetch.bytes 1 MB, fetch.max.bytes 50 MB, fetch.wait.max.ms
+    // 500 ms, queued.max.messages.kbytes 64 MB). Without this the "consumer" scenario measures a
+    // configuration gap rather than the client — the producer scenarios already match buffers
+    // this way via QueueBufferingMaxKbytes. Keep these in sync with ForHighThroughput() by hand:
+    // the preset's fields are private, so there is no compile-time link (same constraint as
+    // QueueBufferingMaxMessages above). librdkafka has no adaptive-fetch-sizing or explicit
+    // max-poll-records equivalent, so these pin the preset's base fetch sizes; the consume loop
+    // is single-message (consumer.Consume) either way.
+
+    /// <summary>Dekaf <c>_fetchMinBytes</c> — fetch.min.bytes.</summary>
+    internal const int FetchMinBytes = 1024;
+
+    /// <summary>Dekaf <c>_fetchMaxWaitMs</c> — fetch.wait.max.ms.</summary>
+    internal const int FetchMaxWaitMs = 200;
+
+    /// <summary>Dekaf <c>_maxPartitionFetchBytes</c> (preset base, pre-adaptive) — max.partition.fetch.bytes.</summary>
+    internal const int MaxPartitionFetchBytes = 4 * 1024 * 1024;
+
+    /// <summary>Dekaf <c>_fetchMaxBytes</c> (preset base, pre-adaptive) — fetch.max.bytes.</summary>
+    internal const int FetchMaxBytes = 100 * 1024 * 1024;
+
+    /// <summary>
+    /// librdkafka's local fetch queue is its prefetch pipeline (analogous to Dekaf's
+    /// <c>_prefetchPipelineDepth = 5</c>). Size it well above the 64 MB default so prefetch, not
+    /// the client's decode loop, is never the bottleneck. Range is 1..2097151 KB (≈2 GB).
+    /// </summary>
+    internal const int QueuedMaxMessagesKbytes = 1024 * 1024;
+
+    /// <summary>Companion to <see cref="QueuedMaxMessagesKbytes"/> — raise the message-count prefetch cap above the 100k default.</summary>
+    internal const int QueuedMinMessages = 1_000_000;
+
     /// <summary>
     /// Queries the high watermark of each partition, mirroring
     /// <see cref="StressTestHelpers.QueryEndOffsetsAsync"/> for Confluent scenarios


### PR DESCRIPTION
## What

The `consumer` stress-test scenario builds the **Dekaf** consumer with `.ForHighThroughput()` but gives the **Confluent** consumer no fetch tuning — it runs on librdkafka defaults. That measures a configuration gap, not the client, and inflates the published *"Dekaf is 15.32x faster"* consumer-throughput number (1,940,004 vs 126,660 msg/sec).

This mirrors the `ForHighThroughput()` fetch sizing onto the Confluent `ConsumerConfig`, following the pattern the **producer** scenarios already use (`ConfluentStressTestHelpers.QueueBufferingMaxKbytes`, byte-matched to Dekaf's `BufferMemory`). Notably the byte-matched producer scenarios show only a 1.1–1.4x gap, while the unmatched consumer shows 15.3x — the asymmetry is the tell.

## Changes

- `ConfluentStressTestHelpers.cs` — new consumer fetch constants mirroring the `ForHighThroughput()` preset (`src/Dekaf/Builders.cs`): `FetchMinBytes` 1024, `FetchMaxWaitMs` 200, `MaxPartitionFetchBytes` 4 MB, `FetchMaxBytes` 100 MB, plus `QueuedMaxMessagesKbytes`/`QueuedMinMessages` raised as the prefetch-pipeline analog. Documented as hand-synced (the preset's fields are private — same constraint as the existing `QueueBufferingMaxMessages`).
- `ConfluentConsumerStressTest.cs` — apply those to the `ConsumerConfig`.

librdkafka has no adaptive-fetch-sizing or `max.poll.records` equivalent, so the constants pin the preset's **base** fetch sizes; the consume loop stays single-message (`consumer.Consume`) either way.

## Verification

- `dotnet build tools/Dekaf.StressTests -c Release` — clean (0 warnings, 0 errors); confirms the Confluent.Kafka 2.15.0 `ConsumerConfig` property names.
- Behavioural rerun of the 15-minute stress test not run here (needs the real multi-broker rig). **The published consumer numbers should be regenerated after merge** — the 15.32x figure is expected to shrink substantially.

## Follow-up (not in this PR)

- Publish message size + partition count on the stress-tests docs page — per-message-overhead benchmarks are size-sensitive.

Closes #1227