### PR TITLE
Make package builds deterministic

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,6 +15,8 @@ env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  ContinuousIntegrationBuild: true
+  Deterministic: true
 
 # concurrency:
 #   group: "benchmarks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  ContinuousIntegrationBuild: true
+  Deterministic: true
 
 jobs:
   build-and-unit-test:

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -18,6 +18,10 @@ concurrency:
   group: stress-tests
   cancel-in-progress: false
 
+env:
+  ContinuousIntegrationBuild: true
+  Deterministic: true
+
 jobs:
   # Run each test scenario in parallel
   stress-test:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,10 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(ContinuousIntegrationBuild)' == '' and ('$(CI)' == 'true' or '$(GITHUB_ACTIONS)' == 'true')">true</ContinuousIntegrationBuild>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>9999</WarningLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
@@ -20,9 +24,14 @@
     <Product>Dekaf</Product>
     <Copyright>Copyright (c) Dekaf Contributors</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/dekaf/dekaf</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/dekaf/dekaf</RepositoryUrl>
+    <PackageProjectUrl>https://thomhurst.github.io/Dekaf/</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/thomhurst/Dekaf</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup Condition="'$(IsPackable)' != 'false' and '$(PackageReadmeFile)' != ''">
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="/" Visible="false" />
+  </ItemGroup>
+</Project>

--- a/tools/Dekaf.Pipeline/Modules/BuildModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/BuildModule.cs
@@ -31,6 +31,8 @@ public class BuildModule : Module<CommandResult>
             Properties =
             [
                 new KeyValue("Version", version),
+                new KeyValue("ContinuousIntegrationBuild", "true"),
+                new KeyValue("Deterministic", "true"),
                 new KeyValue("TreatWarningsAsErrors", "true")
             ]
         }, null, cancellationToken);

--- a/tools/Dekaf.Pipeline/Modules/PackModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/PackModule.cs
@@ -54,10 +54,15 @@ public class PackModule : Module<List<PackedProject>>
                 ProjectSolution = projectFile.Path,
                 Configuration = "Release",
                 NoBuild = true,
+                IncludeSymbols = true,
+                IncludeSource = true,
                 Properties =
                 [
                     new KeyValue("Version", version),
-                    new KeyValue("PackageVersion", version)
+                    new KeyValue("PackageVersion", version),
+                    new KeyValue("ContinuousIntegrationBuild", "true"),
+                    new KeyValue("Deterministic", "true"),
+                    new KeyValue("PublishRepositoryUrl", "true")
                 ]
             }, null, cancellationToken);
 

--- a/tools/Dekaf.Pipeline/Modules/UploadToNuGetModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/UploadToNuGetModule.cs
@@ -54,17 +54,20 @@ public class UploadToNuGetModule(IOptions<NuGetOptions> nuGetOptions) : Module<L
 
             context.Logger.LogInformation("Uploading {PackageName}", package.Name);
 
-            var result = await context.DotNet().Nuget.Push(new DotNetNugetPushOptions
+            results.Add(await PushPackageAsync(nupkgFile.Path));
+        }
+
+        return results;
+
+        Task<CommandResult> PushPackageAsync(string packagePath)
+        {
+            return context.DotNet().Nuget.Push(new DotNetNugetPushOptions
             {
-                Path = nupkgFile.Path,
+                Path = packagePath,
                 Source = options.Source,
                 ApiKey = options.ApiKey,
                 SkipDuplicate = true
             }, null, cancellationToken);
-
-            results.Add(result);
         }
-
-        return results;
     }
 }


### PR DESCRIPTION
## Summary

- Enable deterministic and CI-normalized .NET builds with portable PDBs and SourceLink-ready repository metadata.
- Point NuGet project metadata at the docs site, publish the correct GitHub repository URL, and include the root README in packages.
- Generate symbol/source packages via `DotNetPackOptions.IncludeSymbols` and `IncludeSource`, then rely on `dotnet nuget push` default symbol handling instead of manually pushing `.snupkg` files.
- Set deterministic build properties in GitHub Actions workflows.

## Validation

- `dotnet build --configuration Release`
- `SKIP_INTEGRATION_TESTS=true dotnet run --project tools/Dekaf.Pipeline`
- Inspected generated `Dekaf.1.0.0-build-deterministic-sourcelink.1.nupkg`, `.snupkg`, nuspec, and SourceLink JSON.
- `dotnet format --verify-no-changes --verbosity minimal` was run and fails on existing unrelated whitespace issues in source/test files outside this change.