### PR TITLE
build(compat): establish netstandard2.0 restore baseline

### DIFF
--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -45,6 +45,32 @@ dotnet build src/Dekaf/Dekaf.csproj --configuration Release `
 
 That probe confirmed the work is cross-cutting and should not be shipped as one large PR.
 
+## netstandard2.0 Restore Baseline
+
+The #1299 baseline keeps `Dekaf` defaulting to `net10.0`, but adds the conditional project structure needed for an explicit `netstandard2.0` probe:
+
+- `System.IO.Pipelines`, `System.Threading.Channels`, and `System.Text.Json` package references are included only when `$(TargetFramework)` is `netstandard2.0`.
+- Modern compiler-support shims are included only for `netstandard2.0`, including `IsExternalInit`, required-member attributes, nullable flow annotation support, and `SkipLocalsInitAttribute`.
+- The forced probe now restores successfully and gets past the missing package-reference and required-member compiler-support errors.
+
+Run the current probe with:
+
+```powershell
+dotnet build src/Dekaf/Dekaf.csproj --configuration Release `
+  -p:TargetFrameworks=netstandard2.0 `
+  -p:TargetFramework=netstandard2.0
+```
+
+The probe is still expected to fail until #1300 removes or isolates the remaining core API blockers. Current blocker categories:
+
+- Runtime intrinsics: `System.Runtime.Intrinsics` is not available as a `netstandard2.0` package, so the CRC/vectorized record batch paths need conditional fallbacks.
+- Modern collection and threading APIs: `IReadOnlySet<T>`, `System.Threading.Lock`, `PeriodicTimer`, non-generic `TaskCompletionSource`, and `Task.WaitAsync`.
+- Runtime feature constraints: static abstract interface members, by-ref-like generics, and ref fields are not supported by the `netstandard2.0` target runtime.
+- Buffer and stream APIs: `SequenceReader<T>`, `ArrayBufferWriter<T>`, and span-based `Stream.Write(ReadOnlySpan<byte>)` need compatibility paths.
+- TLS/GSSAPI APIs: `SslClientAuthenticationOptions`, `NegotiateAuthentication`, and `NegotiateAuthenticationClientOptions` need target-specific handling.
+
+This baseline does not declare package support for `netstandard2.0`; it only makes the next compile-blocker work measurable.
+
 ## Blocker Categories
 
 ### Missing Package References

--- a/src/Dekaf/Compatibility/NetStandard20CompilerShims.cs
+++ b/src/Dekaf/Compatibility/NetStandard20CompilerShims.cs
@@ -1,0 +1,47 @@
+#if NETSTANDARD2_0
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Constructor, Inherited = false)]
+    internal sealed class SetsRequiredMembersAttribute : Attribute;
+
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute(bool returnValue) : Attribute
+    {
+        public bool ReturnValue { get; } = returnValue;
+    }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit;
+
+    [AttributeUsage(
+        AttributeTargets.Class
+        | AttributeTargets.Struct
+        | AttributeTargets.Field
+        | AttributeTargets.Property,
+        Inherited = false)]
+    internal sealed class RequiredMemberAttribute : Attribute;
+
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    internal sealed class CompilerFeatureRequiredAttribute(string featureName) : Attribute
+    {
+        public const string RefStructs = nameof(RefStructs);
+        public const string RequiredMembers = nameof(RequiredMembers);
+
+        public string FeatureName { get; } = featureName;
+        public bool IsOptional { get; set; }
+    }
+
+    [AttributeUsage(
+        AttributeTargets.Module
+        | AttributeTargets.Class
+        | AttributeTargets.Struct
+        | AttributeTargets.Interface
+        | AttributeTargets.Constructor
+        | AttributeTargets.Method
+        | AttributeTargets.Property,
+        Inherited = false)]
+    internal sealed class SkipLocalsInitAttribute : Attribute;
+}
+#endif

--- a/src/Dekaf/Dekaf.csproj
+++ b/src/Dekaf/Dekaf.csproj
@@ -24,4 +24,11 @@
     <PackageReference Include="System.IO.Hashing" Version="10.0.9" />
   </ItemGroup>
 
+  <!-- Compatibility probe dependencies only. Dekaf still defaults to net10.0 until netstandard2.0 support is complete. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.IO.Pipelines" Version="10.0.9" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
+    <PackageReference Include="System.Threading.Channels" Version="10.0.9" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add conditional netstandard2.0 probe package references for core inbox APIs
- add netstandard2.0-only compiler support shims for init/required/nullable/SkipLocalsInit
- document the restore baseline and remaining #1300 API blockers

## Test plan
- [x] dotnet build src/Dekaf/Dekaf.csproj --configuration Release -f net10.0
- [x] dotnet build src/Dekaf/Dekaf.csproj --configuration Release -p:TargetFrameworks=netstandard2.0 -p:TargetFramework=netstandard2.0 (expected to fail after restore on documented #1300 blockers)
- [x] npm ci --prefix docs --no-audit --no-fund
- [x] npm run build --prefix docs
- [x] git diff --check

Closes #1299