### PR TITLE
Publish stable NuGet package versions

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,8 +1,12 @@
 mode: ContinuousDelivery
+major-version-bump-message: '\+?semver:\s?(breaking|major)'
+minor-version-bump-message: '\+?semver:\s?(feature|minor)'
+patch-version-bump-message: '\+?semver:\s?(fix|patch)'
+no-bump-message: '\+?semver:\s?(none|skip)'
 branches:
   main:
-    mode: ContinuousDelivery
-    label: ci
+    mode: ContinuousDeployment
+    label: ''
     increment: Patch
   develop:
     mode: ContinuousDelivery

--- a/tools/Dekaf.Pipeline/Modules/PackModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/PackModule.cs
@@ -18,10 +18,12 @@ public class PackModule : Module<List<PackedProject>>
     private static readonly string[] PackageProjects =
     [
         "Dekaf",
+        "Dekaf.Compression.Brotli",
         "Dekaf.Compression.Lz4",
         "Dekaf.Compression.Snappy",
         "Dekaf.Compression.Zstd",
         "Dekaf.Extensions.DependencyInjection",
+        "Dekaf.Extensions.HealthChecks",
         "Dekaf.Extensions.Hosting",
         "Dekaf.OpenTelemetry",
         "Dekaf.SchemaRegistry",


### PR DESCRIPTION
## Summary
- Remove the `ci` prerelease label from `main` NuGet package versions.
- Switch `main` GitVersion mode to `ContinuousDeployment` so stable versions stay stable.
- Allow `semver:major` as well as `+semver: major` bump commits.
- Add `Dekaf.Compression.Brotli` and `Dekaf.Extensions.HealthChecks` to the pack/publish package list.

## Validation
- `dotnet build tools/Dekaf.Pipeline/Dekaf.Pipeline.csproj --configuration Release`
- Simulated merged `main` GitVersion SemVer: `0.0.1`
- Simulated merged `main` after `semver:major` commit: `1.0.0`