### PR TITLE
fix(schema-registry): use generated JSON context

### DIFF
--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -72,13 +72,13 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         var response = await _httpClient.PostAsJsonAsync(
             $"subjects/{Uri.EscapeDataString(subject)}/versions",
             request,
-            SchemaRegistryJsonTypeInfo.RegisterSchemaRequest,
+            SchemaRegistryJsonContext.Default.RegisterSchemaRequest,
             cancellationToken).ConfigureAwait(false);
 
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content.ReadFromJsonAsync<RegisterSchemaResponse>(
-            SchemaRegistryJsonTypeInfo.RegisterSchemaResponse, cancellationToken).ConfigureAwait(false);
+            SchemaRegistryJsonContext.Default.RegisterSchemaResponse, cancellationToken).ConfigureAwait(false);
 
         var id = result!.Id;
 
@@ -99,7 +99,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content.ReadFromJsonAsync<GetSchemaResponse>(
-            SchemaRegistryJsonTypeInfo.GetSchemaResponse, cancellationToken).ConfigureAwait(false);
+            SchemaRegistryJsonContext.Default.GetSchemaResponse, cancellationToken).ConfigureAwait(false);
 
         var schema = new Schema
         {
@@ -129,7 +129,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content.ReadFromJsonAsync<GetSubjectVersionResponse>(
-            SchemaRegistryJsonTypeInfo.GetSubjectVersionResponse, cancellationToken).ConfigureAwait(false);
+            SchemaRegistryJsonContext.Default.GetSubjectVersionResponse, cancellationToken).ConfigureAwait(false);
 
         var schema = new Schema
         {
@@ -176,7 +176,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         var response = await _httpClient.PostAsJsonAsync(
             $"subjects/{Uri.EscapeDataString(subject)}",
             request,
-            SchemaRegistryJsonTypeInfo.RegisterSchemaRequest,
+            SchemaRegistryJsonContext.Default.RegisterSchemaRequest,
             cancellationToken).ConfigureAwait(false);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
@@ -188,7 +188,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content.ReadFromJsonAsync<GetSubjectVersionResponse>(
-            SchemaRegistryJsonTypeInfo.GetSubjectVersionResponse, cancellationToken).ConfigureAwait(false);
+            SchemaRegistryJsonContext.Default.GetSubjectVersionResponse, cancellationToken).ConfigureAwait(false);
 
         var id = result!.Id;
 
@@ -224,7 +224,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content.ReadFromJsonAsync<List<string>>(
-            SchemaRegistryJsonTypeInfo.StringList, cancellationToken).ConfigureAwait(false) ?? [];
+            SchemaRegistryJsonContext.Default.ListString, cancellationToken).ConfigureAwait(false) ?? [];
     }
 
     public async Task<IReadOnlyList<int>> GetVersionsAsync(string subject, CancellationToken cancellationToken = default)
@@ -236,7 +236,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content.ReadFromJsonAsync<List<int>>(
-            SchemaRegistryJsonTypeInfo.Int32List, cancellationToken).ConfigureAwait(false) ?? [];
+            SchemaRegistryJsonContext.Default.ListInt32, cancellationToken).ConfigureAwait(false) ?? [];
     }
 
     public async Task<bool> IsCompatibleAsync(string subject, Schema schema, string version = "latest", CancellationToken cancellationToken = default)
@@ -256,7 +256,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         var response = await _httpClient.PostAsJsonAsync(
             $"compatibility/subjects/{Uri.EscapeDataString(subject)}/versions/{Uri.EscapeDataString(version)}",
             request,
-            SchemaRegistryJsonTypeInfo.RegisterSchemaRequest,
+            SchemaRegistryJsonContext.Default.RegisterSchemaRequest,
             cancellationToken).ConfigureAwait(false);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
@@ -265,7 +265,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content.ReadFromJsonAsync<CompatibilityResponse>(
-            SchemaRegistryJsonTypeInfo.CompatibilityResponse, cancellationToken).ConfigureAwait(false);
+            SchemaRegistryJsonContext.Default.CompatibilityResponse, cancellationToken).ConfigureAwait(false);
 
         return result?.IsCompatible ?? true;
     }
@@ -280,7 +280,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content.ReadFromJsonAsync<List<int>>(
-            SchemaRegistryJsonTypeInfo.Int32List, cancellationToken).ConfigureAwait(false) ?? [];
+            SchemaRegistryJsonContext.Default.ListInt32, cancellationToken).ConfigureAwait(false) ?? [];
     }
 
     private static SchemaType ParseSchemaType(string? schemaType)
@@ -304,7 +304,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         try
         {
             var errorResponse = await response.Content.ReadFromJsonAsync<ErrorResponse>(
-                SchemaRegistryJsonTypeInfo.ErrorResponse, cancellationToken).ConfigureAwait(false);
+                SchemaRegistryJsonContext.Default.ErrorResponse, cancellationToken).ConfigureAwait(false);
             errorMessage = errorResponse?.Message;
             errorCode = errorResponse?.ErrorCode;
         }

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryJsonContext.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryJsonContext.cs
@@ -1,5 +1,4 @@
 using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Metadata;
 
 namespace Dekaf.SchemaRegistry;
 
@@ -16,38 +15,6 @@ namespace Dekaf.SchemaRegistry;
 [JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(List<int>))]
 internal sealed partial class SchemaRegistryJsonContext : JsonSerializerContext;
-
-internal static class SchemaRegistryJsonTypeInfo
-{
-    internal static readonly JsonTypeInfo<RegisterSchemaRequest> RegisterSchemaRequest =
-        GetRequired<RegisterSchemaRequest>();
-
-    internal static readonly JsonTypeInfo<RegisterSchemaResponse> RegisterSchemaResponse =
-        GetRequired<RegisterSchemaResponse>();
-
-    internal static readonly JsonTypeInfo<GetSchemaResponse> GetSchemaResponse =
-        GetRequired<GetSchemaResponse>();
-
-    internal static readonly JsonTypeInfo<GetSubjectVersionResponse> GetSubjectVersionResponse =
-        GetRequired<GetSubjectVersionResponse>();
-
-    internal static readonly JsonTypeInfo<CompatibilityResponse> CompatibilityResponse =
-        GetRequired<CompatibilityResponse>();
-
-    internal static readonly JsonTypeInfo<ErrorResponse> ErrorResponse =
-        GetRequired<ErrorResponse>();
-
-    internal static readonly JsonTypeInfo<List<string>> StringList =
-        GetRequired<List<string>>();
-
-    internal static readonly JsonTypeInfo<List<int>> Int32List =
-        GetRequired<List<int>>();
-
-    private static JsonTypeInfo<T> GetRequired<T>()
-    {
-        return (JsonTypeInfo<T>)SchemaRegistryJsonContext.Default.GetTypeInfo(typeof(T))!;
-    }
-}
 
 internal sealed class RegisterSchemaRequest
 {

--- a/tests/Dekaf.Tests.Integration/JsonSchemaRegistryIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/JsonSchemaRegistryIntegrationTests.cs
@@ -293,5 +293,6 @@ internal sealed class TestOrder
     public decimal Amount { get; set; }
 }
 
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(TestOrder))]
 internal sealed partial class JsonSchemaRegistryIntegrationJsonContext : JsonSerializerContext;

--- a/tests/Dekaf.Tests.Integration/JsonSchemaRegistryIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/JsonSchemaRegistryIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.SchemaRegistry;
@@ -23,13 +24,6 @@ public sealed class JsonSchemaRegistryIntegrationTests(KafkaWithSchemaRegistryCo
             "required": ["OrderId", "CustomerName", "Amount"]
         }
         """;
-
-    private sealed class TestOrder
-    {
-        public int OrderId { get; set; }
-        public string CustomerName { get; set; } = string.Empty;
-        public decimal Amount { get; set; }
-    }
 
     [Test]
     public async Task JsonSchemaRegistry_ProduceAndConsume_RoundTrips()
@@ -83,6 +77,65 @@ public sealed class JsonSchemaRegistryIntegrationTests(KafkaWithSchemaRegistryCo
         await Assert.That(consumed!.OrderId).IsEqualTo(1001);
         await Assert.That(consumed.CustomerName).IsEqualTo("Alice");
         await Assert.That(consumed.Amount).IsEqualTo(99.99m);
+    }
+
+    [Test]
+    public async Task JsonSchemaRegistry_ProduceAndConsume_WithJsonTypeInfo_RoundTrips()
+    {
+        var topic = await testInfra.CreateTestTopicAsync();
+
+        using var registryClient = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = testInfra.RegistryUrl
+        });
+
+        var order = new TestOrder
+        {
+            OrderId = 3003,
+            CustomerName = "Clara",
+            Amount = 42.50m
+        };
+
+        await using var producer = await Kafka.CreateProducer<string, TestOrder>()
+            .WithBootstrapServers(testInfra.BootstrapServers)
+            .UseJsonSchemaRegistry(
+                registryClient,
+                TestOrderSchema,
+                JsonSchemaRegistryIntegrationJsonContext.Default.TestOrder)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(new ProducerMessage<string, TestOrder>
+        {
+            Topic = topic,
+            Key = "order-3003",
+            Value = order
+        }, CancellationToken.None);
+
+        await using var consumer = await Kafka.CreateConsumer<string, TestOrder>()
+            .WithBootstrapServers(testInfra.BootstrapServers)
+            .WithGroupId($"json-sr-aot-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .UseJsonSchemaRegistry(
+                registryClient,
+                JsonSchemaRegistryIntegrationJsonContext.Default.TestOrder)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        TestOrder? consumed = null;
+
+        await foreach (var msg in consumer.ConsumeAsync(cts.Token))
+        {
+            consumed = msg.Value;
+            break;
+        }
+
+        await Assert.That(consumed).IsNotNull();
+        await Assert.That(consumed!.OrderId).IsEqualTo(3003);
+        await Assert.That(consumed.CustomerName).IsEqualTo("Clara");
+        await Assert.That(consumed.Amount).IsEqualTo(42.50m);
     }
 
     [Test]
@@ -232,3 +285,13 @@ public sealed class JsonSchemaRegistryIntegrationTests(KafkaWithSchemaRegistryCo
         await Assert.That(consumed.CustomerName).IsEqualTo("Bob");
     }
 }
+
+internal sealed class TestOrder
+{
+    public int OrderId { get; set; }
+    public string CustomerName { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+}
+
+[JsonSerializable(typeof(TestOrder))]
+internal sealed partial class JsonSchemaRegistryIntegrationJsonContext : JsonSerializerContext;

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryJsonAotTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryJsonAotTests.cs
@@ -39,10 +39,10 @@ public sealed class SchemaRegistryJsonAotTests
 
         var requestJson = JsonSerializer.SerializeToUtf8Bytes(
             request,
-            SchemaRegistryJsonTypeInfo.RegisterSchemaRequest);
+            SchemaRegistryJsonContext.Default.RegisterSchemaRequest);
         var roundTrippedRequest = JsonSerializer.Deserialize(
             requestJson,
-            SchemaRegistryJsonTypeInfo.RegisterSchemaRequest);
+            SchemaRegistryJsonContext.Default.RegisterSchemaRequest);
 
         var subjectResponseJson = """
             {
@@ -62,14 +62,14 @@ public sealed class SchemaRegistryJsonAotTests
             """u8;
         var subjectResponse = JsonSerializer.Deserialize(
             subjectResponseJson,
-            SchemaRegistryJsonTypeInfo.GetSubjectVersionResponse);
+            SchemaRegistryJsonContext.Default.GetSubjectVersionResponse);
 
         var compatibilityJson = JsonSerializer.SerializeToUtf8Bytes(
             new CompatibilityResponse { IsCompatible = true },
-            SchemaRegistryJsonTypeInfo.CompatibilityResponse);
+            SchemaRegistryJsonContext.Default.CompatibilityResponse);
         var errorJson = JsonSerializer.SerializeToUtf8Bytes(
             new ErrorResponse { ErrorCode = 40401, Message = "missing" },
-            SchemaRegistryJsonTypeInfo.ErrorResponse);
+            SchemaRegistryJsonContext.Default.ErrorResponse);
         using var compatibilityDocument = JsonDocument.Parse(compatibilityJson);
         using var errorDocument = JsonDocument.Parse(errorJson);
 


### PR DESCRIPTION
## Summary
- follow up on #1310 review by removing the SchemaRegistryJsonTypeInfo wrapper
- use SchemaRegistryJsonContext.Default generated JsonTypeInfo properties directly
- add JSON Schema Registry integration coverage for JsonTypeInfo<T> producer and consumer overloads

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release
- [x] dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj --configuration Release
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter "/*/*/SchemaRegistryJsonAotTests/*"
- [x] ./tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration --treenode-filter "/*/*/JsonSchemaRegistryIntegrationTests/*"
- [x] git diff --check origin/main..HEAD

Refs #1304
Follow-up to #1310