### PR TITLE
feat(json): add source-gen metadata APIs

### DIFF
--- a/docs/docs/serialization/json.md
+++ b/docs/docs/serialization/json.md
@@ -43,7 +43,7 @@ using Dekaf.Serialization.Json;
 var consumer = await Kafka.CreateConsumer<string, Order>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("order-processors")
-    .WithValueDeserializer(new JsonDeserializer<Order>())
+    .WithValueDeserializer(new JsonSerializer<Order>())
     .SubscribeTo("orders")
     .BuildAsync();
 
@@ -73,6 +73,47 @@ var producer = await Kafka.CreateProducer<string, Order>()
     .WithValueSerializer(new JsonSerializer<Order>(options))
     .BuildAsync();
 ```
+
+## NativeAOT
+
+For NativeAOT, use System.Text.Json source-generated metadata instead of reflection-based `JsonSerializerOptions`:
+
+```csharp
+using System.Text.Json.Serialization;
+using Dekaf.Serialization.Json;
+
+[JsonSerializable(typeof(Order))]
+[JsonSerializable(typeof(OrderKey))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+public partial class OrderJsonContext : JsonSerializerContext { }
+
+var serializer = new JsonSerializer<Order>(OrderJsonContext.Default.Order);
+
+await using var producer = await Kafka.CreateProducer<string, Order>()
+    .WithBootstrapServers("localhost:9092")
+    .WithValueSerializer(serializer)
+    .BuildAsync();
+```
+
+The fluent helpers also accept source-generated metadata:
+
+```csharp
+await using var producer = await Kafka.CreateProducer<OrderKey, Order>()
+    .WithBootstrapServers("localhost:9092")
+    .UseJsonKeySerializer(OrderJsonContext.Default.OrderKey)
+    .UseJsonSerializer(OrderJsonContext.Default.Order)
+    .BuildAsync();
+
+await using var consumer = await Kafka.CreateConsumer<OrderKey, Order>()
+    .WithBootstrapServers("localhost:9092")
+    .WithGroupId("order-processors")
+    .UseJsonKeyDeserializer(OrderJsonContext.Default.OrderKey)
+    .UseJsonDeserializer(OrderJsonContext.Default.Order)
+    .SubscribeTo("orders")
+    .BuildAsync();
+```
+
+`JsonSerializerOptions` overloads remain available for non-AOT applications, but they can require runtime reflection depending on the configured converters and payload types.
 
 ## Both Key and Value
 
@@ -134,18 +175,13 @@ public class OrderShipped : OrderEvent { public string TrackingId { get; set; } 
 ## Performance Considerations
 
 - JSON serialization adds overhead compared to binary formats
-- Consider using source generators for better performance:
+- Use source generators for NativeAOT and better performance:
 
 ```csharp
 [JsonSerializable(typeof(Order))]
 public partial class OrderJsonContext : JsonSerializerContext { }
 
-var options = new JsonSerializerOptions
-{
-    TypeInfoResolver = OrderJsonContext.Default
-};
-
-var serializer = new JsonSerializer<Order>(options);
+var serializer = new JsonSerializer<Order>(OrderJsonContext.Default.Order);
 ```
 
 ## Complete Example
@@ -192,7 +228,7 @@ await producer.ProduceAsync("orders", order.Id, order);
 await using var consumer = await Kafka.CreateConsumer<string, Order>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("order-processors")
-    .WithValueDeserializer(new JsonDeserializer<Order>(jsonOptions))
+    .WithValueDeserializer(new JsonSerializer<Order>(jsonOptions))
     .SubscribeTo("orders")
     .BuildAsync();
 

--- a/src/Dekaf.Serialization.Json/Dekaf.Serialization.Json.csproj
+++ b/src/Dekaf.Serialization.Json/Dekaf.Serialization.Json.csproj
@@ -4,6 +4,7 @@
     <PackageId>Dekaf.Serialization.Json</PackageId>
     <Description>System.Text.Json serialization for Dekaf Kafka client</Description>
     <PackageTags>kafka;serialization;json</PackageTags>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dekaf.Serialization.Json/JsonSerializer.cs
+++ b/src/Dekaf.Serialization.Json/JsonSerializer.cs
@@ -1,5 +1,7 @@
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Dekaf.Serialization.Json;
 
@@ -15,11 +17,25 @@ public sealed class JsonSerializer<T> : ISerde<T>
     [ThreadStatic]
     private static Utf8JsonWriter? t_jsonWriter;
 
-    private readonly JsonSerializerOptions _options;
+    private readonly JsonSerializerOptions? _options;
+    private readonly JsonTypeInfo<T>? _typeInfo;
 
+    [RequiresDynamicCode(JsonSerializerAotMessages.ReflectionSerializationMessage)]
+    [RequiresUnreferencedCode(JsonSerializerAotMessages.ReflectionSerializationMessage)]
     public JsonSerializer(JsonSerializerOptions? options = null)
     {
-        _options = options ?? new JsonSerializerOptions
+        _options = options ?? CreateDefaultOptions();
+    }
+
+    public JsonSerializer(JsonTypeInfo<T> typeInfo)
+    {
+        ArgumentNullException.ThrowIfNull(typeInfo);
+        _typeInfo = typeInfo;
+    }
+
+    private static JsonSerializerOptions CreateDefaultOptions()
+    {
+        return new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             WriteIndented = false
@@ -50,7 +66,15 @@ public sealed class JsonSerializer<T> : ISerde<T>
 
         try
         {
-            System.Text.Json.JsonSerializer.Serialize(jsonWriter, value, _options);
+            if (_typeInfo is not null)
+            {
+                System.Text.Json.JsonSerializer.Serialize(jsonWriter, value, _typeInfo);
+            }
+            else
+            {
+                System.Text.Json.JsonSerializer.Serialize(jsonWriter, value, _options);
+            }
+
             jsonWriter.Flush();
         }
         catch
@@ -67,7 +91,9 @@ public sealed class JsonSerializer<T> : ISerde<T>
 
     public T Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
     {
-        return System.Text.Json.JsonSerializer.Deserialize<T>(data.Span, _options)!;
+        return _typeInfo is not null
+            ? System.Text.Json.JsonSerializer.Deserialize(data.Span, _typeInfo)!
+            : System.Text.Json.JsonSerializer.Deserialize<T>(data.Span, _options)!;
     }
 }
 
@@ -79,6 +105,8 @@ public static class JsonSerializerExtensions
     /// <summary>
     /// Configures the producer to use JSON serialization for values.
     /// </summary>
+    [RequiresDynamicCode(JsonSerializerAotMessages.ReflectionSerializationMessage)]
+    [RequiresUnreferencedCode(JsonSerializerAotMessages.ReflectionSerializationMessage)]
     public static ProducerBuilder<TKey, TValue> UseJsonSerializer<TKey, TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         JsonSerializerOptions? options = null)
@@ -87,8 +115,20 @@ public static class JsonSerializerExtensions
     }
 
     /// <summary>
+    /// Configures the producer to use NativeAOT-safe JSON serialization for values.
+    /// </summary>
+    public static ProducerBuilder<TKey, TValue> UseJsonSerializer<TKey, TValue>(
+        this ProducerBuilder<TKey, TValue> builder,
+        JsonTypeInfo<TValue> typeInfo)
+    {
+        return builder.WithValueSerializer(new JsonSerializer<TValue>(typeInfo));
+    }
+
+    /// <summary>
     /// Configures the producer to use JSON serialization for keys.
     /// </summary>
+    [RequiresDynamicCode(JsonSerializerAotMessages.ReflectionSerializationMessage)]
+    [RequiresUnreferencedCode(JsonSerializerAotMessages.ReflectionSerializationMessage)]
     public static ProducerBuilder<TKey, TValue> UseJsonKeySerializer<TKey, TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         JsonSerializerOptions? options = null)
@@ -97,8 +137,20 @@ public static class JsonSerializerExtensions
     }
 
     /// <summary>
+    /// Configures the producer to use NativeAOT-safe JSON serialization for keys.
+    /// </summary>
+    public static ProducerBuilder<TKey, TValue> UseJsonKeySerializer<TKey, TValue>(
+        this ProducerBuilder<TKey, TValue> builder,
+        JsonTypeInfo<TKey> typeInfo)
+    {
+        return builder.WithKeySerializer(new JsonSerializer<TKey>(typeInfo));
+    }
+
+    /// <summary>
     /// Configures the consumer to use JSON deserialization for values.
     /// </summary>
+    [RequiresDynamicCode(JsonSerializerAotMessages.ReflectionSerializationMessage)]
+    [RequiresUnreferencedCode(JsonSerializerAotMessages.ReflectionSerializationMessage)]
     public static ConsumerBuilder<TKey, TValue> UseJsonDeserializer<TKey, TValue>(
         this ConsumerBuilder<TKey, TValue> builder,
         JsonSerializerOptions? options = null)
@@ -107,12 +159,41 @@ public static class JsonSerializerExtensions
     }
 
     /// <summary>
+    /// Configures the consumer to use NativeAOT-safe JSON deserialization for values.
+    /// </summary>
+    public static ConsumerBuilder<TKey, TValue> UseJsonDeserializer<TKey, TValue>(
+        this ConsumerBuilder<TKey, TValue> builder,
+        JsonTypeInfo<TValue> typeInfo)
+    {
+        return builder.WithValueDeserializer(new JsonSerializer<TValue>(typeInfo));
+    }
+
+    /// <summary>
     /// Configures the consumer to use JSON deserialization for keys.
     /// </summary>
+    [RequiresDynamicCode(JsonSerializerAotMessages.ReflectionSerializationMessage)]
+    [RequiresUnreferencedCode(JsonSerializerAotMessages.ReflectionSerializationMessage)]
     public static ConsumerBuilder<TKey, TValue> UseJsonKeyDeserializer<TKey, TValue>(
         this ConsumerBuilder<TKey, TValue> builder,
         JsonSerializerOptions? options = null)
     {
         return builder.WithKeyDeserializer(new JsonSerializer<TKey>(options));
     }
+
+    /// <summary>
+    /// Configures the consumer to use NativeAOT-safe JSON deserialization for keys.
+    /// </summary>
+    public static ConsumerBuilder<TKey, TValue> UseJsonKeyDeserializer<TKey, TValue>(
+        this ConsumerBuilder<TKey, TValue> builder,
+        JsonTypeInfo<TKey> typeInfo)
+    {
+        return builder.WithKeyDeserializer(new JsonSerializer<TKey>(typeInfo));
+    }
+}
+
+internal static class JsonSerializerAotMessages
+{
+    public const string ReflectionSerializationMessage =
+        "JsonSerializerOptions-based JSON serialization can require runtime reflection. " +
+        "Use the JsonTypeInfo<T> overload for NativeAOT-safe serialization.";
 }

--- a/src/Dekaf.Serialization.Json/JsonSerializer.cs
+++ b/src/Dekaf.Serialization.Json/JsonSerializer.cs
@@ -42,6 +42,8 @@ public sealed class JsonSerializer<T> : ISerde<T>
         };
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = JsonSerializerAotMessages.ReflectionBranchJustification)]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = JsonSerializerAotMessages.ReflectionBranchJustification)]
     public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
     {
@@ -89,6 +91,8 @@ public sealed class JsonSerializer<T> : ISerde<T>
         destination.Advance(written.Length);
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = JsonSerializerAotMessages.ReflectionBranchJustification)]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = JsonSerializerAotMessages.ReflectionBranchJustification)]
     public T Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
     {
         return _typeInfo is not null
@@ -196,4 +200,8 @@ internal static class JsonSerializerAotMessages
     public const string ReflectionSerializationMessage =
         "JsonSerializerOptions-based JSON serialization can require runtime reflection. " +
         "Use the JsonTypeInfo<T> overload for NativeAOT-safe serialization.";
+
+    public const string ReflectionBranchJustification =
+        "The reflection-based System.Text.Json overload is reachable only from the annotated " +
+        "JsonSerializerOptions constructor; JsonTypeInfo construction stays NativeAOT-safe.";
 }

--- a/tests/Dekaf.Tests.Unit/Serialization/JsonSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/JsonSerializerTests.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Dekaf;
 using Dekaf.Serialization;
 using Dekaf.Serialization.Json;
 
@@ -8,8 +9,10 @@ namespace Dekaf.Tests.Unit.Serialization;
 
 public class JsonSerializerTests
 {
-    private static SerializationContext CreateContext(string topic = "test") =>
-        new() { Topic = topic, Component = SerializationComponent.Value };
+    private static SerializationContext CreateContext(
+        string topic = "test",
+        SerializationComponent component = SerializationComponent.Value) =>
+        new() { Topic = topic, Component = component };
 
     #region Basic Roundtrip Tests
 
@@ -83,6 +86,70 @@ public class JsonSerializerTests
         var json = System.Text.Encoding.UTF8.GetString(buffer.WrittenSpan);
         await Assert.That(json).Contains("\"Name\"");
         await Assert.That(json).Contains("\"Age\"");
+    }
+
+    [Test]
+    public async Task Serialize_SourceGeneratedTypeInfo_RoundTrips()
+    {
+        var serializer = new JsonSerializer<SourceGeneratedPerson>(
+            JsonSerializerTestsJsonContext.Default.SourceGeneratedPerson);
+        var buffer = new ArrayBufferWriter<byte>();
+        var context = CreateContext();
+        var person = new SourceGeneratedPerson { Name = "Ava", Age = 42 };
+
+        serializer.Serialize(person, ref buffer, context);
+        var result = serializer.Deserialize(buffer.WrittenMemory, context);
+
+        await Assert.That(result.Name).IsEqualTo("Ava");
+        await Assert.That(result.Age).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Serialize_SourceGeneratedKeyTypeInfo_RoundTrips()
+    {
+        var serializer = new JsonSerializer<SourceGeneratedOrderKey>(
+            JsonSerializerTestsJsonContext.Default.SourceGeneratedOrderKey);
+        var buffer = new ArrayBufferWriter<byte>();
+        var context = CreateContext(component: SerializationComponent.Key);
+        var key = new SourceGeneratedOrderKey { Id = "order-123" };
+
+        serializer.Serialize(key, ref buffer, context);
+        var result = serializer.Deserialize(buffer.WrittenMemory, context);
+
+        var json = System.Text.Encoding.UTF8.GetString(buffer.WrittenSpan);
+        await Assert.That(json).IsEqualTo("{\"id\":\"order-123\"}");
+        await Assert.That(result.Id).IsEqualTo("order-123");
+    }
+
+    [Test]
+    public async Task Serialize_SourceGeneratedTypeInfo_UsesGeneratedNamingPolicy()
+    {
+        var serializer = new JsonSerializer<SourceGeneratedPerson>(
+            JsonSerializerTestsJsonContext.Default.SourceGeneratedPerson);
+        var buffer = new ArrayBufferWriter<byte>();
+        var context = CreateContext();
+
+        serializer.Serialize(new SourceGeneratedPerson { Name = "Ivy", Age = 11 }, ref buffer, context);
+
+        var json = System.Text.Encoding.UTF8.GetString(buffer.WrittenSpan);
+        await Assert.That(json).IsEqualTo("{\"name\":\"Ivy\",\"age\":11}");
+    }
+
+    [Test]
+    public async Task FluentHelpers_SourceGeneratedTypeInfo_ReturnBuilders()
+    {
+        var producerBuilder = new ProducerBuilder<SourceGeneratedOrderKey, SourceGeneratedPerson>();
+        var consumerBuilder = new ConsumerBuilder<SourceGeneratedOrderKey, SourceGeneratedPerson>();
+
+        var configuredProducerBuilder = producerBuilder
+            .UseJsonKeySerializer(JsonSerializerTestsJsonContext.Default.SourceGeneratedOrderKey)
+            .UseJsonSerializer(JsonSerializerTestsJsonContext.Default.SourceGeneratedPerson);
+        var configuredConsumerBuilder = consumerBuilder
+            .UseJsonKeyDeserializer(JsonSerializerTestsJsonContext.Default.SourceGeneratedOrderKey)
+            .UseJsonDeserializer(JsonSerializerTestsJsonContext.Default.SourceGeneratedPerson);
+
+        await Assert.That(configuredProducerBuilder).IsSameReferenceAs(producerBuilder);
+        await Assert.That(configuredConsumerBuilder).IsSameReferenceAs(consumerBuilder);
     }
 
     #endregion
@@ -225,3 +292,19 @@ public class JsonSerializerTests
 
     #endregion
 }
+
+internal sealed class SourceGeneratedPerson
+{
+    public string? Name { get; set; }
+    public int Age { get; set; }
+}
+
+internal sealed class SourceGeneratedOrderKey
+{
+    public string? Id { get; set; }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(SourceGeneratedPerson))]
+[JsonSerializable(typeof(SourceGeneratedOrderKey))]
+internal sealed partial class JsonSerializerTestsJsonContext : JsonSerializerContext;

--- a/tests/Dekaf.Tests.Unit/Serialization/JsonSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/JsonSerializerTests.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Dekaf;
 using Dekaf.Serialization;
 using Dekaf.Serialization.Json;
@@ -150,6 +151,14 @@ public class JsonSerializerTests
 
         await Assert.That(configuredProducerBuilder).IsSameReferenceAs(producerBuilder);
         await Assert.That(configuredConsumerBuilder).IsSameReferenceAs(consumerBuilder);
+    }
+
+    [Test]
+    public async Task Constructor_NullTypeInfo_ThrowsArgumentNullException()
+    {
+        var act = () => new JsonSerializer<SourceGeneratedPerson>((JsonTypeInfo<SourceGeneratedPerson>)null!);
+
+        await Assert.That(act).Throws<ArgumentNullException>();
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- add JsonTypeInfo<T>-based JSON serializer/deserializer paths for NativeAOT-safe use
- add source-generated key/value fluent helper overloads and AOT annotations for JsonSerializerOptions APIs
- enable the JSON package AOT analyzer and suppress only the guarded reflection branch
- document NativeAOT JSON usage and cover source-generated key/value round trips

## Test plan
- [x] `dotnet build src/Dekaf.Serialization.Json/Dekaf.Serialization.Json.csproj --configuration Release`
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- [x] `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter "/*/*/JsonSerializerTests/*"`
- [x] `npm run build --prefix docs`
- [x] `git diff --check`

Closes #1303
