### PR TITLE
feat(consumer): add partition stop callback

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -256,7 +256,10 @@ Server-side pattern subscription requires Kafka 4.1+ brokers with `ConsumerGroup
 
 ### WithRebalanceListener
 
-Get notified of partition changes:
+Get notified of partition changes. If the listener also implements
+`IPartitionStopListener`, `OnPartitionsStoppedAsync` runs during graceful
+`CloseAsync` or `DisposeAsync` with the current assignment before final
+auto-commit, `LeaveGroup`, assignment cleanup, and resource disposal:
 
 ```csharp
 .WithRebalanceListener(new MyRebalanceListener())

--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -265,6 +265,10 @@ auto-commit, `LeaveGroup`, assignment cleanup, and resource disposal:
 .WithRebalanceListener(new MyRebalanceListener())
 ```
 
+The stop callback is best-effort and bounded to five seconds. If it observes
+shutdown cancellation, Dekaf still completes local cleanup before rethrowing the
+cancellation from `CloseAsync`.
+
 ## Networking
 
 ### WithConnectionsMaxIdle

--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -229,6 +229,10 @@ When a consumer leaves gracefully (`await using` or `CloseAsync`):
 4. Consumer sends `LeaveGroup` and releases resources
 5. Remaining consumers get its partitions
 
+The stop callback is bounded to five seconds. If it is cancelled, Dekaf still
+clears local assignment and releases resources before `CloseAsync` rethrows the
+cancellation.
+
 Cancel the token passed to `ConsumeAsync` before closing when you need to stop a pending fetch promptly during shutdown.
 
 ### Maximum Parallelism

--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -77,12 +77,12 @@ When the group membership changes, Kafka rebalances partitions:
 
 ### Rebalance Listener
 
-Get notified when partitions are assigned or revoked:
+Get notified when partitions are assigned, revoked, lost, or stopped during graceful close:
 
 ```csharp
 using Dekaf;
 
-public class MyRebalanceListener : IRebalanceListener
+public class MyRebalanceListener : IRebalanceListener, IPartitionStopListener
 {
     public async ValueTask OnPartitionsAssignedAsync(
         IEnumerable<TopicPartition> partitions,
@@ -107,6 +107,14 @@ public class MyRebalanceListener : IRebalanceListener
         Console.WriteLine($"Lost: {string.Join(", ", partitions)}");
         // Partitions were taken away (e.g., due to timeout)
     }
+
+    public async ValueTask OnPartitionsStoppedAsync(
+        IEnumerable<TopicPartition> partitions,
+        CancellationToken ct)
+    {
+        Console.WriteLine($"Stopped: {string.Join(", ", partitions)}");
+        // Normal shutdown: drain and dispose partition-scoped resources
+    }
 }
 
 var consumer = await Kafka.CreateConsumer<string, string>()
@@ -115,6 +123,14 @@ var consumer = await Kafka.CreateConsumer<string, string>()
     .WithRebalanceListener(new MyRebalanceListener())
     .BuildAsync();
 ```
+
+Callback semantics:
+
+- `OnPartitionsAssignedAsync` runs after the group assigns partitions to this consumer.
+- `OnPartitionsRevokedAsync` runs during cooperative rebalance before ownership is transferred.
+- `OnPartitionsLostAsync` runs when ownership was lost involuntarily, such as heartbeat timeout; do not commit offsets for lost partitions unless you know they are still owned.
+- `OnPartitionsStoppedAsync` runs only for graceful `CloseAsync` or `DisposeAsync`, after heartbeat, leader-refresh, auto-commit, and prefetch tasks stop and before final auto-commit, `LeaveGroup`, assignment cleanup, and resource disposal.
+- Non-cancellation callback exceptions are logged and suppressed. `OperationCanceledException` follows the supplied cancellation token.
 
 ### Cooperative Rebalancing
 
@@ -207,8 +223,11 @@ When you add consumers to a group:
 ### Removing Consumers
 
 When a consumer leaves gracefully (`await using` or `CloseAsync`):
-1. Consumer commits offsets and leaves group
-2. Remaining consumers get its partitions
+1. Heartbeat, leader-refresh, auto-commit, and prefetch tasks stop
+2. `IPartitionStopListener.OnPartitionsStoppedAsync` runs with the current assignment, if implemented by the configured rebalance listener
+3. Final auto-commit runs when auto-commit mode has dirty offsets
+4. Consumer sends `LeaveGroup` and releases resources
+5. Remaining consumers get its partitions
 
 Cancel the token passed to `ConsumeAsync` before closing when you need to stop a pending fetch promptly during shutdown.
 

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -476,7 +476,9 @@ public interface IRebalanceListener
 /// Non-cancellation exceptions follow the rebalance listener policy: they are caught
 /// and logged at <c>Error</c> level. <see cref="OperationCanceledException"/> follows
 /// the <see cref="IKafkaConsumer{TKey,TValue}.CloseAsync"/> token or internal
-/// disposal shutdown token.
+/// disposal shutdown token, but close/disposal teardown still runs before
+/// <c>CloseAsync</c> rethrows the cancellation. The callback is bounded by a
+/// five-second timeout.
 /// </remarks>
 public interface IPartitionStopListener
 {

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -433,9 +433,10 @@ public enum AutoOffsetReset
 /// <summary>
 /// Interface for rebalance callbacks.
 /// <para>
-/// Exceptions thrown by these callbacks are caught and logged at <c>Error</c> level;
-/// they do not abort the rebalance or crash the consume loop. If your callback cannot
-/// set up required state, throw and monitor logs for the
+/// Non-cancellation exceptions thrown by these callbacks are caught and logged at
+/// <c>Error</c> level; they do not abort the rebalance or crash the consume loop.
+/// <see cref="OperationCanceledException"/> follows the supplied cancellation token.
+/// If your callback cannot set up required state, throw and monitor logs for the
 /// <c>{CallbackName} rebalance listener callback threw an exception</c> message,
 /// or handle the failure inside the callback itself.
 /// </para>
@@ -456,4 +457,31 @@ public interface IRebalanceListener
     /// Called when partitions are lost due to an involuntary group removal (e.g., heartbeat timeout).
     /// </summary>
     ValueTask OnPartitionsLostAsync(IEnumerable<TopicPartition> partitions, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Optional companion interface for observing graceful partition stop during
+/// <see cref="IKafkaConsumer{TKey,TValue}.CloseAsync"/> or
+/// <see cref="IAsyncDisposable.DisposeAsync"/>.
+/// </summary>
+/// <remarks>
+/// Implement this on the same object passed to
+/// <see cref="ConsumerBuilder{TKey,TValue}.WithRebalanceListener(IRebalanceListener)"/>
+/// when partition-scoped resources need a normal-shutdown hook in addition to
+/// assign/revoke/lost callbacks. Dekaf calls <see cref="OnPartitionsStoppedAsync"/>
+/// after heartbeat, leader-refresh, auto-commit, and prefetch tasks have stopped,
+/// and before the final auto-commit, <c>LeaveGroup</c>, assignment/resource cleanup,
+/// and disposal. The callback receives the current assigned partitions.
+///
+/// Non-cancellation exceptions follow the rebalance listener policy: they are caught
+/// and logged at <c>Error</c> level. <see cref="OperationCanceledException"/> follows
+/// the <see cref="IKafkaConsumer{TKey,TValue}.CloseAsync"/> token or internal
+/// disposal shutdown token.
+/// </remarks>
+public interface IPartitionStopListener
+{
+    /// <summary>
+    /// Called once during graceful close/disposal while the consumer still owns its current assignment.
+    /// </summary>
+    ValueTask OnPartitionsStoppedAsync(IEnumerable<TopicPartition> partitions, CancellationToken cancellationToken);
 }

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -135,7 +135,8 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
 
     /// <summary>
     /// Gracefully closes the consumer: stops background tasks (heartbeat, auto-commit, prefetch),
-    /// commits pending offsets, leaves the consumer group, and releases resources.
+    /// notifies <see cref="IPartitionStopListener"/> when configured, commits pending offsets,
+    /// leaves the consumer group, and releases resources.
     /// </summary>
     /// <remarks>
     /// <para><b>Optional:</b> Calling <c>CloseAsync</c> explicitly is not required.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4839,7 +4839,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
         }
 
-        // Step 5: Commit pending offsets (if auto-commit enabled and we have a coordinator)
+        // Step 5: Notify partition-scoped resources of normal stop before final commit/leave.
+        await InvokePartitionStopListenerAsync(cancellationToken).ConfigureAwait(false);
+
+        // Step 6: Commit pending offsets (if auto-commit enabled and we have a coordinator)
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null && !_dirtyPositions.IsEmpty)
         {
             for (var attempt = 0; attempt < 3; attempt++)
@@ -4863,7 +4866,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
         }
 
-        // Step 5: Send LeaveGroup request to coordinator
+        // Step 7: Send LeaveGroup request to coordinator
         if (_coordinator is not null)
         {
             try
@@ -4877,10 +4880,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
         }
 
-        // Step 6: Cancel any blocked fetch operations
+        // Step 8: Cancel any blocked fetch operations
         CancelActiveConsumeOperations();
 
-        // Step 7: Clear pending fetch data and dispose to release pooled memory
+        // Step 9: Clear local assignment and per-partition state
+        ClearAssignmentAfterClose();
+
+        // Step 10: Clear pending fetch data and dispose to release pooled memory
         while (_pendingFetches.TryDequeue(out var pending))
         {
             pending.Dispose();
@@ -4894,6 +4900,52 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         await _telemetryManager.StopAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
 
         LogConsumerClosed();
+    }
+
+    private async ValueTask InvokePartitionStopListenerAsync(CancellationToken cancellationToken)
+    {
+        if (_options.RebalanceListener is not IPartitionStopListener listener)
+            return;
+
+        var partitions = _assignmentSnapshot.ToArray();
+        if (partitions.Length == 0)
+            return;
+
+        LogPartitionStopListenerCall(partitions.Length);
+        try
+        {
+            await listener.OnPartitionsStoppedAsync(partitions, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogPartitionStopListenerCallbackError(ex);
+        }
+    }
+
+    private void ClearAssignmentAfterClose()
+    {
+        var partitions = _assignmentSnapshot;
+        if (partitions.Count == 0)
+            return;
+
+        var hadPaused = false;
+        SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
+        try
+        {
+            _assignment.Clear();
+            hadPaused = RemovePartitionState(partitions);
+            PublishAssignmentSnapshot();
+        }
+        finally
+        {
+            SemaphoreHelper.ReleaseSafely(_assignmentLock);
+        }
+
+        if (hadPaused)
+            PublishPausedSnapshot();
+
+        InvalidatePartitionCache();
+        InvalidateFetchRequestCache();
     }
 
     public async ValueTask<IReadOnlyDictionary<TopicPartition, long>> GetOffsetsForTimesAsync(
@@ -5218,6 +5270,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Closing consumer gracefully")]
     private partial void LogClosingConsumer();
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Calling OnPartitionsStopped for {PartitionCount} partitions")]
+    private partial void LogPartitionStopListenerCall(int partitionCount);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "OnPartitionsStopped partition stop listener callback threw an exception")]
+    private partial void LogPartitionStopListenerCallbackError(Exception exception);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Committed pending offsets during close")]
     private partial void LogCommittedPendingOffsets();

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using Dekaf.Compression;
 using Dekaf.Errors;
 using Dekaf.Internal;
@@ -571,6 +572,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// cancellation and timeout handling (~10 checks per second).
     /// </summary>
     private const int AllPartitionsPausedDelayMs = 100;
+    private static readonly TimeSpan PartitionStopListenerTimeout = TimeSpan.FromSeconds(5);
 
     private readonly ConsumerOptions _options;
 
@@ -1170,15 +1172,31 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // yield zero items on the second and third passes.
         var partitionList = partitions as IReadOnlyList<TopicPartition> ?? partitions.ToList();
 
+        RemoveAssignedPartitions(partitionList, clearAll: false);
+    }
+
+    private void RemoveAssignedPartitions(IReadOnlyCollection<TopicPartition> partitions, bool clearAll)
+    {
+        if (partitions.Count == 0)
+            return;
+
         var hadPaused = false;
         SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
         try
         {
-            foreach (var partition in partitionList)
+            if (clearAll)
             {
-                _assignment.Remove(partition);
+                _assignment.Clear();
             }
-            hadPaused = RemovePartitionState(partitionList);
+            else
+            {
+                foreach (var partition in partitions)
+                {
+                    _assignment.Remove(partition);
+                }
+            }
+
+            hadPaused = RemovePartitionState(partitions);
 
             PublishAssignmentSnapshot();
         }
@@ -1188,7 +1206,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         // Clear any pending fetch data for the removed partitions
-        ClearFetchBufferForPartitions(partitionList);
+        ClearFetchBufferForPartitions(partitions);
 
         if (hadPaused)
             PublishPausedSnapshot();
@@ -4840,7 +4858,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         // Step 5: Notify partition-scoped resources of normal stop before final commit/leave.
-        await InvokePartitionStopListenerAsync(cancellationToken).ConfigureAwait(false);
+        var partitionStopCancellation = await InvokePartitionStopListenerAsync(cancellationToken).ConfigureAwait(false);
 
         // Step 6: Commit pending offsets (if auto-commit enabled and we have a coordinator)
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null && !_dirtyPositions.IsEmpty)
@@ -4900,52 +4918,41 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         await _telemetryManager.StopAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
 
         LogConsumerClosed();
+
+        if (partitionStopCancellation is not null)
+            ExceptionDispatchInfo.Capture(partitionStopCancellation).Throw();
     }
 
-    private async ValueTask InvokePartitionStopListenerAsync(CancellationToken cancellationToken)
+    private async ValueTask<OperationCanceledException?> InvokePartitionStopListenerAsync(CancellationToken cancellationToken)
     {
         if (_options.RebalanceListener is not IPartitionStopListener listener)
-            return;
+            return null;
 
         var partitions = _assignmentSnapshot.ToArray();
         if (partitions.Length == 0)
-            return;
+            return null;
 
         LogPartitionStopListenerCall(partitions.Length);
         try
         {
-            await listener.OnPartitionsStoppedAsync(partitions, cancellationToken).ConfigureAwait(false);
+            var listenerTask = listener.OnPartitionsStoppedAsync(partitions, cancellationToken).AsTask();
+            await listenerTask.WaitAsync(PartitionStopListenerTimeout, cancellationToken).ConfigureAwait(false);
+            return null;
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (OperationCanceledException ex)
+        {
+            return ex;
+        }
+        catch (Exception ex)
         {
             LogPartitionStopListenerCallbackError(ex);
+            return null;
         }
     }
 
     private void ClearAssignmentAfterClose()
     {
-        var partitions = _assignmentSnapshot;
-        if (partitions.Count == 0)
-            return;
-
-        var hadPaused = false;
-        SemaphoreHelper.AcquireOrThrowDisposed(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>));
-        try
-        {
-            _assignment.Clear();
-            hadPaused = RemovePartitionState(partitions);
-            PublishAssignmentSnapshot();
-        }
-        finally
-        {
-            SemaphoreHelper.ReleaseSafely(_assignmentLock);
-        }
-
-        if (hadPaused)
-            PublishPausedSnapshot();
-
-        InvalidatePartitionCache();
-        InvalidateFetchRequestCache();
+        RemoveAssignedPartitions(_assignmentSnapshot, clearAll: true);
     }
 
     public async ValueTask<IReadOnlyDictionary<TopicPartition, long>> GetOffsetsForTimesAsync(

--- a/tests/Dekaf.Tests.Integration/RealWorld/GracefulShutdownTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/GracefulShutdownTests.cs
@@ -82,6 +82,47 @@ public sealed class GracefulShutdownTests(KafkaTestContainer kafka) : KafkaInteg
     }
 
     [Test]
+    public async Task GracefulShutdown_CloseAsync_FiresPartitionStopCallbackBeforeLeavingGroup()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
+        var groupId = $"stop-callback-{Guid.NewGuid():N}";
+        var listener = new StopTrackingRebalanceListener();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "key",
+            Value = "value"
+        }, CancellationToken.None);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithRebalanceListener(listener)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var message = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+        await Assert.That(message).IsNotNull();
+
+        var assignmentBeforeClose = consumer.Assignment.ToArray();
+
+        await consumer.CloseAsync(cts.Token);
+
+        await Assert.That(listener.StoppedPartitions).Count().IsEqualTo(1);
+        await Assert.That(listener.StoppedPartitions[0]).IsEquivalentTo(assignmentBeforeClose);
+        await Assert.That(consumer.Assignment).IsEmpty();
+    }
+
+    [Test]
     public async Task GracefulShutdown_AtLeastOnceProcessing_NoMessageLoss()
     {
         // Simulate at-least-once: commit only after successful processing
@@ -422,5 +463,30 @@ public sealed class GracefulShutdownTests(KafkaTestContainer kafka) : KafkaInteg
 
         await Assert.That(secondPass).Count().IsEqualTo(5);
         await Assert.That(secondPass).IsEquivalentTo(firstPass);
+    }
+
+    private sealed class StopTrackingRebalanceListener : IRebalanceListener, IPartitionStopListener
+    {
+        public List<List<TopicPartition>> StoppedPartitions { get; } = [];
+
+        public ValueTask OnPartitionsAssignedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public ValueTask OnPartitionsRevokedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public ValueTask OnPartitionsLostAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public ValueTask OnPartitionsStoppedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            StoppedPartitions.Add(partitions.ToList());
+            return ValueTask.CompletedTask;
+        }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
@@ -55,6 +55,7 @@ public sealed class ConsumerPartitionStopListenerTests
             .Throws<OperationCanceledException>();
         await Assert.That(listener.CancellationTokens).Count().IsEqualTo(1);
         await Assert.That(listener.CancellationTokens[0].IsCancellationRequested).IsTrue();
+        await Assert.That(consumer.Assignment).IsEmpty();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
@@ -1,0 +1,119 @@
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerPartitionStopListenerTests
+{
+    [Test]
+    public async Task CloseAsync_InvokesPartitionStopListenerWithCurrentAssignment()
+    {
+        var listener = new TrackingPartitionStopListener();
+        await using var consumer = CreateConsumer(listener);
+        var partition = new TopicPartition("topic-a", 0);
+        consumer.Assign(partition);
+
+        await consumer.CloseAsync(CancellationToken.None);
+
+        await Assert.That(listener.StoppedPartitions).Count().IsEqualTo(1);
+        await Assert.That(listener.StoppedPartitions[0]).IsEquivalentTo([partition]);
+        await Assert.That(consumer.Assignment).IsEmpty();
+    }
+
+    [Test]
+    public async Task DisposeAsync_InvokesPartitionStopListenerWithCurrentAssignment()
+    {
+        var listener = new TrackingPartitionStopListener();
+        var consumer = CreateConsumer(listener);
+        var partition = new TopicPartition("topic-a", 1);
+        consumer.Assign(partition);
+
+        await consumer.DisposeAsync();
+
+        await Assert.That(listener.StoppedPartitions).Count().IsEqualTo(1);
+        await Assert.That(listener.StoppedPartitions[0]).IsEquivalentTo([partition]);
+        await Assert.That(consumer.Assignment).IsEmpty();
+    }
+
+    [Test]
+    public async Task CloseAsync_PassesCancellationTokenToPartitionStopListener()
+    {
+        var listener = new TrackingPartitionStopListener
+        {
+            OnStopped = (_, cancellationToken) =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return ValueTask.CompletedTask;
+            }
+        };
+        await using var consumer = CreateConsumer(listener);
+        consumer.Assign(new TopicPartition("topic-a", 0));
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.That(async () => await consumer.CloseAsync(cts.Token))
+            .Throws<OperationCanceledException>();
+        await Assert.That(listener.CancellationTokens).Count().IsEqualTo(1);
+        await Assert.That(listener.CancellationTokens[0].IsCancellationRequested).IsTrue();
+    }
+
+    [Test]
+    public async Task CloseAsync_SuppressesPartitionStopListenerNonCancellationException()
+    {
+        var listener = new TrackingPartitionStopListener
+        {
+            OnStopped = (_, _) => throw new InvalidOperationException("stop failed")
+        };
+        await using var consumer = CreateConsumer(listener);
+        consumer.Assign(new TopicPartition("topic-a", 0));
+
+        await Assert.That(async () => await consumer.CloseAsync(CancellationToken.None))
+            .ThrowsNothing();
+        await Assert.That(listener.StoppedPartitions).Count().IsEqualTo(1);
+        await Assert.That(consumer.Assignment).IsEmpty();
+    }
+
+    private static KafkaConsumer<string, string> CreateConsumer(IRebalanceListener listener)
+    {
+        return new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1,
+                RebalanceListener = listener
+            },
+            Serializers.String,
+            Serializers.String);
+    }
+
+    private sealed class TrackingPartitionStopListener : IRebalanceListener, IPartitionStopListener
+    {
+        public List<List<TopicPartition>> StoppedPartitions { get; } = [];
+        public List<CancellationToken> CancellationTokens { get; } = [];
+        public Func<IEnumerable<TopicPartition>, CancellationToken, ValueTask>? OnStopped { get; init; }
+
+        public ValueTask OnPartitionsAssignedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public ValueTask OnPartitionsRevokedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public ValueTask OnPartitionsLostAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public ValueTask OnPartitionsStoppedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            StoppedPartitions.Add(partitions.ToList());
+            CancellationTokens.Add(cancellationToken);
+            return OnStopped is null
+                ? ValueTask.CompletedTask
+                : OnStopped(partitions, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds additive `IPartitionStopListener` companion API for graceful close/dispose partition-stop callbacks.
- Invokes the callback with the current assignment before final auto-commit, `LeaveGroup`, local assignment cleanup, and resource disposal.
- Documents assign/revoke/lost/stop semantics and close ordering.

## Tests
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter "/*/*/ConsumerPartitionStopListenerTests/*"`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter "/*/*/ConsumerCloseTests/*"`
- `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
- `./tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration --treenode-filter "/*/*/GracefulShutdownTests/GracefulShutdown_CloseAsync_FiresPartitionStopCallbackBeforeLeavingGroup"`
- `npm run build --prefix docs`

Closes #1266