### PR TITLE
ci: Ignore generated benchmark docs pushes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/docs/benchmarks.md'
   workflow_dispatch:
     inputs:
       benchmark_filter:


### PR DESCRIPTION
## Summary

- Add a `paths-ignore` filter to the Benchmarks workflow for `docs/docs/benchmarks.md`.

## Why

The benchmark workflow writes benchmark docs, opens a PR, and auto-merges it to `main`. That generated docs-only merge then retriggers the same benchmark workflow, causing a continuous loop.

## Impact

Real code pushes to `main` still run benchmarks. Generated benchmark documentation updates no longer trigger another benchmark run.

## Validation

- `git diff --check HEAD~1 HEAD`