### PR TITLE
feat(schema-registry): add AOT JSON paths

### DIFF
--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -1,7 +1,9 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using Dekaf.Serialization;
 
 namespace Dekaf.SchemaRegistry;
@@ -29,8 +31,12 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     [ThreadStatic]
     private static Utf8JsonWriter? t_jsonWriter;
 
+    private delegate void JsonPayloadSerializer(Utf8JsonWriter writer, T value);
+
     private readonly ISchemaRegistryClient _schemaRegistry;
-    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly JsonPayloadSerializer _serializePayload;
+    private readonly JsonSerializerOptions? _jsonOptions;
+    private readonly JsonTypeInfo<T>? _jsonTypeInfo;
     private readonly SubjectNameStrategy _subjectNameStrategy;
     private readonly ISubjectNameStrategy? _customSubjectNameStrategy;
     private readonly bool _autoRegisterSchemas;
@@ -49,6 +55,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     /// <param name="subjectNameStrategy">Strategy for determining subject names.</param>
     /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
     /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
+    [RequiresUnreferencedCode("JsonSerializerOptions-based JSON serialization uses reflection. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
+    [RequiresDynamicCode("JsonSerializerOptions-based JSON serialization may require runtime code generation. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
     public JsonSchemaRegistrySerializer(
         ISchemaRegistryClient schemaRegistry,
         string jsonSchema,
@@ -58,10 +66,38 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         bool ownsClient = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
-        _jsonOptions = jsonOptions ?? new JsonSerializerOptions
+        _jsonOptions = CreateJsonOptions(jsonOptions);
+        _serializePayload = SerializeWithOptions;
+        _subjectNameStrategy = subjectNameStrategy;
+        _autoRegisterSchemas = autoRegisterSchemas;
+        _ownsClient = ownsClient;
+        _schema = new Schema
         {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            SchemaType = SchemaType.Json,
+            SchemaString = jsonSchema
         };
+    }
+
+    /// <summary>
+    /// Creates a new NativeAOT-safe JSON Schema Registry serializer.
+    /// </summary>
+    /// <param name="schemaRegistry">The Schema Registry client.</param>
+    /// <param name="jsonSchema">The JSON schema string for type T.</param>
+    /// <param name="jsonTypeInfo">Source-generated metadata for type T.</param>
+    /// <param name="subjectNameStrategy">Strategy for determining subject names.</param>
+    /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
+    /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
+    public JsonSchemaRegistrySerializer(
+        ISchemaRegistryClient schemaRegistry,
+        string jsonSchema,
+        JsonTypeInfo<T> jsonTypeInfo,
+        SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
+        bool autoRegisterSchemas = true,
+        bool ownsClient = false)
+    {
+        _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
+        _jsonTypeInfo = jsonTypeInfo ?? throw new ArgumentNullException(nameof(jsonTypeInfo));
+        _serializePayload = SerializeWithTypeInfo;
         _subjectNameStrategy = subjectNameStrategy;
         _autoRegisterSchemas = autoRegisterSchemas;
         _ownsClient = ownsClient;
@@ -81,6 +117,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     /// <param name="jsonOptions">JSON serializer options.</param>
     /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
     /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
+    [RequiresUnreferencedCode("JsonSerializerOptions-based JSON serialization uses reflection. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
+    [RequiresDynamicCode("JsonSerializerOptions-based JSON serialization may require runtime code generation. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
     public JsonSchemaRegistrySerializer(
         ISchemaRegistryClient schemaRegistry,
         string jsonSchema,
@@ -91,10 +129,38 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _customSubjectNameStrategy = customSubjectNameStrategy ?? throw new ArgumentNullException(nameof(customSubjectNameStrategy));
-        _jsonOptions = jsonOptions ?? new JsonSerializerOptions
+        _jsonOptions = CreateJsonOptions(jsonOptions);
+        _serializePayload = SerializeWithOptions;
+        _autoRegisterSchemas = autoRegisterSchemas;
+        _ownsClient = ownsClient;
+        _schema = new Schema
         {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            SchemaType = SchemaType.Json,
+            SchemaString = jsonSchema
         };
+    }
+
+    /// <summary>
+    /// Creates a new NativeAOT-safe JSON Schema Registry serializer with a custom subject name strategy.
+    /// </summary>
+    /// <param name="schemaRegistry">The Schema Registry client.</param>
+    /// <param name="jsonSchema">The JSON schema string for type T.</param>
+    /// <param name="customSubjectNameStrategy">Custom strategy for determining subject names.</param>
+    /// <param name="jsonTypeInfo">Source-generated metadata for type T.</param>
+    /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
+    /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
+    public JsonSchemaRegistrySerializer(
+        ISchemaRegistryClient schemaRegistry,
+        string jsonSchema,
+        ISubjectNameStrategy customSubjectNameStrategy,
+        JsonTypeInfo<T> jsonTypeInfo,
+        bool autoRegisterSchemas = true,
+        bool ownsClient = false)
+    {
+        _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
+        _customSubjectNameStrategy = customSubjectNameStrategy ?? throw new ArgumentNullException(nameof(customSubjectNameStrategy));
+        _jsonTypeInfo = jsonTypeInfo ?? throw new ArgumentNullException(nameof(jsonTypeInfo));
+        _serializePayload = SerializeWithTypeInfo;
         _autoRegisterSchemas = autoRegisterSchemas;
         _ownsClient = ownsClient;
         _schema = new Schema
@@ -125,7 +191,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
 
         try
         {
-            JsonSerializer.Serialize(jsonWriter, value, _jsonOptions);
+            _serializePayload(jsonWriter, value);
             jsonWriter.Flush();
         }
         catch
@@ -197,6 +263,26 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
             _schemaRegistry.Dispose();
         return ValueTask.CompletedTask;
     }
+
+    private static JsonSerializerOptions CreateJsonOptions(JsonSerializerOptions? jsonOptions)
+    {
+        return jsonOptions ?? new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    [RequiresUnreferencedCode("JsonSerializerOptions-based JSON serialization uses reflection. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
+    [RequiresDynamicCode("JsonSerializerOptions-based JSON serialization may require runtime code generation. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
+    private void SerializeWithOptions(Utf8JsonWriter writer, T value)
+    {
+        JsonSerializer.Serialize(writer, value, _jsonOptions);
+    }
+
+    private void SerializeWithTypeInfo(Utf8JsonWriter writer, T value)
+    {
+        JsonSerializer.Serialize(writer, value, _jsonTypeInfo!);
+    }
 }
 
 /// <summary>
@@ -218,8 +304,12 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
     private const byte MagicByte = 0x00;
     private static readonly TimeSpan SchemaRegistryTimeout = TimeSpan.FromSeconds(30);
 
+    private delegate T JsonPayloadDeserializer(ReadOnlySpan<byte> payload);
+
     private readonly ISchemaRegistryClient _schemaRegistry;
-    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly JsonPayloadDeserializer _deserializePayload;
+    private readonly JsonSerializerOptions? _jsonOptions;
+    private readonly JsonTypeInfo<T>? _jsonTypeInfo;
     private readonly bool _ownsClient;
 
     /// <summary>
@@ -228,16 +318,33 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
     /// <param name="schemaRegistry">The Schema Registry client.</param>
     /// <param name="jsonOptions">JSON serializer options.</param>
     /// <param name="ownsClient">Whether this deserializer owns the client and should dispose it.</param>
+    [RequiresUnreferencedCode("JsonSerializerOptions-based JSON deserialization uses reflection. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
+    [RequiresDynamicCode("JsonSerializerOptions-based JSON deserialization may require runtime code generation. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
     public JsonSchemaRegistryDeserializer(
         ISchemaRegistryClient schemaRegistry,
         JsonSerializerOptions? jsonOptions = null,
         bool ownsClient = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
-        _jsonOptions = jsonOptions ?? new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-        };
+        _jsonOptions = CreateJsonOptions(jsonOptions);
+        _deserializePayload = DeserializeWithOptions;
+        _ownsClient = ownsClient;
+    }
+
+    /// <summary>
+    /// Creates a new NativeAOT-safe JSON Schema Registry deserializer.
+    /// </summary>
+    /// <param name="schemaRegistry">The Schema Registry client.</param>
+    /// <param name="jsonTypeInfo">Source-generated metadata for type T.</param>
+    /// <param name="ownsClient">Whether this deserializer owns the client and should dispose it.</param>
+    public JsonSchemaRegistryDeserializer(
+        ISchemaRegistryClient schemaRegistry,
+        JsonTypeInfo<T> jsonTypeInfo,
+        bool ownsClient = false)
+    {
+        _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
+        _jsonTypeInfo = jsonTypeInfo ?? throw new ArgumentNullException(nameof(jsonTypeInfo));
+        _deserializePayload = DeserializeWithTypeInfo;
         _ownsClient = ownsClient;
     }
 
@@ -257,7 +364,7 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
         _ = _schemaRegistry.GetSchemaSync(schemaId, SchemaRegistryTimeout);
 
         // Extract JSON payload and deserialize
-        return JsonSerializer.Deserialize<T>(span.Slice(5), _jsonOptions)!;
+        return _deserializePayload(span.Slice(5));
     }
 
     public ValueTask DisposeAsync()
@@ -265,5 +372,25 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
         if (_ownsClient)
             _schemaRegistry.Dispose();
         return ValueTask.CompletedTask;
+    }
+
+    private static JsonSerializerOptions CreateJsonOptions(JsonSerializerOptions? jsonOptions)
+    {
+        return jsonOptions ?? new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    [RequiresUnreferencedCode("JsonSerializerOptions-based JSON deserialization uses reflection. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
+    [RequiresDynamicCode("JsonSerializerOptions-based JSON deserialization may require runtime code generation. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
+    private T DeserializeWithOptions(ReadOnlySpan<byte> payload)
+    {
+        return JsonSerializer.Deserialize<T>(payload, _jsonOptions)!;
+    }
+
+    private T DeserializeWithTypeInfo(ReadOnlySpan<byte> payload)
+    {
+        return JsonSerializer.Deserialize(payload, _jsonTypeInfo!)!;
     }
 }

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -3,8 +3,6 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Dekaf.SchemaRegistry;
 
@@ -20,7 +18,6 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
     private readonly ConcurrentDictionary<int, Schema> _schemaByIdCache = new();
     private readonly ConcurrentDictionary<(string Subject, Schema Schema), int> _idBySchemaCache = new();
     private readonly object _cacheLock = new();
-    private readonly JsonSerializerOptions _jsonOptions;
     private readonly int _maxCachedSchemas;
     private bool _disposed;
 
@@ -44,12 +41,6 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             _httpClient.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
         }
-
-        _jsonOptions = new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
     }
 
     internal int CachedSchemaByIdCount => _schemaByIdCache.Count;
@@ -81,13 +72,13 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         var response = await _httpClient.PostAsJsonAsync(
             $"subjects/{Uri.EscapeDataString(subject)}/versions",
             request,
-            _jsonOptions,
+            SchemaRegistryJsonTypeInfo.RegisterSchemaRequest,
             cancellationToken).ConfigureAwait(false);
 
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content.ReadFromJsonAsync<RegisterSchemaResponse>(
-            _jsonOptions, cancellationToken).ConfigureAwait(false);
+            SchemaRegistryJsonTypeInfo.RegisterSchemaResponse, cancellationToken).ConfigureAwait(false);
 
         var id = result!.Id;
 
@@ -108,7 +99,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content.ReadFromJsonAsync<GetSchemaResponse>(
-            _jsonOptions, cancellationToken).ConfigureAwait(false);
+            SchemaRegistryJsonTypeInfo.GetSchemaResponse, cancellationToken).ConfigureAwait(false);
 
         var schema = new Schema
         {
@@ -138,7 +129,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content.ReadFromJsonAsync<GetSubjectVersionResponse>(
-            _jsonOptions, cancellationToken).ConfigureAwait(false);
+            SchemaRegistryJsonTypeInfo.GetSubjectVersionResponse, cancellationToken).ConfigureAwait(false);
 
         var schema = new Schema
         {
@@ -185,7 +176,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         var response = await _httpClient.PostAsJsonAsync(
             $"subjects/{Uri.EscapeDataString(subject)}",
             request,
-            _jsonOptions,
+            SchemaRegistryJsonTypeInfo.RegisterSchemaRequest,
             cancellationToken).ConfigureAwait(false);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
@@ -197,7 +188,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content.ReadFromJsonAsync<GetSubjectVersionResponse>(
-            _jsonOptions, cancellationToken).ConfigureAwait(false);
+            SchemaRegistryJsonTypeInfo.GetSubjectVersionResponse, cancellationToken).ConfigureAwait(false);
 
         var id = result!.Id;
 
@@ -233,7 +224,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content.ReadFromJsonAsync<List<string>>(
-            _jsonOptions, cancellationToken).ConfigureAwait(false) ?? [];
+            SchemaRegistryJsonTypeInfo.StringList, cancellationToken).ConfigureAwait(false) ?? [];
     }
 
     public async Task<IReadOnlyList<int>> GetVersionsAsync(string subject, CancellationToken cancellationToken = default)
@@ -245,7 +236,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content.ReadFromJsonAsync<List<int>>(
-            _jsonOptions, cancellationToken).ConfigureAwait(false) ?? [];
+            SchemaRegistryJsonTypeInfo.Int32List, cancellationToken).ConfigureAwait(false) ?? [];
     }
 
     public async Task<bool> IsCompatibleAsync(string subject, Schema schema, string version = "latest", CancellationToken cancellationToken = default)
@@ -265,7 +256,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         var response = await _httpClient.PostAsJsonAsync(
             $"compatibility/subjects/{Uri.EscapeDataString(subject)}/versions/{Uri.EscapeDataString(version)}",
             request,
-            _jsonOptions,
+            SchemaRegistryJsonTypeInfo.RegisterSchemaRequest,
             cancellationToken).ConfigureAwait(false);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
@@ -274,7 +265,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content.ReadFromJsonAsync<CompatibilityResponse>(
-            _jsonOptions, cancellationToken).ConfigureAwait(false);
+            SchemaRegistryJsonTypeInfo.CompatibilityResponse, cancellationToken).ConfigureAwait(false);
 
         return result?.IsCompatible ?? true;
     }
@@ -289,7 +280,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content.ReadFromJsonAsync<List<int>>(
-            _jsonOptions, cancellationToken).ConfigureAwait(false) ?? [];
+            SchemaRegistryJsonTypeInfo.Int32List, cancellationToken).ConfigureAwait(false) ?? [];
     }
 
     private static SchemaType ParseSchemaType(string? schemaType)
@@ -313,7 +304,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         try
         {
             var errorResponse = await response.Content.ReadFromJsonAsync<ErrorResponse>(
-                cancellationToken: cancellationToken).ConfigureAwait(false);
+                SchemaRegistryJsonTypeInfo.ErrorResponse, cancellationToken).ConfigureAwait(false);
             errorMessage = errorResponse?.Message;
             errorCode = errorResponse?.ErrorCode;
         }
@@ -334,55 +325,6 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         _httpClient.Dispose();
     }
 
-    // DTOs for JSON serialization
-    private sealed class RegisterSchemaRequest
-    {
-        public required string Schema { get; init; }
-        public string? SchemaType { get; init; }
-        public List<SchemaReferenceDto>? References { get; init; }
-    }
-
-    private sealed class RegisterSchemaResponse
-    {
-        public int Id { get; init; }
-    }
-
-    private sealed class GetSchemaResponse
-    {
-        public required string Schema { get; init; }
-        public string? SchemaType { get; init; }
-        public List<SchemaReferenceDto>? References { get; init; }
-    }
-
-    private sealed class GetSubjectVersionResponse
-    {
-        public required string Subject { get; init; }
-        public int Version { get; init; }
-        public int Id { get; init; }
-        public required string Schema { get; init; }
-        public string? SchemaType { get; init; }
-        public List<SchemaReferenceDto>? References { get; init; }
-    }
-
-    private sealed class SchemaReferenceDto
-    {
-        public required string Name { get; init; }
-        public required string Subject { get; init; }
-        public int Version { get; init; }
-    }
-
-    private sealed class CompatibilityResponse
-    {
-        [JsonPropertyName("is_compatible")]
-        public bool IsCompatible { get; init; }
-    }
-
-    private sealed class ErrorResponse
-    {
-        [JsonPropertyName("error_code")]
-        public int ErrorCode { get; init; }
-        public string? Message { get; init; }
-    }
 }
 
 /// <summary>

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryExtensions.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryExtensions.cs
@@ -1,5 +1,7 @@
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Dekaf.SchemaRegistry;
 
@@ -20,6 +22,8 @@ public static class SchemaRegistryExtensions
     /// <param name="subjectNameStrategy">Subject name strategy.</param>
     /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
     /// <returns>The builder for chaining.</returns>
+    [RequiresUnreferencedCode("JsonSerializerOptions-based JSON serialization uses reflection. Use the JsonTypeInfo<TValue> overload for NativeAOT.")]
+    [RequiresDynamicCode("JsonSerializerOptions-based JSON serialization may require runtime code generation. Use the JsonTypeInfo<TValue> overload for NativeAOT.")]
     public static ProducerBuilder<TKey, TValue> UseJsonSchemaRegistry<TKey, TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
@@ -39,6 +43,36 @@ public static class SchemaRegistryExtensions
     }
 
     /// <summary>
+    /// Configures the producer to use NativeAOT-safe JSON Schema Registry serialization for values.
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="builder">The producer builder.</param>
+    /// <param name="schemaRegistry">The Schema Registry client.</param>
+    /// <param name="jsonSchema">The JSON schema for the value type.</param>
+    /// <param name="jsonTypeInfo">Source-generated metadata for the value type.</param>
+    /// <param name="subjectNameStrategy">Subject name strategy.</param>
+    /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static ProducerBuilder<TKey, TValue> UseJsonSchemaRegistry<TKey, TValue>(
+        this ProducerBuilder<TKey, TValue> builder,
+        ISchemaRegistryClient schemaRegistry,
+        string jsonSchema,
+        JsonTypeInfo<TValue> jsonTypeInfo,
+        SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
+        bool autoRegisterSchemas = true)
+    {
+        var serializer = new JsonSchemaRegistrySerializer<TValue>(
+            schemaRegistry,
+            jsonSchema,
+            jsonTypeInfo,
+            subjectNameStrategy,
+            autoRegisterSchemas);
+
+        return builder.WithValueSerializer(serializer);
+    }
+
+    /// <summary>
     /// Configures the consumer to use JSON Schema Registry deserialization for values.
     /// </summary>
     /// <typeparam name="TKey">Key type.</typeparam>
@@ -47,6 +81,8 @@ public static class SchemaRegistryExtensions
     /// <param name="schemaRegistry">The Schema Registry client.</param>
     /// <param name="jsonOptions">Optional JSON serializer options.</param>
     /// <returns>The builder for chaining.</returns>
+    [RequiresUnreferencedCode("JsonSerializerOptions-based JSON deserialization uses reflection. Use the JsonTypeInfo<TValue> overload for NativeAOT.")]
+    [RequiresDynamicCode("JsonSerializerOptions-based JSON deserialization may require runtime code generation. Use the JsonTypeInfo<TValue> overload for NativeAOT.")]
     public static ConsumerBuilder<TKey, TValue> UseJsonSchemaRegistry<TKey, TValue>(
         this ConsumerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
@@ -55,6 +91,27 @@ public static class SchemaRegistryExtensions
         var deserializer = new JsonSchemaRegistryDeserializer<TValue>(
             schemaRegistry,
             jsonOptions);
+
+        return builder.WithValueDeserializer(deserializer);
+    }
+
+    /// <summary>
+    /// Configures the consumer to use NativeAOT-safe JSON Schema Registry deserialization for values.
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="builder">The consumer builder.</param>
+    /// <param name="schemaRegistry">The Schema Registry client.</param>
+    /// <param name="jsonTypeInfo">Source-generated metadata for the value type.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static ConsumerBuilder<TKey, TValue> UseJsonSchemaRegistry<TKey, TValue>(
+        this ConsumerBuilder<TKey, TValue> builder,
+        ISchemaRegistryClient schemaRegistry,
+        JsonTypeInfo<TValue> jsonTypeInfo)
+    {
+        var deserializer = new JsonSchemaRegistryDeserializer<TValue>(
+            schemaRegistry,
+            jsonTypeInfo);
 
         return builder.WithValueDeserializer(deserializer);
     }

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryJsonContext.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryJsonContext.cs
@@ -1,0 +1,99 @@
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Dekaf.SchemaRegistry;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(RegisterSchemaRequest))]
+[JsonSerializable(typeof(RegisterSchemaResponse))]
+[JsonSerializable(typeof(GetSchemaResponse))]
+[JsonSerializable(typeof(GetSubjectVersionResponse))]
+[JsonSerializable(typeof(SchemaReferenceDto))]
+[JsonSerializable(typeof(CompatibilityResponse))]
+[JsonSerializable(typeof(ErrorResponse))]
+[JsonSerializable(typeof(List<string>))]
+[JsonSerializable(typeof(List<int>))]
+internal sealed partial class SchemaRegistryJsonContext : JsonSerializerContext;
+
+internal static class SchemaRegistryJsonTypeInfo
+{
+    internal static readonly JsonTypeInfo<RegisterSchemaRequest> RegisterSchemaRequest =
+        GetRequired<RegisterSchemaRequest>();
+
+    internal static readonly JsonTypeInfo<RegisterSchemaResponse> RegisterSchemaResponse =
+        GetRequired<RegisterSchemaResponse>();
+
+    internal static readonly JsonTypeInfo<GetSchemaResponse> GetSchemaResponse =
+        GetRequired<GetSchemaResponse>();
+
+    internal static readonly JsonTypeInfo<GetSubjectVersionResponse> GetSubjectVersionResponse =
+        GetRequired<GetSubjectVersionResponse>();
+
+    internal static readonly JsonTypeInfo<CompatibilityResponse> CompatibilityResponse =
+        GetRequired<CompatibilityResponse>();
+
+    internal static readonly JsonTypeInfo<ErrorResponse> ErrorResponse =
+        GetRequired<ErrorResponse>();
+
+    internal static readonly JsonTypeInfo<List<string>> StringList =
+        GetRequired<List<string>>();
+
+    internal static readonly JsonTypeInfo<List<int>> Int32List =
+        GetRequired<List<int>>();
+
+    private static JsonTypeInfo<T> GetRequired<T>()
+    {
+        return (JsonTypeInfo<T>)SchemaRegistryJsonContext.Default.GetTypeInfo(typeof(T))!;
+    }
+}
+
+internal sealed class RegisterSchemaRequest
+{
+    public required string Schema { get; init; }
+    public string? SchemaType { get; init; }
+    public List<SchemaReferenceDto>? References { get; init; }
+}
+
+internal sealed class RegisterSchemaResponse
+{
+    public int Id { get; init; }
+}
+
+internal sealed class GetSchemaResponse
+{
+    public required string Schema { get; init; }
+    public string? SchemaType { get; init; }
+    public List<SchemaReferenceDto>? References { get; init; }
+}
+
+internal sealed class GetSubjectVersionResponse
+{
+    public required string Subject { get; init; }
+    public int Version { get; init; }
+    public int Id { get; init; }
+    public required string Schema { get; init; }
+    public string? SchemaType { get; init; }
+    public List<SchemaReferenceDto>? References { get; init; }
+}
+
+internal sealed class SchemaReferenceDto
+{
+    public required string Name { get; init; }
+    public required string Subject { get; init; }
+    public int Version { get; init; }
+}
+
+internal sealed class CompatibilityResponse
+{
+    [JsonPropertyName("is_compatible")]
+    public bool IsCompatible { get; init; }
+}
+
+internal sealed class ErrorResponse
+{
+    [JsonPropertyName("error_code")]
+    public int ErrorCode { get; init; }
+    public string? Message { get; init; }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryJsonAotTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryJsonAotTests.cs
@@ -1,0 +1,117 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Dekaf.SchemaRegistry;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class SchemaRegistryJsonAotTests
+{
+    private const string JsonSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "id": { "type": "integer" },
+            "name": { "type": "string" }
+          }
+        }
+        """;
+
+    [Test]
+    public async Task SchemaRegistryJsonContext_SerializesAndDeserializesRegistryDtos()
+    {
+        var request = new RegisterSchemaRequest
+        {
+            Schema = JsonSchema,
+            SchemaType = "JSON",
+            References =
+            [
+                new SchemaReferenceDto
+                {
+                    Name = "shared",
+                    Subject = "shared-value",
+                    Version = 2
+                }
+            ]
+        };
+
+        var requestJson = JsonSerializer.SerializeToUtf8Bytes(
+            request,
+            SchemaRegistryJsonTypeInfo.RegisterSchemaRequest);
+        var roundTrippedRequest = JsonSerializer.Deserialize(
+            requestJson,
+            SchemaRegistryJsonTypeInfo.RegisterSchemaRequest);
+
+        var subjectResponseJson = """
+            {
+              "subject": "orders-value",
+              "version": 3,
+              "id": 42,
+              "schema": "{}",
+              "schemaType": "JSON",
+              "references": [
+                {
+                  "name": "shared",
+                  "subject": "shared-value",
+                  "version": 2
+                }
+              ]
+            }
+            """u8;
+        var subjectResponse = JsonSerializer.Deserialize(
+            subjectResponseJson,
+            SchemaRegistryJsonTypeInfo.GetSubjectVersionResponse);
+
+        var compatibilityJson = JsonSerializer.SerializeToUtf8Bytes(
+            new CompatibilityResponse { IsCompatible = true },
+            SchemaRegistryJsonTypeInfo.CompatibilityResponse);
+        var errorJson = JsonSerializer.SerializeToUtf8Bytes(
+            new ErrorResponse { ErrorCode = 40401, Message = "missing" },
+            SchemaRegistryJsonTypeInfo.ErrorResponse);
+        using var compatibilityDocument = JsonDocument.Parse(compatibilityJson);
+        using var errorDocument = JsonDocument.Parse(errorJson);
+
+        await Assert.That(roundTrippedRequest!.SchemaType).IsEqualTo("JSON");
+        await Assert.That(roundTrippedRequest.References!.Count).IsEqualTo(1);
+        await Assert.That(subjectResponse!.Subject).IsEqualTo("orders-value");
+        await Assert.That(subjectResponse.References!.Count).IsEqualTo(1);
+        await Assert.That(compatibilityDocument.RootElement.TryGetProperty("is_compatible", out _)).IsTrue();
+        await Assert.That(errorDocument.RootElement.TryGetProperty("error_code", out _)).IsTrue();
+    }
+
+    [Test]
+    public async Task JsonSchemaRegistrySerializer_RoundTripsWithJsonTypeInfo()
+    {
+        var registry = new MockSchemaRegistryClient();
+        await using var serializer = new JsonSchemaRegistrySerializer<SchemaRegistryAotPayload>(
+            registry,
+            JsonSchema,
+            SchemaRegistryAotJsonContext.Default.SchemaRegistryAotPayload);
+        await using var deserializer = new JsonSchemaRegistryDeserializer<SchemaRegistryAotPayload>(
+            registry,
+            SchemaRegistryAotJsonContext.Default.SchemaRegistryAotPayload);
+        var payload = new SchemaRegistryAotPayload(7, "test");
+        var context = new SerializationContext
+        {
+            Topic = "orders",
+            Component = SerializationComponent.Value
+        };
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(payload, ref buffer, context);
+        var result = deserializer.Deserialize(buffer.WrittenMemory, context);
+
+        var schemaId = BinaryPrimitives.ReadInt32BigEndian(buffer.WrittenSpan.Slice(1, 4));
+        await Assert.That(buffer.WrittenSpan[0]).IsEqualTo((byte)0);
+        await Assert.That(schemaId).IsGreaterThan(0);
+        await Assert.That(result).IsEqualTo(payload);
+    }
+}
+
+internal sealed record SchemaRegistryAotPayload(int Id, string Name);
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(SchemaRegistryAotPayload))]
+internal sealed partial class SchemaRegistryAotJsonContext : JsonSerializerContext;


### PR DESCRIPTION
## Summary
- switch Schema Registry client DTO JSON to source-generated metadata
- add JsonTypeInfo<T> serializer/deserializer and builder overloads for JSON Schema Registry
- add unit coverage for DTO source-gen metadata and JsonTypeInfo round-trip

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit --configuration Release
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter "/*/*/SchemaRegistryJsonAotTests/*"
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter "/*/*/SchemaRegistryCacheTests/*"
- [x] dotnet build tests/Dekaf.Tests.Integration --configuration Release
- [x] ./tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration --treenode-filter "/*/*/JsonSchemaRegistryIntegrationTests/*"
- [x] NativeAOT smoke publish reached native linker with no SchemaRegistry IL warnings; local Windows C++ linker missing (`Platform linker not found`), and pre-existing src/Dekaf OAuth JSON IL2026/IL3050 warnings remain outside this issue.

Closes #1304