### PR TITLE
feat(consumer): add partitioned runtime

### DIFF
--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -258,7 +258,7 @@ Default behavior is fail-fast:
 
 When `StopPartition` stops a failed partition, the runtime logs the processor exception and pauses the partition while it remains assigned. A later revoke/lost event clears that stopped state so a legitimate reassignment can start a fresh lane.
 
-`Ignore` is opt-in only. It logs the processor exception, waits with exponential backoff between restarts, restarts the partition lane, and keeps the rest of the run active. `IgnoreRestartBackoff` controls the first delay and `IgnoreRestartBackoffMax` caps the delay. Prefer handling retries and dead-letter routing inside the processor so unexpected exceptions remain visible.
+`Ignore` is opt-in only. It logs the processor exception, waits with exponential backoff between restarts, restarts the partition lane, and keeps the rest of the run active. The restart wait is scheduled outside the shared poll/command loop, so healthy partitions continue to fetch and route while the failed partition backs off. `IgnoreRestartBackoff` controls the first delay and must be greater than zero; `IgnoreRestartBackoffMax` caps the delay. Prefer handling retries and dead-letter routing inside the processor so unexpected exceptions remain visible.
 
 If a processor does not stop within `StopTimeout`, the runtime treats that timeout as fatal because it can no longer guarantee one active processor per partition.
 

--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -226,7 +226,9 @@ The runtime must never commit offsets for records that were fetched but not mark
 
 ## Lost Lifecycle
 
-When partitions are lost involuntarily, the runtime cancels those partition lanes and completes their streams. It must not commit offsets for lost partitions by default because ownership is no longer guaranteed.
+When Dekaf's built-in `KafkaConsumer` reports partitions lost involuntarily through the coordinator rebalance callback, the runtime cancels those partition lanes and completes their streams. It does not commit offsets for lost partitions because ownership is no longer guaranteed.
+
+Manual assignment changes and custom `IKafkaConsumer` implementations that do not expose coordinator rebalance events cannot identify involuntary loss separately from ordinary assignment removal.
 
 Applications that write idempotently may still persist their own external offsets, but the runtime-managed Kafka commit policy should remain conservative.
 
@@ -252,7 +254,11 @@ Default behavior is fail-fast:
 
 `StopPartition` is available for advanced users, but it needs careful operational handling because a stopped partition that remains assigned can cause lag.
 
-`Ignore` is opt-in only. Prefer handling retries and dead-letter routing inside the processor so unexpected exceptions remain visible.
+When `StopPartition` stops a failed partition, the runtime pauses it while it remains assigned. A later revoke/lost event clears that stopped state so a legitimate reassignment can start a fresh lane.
+
+`Ignore` is opt-in only. It restarts the partition lane and keeps the rest of the run active. Prefer handling retries and dead-letter routing inside the processor so unexpected exceptions remain visible.
+
+If a processor does not stop within `StopTimeout`, the runtime treats that timeout as fatal because it can no longer guarantee one active processor per partition.
 
 ## Commit Semantics
 

--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -81,6 +81,8 @@ public sealed class PartitionedProcessingOptions
     public PartitionStopPolicy StopPolicy { get; init; } = PartitionStopPolicy.Drain;
     public TimeSpan StopTimeout { get; init; } = TimeSpan.FromSeconds(30);
     public PartitionWorkerErrorPolicy ErrorPolicy { get; init; } = PartitionWorkerErrorPolicy.StopConsumer;
+    public TimeSpan IgnoreRestartBackoff { get; init; } = TimeSpan.FromMilliseconds(100);
+    public TimeSpan IgnoreRestartBackoffMax { get; init; } = TimeSpan.FromSeconds(5);
     public PartitionCommitPolicy CommitPolicy { get; init; } = PartitionCommitPolicy.CommitCompletedOnRevoke;
     public TimeSpan CommitInterval { get; init; } = TimeSpan.FromSeconds(5);
 }
@@ -254,9 +256,9 @@ Default behavior is fail-fast:
 
 `StopPartition` is available for advanced users, but it needs careful operational handling because a stopped partition that remains assigned can cause lag.
 
-When `StopPartition` stops a failed partition, the runtime pauses it while it remains assigned. A later revoke/lost event clears that stopped state so a legitimate reassignment can start a fresh lane.
+When `StopPartition` stops a failed partition, the runtime logs the processor exception and pauses the partition while it remains assigned. A later revoke/lost event clears that stopped state so a legitimate reassignment can start a fresh lane.
 
-`Ignore` is opt-in only. It restarts the partition lane and keeps the rest of the run active. Prefer handling retries and dead-letter routing inside the processor so unexpected exceptions remain visible.
+`Ignore` is opt-in only. It logs the processor exception, waits with exponential backoff between restarts, restarts the partition lane, and keeps the rest of the run active. `IgnoreRestartBackoff` controls the first delay and `IgnoreRestartBackoffMax` caps the delay. Prefer handling retries and dead-letter routing inside the processor so unexpected exceptions remain visible.
 
 If a processor does not stop within `StopTimeout`, the runtime treats that timeout as fatal because it can no longer guarantee one active processor per partition.
 

--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -2,13 +2,13 @@
 sidebar_position: 6
 ---
 
-# Partitioned Async Processing API Proposal
+# Partitioned Async Processing
 
 :::info
-This is the proposed API contract for first-class partitioned async processing. It is not implemented yet. The runtime work is tracked by #1268.
+This page records the first public runtime API. Expanded user-facing docs and samples are tracked by #1269.
 :::
 
-Dekaf already exposes the low-level pieces needed for partition-aware consumers: `ConsumeAsync`, manual commits, `consumer.Partitions.Pause` / `consumer.Partitions.Resume`, and `IRebalanceListener`. The proposed partitioned processing API should make the common advanced model first-class:
+Dekaf already exposes the low-level pieces needed for partition-aware consumers: `ConsumeAsync`, manual commits, `consumer.Partitions.Pause` / `consumer.Partitions.Resume`, and `IRebalanceListener`. The partitioned processing API makes the common advanced model first-class:
 
 - one ordered async lane per assigned `TopicPartition`
 - parallel processing across partitions
@@ -16,7 +16,7 @@ Dekaf already exposes the low-level pieces needed for partition-aware consumers:
 - deterministic assignment, revoke, lost, and graceful stop behavior
 - offset commits based on completed processing, not fetched records
 
-## Proposed Shape
+## API Shape
 
 Add an extension method on `IKafkaConsumer<TKey, TValue>`:
 
@@ -47,7 +47,7 @@ static async ValueTask ProcessPartitionAsync(
 
 The method owns the consume loop while it runs. Applications should not call `ConsumeAsync`, `ConsumeBatchAsync`, `ConsumeRawBatchAsync`, `consumer.Partitions.Assign`, `consumer.Partitions.Unassign`, `consumer.Partitions.Pause`, or `consumer.Partitions.Resume` concurrently with `RunPartitionedAsync` on the same consumer.
 
-## Proposed Public Types
+## Public Types
 
 ```csharp
 public static class PartitionedConsumerExtensions
@@ -177,7 +177,7 @@ For each assigned partition, the runtime starts at most one active processor inv
 
 Different partitions may run concurrently. User code must protect shared application state the same way it would when running multiple tasks.
 
-The runtime may use `ConsumeAsync` or batch fetch APIs internally, but it must route each record to exactly one partition lane. It must not process a later offset for a partition until every earlier yielded offset for that partition has been delivered to the same lane.
+The runtime owns the consume loop internally and routes each record to exactly one partition lane. It must not process a later offset for a partition until every earlier yielded offset for that partition has been delivered to the same lane.
 
 The processor callback is long-lived. It starts when a partition is assigned and ends when that partition is revoked, lost, stopped, or when the whole consumer fails or is cancelled.
 
@@ -185,7 +185,7 @@ The processor callback is long-lived. It starts when a partition is assigned and
 
 Each partition lane has a bounded queue. `MaxBufferedRecordsPerPartition` is the maximum number of records the runtime may buffer for a single partition before applying backpressure.
 
-Default backpressure mode should be `PauseResume`:
+Default backpressure mode is `PauseResume`:
 
 - when a partition queue is full, the runtime pauses that partition
 - when queue capacity returns, the runtime resumes that partition
@@ -240,19 +240,19 @@ On `RunPartitionedAsync` cancellation or consumer close:
 4. Commit completed offsets when `CommitPolicy` permits it.
 5. Dispose partition state.
 
-If #1266 lands as a public graceful partition stop callback, the partitioned runtime can compose with that hook. If not, the runtime should own this lifecycle internally and document that it is the only supported graceful stop path for partitioned processors.
+The partitioned runtime owns this lifecycle internally. The lower-level #1266 partition stop callback remains available for consumers that do not use `RunPartitionedAsync`.
 
 ## Error Policy
 
-Default behavior should be fail-fast:
+Default behavior is fail-fast:
 
 - processor exception stops the partitioned run
 - all active lanes are cancelled or drained according to stop policy
 - the exception is propagated from `RunPartitionedAsync`
 
-`StopPartition` can be added for advanced users, but it needs explicit semantics for ownership, commits, and observability because a stopped partition that remains assigned can cause unbounded lag.
+`StopPartition` is available for advanced users, but it needs careful operational handling because a stopped partition that remains assigned can cause lag.
 
-`Ignore` should be opt-in only. It is appropriate when user code handles failures internally, such as retry plus dead-letter routing.
+`Ignore` is opt-in only. Prefer handling retries and dead-letter routing inside the processor so unexpected exceptions remain visible.
 
 ## Commit Semantics
 
@@ -264,7 +264,7 @@ Runtime-managed Kafka commits require manual offset mode:
 .WithOffsetCommitMode(OffsetCommitMode.Manual)
 ```
 
-If the consumer uses auto commit mode, `PartitionCommitPolicy.UserManaged` should be used or the runtime should reject commit policies that imply ownership of commit timing. Auto commit can commit fetched or yielded positions before partition processing completes, which conflicts with at-least-once partitioned processing.
+If the consumer uses auto commit mode, use `PartitionCommitPolicy.UserManaged`. Auto commit can commit fetched or yielded positions before partition processing completes, which conflicts with at-least-once partitioned processing.
 
 `CommitProcessedAsync` commits only the calling partition's completed offset. Revoke and graceful stop commits may batch completed offsets for multiple partitions into one `CommitAsync` call.
 
@@ -284,6 +284,6 @@ The separate base class is the clearer first version because it keeps existing h
 ## Prerequisites
 
 - #1265: coordinator-driven revocation must discard queued and prefetched records for removed partitions before any consume API yields them.
-- #1266: graceful partition stop semantics should be available, unless `RunPartitionedAsync` owns the full stop lifecycle internally.
-- #1268: implement the runtime after this proposal is accepted.
-- #1269: replace this proposal page with user-facing docs and samples after the runtime lands.
+- #1266: graceful partition stop semantics are available for the low-level listener path.
+- #1268: implements the partitioned runtime.
+- #1269: replaces this API page with full user-facing docs and samples.

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -20,6 +20,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
     private readonly IRebalanceListener? _rebalanceListener;
+    private IRebalanceListener? _runtimeRebalanceListener;
     private readonly ILogger _logger;
 
     private volatile int _coordinatorId = -1;
@@ -77,6 +78,34 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     public CoordinatorState State => _state;
     public IReadOnlySet<TopicPartition> Assignment => _assignedPartitions;
     internal int AssignmentVersion => Volatile.Read(ref _assignmentVersion);
+
+    internal IDisposable RegisterRuntimeRebalanceListener(IRebalanceListener listener)
+    {
+        ArgumentNullException.ThrowIfNull(listener);
+
+        if (Interlocked.CompareExchange(ref _runtimeRebalanceListener, listener, null) is not null)
+            throw new InvalidOperationException("A partitioned runtime rebalance listener is already registered.");
+
+        return new RuntimeRebalanceListenerRegistration(this, listener);
+    }
+
+    private void UnregisterRuntimeRebalanceListener(IRebalanceListener listener)
+    {
+        Interlocked.CompareExchange(ref _runtimeRebalanceListener, null, listener);
+    }
+
+    private sealed class RuntimeRebalanceListenerRegistration(
+        ConsumerCoordinator coordinator,
+        IRebalanceListener listener) : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                coordinator.UnregisterRuntimeRebalanceListener(listener);
+        }
+    }
 
     private static void RemoveEmptyTopicGroups<TItem>(Dictionary<string, List<TItem>> topicGroups)
     {
@@ -324,6 +353,33 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogRebalanceListenerCallbackError(callbackName, ex);
+        }
+    }
+
+    private async ValueTask InvokeRebalanceListenersAsync(
+        string callbackName,
+        IReadOnlyList<TopicPartition> partitions,
+        Func<IRebalanceListener, IEnumerable<TopicPartition>, CancellationToken, ValueTask> callback,
+        CancellationToken cancellationToken)
+    {
+        var configuredListener = _rebalanceListener;
+        if (configuredListener is not null)
+        {
+            await InvokeRebalanceListenerAsync(
+                callbackName,
+                partitions,
+                (items, token) => callback(configuredListener, items, token),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        var runtimeListener = Volatile.Read(ref _runtimeRebalanceListener);
+        if (runtimeListener is not null)
+        {
+            await InvokeRebalanceListenerAsync(
+                callbackName,
+                partitions,
+                (items, token) => callback(runtimeListener, items, token),
+                cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -627,22 +683,22 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         ConsumerHeartbeatResult result,
         CancellationToken cancellationToken)
     {
-        if (!result.AssignmentChanged || _rebalanceListener is null)
+        if (!result.AssignmentChanged)
             return;
 
         if (result.Revoked is { Count: > 0 })
-        {
-            await InvokeRebalanceListenerAsync(
-                "OnPartitionsRevoked", result.Revoked,
-                _rebalanceListener.OnPartitionsRevokedAsync, cancellationToken).ConfigureAwait(false);
-        }
+            await InvokeRebalanceListenersAsync(
+                "OnPartitionsRevoked",
+                result.Revoked,
+                static (listener, partitions, token) => listener.OnPartitionsRevokedAsync(partitions, token),
+                cancellationToken).ConfigureAwait(false);
 
         if (result.Assigned is { Count: > 0 })
-        {
-            await InvokeRebalanceListenerAsync(
-                "OnPartitionsAssigned", result.Assigned,
-                _rebalanceListener.OnPartitionsAssignedAsync, cancellationToken).ConfigureAwait(false);
-        }
+            await InvokeRebalanceListenersAsync(
+                "OnPartitionsAssigned",
+                result.Assigned,
+                static (listener, partitions, token) => listener.OnPartitionsAssignedAsync(partitions, token),
+                cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -1036,16 +1092,14 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                             break;
 
                         case ErrorCode.UnknownMemberId:
-                            if (_rebalanceListener is not null)
+                            var lost = _assignedPartitions.ToList();
+                            if (lost.Count > 0)
                             {
-                                var lost = _assignedPartitions.ToList();
-                                if (lost.Count > 0)
-                                {
-                                    await InvokeRebalanceListenerAsync(
-                                        "OnPartitionsLost", lost,
-                                        _rebalanceListener.OnPartitionsLostAsync,
-                                        CancellationToken.None).ConfigureAwait(false);
-                                }
+                                await InvokeRebalanceListenersAsync(
+                                    "OnPartitionsLost",
+                                    lost,
+                                    static (listener, partitions, token) => listener.OnPartitionsLostAsync(partitions, token),
+                                    CancellationToken.None).ConfigureAwait(false);
                             }
 
                             ResetMemberState();

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -459,6 +459,11 @@ public interface IRebalanceListener
     ValueTask OnPartitionsLostAsync(IEnumerable<TopicPartition> partitions, CancellationToken cancellationToken);
 }
 
+internal interface IConsumerRebalanceEventSource
+{
+    IDisposable RegisterRuntimeRebalanceListener(IRebalanceListener listener);
+}
+
 /// <summary>
 /// Optional companion interface for observing graceful partition stop during
 /// <see cref="IKafkaConsumer{TKey,TValue}.CloseAsync"/> or

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -564,6 +564,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     IConsumerPartitions,
     IConsumerOffsets,
     IConsumerRebalanceEventSource,
+    IConsumerLoggerFactorySource,
     DeadLetter.IRawRecordAccessor,
     IBudgetedInstance
 {
@@ -610,6 +611,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly bool _ownsInfrastructure;
     private readonly ConsumerCoordinator? _coordinator;
     private readonly CompressionCodecRegistry _compressionCodecs;
+    private readonly ILoggerFactory? _loggerFactory;
     private readonly ILogger _logger;
 
     private readonly ConcurrentDictionary<string, byte> _subscription = new();
@@ -892,6 +894,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _memoryBudget = memoryBudget;
         _telemetryMetricCollector = infrastructure.TelemetryMetricCollector;
         _telemetryMetricCollector.RegisterMetricsForSubscription(options.ApplicationMetrics);
+        _loggerFactory = loggerFactory;
         _telemetryManager = new ClientTelemetryManager(
             _connectionPool,
             _metadataManager,
@@ -964,6 +967,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         return _coordinator?.RegisterRuntimeRebalanceListener(listener) ?? NoopDisposable.Instance;
     }
+
+    ILoggerFactory? IConsumerLoggerFactorySource.LoggerFactory => _loggerFactory;
 
     /// <inheritdoc />
     public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -563,6 +563,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     IConsumerPositions,
     IConsumerPartitions,
     IConsumerOffsets,
+    IConsumerRebalanceEventSource,
     DeadLetter.IRawRecordAccessor,
     IBudgetedInstance
 {
@@ -580,6 +581,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private long _currentQueuedMaxBytes;
 
     internal ulong CurrentQueuedMaxBytes => (ulong)Volatile.Read(ref _currentQueuedMaxBytes);
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static readonly NoopDisposable Instance = new();
+
+        private NoopDisposable()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
 
     void IBudgetedInstance.OnBudgetChanged(ulong newLimit)
     {
@@ -945,6 +959,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     public IConsumerPositions Positions => this;
     public IConsumerPartitions Partitions => this;
     public IConsumerOffsets Offsets => this;
+
+    IDisposable IConsumerRebalanceEventSource.RegisterRuntimeRebalanceListener(IRebalanceListener listener)
+    {
+        return _coordinator?.RegisterRuntimeRebalanceListener(listener) ?? NoopDisposable.Instance;
+    }
 
     /// <inheritdoc />
     public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -1,0 +1,815 @@
+using System.Runtime.ExceptionServices;
+using System.Threading.Channels;
+
+namespace Dekaf.Consumer;
+
+/// <summary>
+/// Extension methods for high-level partitioned consumer processing.
+/// </summary>
+public static class PartitionedConsumerExtensions
+{
+    /// <summary>
+    /// Runs one ordered asynchronous processor lane per assigned partition.
+    /// </summary>
+    public static async ValueTask RunPartitionedAsync<TKey, TValue>(
+        this IKafkaConsumer<TKey, TValue> consumer,
+        PartitionProcessor<TKey, TValue> processor,
+        PartitionedProcessingOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(consumer);
+        ArgumentNullException.ThrowIfNull(processor);
+
+        options ??= new PartitionedProcessingOptions();
+        options.Validate();
+
+        var runtime = new PartitionedConsumerRuntime<TKey, TValue>(consumer, processor, options);
+        await runtime.RunAsync(cancellationToken).ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// Processes all messages for one assigned partition.
+/// </summary>
+public delegate ValueTask PartitionProcessor<TKey, TValue>(
+    PartitionProcessorContext<TKey, TValue> context,
+    CancellationToken cancellationToken);
+
+/// <summary>
+/// Partition-scoped processing context.
+/// </summary>
+public sealed class PartitionProcessorContext<TKey, TValue>
+{
+    private readonly PartitionLane<TKey, TValue> _lane;
+
+    internal PartitionProcessorContext(PartitionLane<TKey, TValue> lane)
+    {
+        _lane = lane;
+    }
+
+    /// <summary>
+    /// Gets the partition owned by this processor.
+    /// </summary>
+    public TopicPartition TopicPartition => _lane.TopicPartition;
+
+    /// <summary>
+    /// Gets the ordered message stream for this partition.
+    /// </summary>
+    public IAsyncEnumerable<ConsumeResult<TKey, TValue>> Messages => _lane.Messages;
+
+    /// <summary>
+    /// Gets the token signaled when this partition processor should stop.
+    /// </summary>
+    public CancellationToken StoppingToken => _lane.StoppingToken;
+
+    /// <summary>
+    /// Marks a message as processed and eligible for commit.
+    /// </summary>
+    public void MarkProcessed(ConsumeResult<TKey, TValue> message)
+    {
+        _lane.MarkProcessed(message);
+    }
+
+    /// <summary>
+    /// Commits the last offset marked as processed for this partition.
+    /// </summary>
+    public ValueTask CommitProcessedAsync(CancellationToken cancellationToken = default)
+    {
+        return _lane.CommitProcessedAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets the last message offset marked as processed for this partition.
+    /// </summary>
+    public long? LastProcessedOffset => _lane.LastProcessedOffset;
+}
+
+/// <summary>
+/// Options for partitioned consumer processing.
+/// </summary>
+public sealed class PartitionedProcessingOptions
+{
+    /// <summary>
+    /// Gets the maximum queued records per partition lane.
+    /// </summary>
+    public int MaxBufferedRecordsPerPartition { get; init; } = 256;
+
+    /// <summary>
+    /// Gets how the runtime applies backpressure when a partition lane is full.
+    /// </summary>
+    public PartitionBackpressureMode BackpressureMode { get; init; } = PartitionBackpressureMode.PauseResume;
+
+    /// <summary>
+    /// Gets how partition processors stop during revoke, lost assignment, or shutdown.
+    /// </summary>
+    public PartitionStopPolicy StopPolicy { get; init; } = PartitionStopPolicy.Drain;
+
+    /// <summary>
+    /// Gets the maximum time to wait for a partition processor to stop.
+    /// </summary>
+    public TimeSpan StopTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets how processor failures affect the partitioned run.
+    /// </summary>
+    public PartitionWorkerErrorPolicy ErrorPolicy { get; init; } = PartitionWorkerErrorPolicy.StopConsumer;
+
+    /// <summary>
+    /// Gets how completed partition offsets are committed.
+    /// </summary>
+    public PartitionCommitPolicy CommitPolicy { get; init; } = PartitionCommitPolicy.CommitCompletedOnRevoke;
+
+    /// <summary>
+    /// Gets the interval for periodic completed-offset commits.
+    /// </summary>
+    public TimeSpan CommitInterval { get; init; } = TimeSpan.FromSeconds(5);
+
+    internal void Validate()
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(MaxBufferedRecordsPerPartition, 1);
+
+        if (StopTimeout < TimeSpan.Zero && StopTimeout != Timeout.InfiniteTimeSpan)
+            throw new ArgumentOutOfRangeException(nameof(StopTimeout));
+
+        if (CommitInterval <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(CommitInterval));
+    }
+}
+
+/// <summary>
+/// Backpressure behavior for a full partition lane.
+/// </summary>
+public enum PartitionBackpressureMode
+{
+    /// <summary>
+    /// Pause the full partition and resume it when queue capacity returns.
+    /// </summary>
+    PauseResume,
+
+    /// <summary>
+    /// Await queue capacity without changing the consumer pause state.
+    /// </summary>
+    AwaitCapacity
+}
+
+/// <summary>
+/// Stop behavior for partition processors.
+/// </summary>
+public enum PartitionStopPolicy
+{
+    /// <summary>
+    /// Complete the message stream and let the processor drain queued records.
+    /// </summary>
+    Drain,
+
+    /// <summary>
+    /// Cancel the processor immediately.
+    /// </summary>
+    Cancel
+}
+
+/// <summary>
+/// Failure behavior for partition processors.
+/// </summary>
+public enum PartitionWorkerErrorPolicy
+{
+    /// <summary>
+    /// Stop the whole partitioned run and propagate the exception.
+    /// </summary>
+    StopConsumer,
+
+    /// <summary>
+    /// Stop the failed partition and pause it.
+    /// </summary>
+    StopPartition,
+
+    /// <summary>
+    /// Stop the failed partition and keep the rest of the run active.
+    /// </summary>
+    Ignore
+}
+
+/// <summary>
+/// Offset commit behavior for completed partition records.
+/// </summary>
+public enum PartitionCommitPolicy
+{
+    /// <summary>
+    /// The application owns all offset commits.
+    /// </summary>
+    UserManaged,
+
+    /// <summary>
+    /// Commit completed offsets when partitions stop or are revoked.
+    /// </summary>
+    CommitCompletedOnRevoke,
+
+    /// <summary>
+    /// Commit completed offsets periodically and when partitions stop or are revoked.
+    /// </summary>
+    CommitCompletedPeriodically
+}
+
+internal enum PartitionStopReason
+{
+    Revoke,
+    Shutdown,
+    Failure
+}
+
+internal sealed class PartitionedConsumerRuntime<TKey, TValue>
+{
+    private static readonly TimeSpan ConsumePollTimeout = TimeSpan.FromMilliseconds(100);
+
+    private readonly IKafkaConsumer<TKey, TValue> _consumer;
+    private readonly PartitionProcessor<TKey, TValue> _processor;
+    private readonly PartitionedProcessingOptions _options;
+    private readonly Dictionary<TopicPartition, PartitionLane<TKey, TValue>> _lanes = [];
+    private readonly HashSet<TopicPartition> _pausedByRuntime = [];
+    private readonly HashSet<TopicPartition> _stoppedByFailure = [];
+    private readonly Channel<RuntimeCommand<TKey, TValue>> _commands;
+    private readonly CancellationTokenSource _failureCancellation = new();
+    private readonly object _failureGate = new();
+    private ExceptionDispatchInfo? _failure;
+    private DateTimeOffset _nextPeriodicCommit;
+
+    public PartitionedConsumerRuntime(
+        IKafkaConsumer<TKey, TValue> consumer,
+        PartitionProcessor<TKey, TValue> processor,
+        PartitionedProcessingOptions options)
+    {
+        _consumer = consumer;
+        _processor = processor;
+        _options = options;
+        _commands = Channel.CreateUnbounded<RuntimeCommand<TKey, TValue>>(new UnboundedChannelOptions
+        {
+            AllowSynchronousContinuations = false,
+            SingleReader = true,
+            SingleWriter = false
+        });
+        _nextPeriodicCommit = DateTimeOffset.UtcNow.Add(_options.CommitInterval);
+    }
+
+    public async ValueTask RunAsync(CancellationToken cancellationToken)
+    {
+        using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            _failureCancellation.Token);
+
+        try
+        {
+            await SyncAssignmentAsync(linkedCancellation.Token).ConfigureAwait(false);
+
+            while (true)
+            {
+                linkedCancellation.Token.ThrowIfCancellationRequested();
+
+                await DrainCommandsAsync(linkedCancellation.Token).ConfigureAwait(false);
+                ThrowIfFailed();
+                await CommitPeriodicallyAsync(linkedCancellation.Token).ConfigureAwait(false);
+
+                var result = await _consumer.ConsumeOneAsync(
+                    ConsumePollTimeout,
+                    linkedCancellation.Token).ConfigureAwait(false);
+
+                await DrainCommandsAsync(linkedCancellation.Token).ConfigureAwait(false);
+                ThrowIfFailed();
+                await SyncAssignmentAsync(linkedCancellation.Token).ConfigureAwait(false);
+
+                if (result.HasValue && !result.Value.IsPartitionEof)
+                    await RouteAsync(result.Value, linkedCancellation.Token).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (_failure is not null)
+        {
+        }
+        finally
+        {
+            await StopAllAsync(CancellationToken.None).ConfigureAwait(false);
+            _commands.Writer.TryComplete();
+            CompletePendingCommands();
+        }
+
+        ThrowIfFailed();
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    public ValueTask CommitProcessedAsync(
+        PartitionLane<TKey, TValue> lane,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            return ValueTask.FromCanceled(cancellationToken);
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var command = RuntimeCommand<TKey, TValue>.Commit(lane, completion, cancellationToken);
+
+        if (!_commands.Writer.TryWrite(command))
+            return ValueTask.FromException(new InvalidOperationException("Partitioned processing runtime is not accepting commit requests."));
+
+        return new ValueTask(completion.Task.WaitAsync(cancellationToken));
+    }
+
+    private async ValueTask SyncAssignmentAsync(CancellationToken cancellationToken)
+    {
+        var assignment = _consumer.Partitions.Assignment;
+
+        foreach (var partition in _lanes.Keys.Where(partition => !assignment.Contains(partition)).ToArray())
+        {
+            var lane = _lanes[partition];
+            _lanes.Remove(partition);
+            _pausedByRuntime.Remove(partition);
+            await StopLaneAsync(
+                lane,
+                PartitionStopReason.Revoke,
+                commitProcessed: ShouldCommitOnPartitionStop(),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        foreach (var partition in assignment)
+        {
+            if (_lanes.ContainsKey(partition) || _stoppedByFailure.Contains(partition))
+                continue;
+
+            StartLane(partition);
+        }
+    }
+
+    private async ValueTask RouteAsync(
+        ConsumeResult<TKey, TValue> result,
+        CancellationToken cancellationToken)
+    {
+        var partition = new TopicPartition(result.Topic, result.Partition);
+        if (!_lanes.TryGetValue(partition, out var lane))
+            return;
+
+        while (!lane.TryEnqueue(result))
+        {
+            PauseIfNeeded(lane);
+            var canWrite = await lane.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
+            await DrainCommandsAsync(cancellationToken).ConfigureAwait(false);
+            ThrowIfFailed();
+
+            if (!canWrite || !_lanes.TryGetValue(partition, out lane))
+                return;
+        }
+
+        PauseIfNeeded(lane);
+    }
+
+    private void StartLane(TopicPartition partition)
+    {
+        var lane = new PartitionLane<TKey, TValue>(
+            partition,
+            _options.MaxBufferedRecordsPerPartition,
+            CommitProcessedAsync,
+            OnLaneCapacityAvailable,
+            OnLaneFailed);
+
+        _lanes.Add(partition, lane);
+        lane.Start(_processor);
+    }
+
+    private void PauseIfNeeded(PartitionLane<TKey, TValue> lane)
+    {
+        if (_options.BackpressureMode != PartitionBackpressureMode.PauseResume || !lane.IsFull)
+            return;
+
+        if (_pausedByRuntime.Add(lane.TopicPartition))
+            _consumer.Partitions.Pause(lane.TopicPartition);
+    }
+
+    private void ResumeIfNeeded(PartitionLane<TKey, TValue> lane)
+    {
+        if (_options.BackpressureMode != PartitionBackpressureMode.PauseResume || !lane.HasCapacity)
+            return;
+
+        if (_pausedByRuntime.Remove(lane.TopicPartition))
+            _consumer.Partitions.Resume(lane.TopicPartition);
+    }
+
+    private void OnLaneCapacityAvailable(PartitionLane<TKey, TValue> lane)
+    {
+        _commands.Writer.TryWrite(RuntimeCommand<TKey, TValue>.Resume(lane));
+    }
+
+    private void OnLaneFailed(PartitionLane<TKey, TValue> lane, Exception exception)
+    {
+        if (_options.ErrorPolicy == PartitionWorkerErrorPolicy.StopConsumer)
+        {
+            CaptureFailure(exception);
+            _failureCancellation.Cancel();
+            return;
+        }
+
+        _commands.Writer.TryWrite(RuntimeCommand<TKey, TValue>.StopFailed(lane, exception));
+    }
+
+    private async ValueTask DrainCommandsAsync(CancellationToken cancellationToken)
+    {
+        while (_commands.Reader.TryRead(out var command))
+        {
+            switch (command.Kind)
+            {
+                case RuntimeCommandKind.Resume:
+                    if (_lanes.TryGetValue(command.Lane.TopicPartition, out var lane))
+                        ResumeIfNeeded(lane);
+
+                    break;
+
+                case RuntimeCommandKind.Commit:
+                    await CompleteCommitCommandAsync(command, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case RuntimeCommandKind.StopFailed:
+                    await StopFailedLaneAsync(command.Lane, command.Exception!, cancellationToken).ConfigureAwait(false);
+                    break;
+            }
+        }
+    }
+
+    private async ValueTask CompleteCommitCommandAsync(
+        RuntimeCommand<TKey, TValue> command,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                command.CancellationToken);
+
+            await CommitLaneAsync(command.Lane, linkedCancellation.Token).ConfigureAwait(false);
+            command.Completion!.TrySetResult();
+        }
+        catch (OperationCanceledException ex)
+        {
+            command.Completion!.TrySetCanceled(ex.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            command.Completion!.TrySetException(ex);
+        }
+    }
+
+    private async ValueTask StopFailedLaneAsync(
+        PartitionLane<TKey, TValue> lane,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (!_lanes.Remove(lane.TopicPartition))
+            return;
+
+        _stoppedByFailure.Add(lane.TopicPartition);
+        if (_pausedByRuntime.Add(lane.TopicPartition))
+            _consumer.Partitions.Pause(lane.TopicPartition);
+
+        await StopLaneAsync(
+            lane,
+            PartitionStopReason.Failure,
+            commitProcessed: false,
+            cancellationToken).ConfigureAwait(false);
+
+        if (_options.ErrorPolicy == PartitionWorkerErrorPolicy.StopConsumer)
+        {
+            _failure ??= ExceptionDispatchInfo.Capture(exception);
+            _failureCancellation.Cancel();
+        }
+    }
+
+    private async ValueTask StopLaneAsync(
+        PartitionLane<TKey, TValue> lane,
+        PartitionStopReason reason,
+        bool commitProcessed,
+        CancellationToken cancellationToken)
+    {
+        var exception = await lane.StopAsync(
+            reason == PartitionStopReason.Failure ? PartitionStopPolicy.Cancel : _options.StopPolicy,
+            _options.StopTimeout).ConfigureAwait(false);
+
+        if (commitProcessed)
+            await CommitLaneAsync(lane, cancellationToken).ConfigureAwait(false);
+
+        if (exception is not null && _options.ErrorPolicy == PartitionWorkerErrorPolicy.StopConsumer)
+        {
+            CaptureFailure(exception);
+            _failureCancellation.Cancel();
+        }
+    }
+
+    private async ValueTask StopAllAsync(CancellationToken cancellationToken)
+    {
+        foreach (var lane in _lanes.Values.ToArray())
+        {
+            _lanes.Remove(lane.TopicPartition);
+            await StopLaneAsync(
+                lane,
+                PartitionStopReason.Shutdown,
+                commitProcessed: ShouldCommitOnPartitionStop(),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        if (_pausedByRuntime.Count > 0)
+        {
+            _consumer.Partitions.Resume(_pausedByRuntime.ToArray());
+            _pausedByRuntime.Clear();
+        }
+    }
+
+    private async ValueTask CommitPeriodicallyAsync(CancellationToken cancellationToken)
+    {
+        if (_options.CommitPolicy != PartitionCommitPolicy.CommitCompletedPeriodically)
+            return;
+
+        var now = DateTimeOffset.UtcNow;
+        if (now < _nextPeriodicCommit)
+            return;
+
+        _nextPeriodicCommit = now.Add(_options.CommitInterval);
+
+        var offsets = _lanes.Values
+            .Select(static lane => lane.GetCommitOffset())
+            .OfType<TopicPartitionOffset>()
+            .ToArray();
+
+        if (offsets.Length > 0)
+            await _consumer.CommitAsync(offsets, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask CommitLaneAsync(
+        PartitionLane<TKey, TValue> lane,
+        CancellationToken cancellationToken)
+    {
+        var offset = lane.GetCommitOffset();
+        if (offset.HasValue)
+            await _consumer.CommitAsync([offset.Value], cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool ShouldCommitOnPartitionStop()
+    {
+        return _options.CommitPolicy is PartitionCommitPolicy.CommitCompletedOnRevoke
+            or PartitionCommitPolicy.CommitCompletedPeriodically;
+    }
+
+    private void ThrowIfFailed()
+    {
+        _failure?.Throw();
+    }
+
+    private void CaptureFailure(Exception exception)
+    {
+        lock (_failureGate)
+            _failure ??= ExceptionDispatchInfo.Capture(exception);
+    }
+
+    private void CompletePendingCommands()
+    {
+        while (_commands.Reader.TryRead(out var command))
+        {
+            if (command.Kind == RuntimeCommandKind.Commit)
+                command.Completion!.TrySetCanceled();
+        }
+    }
+}
+
+internal sealed class PartitionLane<TKey, TValue>
+{
+    private readonly Channel<ConsumeResult<TKey, TValue>> _channel;
+    private readonly Func<PartitionLane<TKey, TValue>, CancellationToken, ValueTask> _commitProcessed;
+    private readonly Action<PartitionLane<TKey, TValue>> _capacityAvailable;
+    private readonly Action<PartitionLane<TKey, TValue>, Exception> _failed;
+    private readonly CancellationTokenSource _stopping = new();
+    private readonly PartitionProcessorContext<TKey, TValue> _context;
+    private readonly object _offsetGate = new();
+    private readonly int _capacity;
+    private Task? _processorTask;
+    private int _bufferedCount;
+    private int _completed;
+    private long? _completedOffset;
+    private long? _lastProcessedOffset;
+    private int _lastProcessedLeaderEpoch = -1;
+
+    public PartitionLane(
+        TopicPartition topicPartition,
+        int capacity,
+        Func<PartitionLane<TKey, TValue>, CancellationToken, ValueTask> commitProcessed,
+        Action<PartitionLane<TKey, TValue>> capacityAvailable,
+        Action<PartitionLane<TKey, TValue>, Exception> failed)
+    {
+        TopicPartition = topicPartition;
+        _capacity = capacity;
+        _commitProcessed = commitProcessed;
+        _capacityAvailable = capacityAvailable;
+        _failed = failed;
+        _context = new PartitionProcessorContext<TKey, TValue>(this);
+        _channel = Channel.CreateBounded<ConsumeResult<TKey, TValue>>(new BoundedChannelOptions(capacity)
+        {
+            AllowSynchronousContinuations = false,
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = true
+        });
+    }
+
+    public TopicPartition TopicPartition { get; }
+
+    public CancellationToken StoppingToken => _stopping.Token;
+
+    public IAsyncEnumerable<ConsumeResult<TKey, TValue>> Messages => ReadMessagesAsync(_stopping.Token);
+
+    public long? LastProcessedOffset
+    {
+        get
+        {
+            lock (_offsetGate)
+                return _lastProcessedOffset;
+        }
+    }
+
+    public bool IsFull => Volatile.Read(ref _bufferedCount) >= _capacity;
+
+    public bool HasCapacity => Volatile.Read(ref _bufferedCount) < _capacity;
+
+    public void Start(PartitionProcessor<TKey, TValue> processor)
+    {
+        _processorTask = Task.Run(async () =>
+        {
+            try
+            {
+                await processor(_context, _stopping.Token).ConfigureAwait(false);
+                if (Volatile.Read(ref _completed) == 0)
+                {
+                    _failed(
+                        this,
+                        new InvalidOperationException(
+                            $"Partition processor for {TopicPartition.Topic}:{TopicPartition.Partition} completed before the partition stopped."));
+                }
+            }
+            catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
+            {
+            }
+            catch (Exception ex)
+            {
+                _failed(this, ex);
+                throw;
+            }
+        });
+    }
+
+    public bool TryEnqueue(ConsumeResult<TKey, TValue> result)
+    {
+        if (Volatile.Read(ref _completed) != 0)
+            return false;
+
+        Interlocked.Increment(ref _bufferedCount);
+        if (_channel.Writer.TryWrite(result))
+            return true;
+
+        Interlocked.Decrement(ref _bufferedCount);
+        return false;
+    }
+
+    public ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken)
+    {
+        return _channel.Writer.WaitToWriteAsync(cancellationToken);
+    }
+
+    public void MarkProcessed(ConsumeResult<TKey, TValue> message)
+    {
+        var partition = new TopicPartition(message.Topic, message.Partition);
+        if (partition != TopicPartition)
+            throw new InvalidOperationException("Cannot mark a message from another partition as processed.");
+
+        if (message.IsPartitionEof)
+            return;
+
+        lock (_offsetGate)
+        {
+            var completedOffset = message.Offset + 1;
+            if (!_completedOffset.HasValue || completedOffset > _completedOffset.Value)
+            {
+                _completedOffset = completedOffset;
+                _lastProcessedOffset = message.Offset;
+                _lastProcessedLeaderEpoch = message.LeaderEpoch ?? -1;
+            }
+        }
+    }
+
+    public TopicPartitionOffset? GetCommitOffset()
+    {
+        lock (_offsetGate)
+        {
+            return _completedOffset.HasValue
+                ? new TopicPartitionOffset(
+                    TopicPartition.Topic,
+                    TopicPartition.Partition,
+                    _completedOffset.Value,
+                    _lastProcessedLeaderEpoch)
+                : null;
+        }
+    }
+
+    public ValueTask CommitProcessedAsync(CancellationToken cancellationToken)
+    {
+        return _commitProcessed(this, cancellationToken);
+    }
+
+    public async ValueTask<Exception?> StopAsync(
+        PartitionStopPolicy stopPolicy,
+        TimeSpan timeout)
+    {
+        CompleteWriter();
+
+        if (stopPolicy == PartitionStopPolicy.Cancel)
+            await CancelAsync().ConfigureAwait(false);
+
+        if (_processorTask is null)
+            return null;
+
+        try
+        {
+            if (timeout == Timeout.InfiniteTimeSpan)
+            {
+                await _processorTask.ConfigureAwait(false);
+            }
+            else
+            {
+                await _processorTask.WaitAsync(timeout).ConfigureAwait(false);
+            }
+
+            return null;
+        }
+        catch (TimeoutException)
+        {
+            await CancelAsync().ConfigureAwait(false);
+            _ = _processorTask.ContinueWith(
+                static task => _ = task.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+            return null;
+        }
+        catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
+        {
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+    }
+
+    private async IAsyncEnumerable<ConsumeResult<TKey, TValue>> ReadMessagesAsync(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        while (await _channel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (_channel.Reader.TryRead(out var item))
+            {
+                Interlocked.Decrement(ref _bufferedCount);
+                _capacityAvailable(this);
+                yield return item;
+            }
+        }
+    }
+
+    private void CompleteWriter()
+    {
+        if (Interlocked.Exchange(ref _completed, 1) == 0)
+            _channel.Writer.TryComplete();
+    }
+
+    private async ValueTask CancelAsync()
+    {
+        if (!_stopping.IsCancellationRequested)
+            await _stopping.CancelAsync().ConfigureAwait(false);
+    }
+}
+
+internal enum RuntimeCommandKind
+{
+    Resume,
+    Commit,
+    StopFailed
+}
+
+internal readonly record struct RuntimeCommand<TKey, TValue>(
+    RuntimeCommandKind Kind,
+    PartitionLane<TKey, TValue> Lane,
+    TaskCompletionSource? Completion,
+    Exception? Exception,
+    CancellationToken CancellationToken)
+{
+    public static RuntimeCommand<TKey, TValue> Resume(PartitionLane<TKey, TValue> lane)
+        => new(RuntimeCommandKind.Resume, lane, null, null, CancellationToken.None);
+
+    public static RuntimeCommand<TKey, TValue> Commit(
+        PartitionLane<TKey, TValue> lane,
+        TaskCompletionSource completion,
+        CancellationToken cancellationToken)
+        => new(RuntimeCommandKind.Commit, lane, completion, null, cancellationToken);
+
+    public static RuntimeCommand<TKey, TValue> StopFailed(
+        PartitionLane<TKey, TValue> lane,
+        Exception exception)
+        => new(RuntimeCommandKind.StopFailed, lane, null, exception, CancellationToken.None);
+}

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -184,7 +184,7 @@ public enum PartitionWorkerErrorPolicy
     StopPartition,
 
     /// <summary>
-    /// Stop the failed partition and keep the rest of the run active.
+    /// Restart the failed partition lane and keep the rest of the run active.
     /// </summary>
     Ignore
 }
@@ -213,6 +213,7 @@ public enum PartitionCommitPolicy
 internal enum PartitionStopReason
 {
     Revoke,
+    Lost,
     Shutdown,
     Failure
 }
@@ -252,6 +253,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
 
     public async ValueTask RunAsync(CancellationToken cancellationToken)
     {
+        using var rebalanceRegistration = RegisterRebalanceListener();
         using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
             cancellationToken,
             _failureCancellation.Token);
@@ -285,13 +287,75 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         }
         finally
         {
-            await StopAllAsync(CancellationToken.None).ConfigureAwait(false);
-            _commands.Writer.TryComplete();
-            CompletePendingCommands();
+            try
+            {
+                await StopAllBoundedAsync().ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (_failure is not null)
+            {
+            }
+            finally
+            {
+                _commands.Writer.TryComplete();
+                CompletePendingCommands();
+            }
         }
 
         ThrowIfFailed();
-        cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    private IDisposable? RegisterRebalanceListener()
+    {
+        return _consumer is IConsumerRebalanceEventSource eventSource
+            ? eventSource.RegisterRuntimeRebalanceListener(new RuntimeRebalanceListener(this))
+            : null;
+    }
+
+    private void QueueAssignedPartitions(IEnumerable<TopicPartition> partitions)
+    {
+        var partitionArray = partitions as TopicPartition[] ?? partitions.ToArray();
+        if (partitionArray.Length > 0)
+            _commands.Writer.TryWrite(RuntimeCommand<TKey, TValue>.AssignPartitions(partitionArray));
+    }
+
+    private void QueueStoppedPartitions(
+        IEnumerable<TopicPartition> partitions,
+        PartitionStopReason stopReason)
+    {
+        var partitionArray = partitions as TopicPartition[] ?? partitions.ToArray();
+        if (partitionArray.Length > 0)
+            _commands.Writer.TryWrite(RuntimeCommand<TKey, TValue>.StopPartitions(partitionArray, stopReason));
+    }
+
+    private sealed class RuntimeRebalanceListener(
+        PartitionedConsumerRuntime<TKey, TValue> runtime) : IRebalanceListener
+    {
+        public ValueTask OnPartitionsAssignedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            runtime.QueueAssignedPartitions(partitions);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnPartitionsRevokedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            runtime.QueueStoppedPartitions(partitions, PartitionStopReason.Revoke);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnPartitionsLostAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            runtime.QueueStoppedPartitions(partitions, PartitionStopReason.Lost);
+            return ValueTask.CompletedTask;
+        }
     }
 
     public ValueTask CommitProcessedAsync(
@@ -314,25 +378,21 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
     {
         var assignment = _consumer.Partitions.Assignment;
 
+        foreach (var partition in _stoppedByFailure.Where(partition => !assignment.Contains(partition)).ToArray())
+        {
+            _stoppedByFailure.Remove(partition);
+            _pausedByRuntime.Remove(partition);
+        }
+
         foreach (var partition in _lanes.Keys.Where(partition => !assignment.Contains(partition)).ToArray())
         {
-            var lane = _lanes[partition];
-            _lanes.Remove(partition);
-            _pausedByRuntime.Remove(partition);
-            await StopLaneAsync(
-                lane,
+            await StopPartitionAsync(
+                partition,
                 PartitionStopReason.Revoke,
-                commitProcessed: ShouldCommitOnPartitionStop(),
                 cancellationToken).ConfigureAwait(false);
         }
 
-        foreach (var partition in assignment)
-        {
-            if (_lanes.ContainsKey(partition) || _stoppedByFailure.Contains(partition))
-                continue;
-
-            StartLane(partition);
-        }
+        StartAssignedPartitions(assignment);
     }
 
     private async ValueTask RouteAsync(
@@ -368,6 +428,17 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
 
         _lanes.Add(partition, lane);
         lane.Start(_processor);
+    }
+
+    private void StartAssignedPartitions(IEnumerable<TopicPartition> partitions)
+    {
+        foreach (var partition in partitions)
+        {
+            if (_lanes.ContainsKey(partition) || _stoppedByFailure.Contains(partition))
+                continue;
+
+            StartLane(partition);
+        }
     }
 
     private void PauseIfNeeded(PartitionLane<TKey, TValue> lane)
@@ -412,7 +483,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             switch (command.Kind)
             {
                 case RuntimeCommandKind.Resume:
-                    if (_lanes.TryGetValue(command.Lane.TopicPartition, out var lane))
+                    if (_lanes.TryGetValue(command.Lane!.TopicPartition, out var lane))
                         ResumeIfNeeded(lane);
 
                     break;
@@ -422,7 +493,18 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
                     break;
 
                 case RuntimeCommandKind.StopFailed:
-                    await StopFailedLaneAsync(command.Lane, command.Exception!, cancellationToken).ConfigureAwait(false);
+                    await StopFailedLaneAsync(command.Lane!, command.Exception!, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case RuntimeCommandKind.AssignPartitions:
+                    StartAssignedPartitions(command.Partitions!);
+                    break;
+
+                case RuntimeCommandKind.StopPartitions:
+                    await StopPartitionsAsync(
+                        command.Partitions!,
+                        command.StopReason,
+                        cancellationToken).ConfigureAwait(false);
                     break;
             }
         }
@@ -438,7 +520,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
                 cancellationToken,
                 command.CancellationToken);
 
-            await CommitLaneAsync(command.Lane, linkedCancellation.Token).ConfigureAwait(false);
+            await CommitLaneAsync(command.Lane!, linkedCancellation.Token).ConfigureAwait(false);
             command.Completion!.TrySetResult();
         }
         catch (OperationCanceledException ex)
@@ -459,9 +541,16 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         if (!_lanes.Remove(lane.TopicPartition))
             return;
 
-        _stoppedByFailure.Add(lane.TopicPartition);
-        if (_pausedByRuntime.Add(lane.TopicPartition))
-            _consumer.Partitions.Pause(lane.TopicPartition);
+        if (_options.ErrorPolicy == PartitionWorkerErrorPolicy.StopPartition)
+        {
+            _stoppedByFailure.Add(lane.TopicPartition);
+            if (_pausedByRuntime.Add(lane.TopicPartition))
+                _consumer.Partitions.Pause(lane.TopicPartition);
+        }
+        else if (_pausedByRuntime.Remove(lane.TopicPartition))
+        {
+            _consumer.Partitions.Resume(lane.TopicPartition);
+        }
 
         await StopLaneAsync(
             lane,
@@ -469,10 +558,12 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             commitProcessed: false,
             cancellationToken).ConfigureAwait(false);
 
-        if (_options.ErrorPolicy == PartitionWorkerErrorPolicy.StopConsumer)
+        if (_options.ErrorPolicy == PartitionWorkerErrorPolicy.Ignore
+            && !_failureCancellation.IsCancellationRequested
+            && _consumer.Partitions.Assignment.Contains(lane.TopicPartition)
+            && !_lanes.ContainsKey(lane.TopicPartition))
         {
-            _failure ??= ExceptionDispatchInfo.Capture(exception);
-            _failureCancellation.Cancel();
+            StartLane(lane.TopicPartition);
         }
     }
 
@@ -483,36 +574,89 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         CancellationToken cancellationToken)
     {
         var exception = await lane.StopAsync(
-            reason == PartitionStopReason.Failure ? PartitionStopPolicy.Cancel : _options.StopPolicy,
+            reason is PartitionStopReason.Failure or PartitionStopReason.Lost
+                ? PartitionStopPolicy.Cancel
+                : _options.StopPolicy,
             _options.StopTimeout).ConfigureAwait(false);
 
         if (commitProcessed)
             await CommitLaneAsync(lane, cancellationToken).ConfigureAwait(false);
 
-        if (exception is not null && _options.ErrorPolicy == PartitionWorkerErrorPolicy.StopConsumer)
+        if (exception is not null
+            && (_options.ErrorPolicy == PartitionWorkerErrorPolicy.StopConsumer || exception is TimeoutException))
         {
             CaptureFailure(exception);
             _failureCancellation.Cancel();
         }
     }
 
-    private async ValueTask StopAllAsync(CancellationToken cancellationToken)
+    private async ValueTask StopPartitionsAsync(
+        TopicPartition[] partitions,
+        PartitionStopReason reason,
+        CancellationToken cancellationToken)
     {
-        foreach (var lane in _lanes.Values.ToArray())
+        foreach (var partition in partitions)
         {
-            _lanes.Remove(lane.TopicPartition);
-            await StopLaneAsync(
-                lane,
-                PartitionStopReason.Shutdown,
-                commitProcessed: ShouldCommitOnPartitionStop(),
-                cancellationToken).ConfigureAwait(false);
+            _stoppedByFailure.Remove(partition);
+            await StopPartitionAsync(partition, reason, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask StopPartitionAsync(
+        TopicPartition partition,
+        PartitionStopReason reason,
+        CancellationToken cancellationToken)
+    {
+        if (!_lanes.TryGetValue(partition, out var lane))
+        {
+            _pausedByRuntime.Remove(partition);
+            return;
         }
 
-        if (_pausedByRuntime.Count > 0)
+        _lanes.Remove(partition);
+        _pausedByRuntime.Remove(partition);
+
+        await StopLaneAsync(
+            lane,
+            reason,
+            commitProcessed: reason == PartitionStopReason.Revoke && ShouldCommitOnPartitionStop(),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask StopAllAsync(CancellationToken cancellationToken)
+    {
+        try
         {
-            _consumer.Partitions.Resume(_pausedByRuntime.ToArray());
-            _pausedByRuntime.Clear();
+            foreach (var lane in _lanes.Values.ToArray())
+            {
+                _lanes.Remove(lane.TopicPartition);
+                await StopLaneAsync(
+                    lane,
+                    PartitionStopReason.Shutdown,
+                    commitProcessed: ShouldCommitOnPartitionStop(),
+                    cancellationToken).ConfigureAwait(false);
+            }
         }
+        finally
+        {
+            if (_pausedByRuntime.Count > 0)
+            {
+                _consumer.Partitions.Resume(_pausedByRuntime.ToArray());
+                _pausedByRuntime.Clear();
+            }
+        }
+    }
+
+    private async ValueTask StopAllBoundedAsync()
+    {
+        if (_options.StopTimeout == Timeout.InfiniteTimeSpan)
+        {
+            await StopAllAsync(CancellationToken.None).ConfigureAwait(false);
+            return;
+        }
+
+        using var stopCancellation = new CancellationTokenSource(_options.StopTimeout);
+        await StopAllAsync(stopCancellation.Token).ConfigureAwait(false);
     }
 
     private async ValueTask CommitPeriodicallyAsync(CancellationToken cancellationToken)
@@ -746,7 +890,9 @@ internal sealed class PartitionLane<TKey, TValue>
                 CancellationToken.None,
                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
                 TaskScheduler.Default);
-            return null;
+
+            return new TimeoutException(
+                $"Partition processor for {TopicPartition.Topic}:{TopicPartition.Partition} did not stop within {timeout}.");
         }
         catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
         {
@@ -789,27 +935,39 @@ internal enum RuntimeCommandKind
 {
     Resume,
     Commit,
-    StopFailed
+    StopFailed,
+    AssignPartitions,
+    StopPartitions
 }
 
 internal readonly record struct RuntimeCommand<TKey, TValue>(
     RuntimeCommandKind Kind,
-    PartitionLane<TKey, TValue> Lane,
+    PartitionLane<TKey, TValue>? Lane,
+    TopicPartition[]? Partitions,
+    PartitionStopReason StopReason,
     TaskCompletionSource? Completion,
     Exception? Exception,
     CancellationToken CancellationToken)
 {
     public static RuntimeCommand<TKey, TValue> Resume(PartitionLane<TKey, TValue> lane)
-        => new(RuntimeCommandKind.Resume, lane, null, null, CancellationToken.None);
+        => new(RuntimeCommandKind.Resume, lane, null, default, null, null, CancellationToken.None);
 
     public static RuntimeCommand<TKey, TValue> Commit(
         PartitionLane<TKey, TValue> lane,
         TaskCompletionSource completion,
         CancellationToken cancellationToken)
-        => new(RuntimeCommandKind.Commit, lane, completion, null, cancellationToken);
+        => new(RuntimeCommandKind.Commit, lane, null, default, completion, null, cancellationToken);
 
     public static RuntimeCommand<TKey, TValue> StopFailed(
         PartitionLane<TKey, TValue> lane,
         Exception exception)
-        => new(RuntimeCommandKind.StopFailed, lane, null, exception, CancellationToken.None);
+        => new(RuntimeCommandKind.StopFailed, lane, null, default, null, exception, CancellationToken.None);
+
+    public static RuntimeCommand<TKey, TValue> AssignPartitions(TopicPartition[] partitions)
+        => new(RuntimeCommandKind.AssignPartitions, null, partitions, default, null, null, CancellationToken.None);
+
+    public static RuntimeCommand<TKey, TValue> StopPartitions(
+        TopicPartition[] partitions,
+        PartitionStopReason stopReason)
+        => new(RuntimeCommandKind.StopPartitions, null, partitions, stopReason, null, null, CancellationToken.None);
 }

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -732,6 +732,8 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             _ignoreRestartFailures.Remove(partition);
             await StopPartitionAsync(partition, reason, cancellationToken).ConfigureAwait(false);
         }
+
+        StartAssignedPartitions(_consumer.Partitions.Assignment);
     }
 
     private async ValueTask StopPartitionAsync(

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
@@ -130,6 +131,7 @@ public sealed class PartitionedProcessingOptions
 
     /// <summary>
     /// Gets the first delay before restarting a failed lane when <see cref="ErrorPolicy"/> is <see cref="PartitionWorkerErrorPolicy.Ignore"/>.
+    /// The value must be greater than <see cref="TimeSpan.Zero"/>.
     /// </summary>
     public TimeSpan IgnoreRestartBackoff { get; init; } = TimeSpan.FromMilliseconds(100);
 
@@ -155,10 +157,10 @@ public sealed class PartitionedProcessingOptions
         if (StopTimeout < TimeSpan.Zero && StopTimeout != Timeout.InfiniteTimeSpan)
             throw new ArgumentOutOfRangeException(nameof(StopTimeout));
 
-        if (IgnoreRestartBackoff < TimeSpan.Zero)
+        if (IgnoreRestartBackoff <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(IgnoreRestartBackoff));
 
-        if (IgnoreRestartBackoffMax < TimeSpan.Zero)
+        if (IgnoreRestartBackoffMax <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(IgnoreRestartBackoffMax));
 
         if (IgnoreRestartBackoffMax < IgnoreRestartBackoff)
@@ -262,9 +264,12 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
     private readonly Dictionary<TopicPartition, PartitionLane<TKey, TValue>> _lanes = [];
     private readonly HashSet<TopicPartition> _pausedByRuntime = [];
     private readonly HashSet<TopicPartition> _stoppedByFailure = [];
+    private readonly HashSet<TopicPartition> _pendingIgnoreRestarts = [];
     private readonly Dictionary<TopicPartition, int> _ignoreRestartFailures = [];
+    private readonly ConcurrentDictionary<Task, byte> _ignoreRestartTasks = [];
     private readonly Channel<RuntimeCommand<TKey, TValue>> _commands;
     private readonly CancellationTokenSource _failureCancellation = new();
+    private readonly CancellationTokenSource _restartCancellation = new();
     private readonly object _failureGate = new();
     private ExceptionDispatchInfo? _failure;
     private DateTimeOffset _nextPeriodicCommit;
@@ -333,6 +338,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             }
             finally
             {
+                await StopScheduledRestartsAsync().ConfigureAwait(false);
                 _commands.Writer.TryComplete();
                 CompletePendingCommands();
             }
@@ -422,6 +428,12 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             _ignoreRestartFailures.Remove(partition);
         }
 
+        foreach (var partition in _pendingIgnoreRestarts.Where(partition => !assignment.Contains(partition)).ToArray())
+        {
+            _pendingIgnoreRestarts.Remove(partition);
+            _ignoreRestartFailures.Remove(partition);
+        }
+
         foreach (var partition in _lanes.Keys.Where(partition => !assignment.Contains(partition)).ToArray())
         {
             await StopPartitionAsync(
@@ -473,6 +485,9 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         foreach (var partition in partitions)
         {
             if (_lanes.ContainsKey(partition) || _stoppedByFailure.Contains(partition))
+                continue;
+
+            if (_pendingIgnoreRestarts.Contains(partition))
                 continue;
 
             StartLane(partition);
@@ -535,6 +550,10 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
 
                 case RuntimeCommandKind.StopFailed:
                     await StopFailedLaneAsync(command.Lane!, command.Exception!, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case RuntimeCommandKind.RestartLane:
+                    RestartLaneIfStillAssigned(command.Partition);
                     break;
 
                 case RuntimeCommandKind.AssignPartitions:
@@ -619,18 +638,63 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
                 restartDelay,
                 exception);
 
-            if (restartDelay > TimeSpan.Zero)
-                await Task.Delay(restartDelay, cancellationToken).ConfigureAwait(false);
-
-            if (_failureCancellation.IsCancellationRequested
-                || !_consumer.Partitions.Assignment.Contains(lane.TopicPartition)
-                || _lanes.ContainsKey(lane.TopicPartition))
-            {
-                return;
-            }
-
-            StartLane(lane.TopicPartition);
+            _pendingIgnoreRestarts.Add(lane.TopicPartition);
+            ScheduleIgnoreRestart(lane.TopicPartition, restartDelay);
         }
+    }
+
+    private void RestartLaneIfStillAssigned(TopicPartition partition)
+    {
+        _pendingIgnoreRestarts.Remove(partition);
+
+        if (_failureCancellation.IsCancellationRequested
+            || !_consumer.Partitions.Assignment.Contains(partition)
+            || _stoppedByFailure.Contains(partition)
+            || _lanes.ContainsKey(partition))
+        {
+            return;
+        }
+
+        StartLane(partition);
+    }
+
+    private void ScheduleIgnoreRestart(TopicPartition partition, TimeSpan delay)
+    {
+        var task = ScheduleIgnoreRestartAsync(partition, delay);
+        _ignoreRestartTasks.TryAdd(task, 0);
+
+        _ = task.ContinueWith(
+            static (completedTask, state) =>
+            {
+                var runtime = (PartitionedConsumerRuntime<TKey, TValue>)state!;
+                runtime.CompleteIgnoreRestartTask(completedTask);
+            },
+            this,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private async Task ScheduleIgnoreRestartAsync(
+        TopicPartition partition,
+        TimeSpan delay)
+    {
+        await Task.Delay(delay, _restartCancellation.Token).ConfigureAwait(false);
+        _commands.Writer.TryWrite(RuntimeCommand<TKey, TValue>.RestartLane(partition));
+    }
+
+    private void CompleteIgnoreRestartTask(Task task)
+    {
+        _ignoreRestartTasks.TryRemove(task, out _);
+
+        if (!task.IsFaulted || task.Exception is null)
+            return;
+
+        var exception = task.Exception.InnerExceptions.Count == 1
+            ? task.Exception.InnerException!
+            : task.Exception;
+        CaptureFailure(exception);
+        _failureCancellation.Cancel();
     }
 
     private async ValueTask StopLaneAsync(
@@ -664,6 +728,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         foreach (var partition in partitions)
         {
             _stoppedByFailure.Remove(partition);
+            _pendingIgnoreRestarts.Remove(partition);
             _ignoreRestartFailures.Remove(partition);
             await StopPartitionAsync(partition, reason, cancellationToken).ConfigureAwait(false);
         }
@@ -677,12 +742,14 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         if (!_lanes.TryGetValue(partition, out var lane))
         {
             _pausedByRuntime.Remove(partition);
+            _pendingIgnoreRestarts.Remove(partition);
             _ignoreRestartFailures.Remove(partition);
             return;
         }
 
         _lanes.Remove(partition);
         _pausedByRuntime.Remove(partition);
+        _pendingIgnoreRestarts.Remove(partition);
         _ignoreRestartFailures.Remove(partition);
 
         await StopLaneAsync(
@@ -713,6 +780,8 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
                 _consumer.Partitions.Resume(_pausedByRuntime.ToArray());
                 _pausedByRuntime.Clear();
             }
+
+            _pendingIgnoreRestarts.Clear();
         }
     }
 
@@ -726,6 +795,24 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
 
         using var stopCancellation = new CancellationTokenSource(_options.StopTimeout);
         await StopAllAsync(stopCancellation.Token).ConfigureAwait(false);
+    }
+
+    private async ValueTask StopScheduledRestartsAsync()
+    {
+        await _restartCancellation.CancelAsync().ConfigureAwait(false);
+
+        var tasks = _ignoreRestartTasks.Keys.ToArray();
+
+        if (tasks.Length == 0)
+            return;
+
+        try
+        {
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (_restartCancellation.IsCancellationRequested)
+        {
+        }
     }
 
     private async ValueTask CommitPeriodicallyAsync(CancellationToken cancellationToken)
@@ -1069,6 +1156,7 @@ internal enum RuntimeCommandKind
     Resume,
     Commit,
     StopFailed,
+    RestartLane,
     AssignPartitions,
     StopPartitions
 }
@@ -1077,30 +1165,34 @@ internal readonly record struct RuntimeCommand<TKey, TValue>(
     RuntimeCommandKind Kind,
     PartitionLane<TKey, TValue>? Lane,
     TopicPartition[]? Partitions,
+    TopicPartition Partition,
     PartitionStopReason StopReason,
     TaskCompletionSource? Completion,
     Exception? Exception,
     CancellationToken CancellationToken)
 {
     public static RuntimeCommand<TKey, TValue> Resume(PartitionLane<TKey, TValue> lane)
-        => new(RuntimeCommandKind.Resume, lane, null, default, null, null, CancellationToken.None);
+        => new(RuntimeCommandKind.Resume, lane, null, default, default, null, null, CancellationToken.None);
 
     public static RuntimeCommand<TKey, TValue> Commit(
         PartitionLane<TKey, TValue> lane,
         TaskCompletionSource completion,
         CancellationToken cancellationToken)
-        => new(RuntimeCommandKind.Commit, lane, null, default, completion, null, cancellationToken);
+        => new(RuntimeCommandKind.Commit, lane, null, default, default, completion, null, cancellationToken);
 
     public static RuntimeCommand<TKey, TValue> StopFailed(
         PartitionLane<TKey, TValue> lane,
         Exception exception)
-        => new(RuntimeCommandKind.StopFailed, lane, null, default, null, exception, CancellationToken.None);
+        => new(RuntimeCommandKind.StopFailed, lane, null, default, default, null, exception, CancellationToken.None);
+
+    public static RuntimeCommand<TKey, TValue> RestartLane(TopicPartition partition)
+        => new(RuntimeCommandKind.RestartLane, null, null, partition, default, null, null, CancellationToken.None);
 
     public static RuntimeCommand<TKey, TValue> AssignPartitions(TopicPartition[] partitions)
-        => new(RuntimeCommandKind.AssignPartitions, null, partitions, default, null, null, CancellationToken.None);
+        => new(RuntimeCommandKind.AssignPartitions, null, partitions, default, default, null, null, CancellationToken.None);
 
     public static RuntimeCommand<TKey, TValue> StopPartitions(
         TopicPartition[] partitions,
         PartitionStopReason stopReason)
-        => new(RuntimeCommandKind.StopPartitions, null, partitions, stopReason, null, null, CancellationToken.None);
+        => new(RuntimeCommandKind.StopPartitions, null, partitions, default, stopReason, null, null, CancellationToken.None);
 }

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -1,5 +1,7 @@
 using System.Runtime.ExceptionServices;
 using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Dekaf.Consumer;
 
@@ -23,9 +25,21 @@ public static class PartitionedConsumerExtensions
         options ??= new PartitionedProcessingOptions();
         options.Validate();
 
-        var runtime = new PartitionedConsumerRuntime<TKey, TValue>(consumer, processor, options);
+        var logger = consumer is IConsumerLoggerFactorySource loggerSource
+            ? loggerSource.LoggerFactory?.CreateLogger<PartitionedConsumerRuntime<TKey, TValue>>()
+            : null;
+        var runtime = new PartitionedConsumerRuntime<TKey, TValue>(
+            consumer,
+            processor,
+            options,
+            logger);
         await runtime.RunAsync(cancellationToken).ConfigureAwait(false);
     }
+}
+
+internal interface IConsumerLoggerFactorySource
+{
+    ILoggerFactory? LoggerFactory { get; }
 }
 
 /// <summary>
@@ -115,6 +129,16 @@ public sealed class PartitionedProcessingOptions
     public PartitionWorkerErrorPolicy ErrorPolicy { get; init; } = PartitionWorkerErrorPolicy.StopConsumer;
 
     /// <summary>
+    /// Gets the first delay before restarting a failed lane when <see cref="ErrorPolicy"/> is <see cref="PartitionWorkerErrorPolicy.Ignore"/>.
+    /// </summary>
+    public TimeSpan IgnoreRestartBackoff { get; init; } = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Gets the maximum exponential restart delay for failed lanes when <see cref="ErrorPolicy"/> is <see cref="PartitionWorkerErrorPolicy.Ignore"/>.
+    /// </summary>
+    public TimeSpan IgnoreRestartBackoffMax { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
     /// Gets how completed partition offsets are committed.
     /// </summary>
     public PartitionCommitPolicy CommitPolicy { get; init; } = PartitionCommitPolicy.CommitCompletedOnRevoke;
@@ -130,6 +154,15 @@ public sealed class PartitionedProcessingOptions
 
         if (StopTimeout < TimeSpan.Zero && StopTimeout != Timeout.InfiniteTimeSpan)
             throw new ArgumentOutOfRangeException(nameof(StopTimeout));
+
+        if (IgnoreRestartBackoff < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(IgnoreRestartBackoff));
+
+        if (IgnoreRestartBackoffMax < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(IgnoreRestartBackoffMax));
+
+        if (IgnoreRestartBackoffMax < IgnoreRestartBackoff)
+            throw new ArgumentOutOfRangeException(nameof(IgnoreRestartBackoffMax));
 
         if (CommitInterval <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(CommitInterval));
@@ -225,9 +258,11 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
     private readonly IKafkaConsumer<TKey, TValue> _consumer;
     private readonly PartitionProcessor<TKey, TValue> _processor;
     private readonly PartitionedProcessingOptions _options;
+    private readonly ILogger _logger;
     private readonly Dictionary<TopicPartition, PartitionLane<TKey, TValue>> _lanes = [];
     private readonly HashSet<TopicPartition> _pausedByRuntime = [];
     private readonly HashSet<TopicPartition> _stoppedByFailure = [];
+    private readonly Dictionary<TopicPartition, int> _ignoreRestartFailures = [];
     private readonly Channel<RuntimeCommand<TKey, TValue>> _commands;
     private readonly CancellationTokenSource _failureCancellation = new();
     private readonly object _failureGate = new();
@@ -237,11 +272,13 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
     public PartitionedConsumerRuntime(
         IKafkaConsumer<TKey, TValue> consumer,
         PartitionProcessor<TKey, TValue> processor,
-        PartitionedProcessingOptions options)
+        PartitionedProcessingOptions options,
+        ILogger? logger)
     {
         _consumer = consumer;
         _processor = processor;
         _options = options;
+        _logger = logger ?? NullLogger.Instance;
         _commands = Channel.CreateUnbounded<RuntimeCommand<TKey, TValue>>(new UnboundedChannelOptions
         {
             AllowSynchronousContinuations = false,
@@ -382,6 +419,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         {
             _stoppedByFailure.Remove(partition);
             _pausedByRuntime.Remove(partition);
+            _ignoreRestartFailures.Remove(partition);
         }
 
         foreach (var partition in _lanes.Keys.Where(partition => !assignment.Contains(partition)).ToArray())
@@ -468,6 +506,9 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
     {
         if (_options.ErrorPolicy == PartitionWorkerErrorPolicy.StopConsumer)
         {
+            LogPartitionProcessorFailureStoppingConsumer(
+                lane.TopicPartition,
+                exception);
             CaptureFailure(exception);
             _failureCancellation.Cancel();
             return;
@@ -546,6 +587,10 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             _stoppedByFailure.Add(lane.TopicPartition);
             if (_pausedByRuntime.Add(lane.TopicPartition))
                 _consumer.Partitions.Pause(lane.TopicPartition);
+
+            LogPartitionProcessorFailureStoppingPartition(
+                lane.TopicPartition,
+                exception);
         }
         else if (_pausedByRuntime.Remove(lane.TopicPartition))
         {
@@ -563,6 +608,27 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             && _consumer.Partitions.Assignment.Contains(lane.TopicPartition)
             && !_lanes.ContainsKey(lane.TopicPartition))
         {
+            if (lane.LastProcessedOffset.HasValue)
+                _ignoreRestartFailures.Remove(lane.TopicPartition);
+
+            var restartAttempt = RecordIgnoreRestartFailure(lane.TopicPartition);
+            var restartDelay = GetIgnoreRestartDelay(restartAttempt);
+            LogPartitionProcessorFailureIgnored(
+                lane.TopicPartition,
+                restartAttempt,
+                restartDelay,
+                exception);
+
+            if (restartDelay > TimeSpan.Zero)
+                await Task.Delay(restartDelay, cancellationToken).ConfigureAwait(false);
+
+            if (_failureCancellation.IsCancellationRequested
+                || !_consumer.Partitions.Assignment.Contains(lane.TopicPartition)
+                || _lanes.ContainsKey(lane.TopicPartition))
+            {
+                return;
+            }
+
             StartLane(lane.TopicPartition);
         }
     }
@@ -598,6 +664,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         foreach (var partition in partitions)
         {
             _stoppedByFailure.Remove(partition);
+            _ignoreRestartFailures.Remove(partition);
             await StopPartitionAsync(partition, reason, cancellationToken).ConfigureAwait(false);
         }
     }
@@ -610,11 +677,13 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         if (!_lanes.TryGetValue(partition, out var lane))
         {
             _pausedByRuntime.Remove(partition);
+            _ignoreRestartFailures.Remove(partition);
             return;
         }
 
         _lanes.Remove(partition);
         _pausedByRuntime.Remove(partition);
+        _ignoreRestartFailures.Remove(partition);
 
         await StopLaneAsync(
             lane,
@@ -694,6 +763,33 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             or PartitionCommitPolicy.CommitCompletedPeriodically;
     }
 
+    private int RecordIgnoreRestartFailure(TopicPartition partition)
+    {
+        var nextAttempt = _ignoreRestartFailures.TryGetValue(partition, out var current)
+            && current < int.MaxValue
+                ? current + 1
+                : 1;
+
+        _ignoreRestartFailures[partition] = nextAttempt;
+        return nextAttempt;
+    }
+
+    private TimeSpan GetIgnoreRestartDelay(int attempt)
+    {
+        var delay = _options.IgnoreRestartBackoff;
+        var max = _options.IgnoreRestartBackoffMax;
+
+        for (var i = 1; i < attempt && delay < max; i++)
+        {
+            var doubledTicks = delay.Ticks > max.Ticks / 2
+                ? max.Ticks
+                : delay.Ticks * 2;
+            delay = TimeSpan.FromTicks(doubledTicks);
+        }
+
+        return delay;
+    }
+
     private void ThrowIfFailed()
     {
         _failure?.Throw();
@@ -712,6 +808,43 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             if (command.Kind == RuntimeCommandKind.Commit)
                 command.Completion!.TrySetCanceled();
         }
+    }
+
+    private void LogPartitionProcessorFailureStoppingConsumer(
+        TopicPartition partition,
+        Exception exception)
+    {
+        _logger.LogError(
+            exception,
+            "Partition processor for {Topic}-{Partition} failed; stopping partitioned consumer.",
+            partition.Topic,
+            partition.Partition);
+    }
+
+    private void LogPartitionProcessorFailureStoppingPartition(
+        TopicPartition partition,
+        Exception exception)
+    {
+        _logger.LogWarning(
+            exception,
+            "Partition processor for {Topic}-{Partition} failed under StopPartition; pausing partition.",
+            partition.Topic,
+            partition.Partition);
+    }
+
+    private void LogPartitionProcessorFailureIgnored(
+        TopicPartition partition,
+        int restartAttempt,
+        TimeSpan restartDelay,
+        Exception exception)
+    {
+        _logger.LogWarning(
+            exception,
+            "Partition processor for {Topic}-{Partition} failed under Ignore; restarting after {RestartDelayMs}ms (attempt {RestartAttempt}).",
+            partition.Topic,
+            partition.Partition,
+            restartDelay.TotalMilliseconds,
+            restartAttempt);
     }
 }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1626,8 +1626,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
             catch (Exception batchEx)
             {
-                try { FailAndCleanupBatch(batch, new InvalidOperationException(
-                    "Unexpected exception during response processing", batchEx)); }
+                try
+                {
+                    FailAndCleanupBatch(batch, new InvalidOperationException(
+                    "Unexpected exception during response processing", batchEx));
+                }
                 catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
                 batches[j] = null!;
             }
@@ -2715,8 +2718,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
         try { batch.Fail(ex); }
         catch (Exception failEx) { LogBatchCleanupStepFailed(failEx, _brokerId); }
-        try { _onAcknowledgement?.Invoke(batch.TopicPartition, -1, DateTimeOffset.UtcNow,
-            batch.CompletionSourcesCount, ex); }
+        try
+        {
+            _onAcknowledgement?.Invoke(batch.TopicPartition, -1, DateTimeOffset.UtcNow,
+            batch.CompletionSourcesCount, ex);
+        }
         catch (Exception ackEx) { LogBatchCleanupStepFailed(ackEx, _brokerId); }
         try { CleanupBatch(batch); }
         catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }

--- a/src/Dekaf/Security/Sasl/OAuthBearerJwtAssertion.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerJwtAssertion.cs
@@ -259,18 +259,18 @@ internal static class OAuthBearerJwtAssertion
         AsymmetricAlgorithm key,
         OAuthBearerJwtSigningAlgorithm algorithm,
         byte[] signingInput) => algorithm switch
-    {
-        OAuthBearerJwtSigningAlgorithm.Rs256 => SignRsa(key, signingInput, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1),
-        OAuthBearerJwtSigningAlgorithm.Rs384 => SignRsa(key, signingInput, HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1),
-        OAuthBearerJwtSigningAlgorithm.Rs512 => SignRsa(key, signingInput, HashAlgorithmName.SHA512, RSASignaturePadding.Pkcs1),
-        OAuthBearerJwtSigningAlgorithm.Ps256 => SignRsa(key, signingInput, HashAlgorithmName.SHA256, RSASignaturePadding.Pss),
-        OAuthBearerJwtSigningAlgorithm.Ps384 => SignRsa(key, signingInput, HashAlgorithmName.SHA384, RSASignaturePadding.Pss),
-        OAuthBearerJwtSigningAlgorithm.Ps512 => SignRsa(key, signingInput, HashAlgorithmName.SHA512, RSASignaturePadding.Pss),
-        OAuthBearerJwtSigningAlgorithm.Es256 => SignEcdsa(key, signingInput, HashAlgorithmName.SHA256),
-        OAuthBearerJwtSigningAlgorithm.Es384 => SignEcdsa(key, signingInput, HashAlgorithmName.SHA384),
-        OAuthBearerJwtSigningAlgorithm.Es512 => SignEcdsa(key, signingInput, HashAlgorithmName.SHA512),
-        _ => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null)
-    };
+        {
+            OAuthBearerJwtSigningAlgorithm.Rs256 => SignRsa(key, signingInput, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1),
+            OAuthBearerJwtSigningAlgorithm.Rs384 => SignRsa(key, signingInput, HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1),
+            OAuthBearerJwtSigningAlgorithm.Rs512 => SignRsa(key, signingInput, HashAlgorithmName.SHA512, RSASignaturePadding.Pkcs1),
+            OAuthBearerJwtSigningAlgorithm.Ps256 => SignRsa(key, signingInput, HashAlgorithmName.SHA256, RSASignaturePadding.Pss),
+            OAuthBearerJwtSigningAlgorithm.Ps384 => SignRsa(key, signingInput, HashAlgorithmName.SHA384, RSASignaturePadding.Pss),
+            OAuthBearerJwtSigningAlgorithm.Ps512 => SignRsa(key, signingInput, HashAlgorithmName.SHA512, RSASignaturePadding.Pss),
+            OAuthBearerJwtSigningAlgorithm.Es256 => SignEcdsa(key, signingInput, HashAlgorithmName.SHA256),
+            OAuthBearerJwtSigningAlgorithm.Es384 => SignEcdsa(key, signingInput, HashAlgorithmName.SHA384),
+            OAuthBearerJwtSigningAlgorithm.Es512 => SignEcdsa(key, signingInput, HashAlgorithmName.SHA512),
+            _ => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null)
+        };
 
     private static byte[] SignRsa(
         AsymmetricAlgorithm key,

--- a/tests/Dekaf.Tests.Integration/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Integration/DependencyInjectionTests.cs
@@ -35,7 +35,7 @@ public sealed class DependencyInjectionTests(KafkaTestContainer kafka) : KafkaIn
 
         // Warm up to ensure broker has initialized partition state
         await producer.FireAsync(new ProducerMessage<string, string>
-            { Topic = topic, Key = "warmup", Value = "warmup" });
+        { Topic = topic, Key = "warmup", Value = "warmup" });
 
         var metadata = await producer.ProduceAsync(new ProducerMessage<string, string>
         {
@@ -64,7 +64,7 @@ public sealed class DependencyInjectionTests(KafkaTestContainer kafka) : KafkaIn
 
         // Warm up to ensure broker has initialized partition state
         await producer.FireAsync(new ProducerMessage<string, string>
-            { Topic = topic, Key = "warmup", Value = "warmup" });
+        { Topic = topic, Key = "warmup", Value = "warmup" });
 
         await producer.ProduceAsync(new ProducerMessage<string, string>
         {
@@ -159,7 +159,7 @@ public sealed class DependencyInjectionTests(KafkaTestContainer kafka) : KafkaIn
 
         // Warm up to ensure broker has initialized partition state
         await producerFromDi.FireAsync(new ProducerMessage<string, string>
-            { Topic = topic, Key = "warmup", Value = "warmup" });
+        { Topic = topic, Key = "warmup", Value = "warmup" });
 
         // Produce
         await producerFromDi.ProduceAsync(new ProducerMessage<string, string>

--- a/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
+++ b/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
@@ -35,7 +35,7 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
         // Warm up to ensure broker has initialized partition state
         // (topic metadata is cached after this call)
         await producer.FireAsync(new ProducerMessage<string, string>
-            { Topic = topic, Key = "warmup", Value = "warmup" });
+        { Topic = topic, Key = "warmup", Value = "warmup" });
 
         // Build host with consumer service
         var builder = Host.CreateApplicationBuilder();

--- a/tests/Dekaf.Tests.Integration/LogCompactionTests.cs
+++ b/tests/Dekaf.Tests.Integration/LogCompactionTests.cs
@@ -58,7 +58,7 @@ public sealed class LogCompactionTests(KafkaTestContainer kafka) : KafkaIntegrat
 
         // Warm up to ensure broker has initialized partition state
         await producer.FireAsync(new ProducerMessage<string, string>
-            { Topic = topic, Key = "warmup", Value = "warmup" });
+        { Topic = topic, Key = "warmup", Value = "warmup" });
 
         // Produce two messages with the same key
         await producer.ProduceAsync(new ProducerMessage<string, string>

--- a/tests/Dekaf.Tests.Integration/MemoryBudgetTests.cs
+++ b/tests/Dekaf.Tests.Integration/MemoryBudgetTests.cs
@@ -23,58 +23,58 @@ public class MemoryBudgetTests(KafkaTestContainer kafka) : KafkaIntegrationTest(
         DekafMemoryBudget.SetBudget(512UL * 1024 * 1024);
         try
         {
-        // Build first auto-tuned producer (no explicit BufferMemory).
-        await using var producer1 = (KafkaProducer<string, string>)await Kafka.CreateProducer<string, string>()
-            .WithBootstrapServers(KafkaContainer.BootstrapServers)
-            .WithClientId("budget-test-1")
-            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
-            .BuildAsync();
+            // Build first auto-tuned producer (no explicit BufferMemory).
+            await using var producer1 = (KafkaProducer<string, string>)await Kafka.CreateProducer<string, string>()
+                .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                .WithClientId("budget-test-1")
+                .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+                .BuildAsync();
 
-        var initialLimit = producer1.RecordAccumulator.MaxBufferMemory;
-        Console.WriteLine($"[MemoryBudgetTests] producer1 initial limit: {initialLimit / (1024 * 1024)} MiB");
+            var initialLimit = producer1.RecordAccumulator.MaxBufferMemory;
+            Console.WriteLine($"[MemoryBudgetTests] producer1 initial limit: {initialLimit / (1024 * 1024)} MiB");
 
-        // Build a second auto-tuned producer - this should trigger rebalance.
-        var producer2 = (KafkaProducer<string, string>)await Kafka.CreateProducer<string, string>()
-            .WithBootstrapServers(KafkaContainer.BootstrapServers)
-            .WithClientId("budget-test-2")
-            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
-            .BuildAsync();
+            // Build a second auto-tuned producer - this should trigger rebalance.
+            var producer2 = (KafkaProducer<string, string>)await Kafka.CreateProducer<string, string>()
+                .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                .WithClientId("budget-test-2")
+                .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+                .BuildAsync();
 
-        try
-        {
-            var rebalancedLimit1 = producer1.RecordAccumulator.MaxBufferMemory;
-            var limit2 = producer2.RecordAccumulator.MaxBufferMemory;
-            Console.WriteLine($"[MemoryBudgetTests] after 2nd build - p1: {rebalancedLimit1 / (1024 * 1024)} MiB, p2: {limit2 / (1024 * 1024)} MiB");
-
-            // producer1's limit should have shrunk (unless it was already at the floor).
-            if (initialLimit > ProducerFloorBytes)
+            try
             {
-                await Assert.That(rebalancedLimit1).IsLessThan(initialLimit);
+                var rebalancedLimit1 = producer1.RecordAccumulator.MaxBufferMemory;
+                var limit2 = producer2.RecordAccumulator.MaxBufferMemory;
+                Console.WriteLine($"[MemoryBudgetTests] after 2nd build - p1: {rebalancedLimit1 / (1024 * 1024)} MiB, p2: {limit2 / (1024 * 1024)} MiB");
+
+                // producer1's limit should have shrunk (unless it was already at the floor).
+                if (initialLimit > ProducerFloorBytes)
+                {
+                    await Assert.That(rebalancedLimit1).IsLessThan(initialLimit);
+                }
+
+                // Both producers should receive the same per-instance share, respecting the floor.
+                await Assert.That(rebalancedLimit1).IsEqualTo(limit2);
+                await Assert.That(rebalancedLimit1).IsGreaterThanOrEqualTo(ProducerFloorBytes);
+
+                // Verify both producers still function end-to-end.
+                var result1 = await producer1.ProduceAsync(topic, "k1", "v1");
+                var result2 = await producer2.ProduceAsync(topic, "k2", "v2");
+                await Assert.That(result1.Offset).IsGreaterThanOrEqualTo(0);
+                await Assert.That(result2.Offset).IsGreaterThanOrEqualTo(0);
+            }
+            finally
+            {
+                await producer2.DisposeAsync();
             }
 
-            // Both producers should receive the same per-instance share, respecting the floor.
-            await Assert.That(rebalancedLimit1).IsEqualTo(limit2);
-            await Assert.That(rebalancedLimit1).IsGreaterThanOrEqualTo(ProducerFloorBytes);
+            // After disposing producer2, producer1 should grow back to (roughly) the initial limit.
+            await WaitForConditionAsync(
+                () => producer1.RecordAccumulator.MaxBufferMemory >= initialLimit,
+                TimeSpan.FromSeconds(5));
 
-            // Verify both producers still function end-to-end.
-            var result1 = await producer1.ProduceAsync(topic, "k1", "v1");
-            var result2 = await producer2.ProduceAsync(topic, "k2", "v2");
-            await Assert.That(result1.Offset).IsGreaterThanOrEqualTo(0);
-            await Assert.That(result2.Offset).IsGreaterThanOrEqualTo(0);
-        }
-        finally
-        {
-            await producer2.DisposeAsync();
-        }
-
-        // After disposing producer2, producer1 should grow back to (roughly) the initial limit.
-        await WaitForConditionAsync(
-            () => producer1.RecordAccumulator.MaxBufferMemory >= initialLimit,
-            TimeSpan.FromSeconds(5));
-
-        var finalLimit = producer1.RecordAccumulator.MaxBufferMemory;
-        Console.WriteLine($"[MemoryBudgetTests] producer1 final limit: {finalLimit / (1024 * 1024)} MiB");
-        await Assert.That(finalLimit).IsGreaterThanOrEqualTo(initialLimit);
+            var finalLimit = producer1.RecordAccumulator.MaxBufferMemory;
+            Console.WriteLine($"[MemoryBudgetTests] producer1 final limit: {finalLimit / (1024 * 1024)} MiB");
+            await Assert.That(finalLimit).IsGreaterThanOrEqualTo(initialLimit);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Integration/MultiInflightProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/MultiInflightProducerTests.cs
@@ -89,7 +89,10 @@ public sealed class MultiInflightProducerTests(KafkaTestContainer kafka) : Kafka
         for (var p = 0; p < partitionCount; p++)
             await producer.ProduceAsync(new ProducerMessage<int, string>
             {
-                Topic = topic, Key = -1, Value = "warmup", Partition = p
+                Topic = topic,
+                Key = -1,
+                Value = "warmup",
+                Partition = p
             }, CancellationToken.None);
 
         // Produce messages keyed by partition index
@@ -388,7 +391,10 @@ public sealed class MultiInflightProducerTests(KafkaTestContainer kafka) : Kafka
         for (var p = 0; p < partitionCount; p++)
             await producer.ProduceAsync(new ProducerMessage<int, string>
             {
-                Topic = topic, Key = -1, Value = "warmup", Partition = p
+                Topic = topic,
+                Key = -1,
+                Value = "warmup",
+                Partition = p
             }, CancellationToken.None);
 
         // Produce to all partitions to trigger coalescing

--- a/tests/Dekaf.Tests.Integration/PartitionedProcessingIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/PartitionedProcessingIntegrationTests.cs
@@ -67,7 +67,7 @@ public sealed class PartitionedProcessingIntegrationTests(KafkaTestContainer kaf
                     context.MarkProcessed(message);
 
                     if (message.Partition == 1 && !releaseFirstPartition.Task.IsCompleted)
-                        secondPartitionProcessedWhileFirstBlocked.SetResult();
+                        secondPartitionProcessedWhileFirstBlocked.TrySetResult();
 
                     if (processed.Values.Sum(static values =>
                         {

--- a/tests/Dekaf.Tests.Integration/PartitionedProcessingIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/PartitionedProcessingIntegrationTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Concurrent;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("ConsumerGroup")]
+public sealed class PartitionedProcessingIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task RunPartitionedAsync_MultiPartition_ProcessesOrderedLanesConcurrentlyAndCommits()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
+        var groupId = $"partitioned-runtime-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        for (var offset = 0; offset < 3; offset++)
+        {
+            for (var partition = 0; partition < 2; partition++)
+            {
+                await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Partition = partition,
+                    Key = $"key-{partition}-{offset}",
+                    Value = $"value-{partition}-{offset}"
+                }, CancellationToken.None);
+            }
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithQueuedMinMessages(1)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        var processed = new ConcurrentDictionary<int, List<long>>();
+        var firstPartitionStarted = NewCompletionSource();
+        var releaseFirstPartition = NewCompletionSource();
+        var secondPartitionProcessedWhileFirstBlocked = NewCompletionSource();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var runTask = consumer.RunPartitionedAsync(
+            async (context, cancellationToken) =>
+            {
+                await foreach (var message in context.Messages.WithCancellation(cancellationToken))
+                {
+                    if (message.Partition == 0 && message.Offset == 0)
+                    {
+                        firstPartitionStarted.SetResult();
+                        await releaseFirstPartition.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    var offsets = processed.GetOrAdd(message.Partition, static _ => []);
+                    lock (offsets)
+                        offsets.Add(message.Offset);
+
+                    context.MarkProcessed(message);
+
+                    if (message.Partition == 1 && !releaseFirstPartition.Task.IsCompleted)
+                        secondPartitionProcessedWhileFirstBlocked.SetResult();
+
+                    if (processed.Values.Sum(static values =>
+                        {
+                            lock (values)
+                                return values.Count;
+                        }) >= 6)
+                    {
+                        await cts.CancelAsync().ConfigureAwait(false);
+                    }
+                }
+            },
+            new PartitionedProcessingOptions
+            {
+                MaxBufferedRecordsPerPartition = 4,
+                CommitPolicy = PartitionCommitPolicy.CommitCompletedOnRevoke,
+                StopPolicy = PartitionStopPolicy.Drain
+            },
+            cts.Token).AsTask();
+
+        await firstPartitionStarted.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        await secondPartitionProcessedWhileFirstBlocked.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+
+        releaseFirstPartition.SetResult();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await runTask.ConfigureAwait(false));
+
+        await Assert.That(Snapshot(processed, 0)).IsEquivalentTo([0L, 1L, 2L]);
+        await Assert.That(Snapshot(processed, 1)).IsEquivalentTo([0L, 1L, 2L]);
+
+        await Assert.That(await consumer.GetCommittedOffsetAsync(new TopicPartition(topic, 0), CancellationToken.None))
+            .IsEqualTo(3);
+        await Assert.That(await consumer.GetCommittedOffsetAsync(new TopicPartition(topic, 1), CancellationToken.None))
+            .IsEqualTo(3);
+    }
+
+    private static TaskCompletionSource NewCompletionSource()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static long[] Snapshot(
+        ConcurrentDictionary<int, List<long>> processed,
+        int partition)
+    {
+        if (!processed.TryGetValue(partition, out var offsets))
+            return [];
+
+        lock (offsets)
+            return offsets.ToArray();
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ProducerOrderingTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerOrderingTests.cs
@@ -78,7 +78,7 @@ public sealed class ProducerOrderingTests(KafkaTestContainer kafka) : KafkaInteg
     {
         // Fire many concurrent produces and verify per-partition ordering is preserved
         // even when multiple in-flight requests are pipelined.
-    
+
         var topic = await KafkaContainer.CreateTestTopicAsync();
         const int messageCount = 500;
 
@@ -137,7 +137,7 @@ public sealed class ProducerOrderingTests(KafkaTestContainer kafka) : KafkaInteg
     {
         // Verify that messages to a single partition always maintain order
         // even with small batch sizes that force many in-flight batches.
-    
+
         var topic = await KafkaContainer.CreateTestTopicAsync();
         const int messageCount = 200;
 
@@ -195,7 +195,7 @@ public sealed class ProducerOrderingTests(KafkaTestContainer kafka) : KafkaInteg
     {
         // With multiple partitions, verify that ordering is maintained within each partition
         // when messages are produced concurrently across partitions.
-    
+
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 4);
         const int messagesPerPartition = 50;
 
@@ -287,7 +287,7 @@ public sealed class ProducerOrderingTests(KafkaTestContainer kafka) : KafkaInteg
                 .WithBootstrapServers(KafkaContainer.BootstrapServers)
                 .WithClientId($"test-concurrent-flush-{producerId}")
                 .WithAcks(Acks.All)
-    
+
                 .BuildAsync();
 
             await producer.WarmUpAllPartitionsAsync(topic, 3);
@@ -444,7 +444,7 @@ public sealed class ProducerOrderingTests(KafkaTestContainer kafka) : KafkaInteg
         // With tiny batch size (256 bytes) and single partition, most batches are deferred
         // (gate-busy) and must be chained. The gate must be held for the entire chain
         // to prevent the sender loop's next drain from stealing it via non-blocking Wait(0).
-    
+
         var topic = await KafkaContainer.CreateTestTopicAsync();
         const int messageCount = 1000;
 
@@ -502,7 +502,7 @@ public sealed class ProducerOrderingTests(KafkaTestContainer kafka) : KafkaInteg
         // Regression test: produces in waves to force multiple drain cycles, each with
         // deferred batches. Verifies that deferred chains from one drain don't race with
         // coalesced sends from the next drain on the same partition.
-    
+
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 4);
         const int wavesCount = 5;
         const int messagesPerWave = 200;
@@ -659,7 +659,7 @@ public sealed class ProducerOrderingTests(KafkaTestContainer kafka) : KafkaInteg
         // batch size creates interleaved deferred chains for both partitions. Verifies that
         // deferred chains for different partitions run independently without cross-interference,
         // and that each partition's chain holds its own gate correctly.
-    
+
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
         const int messagesPerPartition = 400;
 
@@ -740,7 +740,7 @@ public sealed class ProducerOrderingTests(KafkaTestContainer kafka) : KafkaInteg
         // Stress test: 16 partitions with concurrent produces forces complex broker grouping
         // and many deferred chains. With a single-broker test container, all partitions map
         // to the same broker, creating large coalesced requests.
-    
+
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 16);
         const int messagesPerPartition = 100;
 
@@ -816,7 +816,7 @@ public sealed class ProducerOrderingTests(KafkaTestContainer kafka) : KafkaInteg
     {
         // Regression test: rapid fire-and-forget with small batch size forces many batches
         // on a single partition, exercising deferred chains with the coalescing path.
-    
+
         var topic = await KafkaContainer.CreateTestTopicAsync();
         const int messageCount = 300;
 
@@ -874,7 +874,7 @@ public sealed class ProducerOrderingTests(KafkaTestContainer kafka) : KafkaInteg
         // flushes between waves. Each wave fires concurrent produces while previous waves'
         // deferred chains may still be completing. This exercises the interaction between
         // active deferred chains and new drain cycles.
-    
+
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 4);
         const int waves = 10;
         const int messagesPerWave = 100;

--- a/tests/Dekaf.Tests.Integration/ProducerTestExtensions.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTestExtensions.cs
@@ -39,7 +39,10 @@ internal static class ProducerTestExtensions
         {
             await producer.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic, Key = "warmup", Value = "warmup", Partition = p
+                Topic = topic,
+                Key = "warmup",
+                Value = "warmup",
+                Partition = p
             }, CancellationToken.None);
         }
     }

--- a/tests/Dekaf.Tests.Integration/RealWorld/ConsumerLagEdgeCaseTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/ConsumerLagEdgeCaseTests.cs
@@ -271,21 +271,30 @@ public sealed class ConsumerLagEdgeCaseTests(KafkaTestContainer kafka) : KafkaIn
         {
             await producer.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic, Key = $"p0-{i}", Value = $"value", Partition = 0
+                Topic = topic,
+                Key = $"p0-{i}",
+                Value = $"value",
+                Partition = 0
             }, CancellationToken.None);
         }
         for (var i = 0; i < 5; i++)
         {
             await producer.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic, Key = $"p1-{i}", Value = $"value", Partition = 1
+                Topic = topic,
+                Key = $"p1-{i}",
+                Value = $"value",
+                Partition = 1
             }, CancellationToken.None);
         }
         for (var i = 0; i < 10; i++)
         {
             await producer.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic, Key = $"p2-{i}", Value = $"value", Partition = 2
+                Topic = topic,
+                Key = $"p2-{i}",
+                Value = $"value",
+                Partition = 2
             }, CancellationToken.None);
         }
 

--- a/tests/Dekaf.Tests.Integration/RealWorld/MessageOrderingTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/MessageOrderingTests.cs
@@ -493,7 +493,9 @@ public sealed class MessageOrderingTests(KafkaTestContainer kafka) : KafkaIntegr
                 // Fire-and-forget
                 await producer.ProduceAsync(new ProducerMessage<string, string>
                 {
-                    Topic = topic, Key = "mixed", Value = $"seq-{i:D4}"
+                    Topic = topic,
+                    Key = "mixed",
+                    Value = $"seq-{i:D4}"
                 }, CancellationToken.None);
             }
             else
@@ -501,7 +503,9 @@ public sealed class MessageOrderingTests(KafkaTestContainer kafka) : KafkaIntegr
                 // Awaited
                 await producer.ProduceAsync(new ProducerMessage<string, string>
                 {
-                    Topic = topic, Key = "mixed", Value = $"seq-{i:D4}"
+                    Topic = topic,
+                    Key = "mixed",
+                    Value = $"seq-{i:D4}"
                 }, CancellationToken.None);
             }
         }

--- a/tests/Dekaf.Tests.Integration/RealWorld/ProducerDeliveryGuaranteeTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/ProducerDeliveryGuaranteeTests.cs
@@ -366,15 +366,21 @@ public sealed class ProducerDeliveryGuaranteeTests(KafkaTestContainer kafka) : K
         {
             await producer.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic1, Key = $"t1-key-{i}", Value = $"t1-value-{i}"
+                Topic = topic1,
+                Key = $"t1-key-{i}",
+                Value = $"t1-value-{i}"
             }, CancellationToken.None);
             await producer.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic2, Key = $"t2-key-{i}", Value = $"t2-value-{i}"
+                Topic = topic2,
+                Key = $"t2-key-{i}",
+                Value = $"t2-value-{i}"
             }, CancellationToken.None);
             await producer.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic3, Key = $"t3-key-{i}", Value = $"t3-value-{i}"
+                Topic = topic3,
+                Key = $"t3-key-{i}",
+                Value = $"t3-value-{i}"
             }, CancellationToken.None);
         }
 

--- a/tests/Dekaf.Tests.Integration/RealWorld/SerializerVarietyTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/SerializerVarietyTests.cs
@@ -308,15 +308,21 @@ public sealed class SerializerVarietyTests(KafkaTestContainer kafka) : KafkaInte
         var guidKey = Guid.NewGuid();
         var intTask = intProducer.ProduceAsync(new ProducerMessage<int, string>
         {
-            Topic = intTopic, Key = 100, Value = "int-event"
+            Topic = intTopic,
+            Key = 100,
+            Value = "int-event"
         }, CancellationToken.None);
         var guidTask = guidProducer.ProduceAsync(new ProducerMessage<Guid, string>
         {
-            Topic = guidTopic, Key = guidKey, Value = "guid-event"
+            Topic = guidTopic,
+            Key = guidKey,
+            Value = "guid-event"
         }, CancellationToken.None);
         var bytesTask = bytesProducer.ProduceAsync(new ProducerMessage<string, byte[]>
         {
-            Topic = bytesTopic, Key = "bytes-key", Value = [0xAB, 0xCD]
+            Topic = bytesTopic,
+            Key = "bytes-key",
+            Value = [0xAB, 0xCD]
         }, CancellationToken.None);
 
         await intTask;

--- a/tests/Dekaf.Tests.Integration/SupportsKafkaAttribute.cs
+++ b/tests/Dekaf.Tests.Integration/SupportsKafkaAttribute.cs
@@ -12,7 +12,7 @@ public class SupportsKafkaAttribute(int supportedKafkaVersion) : SkipAttribute(s
     protected override string GetSkipReason(TestRegisteredContext context)
     {
         var kafkaVersionUsedInTest = GetKafkaVersionUsedInTest(context);
-        
+
         return $"The test requires Kafka {supportedKafkaVersion} or above, but this test is testing {kafkaVersionUsedInTest}";
     }
 

--- a/tests/Dekaf.Tests.Integration/TimeoutIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/TimeoutIntegrationTests.cs
@@ -260,7 +260,9 @@ public class TimeoutIntegrationTests(KafkaTestContainer kafka) : KafkaIntegratio
         // Warm up: establish connection and metadata cache
         await producer.ProduceAsync(new ProducerMessage<string, string>
         {
-            Topic = topic, Key = "warmup", Value = "warmup"
+            Topic = topic,
+            Key = "warmup",
+            Value = "warmup"
         }, CancellationToken.None);
 
         // Act - Produce with a cancellation token, wait for delivery to complete,

--- a/tests/Dekaf.Tests.Integration/TransactionV2Tests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionV2Tests.cs
@@ -31,7 +31,9 @@ public class TransactionV2Tests(KafkaTestContainer kafka) : KafkaIntegrationTest
         {
             await txn.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic, Key = "k1", Value = "v1"
+                Topic = topic,
+                Key = "k1",
+                Value = "v1"
             }, CancellationToken.None);
 
             await txn.CommitAsync();
@@ -42,7 +44,9 @@ public class TransactionV2Tests(KafkaTestContainer kafka) : KafkaIntegrationTest
         {
             await txn.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic, Key = "k2", Value = "v2"
+                Topic = topic,
+                Key = "k2",
+                Value = "v2"
             }, CancellationToken.None);
 
             await txn.CommitAsync();
@@ -84,7 +88,9 @@ public class TransactionV2Tests(KafkaTestContainer kafka) : KafkaIntegrationTest
         {
             await txn.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic, Key = "aborted-key", Value = "aborted-value"
+                Topic = topic,
+                Key = "aborted-key",
+                Value = "aborted-value"
             }, CancellationToken.None);
 
             await txn.AbortAsync();
@@ -96,7 +102,9 @@ public class TransactionV2Tests(KafkaTestContainer kafka) : KafkaIntegrationTest
         {
             await txn.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic, Key = "committed-key", Value = "committed-value"
+                Topic = topic,
+                Key = "committed-key",
+                Value = "committed-value"
             }, CancellationToken.None);
 
             await txn.CommitAsync();
@@ -140,7 +148,9 @@ public class TransactionV2Tests(KafkaTestContainer kafka) : KafkaIntegrationTest
             await using var txn = producer.BeginTransaction();
             await txn.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic, Key = $"aborted-{i}", Value = $"aborted-{i}"
+                Topic = topic,
+                Key = $"aborted-{i}",
+                Value = $"aborted-{i}"
             }, CancellationToken.None);
             await txn.AbortAsync();
         }
@@ -150,7 +160,9 @@ public class TransactionV2Tests(KafkaTestContainer kafka) : KafkaIntegrationTest
         {
             await txn.ProduceAsync(new ProducerMessage<string, string>
             {
-                Topic = topic, Key = "final", Value = "final-value"
+                Topic = topic,
+                Key = "final",
+                Value = "final-value"
             }, CancellationToken.None);
             await txn.CommitAsync();
         }

--- a/tests/Dekaf.Tests.Unit/Admin/AdminDescribeTopicPartitionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminDescribeTopicPartitionsTests.cs
@@ -198,9 +198,9 @@ public sealed class AdminDescribeTopicPartitionsTests
         string topicName,
         int partitionIndex,
         DescribeTopicPartitionsResponseCursor? nextCursor) => new()
-    {
-        ThrottleTimeMs = 0,
-        Topics =
+        {
+            ThrottleTimeMs = 0,
+            Topics =
         [
             new DescribeTopicPartitionsResponseTopic
             {
@@ -225,8 +225,8 @@ public sealed class AdminDescribeTopicPartitionsTests
                 ]
             }
         ],
-        NextCursor = nextCursor
-    };
+            NextCursor = nextCursor
+        };
 
     private sealed class AdminTestContext : IAsyncDisposable
     {

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -255,6 +255,53 @@ public sealed class PartitionedConsumerRuntimeTests
     }
 
     [Test]
+    public async Task RunPartitionedAsync_RapidReassignRestartsPartitionLane()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var consumer = new TestConsumer();
+        consumer.AssignFromCoordinator(partition);
+
+        var starts = 0;
+        var secondLaneStarted = NewCompletionSource();
+        var processedAfterReassign = NewCompletionSource();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            async (context, cancellationToken) =>
+            {
+                if (Interlocked.Increment(ref starts) == 2)
+                    secondLaneStarted.SetResult();
+
+                await foreach (var message in context.Messages.WithCancellation(cancellationToken))
+                {
+                    context.MarkProcessed(message);
+                    processedAfterReassign.SetResult();
+                }
+            },
+            new PartitionedProcessingOptions
+            {
+                CommitPolicy = PartitionCommitPolicy.UserManaged,
+                StopPolicy = PartitionStopPolicy.Drain
+            },
+            cts.Token).AsTask();
+
+        await Assert.That(() => Volatile.Read(ref starts))
+            .Eventually(count => count.IsEqualTo(1), TimeSpan.FromSeconds(5));
+
+        consumer.RevokeFromCoordinator(partition);
+        consumer.AssignFromCoordinator(partition);
+
+        await secondLaneStarted.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        consumer.Enqueue(CreateResult(partition, 1));
+        await processedAfterReassign.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+
+        await Assert.That(Volatile.Read(ref starts)).IsEqualTo(2);
+        await Assert.That(consumer.CommitCalls).IsEmpty();
+
+        await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
+    }
+
+    [Test]
     public async Task RunPartitionedAsync_StopPartitionPausesUntilPartitionLeavesAssignment()
     {
         var partition = new TopicPartition("topic-a", 0);

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -377,6 +377,76 @@ public sealed class PartitionedConsumerRuntimeTests
     }
 
     [Test]
+    public async Task RunPartitionedAsync_IgnoreBackoffDoesNotStallHealthyPartitions()
+    {
+        var failingPartition = new TopicPartition("topic-a", 0);
+        var healthyPartition = new TopicPartition("topic-a", 1);
+        var loggerFactory = new CapturingLoggerFactory();
+        var consumer = new TestConsumer { LoggerFactory = loggerFactory };
+        consumer.AssignFromCoordinator(failingPartition, healthyPartition);
+
+        var failingAttempts = 0;
+        var healthyProcessed = NewCompletionSource();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            async (context, cancellationToken) =>
+            {
+                if (context.TopicPartition == failingPartition)
+                {
+                    Interlocked.Increment(ref failingAttempts);
+                    throw new InvalidOperationException("still failing");
+                }
+
+                await foreach (var message in context.Messages.WithCancellation(cancellationToken))
+                {
+                    context.MarkProcessed(message);
+                    healthyProcessed.TrySetResult();
+                }
+            },
+            new PartitionedProcessingOptions
+            {
+                ErrorPolicy = PartitionWorkerErrorPolicy.Ignore,
+                IgnoreRestartBackoff = TimeSpan.FromSeconds(30),
+                IgnoreRestartBackoffMax = TimeSpan.FromSeconds(30)
+            },
+            cts.Token).AsTask();
+
+        await Assert.That(() => Volatile.Read(ref failingAttempts))
+            .Eventually(count => count.IsEqualTo(1), TimeSpan.FromSeconds(5));
+        await Assert.That(() => loggerFactory.Entries.Any(
+                static entry => entry.LogLevel == LogLevel.Warning
+                    && entry.Message.Contains("restarting after", StringComparison.Ordinal)))
+            .Eventually(logged => logged.IsTrue(), TimeSpan.FromSeconds(5));
+
+        consumer.Enqueue(CreateResult(healthyPartition, 0));
+
+        await healthyProcessed.Task.WaitAsync(TimeSpan.FromSeconds(2), cts.Token).ConfigureAwait(false);
+        await Assert.That(Volatile.Read(ref failingAttempts)).IsEqualTo(1);
+
+        await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_RejectsZeroIgnoreRestartBackoff()
+    {
+        var consumer = new TestConsumer();
+
+        async Task Act()
+        {
+            await consumer.RunPartitionedAsync<string, string>(
+                static (_, _) => ValueTask.CompletedTask,
+                new PartitionedProcessingOptions
+                {
+                    ErrorPolicy = PartitionWorkerErrorPolicy.Ignore,
+                    IgnoreRestartBackoff = TimeSpan.Zero
+                });
+        }
+
+        await Assert.That(Act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     public async Task RunPartitionedAsync_StopTimeoutOnRevokePropagates()
     {
         var partition = new TopicPartition("topic-a", 0);

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -211,7 +211,7 @@ public sealed class PartitionedConsumerRuntimeTests
     {
         var partition = new TopicPartition("topic-a", 0);
         var consumer = new TestConsumer();
-        consumer.AssignFromCoordinator(partition);
+        consumer.SetAssignment(partition);
 
         var processorStarted = NewCompletionSource();
         var processed = NewCompletionSource();
@@ -260,7 +260,7 @@ public sealed class PartitionedConsumerRuntimeTests
     {
         var partition = new TopicPartition("topic-a", 0);
         var consumer = new TestConsumer();
-        consumer.AssignFromCoordinator(partition);
+        consumer.SetAssignment(partition);
 
         var starts = 0;
         var secondLaneStarted = NewCompletionSource();
@@ -308,7 +308,7 @@ public sealed class PartitionedConsumerRuntimeTests
         var partition = new TopicPartition("topic-a", 0);
         var loggerFactory = new CapturingLoggerFactory();
         var consumer = new TestConsumer { LoggerFactory = loggerFactory };
-        consumer.AssignFromCoordinator(partition);
+        consumer.SetAssignment(partition);
 
         var attempts = 0;
 
@@ -349,7 +349,7 @@ public sealed class PartitionedConsumerRuntimeTests
     {
         var partition = new TopicPartition("topic-a", 0);
         var consumer = new TestConsumer();
-        consumer.AssignFromCoordinator(partition);
+        consumer.SetAssignment(partition);
 
         var attempts = 0;
         var processed = NewCompletionSource();
@@ -390,7 +390,7 @@ public sealed class PartitionedConsumerRuntimeTests
         var partition = new TopicPartition("topic-a", 0);
         var loggerFactory = new CapturingLoggerFactory();
         var consumer = new TestConsumer { LoggerFactory = loggerFactory };
-        consumer.AssignFromCoordinator(partition);
+        consumer.SetAssignment(partition);
 
         var attempts = 0;
 
@@ -431,7 +431,7 @@ public sealed class PartitionedConsumerRuntimeTests
         var healthyPartition = new TopicPartition("topic-a", 1);
         var loggerFactory = new CapturingLoggerFactory();
         var consumer = new TestConsumer { LoggerFactory = loggerFactory };
-        consumer.AssignFromCoordinator(failingPartition, healthyPartition);
+        consumer.SetAssignment(failingPartition, healthyPartition);
 
         var failingAttempts = 0;
         var healthyProcessed = NewCompletionSource();

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -1,0 +1,611 @@
+using System.Collections.Concurrent;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+using Dekaf.Telemetry;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+[NotInParallel("PartitionedConsumerRuntime")]
+public sealed class PartitionedConsumerRuntimeTests
+{
+    [Test]
+    public async Task RunPartitionedAsync_RoutesAssignedPartitionsInOrderAndConcurrently()
+    {
+        var firstPartition = new TopicPartition("topic-a", 0);
+        var secondPartition = new TopicPartition("topic-a", 1);
+        var consumer = new TestConsumer();
+        consumer.SetAssignment(firstPartition, secondPartition);
+
+        var processed = new ConcurrentDictionary<TopicPartition, List<long>>();
+        var firstPartitionStarted = NewCompletionSource();
+        var releaseFirstPartition = NewCompletionSource();
+        var secondPartitionProcessed = NewCompletionSource();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            async (context, cancellationToken) =>
+            {
+                await foreach (var message in context.Messages.WithCancellation(cancellationToken))
+                {
+                    if (context.TopicPartition == firstPartition && message.Offset == 0)
+                    {
+                        firstPartitionStarted.SetResult();
+                        await releaseFirstPartition.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    var offsets = processed.GetOrAdd(context.TopicPartition, static _ => []);
+                    lock (offsets)
+                        offsets.Add(message.Offset);
+
+                    context.MarkProcessed(message);
+
+                    if (context.TopicPartition == secondPartition)
+                        secondPartitionProcessed.SetResult();
+                }
+            },
+            new PartitionedProcessingOptions { MaxBufferedRecordsPerPartition = 4 },
+            cts.Token).AsTask();
+
+        consumer.Enqueue(
+            CreateResult(firstPartition, 0),
+            CreateResult(firstPartition, 1),
+            CreateResult(secondPartition, 0));
+
+        await firstPartitionStarted.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        await secondPartitionProcessed.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+
+        releaseFirstPartition.SetResult();
+
+        await Assert.That(() => Snapshot(processed, firstPartition))
+            .Eventually(offsets => offsets.IsEquivalentTo(new long[] { 0, 1 }), TimeSpan.FromSeconds(5));
+
+        await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_PauseResumeWhenLaneIsFull()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var consumer = new TestConsumer();
+        consumer.SetAssignment(partition);
+
+        var processorStarted = NewCompletionSource();
+        var allowRead = NewCompletionSource();
+        var processed = new ConcurrentBag<long>();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            async (context, cancellationToken) =>
+            {
+                processorStarted.SetResult();
+                await allowRead.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                await foreach (var message in context.Messages.WithCancellation(cancellationToken))
+                {
+                    processed.Add(message.Offset);
+                    context.MarkProcessed(message);
+                }
+            },
+            new PartitionedProcessingOptions { MaxBufferedRecordsPerPartition = 1 },
+            cts.Token).AsTask();
+
+        await processorStarted.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        consumer.Enqueue(CreateResult(partition, 0), CreateResult(partition, 1));
+
+        await Assert.That(() => consumer.PauseCalls.Count)
+            .Eventually(count => count.IsGreaterThanOrEqualTo(1), TimeSpan.FromSeconds(5));
+
+        allowRead.SetResult();
+
+        await Assert.That(() => consumer.ResumeCalls.Count)
+            .Eventually(count => count.IsGreaterThanOrEqualTo(1), TimeSpan.FromSeconds(5));
+        await Assert.That(() => processed.Count)
+            .Eventually(count => count.IsEqualTo(2), TimeSpan.FromSeconds(5));
+
+        await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_RevokedPartitionStopsRoutingAndCommitsProcessedOnly()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var consumer = new TestConsumer();
+        consumer.SetAssignment(partition);
+
+        var processorStarted = NewCompletionSource();
+        var processedFirst = NewCompletionSource();
+        var processed = new ConcurrentBag<long>();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            async (context, cancellationToken) =>
+            {
+                processorStarted.SetResult();
+                await foreach (var message in context.Messages.WithCancellation(cancellationToken))
+                {
+                    processed.Add(message.Offset);
+                    context.MarkProcessed(message);
+                    processedFirst.TrySetResult();
+                }
+            },
+            new PartitionedProcessingOptions
+            {
+                MaxBufferedRecordsPerPartition = 4,
+                CommitPolicy = PartitionCommitPolicy.CommitCompletedOnRevoke
+            },
+            cts.Token).AsTask();
+
+        await processorStarted.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        consumer.Enqueue(CreateResult(partition, 0));
+        await processedFirst.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+
+        consumer.SetAssignment();
+        consumer.Enqueue(CreateResult(partition, 1));
+
+        await Assert.That(() => consumer.CommitCalls.SelectMany(static offsets => offsets).ToArray())
+            .Eventually(offsets => offsets.IsEquivalentTo(new[] { new TopicPartitionOffset("topic-a", 0, 1) }), TimeSpan.FromSeconds(5));
+
+        await Task.Delay(250, cts.Token).ConfigureAwait(false);
+        await Assert.That(processed.ToArray()).IsEquivalentTo(new long[] { 0 });
+
+        await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_StopPolicyCancelCancelsActiveWorkers()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var consumer = new TestConsumer();
+        consumer.SetAssignment(partition);
+
+        var started = NewCompletionSource();
+        var cancelled = NewCompletionSource();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            async (_, cancellationToken) =>
+            {
+                started.SetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    cancelled.SetResult();
+                }
+            },
+            new PartitionedProcessingOptions
+            {
+                StopPolicy = PartitionStopPolicy.Cancel,
+                StopTimeout = TimeSpan.FromSeconds(5)
+            },
+            cts.Token).AsTask();
+
+        await started.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        await cts.CancelAsync().ConfigureAwait(false);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await runTask.ConfigureAwait(false));
+        await cancelled.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_ProcessorFailurePropagates()
+    {
+        var consumer = new TestConsumer();
+        consumer.SetAssignment(new TopicPartition("topic-a", 0));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await Assert.That(async () => await consumer.RunPartitionedAsync<string, string>(
+                (_, _) => throw new InvalidOperationException("worker failed"),
+                cancellationToken: cts.Token))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task CommitProcessedAsync_CommitsCurrentPartitionOffset()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var consumer = new TestConsumer();
+        consumer.SetAssignment(partition);
+
+        var processorStarted = NewCompletionSource();
+        var committed = NewCompletionSource();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            async (context, cancellationToken) =>
+            {
+                processorStarted.SetResult();
+                await foreach (var message in context.Messages.WithCancellation(cancellationToken))
+                {
+                    context.MarkProcessed(message);
+                    await context.CommitProcessedAsync(cancellationToken).ConfigureAwait(false);
+                    committed.SetResult();
+                }
+            },
+            new PartitionedProcessingOptions
+            {
+                CommitPolicy = PartitionCommitPolicy.UserManaged
+            },
+            cts.Token).AsTask();
+
+        await processorStarted.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        consumer.Enqueue(CreateResult(partition, 4, leaderEpoch: 7));
+
+        await committed.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+
+        await Assert.That(consumer.CommitCalls.Single()).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 0, 5, 7)
+        ]);
+
+        await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
+    }
+
+    private static async ValueTask StopRuntimeAsync(
+        CancellationTokenSource cancellationTokenSource,
+        Task runTask)
+    {
+        await cancellationTokenSource.CancelAsync().ConfigureAwait(false);
+
+        try
+        {
+            await runTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private static TaskCompletionSource NewCompletionSource()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static long[] Snapshot(
+        ConcurrentDictionary<TopicPartition, List<long>> processed,
+        TopicPartition partition)
+    {
+        if (!processed.TryGetValue(partition, out var offsets))
+            return [];
+
+        lock (offsets)
+            return offsets.ToArray();
+    }
+
+    private static ConsumeResult<string, string> CreateResult(
+        TopicPartition partition,
+        long offset,
+        int? leaderEpoch = null)
+    {
+        return new ConsumeResult<string, string>(
+            topic: partition.Topic,
+            partition: partition.Partition,
+            offset: offset,
+            keyData: default,
+            isKeyNull: true,
+            valueData: default,
+            isValueNull: true,
+            headers: null,
+            timestampMs: 0,
+            timestampType: TimestampType.NotAvailable,
+            leaderEpoch: leaderEpoch,
+            keyDeserializer: null,
+            valueDeserializer: null);
+    }
+
+    private sealed class TestConsumer :
+        IKafkaConsumer<string, string>,
+        IConsumerPositions,
+        IConsumerPartitions,
+        IConsumerOffsets
+    {
+        private readonly object _gate = new();
+        private readonly Queue<ConsumeResult<string, string>> _records = [];
+        private readonly HashSet<TopicPartition> _assignment = [];
+        private readonly HashSet<TopicPartition> _paused = [];
+        private readonly SemaphoreSlim _changed = new(0);
+
+        public IReadOnlySet<string> Subscription => new HashSet<string>(StringComparer.Ordinal);
+
+        public string? SubscriptionPattern => null;
+
+        public IReadOnlySet<TopicPartition> Assignment
+        {
+            get
+            {
+                lock (_gate)
+                    return _assignment.ToHashSet();
+            }
+        }
+
+        public IReadOnlySet<TopicPartition> Paused
+        {
+            get
+            {
+                lock (_gate)
+                    return _paused.ToHashSet();
+            }
+        }
+
+        public string? MemberId => "member-a";
+
+        public ConsumerGroupMetadata? ConsumerGroupMetadata => new()
+        {
+            GroupId = "group-a",
+            GenerationId = 1,
+            MemberId = "member-a"
+        };
+
+        public IConsumerPositions Positions => this;
+
+        public IConsumerPartitions Partitions => this;
+
+        public IConsumerOffsets Offsets => this;
+
+        public List<TopicPartition[]> PauseCalls { get; } = [];
+
+        public List<TopicPartition[]> ResumeCalls { get; } = [];
+
+        public List<TopicPartitionOffset[]> CommitCalls { get; } = [];
+
+        IReadOnlySet<TopicPartition> IConsumerPartitions.Assignment => Assignment;
+
+        IReadOnlySet<TopicPartition> IConsumerPartitions.Paused => Paused;
+
+        public ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
+        public void Subscribe(params string[] topics)
+            => throw new NotSupportedException();
+
+        public void Subscribe(Func<string, bool> topicFilter)
+            => throw new NotSupportedException();
+
+        public void SubscribePattern(string pattern)
+            => throw new NotSupportedException();
+
+        public void Unsubscribe()
+            => throw new NotSupportedException();
+
+        public async IAsyncEnumerable<ConsumeResult<string, string>> ConsumeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var result = await ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+                if (result.HasValue)
+                    yield return result.Value;
+            }
+        }
+
+        public async ValueTask<ConsumeResult<string, string>?> ConsumeOneAsync(
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default)
+        {
+            var deadline = timeout == Timeout.InfiniteTimeSpan
+                ? DateTimeOffset.MaxValue
+                : DateTimeOffset.UtcNow.Add(timeout);
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (TryDequeueAvailable(out var result))
+                    return result;
+
+                if (timeout == TimeSpan.Zero)
+                    return null;
+
+                if (timeout == Timeout.InfiniteTimeSpan)
+                {
+                    await _changed.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                var remaining = deadline - DateTimeOffset.UtcNow;
+                if (remaining <= TimeSpan.Zero)
+                    return null;
+
+                if (!await _changed.WaitAsync(remaining, cancellationToken).ConfigureAwait(false))
+                    return null;
+            }
+        }
+
+        public async IAsyncEnumerable<ConsumeBatch<string, string>> ConsumeBatchAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.CompletedTask.ConfigureAwait(false);
+            throw new NotSupportedException();
+#pragma warning disable CS0162
+            yield break;
+#pragma warning restore CS0162
+        }
+
+        public async IAsyncEnumerable<ConsumeRawBatch> ConsumeRawBatchAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.CompletedTask.ConfigureAwait(false);
+            throw new NotSupportedException();
+#pragma warning disable CS0162
+            yield break;
+#pragma warning restore CS0162
+        }
+
+        public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+        {
+        }
+
+        public void UnregisterMetricFromSubscription(string name)
+        {
+        }
+
+        public ValueTask CommitAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask CommitAsync(
+            IEnumerable<TopicPartitionOffset> offsets,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(offsets);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            lock (_gate)
+                CommitCalls.Add(offsets.ToArray());
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask CloseAsync(CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync()
+            => ValueTask.CompletedTask;
+
+        public ValueTask<long?> GetCommittedOffsetAsync(
+            TopicPartition partition,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<long?>(null);
+
+        public long? GetPosition(TopicPartition partition)
+            => null;
+
+        public void Seek(TopicPartitionOffset offset)
+        {
+        }
+
+        public void SeekToBeginning(params TopicPartition[] partitions)
+        {
+        }
+
+        public void SeekToEnd(params TopicPartition[] partitions)
+        {
+        }
+
+        public void Assign(params TopicPartition[] partitions)
+            => SetAssignment(partitions);
+
+        public void Unassign()
+            => SetAssignment();
+
+        public void IncrementalAssign(IEnumerable<TopicPartitionOffset> partitions)
+        {
+            ArgumentNullException.ThrowIfNull(partitions);
+
+            lock (_gate)
+            {
+                foreach (var offset in partitions)
+                    _assignment.Add(new TopicPartition(offset.Topic, offset.Partition));
+            }
+
+            _changed.Release();
+        }
+
+        public void IncrementalUnassign(IEnumerable<TopicPartition> partitions)
+        {
+            ArgumentNullException.ThrowIfNull(partitions);
+
+            lock (_gate)
+            {
+                foreach (var partition in partitions)
+                    _assignment.Remove(partition);
+            }
+
+            _changed.Release();
+        }
+
+        public void Pause(params TopicPartition[] partitions)
+        {
+            ArgumentNullException.ThrowIfNull(partitions);
+
+            lock (_gate)
+            {
+                PauseCalls.Add(partitions.ToArray());
+                foreach (var partition in partitions)
+                    _paused.Add(partition);
+            }
+
+            _changed.Release();
+        }
+
+        public void Resume(params TopicPartition[] partitions)
+        {
+            ArgumentNullException.ThrowIfNull(partitions);
+
+            lock (_gate)
+            {
+                ResumeCalls.Add(partitions.ToArray());
+                foreach (var partition in partitions)
+                    _paused.Remove(partition);
+            }
+
+            _changed.Release();
+        }
+
+        public ValueTask<IReadOnlyDictionary<TopicPartition, long>> GetOffsetsForTimesAsync(
+            IEnumerable<TopicPartitionTimestamp> timestampsToSearch,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<IReadOnlyDictionary<TopicPartition, long>>(new Dictionary<TopicPartition, long>());
+
+        public WatermarkOffsets? GetWatermarkOffsets(TopicPartition topicPartition)
+            => null;
+
+        public ValueTask<WatermarkOffsets> QueryWatermarkOffsetsAsync(
+            TopicPartition topicPartition,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(new WatermarkOffsets(0, 0));
+
+        public void SetAssignment(params TopicPartition[] partitions)
+        {
+            lock (_gate)
+            {
+                _assignment.Clear();
+                _paused.RemoveWhere(partition => !partitions.Contains(partition));
+                foreach (var partition in partitions)
+                    _assignment.Add(partition);
+            }
+
+            _changed.Release();
+        }
+
+        public void Enqueue(params ConsumeResult<string, string>[] results)
+        {
+            lock (_gate)
+            {
+                foreach (var result in results)
+                    _records.Enqueue(result);
+            }
+
+            _changed.Release(results.Length);
+        }
+
+        private bool TryDequeueAvailable(out ConsumeResult<string, string> result)
+        {
+            lock (_gate)
+            {
+                var count = _records.Count;
+                for (var i = 0; i < count; i++)
+                {
+                    var candidate = _records.Dequeue();
+                    var partition = new TopicPartition(candidate.Topic, candidate.Partition);
+                    if (_assignment.Contains(partition) && !_paused.Contains(partition))
+                    {
+                        result = candidate;
+                        return true;
+                    }
+
+                    _records.Enqueue(candidate);
+                }
+            }
+
+            result = default;
+            return false;
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -3,6 +3,7 @@ using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.Serialization;
 using Dekaf.Telemetry;
+using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
@@ -257,7 +258,8 @@ public sealed class PartitionedConsumerRuntimeTests
     public async Task RunPartitionedAsync_StopPartitionPausesUntilPartitionLeavesAssignment()
     {
         var partition = new TopicPartition("topic-a", 0);
-        var consumer = new TestConsumer();
+        var loggerFactory = new CapturingLoggerFactory();
+        var consumer = new TestConsumer { LoggerFactory = loggerFactory };
         consumer.AssignFromCoordinator(partition);
 
         var attempts = 0;
@@ -279,6 +281,11 @@ public sealed class PartitionedConsumerRuntimeTests
             .Eventually(count => count.IsEqualTo(1), TimeSpan.FromSeconds(5));
         await Assert.That(() => consumer.Paused.Contains(partition))
             .Eventually(paused => paused.IsTrue(), TimeSpan.FromSeconds(5));
+        await Assert.That(() => loggerFactory.Entries.Any(
+                static entry => entry.LogLevel == LogLevel.Warning
+                    && entry.Exception is InvalidOperationException
+                    && entry.Message.Contains("pausing partition", StringComparison.Ordinal)))
+            .Eventually(logged => logged.IsTrue(), TimeSpan.FromSeconds(5));
 
         consumer.RevokeFromCoordinator(partition);
         consumer.AssignFromCoordinator(partition);
@@ -325,6 +332,46 @@ public sealed class PartitionedConsumerRuntimeTests
 
         await processed.Task.WaitAsync(cts.Token).ConfigureAwait(false);
         await Assert.That(consumer.PauseCalls).IsEmpty();
+
+        await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_IgnoreBacksOffAndLogsPersistentFailures()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var loggerFactory = new CapturingLoggerFactory();
+        var consumer = new TestConsumer { LoggerFactory = loggerFactory };
+        consumer.AssignFromCoordinator(partition);
+
+        var attempts = 0;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync<string, string>(
+            (_, _) =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw new InvalidOperationException("still failing");
+            },
+            new PartitionedProcessingOptions
+            {
+                ErrorPolicy = PartitionWorkerErrorPolicy.Ignore,
+                IgnoreRestartBackoff = TimeSpan.FromSeconds(30),
+                IgnoreRestartBackoffMax = TimeSpan.FromSeconds(30)
+            },
+            cts.Token).AsTask();
+
+        await Assert.That(() => Volatile.Read(ref attempts))
+            .Eventually(count => count.IsEqualTo(1), TimeSpan.FromSeconds(5));
+        await Assert.That(() => loggerFactory.Entries.Any(
+                static entry => entry.LogLevel == LogLevel.Warning
+                    && entry.Exception is InvalidOperationException
+                    && entry.Message.Contains("restarting after", StringComparison.Ordinal)
+                    && entry.Message.Contains("attempt 1", StringComparison.Ordinal)))
+            .Eventually(logged => logged.IsTrue(), TimeSpan.FromSeconds(5));
+
+        await Task.Delay(100, cts.Token).ConfigureAwait(false);
+        await Assert.That(Volatile.Read(ref attempts)).IsEqualTo(1);
 
         await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
     }
@@ -501,7 +548,8 @@ public sealed class PartitionedConsumerRuntimeTests
         IConsumerPositions,
         IConsumerPartitions,
         IConsumerOffsets,
-        IConsumerRebalanceEventSource
+        IConsumerRebalanceEventSource,
+        IConsumerLoggerFactorySource
     {
         private readonly object _gate = new();
         private readonly Queue<ConsumeResult<string, string>> _records = [];
@@ -556,6 +604,8 @@ public sealed class PartitionedConsumerRuntimeTests
         public TaskCompletionSource? CommitStarted { get; init; }
 
         public TaskCompletionSource? ReleaseCommit { get; init; }
+
+        public ILoggerFactory? LoggerFactory { get; init; }
 
         IReadOnlySet<TopicPartition> IConsumerPartitions.Assignment => Assignment;
 
@@ -886,4 +936,34 @@ public sealed class PartitionedConsumerRuntimeTests
             }
         }
     }
+
+    private sealed class CapturingLoggerFactory : ILoggerFactory
+    {
+        public ConcurrentQueue<LogEntry> Entries { get; } = new();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(Entries);
+
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingLogger(ConcurrentQueue<LogEntry> entries) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            entries.Enqueue(new LogEntry(logLevel, formatter(state, exception), exception));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel LogLevel, string Message, Exception? Exception);
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -205,6 +205,207 @@ public sealed class PartitionedConsumerRuntimeTests
     }
 
     [Test]
+    public async Task RunPartitionedAsync_LostPartitionCancelsWithoutCommit()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var consumer = new TestConsumer();
+        consumer.AssignFromCoordinator(partition);
+
+        var processorStarted = NewCompletionSource();
+        var processed = NewCompletionSource();
+        var stopped = NewCompletionSource();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            async (context, cancellationToken) =>
+            {
+                processorStarted.SetResult();
+                try
+                {
+                    await foreach (var message in context.Messages.WithCancellation(cancellationToken))
+                    {
+                        context.MarkProcessed(message);
+                        processed.SetResult();
+                    }
+                }
+                finally
+                {
+                    stopped.SetResult();
+                }
+            },
+            new PartitionedProcessingOptions
+            {
+                CommitPolicy = PartitionCommitPolicy.CommitCompletedOnRevoke,
+                StopPolicy = PartitionStopPolicy.Drain
+            },
+            cts.Token).AsTask();
+
+        await processorStarted.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+
+        consumer.Enqueue(CreateResult(partition, 0));
+        await processed.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+
+        consumer.LoseFromCoordinator(partition);
+
+        await stopped.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        await Assert.That(consumer.CommitCalls).IsEmpty();
+
+        await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_StopPartitionPausesUntilPartitionLeavesAssignment()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var consumer = new TestConsumer();
+        consumer.AssignFromCoordinator(partition);
+
+        var attempts = 0;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync<string, string>(
+            (_, _) =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw new InvalidOperationException("partition failed");
+            },
+            new PartitionedProcessingOptions
+            {
+                ErrorPolicy = PartitionWorkerErrorPolicy.StopPartition
+            },
+            cts.Token).AsTask();
+
+        await Assert.That(() => Volatile.Read(ref attempts))
+            .Eventually(count => count.IsEqualTo(1), TimeSpan.FromSeconds(5));
+        await Assert.That(() => consumer.Paused.Contains(partition))
+            .Eventually(paused => paused.IsTrue(), TimeSpan.FromSeconds(5));
+
+        consumer.RevokeFromCoordinator(partition);
+        consumer.AssignFromCoordinator(partition);
+
+        await Assert.That(() => Volatile.Read(ref attempts))
+            .Eventually(count => count.IsEqualTo(2), TimeSpan.FromSeconds(5));
+
+        await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_IgnoreRestartsPartitionLane()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var consumer = new TestConsumer();
+        consumer.AssignFromCoordinator(partition);
+
+        var attempts = 0;
+        var processed = NewCompletionSource();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            async (context, cancellationToken) =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                    throw new InvalidOperationException("ignored failure");
+
+                await foreach (var message in context.Messages.WithCancellation(cancellationToken))
+                {
+                    context.MarkProcessed(message);
+                    processed.SetResult();
+                }
+            },
+            new PartitionedProcessingOptions
+            {
+                ErrorPolicy = PartitionWorkerErrorPolicy.Ignore
+            },
+            cts.Token).AsTask();
+
+        await Assert.That(() => Volatile.Read(ref attempts))
+            .Eventually(count => count.IsEqualTo(2), TimeSpan.FromSeconds(5));
+
+        consumer.Enqueue(CreateResult(partition, 0));
+
+        await processed.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        await Assert.That(consumer.PauseCalls).IsEmpty();
+
+        await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_StopTimeoutOnRevokePropagates()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var consumer = new TestConsumer();
+        consumer.SetAssignment(partition);
+
+        var started = NewCompletionSource();
+        var release = NewCompletionSource();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            async (_, _) =>
+            {
+                started.SetResult();
+                await release.Task.ConfigureAwait(false);
+            },
+            new PartitionedProcessingOptions
+            {
+                StopTimeout = TimeSpan.FromMilliseconds(50)
+            },
+            cts.Token).AsTask();
+
+        await started.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+
+        consumer.SetAssignment();
+
+        await Assert.ThrowsAsync<TimeoutException>(async () => await runTask.ConfigureAwait(false));
+        release.SetResult();
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_ShutdownCommitUsesStopTimeout()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var consumer = new TestConsumer
+        {
+            CommitStarted = NewCompletionSource(),
+            ReleaseCommit = NewCompletionSource()
+        };
+        consumer.SetAssignment(partition);
+
+        var processorStarted = NewCompletionSource();
+        var processed = NewCompletionSource();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            async (context, cancellationToken) =>
+            {
+                processorStarted.SetResult();
+                await foreach (var message in context.Messages.WithCancellation(cancellationToken))
+                {
+                    context.MarkProcessed(message);
+                    processed.SetResult();
+                }
+            },
+            new PartitionedProcessingOptions
+            {
+                CommitPolicy = PartitionCommitPolicy.CommitCompletedOnRevoke,
+                StopTimeout = TimeSpan.FromMilliseconds(50)
+            },
+            cts.Token).AsTask();
+
+        await processorStarted.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        consumer.Enqueue(CreateResult(partition, 0));
+        await processed.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+
+        await cts.CancelAsync().ConfigureAwait(false);
+
+        await consumer.CommitStarted!.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await runTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false));
+
+        consumer.ReleaseCommit!.SetResult();
+    }
+
+    [Test]
     public async Task CommitProcessedAsync_CommitsCurrentPartitionOffset()
     {
         var partition = new TopicPartition("topic-a", 0);
@@ -299,12 +500,14 @@ public sealed class PartitionedConsumerRuntimeTests
         IKafkaConsumer<string, string>,
         IConsumerPositions,
         IConsumerPartitions,
-        IConsumerOffsets
+        IConsumerOffsets,
+        IConsumerRebalanceEventSource
     {
         private readonly object _gate = new();
         private readonly Queue<ConsumeResult<string, string>> _records = [];
         private readonly HashSet<TopicPartition> _assignment = [];
         private readonly HashSet<TopicPartition> _paused = [];
+        private readonly List<IRebalanceListener> _rebalanceListeners = [];
         private readonly SemaphoreSlim _changed = new(0);
 
         public IReadOnlySet<string> Subscription => new HashSet<string>(StringComparer.Ordinal);
@@ -350,9 +553,21 @@ public sealed class PartitionedConsumerRuntimeTests
 
         public List<TopicPartitionOffset[]> CommitCalls { get; } = [];
 
+        public TaskCompletionSource? CommitStarted { get; init; }
+
+        public TaskCompletionSource? ReleaseCommit { get; init; }
+
         IReadOnlySet<TopicPartition> IConsumerPartitions.Assignment => Assignment;
 
         IReadOnlySet<TopicPartition> IConsumerPartitions.Paused => Paused;
+
+        IDisposable IConsumerRebalanceEventSource.RegisterRuntimeRebalanceListener(IRebalanceListener listener)
+        {
+            lock (_gate)
+                _rebalanceListeners.Add(listener);
+
+            return new RebalanceRegistration(this, listener);
+        }
 
         public ValueTask InitializeAsync(CancellationToken cancellationToken = default)
             => ValueTask.CompletedTask;
@@ -449,17 +664,19 @@ public sealed class PartitionedConsumerRuntimeTests
             return ValueTask.CompletedTask;
         }
 
-        public ValueTask CommitAsync(
+        public async ValueTask CommitAsync(
             IEnumerable<TopicPartitionOffset> offsets,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(offsets);
             cancellationToken.ThrowIfCancellationRequested();
 
+            CommitStarted?.TrySetResult();
+            if (ReleaseCommit is not null)
+                await ReleaseCommit.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+
             lock (_gate)
                 CommitCalls.Add(offsets.ToArray());
-
-            return ValueTask.CompletedTask;
         }
 
         public ValueTask CloseAsync(CancellationToken cancellationToken = default)
@@ -574,6 +791,24 @@ public sealed class PartitionedConsumerRuntimeTests
             _changed.Release();
         }
 
+        public void AssignFromCoordinator(params TopicPartition[] partitions)
+        {
+            SetAssignment(partitions);
+            FireRebalanceListener(listener => listener.OnPartitionsAssignedAsync(partitions, CancellationToken.None));
+        }
+
+        public void RevokeFromCoordinator(params TopicPartition[] partitions)
+        {
+            RemoveAssignment(partitions);
+            FireRebalanceListener(listener => listener.OnPartitionsRevokedAsync(partitions, CancellationToken.None));
+        }
+
+        public void LoseFromCoordinator(params TopicPartition[] partitions)
+        {
+            RemoveAssignment(partitions);
+            FireRebalanceListener(listener => listener.OnPartitionsLostAsync(partitions, CancellationToken.None));
+        }
+
         public void Enqueue(params ConsumeResult<string, string>[] results)
         {
             lock (_gate)
@@ -606,6 +841,49 @@ public sealed class PartitionedConsumerRuntimeTests
 
             result = default;
             return false;
+        }
+
+        private void RemoveAssignment(params TopicPartition[] partitions)
+        {
+            lock (_gate)
+            {
+                foreach (var partition in partitions)
+                {
+                    _assignment.Remove(partition);
+                    _paused.Remove(partition);
+                }
+            }
+
+            _changed.Release();
+        }
+
+        private void RemoveRebalanceListener(IRebalanceListener listener)
+        {
+            lock (_gate)
+                _rebalanceListeners.Remove(listener);
+        }
+
+        private void FireRebalanceListener(Func<IRebalanceListener, ValueTask> callback)
+        {
+            IRebalanceListener[] listeners;
+            lock (_gate)
+                listeners = _rebalanceListeners.ToArray();
+
+            foreach (var listener in listeners)
+                callback(listener).AsTask().GetAwaiter().GetResult();
+        }
+
+        private sealed class RebalanceRegistration(
+            TestConsumer consumer,
+            IRebalanceListener listener) : IDisposable
+        {
+            private int _disposed;
+
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                    consumer.RemoveRebalanceListener(listener);
+            }
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -7,7 +7,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
-[NotInParallel("PartitionedConsumerRuntime")]
+// Full isolation: these tests assert timing-sensitive partition runtime scheduling.
+[NotInParallel]
 public sealed class PartitionedConsumerRuntimeTests
 {
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -26,16 +26,16 @@ public sealed class BrokerSenderSendLoopTests
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 100, int retryBackoffMaxMs = 1000,
         int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000) => new()
-    {
-        BootstrapServers = ["localhost:9092"],
-        MaxInFlightRequestsPerConnection = maxInFlight,
-        Acks = acks,
-        DeliveryTimeoutMs = deliveryTimeoutMs,
-        RetryBackoffMs = retryBackoffMs,
-        RetryBackoffMaxMs = retryBackoffMaxMs,
-        RequestTimeoutMs = requestTimeoutMs,
-        LingerMs = 0
-    };
+        {
+            BootstrapServers = ["localhost:9092"],
+            MaxInFlightRequestsPerConnection = maxInFlight,
+            Acks = acks,
+            DeliveryTimeoutMs = deliveryTimeoutMs,
+            RetryBackoffMs = retryBackoffMs,
+            RetryBackoffMaxMs = retryBackoffMaxMs,
+            RequestTimeoutMs = requestTimeoutMs,
+            LingerMs = 0
+        };
 
     /// <summary>
     /// Creates a mock connection pool that returns a controllable mock connection.

--- a/tests/Dekaf.Tests.Unit/Protocol/PartitionReassignmentMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/PartitionReassignmentMessageTests.cs
@@ -167,10 +167,10 @@ public sealed class PartitionReassignmentMessageTests
     private static AlterPartitionReassignmentsRequest CreateAlterRequest(
         IReadOnlyList<int>? replicas,
         bool allowReplicationFactorChange) => new()
-    {
-        TimeoutMs = 60000,
-        AllowReplicationFactorChange = allowReplicationFactorChange,
-        Topics =
+        {
+            TimeoutMs = 60000,
+            AllowReplicationFactorChange = allowReplicationFactorChange,
+            Topics =
         [
             new AlterPartitionReassignmentsRequestTopic
             {
@@ -185,7 +185,7 @@ public sealed class PartitionReassignmentMessageTests
                 ]
             }
         ]
-    };
+        };
 
     private static byte[] BuildAlterResponse(short version, ErrorCode errorCode)
     {

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -1091,7 +1091,10 @@ public class RecordBatchTests
         var buffer = new ArrayBufferWriter<byte>();
         var batch = new RecordBatch
         {
-            BaseOffset = 0, PartitionLeaderEpoch = -1, BaseTimestamp = 1000, MaxTimestamp = 1000,
+            BaseOffset = 0,
+            PartitionLeaderEpoch = -1,
+            BaseTimestamp = 1000,
+            MaxTimestamp = 1000,
             Records = [new Record { OffsetDelta = 0, TimestampDelta = 0, Value = "v"u8.ToArray() }]
         };
         batch.Write(buffer);
@@ -1119,7 +1122,10 @@ public class RecordBatchTests
         var buffer = new ArrayBufferWriter<byte>();
         var batch = new RecordBatch
         {
-            BaseOffset = 0, PartitionLeaderEpoch = -1, BaseTimestamp = 1000, MaxTimestamp = 1000,
+            BaseOffset = 0,
+            PartitionLeaderEpoch = -1,
+            BaseTimestamp = 1000,
+            MaxTimestamp = 1000,
             Records = [new Record { OffsetDelta = 0, TimestampDelta = 0, Value = "value"u8.ToArray() }]
         };
         batch.Write(buffer);
@@ -1148,7 +1154,10 @@ public class RecordBatchTests
         var buffer = new ArrayBufferWriter<byte>();
         var batch = new RecordBatch
         {
-            BaseOffset = 0, PartitionLeaderEpoch = -1, BaseTimestamp = 1000, MaxTimestamp = 1000,
+            BaseOffset = 0,
+            PartitionLeaderEpoch = -1,
+            BaseTimestamp = 1000,
+            MaxTimestamp = 1000,
             Records = [new Record { OffsetDelta = 0, TimestampDelta = 0, Value = "value"u8.ToArray() }]
         };
         batch.Write(buffer);


### PR DESCRIPTION
## Summary
- add `RunPartitionedAsync` with one bounded ordered lane per assigned partition
- support pause/resume backpressure, graceful drain/cancel stop, processed-offset commits, and worker failure handling
- add focused unit coverage and Kafka integration coverage for multi-partition ordering/concurrency/commits
- update the partitioned processing API page from proposal language to initial runtime language

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
- [x] `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter "/*/*/PartitionedConsumerRuntimeTests/*"` x5 after CI timing fix
- [x] `./tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration --treenode-filter "/*/*/PartitionedProcessingIntegrationTests/*"`
- [x] `npm ci --prefix docs`
- [x] `(cd docs; ./node_modules/.bin/docusaurus.cmd build)`
- [x] `git diff --check HEAD~1..HEAD`
- [!] Full local unit reruns after the timing fix now fail only unrelated `ClientDnsLookupTests.KafkaConnection_ConnectAsync_TriesAllResolvedAddresses` with `OperationCanceledException` after 4123/4124 pass.

Closes #1268