### PR TITLE
fix(consumer): clear revoked fetch buffers

### DIFF
--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -16,14 +16,17 @@ namespace Dekaf.Consumer
         private readonly PendingFetchData _pendingFetchData;
         private readonly IDeserializer<TKey>? _keyDeserializer;
         private readonly IDeserializer<TValue>? _valueDeserializer;
+        private readonly Func<TopicPartition, bool>? _isPartitionStillAssigned;
 
         internal ConsumeBatch(PendingFetchData pendingFetchData,
             IDeserializer<TKey>? keyDeserializer,
-            IDeserializer<TValue>? valueDeserializer)
+            IDeserializer<TValue>? valueDeserializer,
+            Func<TopicPartition, bool>? isPartitionStillAssigned = null)
         {
             _pendingFetchData = pendingFetchData;
             _keyDeserializer = keyDeserializer;
             _valueDeserializer = valueDeserializer;
+            _isPartitionStillAssigned = isPartitionStillAssigned;
         }
 
         /// <summary>
@@ -96,6 +99,12 @@ namespace Dekaf.Consumer
             public bool MoveNext()
             {
                 PendingFetchData pending = _batch._pendingFetchData;
+
+                if (_batch._isPartitionStillAssigned is not null
+                    && !_batch._isPartitionStillAssigned(pending.TopicPartition))
+                {
+                    return false;
+                }
 
                 if (!pending.MoveNext())
                 {

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -41,10 +41,14 @@ namespace Dekaf.Consumer
     public sealed class ConsumeRawBatch : IEnumerable<ConsumeRawRecord>
     {
         private readonly PendingFetchData _pendingFetchData;
+        private readonly Func<TopicPartition, bool>? _isPartitionStillAssigned;
 
-        internal ConsumeRawBatch(PendingFetchData pendingFetchData)
+        internal ConsumeRawBatch(
+            PendingFetchData pendingFetchData,
+            Func<TopicPartition, bool>? isPartitionStillAssigned = null)
         {
             _pendingFetchData = pendingFetchData;
+            _isPartitionStillAssigned = isPartitionStillAssigned;
         }
 
         /// <summary>
@@ -116,6 +120,12 @@ namespace Dekaf.Consumer
             public bool MoveNext()
             {
                 PendingFetchData pending = _batch._pendingFetchData;
+
+                if (_batch._isPartitionStillAssigned is not null
+                    && !_batch._isPartitionStillAssigned(pending.TopicPartition))
+                {
+                    return false;
+                }
 
                 if (!pending.MoveNext())
                 {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -638,6 +638,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // ConsumeAsync iterates the front of _pendingFetches while it is still queued, and
     // user code at the yield point can trigger such a clear; the version check lets the
     // iterator detect that its current fetch was disposed underneath it.
+    // Coarse-grained by design: unrelated partition clears may restart the current
+    // iteration, avoiding per-partition tracking on the per-message hot path.
     private int _pendingFetchesVersion;
     // Keeps the pending flag and dictionary in sync while preserving the volatile hot-path check.
     private readonly object _coordinatorRevokedPartitionsPendingFetchClearLock = new();
@@ -1603,7 +1605,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     pending.EagerParseAll();
 
                     // Yield the batch to the caller for synchronous iteration
-                    ConsumeBatch<TKey, TValue> batch = new(pending, _keyDeserializer, _valueDeserializer);
+                    ConsumeBatch<TKey, TValue> batch = new(
+                        pending,
+                        _keyDeserializer,
+                        _valueDeserializer,
+                        IsCurrentlyAssigned);
                     yield return batch;
 
                     // After caller finishes iterating: update positions once per batch
@@ -1746,7 +1752,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     pending.EagerParseAll();
 
                     // Yield the raw batch to the caller for synchronous iteration
-                    ConsumeRawBatch batch = new(pending);
+                    ConsumeRawBatch batch = new(pending, IsCurrentlyAssigned);
                     yield return batch;
 
                     // After caller finishes iterating: update positions once per batch
@@ -2186,12 +2192,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 partitionResponse.AbortedTransactions,
                                 activityName: activityName);
 
-                            // Track memory before adding to channel
-                            TrackPrefetchedBytes(pending, release: false);
-
-                            // Update fetch positions for next prefetch
-                            UpdateFetchPositionsFromPrefetch(pending);
-
                             // Collect for later - we'll assign memory owner to the last one
                             pendingItems.Add(pending);
                         }
@@ -2226,14 +2226,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     memoryOwner = null; // Transferred
                 }
 
-                for (var i = 0; i < pendingItems.Count; i++)
-                {
-                    while (!_prefetchBuffer.TryWrite(pendingItems[i]))
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        await _prefetchBuffer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
-                    }
-                }
+                await WritePrefetchedItemsAsync(pendingItems, cancellationToken).ConfigureAwait(false);
             }
 
             // If no pending items were created but we have a memory owner, dispose it
@@ -3015,6 +3008,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
+    private void CancelCoordinatorRevokedPartitionsFetchClear(IReadOnlyList<TopicPartition> partitions)
+    {
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            foreach (var partition in partitions)
+            {
+                _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
+            }
+
+            if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
+        }
+    }
+
     private bool ClearFetchBufferForPendingCoordinatorRevocations()
     {
         if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) == 0)
@@ -3044,6 +3051,37 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         ClearFetchBufferForPartitions(partitionsToRemove);
         return true;
+    }
+
+    private bool IsCurrentlyAssigned(TopicPartition partition)
+    {
+        return _assignmentSnapshot.Contains(partition);
+    }
+
+    private async ValueTask WritePrefetchedItemsAsync(
+        IReadOnlyList<PendingFetchData> pendingItems,
+        CancellationToken cancellationToken)
+    {
+        for (var i = 0; i < pendingItems.Count; i++)
+        {
+            var pending = pendingItems[i];
+            if (!IsCurrentlyAssigned(pending.TopicPartition))
+            {
+                pending.Dispose();
+                continue;
+            }
+
+            // Track memory and advance fetch positions only after confirming
+            // this pipelined response still belongs to the current assignment.
+            TrackPrefetchedBytes(pending, release: false);
+            UpdateFetchPositionsFromPrefetch(pending);
+
+            while (!_prefetchBuffer.TryWrite(pending))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await _prefetchBuffer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
     }
 
     private void DrainPrefetchBufferForPartitions(HashSet<TopicPartition> partitionsToRemove)
@@ -3464,6 +3502,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // Initialize positions for new partitions
                 if (newPartitions is { Count: > 0 })
                 {
+                    CancelCoordinatorRevokedPartitionsFetchClear(newPartitions);
                     await InitializePositionsAsync(newPartitions, cancellationToken).ConfigureAwait(false);
                 }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -639,6 +639,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // user code at the yield point can trigger such a clear; the version check lets the
     // iterator detect that its current fetch was disposed underneath it.
     private int _pendingFetchesVersion;
+    private readonly ConcurrentDictionary<TopicPartition, byte> _coordinatorRevokedPartitionsPendingFetchClear = new();
+    private int _coordinatorRevokedPartitionsPendingFetchClearPending;
 
     // Background prefetch support
     private readonly MpscFetchBuffer _prefetchBuffer;
@@ -1223,6 +1225,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             ThrowPendingFetchException();
 
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+            ClearFetchBufferForPendingCoordinatorRevocations();
 
             if (_assignmentSnapshot.Count == 0)
             {
@@ -1320,6 +1323,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                     while (true)
                     {
+                        if (ClearFetchBufferForPendingCoordinatorRevocations()
+                            && Volatile.Read(ref _pendingFetchesVersion) != pendingFetchesVersion)
+                        {
+                            break;
+                        }
+
                         // Wrap MoveNext + record parsing in try-catch so a corrupted fetch
                         // does not kill the consumer permanently. The yield must be outside
                         // the try block (CS1626), so we build the result first then yield below.
@@ -1512,6 +1521,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             ThrowPendingFetchException();
 
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+            ClearFetchBufferForPendingCoordinatorRevocations();
 
             if (_assignmentSnapshot.Count == 0)
             {
@@ -1578,6 +1588,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             while (_pendingFetches.Count > 0)
             {
+                if (ClearFetchBufferForPendingCoordinatorRevocations())
+                    continue;
+
                 PendingFetchData pending = _pendingFetches.Dequeue();
                 long? batchProcessingStarted = _adaptiveFetchSizer is not null
                     ? System.Diagnostics.Stopwatch.GetTimestamp() : null;
@@ -1651,6 +1664,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             ThrowPendingFetchException();
 
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+            ClearFetchBufferForPendingCoordinatorRevocations();
 
             if (_assignmentSnapshot.Count == 0)
             {
@@ -1717,6 +1731,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             while (_pendingFetches.Count > 0)
             {
+                if (ClearFetchBufferForPendingCoordinatorRevocations())
+                    continue;
+
                 PendingFetchData pending = _pendingFetches.Dequeue();
                 long? batchProcessingStarted = _adaptiveFetchSizer is not null
                     ? System.Diagnostics.Stopwatch.GetTimestamp() : null;
@@ -2505,6 +2522,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             ThrowPendingFetchException();
 
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+            ClearFetchBufferForPendingCoordinatorRevocations();
 
             if (_assignmentSnapshot.Count == 0)
             {
@@ -2596,6 +2614,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (_pendingFetches.Count > 0)
         {
+            if (ClearFetchBufferForPendingCoordinatorRevocations())
+                continue;
+
             var pending = _pendingFetches.Peek();
             long? batchProcessingStarted = _adaptiveFetchSizer is not null
                 ? System.Diagnostics.Stopwatch.GetTimestamp() : null;
@@ -2977,6 +2998,41 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // buffer would be consumed after an incremental unassign (cooperative rebalance),
         // causing data for partitions no longer owned by this consumer to be yielded.
         DrainPrefetchBufferForPartitions(removeSet);
+    }
+
+    private void QueueCoordinatorRevokedPartitionsForFetchClear(IReadOnlyList<TopicPartition> partitions)
+    {
+        foreach (var partition in partitions)
+        {
+            _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
+        }
+
+        Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+    }
+
+    private bool ClearFetchBufferForPendingCoordinatorRevocations()
+    {
+        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) == 0)
+            return false;
+
+        HashSet<TopicPartition>? partitionsToRemove = null;
+        foreach (var partition in _coordinatorRevokedPartitionsPendingFetchClear.Keys)
+        {
+            if (!_coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _))
+                continue;
+
+            partitionsToRemove ??= [];
+            partitionsToRemove.Add(partition);
+        }
+
+        if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
+            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
+
+        if (partitionsToRemove is null || partitionsToRemove.Count == 0)
+            return false;
+
+        ClearFetchBufferForPartitions(partitionsToRemove);
+        return true;
     }
 
     private void DrainPrefetchBufferForPartitions(HashSet<TopicPartition> partitionsToRemove)
@@ -3389,6 +3445,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // Clean up state for removed partitions
                 if (removedPartitions is not null)
                 {
+                    QueueCoordinatorRevokedPartitionsForFetchClear(removedPartitions);
                     if (RemovePartitionState(removedPartitions))
                         PublishPausedSnapshot();
                 }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -639,6 +639,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // user code at the yield point can trigger such a clear; the version check lets the
     // iterator detect that its current fetch was disposed underneath it.
     private int _pendingFetchesVersion;
+    // Keeps the pending flag and dictionary in sync while preserving the volatile hot-path check.
+    private readonly object _coordinatorRevokedPartitionsPendingFetchClearLock = new();
     private readonly ConcurrentDictionary<TopicPartition, byte> _coordinatorRevokedPartitionsPendingFetchClear = new();
     private int _coordinatorRevokedPartitionsPendingFetchClearPending;
 
@@ -3002,12 +3004,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void QueueCoordinatorRevokedPartitionsForFetchClear(IReadOnlyList<TopicPartition> partitions)
     {
-        foreach (var partition in partitions)
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
-        }
+            foreach (var partition in partitions)
+            {
+                _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
+            }
 
-        Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+        }
     }
 
     private bool ClearFetchBufferForPendingCoordinatorRevocations()
@@ -3015,20 +3020,26 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) == 0)
             return false;
 
-        HashSet<TopicPartition>? partitionsToRemove = null;
-        foreach (var partition in _coordinatorRevokedPartitionsPendingFetchClear.Keys)
+        HashSet<TopicPartition>? partitionsToRemove;
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            if (!_coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _))
-                continue;
+            if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
+            {
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
+                return false;
+            }
 
-            partitionsToRemove ??= [];
-            partitionsToRemove.Add(partition);
+            partitionsToRemove = [];
+            foreach (var partition in _coordinatorRevokedPartitionsPendingFetchClear.Keys)
+            {
+                if (_coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _))
+                    partitionsToRemove.Add(partition);
+            }
+
+            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
         }
 
-        if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
-            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
-
-        if (partitionsToRemove is null || partitionsToRemove.Count == 0)
+        if (partitionsToRemove.Count == 0)
             return false;
 
         ClearFetchBufferForPartitions(partitionsToRemove);

--- a/tests/Dekaf.Tests.Integration/CooperativeStickyRebalanceTests.cs
+++ b/tests/Dekaf.Tests.Integration/CooperativeStickyRebalanceTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 
@@ -213,6 +214,133 @@ public sealed class CooperativeStickyRebalanceTests(KafkaTestContainer kafka) : 
         await cts2.CancelAsync();
         try { await Task.WhenAll(consumer1Task, consumer2Task); }
         catch (OperationCanceledException) { }
+    }
+
+    [Test]
+    public async Task CooperativeRebalance_WithPrefetch_DoesNotEmitRevokedPartitionRecordsAfterAssignmentChanges()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 4);
+        var groupId = $"prefetch-revoke-{Guid.NewGuid():N}";
+        var afterRebalanceMessages = new ConcurrentQueue<ConsumeResult<string, string>>();
+        var collectAfterRebalance = 0;
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        for (var partition = 0; partition < 4; partition++)
+        {
+            for (var i = 0; i < 80; i++)
+            {
+                await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Key = $"key-{partition}-{i}",
+                    Value = $"value-{partition}-{i}",
+                    Partition = partition
+                }, CancellationToken.None);
+            }
+        }
+
+        await using var consumer1 = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithQueuedMinMessages(16)
+            .WithFetchMaxWait(TimeSpan.FromMilliseconds(100))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        consumer1.Subscribe(topic);
+
+        using var cts1 = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+        var consumer1Task = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var message in consumer1.ConsumeAsync(cts1.Token))
+                {
+                    if (Volatile.Read(ref collectAfterRebalance) != 0)
+                        afterRebalanceMessages.Enqueue(message);
+
+                    await Task.Delay(10, cts1.Token);
+                }
+            }
+            catch (OperationCanceledException) { }
+        });
+
+        await Assert.That(() => consumer1.Assignment.ToArray().Count(tp => tp.Topic == topic))
+            .Eventually(x => x.IsEqualTo(4), TimeSpan.FromSeconds(30));
+
+        await using var consumer2 = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithQueuedMinMessages(16)
+            .WithFetchMaxWait(TimeSpan.FromMilliseconds(100))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        consumer2.Subscribe(topic);
+
+        using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+        var consumer2Task = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var _ in consumer2.ConsumeAsync(cts2.Token))
+                {
+                }
+            }
+            catch (OperationCanceledException) { }
+        });
+
+        try
+        {
+            await Assert.That(() => consumer1.Assignment.ToArray().Count(tp => tp.Topic == topic))
+                .Eventually(x => x.IsEqualTo(2), TimeSpan.FromSeconds(45));
+            await Assert.That(() => consumer2.Assignment.ToArray().Count(tp => tp.Topic == topic))
+                .Eventually(x => x.IsEqualTo(2), TimeSpan.FromSeconds(45));
+
+            var retainedPartitions = consumer1.Assignment
+                .Where(tp => tp.Topic == topic)
+                .Select(tp => tp.Partition)
+                .ToHashSet();
+            var revokedPartitions = Enumerable.Range(0, 4)
+                .Where(partition => !retainedPartitions.Contains(partition))
+                .ToHashSet();
+
+            Volatile.Write(ref collectAfterRebalance, 1);
+
+            foreach (var partition in retainedPartitions)
+            {
+                for (var i = 0; i < 10; i++)
+                {
+                    await producer.ProduceAsync(new ProducerMessage<string, string>
+                    {
+                        Topic = topic,
+                        Key = $"post-key-{partition}-{i}",
+                        Value = $"post-value-{partition}-{i}",
+                        Partition = partition
+                    }, CancellationToken.None);
+                }
+            }
+
+            await Assert.That(() => afterRebalanceMessages.Count)
+                .Eventually(x => x.IsGreaterThanOrEqualTo(10), TimeSpan.FromSeconds(30));
+
+            var revokedAfterRebalance = afterRebalanceMessages
+                .Where(message => revokedPartitions.Contains(message.Partition))
+                .ToList();
+
+            await Assert.That(revokedAfterRebalance).IsEmpty();
+        }
+        finally
+        {
+            await cts1.CancelAsync();
+            await cts2.CancelAsync();
+            try { await Task.WhenAll(consumer1Task, consumer2Task); }
+            catch (OperationCanceledException) { }
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
@@ -114,6 +114,26 @@ public class ConsumeBatchTests
         }
     }
 
+    [Test]
+    public async Task ConsumeBatch_StopsEnumerationWhenPartitionIsNoLongerAssigned()
+    {
+        using var pending = CreatePendingFetchData("test-topic", partitionIndex: 0, baseOffset: 0, messageCount: 3);
+        var assigned = true;
+        var batch = new ConsumeBatch<string, string>(
+            pending,
+            Serializers.String,
+            Serializers.String,
+            _ => assigned);
+
+        using var enumerator = batch.GetEnumerator();
+
+        await Assert.That(enumerator.MoveNext()).IsTrue();
+        assigned = false;
+
+        await Assert.That(enumerator.MoveNext()).IsFalse();
+        await Assert.That(batch.Count).IsEqualTo(1);
+    }
+
     /// <summary>
     /// Creates a PendingFetchData with a single RecordBatch containing the specified number of records.
     /// </summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
@@ -146,6 +146,22 @@ public class ConsumeRawBatchTests
         await Assert.That(results[0].Value.Length).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task ConsumeRawBatch_StopsEnumerationWhenPartitionIsNoLongerAssigned()
+    {
+        using var pending = CreatePendingFetchData("test-topic", partitionIndex: 0, baseOffset: 0, messageCount: 3);
+        var assigned = true;
+        var batch = new ConsumeRawBatch(pending, _ => assigned);
+
+        using var enumerator = batch.GetEnumerator();
+
+        await Assert.That(enumerator.MoveNext()).IsTrue();
+        assigned = false;
+
+        await Assert.That(enumerator.MoveNext()).IsFalse();
+        await Assert.That(batch.Count).IsEqualTo(1);
+    }
+
     /// <summary>
     /// Creates a PendingFetchData with a single RecordBatch containing the specified number of records.
     /// </summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -205,6 +205,52 @@ public sealed class ConsumerAssignmentFastPathTests
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task CancelCoordinatorRevokedPartitionsFetchClear_ReassignedPartitionRemovesPendingClear()
+    {
+        await using var consumer = CreateConsumer();
+        var reassignedPartition = new TopicPartition("test-topic", 0);
+        var stillRevokedPartition = new TopicPartition("test-topic", 1);
+
+        QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [reassignedPartition, stillRevokedPartition]);
+
+        CancelCoordinatorRevokedPartitionsFetchClear(consumer, [reassignedPartition]);
+
+        var pendingRevocations = GetCoordinatorRevokedPartitionsPendingFetchClear(consumer);
+        await Assert.That(pendingRevocations.ContainsKey(reassignedPartition)).IsFalse();
+        await Assert.That(pendingRevocations.ContainsKey(stillRevokedPartition)).IsTrue();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(1);
+
+        CancelCoordinatorRevokedPartitionsFetchClear(consumer, [stillRevokedPartition]);
+
+        await Assert.That(pendingRevocations).IsEmpty();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task WritePrefetchedItemsAsync_DropsUnassignedPartitionsBeforeAdvancingFetchPosition()
+    {
+        await using var consumer = CreateConsumer();
+        var revokedPartition = new TopicPartition("test-topic", 0);
+        var retainedPartition = new TopicPartition("test-topic", 1);
+        var revokedFetch = CreateFetch(partition: 0, baseOffset: 10, value: "revoked-prefetch");
+        var retainedFetch = CreateFetch(partition: 1, baseOffset: 20, value: "retained-prefetch");
+
+        consumer.IncrementalAssign([new TopicPartitionOffset("test-topic", 1, 20)]);
+
+        await WritePrefetchedItemsAsync(consumer, [revokedFetch, retainedFetch]);
+
+        var fetchPositions = GetFetchPositions(consumer);
+        await Assert.That(fetchPositions.ContainsKey(revokedPartition)).IsFalse();
+        await Assert.That(fetchPositions[retainedPartition]).IsEqualTo(21L);
+        await Assert.That(GetPrefetchBuffer(consumer).TryRead(out var prefetched)).IsTrue();
+        await Assert.That(prefetched!.TopicPartition).IsEqualTo(retainedPartition);
+        await Assert.That(GetPrefetchBuffer(consumer).TryRead(out _)).IsFalse();
+
+        prefetched.Dispose();
+        SetPrefetchedBytes(consumer, 0);
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer()
     {
         return new KafkaConsumer<string, string>(
@@ -484,6 +530,17 @@ public sealed class ConsumerAssignmentFastPathTests
         return (int)field.GetValue(consumer)!;
     }
 
+    private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions(
+        KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_fetchPositions",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_fetchPositions field not found.");
+
+        return (ConcurrentDictionary<TopicPartition, long>)field.GetValue(consumer)!;
+    }
+
     private static void QueueCoordinatorRevokedPartitionsForFetchClear(
         KafkaConsumer<string, string> consumer,
         TopicPartition[] partitions)
@@ -496,6 +553,18 @@ public sealed class ConsumerAssignmentFastPathTests
         method.Invoke(consumer, [partitions]);
     }
 
+    private static void CancelCoordinatorRevokedPartitionsFetchClear(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition[] partitions)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "CancelCoordinatorRevokedPartitionsFetchClear",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("CancelCoordinatorRevokedPartitionsFetchClear method not found.");
+
+        method.Invoke(consumer, [partitions]);
+    }
+
     private static bool ClearFetchBufferForPendingCoordinatorRevocations(KafkaConsumer<string, string> consumer)
     {
         var method = typeof(KafkaConsumer<string, string>).GetMethod(
@@ -504,6 +573,19 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("ClearFetchBufferForPendingCoordinatorRevocations method not found.");
 
         return (bool)method.Invoke(consumer, [])!;
+    }
+
+    private static async ValueTask WritePrefetchedItemsAsync(
+        KafkaConsumer<string, string> consumer,
+        IReadOnlyList<PendingFetchData> pendingItems)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "WritePrefetchedItemsAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("WritePrefetchedItemsAsync method not found.");
+
+        var valueTask = (ValueTask)method.Invoke(consumer, [pendingItems, CancellationToken.None])!;
+        await valueTask;
     }
 
     private static void SetPrefetchedBytes(KafkaConsumer<string, string> consumer, long bytes)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1,9 +1,11 @@
 using System.Reflection;
+using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 using NSubstitute;
 
@@ -126,6 +128,54 @@ public sealed class ConsumerAssignmentFastPathTests
         await Assert.That(consumer.Assignment).Contains(new TopicPartition("test-topic", 1));
     }
 
+    [Test]
+    public async Task ConsumeOneAsync_CoordinatorRevocation_ClearsPendingAndPrefetchedRecordsForRemovedPartitions()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupRevokingConsumerGroupHeartbeat(connection);
+        SetupOffsetFetch(connection);
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager, queuedMinMessages: 2);
+        SetInitialized(consumer);
+        SetPrefetchStarted(consumer);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var revokedPartition = new TopicPartition("test-topic", 0);
+        var retainedPartition = new TopicPartition("test-topic", 1);
+        var revokedPending = CreateFetch(partition: 0, baseOffset: 10, value: "revoked-pending");
+        var retainedPending = CreateFetch(partition: 1, baseOffset: 20, value: "retained-pending");
+        var revokedPrefetched = CreateFetch(partition: 0, baseOffset: 30, value: "revoked-prefetched");
+        var retainedPrefetched = CreateFetch(partition: 1, baseOffset: 40, value: "retained-prefetched");
+
+        GetPendingFetches(consumer).Enqueue(revokedPending);
+        GetPendingFetches(consumer).Enqueue(retainedPending);
+        await Assert.That(GetPrefetchBuffer(consumer).TryWrite(revokedPrefetched)).IsTrue();
+        await Assert.That(GetPrefetchBuffer(consumer).TryWrite(retainedPrefetched)).IsTrue();
+        SetPrefetchedBytes(
+            consumer,
+            KafkaConsumer<string, string>.EstimatePendingFetchBytes(revokedPrefetched)
+            + KafkaConsumer<string, string>.EstimatePendingFetchBytes(retainedPrefetched));
+
+        GetCoordinator(consumer).RequestRejoin();
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Partition).IsEqualTo(1);
+        await Assert.That(result.Value.Offset).IsEqualTo(20L);
+        await Assert.That(result.Value.Value).IsEqualTo("retained-pending");
+        await Assert.That(consumer.Assignment).DoesNotContain(revokedPartition);
+        await Assert.That(consumer.Assignment).Contains(retainedPartition);
+        await Assert.That(GetPrefetchedBytes(consumer)).IsEqualTo(0L);
+        await Assert.That(GetPendingFetches(consumer).Any(p => p.TopicPartition == revokedPartition)).IsFalse();
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer()
     {
         return new KafkaConsumer<string, string>(
@@ -141,7 +191,8 @@ public sealed class ConsumerAssignmentFastPathTests
 
     private static KafkaConsumer<string, string> CreateGroupConsumer(
         IConnectionPool connectionPool,
-        MetadataManager metadataManager)
+        MetadataManager metadataManager,
+        int queuedMinMessages = 1)
     {
         return new KafkaConsumer<string, string>(
             new ConsumerOptions
@@ -149,7 +200,7 @@ public sealed class ConsumerAssignmentFastPathTests
                 BootstrapServers = ["localhost:9092"],
                 GroupId = "group-a",
                 OffsetCommitMode = OffsetCommitMode.Manual,
-                QueuedMinMessages = 1
+                QueuedMinMessages = queuedMinMessages
             },
             Serializers.String,
             Serializers.String,
@@ -271,6 +322,27 @@ public sealed class ConsumerAssignmentFastPathTests
             });
     }
 
+    private static void SetupRevokingConsumerGroupHeartbeat(IKafkaConnection connection)
+    {
+        var callCount = 0;
+        connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = count,
+                    HeartbeatIntervalMs = 60000,
+                    Assignment = count == 1 ? CreateAssignment(0, 1) : CreateAssignment(1)
+                });
+            });
+    }
+
     private static void SetupOffsetFetch(IKafkaConnection connection)
     {
         connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
@@ -331,6 +403,66 @@ public sealed class ConsumerAssignmentFastPathTests
         return (SemaphoreSlim)field.GetValue(consumer)!;
     }
 
+    private static Queue<PendingFetchData> GetPendingFetches(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_pendingFetches",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_pendingFetches field not found.");
+
+        return (Queue<PendingFetchData>)field.GetValue(consumer)!;
+    }
+
+    private static MpscFetchBuffer GetPrefetchBuffer(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_prefetchBuffer",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_prefetchBuffer field not found.");
+
+        return (MpscFetchBuffer)field.GetValue(consumer)!;
+    }
+
+    private static long GetPrefetchedBytes(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_prefetchedBytes",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_prefetchedBytes field not found.");
+
+        return (long)field.GetValue(consumer)!;
+    }
+
+    private static void SetPrefetchedBytes(KafkaConsumer<string, string> consumer, long bytes)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_prefetchedBytes",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_prefetchedBytes field not found.");
+
+        field.SetValue(consumer, bytes);
+    }
+
+    private static void SetPrefetchStarted(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_prefetchTask",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_prefetchTask field not found.");
+
+        field.SetValue(consumer, Task.CompletedTask);
+    }
+
+    private static void SetInitialized(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_initialized",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_initialized field not found.");
+
+        field.SetValue(consumer, true);
+    }
+
     private static ConsumerCoordinator GetCoordinator(KafkaConsumer<string, string> consumer)
     {
         var field = typeof(KafkaConsumer<string, string>).GetField(
@@ -339,5 +471,32 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("_coordinator field not found.");
 
         return (ConsumerCoordinator)field.GetValue(consumer)!;
+    }
+
+    private static PendingFetchData CreateFetch(int partition, long baseOffset, string value)
+    {
+        return PendingFetchData.Create("test-topic", partition,
+        [
+            new RecordBatch
+            {
+                BaseOffset = baseOffset,
+                BaseTimestamp = 1700000000000L,
+                Attributes = 0,
+                Records =
+                [
+                    new Record
+                    {
+                        OffsetDelta = 0,
+                        TimestampDelta = 0,
+                        Key = Encoding.UTF8.GetBytes($"key-{partition}"),
+                        IsKeyNull = false,
+                        Value = Encoding.UTF8.GetBytes(value),
+                        IsValueNull = false,
+                        Headers = null,
+                        HeaderCount = 0
+                    }
+                ]
+            }
+        ]);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text;
 using Dekaf.Consumer;
@@ -174,6 +175,34 @@ public sealed class ConsumerAssignmentFastPathTests
         await Assert.That(consumer.Assignment).Contains(retainedPartition);
         await Assert.That(GetPrefetchedBytes(consumer)).IsEqualTo(0L);
         await Assert.That(GetPendingFetches(consumer).Any(p => p.TopicPartition == revokedPartition)).IsFalse();
+    }
+
+    [Test]
+    public async Task CoordinatorRevocationFetchClear_ConcurrentQueueAndDrain_KeepsPendingFlagConsistent()
+    {
+        await using var consumer = CreateConsumer();
+        var tasks = new List<Task>();
+
+        for (var i = 0; i < 500; i++)
+        {
+            var partition = new TopicPartition("test-topic", i);
+            tasks.Add(Task.Run(() => QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [partition])));
+            tasks.Add(Task.Run(() => ClearFetchBufferForPendingCoordinatorRevocations(consumer)));
+        }
+
+        await Task.WhenAll(tasks);
+
+        var pendingRevocations = GetCoordinatorRevokedPartitionsPendingFetchClear(consumer);
+        var pendingFlag = GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer);
+
+        await Assert.That(pendingFlag == 1 || pendingRevocations.IsEmpty).IsTrue();
+
+        while (ClearFetchBufferForPendingCoordinatorRevocations(consumer))
+        {
+        }
+
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).IsEmpty();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
     }
 
     private static KafkaConsumer<string, string> CreateConsumer()
@@ -431,6 +460,50 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("_prefetchedBytes field not found.");
 
         return (long)field.GetValue(consumer)!;
+    }
+
+    private static ConcurrentDictionary<TopicPartition, byte> GetCoordinatorRevokedPartitionsPendingFetchClear(
+        KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_coordinatorRevokedPartitionsPendingFetchClear",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClear field not found.");
+
+        return (ConcurrentDictionary<TopicPartition, byte>)field.GetValue(consumer)!;
+    }
+
+    private static int GetCoordinatorRevokedPartitionsPendingFetchClearPending(
+        KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_coordinatorRevokedPartitionsPendingFetchClearPending",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClearPending field not found.");
+
+        return (int)field.GetValue(consumer)!;
+    }
+
+    private static void QueueCoordinatorRevokedPartitionsForFetchClear(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition[] partitions)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "QueueCoordinatorRevokedPartitionsForFetchClear",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("QueueCoordinatorRevokedPartitionsForFetchClear method not found.");
+
+        method.Invoke(consumer, [partitions]);
+    }
+
+    private static bool ClearFetchBufferForPendingCoordinatorRevocations(KafkaConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "ClearFetchBufferForPendingCoordinatorRevocations",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ClearFetchBufferForPendingCoordinatorRevocations method not found.");
+
+        return (bool)method.Invoke(consumer, [])!;
     }
 
     private static void SetPrefetchedBytes(KafkaConsumer<string, string> consumer, long bytes)


### PR DESCRIPTION
## Summary
- clear pending and prefetched fetch data for coordinator-revoked partitions before consumers yield more records
- cover coordinator revocation with pending/prefetched unit coverage
- add real two-consumer rebalance coverage with prefetch enabled

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release
- [x] dotnet build tests\Dekaf.Tests.Integration --configuration Release
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/ConsumerAssignmentFastPathTests/ConsumeOneAsync_CoordinatorRevocation_ClearsPendingAndPrefetchedRecordsForRemovedPartitions
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/ConsumerAssignmentFastPathTests/*
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/Dekaf.Tests.Unit.Consumer/*/*
- [x] tests\Dekaf.Tests.Integration\bin\Release\net10.0\Dekaf.Tests.Integration.exe --treenode-filter /*/*/CooperativeStickyRebalanceTests/CooperativeRebalance_WithPrefetch_DoesNotEmitRevokedPartitionRecordsAfterAssignmentChanges

Closes #1265
