### PR TITLE
fix(compat): compile netstandard core

### DIFF
--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -61,15 +61,16 @@ dotnet build src/Dekaf/Dekaf.csproj --configuration Release `
   -p:TargetFramework=netstandard2.0
 ```
 
-The probe is still expected to fail until #1300 removes or isolates the remaining core API blockers. Current blocker categories:
+After the #1300 core API blocker pass, the forced `src/Dekaf` probe builds clean for `netstandard2.0` while the package still defaults to `net10.0`.
 
-- Runtime intrinsics: `System.Runtime.Intrinsics` is not available as a `netstandard2.0` package, so the CRC/vectorized record batch paths need conditional fallbacks.
-- Modern collection and threading APIs: `IReadOnlySet<T>`, `System.Threading.Lock`, `PeriodicTimer`, non-generic `TaskCompletionSource`, and `Task.WaitAsync`.
-- Runtime feature constraints: static abstract interface members, by-ref-like generics, and ref fields are not supported by the `netstandard2.0` target runtime.
-- Buffer and stream APIs: `SequenceReader<T>`, `ArrayBufferWriter<T>`, and span-based `Stream.Write(ReadOnlySpan<byte>)` need compatibility paths.
-- TLS/GSSAPI APIs: `SslClientAuthenticationOptions`, `NegotiateAuthentication`, and `NegotiateAuthenticationClientOptions` need target-specific handling.
+This does not declare package support for `netstandard2.0`. It means the core source can be compiled under the forced target so #1301 can add package/smoke validation and decide the final supported asset set.
 
-This baseline does not declare package support for `netstandard2.0`; it only makes the next compile-blocker work measurable.
+Target-specific compatibility notes:
+
+- Runtime intrinsics: CRC32C uses the existing software fallback on `netstandard2.0`; hardware intrinsics remain on the `net10.0` path.
+- Modern BCL APIs: internal compatibility helpers cover throw helpers, `Task.WaitAsync`, collection helpers, `ArrayBufferWriter<T>`, `SequenceReader<T>`, `PeriodicTimer`, and related API gaps.
+- TLS/GSSAPI: basic TLS paths compile for `netstandard2.0`; PEM certificate loading, custom root trust, and ECDSA JWT-bearer signing throw `PlatformNotSupportedException` on the compatibility target where the runtime APIs are unavailable.
+- Serializer hot paths keep ref-struct writer support on `net10.0`; `netstandard2.0` uses non-ref-struct generic constraints required by the target runtime.
 
 ## Blocker Categories
 

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -369,7 +369,7 @@ public sealed class AdminClient : IAdminClient
         CancellationToken cancellationToken = default)
     {
         var opts = options ?? new DescribeTopicPartitionsOptions();
-        ArgumentOutOfRangeException.ThrowIfLessThan(opts.ResponsePartitionLimit, 1);
+        CompatibilityThrowHelpers.ThrowIfLessThan(opts.ResponsePartitionLimit, 1);
 
         var topicList = topicNames.ToList();
         if (topicList.Count == 0)
@@ -410,7 +410,7 @@ public sealed class AdminClient : IAdminClient
         CancellationToken cancellationToken = default)
     {
         var opts = options ?? new DescribeTopicPartitionsPageOptions();
-        ArgumentOutOfRangeException.ThrowIfLessThan(opts.ResponsePartitionLimit, 1);
+        CompatibilityThrowHelpers.ThrowIfLessThan(opts.ResponsePartitionLimit, 1);
 
         var topicList = topicNames.ToList();
         if (topicList.Count == 0)
@@ -914,7 +914,7 @@ public sealed class AdminClient : IAdminClient
         IEnumerable<string> transactionalIds,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(transactionalIds);
+        CompatibilityThrowHelpers.ThrowIfNull(transactionalIds);
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
@@ -997,7 +997,7 @@ public sealed class AdminClient : IAdminClient
         IEnumerable<TopicPartition> partitions,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(partitions);
+        CompatibilityThrowHelpers.ThrowIfNull(partitions);
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
@@ -1408,7 +1408,7 @@ public sealed class AdminClient : IAdminClient
         AlterPartitionReassignmentsOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(reassignments);
+        CompatibilityThrowHelpers.ThrowIfNull(reassignments);
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
         var opts = options ?? new AlterPartitionReassignmentsOptions();
@@ -1576,7 +1576,7 @@ public sealed class AdminClient : IAdminClient
 
     private static void ValidateTopicPartition(TopicPartition topicPartition)
     {
-        ArgumentException.ThrowIfNullOrEmpty(topicPartition.Topic);
+        CompatibilityThrowHelpers.ThrowIfNullOrEmpty(topicPartition.Topic);
         if (topicPartition.Partition < 0)
         {
             throw new ArgumentOutOfRangeException(nameof(topicPartition), topicPartition.Partition, "Partition index must not be negative.");
@@ -1672,7 +1672,7 @@ public sealed class AdminClient : IAdminClient
                     break;
 
                 case UserScramCredentialUpsertion upsertion:
-                    var salt = upsertion.Salt ?? RandomNumberGenerator.GetBytes(32);
+                    var salt = upsertion.Salt ?? CompatibilityBcl.GetRandomBytes(32);
                     var saltedPassword = ComputeSaltedPassword(
                         upsertion.Password,
                         salt,
@@ -1728,7 +1728,7 @@ public sealed class AdminClient : IAdminClient
         DescribeClientQuotasOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(filter);
+        CompatibilityThrowHelpers.ThrowIfNull(filter);
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
         var components = BuildDescribeClientQuotaComponents(filter);
@@ -1775,7 +1775,7 @@ public sealed class AdminClient : IAdminClient
         AlterClientQuotasOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(alterations);
+        CompatibilityThrowHelpers.ThrowIfNull(alterations);
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
         var opts = options ?? new AlterClientQuotasOptions();
@@ -1829,7 +1829,7 @@ public sealed class AdminClient : IAdminClient
 
         return filter.Components.Select(component =>
         {
-            ArgumentNullException.ThrowIfNull(component);
+            CompatibilityThrowHelpers.ThrowIfNull(component);
             component.Validate();
             return new DescribeClientQuotasRequestComponent
             {
@@ -1842,14 +1842,14 @@ public sealed class AdminClient : IAdminClient
 
     private static AlterClientQuotasRequestEntry BuildAlterClientQuotaEntry(ClientQuotaAlteration alteration)
     {
-        ArgumentNullException.ThrowIfNull(alteration);
+        CompatibilityThrowHelpers.ThrowIfNull(alteration);
         alteration.Validate();
 
         return new AlterClientQuotasRequestEntry
         {
             Entity = alteration.Entity.Components.Select(component =>
             {
-                ArgumentNullException.ThrowIfNull(component);
+                CompatibilityThrowHelpers.ThrowIfNull(component);
                 return new AlterClientQuotasEntityData
                 {
                     EntityType = ClientQuotaEntityTypeNames.ToProtocolName(component.EntityType),
@@ -1858,8 +1858,8 @@ public sealed class AdminClient : IAdminClient
             }).ToList(),
             Ops = alteration.Operations.Select(operation =>
             {
-                ArgumentNullException.ThrowIfNull(operation);
-                ArgumentException.ThrowIfNullOrEmpty(operation.Key);
+                CompatibilityThrowHelpers.ThrowIfNull(operation);
+                CompatibilityThrowHelpers.ThrowIfNullOrEmpty(operation.Key);
 
                 return new AlterClientQuotasOpData
                 {
@@ -1965,7 +1965,7 @@ public sealed class AdminClient : IAdminClient
         TimeSpan? renewPeriod = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(hmac);
+        CompatibilityThrowHelpers.ThrowIfNull(hmac);
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
         var renewPeriodMs = ToKafkaMilliseconds(renewPeriod, nameof(renewPeriod));
@@ -2003,7 +2003,7 @@ public sealed class AdminClient : IAdminClient
         TimeSpan? expiryTimePeriod = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(hmac);
+        CompatibilityThrowHelpers.ThrowIfNull(hmac);
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
         var expiryTimePeriodMs = ToKafkaMilliseconds(expiryTimePeriod, nameof(expiryTimePeriod));
@@ -2145,7 +2145,7 @@ public sealed class AdminClient : IAdminClient
 
         var hashSize = mechanism == ScramMechanism.ScramSha256 ? 32 : 64;
 
-        return Rfc2898DeriveBytes.Pbkdf2(
+        return CompatibilityBcl.Pbkdf2(
             Encoding.UTF8.GetBytes(password),
             salt,
             iterations,
@@ -2565,8 +2565,8 @@ public sealed class AdminClient : IAdminClient
         DeleteConsumerGroupOffsetsOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(groupId);
-        ArgumentNullException.ThrowIfNull(partitions);
+        CompatibilityThrowHelpers.ThrowIfNull(groupId);
+        CompatibilityThrowHelpers.ThrowIfNull(partitions);
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
@@ -2824,7 +2824,7 @@ public sealed class AdminClient : IAdminClient
         IEnumerable<TopicPartition>? partitions = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(brokerIds);
+        CompatibilityThrowHelpers.ThrowIfNull(brokerIds);
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
@@ -2910,7 +2910,7 @@ public sealed class AdminClient : IAdminClient
         IReadOnlyDictionary<TopicPartitionReplica, string> replicaAssignments,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(replicaAssignments);
+        CompatibilityThrowHelpers.ThrowIfNull(replicaAssignments);
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
@@ -3933,7 +3933,7 @@ public sealed class AdminClientBuilder
     public AdminClientBuilder WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentNullException.ThrowIfNull(options);
+        CompatibilityThrowHelpers.ThrowIfNull(options);
         var oauthConfig = options.ToOAuthBearerConfig();
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthConfig = oauthConfig;
@@ -3948,7 +3948,7 @@ public sealed class AdminClientBuilder
     /// <param name="configure">Callback that configures the JWT-bearer OAuth options.</param>
     public AdminClientBuilder WithOAuthBearerJwtBearer(Action<OAuthBearerJwtBearerOptions> configure)
     {
-        ArgumentNullException.ThrowIfNull(configure);
+        CompatibilityThrowHelpers.ThrowIfNull(configure);
         var options = new OAuthBearerJwtBearerOptions();
         configure(options);
         return WithOAuthBearerJwtBearer(options);
@@ -3994,7 +3994,7 @@ public sealed class AdminClientBuilder
     /// <param name="metric">The application metric to register.</param>
     public AdminClientBuilder RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
     {
-        ArgumentNullException.ThrowIfNull(metric);
+        CompatibilityThrowHelpers.ThrowIfNull(metric);
         _applicationMetrics[metric.Name] = metric;
         return this;
     }
@@ -4006,7 +4006,7 @@ public sealed class AdminClientBuilder
     /// <param name="name">The application metric name.</param>
     public AdminClientBuilder UnregisterMetricFromSubscription(string name)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(name);
         _applicationMetrics.Remove(name);
         return this;
     }
@@ -4066,7 +4066,7 @@ public sealed class AdminClientBuilder
     {
         if (timeout <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(timeout), "Request timeout must be positive");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
 
         _requestTimeoutMs = (int)timeout.TotalMilliseconds;
         return this;

--- a/src/Dekaf/Admin/ClientQuotaTypes.cs
+++ b/src/Dekaf/Admin/ClientQuotaTypes.cs
@@ -333,7 +333,7 @@ public sealed class ClientQuotaAlteration
     /// </summary>
     public void Validate()
     {
-        ArgumentNullException.ThrowIfNull(Entity);
+        CompatibilityThrowHelpers.ThrowIfNull(Entity);
 
         if (Entity.Components is null || Entity.Components.Count == 0)
         {
@@ -342,7 +342,7 @@ public sealed class ClientQuotaAlteration
 
         foreach (var component in Entity.Components)
         {
-            ArgumentNullException.ThrowIfNull(component);
+            CompatibilityThrowHelpers.ThrowIfNull(component);
             _ = ClientQuotaEntityTypeNames.ToProtocolName(component.EntityType);
         }
 
@@ -353,8 +353,8 @@ public sealed class ClientQuotaAlteration
 
         foreach (var operation in Operations)
         {
-            ArgumentNullException.ThrowIfNull(operation);
-            ArgumentException.ThrowIfNullOrEmpty(operation.Key);
+            CompatibilityThrowHelpers.ThrowIfNull(operation);
+            CompatibilityThrowHelpers.ThrowIfNullOrEmpty(operation.Key);
         }
     }
 }

--- a/src/Dekaf/Admin/PartitionReassignmentTypes.cs
+++ b/src/Dekaf/Admin/PartitionReassignmentTypes.cs
@@ -39,7 +39,7 @@ public static class Optional
     /// </summary>
     public static Optional<T> Some<T>(T value)
     {
-        ArgumentNullException.ThrowIfNull(value);
+        CompatibilityThrowHelpers.ThrowIfNull(value);
         return new Optional<T>(value);
     }
 

--- a/src/Dekaf/BootstrapServerList.cs
+++ b/src/Dekaf/BootstrapServerList.cs
@@ -4,13 +4,13 @@ internal static class BootstrapServerList
 {
     internal static string[] FromCommaSeparated(string servers)
     {
-        ArgumentNullException.ThrowIfNull(servers);
+        CompatibilityThrowHelpers.ThrowIfNull(servers);
         return FromValues(servers.Split(','));
     }
 
     internal static string[] FromValues(params string[] servers)
     {
-        ArgumentNullException.ThrowIfNull(servers);
+        CompatibilityThrowHelpers.ThrowIfNull(servers);
 
         if (servers.Length == 0)
             throw new ArgumentException("At least one bootstrap server must be specified.", nameof(servers));

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -122,7 +122,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <param name="linger">The time to wait before sending a batch.</param>
     public ProducerBuilder<TKey, TValue> WithLinger(TimeSpan linger)
     {
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(linger.TotalMilliseconds, int.MaxValue, nameof(linger));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(linger.TotalMilliseconds, int.MaxValue, nameof(linger));
         _lingerMs = (int)linger.TotalMilliseconds;
         return this;
     }
@@ -163,7 +163,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     {
         if (maxBlock <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(maxBlock), "MaxBlock must be positive");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(maxBlock.TotalMilliseconds, int.MaxValue, nameof(maxBlock));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(maxBlock.TotalMilliseconds, int.MaxValue, nameof(maxBlock));
 
         _maxBlockMs = (int)maxBlock.TotalMilliseconds;
         return this;
@@ -214,8 +214,8 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithConnectionsPerBroker(int connectionsPerBroker)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentOutOfRangeException.ThrowIfLessThan(connectionsPerBroker, 1);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(connectionsPerBroker, 32);
+        CompatibilityThrowHelpers.ThrowIfLessThan(connectionsPerBroker, 1);
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(connectionsPerBroker, 32);
         _connectionsPerBroker = connectionsPerBroker;
         return this;
     }
@@ -239,7 +239,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithAdaptiveConnections(int maxConnections = 10)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentOutOfRangeException.ThrowIfLessThan(maxConnections, 1);
+        CompatibilityThrowHelpers.ThrowIfLessThan(maxConnections, 1);
         _enableAdaptiveConnections = true;
         _maxConnectionsPerBroker = maxConnections;
         return this;
@@ -264,7 +264,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithSocketSendBufferBytes(int bytes)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        CompatibilityThrowHelpers.ThrowIfNegative(bytes);
         _socketSendBufferBytes = bytes;
         return this;
     }
@@ -277,7 +277,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithSocketReceiveBufferBytes(int bytes)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        CompatibilityThrowHelpers.ThrowIfNegative(bytes);
         _socketReceiveBufferBytes = bytes;
         return this;
     }
@@ -298,7 +298,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     {
         if (timeout <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(timeout), "Transaction timeout must be positive");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
 
         _transactionTimeoutMs = (int)timeout.TotalMilliseconds;
         return this;
@@ -488,7 +488,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentNullException.ThrowIfNull(options);
+        CompatibilityThrowHelpers.ThrowIfNull(options);
         var oauthConfig = options.ToOAuthBearerConfig();
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthConfig = oauthConfig;
@@ -503,7 +503,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <param name="configure">Callback that configures the JWT-bearer OAuth options.</param>
     public ProducerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(Action<OAuthBearerJwtBearerOptions> configure)
     {
-        ArgumentNullException.ThrowIfNull(configure);
+        CompatibilityThrowHelpers.ThrowIfNull(configure);
         var options = new OAuthBearerJwtBearerOptions();
         configure(options);
         return WithOAuthBearerJwtBearer(options);
@@ -573,7 +573,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithMetadataRecoveryRebootstrapTrigger(TimeSpan trigger)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(trigger.TotalMilliseconds, int.MaxValue, nameof(trigger));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(trigger.TotalMilliseconds, int.MaxValue, nameof(trigger));
         _metadataRecoveryRebootstrapTriggerMs = (int)trigger.TotalMilliseconds;
         return this;
     }
@@ -675,7 +675,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <returns>The builder instance for method chaining.</returns>
     public ProducerBuilder<TKey, TValue> AddInterceptor(IProducerInterceptor<TKey, TValue> interceptor)
     {
-        ArgumentNullException.ThrowIfNull(interceptor);
+        CompatibilityThrowHelpers.ThrowIfNull(interceptor);
         _interceptors ??= [];
         _interceptors.Add(interceptor);
         return this;
@@ -703,7 +703,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     {
         if (timeout <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(timeout), "Delivery timeout must be positive");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
 
         _deliveryTimeoutMs = (int)timeout.TotalMilliseconds;
         return this;
@@ -719,7 +719,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     {
         if (timeout <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(timeout), "Request timeout must be positive");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
 
         _requestTimeoutMs = (int)timeout.TotalMilliseconds;
         return this;
@@ -786,7 +786,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <param name="metric">The application metric to register.</param>
     public ProducerBuilder<TKey, TValue> RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
     {
-        ArgumentNullException.ThrowIfNull(metric);
+        CompatibilityThrowHelpers.ThrowIfNull(metric);
         _applicationMetrics[metric.Name] = metric;
         return this;
     }
@@ -798,7 +798,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <param name="name">The application metric name.</param>
     public ProducerBuilder<TKey, TValue> UnregisterMetricFromSubscription(string name)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(name);
         _applicationMetrics.Remove(name);
         return this;
     }
@@ -806,14 +806,14 @@ public sealed class ProducerBuilder<TKey, TValue>
     internal ProducerBuilder<TKey, TValue> WithMaxInFlightRequestsPerConnection(int maxInFlightRequestsPerConnection)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentOutOfRangeException.ThrowIfLessThan(maxInFlightRequestsPerConnection, 1);
+        CompatibilityThrowHelpers.ThrowIfLessThan(maxInFlightRequestsPerConnection, 1);
         _maxInFlightRequestsPerConnection = maxInFlightRequestsPerConnection;
         return this;
     }
 
     internal ProducerBuilder<TKey, TValue> WithRetries(int retries)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(retries);
+        CompatibilityThrowHelpers.ThrowIfNegative(retries);
         _retries = retries;
         return this;
     }
@@ -822,7 +822,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     {
         if (backoff < TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(backoff), "Retry backoff cannot be negative");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
 
         _retryBackoffMs = (int)backoff.TotalMilliseconds;
         return this;
@@ -832,7 +832,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     {
         if (backoff < TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(backoff), "Maximum retry backoff cannot be negative");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
 
         _retryBackoffMaxMs = (int)backoff.TotalMilliseconds;
         return this;
@@ -842,7 +842,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     {
         if (timeout < TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(timeout), "Close timeout cannot be negative");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
 
         _closeTimeoutMs = (int)timeout.TotalMilliseconds;
         return this;
@@ -850,28 +850,28 @@ public sealed class ProducerBuilder<TKey, TValue>
 
     internal ProducerBuilder<TKey, TValue> WithMaxRequestSize(int maxRequestSize)
     {
-        ArgumentOutOfRangeException.ThrowIfLessThan(maxRequestSize, 1);
+        CompatibilityThrowHelpers.ThrowIfLessThan(maxRequestSize, 1);
         _maxRequestSize = maxRequestSize;
         return this;
     }
 
     internal ProducerBuilder<TKey, TValue> WithValueTaskSourcePoolSize(int poolSize)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(poolSize);
+        CompatibilityThrowHelpers.ThrowIfNegative(poolSize);
         _valueTaskSourcePoolSize = poolSize;
         return this;
     }
 
     internal ProducerBuilder<TKey, TValue> WithArenaCapacity(int arenaCapacity)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(arenaCapacity);
+        CompatibilityThrowHelpers.ThrowIfNegative(arenaCapacity);
         _arenaCapacity = arenaCapacity;
         return this;
     }
 
     internal ProducerBuilder<TKey, TValue> WithInitialBatchRecordCapacity(int capacity)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(capacity);
+        CompatibilityThrowHelpers.ThrowIfNegative(capacity);
         _initialBatchRecordCapacity = capacity;
         return this;
     }
@@ -929,7 +929,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         string topic,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(topic);
+        CompatibilityThrowHelpers.ThrowIfNull(topic);
         var producer = await BuildAsync(cancellationToken).ConfigureAwait(false);
         return new TopicProducer<TKey, TValue>(producer, topic, ownsProducer: true);
     }
@@ -1088,7 +1088,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <returns>A producer bound to the specified topic.</returns>
     public ITopicProducer<TKey, TValue> BuildForTopic(string topic)
     {
-        ArgumentNullException.ThrowIfNull(topic);
+        CompatibilityThrowHelpers.ThrowIfNull(topic);
         var producer = Build();
         return new TopicProducer<TKey, TValue>(producer, topic, ownsProducer: true);
     }
@@ -1301,7 +1301,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="pattern">The RE2/J topic regex pattern.</param>
     public ConsumerBuilder<TKey, TValue> SubscribeToPattern(string pattern)
     {
-        ArgumentNullException.ThrowIfNull(pattern);
+        CompatibilityThrowHelpers.ThrowIfNull(pattern);
         if (string.IsNullOrWhiteSpace(pattern))
         {
             throw new ArgumentException("Subscription pattern must be specified.", nameof(pattern));
@@ -1318,7 +1318,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="interval">The interval between automatic commits.</param>
     public ConsumerBuilder<TKey, TValue> WithAutoCommitInterval(TimeSpan interval)
     {
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(interval.TotalMilliseconds, int.MaxValue, nameof(interval));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(interval.TotalMilliseconds, int.MaxValue, nameof(interval));
         _autoCommitIntervalMs = (int)interval.TotalMilliseconds;
         return this;
     }
@@ -1459,7 +1459,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     {
         if (maxWait <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(maxWait), "Fetch max wait must be positive");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(maxWait.TotalMilliseconds, int.MaxValue, nameof(maxWait));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(maxWait.TotalMilliseconds, int.MaxValue, nameof(maxWait));
         _fetchMaxWaitMs = (int)maxWait.TotalMilliseconds;
         return this;
     }
@@ -1480,7 +1480,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="timeout">The session timeout duration.</param>
     public ConsumerBuilder<TKey, TValue> WithSessionTimeout(TimeSpan timeout)
     {
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
         _sessionTimeoutMs = (int)timeout.TotalMilliseconds;
         return this;
     }
@@ -1497,7 +1497,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     {
         if (interval <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(interval), "Heartbeat interval must be positive");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(interval.TotalMilliseconds, int.MaxValue, nameof(interval));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(interval.TotalMilliseconds, int.MaxValue, nameof(interval));
 
         _heartbeatIntervalMs = (int)interval.TotalMilliseconds;
         return this;
@@ -1644,7 +1644,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     public ConsumerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentNullException.ThrowIfNull(options);
+        CompatibilityThrowHelpers.ThrowIfNull(options);
         var oauthConfig = options.ToOAuthBearerConfig();
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthConfig = oauthConfig;
@@ -1659,7 +1659,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="configure">Callback that configures the JWT-bearer OAuth options.</param>
     public ConsumerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(Action<OAuthBearerJwtBearerOptions> configure)
     {
-        ArgumentNullException.ThrowIfNull(configure);
+        CompatibilityThrowHelpers.ThrowIfNull(configure);
         var options = new OAuthBearerJwtBearerOptions();
         configure(options);
         return WithOAuthBearerJwtBearer(options);
@@ -1798,7 +1798,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     public ConsumerBuilder<TKey, TValue> WithConnectionsPerBroker(int connectionsPerBroker)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentOutOfRangeException.ThrowIfLessThan(connectionsPerBroker, 1);
+        CompatibilityThrowHelpers.ThrowIfLessThan(connectionsPerBroker, 1);
         _connectionsPerBroker = connectionsPerBroker;
         return this;
     }
@@ -1813,7 +1813,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     public ConsumerBuilder<TKey, TValue> WithAdaptiveConnections(int maxConnections = 4)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentOutOfRangeException.ThrowIfLessThan(maxConnections, 1);
+        CompatibilityThrowHelpers.ThrowIfLessThan(maxConnections, 1);
         _enableAdaptiveConnections = true;
         _maxConnectionsPerBroker = maxConnections;
         return this;
@@ -1849,7 +1849,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     public ConsumerBuilder<TKey, TValue> WithMetadataRecoveryRebootstrapTrigger(TimeSpan trigger)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(trigger.TotalMilliseconds, int.MaxValue, nameof(trigger));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(trigger.TotalMilliseconds, int.MaxValue, nameof(trigger));
         _metadataRecoveryRebootstrapTriggerMs = (int)trigger.TotalMilliseconds;
         return this;
     }
@@ -1993,7 +1993,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <returns>The builder instance for method chaining.</returns>
     public ConsumerBuilder<TKey, TValue> AddInterceptor(IConsumerInterceptor<TKey, TValue> interceptor)
     {
-        ArgumentNullException.ThrowIfNull(interceptor);
+        CompatibilityThrowHelpers.ThrowIfNull(interceptor);
         _interceptors ??= [];
         _interceptors.Add(interceptor);
         return this;
@@ -2031,7 +2031,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="metric">The application metric to register.</param>
     public ConsumerBuilder<TKey, TValue> RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
     {
-        ArgumentNullException.ThrowIfNull(metric);
+        CompatibilityThrowHelpers.ThrowIfNull(metric);
         _applicationMetrics[metric.Name] = metric;
         return this;
     }
@@ -2043,7 +2043,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <param name="name">The application metric name.</param>
     public ConsumerBuilder<TKey, TValue> UnregisterMetricFromSubscription(string name)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(name);
         _applicationMetrics.Remove(name);
         return this;
     }
@@ -2052,7 +2052,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     {
         if (interval <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(interval), "Max poll interval must be positive");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(interval.TotalMilliseconds, int.MaxValue, nameof(interval));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(interval.TotalMilliseconds, int.MaxValue, nameof(interval));
 
         _maxPollIntervalMs = (int)interval.TotalMilliseconds;
         return this;
@@ -2062,7 +2062,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     {
         if (timeout <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(timeout), "Rebalance timeout must be positive");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
 
         _rebalanceTimeoutMs = (int)timeout.TotalMilliseconds;
         return this;
@@ -2072,7 +2072,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     {
         if (timeout <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(timeout), "Request timeout must be positive");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
 
         _requestTimeoutMs = (int)timeout.TotalMilliseconds;
         return this;
@@ -2087,7 +2087,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     internal ConsumerBuilder<TKey, TValue> WithSocketSendBufferBytes(int bytes)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        CompatibilityThrowHelpers.ThrowIfNegative(bytes);
         _socketSendBufferBytes = bytes;
         return this;
     }
@@ -2095,7 +2095,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     internal ConsumerBuilder<TKey, TValue> WithSocketReceiveBufferBytes(int bytes)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        CompatibilityThrowHelpers.ThrowIfNegative(bytes);
         _socketReceiveBufferBytes = bytes;
         return this;
     }
@@ -2579,7 +2579,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
     {
         ThrowIfClientOwnedConnectionSettings();
-        ArgumentNullException.ThrowIfNull(options);
+        CompatibilityThrowHelpers.ThrowIfNull(options);
         var oauthConfig = options.ToOAuthBearerConfig();
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthConfig = oauthConfig;
@@ -2590,7 +2590,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
 
     public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerJwtBearer(Action<OAuthBearerJwtBearerOptions> configure)
     {
-        ArgumentNullException.ThrowIfNull(configure);
+        CompatibilityThrowHelpers.ThrowIfNull(configure);
         var options = new OAuthBearerJwtBearerOptions();
         configure(options);
         return WithOAuthBearerJwtBearer(options);
@@ -2711,7 +2711,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     {
         if (_bootstrapServers.Count == 0)
             throw new InvalidOperationException("Bootstrap servers must be specified. Call WithBootstrapServers() before Build().");
-        ArgumentNullException.ThrowIfNullOrEmpty(_groupId, nameof(_groupId));
+        CompatibilityThrowHelpers.ThrowIfNullOrEmpty(_groupId, nameof(_groupId));
         ReconnectBackoffValidation.ValidateMilliseconds(_reconnectBackoffMs, _reconnectBackoffMaxMs);
 
         GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);

--- a/src/Dekaf/Compatibility/NetStandard20BclShims.cs
+++ b/src/Dekaf/Compatibility/NetStandard20BclShims.cs
@@ -1,0 +1,782 @@
+#if NETSTANDARD2_0
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace System
+{
+    internal struct HashCode
+    {
+        private int _hash;
+
+        public static int Combine<T1, T2>(T1 value1, T2 value2)
+        {
+            unchecked
+            {
+                var hash = 17;
+                hash = (hash * 31) + EqualityComparer<T1>.Default.GetHashCode(value1!);
+                hash = (hash * 31) + EqualityComparer<T2>.Default.GetHashCode(value2!);
+                return hash;
+            }
+        }
+
+        public void Add<T>(T value)
+        {
+            unchecked
+            {
+                _hash = ((_hash == 0 ? 17 : _hash) * 31) + EqualityComparer<T>.Default.GetHashCode(value!);
+            }
+        }
+
+        public readonly int ToHashCode() => _hash;
+    }
+
+    internal static class StringCompatibilityExtensions
+    {
+        public static bool Contains(this string value, string comparison, StringComparison comparisonType)
+            => value.IndexOf(comparison, comparisonType) >= 0;
+
+        public static bool Contains(this string value, char comparison, StringComparison comparisonType)
+            => value.IndexOf(comparison.ToString(), comparisonType) >= 0;
+    }
+}
+
+namespace System.Numerics
+{
+    internal static class BitOperations
+    {
+        public static int Log2(uint value)
+        {
+            var result = 0;
+            while ((value >>= 1) != 0)
+            {
+                result++;
+            }
+
+            return result;
+        }
+
+        public static int Log2(ulong value)
+        {
+            var result = 0;
+            while ((value >>= 1) != 0)
+            {
+                result++;
+            }
+
+            return result;
+        }
+
+        public static uint RoundUpToPowerOf2(uint value)
+        {
+            if (value <= 1)
+                return 1;
+
+            value--;
+            value |= value >> 1;
+            value |= value >> 2;
+            value |= value >> 4;
+            value |= value >> 8;
+            value |= value >> 16;
+            return value + 1;
+        }
+    }
+}
+
+namespace System.Buffers
+{
+    internal ref struct SequenceReader<T>
+    {
+        private readonly ReadOnlyMemory<T> _memory;
+        private int _position;
+
+        public SequenceReader(ReadOnlySequence<T> sequence)
+        {
+            _memory = sequence.IsSingleSegment ? sequence.First : sequence.ToArray();
+            _position = 0;
+        }
+
+        public long Consumed => _position;
+
+        public long Remaining => _memory.Length - _position;
+
+        public bool End => _position >= _memory.Length;
+
+        public ReadOnlySpan<T> UnreadSpan => _memory.Span.Slice(_position);
+
+        public ReadOnlySequence<T> UnreadSequence => new(_memory.Slice(_position));
+
+        public bool TryRead(out T value)
+        {
+            if (_position >= _memory.Length)
+            {
+                value = default!;
+                return false;
+            }
+
+            value = _memory.Span[_position++];
+            return true;
+        }
+
+        public void Advance(long count)
+        {
+            if (count < 0 || count > Remaining)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
+            _position += checked((int)count);
+        }
+
+        public bool TryCopyTo(scoped Span<T> destination)
+        {
+            if (destination.Length > Remaining)
+                return false;
+
+            UnreadSpan.Slice(0, destination.Length).CopyTo(destination);
+            return true;
+        }
+    }
+
+    internal sealed class ArrayBufferWriter<T> : IBufferWriter<T>
+    {
+        private const int DefaultInitialCapacity = 256;
+        private T[] _buffer;
+
+        public ArrayBufferWriter()
+            : this(DefaultInitialCapacity)
+        {
+        }
+
+        public ArrayBufferWriter(int initialCapacity)
+        {
+            if (initialCapacity < 0)
+                throw new ArgumentOutOfRangeException(nameof(initialCapacity));
+
+            _buffer = initialCapacity == 0 ? Array.Empty<T>() : new T[initialCapacity];
+        }
+
+        public int WrittenCount { get; private set; }
+
+        public ReadOnlyMemory<T> WrittenMemory => _buffer.AsMemory(0, WrittenCount);
+
+        public ReadOnlySpan<T> WrittenSpan => _buffer.AsSpan(0, WrittenCount);
+
+        public void Advance(int count)
+        {
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
+            if (WrittenCount > _buffer.Length - count)
+                throw new InvalidOperationException("Cannot advance past the end of the buffer.");
+
+            WrittenCount += count;
+        }
+
+        public Memory<T> GetMemory(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+            return _buffer.AsMemory(WrittenCount);
+        }
+
+        public Span<T> GetSpan(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+            return _buffer.AsSpan(WrittenCount);
+        }
+
+        private void EnsureCapacity(int sizeHint)
+        {
+            if (sizeHint < 0)
+                throw new ArgumentOutOfRangeException(nameof(sizeHint));
+
+            if (sizeHint == 0)
+                sizeHint = 1;
+
+            if (sizeHint <= _buffer.Length - WrittenCount)
+                return;
+
+            var growBy = Math.Max(sizeHint, _buffer.Length);
+            var newSize = checked(_buffer.Length + growBy);
+            if (newSize == 0)
+                newSize = DefaultInitialCapacity;
+
+            Array.Resize(ref _buffer, newSize);
+        }
+    }
+}
+
+namespace System.Collections.Generic
+{
+    public interface IReadOnlySet<T> : IReadOnlyCollection<T>
+    {
+        bool Contains(T item);
+        bool IsProperSubsetOf(IEnumerable<T> other);
+        bool IsProperSupersetOf(IEnumerable<T> other);
+        bool IsSubsetOf(IEnumerable<T> other);
+        bool IsSupersetOf(IEnumerable<T> other);
+        bool Overlaps(IEnumerable<T> other);
+        bool SetEquals(IEnumerable<T> other);
+    }
+
+    internal static class CollectionCompatibilityExtensions
+    {
+        public static void Deconstruct<TKey, TValue>(
+            this KeyValuePair<TKey, TValue> pair,
+            out TKey key,
+            out TValue value)
+        {
+            key = pair.Key;
+            value = pair.Value;
+        }
+
+        public static bool TryDequeue<T>(this Queue<T> queue, out T value)
+        {
+            if (queue.Count == 0)
+            {
+                value = default!;
+                return false;
+            }
+
+            value = queue.Dequeue();
+            return true;
+        }
+
+        public static int EnsureCapacity<T>(this List<T> list, int capacity)
+        {
+            if (list.Capacity < capacity)
+                list.Capacity = capacity;
+
+            return list.Capacity;
+        }
+
+        public static TValue? GetValueOrDefault<TKey, TValue>(
+            this IReadOnlyDictionary<TKey, TValue> dictionary,
+            TKey key)
+            => dictionary.TryGetValue(key, out var value) ? value : default;
+
+        public static TValue GetValueOrDefault<TKey, TValue>(
+            this IReadOnlyDictionary<TKey, TValue> dictionary,
+            TKey key,
+            TValue defaultValue)
+            => dictionary.TryGetValue(key, out var value) ? value : defaultValue;
+
+        public static bool TryAdd<TKey, TValue>(
+            this IDictionary<TKey, TValue> dictionary,
+            TKey key,
+            TValue value)
+        {
+            if (dictionary.ContainsKey(key))
+                return false;
+
+            dictionary.Add(key, value);
+            return true;
+        }
+
+        public static bool Remove<TKey, TValue>(
+            this IDictionary<TKey, TValue> dictionary,
+            TKey key,
+            out TValue value)
+        {
+            if (!dictionary.TryGetValue(key, out value!))
+                return false;
+
+            return dictionary.Remove(key);
+        }
+    }
+}
+
+namespace System.Collections.Concurrent
+{
+    internal static class ConcurrentCollectionCompatibilityExtensions
+    {
+        public static TValue? GetValueOrDefault<TKey, TValue>(
+            this ConcurrentDictionary<TKey, TValue> dictionary,
+            TKey key)
+            where TKey : notnull
+            => dictionary.TryGetValue(key, out var value) ? value : default;
+
+        public static TValue GetValueOrDefault<TKey, TValue>(
+            this ConcurrentDictionary<TKey, TValue> dictionary,
+            TKey key,
+            TValue defaultValue)
+            where TKey : notnull
+            => dictionary.TryGetValue(key, out var value) ? value : defaultValue;
+
+        public static TValue GetOrAdd<TKey, TValue, TArg>(
+            this ConcurrentDictionary<TKey, TValue> dictionary,
+            TKey key,
+            Func<TKey, TArg, TValue> valueFactory,
+            TArg factoryArgument)
+            where TKey : notnull
+            => dictionary.GetOrAdd(key, item => valueFactory(item, factoryArgument));
+
+        public static TValue AddOrUpdate<TKey, TValue, TArg>(
+            this ConcurrentDictionary<TKey, TValue> dictionary,
+            TKey key,
+            Func<TKey, TArg, TValue> addValueFactory,
+            Func<TKey, TValue, TArg, TValue> updateValueFactory,
+            TArg factoryArgument)
+            where TKey : notnull
+        {
+            return dictionary.AddOrUpdate(
+                key,
+                item => addValueFactory(item, factoryArgument),
+                (item, existing) => updateValueFactory(item, existing, factoryArgument));
+        }
+
+        public static void Clear<T>(this ConcurrentQueue<T> queue)
+        {
+            while (queue.TryDequeue(out _))
+            {
+            }
+        }
+
+        public static bool TryRemove<TKey, TValue>(
+            this ConcurrentDictionary<TKey, TValue> dictionary,
+            KeyValuePair<TKey, TValue> item)
+            where TKey : notnull
+        {
+            if (!dictionary.TryGetValue(item.Key, out var value) ||
+                !EqualityComparer<TValue>.Default.Equals(value, item.Value))
+            {
+                return false;
+            }
+
+            return dictionary.TryRemove(item.Key, out _);
+        }
+    }
+}
+
+namespace System.Linq
+{
+    internal static class EnumerableCompatibilityExtensions
+    {
+        public static bool TryGetNonEnumeratedCount<TSource>(
+            this IEnumerable<TSource> source,
+            out int count)
+        {
+            if (source is ICollection<TSource> collection)
+            {
+                count = collection.Count;
+                return true;
+            }
+
+            if (source is IReadOnlyCollection<TSource> readOnlyCollection)
+            {
+                count = readOnlyCollection.Count;
+                return true;
+            }
+
+            count = 0;
+            return false;
+        }
+
+        public static IOrderedEnumerable<TSource> Order<TSource>(this IEnumerable<TSource> source)
+            => source.OrderBy(static item => item);
+
+        public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> source)
+            => new(source);
+    }
+}
+
+namespace System.Threading
+{
+    internal sealed class Lock
+    {
+    }
+
+    internal sealed class PeriodicTimer : IDisposable
+    {
+        private readonly TimeSpan _period;
+        private volatile bool _disposed;
+
+        public PeriodicTimer(TimeSpan period)
+        {
+            if (period <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(period));
+
+            _period = period;
+        }
+
+        public async ValueTask<bool> WaitForNextTickAsync(CancellationToken cancellationToken = default)
+        {
+            if (_disposed)
+                return false;
+
+            try
+            {
+                await Task.Delay(_period, cancellationToken).ConfigureAwait(false);
+                return !_disposed;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            _disposed = true;
+        }
+    }
+
+    internal static class ThreadingCompatibilityExtensions
+    {
+        public static Task CancelAsync(this CancellationTokenSource cancellationTokenSource)
+        {
+            cancellationTokenSource.Cancel();
+            return Task.CompletedTask;
+        }
+
+        public static CancellationTokenRegistration UnsafeRegister(
+            this CancellationToken cancellationToken,
+            Action<object?> callback,
+            object? state)
+            => cancellationToken.Register(callback, state);
+
+        public static CancellationTokenRegistration UnsafeRegister(
+            this CancellationToken cancellationToken,
+            Action<object?, CancellationToken> callback,
+            object? state)
+            => cancellationToken.Register(static captured =>
+            {
+                var (innerCallback, innerState, innerToken) =
+                    ((Action<object?, CancellationToken>, object?, CancellationToken))captured!;
+                innerCallback(innerState, innerToken);
+            }, (callback, state, cancellationToken));
+
+        public static bool TryReset(this CancellationTokenSource cancellationTokenSource)
+            => false;
+    }
+}
+
+namespace System.Threading.Tasks
+{
+    internal sealed class TaskCompletionSource
+    {
+        private readonly TaskCompletionSource<object?> _inner;
+
+        public TaskCompletionSource()
+            : this(TaskCreationOptions.None)
+        {
+        }
+
+        public TaskCompletionSource(TaskCreationOptions creationOptions)
+        {
+            _inner = new TaskCompletionSource<object?>(creationOptions);
+        }
+
+        public Task Task => _inner.Task;
+
+        public bool TrySetResult() => _inner.TrySetResult(null);
+
+        public bool TrySetException(Exception exception) => _inner.TrySetException(exception);
+    }
+
+    internal static class TaskWaitAsyncCompatibilityExtensions
+    {
+        public static Task WaitAsync(this Task task, CancellationToken cancellationToken)
+            => WaitAsync(task, Timeout.InfiniteTimeSpan, cancellationToken);
+
+        public static Task WaitAsync(this Task task, TimeSpan timeout)
+            => WaitAsync(task, timeout, CancellationToken.None);
+
+        public static async Task WaitAsync(this Task task, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            if (task.IsCompleted)
+            {
+                await task.ConfigureAwait(false);
+                return;
+            }
+
+            using var cts = CreateDelayTokenSource(timeout, cancellationToken);
+            var delayTask = Task.Delay(timeout, cts.Token);
+            var completed = await Task.WhenAny(task, delayTask).ConfigureAwait(false);
+            if (completed == task)
+            {
+                cts.Cancel();
+                await task.ConfigureAwait(false);
+                return;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            throw new TimeoutException();
+        }
+
+        public static Task<T> WaitAsync<T>(this Task<T> task, CancellationToken cancellationToken)
+            => WaitAsync(task, Timeout.InfiniteTimeSpan, cancellationToken);
+
+        public static Task<T> WaitAsync<T>(this Task<T> task, TimeSpan timeout)
+            => WaitAsync(task, timeout, CancellationToken.None);
+
+        public static async Task<T> WaitAsync<T>(this Task<T> task, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            if (task.IsCompleted)
+                return await task.ConfigureAwait(false);
+
+            using var cts = CreateDelayTokenSource(timeout, cancellationToken);
+            var delayTask = Task.Delay(timeout, cts.Token);
+            var completed = await Task.WhenAny(task, delayTask).ConfigureAwait(false);
+            if (completed == task)
+            {
+                cts.Cancel();
+                return await task.ConfigureAwait(false);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            throw new TimeoutException();
+        }
+
+        private static CancellationTokenSource CreateDelayTokenSource(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            if (timeout == Timeout.InfiniteTimeSpan)
+                return CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            if (timeout < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(timeout));
+
+            return CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        }
+    }
+}
+
+namespace System.IO
+{
+    internal static class StreamCompatibilityExtensions
+    {
+        public static ValueTask DisposeAsync(this Stream stream)
+        {
+            stream.Dispose();
+            return default;
+        }
+
+        public static Task WriteAsync(
+            this Stream stream,
+            ReadOnlyMemory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            if (MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment))
+                return stream.WriteAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken);
+
+            return WriteAsyncSlow(stream, buffer, cancellationToken);
+        }
+
+        public static Task<int> ReadAsync(
+            this Stream stream,
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            if (MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment))
+                return stream.ReadAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken);
+
+            return ReadAsyncSlow(stream, buffer, cancellationToken);
+        }
+
+        private static async Task WriteAsyncSlow(
+            Stream stream,
+            ReadOnlyMemory<byte> buffer,
+            CancellationToken cancellationToken)
+        {
+            var rented = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                buffer.CopyTo(rented);
+                await stream.WriteAsync(rented, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        private static async Task<int> ReadAsyncSlow(
+            Stream stream,
+            Memory<byte> buffer,
+            CancellationToken cancellationToken)
+        {
+            var rented = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                var read = await stream.ReadAsync(rented, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+                rented.AsMemory(0, read).CopyTo(buffer);
+                return read;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+}
+
+namespace System.Net.Sockets
+{
+    internal static class SocketCompatibilityExtensions
+    {
+        public static Task<int> ReceiveAsync(
+            this Socket socket,
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+            => socket.ReceiveAsync(buffer, SocketFlags.None, cancellationToken);
+
+        public static Task<int> ReceiveAsync(
+            this Socket socket,
+            Memory<byte> buffer,
+            SocketFlags socketFlags,
+            CancellationToken cancellationToken = default)
+        {
+            if (MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment))
+                return socket.ReceiveAsync(segment, socketFlags).WaitAsync(cancellationToken);
+
+            return ReceiveAsyncSlow(socket, buffer, socketFlags, cancellationToken);
+        }
+
+        public static Task<int> ReceiveAsync(
+            this Socket socket,
+            Memory<byte> buffer,
+            SocketFlags socketFlags)
+            => ReceiveAsync(socket, buffer, socketFlags, CancellationToken.None);
+
+        public static Task ConnectAsync(
+            this Socket socket,
+            EndPoint remoteEndPoint,
+            CancellationToken cancellationToken = default)
+            => socket.ConnectAsync(remoteEndPoint).WaitAsync(cancellationToken);
+
+        private static async Task<int> ReceiveAsyncSlow(
+            Socket socket,
+            Memory<byte> buffer,
+            SocketFlags socketFlags,
+            CancellationToken cancellationToken)
+        {
+            var rented = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                var read = await socket.ReceiveAsync(new ArraySegment<byte>(rented, 0, buffer.Length), socketFlags)
+                    .WaitAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                rented.AsMemory(0, read).CopyTo(buffer);
+                return read;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+}
+
+namespace System.Net.Http
+{
+    internal static class HttpContentCompatibilityExtensions
+    {
+        public static Task<string> ReadAsStringAsync(
+            this HttpContent content,
+            CancellationToken cancellationToken)
+            => content.ReadAsStringAsync().WaitAsync(cancellationToken);
+    }
+}
+
+namespace System.Text
+{
+    internal static class EncodingCompatibilityExtensions
+    {
+        public static int GetByteCount(this Encoding encoding, ReadOnlySpan<char> value)
+            => encoding.GetByteCount(value.ToArray());
+
+        public static int GetBytes(this Encoding encoding, ReadOnlySpan<char> value, Span<byte> destination)
+        {
+            var bytes = encoding.GetBytes(value.ToArray());
+            bytes.CopyTo(destination);
+            return bytes.Length;
+        }
+
+        public static int GetBytes(this Encoding encoding, string value, Span<byte> destination)
+        {
+            var bytes = encoding.GetBytes(value);
+            bytes.CopyTo(destination);
+            return bytes.Length;
+        }
+
+        public static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+            => encoding.GetString(bytes.ToArray());
+    }
+}
+
+namespace System.Net.Security
+{
+    internal sealed class SslClientAuthenticationOptions
+    {
+        public string? TargetHost { get; set; }
+
+        public X509CertificateCollection? ClientCertificates { get; set; }
+
+        public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; set; }
+
+        public SslProtocols EnabledSslProtocols { get; set; } = SslProtocols.None;
+
+        public X509RevocationMode CertificateRevocationCheckMode { get; set; } = X509RevocationMode.NoCheck;
+    }
+
+    internal static class SslStreamCompatibilityExtensions
+    {
+        public static Task AuthenticateAsClientAsync(
+            this SslStream sslStream,
+            SslClientAuthenticationOptions sslOptions,
+            CancellationToken cancellationToken)
+        {
+            var authenticateTask = sslStream.AuthenticateAsClientAsync(
+                sslOptions.TargetHost ?? string.Empty,
+                clientCertificates: sslOptions.ClientCertificates,
+                enabledSslProtocols: sslOptions.EnabledSslProtocols,
+                checkCertificateRevocation: sslOptions.CertificateRevocationCheckMode != X509RevocationMode.NoCheck);
+
+            return authenticateTask.WaitAsync(cancellationToken);
+        }
+    }
+
+    internal sealed class NegotiateAuthenticationClientOptions
+    {
+        public string? Package { get; set; }
+
+        public string? TargetName { get; set; }
+
+        public ProtectionLevel RequiredProtectionLevel { get; set; }
+
+        public System.Security.Principal.TokenImpersonationLevel AllowedImpersonationLevel { get; set; }
+
+        public System.Net.NetworkCredential? Credential { get; set; }
+    }
+
+    internal enum NegotiateAuthenticationStatusCode
+    {
+        Completed,
+        ContinueNeeded
+    }
+
+    internal sealed class NegotiateAuthentication : IDisposable
+    {
+        public NegotiateAuthentication(NegotiateAuthenticationClientOptions options)
+        {
+            throw new PlatformNotSupportedException("GSSAPI is not available on the netstandard2.0 compatibility target.");
+        }
+
+        public byte[]? GetOutgoingBlob(ReadOnlySpan<byte> incomingBlob, out NegotiateAuthenticationStatusCode statusCode)
+        {
+            GC.KeepAlive(this);
+            statusCode = default;
+            throw new PlatformNotSupportedException("GSSAPI is not available on the netstandard2.0 compatibility target.");
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}
+
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20CompilerShims.cs
+++ b/src/Dekaf/Compatibility/NetStandard20CompilerShims.cs
@@ -1,4 +1,73 @@
 #if NETSTANDARD2_0
+namespace System
+{
+    public readonly struct Index
+    {
+        private readonly int _value;
+
+        public Index(int value, bool fromEnd = false)
+        {
+            if (value < 0)
+                throw new ArgumentOutOfRangeException(nameof(value));
+
+            _value = fromEnd ? ~value : value;
+        }
+
+        private Index(int value)
+        {
+            _value = value;
+        }
+
+        public static Index Start => new(0);
+
+        public static Index End => new(~0);
+
+        public int Value => _value < 0 ? ~_value : _value;
+
+        public bool IsFromEnd => _value < 0;
+
+        public int GetOffset(int length)
+        {
+            var offset = IsFromEnd ? length - Value : Value;
+            if ((uint)offset > (uint)length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+
+            return offset;
+        }
+
+        public static implicit operator Index(int value) => new(value);
+    }
+
+    public readonly struct Range
+    {
+        public Range(Index start, Index end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        public Index Start { get; }
+
+        public Index End { get; }
+
+        public static Range All => new(Index.Start, Index.End);
+
+        public static Range StartAt(Index start) => new(start, Index.End);
+
+        public static Range EndAt(Index end) => new(Index.Start, end);
+
+        public (int Offset, int Length) GetOffsetAndLength(int length)
+        {
+            var start = Start.GetOffset(length);
+            var end = End.GetOffset(length);
+            if (end < start)
+                throw new ArgumentOutOfRangeException(nameof(length));
+
+            return (start, end - start);
+        }
+    }
+}
+
 namespace System.Diagnostics.CodeAnalysis
 {
     [AttributeUsage(AttributeTargets.Constructor, Inherited = false)]
@@ -9,11 +78,20 @@ namespace System.Diagnostics.CodeAnalysis
     {
         public bool ReturnValue { get; } = returnValue;
     }
+
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class NotNullAttribute : Attribute;
 }
 
 namespace System.Runtime.CompilerServices
 {
     internal static class IsExternalInit;
+
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public sealed class CallerArgumentExpressionAttribute(string parameterName) : Attribute
+    {
+        public string ParameterName { get; } = parameterName;
+    }
 
     [AttributeUsage(
         AttributeTargets.Class
@@ -43,5 +121,16 @@ namespace System.Runtime.CompilerServices
         | AttributeTargets.Property,
         Inherited = false)]
     internal sealed class SkipLocalsInitAttribute : Attribute;
+
+    internal static class RuntimeHelpers
+    {
+        public static T[] GetSubArray<T>(T[] array, Range range)
+        {
+            var (offset, length) = range.GetOffsetAndLength(array.Length);
+            var result = new T[length];
+            Array.Copy(array, offset, result, 0, length);
+            return result;
+        }
+    }
 }
 #endif

--- a/src/Dekaf/Compression/BuiltInCodecs.cs
+++ b/src/Dekaf/Compression/BuiltInCodecs.cs
@@ -67,8 +67,17 @@ public sealed class GzipCompressionCodec : ICompressionCodec
             0 => CompressionLevel.NoCompression,
             >= 1 and <= 3 => CompressionLevel.Fastest,
             >= 4 and <= 6 => CompressionLevel.Optimal,
-            _ => CompressionLevel.SmallestSize
+            _ => GetSmallestCompressionLevel()
         };
+    }
+
+    private static CompressionLevel GetSmallestCompressionLevel()
+    {
+#if NETSTANDARD2_0
+        return CompressionLevel.Optimal;
+#else
+        return CompressionLevel.SmallestSize;
+#endif
     }
 
     public CompressionType Type => CompressionType.Gzip;
@@ -80,7 +89,12 @@ public sealed class GzipCompressionCodec : ICompressionCodec
 
         foreach (var segment in source)
         {
+#if NETSTANDARD2_0
+            var buffer = segment.ToArray();
+            gzipStream.Write(buffer, 0, buffer.Length);
+#else
             gzipStream.Write(segment.Span);
+#endif
         }
     }
 
@@ -99,6 +113,26 @@ internal static class CompressionStreamCopy
 
     internal static void CopyToBufferWriter(Stream source, IBufferWriter<byte> destination)
     {
+#if NETSTANDARD2_0
+        var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+        try
+        {
+            while (true)
+            {
+                var bytesRead = source.Read(buffer, 0, buffer.Length);
+                if (bytesRead == 0)
+                    break;
+
+                var span = destination.GetSpan(bytesRead);
+                buffer.AsSpan(0, bytesRead).CopyTo(span);
+                destination.Advance(bytesRead);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+#else
         while (true)
         {
             var span = destination.GetSpan(BufferSize);
@@ -108,6 +142,7 @@ internal static class CompressionStreamCopy
 
             destination.Advance(bytesRead);
         }
+#endif
     }
 }
 
@@ -151,12 +186,14 @@ internal sealed class BufferWriterStream : Stream
         _writer.Advance(count);
     }
 
+#if !NETSTANDARD2_0
     public override void Write(ReadOnlySpan<byte> buffer)
     {
         var span = _writer.GetSpan(buffer.Length);
         buffer.CopyTo(span);
         _writer.Advance(buffer.Length);
     }
+#endif
 }
 
 /// <summary>

--- a/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
+++ b/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
@@ -129,12 +129,12 @@ internal sealed class AdaptiveFetchSizer
         if (_lastFetchStartTimestamp == 0 || _lastFetchEndTimestamp == 0)
             return;
 
-        var fetchDuration = Stopwatch.GetElapsedTime(_lastFetchStartTimestamp, _lastFetchEndTimestamp);
+        var fetchDuration = CompatibilityBcl.GetElapsedTime(_lastFetchStartTimestamp, _lastFetchEndTimestamp);
 
         if (fetchDuration <= TimeSpan.Zero)
             return;
 
-        var ratio = processingDuration / fetchDuration;
+        var ratio = processingDuration.Ticks / (double)fetchDuration.Ticks;
         EvaluateAndAdjust(ratio);
     }
 

--- a/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
+++ b/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
@@ -90,12 +90,12 @@ internal sealed class ConsumerConnectionScaler
     {
         var now = GetTimestamp();
 
-        if (_lastScaleTimestamp != 0 && Stopwatch.GetElapsedTime(_lastScaleTimestamp, now) < Cooldown)
+        if (_lastScaleTimestamp != 0 && CompatibilityBcl.GetElapsedTime(_lastScaleTimestamp, now) < Cooldown)
             return;
 
         if (_saturationStartTimestamp != 0
             && _currentConnectionCount < _maxConnectionCount
-            && Stopwatch.GetElapsedTime(_saturationStartTimestamp, now) >= ScaleUpSustained)
+            && CompatibilityBcl.GetElapsedTime(_saturationStartTimestamp, now) >= ScaleUpSustained)
         {
             Interlocked.Increment(ref _currentConnectionCount);
             _saturationStartTimestamp = 0;
@@ -106,7 +106,7 @@ internal sealed class ConsumerConnectionScaler
 
         if (_lowUtilizationStartTimestamp != 0
             && _currentConnectionCount > _initialConnectionCount
-            && Stopwatch.GetElapsedTime(_lowUtilizationStartTimestamp, now) >= ScaleDownSustained)
+            && CompatibilityBcl.GetElapsedTime(_lowUtilizationStartTimestamp, now) >= ScaleDownSustained)
         {
             Interlocked.Decrement(ref _currentConnectionCount);
             _lowUtilizationStartTimestamp = 0;

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -6,6 +6,13 @@ using Dekaf.Retry;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Microsoft.Extensions.Logging;
+#if NETSTANDARD2_0
+using TopicNameSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using TopicNameSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
 
 namespace Dekaf.Consumer;
 
@@ -48,7 +55,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     // KIP-848 consumer protocol state
     private volatile int _heartbeatIntervalMs;
     private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
-    private volatile IReadOnlySet<string>? _subscribedTopics;
+    private volatile TopicNameSet? _subscribedTopics;
     private volatile string? _subscribedTopicRegex;
 
     internal static int GetCoordinationConnectionIndex(int connectionsPerBroker)
@@ -75,7 +82,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     public string? MemberId => _memberId;
     public int GenerationId => _generationId;
     public CoordinatorState State => _state;
-    public IReadOnlySet<TopicPartition> Assignment => _assignedPartitions;
+    public TopicPartitionSet Assignment => _assignedPartitions;
     internal int AssignmentVersion => Volatile.Read(ref _assignmentVersion);
 
     private static void RemoveEmptyTopicGroups<TItem>(Dictionary<string, List<TItem>> topicGroups)
@@ -114,12 +121,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// Ensures the consumer has joined the group.
     /// </summary>
     public ValueTask EnsureActiveGroupAsync(
-        IReadOnlySet<string> topics,
+        TopicNameSet topics,
         CancellationToken cancellationToken)
         => EnsureActiveGroupAsync(topics, null, cancellationToken);
 
     public async ValueTask EnsureActiveGroupAsync(
-        IReadOnlySet<string> topics,
+        TopicNameSet topics,
         string? subscribedTopicRegex,
         CancellationToken cancellationToken)
     {
@@ -152,7 +159,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             or ErrorCode.CoordinatorNotAvailable
             or ErrorCode.CoordinatorLoadInProgress;
 
-    private static bool SetEquals(IReadOnlySet<string>? current, IReadOnlySet<string> next)
+    private static bool SetEquals(TopicNameSet? current, TopicNameSet next)
     {
         if (ReferenceEquals(current, next))
             return true;
@@ -169,11 +176,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         return true;
     }
 
-    private bool SubscriptionMatches(IReadOnlySet<string> topics, string? subscribedTopicRegex)
+    private bool SubscriptionMatches(TopicNameSet topics, string? subscribedTopicRegex)
         => string.Equals(_subscribedTopicRegex, subscribedTopicRegex, StringComparison.Ordinal) &&
            SetEquals(_subscribedTopics, topics);
 
-    private void UpdateSubscription(IReadOnlySet<string> topics, string? subscribedTopicRegex)
+    private void UpdateSubscription(TopicNameSet topics, string? subscribedTopicRegex)
     {
         if (SubscriptionMatches(topics, subscribedTopicRegex))
             return;
@@ -385,9 +392,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                 var request = new OffsetCommitRequest
                 {
-                    GroupId = _options.GroupId,
+                    GroupId = _options.GroupId!,
                     GenerationIdOrMemberEpoch = _generationId,
-                    MemberId = _memberId,
+                    MemberId = _memberId!,
                     GroupInstanceId = _options.GroupInstanceId,
                     Topics = topicOffsets
                 };
@@ -482,7 +489,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                 var request = new OffsetFetchRequest
                 {
-                    GroupId = _options.GroupId,
+                    GroupId = _options.GroupId!,
                     Topics = topicPartitions
                 };
 
@@ -873,7 +880,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// KIP-848 entry point: ensures the consumer has joined the group using the ConsumerGroupHeartbeat API.
     /// </summary>
     private async ValueTask EnsureActiveGroupConsumerProtocolAsync(
-        IReadOnlySet<string> topics,
+        TopicNameSet topics,
         string? subscribedTopicRegex,
         CancellationToken cancellationToken)
     {
@@ -909,11 +916,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
             while (_state != CoordinatorState.Stable)
             {
-                if (Stopwatch.GetElapsedTime(startedAt) > rebalanceTimeout)
+                if (CompatibilityBcl.GetElapsedTime(startedAt) > rebalanceTimeout)
                 {
                     throw new KafkaTimeoutException(
                         TimeoutKind.Rebalance,
-                        Stopwatch.GetElapsedTime(startedAt),
+                        CompatibilityBcl.GetElapsedTime(startedAt),
                         rebalanceTimeout,
                         $"Failed to join group '{_options.GroupId}' within rebalance timeout ({_options.RebalanceTimeoutMs}ms)");
                 }
@@ -935,7 +942,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     _state = CoordinatorState.Stable;
 
                     Diagnostics.DekafMetrics.RebalanceDuration.Record(
-                        Stopwatch.GetElapsedTime(startedAt).TotalSeconds,
+                        CompatibilityBcl.GetElapsedTime(startedAt).TotalSeconds,
                         new System.Diagnostics.TagList
                             { { Diagnostics.DekafDiagnostics.MessagingConsumerGroupName, _options.GroupId } });
 

--- a/src/Dekaf/Consumer/ConsumerExtensions.cs
+++ b/src/Dekaf/Consumer/ConsumerExtensions.cs
@@ -21,8 +21,8 @@ public static class ConsumerExtensions
         Func<ConsumeResult<TKey, TValue>, bool> predicate,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(predicate);
+        CompatibilityThrowHelpers.ThrowIfNull(source);
+        CompatibilityThrowHelpers.ThrowIfNull(predicate);
 
         await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
@@ -48,8 +48,8 @@ public static class ConsumerExtensions
         Func<ConsumeResult<TKey, TValue>, TResult> selector,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(selector);
+        CompatibilityThrowHelpers.ThrowIfNull(source);
+        CompatibilityThrowHelpers.ThrowIfNull(selector);
 
         await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
@@ -71,8 +71,8 @@ public static class ConsumerExtensions
         int count,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        CompatibilityThrowHelpers.ThrowIfNull(source);
+        CompatibilityThrowHelpers.ThrowIfNegative(count);
 
         if (count == 0)
         {
@@ -108,8 +108,8 @@ public static class ConsumerExtensions
         int batchSize,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentOutOfRangeException.ThrowIfLessThan(batchSize, 1);
+        CompatibilityThrowHelpers.ThrowIfNull(source);
+        CompatibilityThrowHelpers.ThrowIfLessThan(batchSize, 1);
 
         var batch = new List<ConsumeResult<TKey, TValue>>(batchSize);
 
@@ -144,8 +144,8 @@ public static class ConsumerExtensions
         Func<ConsumeResult<TKey, TValue>, bool> predicate,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(predicate);
+        CompatibilityThrowHelpers.ThrowIfNull(source);
+        CompatibilityThrowHelpers.ThrowIfNull(predicate);
 
         var skipping = true;
         await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
@@ -174,8 +174,8 @@ public static class ConsumerExtensions
         Func<ConsumeResult<TKey, TValue>, bool> predicate,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(predicate);
+        CompatibilityThrowHelpers.ThrowIfNull(source);
+        CompatibilityThrowHelpers.ThrowIfNull(predicate);
 
         await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
@@ -202,8 +202,8 @@ public static class ConsumerExtensions
         Func<ConsumeResult<TKey, TValue>, ValueTask> processor,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
-        ArgumentNullException.ThrowIfNull(processor);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(processor);
 
         await foreach (var result in consumer.ConsumeAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -225,8 +225,8 @@ public static class ConsumerExtensions
         Action<ConsumeResult<TKey, TValue>> processor,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
-        ArgumentNullException.ThrowIfNull(processor);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(processor);
 
         await foreach (var result in consumer.ConsumeAsync(cancellationToken).ConfigureAwait(false))
         {

--- a/src/Dekaf/Consumer/ConsumerFacetExtensions.cs
+++ b/src/Dekaf/Consumer/ConsumerFacetExtensions.cs
@@ -14,7 +14,7 @@ public static class ConsumerFacetExtensions
         this IKafkaConsumer<TKey, TValue> consumer,
         params TopicPartition[] partitions)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         consumer.Partitions.Assign(partitions);
     }
 
@@ -23,7 +23,7 @@ public static class ConsumerFacetExtensions
     /// </summary>
     public static void Unassign<TKey, TValue>(this IKafkaConsumer<TKey, TValue> consumer)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         consumer.Partitions.Unassign();
     }
 
@@ -34,7 +34,7 @@ public static class ConsumerFacetExtensions
         this IKafkaConsumer<TKey, TValue> consumer,
         IEnumerable<TopicPartitionOffset> partitions)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         consumer.Partitions.IncrementalAssign(partitions);
     }
 
@@ -45,7 +45,7 @@ public static class ConsumerFacetExtensions
         this IKafkaConsumer<TKey, TValue> consumer,
         IEnumerable<TopicPartition> partitions)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         consumer.Partitions.IncrementalUnassign(partitions);
     }
 
@@ -57,7 +57,7 @@ public static class ConsumerFacetExtensions
         TopicPartition partition,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         return consumer.Positions.GetCommittedOffsetAsync(partition, cancellationToken);
     }
 
@@ -68,7 +68,7 @@ public static class ConsumerFacetExtensions
         this IKafkaConsumer<TKey, TValue> consumer,
         TopicPartition partition)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         return consumer.Positions.GetPosition(partition);
     }
 
@@ -79,7 +79,7 @@ public static class ConsumerFacetExtensions
         this IKafkaConsumer<TKey, TValue> consumer,
         TopicPartitionOffset offset)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         consumer.Positions.Seek(offset);
     }
 
@@ -90,7 +90,7 @@ public static class ConsumerFacetExtensions
         this IKafkaConsumer<TKey, TValue> consumer,
         params TopicPartition[] partitions)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         consumer.Positions.SeekToBeginning(partitions);
     }
 
@@ -101,7 +101,7 @@ public static class ConsumerFacetExtensions
         this IKafkaConsumer<TKey, TValue> consumer,
         params TopicPartition[] partitions)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         consumer.Positions.SeekToEnd(partitions);
     }
 
@@ -112,7 +112,7 @@ public static class ConsumerFacetExtensions
         this IKafkaConsumer<TKey, TValue> consumer,
         params TopicPartition[] partitions)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         consumer.Partitions.Pause(partitions);
     }
 
@@ -123,7 +123,7 @@ public static class ConsumerFacetExtensions
         this IKafkaConsumer<TKey, TValue> consumer,
         params TopicPartition[] partitions)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         consumer.Partitions.Resume(partitions);
     }
 
@@ -135,7 +135,7 @@ public static class ConsumerFacetExtensions
         IEnumerable<TopicPartitionTimestamp> timestampsToSearch,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         return consumer.Offsets.GetOffsetsForTimesAsync(timestampsToSearch, cancellationToken);
     }
 
@@ -146,7 +146,7 @@ public static class ConsumerFacetExtensions
         this IKafkaConsumer<TKey, TValue> consumer,
         TopicPartition topicPartition)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         return consumer.Offsets.GetWatermarkOffsets(topicPartition);
     }
 
@@ -158,7 +158,7 @@ public static class ConsumerFacetExtensions
         TopicPartition topicPartition,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(consumer);
+        CompatibilityThrowHelpers.ThrowIfNull(consumer);
         return consumer.Offsets.QueryWatermarkOffsetsAsync(topicPartition, cancellationToken);
     }
 }

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -375,7 +375,7 @@ public sealed class ConsumerOptions
         get => _maxConnectionsPerBroker;
         init
         {
-            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            CompatibilityThrowHelpers.ThrowIfLessThan(value, 1);
             _maxConnectionsPerBroker = value;
         }
     }

--- a/src/Dekaf/Consumer/FetchSessionHandler.cs
+++ b/src/Dekaf/Consumer/FetchSessionHandler.cs
@@ -216,7 +216,7 @@ internal sealed class FetchSessionHandler
     private static string ResolveTopicName(FetchRequestTopic topic, ClusterMetadata? clusterMetadata)
     {
         if (!string.IsNullOrEmpty(topic.Topic))
-            return topic.Topic;
+            return topic.Topic!;
 
         return topic.TopicId == Guid.Empty
             ? string.Empty

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -1,6 +1,13 @@
 using Dekaf.Producer;
 using Dekaf.Serialization;
 using Dekaf.Telemetry;
+#if NETSTANDARD2_0
+using TopicNameSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using TopicNameSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
 
 namespace Dekaf.Consumer;
 
@@ -14,7 +21,7 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <summary>
     /// Gets the current subscription.
     /// </summary>
-    IReadOnlySet<string> Subscription { get; }
+    TopicNameSet Subscription { get; }
 
     /// <summary>
     /// Gets the current server-side topic regex subscription, if any.
@@ -24,12 +31,12 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <summary>
     /// Gets the current assignment.
     /// </summary>
-    IReadOnlySet<TopicPartition> Assignment { get; }
+    TopicPartitionSet Assignment { get; }
 
     /// <summary>
     /// Gets the paused partitions.
     /// </summary>
-    IReadOnlySet<TopicPartition> Paused { get; }
+    TopicPartitionSet Paused { get; }
 
     /// <summary>
     /// Gets the member ID if part of a consumer group.
@@ -196,12 +203,12 @@ public interface IConsumerPartitions
     /// <summary>
     /// Gets the current assignment.
     /// </summary>
-    IReadOnlySet<TopicPartition> Assignment { get; }
+    TopicPartitionSet Assignment { get; }
 
     /// <summary>
     /// Gets the paused partitions.
     /// </summary>
-    IReadOnlySet<TopicPartition> Paused { get; }
+    TopicPartitionSet Paused { get; }
 
     /// <summary>
     /// Manually assigns partitions.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -17,6 +17,15 @@ using Dekaf.Retry;
 using Dekaf.Serialization;
 using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
+#if NETSTANDARD2_0
+using Lock = System.Object;
+using TopicNameSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using Lock = System.Threading.Lock;
+using TopicNameSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
 
 namespace Dekaf.Consumer;
 
@@ -600,10 +609,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private readonly ConcurrentDictionary<string, byte> _subscription = new();
     private readonly HashSet<TopicPartition> _assignment = [];
-    private volatile IReadOnlySet<TopicPartition> _assignmentSnapshot = new HashSet<TopicPartition>();
+    private volatile TopicPartitionSet _assignmentSnapshot = new HashSet<TopicPartition>();
     private readonly ConcurrentDictionary<TopicPartition, byte> _paused = new();
-    private volatile IReadOnlySet<string> _subscriptionSnapshot = new HashSet<string>();
-    private volatile IReadOnlySet<TopicPartition> _pausedSnapshot = new HashSet<TopicPartition>();
+    private volatile TopicNameSet _subscriptionSnapshot = new HashSet<string>();
+    private volatile TopicPartitionSet _pausedSnapshot = new HashSet<TopicPartition>();
 
     // Pattern subscription support
     private volatile Func<string, bool>? _topicFilter;
@@ -842,8 +851,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         bool ownsInfrastructure,
         IDekafMemoryBudget memoryBudget)
     {
-        ArgumentOutOfRangeException.ThrowIfLessThan(options.ConnectionsPerBroker, 1);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(options.ConnectionsPerBroker, options.MaxConnectionsPerBroker);
+        CompatibilityThrowHelpers.ThrowIfLessThan(options.ConnectionsPerBroker, 1);
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(options.ConnectionsPerBroker, options.MaxConnectionsPerBroker);
         AutoOffsetResetStrategy.ValidateOptions(options);
 
         _options = options;
@@ -937,11 +946,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         Diagnostics.DekafMetrics.RegisterConsumerLagCallback(ObserveConsumerLag);
     }
 
-    public IReadOnlySet<string> Subscription => _subscriptionSnapshot;
+    public TopicNameSet Subscription => _subscriptionSnapshot;
     public string? SubscriptionPattern => _topicPattern;
-    public IReadOnlySet<TopicPartition> Assignment => _assignmentSnapshot;
+    public TopicPartitionSet Assignment => _assignmentSnapshot;
     public string? MemberId => _coordinator?.MemberId;
-    public IReadOnlySet<TopicPartition> Paused => _pausedSnapshot;
+    public TopicPartitionSet Paused => _pausedSnapshot;
     public IConsumerPositions Positions => this;
     public IConsumerPartitions Partitions => this;
     public IConsumerOffsets Offsets => this;
@@ -992,9 +1001,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             return new ConsumerGroupMetadata
             {
-                GroupId = _options.GroupId,
+                GroupId = _options.GroupId!,
                 GenerationId = _coordinator.GenerationId,
-                MemberId = _coordinator.MemberId,
+                MemberId = _coordinator.MemberId!,
                 GroupInstanceId = _options.GroupInstanceId
             };
         }
@@ -1015,7 +1024,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     public void Subscribe(Func<string, bool> topicFilter)
     {
-        ArgumentNullException.ThrowIfNull(topicFilter);
+        CompatibilityThrowHelpers.ThrowIfNull(topicFilter);
 
         _topicFilter = topicFilter;
         _topicPattern = null;
@@ -1026,7 +1035,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     public void SubscribePattern(string pattern)
     {
-        ArgumentNullException.ThrowIfNull(pattern);
+        CompatibilityThrowHelpers.ThrowIfNull(pattern);
         if (string.IsNullOrWhiteSpace(pattern))
         {
             throw new ArgumentException("Subscription pattern must be specified.", nameof(pattern));
@@ -1477,7 +1486,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Report batch processing time to the adaptive fetch sizer (per-batch, not per-message)
                     if (batchProcessingStarted.HasValue)
                     {
-                        var processingDuration = System.Diagnostics.Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
+                        var processingDuration = CompatibilityBcl.GetElapsedTime(batchProcessingStarted.Value);
                         _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
                     }
 
@@ -1642,7 +1651,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Report batch processing time to the adaptive fetch sizer
                     if (batchProcessingStarted.HasValue)
                     {
-                        TimeSpan processingDuration = System.Diagnostics.Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
+                        TimeSpan processingDuration = CompatibilityBcl.GetElapsedTime(batchProcessingStarted.Value);
                         _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
                     }
                 }
@@ -1785,7 +1794,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Report batch processing time to the adaptive fetch sizer
                     if (batchProcessingStarted.HasValue)
                     {
-                        TimeSpan processingDuration = System.Diagnostics.Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
+                        TimeSpan processingDuration = CompatibilityBcl.GetElapsedTime(batchProcessingStarted.Value);
                         _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
                     }
                 }
@@ -1953,8 +1962,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // the bottleneck (slowest broker) which is the right signal for adaptive sizing.
                 _adaptiveFetchSizer?.RecordFetchStart();
 
+#if NETSTANDARD2_0
+                await Task.WhenAll(fetchTasks.Take(taskCount)).ConfigureAwait(false);
+#else
                 // ReadOnlySpan overload (.NET 9+) avoids internal array copy and ArraySegment boxing
                 await Task.WhenAll(new ReadOnlySpan<Task>(fetchTasks, 0, taskCount)).ConfigureAwait(false);
+#endif
 
                 _adaptiveFetchSizer?.RecordFetchEnd();
             }
@@ -2039,7 +2052,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     internal static int CalculatePrefetchBufferCapacity(ConsumerOptions options)
     {
-        ArgumentNullException.ThrowIfNull(options);
+        CompatibilityThrowHelpers.ThrowIfNull(options);
 
         return PoolSizing.ForConsumerPrefetchBuffer(
             options.QueuedMaxMessagesKbytes,
@@ -2715,7 +2728,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             if (batchProcessingStarted.HasValue)
             {
-                var processingDuration = System.Diagnostics.Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
+                var processingDuration = CompatibilityBcl.GetElapsedTime(batchProcessingStarted.Value);
                 _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
             }
 
@@ -2859,7 +2872,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             return;
 
         Diagnostics.DekafMetrics.FetchDuration.Record(
-            Stopwatch.GetElapsedTime(fetchStarted).TotalSeconds,
+            CompatibilityBcl.GetElapsedTime(fetchStarted).TotalSeconds,
             GetFetchDurationMetricTags(brokerId));
     }
 
@@ -3365,7 +3378,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         const long refreshIntervalTicks = 30 * TimeSpan.TicksPerSecond;
 
-        var now = Environment.TickCount64;
+        var now = CompatibilityBcl.TickCount64;
         var lastRefresh = Volatile.Read(ref _lastFilterRefreshTicks);
 
         // Rate-limit: skip if we refreshed recently (unless this is the first call)
@@ -3813,8 +3826,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // the bottleneck (slowest broker) which is the right signal for adaptive sizing.
                 _adaptiveFetchSizer?.RecordFetchStart();
 
+#if NETSTANDARD2_0
+                await Task.WhenAll(fetchTasks.Take(taskCount)).ConfigureAwait(false);
+#else
                 // ReadOnlySpan overload: same zero-copy benefit as above
                 await Task.WhenAll(new ReadOnlySpan<Task<List<PendingFetchData>?>>(fetchTasks, 0, taskCount)).ConfigureAwait(false);
+#endif
 
                 _adaptiveFetchSizer?.RecordFetchEnd();
 
@@ -3958,7 +3975,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 brokerTasks[i] = ResolvePartitionFetchBrokerAsync(assignmentArray[i], cancellationToken);
             }
 
+#if NETSTANDARD2_0
+            await Task.WhenAll(brokerTasks.Take(assignmentCount)).ConfigureAwait(false);
+#else
             await Task.WhenAll(new ReadOnlySpan<Task<(TopicPartition Partition, BrokerNode? Broker)>>(brokerTasks, 0, assignmentCount)).ConfigureAwait(false);
+#endif
         }
         finally
         {
@@ -4446,7 +4467,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (!updated)
             ScheduleLeaderRefresh(topic);
 
-        return ValueTask.CompletedTask;
+        return default;
     }
 
     private void UpdatePreferredReadReplica(string topic, FetchResponsePartition partitionResponse)
@@ -4532,7 +4553,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
             return;
 
-        TaskCompletionSource refreshCompletion;
+        TaskCompletionSource<bool> refreshCompletion;
         CancellationToken cancellationToken;
 
         lock (_leaderRefreshTasksLock)
@@ -4552,7 +4573,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 return;
             }
 
-            refreshCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            refreshCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _pendingLeaderRefreshTasks[topic] = refreshCompletion.Task;
         }
 
@@ -4561,7 +4582,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private async Task ExecuteLeaderRefreshAsync(
         string topic,
-        TaskCompletionSource refreshCompletion,
+        TaskCompletionSource<bool> refreshCompletion,
         CancellationToken cancellationToken)
     {
         try
@@ -4584,7 +4605,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 }
             }
 
-            refreshCompletion.TrySetResult();
+            refreshCompletion.TrySetResult(true);
         }
     }
 
@@ -5066,7 +5087,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         IEnumerable<TopicPartitionTimestamp> timestampsToSearch,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(timestampsToSearch);
+        CompatibilityThrowHelpers.ThrowIfNull(timestampsToSearch);
 
         if (Volatile.Read(ref _consumerDisposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));
@@ -5228,7 +5249,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
         }
 
-        var closeElapsedMs = System.Diagnostics.Stopwatch.GetElapsedTime(disposeStart).TotalMilliseconds;
+        var closeElapsedMs = CompatibilityBcl.GetElapsedTime(disposeStart).TotalMilliseconds;
         LogConsumerCloseCompleted(closeElapsedMs);
 
         CancelActiveConsumeOperations();
@@ -5297,7 +5318,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             await _connectionPool.DisposeAsync().ConfigureAwait(false);
         }
 
-        var disposeElapsedMs = System.Diagnostics.Stopwatch.GetElapsedTime(disposeStart).TotalMilliseconds;
+        var disposeElapsedMs = CompatibilityBcl.GetElapsedTime(disposeStart).TotalMilliseconds;
         LogConsumerDisposed(disposeElapsedMs);
     }
 

--- a/src/Dekaf/Diagnostics/TraceContextPropagator.cs
+++ b/src/Dekaf/Diagnostics/TraceContextPropagator.cs
@@ -38,7 +38,7 @@ internal static class TraceContextPropagator
 
         if (!string.IsNullOrEmpty(activity.TraceStateString))
         {
-            headers.Add(TracestateHeader, activity.TraceStateString);
+            headers.Add(TracestateHeader, activity.TraceStateString!);
         }
 
         return headers;

--- a/src/Dekaf/GlobalUsings.cs
+++ b/src/Dekaf/GlobalUsings.cs
@@ -1,1 +1,2 @@
 global using KafkaException = Dekaf.Errors.KafkaException;
+global using Dekaf.Internal;

--- a/src/Dekaf/Internal/ClientMemoryBudget.cs
+++ b/src/Dekaf/Internal/ClientMemoryBudget.cs
@@ -147,10 +147,7 @@ internal sealed class ClientMemoryBudget : IDekafMemoryBudget
         if (_explicitBudget.HasValue)
             return _explicitBudget.Value;
 
-        var available = (ulong)GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
-        if (available == 0)
-            return FallbackBudgetBytes;
-
+        var available = CompatibilityBcl.GetTotalAvailableMemoryBytes(FallbackBudgetBytes);
         return (ulong)(available * _percentOfAvailable);
     }
 

--- a/src/Dekaf/Internal/CompatibilityBcl.cs
+++ b/src/Dekaf/Internal/CompatibilityBcl.cs
@@ -1,0 +1,508 @@
+using System.Diagnostics;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Dekaf.Internal;
+
+internal static class CompatibilityBcl
+{
+    public static int ArrayMaxLength
+    {
+        get
+        {
+#if NETSTANDARD2_0
+            return 0x7FFFFFC7;
+#else
+            return Array.MaxLength;
+#endif
+        }
+    }
+
+    public static long TickCount64
+    {
+        get
+        {
+#if NETSTANDARD2_0
+            return Stopwatch.GetTimestamp() * 1000 / Stopwatch.Frequency;
+#else
+            return Environment.TickCount64;
+#endif
+        }
+    }
+
+    public static DateTime UnixEpoch { get; } = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    public static TimeSpan GetElapsedTime(long startingTimestamp)
+    {
+#if NETSTANDARD2_0
+        return GetElapsedTime(startingTimestamp, Stopwatch.GetTimestamp());
+#else
+        return Stopwatch.GetElapsedTime(startingTimestamp);
+#endif
+    }
+
+    public static TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp)
+    {
+#if NETSTANDARD2_0
+        var elapsedTicks = endingTimestamp - startingTimestamp;
+        var ticks = (long)(elapsedTicks * (TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency));
+        return new TimeSpan(ticks);
+#else
+        return Stopwatch.GetElapsedTime(startingTimestamp, endingTimestamp);
+#endif
+    }
+
+    public static T Clamp<T>(T value, T min, T max)
+        where T : IComparable<T>
+    {
+        if (min.CompareTo(max) > 0)
+            throw new ArgumentException("Minimum value must not exceed maximum value.", nameof(min));
+        if (value.CompareTo(min) < 0)
+            return min;
+        return value.CompareTo(max) > 0 ? max : value;
+    }
+
+    public static ValueTask CompletedValueTask => default;
+
+    public static ValueTask<T> FromException<T>(Exception exception)
+    {
+#if NETSTANDARD2_0
+        return new ValueTask<T>(Task.FromException<T>(exception));
+#else
+        return ValueTask.FromException<T>(exception);
+#endif
+    }
+
+    public static int RandomNext(int minValue, int maxValue)
+        => CompatibilityRandom.Next(minValue, maxValue);
+
+    public static int RandomNext(int maxValue)
+        => CompatibilityRandom.Next(maxValue);
+
+    public static double RandomNextDouble()
+        => CompatibilityRandom.NextDouble();
+
+    public static Guid ReadGuidBigEndian(ReadOnlySpan<byte> source)
+    {
+#if NETSTANDARD2_0
+        if (source.Length < 16)
+            throw new ArgumentException("Guid source must contain at least 16 bytes.", nameof(source));
+
+        var bytes = source.Slice(0, 16).ToArray();
+        Array.Reverse(bytes, 0, 4);
+        Array.Reverse(bytes, 4, 2);
+        Array.Reverse(bytes, 6, 2);
+        return new Guid(bytes);
+#else
+        return new Guid(source, bigEndian: true);
+#endif
+    }
+
+    public static bool TryWriteGuidBigEndian(Guid value, Span<byte> destination)
+    {
+        if (destination.Length < 16)
+            return false;
+
+#if NETSTANDARD2_0
+        var bytes = value.ToByteArray();
+        destination[0] = bytes[3];
+        destination[1] = bytes[2];
+        destination[2] = bytes[1];
+        destination[3] = bytes[0];
+        destination[4] = bytes[5];
+        destination[5] = bytes[4];
+        destination[6] = bytes[7];
+        destination[7] = bytes[6];
+        bytes.AsSpan(8, 8).CopyTo(destination.Slice(8));
+        return true;
+#else
+        return value.TryWriteBytes(destination, bigEndian: true, out _);
+#endif
+    }
+
+    public static double ReadDoubleBigEndian(ReadOnlySpan<byte> source)
+    {
+#if NETSTANDARD2_0
+        if (source.Length < sizeof(double))
+            throw new ArgumentException("Double source must contain at least 8 bytes.", nameof(source));
+
+        Span<byte> bytes = stackalloc byte[sizeof(double)];
+        source.Slice(0, sizeof(double)).CopyTo(bytes);
+        if (BitConverter.IsLittleEndian)
+            Reverse(bytes);
+        return BitConverter.ToDouble(bytes.ToArray(), 0);
+#else
+        return System.Buffers.Binary.BinaryPrimitives.ReadDoubleBigEndian(source);
+#endif
+    }
+
+    public static void WriteDoubleBigEndian(Span<byte> destination, double value)
+    {
+#if NETSTANDARD2_0
+        if (destination.Length < sizeof(double))
+            throw new ArgumentException("Double destination must contain at least 8 bytes.", nameof(destination));
+
+        var bytes = BitConverter.GetBytes(value);
+        if (BitConverter.IsLittleEndian)
+            Array.Reverse(bytes);
+        bytes.CopyTo(destination);
+#else
+        System.Buffers.Binary.BinaryPrimitives.WriteDoubleBigEndian(destination, value);
+#endif
+    }
+
+    public static float ReadSingleBigEndian(ReadOnlySpan<byte> source)
+    {
+#if NETSTANDARD2_0
+        if (source.Length < sizeof(float))
+            throw new ArgumentException("Single source must contain at least 4 bytes.", nameof(source));
+
+        Span<byte> bytes = stackalloc byte[sizeof(float)];
+        source.Slice(0, sizeof(float)).CopyTo(bytes);
+        if (BitConverter.IsLittleEndian)
+            Reverse(bytes);
+        return BitConverter.ToSingle(bytes.ToArray(), 0);
+#else
+        return System.Buffers.Binary.BinaryPrimitives.ReadSingleBigEndian(source);
+#endif
+    }
+
+    public static void WriteSingleBigEndian(Span<byte> destination, float value)
+    {
+#if NETSTANDARD2_0
+        if (destination.Length < sizeof(float))
+            throw new ArgumentException("Single destination must contain at least 4 bytes.", nameof(destination));
+
+        var bytes = BitConverter.GetBytes(value);
+        if (BitConverter.IsLittleEndian)
+            Array.Reverse(bytes);
+        bytes.CopyTo(destination);
+#else
+        System.Buffers.Binary.BinaryPrimitives.WriteSingleBigEndian(destination, value);
+#endif
+    }
+
+    public static bool IsFinite(double value)
+        => !double.IsNaN(value) && !double.IsInfinity(value);
+
+    public static bool IsFinite(float value)
+        => !float.IsNaN(value) && !float.IsInfinity(value);
+
+    public static byte[] GetRandomBytes(int count)
+    {
+#if NETSTANDARD2_0
+        var bytes = new byte[count];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(bytes);
+        return bytes;
+#else
+        return RandomNumberGenerator.GetBytes(count);
+#endif
+    }
+
+    public static T[] AllocateUninitializedArray<T>(int length)
+    {
+#if NETSTANDARD2_0
+        return new T[length];
+#else
+        return GC.AllocateUninitializedArray<T>(length);
+#endif
+    }
+
+    public static T[] AllocateUninitializedArray<T>(int length, bool pinned)
+    {
+#if NETSTANDARD2_0
+        return new T[length];
+#else
+        return GC.AllocateUninitializedArray<T>(length, pinned);
+#endif
+    }
+
+    public static ulong GetTotalAvailableMemoryBytes(ulong fallback)
+    {
+#if NETSTANDARD2_0
+        return fallback;
+#else
+        var available = (ulong)GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+        return available == 0 ? fallback : available;
+#endif
+    }
+
+    public static int GetCurrentProcessorId()
+    {
+#if NETSTANDARD2_0
+        return Environment.CurrentManagedThreadId;
+#else
+        return Thread.GetCurrentProcessorId();
+#endif
+    }
+
+    public static void FillArray<T>(T[] array, T value)
+    {
+#if NETSTANDARD2_0
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = value;
+        }
+#else
+        Array.Fill(array, value);
+#endif
+    }
+
+    public static bool IsCompletedSuccessfully(Task task)
+    {
+#if NETSTANDARD2_0
+        return task.Status == TaskStatus.RanToCompletion;
+#else
+        return task.IsCompletedSuccessfully;
+#endif
+    }
+
+    public static int GetUtf8Bytes(string value, Span<byte> destination)
+    {
+#if NETSTANDARD2_0
+        var bytes = Encoding.UTF8.GetBytes(value);
+        bytes.CopyTo(destination);
+        return bytes.Length;
+#else
+        return Encoding.UTF8.GetBytes(value, destination);
+#endif
+    }
+
+    public static byte[] Sha256HashData(ReadOnlySpan<byte> data)
+    {
+#if NETSTANDARD2_0
+        using var hash = SHA256.Create();
+        return hash.ComputeHash(data.ToArray());
+#else
+        return SHA256.HashData(data);
+#endif
+    }
+
+    public static byte[] Sha512HashData(ReadOnlySpan<byte> data)
+    {
+#if NETSTANDARD2_0
+        using var hash = SHA512.Create();
+        return hash.ComputeHash(data.ToArray());
+#else
+        return SHA512.HashData(data);
+#endif
+    }
+
+    public static byte[] HmacSha256HashData(byte[] key, byte[] data)
+    {
+#if NETSTANDARD2_0
+        using var hmac = new HMACSHA256(key);
+        return hmac.ComputeHash(data);
+#else
+        return HMACSHA256.HashData(key, data);
+#endif
+    }
+
+    public static byte[] HmacSha512HashData(byte[] key, byte[] data)
+    {
+#if NETSTANDARD2_0
+        using var hmac = new HMACSHA512(key);
+        return hmac.ComputeHash(data);
+#else
+        return HMACSHA512.HashData(key, data);
+#endif
+    }
+
+    public static long DoubleToInt64Bits(double value)
+    {
+#if NETSTANDARD2_0
+        var bytes = BitConverter.GetBytes(value);
+        return BitConverter.ToInt64(bytes, 0);
+#else
+        return BitConverter.DoubleToInt64Bits(value);
+#endif
+    }
+
+    public static byte[] Pbkdf2(
+        byte[] password,
+        byte[] salt,
+        int iterations,
+        HashAlgorithmName hashAlgorithm,
+        int outputLength)
+    {
+#if NETSTANDARD2_0
+        return Pbkdf2NetStandard(password, salt, iterations, hashAlgorithm, outputLength);
+#else
+        return Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithm, outputLength);
+#endif
+    }
+
+#if NETSTANDARD2_0
+    private static byte[] Pbkdf2NetStandard(
+        byte[] password,
+        byte[] salt,
+        int iterations,
+        HashAlgorithmName hashAlgorithm,
+        int outputLength)
+    {
+        if (iterations <= 0)
+            throw new ArgumentOutOfRangeException(nameof(iterations));
+        if (outputLength < 0)
+            throw new ArgumentOutOfRangeException(nameof(outputLength));
+
+        using var hmac = CreatePbkdf2Hmac(hashAlgorithm, password);
+        var hashLength = hmac.HashSize / 8;
+        var blockCount = (outputLength + hashLength - 1) / hashLength;
+        var result = new byte[outputLength];
+        var saltAndBlock = new byte[salt.Length + 4];
+        Buffer.BlockCopy(salt, 0, saltAndBlock, 0, salt.Length);
+
+        var destinationOffset = 0;
+        for (var block = 1; block <= blockCount; block++)
+        {
+            WriteInt32BigEndian(saltAndBlock, salt.Length, block);
+            var u = hmac.ComputeHash(saltAndBlock);
+            var t = (byte[])u.Clone();
+
+            for (var i = 1; i < iterations; i++)
+            {
+                u = hmac.ComputeHash(u);
+                for (var j = 0; j < t.Length; j++)
+                {
+                    t[j] ^= u[j];
+                }
+            }
+
+            var bytesToCopy = Math.Min(hashLength, outputLength - destinationOffset);
+            Buffer.BlockCopy(t, 0, result, destinationOffset, bytesToCopy);
+            destinationOffset += bytesToCopy;
+        }
+
+        return result;
+    }
+
+    private static HMAC CreatePbkdf2Hmac(HashAlgorithmName hashAlgorithm, byte[] password)
+    {
+        if (hashAlgorithm == HashAlgorithmName.SHA256)
+            return new HMACSHA256(password);
+        if (hashAlgorithm == HashAlgorithmName.SHA384)
+            return new HMACSHA384(password);
+        if (hashAlgorithm == HashAlgorithmName.SHA512)
+            return new HMACSHA512(password);
+
+        throw new NotSupportedException($"PBKDF2 hash algorithm '{hashAlgorithm.Name}' is not supported.");
+    }
+
+    private static void WriteInt32BigEndian(byte[] buffer, int offset, int value)
+    {
+        unchecked
+        {
+            buffer[offset] = (byte)(value >> 24);
+            buffer[offset + 1] = (byte)(value >> 16);
+            buffer[offset + 2] = (byte)(value >> 8);
+            buffer[offset + 3] = (byte)value;
+        }
+    }
+#endif
+
+    public static bool FixedTimeEquals(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
+    {
+#if NETSTANDARD2_0
+        if (left.Length != right.Length)
+            return false;
+
+        var differences = 0;
+        for (var i = 0; i < left.Length; i++)
+        {
+            differences |= left[i] ^ right[i];
+        }
+
+        return differences == 0;
+#else
+        return CryptographicOperations.FixedTimeEquals(left, right);
+#endif
+    }
+
+    public static void ZeroMemory(Span<byte> buffer)
+    {
+#if NETSTANDARD2_0
+        buffer.Clear();
+#else
+        CryptographicOperations.ZeroMemory(buffer);
+#endif
+    }
+
+    public static string Base64UrlEncode(ReadOnlySpan<byte> data)
+    {
+        return Convert.ToBase64String(data.ToArray())
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    public static string ToHexStringLower(ReadOnlySpan<byte> bytes)
+    {
+        const string hex = "0123456789abcdef";
+        var chars = new char[bytes.Length * 2];
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            chars[i * 2] = hex[bytes[i] >> 4];
+            chars[(i * 2) + 1] = hex[bytes[i] & 0xF];
+        }
+
+        return new string(chars);
+    }
+
+    public static async Task<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken)
+    {
+#if NETSTANDARD2_0
+        var task = Dns.GetHostAddressesAsync(host);
+        return await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+#else
+        return await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
+#endif
+    }
+
+    public static async Task<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken)
+    {
+#if NETSTANDARD2_0
+        var task = Dns.GetHostEntryAsync(host);
+        return await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+#else
+        return await Dns.GetHostEntryAsync(host, cancellationToken).ConfigureAwait(false);
+#endif
+    }
+
+    private static void Reverse(Span<byte> bytes)
+    {
+        for (int left = 0, right = bytes.Length - 1; left < right; left++, right--)
+        {
+            (bytes[left], bytes[right]) = (bytes[right], bytes[left]);
+        }
+    }
+}
+
+internal static class CompatibilityRandom
+{
+    [ThreadStatic]
+    private static Random? t_random;
+
+    public static int Next(int minValue, int maxValue)
+        => Current.Next(minValue, maxValue);
+
+    public static int Next(int maxValue)
+        => Current.Next(maxValue);
+
+    public static double NextDouble()
+        => Current.NextDouble();
+
+    private static Random Current
+    {
+        get
+        {
+#if NETSTANDARD2_0
+            var threadId = Environment.CurrentManagedThreadId;
+#else
+            var threadId = Environment.CurrentManagedThreadId;
+#endif
+            return t_random ??= new Random(unchecked(Environment.TickCount * 31 + threadId));
+        }
+    }
+}

--- a/src/Dekaf/Internal/CompatibilityThrowHelpers.cs
+++ b/src/Dekaf/Internal/CompatibilityThrowHelpers.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Dekaf.Internal;
+
+internal static class CompatibilityThrowHelpers
+{
+    public static void ThrowIfNull(
+        [NotNull] object? argument,
+        [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+        if (argument is null)
+            throw new ArgumentNullException(paramName);
+    }
+
+    public static void ThrowIfNullOrEmpty(
+        [NotNull] string? argument,
+        [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+        if (argument is null)
+            throw new ArgumentNullException(paramName);
+
+        if (argument.Length == 0)
+            throw new ArgumentException("Value cannot be empty.", paramName);
+    }
+
+    public static void ThrowIfNullOrWhiteSpace(
+        [NotNull] string? argument,
+        [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+        if (argument is null)
+            throw new ArgumentNullException(paramName);
+
+        if (string.IsNullOrWhiteSpace(argument))
+            throw new ArgumentException("Value cannot be whitespace.", paramName);
+    }
+
+    public static void ThrowIfGreaterThan<T>(
+        T value,
+        T other,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IComparable<T>
+    {
+        if (value.CompareTo(other) > 0)
+            throw new ArgumentOutOfRangeException(paramName, value, $"Value must be less than or equal to {other}.");
+    }
+
+    public static void ThrowIfGreaterThanOrEqual<T>(
+        T value,
+        T other,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IComparable<T>
+    {
+        if (value.CompareTo(other) >= 0)
+            throw new ArgumentOutOfRangeException(paramName, value, $"Value must be less than {other}.");
+    }
+
+    public static void ThrowIfLessThan<T>(
+        T value,
+        T other,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IComparable<T>
+    {
+        if (value.CompareTo(other) < 0)
+            throw new ArgumentOutOfRangeException(paramName, value, $"Value must be greater than or equal to {other}.");
+    }
+
+    public static void ThrowIfNegative<T>(
+        T value,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : struct, IComparable<T>
+    {
+        if (value.CompareTo(default) < 0)
+            throw new ArgumentOutOfRangeException(paramName, value, "Value must be non-negative.");
+    }
+
+    public static void ThrowIfNegativeOrZero<T>(
+        T value,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : struct, IComparable<T>
+    {
+        if (value.CompareTo(default) <= 0)
+            throw new ArgumentOutOfRangeException(paramName, value, "Value must be positive.");
+    }
+
+    public static void ThrowIfZero<T>(
+        T value,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : struct, IComparable<T>
+    {
+        if (value.CompareTo(default) == 0)
+            throw new ArgumentOutOfRangeException(paramName, value, "Value must be non-zero.");
+    }
+
+    public static void ThrowIfObjectDisposed(bool condition, object instance)
+    {
+        if (condition)
+            throw new ObjectDisposedException(instance.GetType().Name);
+    }
+}

--- a/src/Dekaf/Internal/DekafMemoryBudget.cs
+++ b/src/Dekaf/Internal/DekafMemoryBudget.cs
@@ -97,7 +97,7 @@ public static class DekafMemoryBudget
     /// </summary>
     public static void SetBudget(ulong bytes)
     {
-        ArgumentOutOfRangeException.ThrowIfZero(bytes);
+        CompatibilityThrowHelpers.ThrowIfZero(bytes);
         RebalanceSnapshot snapshot;
         lock (_lock)
         {
@@ -248,10 +248,7 @@ public static class DekafMemoryBudget
         if (_explicitBudget.HasValue)
             return _explicitBudget.Value;
 
-        var available = (ulong)GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
-        if (available == 0)
-            return FallbackBudgetBytes;
-
+        var available = CompatibilityBcl.GetTotalAvailableMemoryBytes(FallbackBudgetBytes);
         return (ulong)(available * _percentOfAvailable);
     }
 

--- a/src/Dekaf/Internal/LockFreeStack.cs
+++ b/src/Dekaf/Internal/LockFreeStack.cs
@@ -48,7 +48,7 @@ internal sealed class LockFreeStack<T> where T : class
     /// <param name="capacity">Maximum number of items the stack can hold.</param>
     public LockFreeStack(int capacity)
     {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+        CompatibilityThrowHelpers.ThrowIfNegativeOrZero(capacity);
         _capacity = capacity;
 
         var stripeCount = ComputeStripeCount(capacity);
@@ -175,7 +175,7 @@ internal sealed class LockFreeStack<T> where T : class
     {
         foreach (var stripe in _stripes)
         {
-            Array.Clear(stripe.Slots);
+            Array.Clear(stripe.Slots, 0, stripe.Slots.Length);
             Volatile.Write(ref stripe.Top, 0);
         }
     }
@@ -193,5 +193,5 @@ internal sealed class LockFreeStack<T> where T : class
     private int GetStartStripe()
         => _stripes.Length == 1
             ? 0
-            : (Thread.GetCurrentProcessorId() & int.MaxValue) % _stripes.Length;
+            : (CompatibilityBcl.GetCurrentProcessorId() & int.MaxValue) % _stripes.Length;
 }

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -74,33 +74,33 @@ internal static class PoolSizing
         // — which is the failure mode previously observed in single-broker idempotent stress.
         var clampedMaxConns = Math.Max(1, maxConnectionsPerBroker);
         var clampedMaxInFlight = Math.Max(1, maxInFlightRequestsPerConnection);
-        // Compute in long to make the final Math.Clamp ceiling unconditional — pathological
+        // Compute in long to make the final CompatibilityBcl.Clamp ceiling unconditional — pathological
         // inputs (e.g. misconfigured maxConnectionsPerBroker) would otherwise overflow int
         // and produce a negative intermediate that clamps to the floor instead of the ceiling.
         var peakInflightEntries = (long)clampedMaxConns * clampedMaxInFlight * InflightEntriesPerBatch;
         var bufferDerivedEntries = (long)maxBatches * InflightEntriesPerBatch;
         var inflightEntries = Math.Max(peakInflightEntries, bufferDerivedEntries);
 
-        var pendingAppends = Math.Clamp(clampedMaxConns * clampedMaxInFlight * 4, 64, 1024);
+        var pendingAppends = CompatibilityBcl.Clamp(clampedMaxConns * clampedMaxInFlight * 4, 64, 1024);
 
         return new ProducerPoolSizes
         {
-            ValueTaskSources = Math.Clamp(estimatedMessages, MinValueTaskSources, MaxValueTaskSources),
+            ValueTaskSources = CompatibilityBcl.Clamp(estimatedMessages, MinValueTaskSources, MaxValueTaskSources),
             // Floor at 256KB to avoid ArrayPool thrash from frequent grow/shrink on modest workloads.
             MaxRetainedBufferSize = Math.Max(batchSize, 256 * 1024),
-            InflightEntries = (int)Math.Clamp(inflightEntries, 128L, 16384L),
+            InflightEntries = (int)CompatibilityBcl.Clamp(inflightEntries, 128L, 16384L),
             PendingAppends = pendingAppends,
         };
     }
 
     internal static ConnectionPoolSizes ForConnection(int maxInFlightRequestsPerConnection)
     {
-        var pendingRequests = Math.Clamp(maxInFlightRequestsPerConnection * 4, 64, 1024);
+        var pendingRequests = CompatibilityBcl.Clamp(maxInFlightRequestsPerConnection * 4, 64, 1024);
 
         return new ConnectionPoolSizes
         {
             PendingRequests = pendingRequests,
-            CancellationTokenSources = Math.Clamp(maxInFlightRequestsPerConnection * 8, 64, 2048),
+            CancellationTokenSources = CompatibilityBcl.Clamp(maxInFlightRequestsPerConnection * 8, 64, 2048),
         };
     }
 
@@ -108,8 +108,8 @@ internal static class PoolSizing
     {
         return new ConsumerPoolSizes
         {
-            FetchDataPool = Math.Clamp(maxPartitionCount * 2, 32, 512),
-            CancellationTokenSources = Math.Clamp(maxPartitionCount * 4, 64, 2048),
+            FetchDataPool = CompatibilityBcl.Clamp(maxPartitionCount * 2, 32, 512),
+            CancellationTokenSources = CompatibilityBcl.Clamp(maxPartitionCount * 4, 64, 2048),
         };
     }
 
@@ -132,7 +132,7 @@ internal static class PoolSizing
         var pipelineFloor = pipelineDepth * connectionCount;
         var capacity = Math.Max(Math.Max(byteBoundItems, pipelineItems), pipelineFloor);
 
-        return (int)Math.Clamp(
+        return (int)CompatibilityBcl.Clamp(
             capacity,
             MinConsumerPrefetchBufferCapacity,
             MaxConsumerPrefetchBufferCapacity);
@@ -202,7 +202,7 @@ internal static class PoolSizing
         int batchSize = 1048576,
         int maxConnectionsPerBroker = 10)
     {
-        var clampedBrokers = Math.Clamp(brokerCount, 1, 16);
+        var clampedBrokers = CompatibilityBcl.Clamp(brokerCount, 1, 16);
         var clampedConnections = Math.Max(1, connectionsPerBroker);
         var clampedMaxConnections = Math.Max(clampedConnections, maxConnectionsPerBroker);
         var clampedMaxInFlight = Math.Max(1, maxInFlightRequestsPerConnection);
@@ -214,8 +214,8 @@ internal static class PoolSizing
         // each message rents key+value arrays that are held until batch cleanup.
         // Arrays in-flight ≈ messagesPerBatch × inFlightBatches × connections.
         // Use maxConnectionsPerBroker (not current) since adaptive scaling can ramp up.
-        var clampedBatchSize = Math.Clamp(batchSize, 1024, 4 * 1024 * 1024);
-        var estimatedMessagesPerBatch = Math.Clamp(clampedBatchSize / 256, 8, 512);
+        var clampedBatchSize = CompatibilityBcl.Clamp(batchSize, 1024, 4 * 1024 * 1024);
+        var estimatedMessagesPerBatch = CompatibilityBcl.Clamp(clampedBatchSize / 256, 8, 512);
         var peakInFlightBatches = SaturatingMultiply(totalMaxConnections, clampedMaxInFlight);
         var producerDataArrays = ClampPoolDepth(
             SaturatingMultiply(estimatedMessagesPerBatch, peakInFlightBatches),
@@ -262,7 +262,7 @@ internal static class PoolSizing
     }
 
     private static int ClampPoolDepth(long value, int floor, int ceiling) =>
-        (int)Math.Clamp(value, floor, (long)ceiling);
+        (int)CompatibilityBcl.Clamp(value, floor, (long)ceiling);
 
     private static long SaturatingMultiply(long left, long right)
     {

--- a/src/Dekaf/Internal/RatchetableArrayPool.cs
+++ b/src/Dekaf/Internal/RatchetableArrayPool.cs
@@ -1,4 +1,9 @@
 using System.Buffers;
+#if NETSTANDARD2_0
+using Lock = System.Object;
+#else
+using Lock = System.Threading.Lock;
+#endif
 
 namespace Dekaf.Internal;
 

--- a/src/Dekaf/Internal/ReconnectBackoffValidation.cs
+++ b/src/Dekaf/Internal/ReconnectBackoffValidation.cs
@@ -6,15 +6,15 @@ internal static class ReconnectBackoffValidation
     {
         if (value < TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(parameterName, errorMessage);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(value.TotalMilliseconds, int.MaxValue, parameterName);
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(value.TotalMilliseconds, int.MaxValue, parameterName);
 
         return (int)value.TotalMilliseconds;
     }
 
     public static void ValidateMilliseconds(int reconnectBackoffMs, int reconnectBackoffMaxMs)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(reconnectBackoffMs);
-        ArgumentOutOfRangeException.ThrowIfNegative(reconnectBackoffMaxMs);
+        CompatibilityThrowHelpers.ThrowIfNegative(reconnectBackoffMs);
+        CompatibilityThrowHelpers.ThrowIfNegative(reconnectBackoffMaxMs);
         if (reconnectBackoffMaxMs < reconnectBackoffMs)
         {
             throw new ArgumentOutOfRangeException(

--- a/src/Dekaf/Kafka.cs
+++ b/src/Dekaf/Kafka.cs
@@ -36,7 +36,7 @@ public static class Kafka
     /// <param name="configure">Optional root-client configuration.</param>
     public static KafkaClient Connect(string bootstrapServers, Action<KafkaClientBuilder> configure)
     {
-        ArgumentNullException.ThrowIfNull(configure);
+        CompatibilityThrowHelpers.ThrowIfNull(configure);
 
         var builder = new KafkaClientBuilder()
             .WithBootstrapServers(bootstrapServers);

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -127,7 +127,7 @@ public sealed class KafkaClientBuilder
     {
         if (timeout <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(timeout), "Request timeout must be positive");
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
 
         _requestTimeoutMs = (int)timeout.TotalMilliseconds;
         return this;
@@ -238,7 +238,7 @@ public sealed class KafkaClientBuilder
 
     public KafkaClientBuilder WithOAuthBearerJwtBearer(OAuthBearerJwtBearerOptions options)
     {
-        ArgumentNullException.ThrowIfNull(options);
+        CompatibilityThrowHelpers.ThrowIfNull(options);
         var oauthConfig = options.ToOAuthBearerConfig();
         _saslMechanism = SaslMechanism.OAuthBearer;
         _oauthConfig = oauthConfig;
@@ -249,7 +249,7 @@ public sealed class KafkaClientBuilder
 
     public KafkaClientBuilder WithOAuthBearerJwtBearer(Action<OAuthBearerJwtBearerOptions> configure)
     {
-        ArgumentNullException.ThrowIfNull(configure);
+        CompatibilityThrowHelpers.ThrowIfNull(configure);
         var options = new OAuthBearerJwtBearerOptions();
         configure(options);
         return WithOAuthBearerJwtBearer(options);
@@ -278,37 +278,37 @@ public sealed class KafkaClientBuilder
 
     public KafkaClientBuilder WithSocketSendBufferBytes(int bytes)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        CompatibilityThrowHelpers.ThrowIfNegative(bytes);
         _socketSendBufferBytes = bytes;
         return this;
     }
 
     public KafkaClientBuilder WithSocketReceiveBufferBytes(int bytes)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        CompatibilityThrowHelpers.ThrowIfNegative(bytes);
         _socketReceiveBufferBytes = bytes;
         return this;
     }
 
     public KafkaClientBuilder WithConnectionsPerBroker(int connectionsPerBroker)
     {
-        ArgumentOutOfRangeException.ThrowIfLessThan(connectionsPerBroker, 1);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(connectionsPerBroker, 32);
+        CompatibilityThrowHelpers.ThrowIfLessThan(connectionsPerBroker, 1);
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(connectionsPerBroker, 32);
         _connectionsPerBroker = connectionsPerBroker;
         return this;
     }
 
     public KafkaClientBuilder WithMaxInFlightRequestsPerConnection(int maxInFlightRequestsPerConnection)
     {
-        ArgumentOutOfRangeException.ThrowIfLessThan(maxInFlightRequestsPerConnection, 1);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(maxInFlightRequestsPerConnection, 1000000);
+        CompatibilityThrowHelpers.ThrowIfLessThan(maxInFlightRequestsPerConnection, 1);
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(maxInFlightRequestsPerConnection, 1000000);
         _maxInFlightRequestsPerConnection = maxInFlightRequestsPerConnection;
         return this;
     }
 
     public KafkaClientBuilder WithMaxConnectionsPerBroker(int maxConnectionsPerBroker)
     {
-        ArgumentOutOfRangeException.ThrowIfLessThan(maxConnectionsPerBroker, 1);
+        CompatibilityThrowHelpers.ThrowIfLessThan(maxConnectionsPerBroker, 1);
         _maxConnectionsPerBroker = maxConnectionsPerBroker;
         return this;
     }
@@ -341,7 +341,7 @@ public sealed class KafkaClientBuilder
 
     public KafkaClientBuilder WithMetadataRecoveryRebootstrapTrigger(TimeSpan trigger)
     {
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(trigger.TotalMilliseconds, int.MaxValue, nameof(trigger));
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(trigger.TotalMilliseconds, int.MaxValue, nameof(trigger));
         _metadataRecoveryRebootstrapTriggerMs = (int)trigger.TotalMilliseconds;
         return this;
     }
@@ -357,7 +357,7 @@ public sealed class KafkaClientBuilder
 
     public KafkaClientBuilder WithMemoryBudget(ulong bytes)
     {
-        ArgumentOutOfRangeException.ThrowIfZero(bytes);
+        CompatibilityThrowHelpers.ThrowIfZero(bytes);
         _memoryBudgetBytes = bytes;
         return this;
     }

--- a/src/Dekaf/Metadata/ClusterMetadata.cs
+++ b/src/Dekaf/Metadata/ClusterMetadata.cs
@@ -272,7 +272,7 @@ public sealed class ClusterMetadata
             if (currentPartition.LeaderEpoch >= 0 && leaderEpoch <= currentPartition.LeaderEpoch)
                 return false;
 
-            var brokers = new Dictionary<int, BrokerNode>(existing.Brokers);
+            var brokers = existing.Brokers.ToDictionary(static pair => pair.Key, static pair => pair.Value);
             if (leaderEndpoint is not null)
             {
                 if (leaderEndpoint.NodeId != leaderId)
@@ -312,8 +312,8 @@ public sealed class ClusterMetadata
             if (!updated)
                 return false;
 
-            var topics = new Dictionary<string, TopicInfo>(existing.Topics);
-            var topicsById = new Dictionary<Guid, TopicInfo>(existing.TopicsById);
+            var topics = existing.Topics.ToDictionary(static pair => pair.Key, static pair => pair.Value);
+            var topicsById = existing.TopicsById.ToDictionary(static pair => pair.Key, static pair => pair.Value);
             var updatedTopic = new TopicInfo
             {
                 Name = topic.Name,

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -57,7 +57,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
     internal IDisposable AddBrokerCountDiscoveredCallback(Action<int> callback)
     {
-        ArgumentNullException.ThrowIfNull(callback);
+        CompatibilityThrowHelpers.ThrowIfNull(callback);
 
         lock (_brokerCountDiscoveredLock)
         {
@@ -126,9 +126,14 @@ public sealed partial class MetadataManager : IAsyncDisposable
             var colonIndex = server.IndexOf(':');
             if (colonIndex > 0 && colonIndex < server.Length - 1)
             {
+#if NETSTANDARD2_0
+                var host = server.Substring(0, colonIndex);
+                if (int.TryParse(server.Substring(colonIndex + 1), out var port))
+#else
                 var host = server[..colonIndex];
                 // Use span-based parsing to avoid string allocation for port
                 if (int.TryParse(server.AsSpan(colonIndex + 1), out var port))
+#endif
                 {
                     _bootstrapEndpoints.Add((host, port));
                     _originalBootstrapHostnames.Add(server);
@@ -671,7 +676,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// </summary>
     internal async ValueTask<bool> TryRebootstrapAsync(IEnumerable<string>? topics, CancellationToken cancellationToken)
     {
-        var now = Environment.TickCount64;
+        var now = CompatibilityBcl.TickCount64;
 
         // Atomically set the timestamp only if it hasn't been set yet (compare-and-set from 0)
         if (Interlocked.CompareExchange(ref _allBrokersUnavailableSince, now, 0) == 0)
@@ -795,7 +800,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 IPAddress[] addresses;
                 if (_options.ClientDnsLookup == ClientDnsLookup.ResolveCanonicalBootstrapServersOnly)
                 {
-                    var entry = await Dns.GetHostEntryAsync(host, dnsCts.Token).ConfigureAwait(false);
+                    var entry = await CompatibilityBcl.GetHostEntryAsync(host, dnsCts.Token).ConfigureAwait(false);
                     addresses = entry.AddressList;
                     var canonicalHost = string.IsNullOrWhiteSpace(entry.HostName) ? host : entry.HostName;
                     var canonicalEndpoint = (canonicalHost, port);
@@ -806,7 +811,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 }
                 else
                 {
-                    addresses = await Dns.GetHostAddressesAsync(host, dnsCts.Token).ConfigureAwait(false);
+                    addresses = await CompatibilityBcl.GetHostAddressesAsync(host, dnsCts.Token).ConfigureAwait(false);
                     foreach (var address in addresses)
                     {
                         var endpoint = (address.ToString(), port);
@@ -944,8 +949,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 currentBrokers.Count + _bootstrapEndpoints.Count);
 
             // First try known brokers, tracking seen endpoints for O(1) dedup
-            var seen = new HashSet<(string Host, int Port)>(
-                currentBrokers.Count + _bootstrapEndpoints.Count);
+            var seen = new HashSet<(string Host, int Port)>();
 
             foreach (var broker in currentBrokers)
             {

--- a/src/Dekaf/Networking/CancelledCorrelationIdTracker.cs
+++ b/src/Dekaf/Networking/CancelledCorrelationIdTracker.cs
@@ -10,7 +10,7 @@ internal sealed class CancelledCorrelationIdTracker
 
     public CancelledCorrelationIdTracker(int capacity)
     {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+        CompatibilityThrowHelpers.ThrowIfNegativeOrZero(capacity);
         _capacity = capacity;
     }
 

--- a/src/Dekaf/Networking/ClientDnsEndpointResolver.cs
+++ b/src/Dekaf/Networking/ClientDnsEndpointResolver.cs
@@ -93,11 +93,11 @@ internal sealed class SystemDnsLookup : IDnsLookup
 {
     public async ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken)
     {
-        return await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
+        return await CompatibilityBcl.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
     }
 
     public async ValueTask<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken)
     {
-        return await Dns.GetHostEntryAsync(host, cancellationToken).ConfigureAwait(false);
+        return await CompatibilityBcl.GetHostEntryAsync(host, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -4,6 +4,11 @@ using Dekaf.Internal;
 using Dekaf.Security.Sasl;
 using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
+#if NETSTANDARD2_0
+using Lock = System.Object;
+#else
+using Lock = System.Threading.Lock;
+#endif
 
 namespace Dekaf.Networking;
 
@@ -442,7 +447,7 @@ public sealed partial class ConnectionPool : IConnectionPool
     {
         foreach (var task in tasks)
         {
-            if (task is not null && task.IsCompletedSuccessfully)
+            if (task is not null && CompatibilityBcl.IsCompletedSuccessfully(task))
             {
                 try { await task.Result.DisposeAsync().ConfigureAwait(false); }
                 catch { /* best-effort cleanup */ }
@@ -527,7 +532,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(ConnectionPool));
 
-        ArgumentOutOfRangeException.ThrowIfLessThan(newCount, 1);
+        CompatibilityThrowHelpers.ThrowIfLessThan(newCount, 1);
 
         // Check current group size without locking
         if (!_connectionGroupsById.TryGetValue(brokerId, out var currentGroup) || currentGroup.Length <= newCount)
@@ -1006,7 +1011,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         if (baseMs < maxMs)
         {
             var jitterMaxMs = Math.Max(1, (int)Math.Ceiling(baseMs * 0.2));
-            baseMs = Math.Min(maxMs, baseMs + Random.Shared.Next(jitterMaxMs + 1));
+            baseMs = Math.Min(maxMs, baseMs + CompatibilityBcl.RandomNext(jitterMaxMs + 1));
         }
 
         return TimeSpan.FromMilliseconds(baseMs);
@@ -1031,7 +1036,7 @@ public sealed partial class ConnectionPool : IConnectionPool
             if (Volatile.Read(ref _disposed) != 0)
                 return 0;
 
-            var now = Environment.TickCount64;
+            var now = CompatibilityBcl.TickCount64;
             var reaped = 0;
 
             foreach (var (endpoint, connection) in _connectionsByEndpoint.ToArray())
@@ -1218,7 +1223,7 @@ public sealed partial class ConnectionPool : IConnectionPool
     }
 
     private static TimeSpan GetIdleReaperInterval(int connectionsMaxIdleMs)
-        => TimeSpan.FromMilliseconds(Math.Clamp(connectionsMaxIdleMs / 2, 1000, 60000));
+        => TimeSpan.FromMilliseconds(CompatibilityBcl.Clamp(connectionsMaxIdleMs / 2, 1000, 60000));
 
     public async ValueTask RemoveConnectionAsync(int brokerId)
     {

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -120,7 +120,7 @@ internal static class ConnectionHelper
         var totalConnections = (ulong)connectionsPerBroker * (ulong)brokerCount;
         var perPipeBudget = bufferMemory / totalConnections / BufferMemoryDivisor;
 
-        var pauseThreshold = Math.Clamp((long)perPipeBudget, MinimumPauseThresholdBytes, MaximumPauseThresholdBytes);
+        var pauseThreshold = CompatibilityBcl.Clamp((long)perPipeBudget, MinimumPauseThresholdBytes, MaximumPauseThresholdBytes);
 
         var resumeThreshold = pauseThreshold / 2;
 
@@ -172,7 +172,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
     private readonly PendingRequestShard[] _pendingRequestShards;
     private readonly SemaphoreSlim _pendingRequestSlots;
     private readonly CancellationTokenSource _pendingRequestSlotCts = new();
-    private readonly TaskCompletionSource _pendingRequestSlotOperationsDrained =
+    private readonly TaskCompletionSource<bool> _pendingRequestSlotOperationsDrained =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int _pendingRequestSlotOperationCount;
     private int _pendingRequestSlotsClosed;
@@ -191,7 +191,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
     private OAuthBearerTokenProvider? _ownedTokenProvider;
     private int _disposed;
     private int _connected;
-    private long _lastUsedTimestampMs = Environment.TickCount64;
+    private long _lastUsedTimestampMs = CompatibilityBcl.TickCount64;
     private readonly SemaphoreSlim _connectLock = new(1, 1);
 
     // SASL re-authentication (KIP-368)
@@ -548,8 +548,8 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         Touch();
         var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
-        var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
-        var responseHeaderVersion = TRequest.GetResponseHeaderVersion(apiVersion);
+        var headerVersion = KafkaRequestMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
+        var responseHeaderVersion = KafkaRequestMetadata<TRequest, TResponse>.GetResponseHeaderVersion(apiVersion);
 
         await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
         var pending = _pendingRequestPool.Rent();
@@ -572,7 +572,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             var telemetryStartTimestamp = _telemetryMetricCollector is null ? 0 : Stopwatch.GetTimestamp();
 
             // Write phase
-            LogSendingRequest(TRequest.ApiKey, correlationId, apiVersion, _host, _port);
+            LogSendingRequest(KafkaRequestMetadata<TRequest, TResponse>.ApiKey, correlationId, apiVersion, _host, _port);
 
             await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken)
                 .ConfigureAwait(false);
@@ -643,11 +643,11 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         Touch();
         var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
-        var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
+        var headerVersion = KafkaRequestMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
 
         // Don't register a pending request - we won't receive a response
 
-        LogSendingFireAndForgetRequest(TRequest.ApiKey, correlationId, apiVersion, _host, _port);
+        LogSendingFireAndForgetRequest(KafkaRequestMetadata<TRequest, TResponse>.ApiKey, correlationId, apiVersion, _host, _port);
 
         await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken, callerOwnsTimeout)
             .ConfigureAwait(false);
@@ -699,8 +699,8 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         Touch();
         var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
-        var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
-        var responseHeaderVersion = TRequest.GetResponseHeaderVersion(apiVersion);
+        var headerVersion = KafkaRequestMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
+        var responseHeaderVersion = KafkaRequestMetadata<TRequest, TResponse>.GetResponseHeaderVersion(apiVersion);
 
         await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
         var pending = _pendingRequestPool.Rent();
@@ -772,7 +772,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    throw CreateResponseTimeoutException(TRequest.ApiKey, correlationId);
+                    throw CreateResponseTimeoutException(KafkaRequestMetadata<TRequest, TResponse>.ApiKey, correlationId);
                 }
                 finally
                 {
@@ -798,7 +798,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 }
                 catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
-                    throw CreateResponseTimeoutException(TRequest.ApiKey, correlationId);
+                    throw CreateResponseTimeoutException(KafkaRequestMetadata<TRequest, TResponse>.ApiKey, correlationId);
                 }
                 finally
                 {
@@ -810,7 +810,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
             LogResponseReceived(correlationId);
 
-            var isFetchResponse = TRequest.ApiKey == ApiKey.Fetch;
+            var isFetchResponse = KafkaRequestMetadata<TRequest, TResponse>.ApiKey == ApiKey.Fetch;
 
             if (isFetchResponse)
             {
@@ -818,7 +818,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 using var parsingScope = ResponseParsingContext.SetPooledMemory(memoryOwner);
 
                 var reader = new KafkaProtocolReader(pooledBuffer.Data);
-                var response = (TResponse)TResponse.Read(ref reader, apiVersion);
+                var response = (TResponse)KafkaResponseMetadata<TResponse>.Read(ref reader, apiVersion);
 
                 if (ResponseParsingContext.WasMemoryUsed)
                 {
@@ -844,7 +844,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 try
                 {
                     var reader = new KafkaProtocolReader(pooledBuffer.Data);
-                    return (TResponse)TResponse.Read(ref reader, apiVersion);
+                    return (TResponse)KafkaResponseMetadata<TResponse>.Read(ref reader, apiVersion);
                 }
                 finally
                 {
@@ -900,7 +900,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         var bodyWriter = new KafkaProtocolWriter(writer);
         var header = new RequestHeader
         {
-            ApiKey = TRequest.ApiKey,
+            ApiKey = KafkaRequestMetadata<TRequest, TResponse>.ApiKey,
             ApiVersion = apiVersion,
             CorrelationId = correlationId,
             ClientId = _clientId,
@@ -935,7 +935,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         where TResponse : IKafkaResponse
     {
         var (serializedArray, serializedLength) = PreSerializeRequest<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion);
-        var clearSerializedArray = TRequest.ApiKey == ApiKey.SaslAuthenticate;
+        var clearSerializedArray = KafkaRequestMetadata<TRequest, TResponse>.ApiKey == ApiKey.SaslAuthenticate;
         byte[]? arrayToReturn = serializedArray;
         try
         {
@@ -1223,7 +1223,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             if (_pendingRequestSlots.Wait(0, cancellationToken))
             {
                 if (Volatile.Read(ref _disposed) == 0)
-                    return ValueTask.CompletedTask;
+                    return default;
 
                 _pendingRequestSlots.Release();
                 throw new ObjectDisposedException(nameof(KafkaConnection));
@@ -1354,7 +1354,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         if (count == 0 && Volatile.Read(ref _pendingRequestSlotsClosed) != 0)
         {
-            _pendingRequestSlotOperationsDrained.TrySetResult();
+            _pendingRequestSlotOperationsDrained.TrySetResult(true);
         }
     }
 
@@ -1415,7 +1415,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         return count;
     }
 
-    private void Touch() => Volatile.Write(ref _lastUsedTimestampMs, Environment.TickCount64);
+    private void Touch() => Volatile.Write(ref _lastUsedTimestampMs, CompatibilityBcl.TickCount64);
 
     private bool TryReadResponse(
         ref ReadOnlySequence<byte> buffer,
@@ -1473,7 +1473,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         correlationId = 0;
         responseData = default;
 
-        var span = buffer.FirstSpan;
+        var span = buffer.First.Span;
 
         // Read size prefix directly from span
         var size = BinaryPrimitives.ReadInt32BigEndian(span);
@@ -1650,6 +1650,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         TrySetSocketOption(socket, SocketOptionLevel.Socket, SocketOptionName.KeepAlive, 1);
 
+#if !NETSTANDARD2_0
         var keepAliveTimeSeconds = ToPositiveSeconds(_options.TcpKeepAliveTime);
         if (keepAliveTimeSeconds > 0)
             TrySetSocketOption(socket, SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, keepAliveTimeSeconds);
@@ -1660,6 +1661,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         if (_options.TcpKeepAliveRetryCount > 0)
             TrySetSocketOption(socket, SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, _options.TcpKeepAliveRetryCount);
+#endif
     }
 
     private static int ToPositiveSeconds(TimeSpan value)
@@ -1734,13 +1736,21 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         if (extension is ".pfx" or ".p12")
         {
+#if NETSTANDARD2_0
+            collection.Add(new X509Certificate2(path));
+#else
             // Load PFX/PKCS12 file using modern API
             collection.Add(X509CertificateLoader.LoadPkcs12FromFile(path, password: null));
+#endif
         }
         else
         {
+#if NETSTANDARD2_0
+            throw new PlatformNotSupportedException("PEM certificate loading is not supported on the netstandard2.0 compatibility target.");
+#else
             // Assume PEM format - can contain multiple certificates
             collection.ImportFromPemFile(path);
+#endif
         }
 
         return collection;
@@ -1768,13 +1778,22 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             X509Certificate2 cert;
             if (extension is ".pfx" or ".p12")
             {
+#if NETSTANDARD2_0
+                cert = new X509Certificate2(
+                    certPath,
+                    string.IsNullOrEmpty(tlsConfig.ClientKeyPassword) ? null : tlsConfig.ClientKeyPassword);
+#else
                 // Load PFX/PKCS12 file (contains both certificate and private key) using modern API
                 cert = X509CertificateLoader.LoadPkcs12FromFile(
                     certPath,
                     string.IsNullOrEmpty(tlsConfig.ClientKeyPassword) ? null : tlsConfig.ClientKeyPassword);
+#endif
             }
             else
             {
+#if NETSTANDARD2_0
+                throw new PlatformNotSupportedException("PEM client certificate loading is not supported on the netstandard2.0 compatibility target.");
+#else
                 // PEM format - need separate key file
                 if (tlsConfig.ClientKeyPath is null)
                 {
@@ -1785,6 +1804,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 cert = string.IsNullOrEmpty(tlsConfig.ClientKeyPassword)
                     ? X509Certificate2.CreateFromPemFile(certPath, tlsConfig.ClientKeyPath)
                     : X509Certificate2.CreateFromEncryptedPemFile(certPath, tlsConfig.ClientKeyPassword, tlsConfig.ClientKeyPath);
+#endif
             }
 
             _loadedClientCertificate = cert;
@@ -1810,6 +1830,9 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         // If the only error is an untrusted root, validate against our custom CA
         if (sslPolicyErrors == SslPolicyErrors.RemoteCertificateChainErrors && chain is not null)
         {
+#if NETSTANDARD2_0
+            return false;
+#else
             // Track if we created a new certificate to dispose it later
             X509Certificate2? ownedCert = null;
             try
@@ -1852,6 +1875,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             {
                 ownedCert?.Dispose();
             }
+#endif
         }
 
         return false;
@@ -2225,7 +2249,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             throw new InvalidOperationException("Not connected");
 
         var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
-        var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
+        var headerVersion = KafkaRequestMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
 
         // Write to stream directly (no pipe yet). Use the pooled serializer path instead
         // of the thread-local SASL buffer so credential-bearing requests can be cleared.
@@ -2234,7 +2258,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             correlationId,
             apiVersion,
             headerVersion);
-        var clearSerializedArray = TRequest.ApiKey == ApiKey.SaslAuthenticate;
+        var clearSerializedArray = KafkaRequestMetadata<TRequest, TResponse>.ApiKey == ApiKey.SaslAuthenticate;
         try
         {
             await _stream.WriteAsync(buffer.AsMemory(0, totalSize), cancellationToken).ConfigureAwait(false);
@@ -2266,7 +2290,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 }
 
                 // Skip response header and parse body
-                var responseHeaderVersion = TRequest.GetResponseHeaderVersion(apiVersion);
+                var responseHeaderVersion = KafkaRequestMetadata<TRequest, TResponse>.GetResponseHeaderVersion(apiVersion);
                 var offset = 4; // Correlation ID
 
                 if (responseHeaderVersion >= 1)
@@ -2304,7 +2328,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 }
 
                 var reader = new KafkaProtocolReader(responseBuffer.AsMemory(offset, responseSize - offset));
-                return (TResponse)TResponse.Read(ref reader, apiVersion);
+                return (TResponse)KafkaResponseMetadata<TResponse>.Read(ref reader, apiVersion);
             }
             finally
             {
@@ -2627,7 +2651,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             var destination = context.Buffer.AsSpan(context.Offset, available);
 
             if (buffer.IsSingleSegment)
-                buffer.FirstSpan.Slice(0, available).CopyTo(destination);
+                buffer.First.Span.Slice(0, available).CopyTo(destination);
             else
                 buffer.Slice(0, available).CopyTo(destination);
 
@@ -2821,7 +2845,7 @@ public sealed class ConnectionOptions
                 paramName,
                 "Connections max idle must be non-negative, or Timeout.InfiniteTimeSpan to disable.");
 
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(value.TotalMilliseconds, int.MaxValue, paramName);
+        CompatibilityThrowHelpers.ThrowIfGreaterThan(value.TotalMilliseconds, int.MaxValue, paramName);
         return (int)value.TotalMilliseconds;
     }
 

--- a/src/Dekaf/Networking/PipeMemoryPool.cs
+++ b/src/Dekaf/Networking/PipeMemoryPool.cs
@@ -81,7 +81,7 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
 
     public override IMemoryOwner<byte> Rent(int minBufferSize = -1)
     {
-        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        CompatibilityThrowHelpers.ThrowIfObjectDisposed(Volatile.Read(ref _disposed) != 0, this);
 
         if (minBufferSize < 0)
             minBufferSize = 4096;
@@ -172,7 +172,7 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
             get
             {
                 var array = _array;
-                ObjectDisposedException.ThrowIf(array is null, this);
+                CompatibilityThrowHelpers.ThrowIfObjectDisposed(array is null, this);
                 return array;
             }
         }

--- a/src/Dekaf/Networking/RentedBufferWriter.cs
+++ b/src/Dekaf/Networking/RentedBufferWriter.cs
@@ -90,8 +90,8 @@ internal sealed class RentedBufferWriter : IBufferWriter<byte>, IDisposable
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void Grow(int sizeHint)
     {
-        var doubled = Math.Min((long)_buffer.Length * 2, Array.MaxLength);
-        var required = Math.Min((long)_written + sizeHint, Array.MaxLength);
+        var doubled = Math.Min((long)_buffer.Length * 2, CompatibilityBcl.ArrayMaxLength);
+        var required = Math.Min((long)_written + sizeHint, CompatibilityBcl.ArrayMaxLength);
         var newSize = (int)Math.Max(doubled, required);
 
         if (newSize <= _buffer.Length)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1255,7 +1255,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 LogDeliveryTimeoutExceeded(_brokerId, batch.TopicPartition.Topic, batch.TopicPartition.Partition);
                 UnmutePartition(batch.TopicPartition);
-                var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks);
+                var elapsed = CompatibilityBcl.GetElapsedTime(batch.StopwatchCreatedTicks);
                 var configured = TimeSpan.FromMilliseconds(_options.DeliveryTimeoutMs);
                 FailAndCleanupBatch(batch, new KafkaTimeoutException(
                     TimeoutKind.Delivery,
@@ -1700,7 +1700,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     if (now >= batch.StopwatchCreatedTicks + deliveryTimeoutTicks)
                     {
                         UnmutePartition(batch.TopicPartition);
-                        var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks);
+                        var elapsed = CompatibilityBcl.GetElapsedTime(batch.StopwatchCreatedTicks);
                         var configured = TimeSpan.FromMilliseconds(_options.DeliveryTimeoutMs);
                         try
                         {
@@ -1815,7 +1815,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         {
             LogDeliveryTimeoutExceeded(_brokerId, batch.TopicPartition.Topic, batch.TopicPartition.Partition);
             UnmutePartition(batch.TopicPartition);
-            var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks);
+            var elapsed = CompatibilityBcl.GetElapsedTime(batch.StopwatchCreatedTicks);
             var configured = TimeSpan.FromMilliseconds(_options.DeliveryTimeoutMs);
             var ex = new KafkaTimeoutException(
                 TimeoutKind.Delivery,
@@ -2219,7 +2219,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     if (Stopwatch.GetTimestamp() >= deliveryDeadlineTicks)
                     {
                         UnmutePartition(batch.TopicPartition);
-                        var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks);
+                        var elapsed = CompatibilityBcl.GetElapsedTime(batch.StopwatchCreatedTicks);
                         var configured = TimeSpan.FromMilliseconds(_options.DeliveryTimeoutMs);
                         FailAndCleanupBatch(batch, new KafkaTimeoutException(
                             TimeoutKind.Delivery,
@@ -2330,8 +2330,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // batches are rare; the common case (single topic or already sorted) skips the sort.
             if (!alreadySorted)
             {
+#if NETSTANDARD2_0
+                Array.Sort(batches, 0, count, Comparer<ReadyBatch>.Create(static (a, b) =>
+                    string.Compare(a.TopicPartition.Topic, b.TopicPartition.Topic, StringComparison.Ordinal)));
+#else
                 batchesSpan.Sort(static (a, b) =>
                     string.Compare(a.TopicPartition.Topic, b.TopicPartition.Topic, StringComparison.Ordinal));
+#endif
 
                 // Discard the partial topicCount from the pre-scan and recount from scratch.
                 // Post-sort, topics are contiguous so simple != equality suffices (no need for
@@ -2687,7 +2692,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                 LogDeliveryTimeoutExceeded(_brokerId, batch.TopicPartition.Topic,
                     batch.TopicPartition.Partition);
-                var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks);
+                var elapsed = CompatibilityBcl.GetElapsedTime(batch.StopwatchCreatedTicks);
                 var configured = TimeSpan.FromMilliseconds(_options.DeliveryTimeoutMs);
                 FailAndCleanupBatch(batch, new KafkaTimeoutException(
                     TimeoutKind.Delivery,
@@ -2775,7 +2780,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // After the send loop exits, these won't be polled by MaybeScaleConnections.
         if (_pendingShrinkTask is not null)
         {
-            if (_pendingShrinkTask.IsCompletedSuccessfully)
+            if (CompatibilityBcl.IsCompletedSuccessfully(_pendingShrinkTask))
             {
                 var removedConn = _pendingShrinkTask.Result;
                 if (removedConn is not null)
@@ -2869,7 +2874,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var task = _pendingScaleTask;
             _pendingScaleTask = null;
 
-            if (task.IsCompletedSuccessfully)
+            if (CompatibilityBcl.IsCompletedSuccessfully(task))
             {
                 var actualCount = task.Result;
                 if (actualCount > _connectionCount)
@@ -2894,7 +2899,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var task = _pendingShrinkTask;
             _pendingShrinkTask = null;
 
-            if (task.IsCompletedSuccessfully)
+            if (CompatibilityBcl.IsCompletedSuccessfully(task))
             {
                 var removedConnection = task.Result;
                 if (removedConnection is not null)
@@ -2910,7 +2915,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return 0;
         }
 
-        var now = Environment.TickCount64;
+        var now = CompatibilityBcl.TickCount64;
 
         // Cooldown applies to both scale-up and scale-down
         if (now - _lastScaleTimeTicks < ScaleCooldownMs)

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -15,6 +15,11 @@ using Dekaf.Retry;
 using Dekaf.Serialization;
 using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
+#if NETSTANDARD2_0
+using Lock = System.Object;
+#else
+using Lock = System.Threading.Lock;
+#endif
 
 namespace Dekaf.Producer;
 
@@ -89,8 +94,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     // the fail-fast produce guard for context. ErrorCode is short-backed, so volatile is valid.
     internal volatile ErrorCode _lastTransactionError = ErrorCode.None;
     private readonly SemaphoreSlim _transactionLock = new(1, 1);
-    private readonly System.Threading.Lock _epochBumpLock = new();
-    internal readonly System.Threading.Lock _partitionsInTransactionLock = new();
+    private readonly Lock _epochBumpLock = new();
+    internal readonly Lock _partitionsInTransactionLock = new();
     internal readonly HashSet<TopicPartition> _partitionsInTransaction = [];
     internal volatile bool _currentTransactionUsesTV2;
 
@@ -672,7 +677,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         Diagnostics.DekafMetrics.MessagesSent.Add(1, tagList);
         Diagnostics.DekafMetrics.BytesSent.Add(metadata.KeySize + metadata.ValueSize, tagList);
         Diagnostics.DekafMetrics.OperationDuration.Record(
-            Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds, tagList);
+            CompatibilityBcl.GetElapsedTime(startTimestamp).TotalSeconds, tagList);
     }
 
     private TagList GetMetricTags(string topic)
@@ -936,7 +941,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // Check if cache is for this metadata manager, topic, and still valid
         // Use signed comparison to handle TickCount64 wraparound (every ~292 million years)
         var cache = GetOrCreateCache();
-        var currentTicks = Environment.TickCount64;
+        var currentTicks = CompatibilityBcl.TickCount64;
         if (cache.CachedMetadataManager == _metadataManager &&
             cache.CachedTopicName == topic &&
             cache.CachedTopicInfo is not null &&
@@ -963,7 +968,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         cache.CachedTopicInfo = topicInfo;
         // Cache valid for ~1 second (1000 ticks) - enough for high-throughput bursts
         // while still detecting stale metadata reasonably quickly
-        cache.CachedTopicValidUntilTicks = Environment.TickCount64 + 1000;
+        cache.CachedTopicValidUntilTicks = CompatibilityBcl.TickCount64 + 1000;
     }
 
     /// <summary>
@@ -1227,7 +1232,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         ThrowIfNotInitialized();
 
-        ArgumentNullException.ThrowIfNull(deliveryHandler);
+        CompatibilityThrowHelpers.ThrowIfNull(deliveryHandler);
 
         // Apply OnSend interceptors before serialization
         message = ApplyOnSendInterceptors(message);
@@ -1370,7 +1375,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         IEnumerable<ProducerMessage<TKey, TValue>> messages,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(messages);
+        CompatibilityThrowHelpers.ThrowIfNull(messages);
 
         // Convert to list to get count and allow multiple enumeration
         var messageList = messages as IList<ProducerMessage<TKey, TValue>> ?? messages.ToList();
@@ -1395,8 +1400,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         IEnumerable<(TKey? Key, TValue Value)> messages,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(topic);
-        ArgumentNullException.ThrowIfNull(messages);
+        CompatibilityThrowHelpers.ThrowIfNull(topic);
+        CompatibilityThrowHelpers.ThrowIfNull(messages);
 
         // Convert to list to get count and allow multiple enumeration
         var messageList = messages as IList<(TKey? Key, TValue Value)> ?? messages.ToList();
@@ -1440,7 +1445,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         ThrowIfNotInitialized();
 
         if ((options & PurgeOptions.All) == PurgeOptions.None)
-            return ValueTask.CompletedTask;
+            return default;
 
         ThrowIfPurgeCannotRun();
 
@@ -1449,7 +1454,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             "Produce operation was purged before delivery completed.");
 
         _accumulator.Purge(options, exception, CompleteInflightEntry);
-        return ValueTask.CompletedTask;
+        return default;
     }
 
     private void ThrowIfPurgeCannotRun()
@@ -2131,7 +2136,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// <inheritdoc />
     public ITopicProducer<TKey, TValue> ForTopic(string topic)
     {
-        ArgumentNullException.ThrowIfNull(topic);
+        CompatibilityThrowHelpers.ThrowIfNull(topic);
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>));
 
@@ -2514,7 +2519,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
                 var configured = TimeSpan.FromMilliseconds(_options.MaxBlockMs);
-                var elapsed = Stopwatch.GetElapsedTime(startedAt);
+                var elapsed = CompatibilityBcl.GetElapsedTime(startedAt);
                 throw new KafkaTimeoutException(
                     TimeoutKind.Metadata,
                     elapsed,
@@ -3104,10 +3109,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     {
         var cache = GetOrCreateCache();
 
-        // Use Environment.TickCount64 (cheap counter) to determine if we need to refresh.
+        // Use CompatibilityBcl.TickCount64 (cheap counter) to determine if we need to refresh.
         // TickCount64 increments every ~15.6ms on Windows, ~1ms on Linux, but checking
         // the difference is still much cheaper than calling DateTimeOffset.UtcNow.
-        var currentTicks = Environment.TickCount64;
+        var currentTicks = CompatibilityBcl.TickCount64;
 
         // Refresh if more than ~1ms has passed (or on first call when CachedTimestampTicks is 0)
         if (currentTicks - cache.CachedTimestampTicks > 1 || cache.CachedTimestampTicks == 0)
@@ -3206,7 +3211,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         {
             // Graceful shutdown timed out - fall back to forceful shutdown
             gracefulShutdown = false;
-            var gracefulElapsed = Stopwatch.GetElapsedTime(disposeStart);
+            var gracefulElapsed = CompatibilityBcl.GetElapsedTime(disposeStart);
             var gracefulElapsedMs = gracefulElapsed.TotalMilliseconds;
             LogGracefulShutdownTimedOut(gracefulMs, gracefulElapsedMs);
         }
@@ -3377,7 +3382,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 "network");
         }
 
-        var disposeElapsedMs = Stopwatch.GetElapsedTime(disposeStart).TotalMilliseconds;
+        var disposeElapsedMs = CompatibilityBcl.GetElapsedTime(disposeStart).TotalMilliseconds;
         LogProducerDisposed(disposeElapsedMs, gracefulShutdown);
     }
 
@@ -3685,7 +3690,11 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
 /// Used with thread-local buffers to avoid per-message ArrayPool rentals.
 /// After serialization, ToPooledMemory() copies data to a right-sized pooled buffer.
 /// </summary>
+#if NETSTANDARD2_0
+internal struct ReusableBufferWriter : IBufferWriter<byte>
+#else
 internal ref struct ReusableBufferWriter : IBufferWriter<byte>
+#endif
 {
     private byte[] _buffer;
     private int _written;
@@ -3808,7 +3817,11 @@ internal ref struct ReusableBufferWriter : IBufferWriter<byte>
 /// to the pool or use-after-disposal.
 /// </para>
 /// </remarks>
+#if NETSTANDARD2_0
+internal struct PooledBufferWriter : IBufferWriter<byte>
+#else
 internal ref struct PooledBufferWriter : IBufferWriter<byte>
+#endif
 {
     private byte[]? _buffer;
     private int _written;
@@ -3832,7 +3845,7 @@ internal ref struct PooledBufferWriter : IBufferWriter<byte>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Advance(int count)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        CompatibilityThrowHelpers.ThrowIfNegative(count);
 
         if (_buffer is null)
             throw new ObjectDisposedException(nameof(PooledBufferWriter));
@@ -3918,7 +3931,7 @@ internal ref struct PooledBufferWriter : IBufferWriter<byte>
     private void Grow(int sizeHint)
     {
         // Calculate new size: at least double, but ensure it fits the requested size
-        // Use checked arithmetic to detect overflow and cap at Array.MaxLength
+        // Use checked arithmetic to detect overflow and cap at CompatibilityBcl.ArrayMaxLength
         var currentLength = _buffer!.Length;
         int newSize;
         try
@@ -3930,12 +3943,12 @@ internal ref struct PooledBufferWriter : IBufferWriter<byte>
         catch (OverflowException)
         {
             // On overflow, use the maximum array size
-            newSize = Array.MaxLength;
+            newSize = CompatibilityBcl.ArrayMaxLength;
         }
 
         // Ensure we don't exceed the maximum array size
-        if (newSize > Array.MaxLength)
-            newSize = Array.MaxLength;
+        if (newSize > CompatibilityBcl.ArrayMaxLength)
+            newSize = CompatibilityBcl.ArrayMaxLength;
 
         // If we can't grow anymore and current capacity isn't enough, throw
         if (newSize <= currentLength)

--- a/src/Dekaf/Producer/ObjectPool.cs
+++ b/src/Dekaf/Producer/ObjectPool.cs
@@ -37,7 +37,7 @@ internal abstract class ObjectPool<T> where T : class
 
     protected ObjectPool(int maxPoolSize)
     {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPoolSize);
+        CompatibilityThrowHelpers.ThrowIfNegativeOrZero(maxPoolSize);
         MaxPoolSize = maxPoolSize;
         _stack = new LockFreeStack<T>(maxPoolSize);
     }

--- a/src/Dekaf/Producer/PartitionInflightTracker.cs
+++ b/src/Dekaf/Producer/PartitionInflightTracker.cs
@@ -40,7 +40,7 @@ internal sealed class InflightEntry
         return true;
     }
 
-    private TaskCompletionSource? _completionSignal;
+    private TaskCompletionSource<bool>? _completionSignal;
 
     /// <summary>
     /// Initializes the entry for use. Called after renting from pool.
@@ -56,9 +56,9 @@ internal sealed class InflightEntry
     /// Gets or lazily creates the completion signal TCS.
     /// Only called on OutOfOrderSequenceNumber (failure path), so zero allocation in happy path.
     /// </summary>
-    internal TaskCompletionSource GetOrCreateCompletionSignal()
+    internal TaskCompletionSource<bool> GetOrCreateCompletionSignal()
     {
-        return _completionSignal ??= new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        return _completionSignal ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
     /// <summary>
@@ -67,7 +67,7 @@ internal sealed class InflightEntry
     /// </summary>
     internal void SignalComplete()
     {
-        _completionSignal?.TrySetResult();
+        _completionSignal?.TrySetResult(true);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -49,7 +49,7 @@ public sealed class DefaultPartitioner : IPartitioner
 public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwarePartitioner
 {
     private readonly ConcurrentDictionary<string, int> _stickyPartitions = new();
-    private uint _counter;
+    private int _counter;
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
@@ -64,7 +64,7 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
             // Cold path: topic not yet seen, compute and add a partition.
             // Use uint to avoid overflow to negative values.
             // GetOrAdd handles the race condition - if another thread added first, we use their value.
-            var newPartition = (int)(Interlocked.Increment(ref _counter) % (uint)partitionCount);
+            var newPartition = (int)((uint)Interlocked.Increment(ref _counter) % (uint)partitionCount);
             return _stickyPartitions.GetOrAdd(topic, newPartition);
         }
 
@@ -80,8 +80,8 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
         // Use uint to avoid overflow to negative values.
         _stickyPartitions.AddOrUpdate(
             topic,
-            _ => (int)(Interlocked.Increment(ref _counter) % (uint)partitionCount),
-            (_, _) => (int)(Interlocked.Increment(ref _counter) % (uint)partitionCount));
+            _ => (int)((uint)Interlocked.Increment(ref _counter) % (uint)partitionCount),
+            (_, _) => (int)((uint)Interlocked.Increment(ref _counter) % (uint)partitionCount));
     }
 }
 

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -132,7 +132,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _pool = pool;
 
         // Arm timeout timer. Compute remaining ms from deadline.
-        var remainingMs = deadlineTickCount - Environment.TickCount64;
+        var remainingMs = deadlineTickCount - CompatibilityBcl.TickCount64;
         if (remainingMs > 0)
         {
             _timer.Change(remainingMs, Timeout.Infinite);
@@ -212,7 +212,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
 
     /// <summary>
     /// Manually returns this instance to the pool when TryFail succeeded but the caller
-    /// bypasses the normal GetResult path (e.g., returning ValueTask.FromException directly).
+    /// bypasses the normal GetResult path (e.g., returning CompatibilityBcl.FromException directly).
     /// Must only be called after TryFail returned true.
     /// </summary>
     internal void ReturnToPoolAfterTryFail() => ResetAndReturnToPool();
@@ -220,7 +220,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     private void OnTimeout()
     {
         var configured = TimeSpan.FromMilliseconds(_accumulator.MaxBlockMsOption);
-        var elapsed = TimeSpan.FromMilliseconds(Environment.TickCount64 - _startTicks);
+        var elapsed = TimeSpan.FromMilliseconds(CompatibilityBcl.TickCount64 - _startTicks);
 
         var exception = new KafkaTimeoutException(
             TimeoutKind.MaxBlock,

--- a/src/Dekaf/Producer/PendingAppendPool.cs
+++ b/src/Dekaf/Producer/PendingAppendPool.cs
@@ -23,7 +23,7 @@ internal sealed class PendingAppendPool
     /// <param name="maxPoolSize">Maximum number of instances to keep in the pool.</param>
     public PendingAppendPool(int maxPoolSize)
     {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPoolSize);
+        CompatibilityThrowHelpers.ThrowIfNegativeOrZero(maxPoolSize);
         _stack = new LockFreeStack<PendingAppend>(maxPoolSize);
     }
 

--- a/src/Dekaf/Producer/ProducerExtensions.cs
+++ b/src/Dekaf/Producer/ProducerExtensions.cs
@@ -27,8 +27,8 @@ public static class ProducerExtensions
         Headers headers,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(producer);
-        ArgumentNullException.ThrowIfNull(topic);
+        CompatibilityThrowHelpers.ThrowIfNull(producer);
+        CompatibilityThrowHelpers.ThrowIfNull(topic);
 
         if (producer is IProducerFastPath<TKey, TValue> fastPath)
             return fastPath.ProduceAsync(topic, key, value, headers, partition: null, timestamp: null, cancellationToken);
@@ -62,8 +62,8 @@ public static class ProducerExtensions
         TValue value,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(producer);
-        ArgumentNullException.ThrowIfNull(topic);
+        CompatibilityThrowHelpers.ThrowIfNull(producer);
+        CompatibilityThrowHelpers.ThrowIfNull(topic);
 
         if (producer is IProducerFastPath<TKey, TValue> fastPath)
             return fastPath.ProduceAsync(topic, key, value, headers: null, partition: partition, timestamp: null, cancellationToken);
@@ -94,8 +94,8 @@ public static class ProducerExtensions
         TValue value,
         Headers headers)
     {
-        ArgumentNullException.ThrowIfNull(producer);
-        ArgumentNullException.ThrowIfNull(topic);
+        CompatibilityThrowHelpers.ThrowIfNull(producer);
+        CompatibilityThrowHelpers.ThrowIfNull(topic);
 
         return producer.FireAsync(new ProducerMessage<TKey, TValue>
         {

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -451,7 +451,7 @@ public sealed class ProducerOptions
         get => _maxConnectionsPerBroker;
         init
         {
-            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            CompatibilityThrowHelpers.ThrowIfLessThan(value, 1);
             _maxConnectionsPerBroker = value;
         }
     }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -23,9 +23,22 @@ namespace Dekaf.Producer;
 /// </summary>
 internal ref struct SpinLockGuard
 {
+#if NETSTANDARD2_0
+    private readonly object _lock;
+#else
     private ref SpinLock _lock;
+#endif
     private bool _taken;
 
+#if NETSTANDARD2_0
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public SpinLockGuard(ref object gate)
+    {
+        _lock = gate;
+        _taken = false;
+        Monitor.Enter(_lock, ref _taken);
+    }
+#else
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public SpinLockGuard(ref SpinLock spinLock)
     {
@@ -33,11 +46,16 @@ internal ref struct SpinLockGuard
         _taken = false;
         _lock.Enter(ref _taken);
     }
+#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Dispose()
     {
+#if NETSTANDARD2_0
+        if (_taken) Monitor.Exit(_lock);
+#else
         if (_taken) _lock.Exit();
+#endif
     }
 }
 
@@ -546,7 +564,7 @@ internal sealed class BatchArena
 
     internal BatchArena(int capacity, int maxPooledCapacity)
     {
-        _buffer = GC.AllocateUninitializedArray<byte>(capacity, pinned: true);
+        _buffer = CompatibilityBcl.AllocateUninitializedArray<byte>(capacity, pinned: true);
         _position = 0;
         _maxPooledCapacity = maxPooledCapacity;
     }
@@ -614,7 +632,7 @@ internal sealed class BatchArena
 
         // Buffer too small (or null) - allocate a new permanent buffer.
         // The old buffer (if any) will be collected by GC.
-        _buffer = GC.AllocateUninitializedArray<byte>(capacity, pinned: true);
+        _buffer = CompatibilityBcl.AllocateUninitializedArray<byte>(capacity, pinned: true);
         _position = 0;
     }
 
@@ -971,7 +989,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // re-enter the wait loop — O(1) wake latency instead of O(N).
     // The TCS allocation per signal is acceptable: it only fires on the backpressure slow
     // path (buffer full), not per-message, and is guarded by a waiter count.
-    private volatile TaskCompletionSource _bufferSpaceSignal = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private volatile TaskCompletionSource<bool> _bufferSpaceSignal = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int _bufferSpaceWaiters; // Number of threads waiting on _bufferSpaceSignal
 
     // Pooled slow path: replaces async state machine allocation with a pooled IValueTaskSource<bool>.
@@ -996,7 +1014,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         /// <summary>Per-partition lock for deque access (matches Java's synchronized(deque)).
         /// SpinLock avoids kernel transitions for the brief critical sections in append/drain paths.</summary>
+#if NETSTANDARD2_0
+        public object Lock = new();
+#else
         public SpinLock Lock = new(enableThreadOwnerTracking: false);
+#endif
 
         /// <summary>Current unsealed batch accepting new records. Null if no active batch.</summary>
         public PartitionBatch? CurrentBatch;
@@ -1611,8 +1633,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         var prev = Interlocked.Exchange(
             ref _bufferSpaceSignal,
-            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
-        prev.TrySetResult();
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously));
+        prev.TrySetResult(true);
     }
 
     internal ValueTask<bool> WaitForWakeupAsync(int timeoutMs)
@@ -1674,7 +1696,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         // Create per-partition-affine append worker channels.
         // Each channel is SingleReader (one worker) but allows multiple writers (caller threads).
-        _appendWorkerCount = Math.Clamp(Environment.ProcessorCount, 1, 8);
+        _appendWorkerCount = CompatibilityBcl.Clamp(Environment.ProcessorCount, 1, 8);
         _appendWorkerChannels = new Channel<AppendWorkItem>[_appendWorkerCount];
         for (var i = 0; i < _appendWorkerCount; i++)
         {
@@ -1697,7 +1719,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // allocations during ramp-up but avoids excessive steady-state POH retention.
         // With default 256MB/1MB = 256 batches, pool = max(64, 128) = 128 (DefaultPoolSize floor), ~140MB of arenas.
         var batchCapacity = (int)Math.Min(options.BufferMemory / (ulong)Math.Max(options.BatchSize, 1), int.MaxValue);
-        return Math.Clamp(batchCapacity / 4, BatchArena.DefaultPoolSize, BatchArena.MaxPoolSizeCap);
+        return CompatibilityBcl.Clamp(batchCapacity / 4, BatchArena.DefaultPoolSize, BatchArena.MaxPoolSizeCap);
     }
 
     /// <summary>
@@ -2280,7 +2302,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             key.Return();
             value.Return();
             ReturnPooledHeaders(headers);
-            return ValueTask.FromException<bool>(new ObjectDisposedException(nameof(RecordAccumulator)));
+            return CompatibilityBcl.FromException<bool>(new ObjectDisposedException(nameof(RecordAccumulator)));
         }
 
         if (cancellationToken.IsCancellationRequested)
@@ -2288,7 +2310,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             key.Return();
             value.Return();
             ReturnPooledHeaders(headers);
-            return ValueTask.FromException<bool>(new OperationCanceledException(cancellationToken));
+            return CompatibilityBcl.FromException<bool>(new OperationCanceledException(cancellationToken));
         }
 
         var (startTicks, deadline) = BeginReservationWait(recordSize);
@@ -2310,7 +2332,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 // Caller gets a pre-built exception ValueTask, so nobody will call GetResult
                 // on this op. Manually return it to the pool to avoid leaking.
                 op.ReturnToPoolAfterTryFail();
-                return ValueTask.FromException<bool>(disposedException);
+                return CompatibilityBcl.FromException<bool>(disposedException);
             }
         }
 
@@ -2965,7 +2987,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var currentBufferedBytes = Volatile.Read(ref _bufferedBytes);
         var currentMaxBufferMemory = (ulong)Volatile.Read(ref _maxBufferMemory);
         LogBufferMemoryWaiting(recordSize, currentBufferedBytes, currentMaxBufferMemory);
-        var currentTicks = Environment.TickCount64;
+        var currentTicks = CompatibilityBcl.TickCount64;
         var deadline = (long.MaxValue - currentTicks > _options.MaxBlockMs)
             ? currentTicks + _options.MaxBlockMs
             : long.MaxValue;
@@ -2995,7 +3017,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var remainingMs = deadline - Environment.TickCount64;
+            var remainingMs = deadline - CompatibilityBcl.TickCount64;
             if (remainingMs <= 0)
                 ThrowBufferMemoryTimeout(recordSize, startTicks);
 
@@ -3074,7 +3096,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private void ThrowBufferMemoryTimeout(int recordSize, long startTicks)
     {
         var configured = TimeSpan.FromMilliseconds(_options.MaxBlockMs);
-        var elapsed = TimeSpan.FromMilliseconds(Environment.TickCount64 - startTicks);
+        var elapsed = TimeSpan.FromMilliseconds(CompatibilityBcl.TickCount64 - startTicks);
         throw new KafkaTimeoutException(
             TimeoutKind.MaxBlock,
             elapsed,
@@ -3195,7 +3217,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             // Reset oldest batch tracking since there are no batches
             Volatile.Write(ref _oldestBatchCreatedTicks, long.MaxValue);
-            return ValueTask.CompletedTask;
+            return default;
         }
 
         // Fast path 2: if the oldest batch hasn't reached linger time yet AND there are no
@@ -3206,11 +3228,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             var oldestTicks = Volatile.Read(ref _oldestBatchCreatedTicks);
             if (oldestTicks != long.MaxValue)
             {
-                var millisSinceOldest = (long)Stopwatch.GetElapsedTime(oldestTicks).TotalMilliseconds;
+                var millisSinceOldest = (long)CompatibilityBcl.GetElapsedTime(oldestTicks).TotalMilliseconds;
                 if (millisSinceOldest < _options.LingerMs)
                 {
                     // No batch is old enough to flush yet.
-                    return ValueTask.CompletedTask;
+                    return default;
                 }
             }
         }
@@ -3599,7 +3621,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 continue; // Another thread already handled this batch
 
             expiredCount++;
-            var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks);
+            var elapsed = CompatibilityBcl.GetElapsedTime(batch.StopwatchCreatedTicks);
 
             // Diagnostic: capture partition state to help identify why batch was orphaned
             var isMuted = _mutedPartitions.ContainsKey(batch.TopicPartition);
@@ -3687,7 +3709,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </returns>
     internal int Purge(PurgeOptions options, Exception exception, Action<ReadyBatch>? onPurgingBatch = null)
     {
-        ArgumentNullException.ThrowIfNull(exception);
+        CompatibilityThrowHelpers.ThrowIfNull(exception);
 
         var purgedCount = 0;
 
@@ -3894,7 +3916,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // Fast path: no unsealed batches AND no in-flight batches - avoid async overhead entirely
         if (!HasUnsealedBatches() && Volatile.Read(ref _inFlightBatchCount) == 0)
         {
-            return ValueTask.CompletedTask;
+            return default;
         }
 
         return FlushAsyncCore(cancellationToken);
@@ -4174,7 +4196,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         _disposalCts?.Dispose();
         // _bufferSpaceSignal is a TaskCompletionSource — no Dispose needed.
         // Signal any remaining waiters so they can observe disposal.
-        _bufferSpaceSignal.TrySetResult();
+        _bufferSpaceSignal.TrySetResult(true);
         _flushLingerLock.Dispose();
         // _flushTcs doesn't need disposal - it's a TaskCompletionSource
     }
@@ -4339,7 +4361,7 @@ internal sealed class PartitionBatch
         _createdStopwatchTimestamp = Stopwatch.GetTimestamp();
 
         _initialRecordCapacity = options.InitialBatchRecordCapacity > 0
-            ? Math.Clamp(options.InitialBatchRecordCapacity, 16, 16384)
+            ? CompatibilityBcl.Clamp(options.InitialBatchRecordCapacity, 16, 16384)
             : ComputeInitialRecordCapacity(options.BatchSize);
 
         // Create arena for append-time record encoding
@@ -4721,7 +4743,7 @@ internal sealed class PartitionBatch
         if (Volatile.Read(ref _recordCount) == 0)
             return false;
 
-        var elapsedMs = Stopwatch.GetElapsedTime(_createdStopwatchTimestamp, nowStopwatchTimestamp).TotalMilliseconds;
+        var elapsedMs = CompatibilityBcl.GetElapsedTime(_createdStopwatchTimestamp, nowStopwatchTimestamp).TotalMilliseconds;
 
         // Awaited produces: use micro-linger instead of immediate flush.
         // When LingerMs > 0 (default is 5), wait min(1ms, LingerMs/10) to let co-temporal messages batch.

--- a/src/Dekaf/Producer/TopicProducer.cs
+++ b/src/Dekaf/Producer/TopicProducer.cs
@@ -27,8 +27,8 @@ internal sealed class TopicProducer<TKey, TValue> : ITopicProducer<TKey, TValue>
     /// <param name="ownsProducer">If true, this topic producer will dispose the underlying producer on disposal.</param>
     internal TopicProducer(IKafkaProducer<TKey, TValue> producer, string topic, bool ownsProducer)
     {
-        ArgumentNullException.ThrowIfNull(producer);
-        ArgumentNullException.ThrowIfNull(topic);
+        CompatibilityThrowHelpers.ThrowIfNull(producer);
+        CompatibilityThrowHelpers.ThrowIfNull(topic);
 
         _producer = producer;
         Topic = topic;
@@ -101,7 +101,7 @@ internal sealed class TopicProducer<TKey, TValue> : ITopicProducer<TKey, TValue>
         CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
-        ArgumentNullException.ThrowIfNull(message);
+        CompatibilityThrowHelpers.ThrowIfNull(message);
 
         if (_producer is IProducerFastPath<TKey, TValue> fastPath)
         {
@@ -153,7 +153,7 @@ internal sealed class TopicProducer<TKey, TValue> : ITopicProducer<TKey, TValue>
         CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
-        ArgumentNullException.ThrowIfNull(messages);
+        CompatibilityThrowHelpers.ThrowIfNull(messages);
         return _producer.ProduceAllAsync(Topic, messages, cancellationToken);
     }
 
@@ -163,7 +163,7 @@ internal sealed class TopicProducer<TKey, TValue> : ITopicProducer<TKey, TValue>
         CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
-        ArgumentNullException.ThrowIfNull(messages);
+        CompatibilityThrowHelpers.ThrowIfNull(messages);
 
         // Convert TopicProducerMessage to ProducerMessage with embedded topic
         var producerMessages = messages.Select(m => new ProducerMessage<TKey, TValue>

--- a/src/Dekaf/Producer/ValueTaskSourcePool.cs
+++ b/src/Dekaf/Producer/ValueTaskSourcePool.cs
@@ -137,10 +137,10 @@ public sealed class ValueTaskSourcePool<T> : IAsyncDisposable
     public ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
-            return ValueTask.CompletedTask;
+            return default;
 
         _stack.Clear();
 
-        return ValueTask.CompletedTask;
+        return default;
     }
 }

--- a/src/Dekaf/Protocol/IKafkaMessage.cs
+++ b/src/Dekaf/Protocol/IKafkaMessage.cs
@@ -5,6 +5,7 @@ namespace Dekaf.Protocol;
 /// </summary>
 public interface IKafkaMessage
 {
+#if !NETSTANDARD2_0
     /// <summary>
     /// The API key for this message type.
     /// </summary>
@@ -19,6 +20,7 @@ public interface IKafkaMessage
     /// The highest supported API version.
     /// </summary>
     static abstract short HighestSupportedVersion { get; }
+#endif
 }
 
 /// <summary>
@@ -32,6 +34,7 @@ public interface IKafkaRequest<TResponse> : IKafkaMessage
     /// </summary>
     void Write(ref KafkaProtocolWriter writer, short version);
 
+#if !NETSTANDARD2_0
     /// <summary>
     /// Returns true if this API version uses flexible encoding.
     /// With Kafka 4.0+ all supported versions are flexible.
@@ -49,6 +52,7 @@ public interface IKafkaRequest<TResponse> : IKafkaMessage
     /// With Kafka 4.0+ all responses use header v1.
     /// </summary>
     static virtual short GetResponseHeaderVersion(short version) => 1;
+#endif
 }
 
 /// <summary>
@@ -56,8 +60,10 @@ public interface IKafkaRequest<TResponse> : IKafkaMessage
 /// </summary>
 public interface IKafkaResponse : IKafkaMessage
 {
+#if !NETSTANDARD2_0
     /// <summary>
     /// Reads the response body from the protocol reader.
     /// </summary>
     static abstract IKafkaResponse Read(ref KafkaProtocolReader reader, short version);
+#endif
 }

--- a/src/Dekaf/Protocol/KafkaMessageMetadata.cs
+++ b/src/Dekaf/Protocol/KafkaMessageMetadata.cs
@@ -1,0 +1,78 @@
+using System.Reflection;
+
+namespace Dekaf.Protocol;
+
+internal static class KafkaRequestMetadata<TRequest, TResponse>
+    where TRequest : IKafkaRequest<TResponse>
+    where TResponse : IKafkaResponse
+{
+#if NETSTANDARD2_0
+    private static readonly Func<short, short> s_getRequestHeaderVersion =
+        CreateVersionResolver("GetRequestHeaderVersion", 2);
+    private static readonly Func<short, short> s_getResponseHeaderVersion =
+        CreateVersionResolver("GetResponseHeaderVersion", 1);
+
+    public static ApiKey ApiKey { get; } = GetApiKey();
+
+    public static short GetRequestHeaderVersion(short version) => s_getRequestHeaderVersion(version);
+
+    public static short GetResponseHeaderVersion(short version) => s_getResponseHeaderVersion(version);
+
+    private static ApiKey GetApiKey()
+    {
+        var property = typeof(TRequest).GetProperty("ApiKey", BindingFlags.Public | BindingFlags.Static);
+        if (property?.GetValue(null) is ApiKey apiKey)
+            return apiKey;
+
+        throw new InvalidOperationException($"{typeof(TRequest).FullName} does not expose a static ApiKey property.");
+    }
+
+    private static Func<short, short> CreateVersionResolver(string methodName, short defaultValue)
+    {
+        var method = typeof(TRequest).GetMethod(
+            methodName,
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: new[] { typeof(short) },
+            modifiers: null);
+        if (method is null)
+            return _ => defaultValue;
+
+        return (Func<short, short>)Delegate.CreateDelegate(typeof(Func<short, short>), method);
+    }
+#else
+    public static ApiKey ApiKey => TRequest.ApiKey;
+
+    public static short GetRequestHeaderVersion(short version) => TRequest.GetRequestHeaderVersion(version);
+
+    public static short GetResponseHeaderVersion(short version) => TRequest.GetResponseHeaderVersion(version);
+#endif
+}
+
+internal static class KafkaResponseMetadata<TResponse>
+    where TResponse : IKafkaResponse
+{
+#if NETSTANDARD2_0
+    private delegate IKafkaResponse ReadResponseDelegate(ref KafkaProtocolReader reader, short version);
+
+    private static readonly ReadResponseDelegate s_read = CreateReadDelegate();
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version) => s_read(ref reader, version);
+
+    private static ReadResponseDelegate CreateReadDelegate()
+    {
+        var method = typeof(TResponse).GetMethod(
+            "Read",
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: new[] { typeof(KafkaProtocolReader).MakeByRefType(), typeof(short) },
+            modifiers: null);
+        if (method is null)
+            throw new InvalidOperationException($"{typeof(TResponse).FullName} does not expose a static Read method.");
+
+        return (ReadResponseDelegate)Delegate.CreateDelegate(typeof(ReadResponseDelegate), method);
+    }
+#else
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version) => TResponse.Read(ref reader, version);
+#endif
+}

--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -68,7 +68,7 @@ public ref struct KafkaProtocolReader
         if (buffer.IsSingleSegment)
         {
             // Fast path: Single segment - use direct span access
-            _span = buffer.FirstSpan;
+            _span = buffer.First.Span;
             _memory = buffer.First;
             _hasMemory = true;
             _position = 0;
@@ -302,7 +302,7 @@ public ref struct KafkaProtocolReader
         {
             if (_position + 16 > _span.Length)
                 ThrowInsufficientData();
-            var result = new Guid(_span.Slice(_position, 16), bigEndian: true);
+            var result = CompatibilityBcl.ReadGuidBigEndian(_span.Slice(_position, 16));
             _position += 16;
             return result;
         }
@@ -314,7 +314,7 @@ public ref struct KafkaProtocolReader
     {
         if (_reader.UnreadSpan.Length >= 16)
         {
-            var result = new Guid(_reader.UnreadSpan[..16], bigEndian: true);
+            var result = CompatibilityBcl.ReadGuidBigEndian(_reader.UnreadSpan[..16]);
             _reader.Advance(16);
             return result;
         }
@@ -322,7 +322,7 @@ public ref struct KafkaProtocolReader
         if (!_reader.TryCopyTo(buffer))
             ThrowInsufficientData();
         _reader.Advance(16);
-        return new Guid(buffer, bigEndian: true);
+        return CompatibilityBcl.ReadGuidBigEndian(buffer);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -332,7 +332,7 @@ public ref struct KafkaProtocolReader
         {
             if (_position + 8 > _span.Length)
                 ThrowInsufficientData();
-            var result = BinaryPrimitives.ReadDoubleBigEndian(_span.Slice(_position));
+            var result = CompatibilityBcl.ReadDoubleBigEndian(_span.Slice(_position));
             _position += 8;
             return result;
         }
@@ -344,7 +344,7 @@ public ref struct KafkaProtocolReader
     {
         if (_reader.UnreadSpan.Length >= 8)
         {
-            var result = BinaryPrimitives.ReadDoubleBigEndian(_reader.UnreadSpan);
+            var result = CompatibilityBcl.ReadDoubleBigEndian(_reader.UnreadSpan);
             _reader.Advance(8);
             return result;
         }
@@ -352,7 +352,7 @@ public ref struct KafkaProtocolReader
         if (!_reader.TryCopyTo(buffer))
             ThrowInsufficientData();
         _reader.Advance(8);
-        return BinaryPrimitives.ReadDoubleBigEndian(buffer);
+        return CompatibilityBcl.ReadDoubleBigEndian(buffer);
     }
 
     /// <summary>

--- a/src/Dekaf/Protocol/KafkaProtocolWriter.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolWriter.cs
@@ -94,7 +94,7 @@ public ref struct KafkaProtocolWriter
     public void WriteUuid(Guid value)
     {
         var span = _output.GetSpan(16);
-        value.TryWriteBytes(span, bigEndian: true, out _);
+        CompatibilityBcl.TryWriteGuidBigEndian(value, span);
         _output.Advance(16);
         _bytesWritten += 16;
     }
@@ -103,7 +103,7 @@ public ref struct KafkaProtocolWriter
     public void WriteFloat64(double value)
     {
         var span = _output.GetSpan(8);
-        BinaryPrimitives.WriteDoubleBigEndian(span, value);
+        CompatibilityBcl.WriteDoubleBigEndian(span, value);
         _output.Advance(8);
         _bytesWritten += 8;
     }

--- a/src/Dekaf/Protocol/Messages/FetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FetchResponse.cs
@@ -52,7 +52,7 @@ public sealed class FetchResponse : IKafkaResponse
     {
         get
         {
-            ObjectDisposedException.ThrowIf(Volatile.Read(ref _pooled) != 0, this);
+            CompatibilityThrowHelpers.ThrowIfObjectDisposed(Volatile.Read(ref _pooled) != 0, this);
             return _responses;
         }
         internal set => _responses = value;
@@ -195,7 +195,7 @@ public sealed class FetchResponseTopic
     {
         get
         {
-            ObjectDisposedException.ThrowIf(Volatile.Read(ref _pooled) != 0, this);
+            CompatibilityThrowHelpers.ThrowIfObjectDisposed(Volatile.Read(ref _pooled) != 0, this);
             return _partitions;
         }
         internal set => _partitions = value;
@@ -349,7 +349,7 @@ public sealed class FetchResponsePartition
     {
         get
         {
-            ObjectDisposedException.ThrowIf(Volatile.Read(ref _pooled) != 0, this);
+            CompatibilityThrowHelpers.ThrowIfObjectDisposed(Volatile.Read(ref _pooled) != 0, this);
             return _abortedTransactions;
         }
         internal set => _abortedTransactions = value;
@@ -367,7 +367,7 @@ public sealed class FetchResponsePartition
     {
         get
         {
-            ObjectDisposedException.ThrowIf(Volatile.Read(ref _pooled) != 0, this);
+            CompatibilityThrowHelpers.ThrowIfObjectDisposed(Volatile.Read(ref _pooled) != 0, this);
             return _records;
         }
         internal set => _records = value;

--- a/src/Dekaf/Protocol/Messages/ProduceResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceResponse.cs
@@ -1,3 +1,9 @@
+#if NETSTANDARD2_0
+using Lock = System.Object;
+#else
+using Lock = System.Threading.Lock;
+#endif
+
 namespace Dekaf.Protocol.Messages;
 
 /// <summary>

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -2,8 +2,10 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+#if !NETSTANDARD2_0
 using System.Runtime.Intrinsics.X86;
 using ArmCrc32 = System.Runtime.Intrinsics.Arm.Crc32;
+#endif
 using Dekaf.Compression;
 using Dekaf.Internal;
 using Dekaf.Producer;
@@ -131,8 +133,8 @@ internal sealed class PooledReusableBufferWriter : IBufferWriter<byte>, IDisposa
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void Grow(int sizeHint)
     {
-        var doubled = Math.Min((long)_buffer.Length * 2, Array.MaxLength);
-        var required = Math.Min((long)_written + sizeHint, Array.MaxLength);
+        var doubled = Math.Min((long)_buffer.Length * 2, CompatibilityBcl.ArrayMaxLength);
+        var required = Math.Min((long)_written + sizeHint, CompatibilityBcl.ArrayMaxLength);
         var newSize = (int)Math.Max(doubled, required);
 
         if (newSize <= _buffer.Length)
@@ -252,8 +254,8 @@ internal sealed class DetachableBufferWriter : IBufferWriter<byte>, IDisposable
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void Grow(int sizeHint)
     {
-        var doubled = Math.Min((long)_buffer.Length * 2, Array.MaxLength);
-        var required = Math.Min((long)_written + sizeHint, Array.MaxLength);
+        var doubled = Math.Min((long)_buffer.Length * 2, CompatibilityBcl.ArrayMaxLength);
+        var required = Math.Min((long)_written + sizeHint, CompatibilityBcl.ArrayMaxLength);
         var newSize = (int)Math.Max(doubled, required);
 
         if (newSize <= _buffer.Length)
@@ -1161,7 +1163,7 @@ internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
 
             // Re-check after parsing — EnsureParsedUpTo may have reduced _count
             // due to truncated data, making this index out of range.
-            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _count);
+            CompatibilityThrowHelpers.ThrowIfGreaterThanOrEqual(index, _count);
 
             return _parsedRecords![index];
         }
@@ -1396,6 +1398,9 @@ internal static class Crc32C
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static uint Compute(ReadOnlySpan<byte> data)
     {
+#if NETSTANDARD2_0
+        return ComputeSoftware(data);
+#else
         if (Sse42.IsSupported)
         {
             return ComputeHardwareX86(data);
@@ -1407,8 +1412,10 @@ internal static class Crc32C
         }
 
         return ComputeSoftware(data);
+#endif
     }
 
+#if !NETSTANDARD2_0
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static uint ComputeHardwareX86(ReadOnlySpan<byte> data)
     {
@@ -1532,6 +1539,7 @@ internal static class Crc32C
 
         return crc ^ 0xFFFFFFFFu;
     }
+#endif
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     internal static uint ComputeSoftware(ReadOnlySpan<byte> data)

--- a/src/Dekaf/Protocol/RefCountedMemoryOwner.cs
+++ b/src/Dekaf/Protocol/RefCountedMemoryOwner.cs
@@ -36,7 +36,7 @@ internal sealed class RefCountedMemoryOwner : IPooledMemory
 
     private void Initialize(IPooledMemory inner, int initialRefCount, bool pooled)
     {
-        ArgumentOutOfRangeException.ThrowIfLessThan(initialRefCount, 1);
+        CompatibilityThrowHelpers.ThrowIfLessThan(initialRefCount, 1);
         _inner = inner;
         _refCount = initialRefCount;
         _pooled = pooled ? 1 : 0;

--- a/src/Dekaf/Retry/ExponentialBackoffRetryPolicy.cs
+++ b/src/Dekaf/Retry/ExponentialBackoffRetryPolicy.cs
@@ -42,7 +42,7 @@ public sealed class ExponentialBackoffRetryPolicy : IRetryPolicy
         if (Jitter)
         {
             // Jitter range: 0.5x to 1.5x of computed delay
-            var jitterMultiplier = 0.5 + Random.Shared.NextDouble();
+            var jitterMultiplier = 0.5 + CompatibilityBcl.RandomNextDouble();
             delayTicks = (long)(delayTicks * jitterMultiplier);
 
             // Clamp again so jitter cannot exceed MaxDelay

--- a/src/Dekaf/Retry/RetryHelper.cs
+++ b/src/Dekaf/Retry/RetryHelper.cs
@@ -42,7 +42,7 @@ internal static class RetryHelper
                 if (onRetry is not null)
                     await onRetry(cancellationToken).ConfigureAwait(false);
 
-                var jitter = Random.Shared.Next(0, 100);
+                var jitter = CompatibilityBcl.RandomNext(0, 100);
                 await Task.Delay(RetryDelayMs + jitter, cancellationToken).ConfigureAwait(false);
             }
         }
@@ -75,7 +75,7 @@ internal static class RetryHelper
                 if (onRetry is not null)
                     await onRetry(cancellationToken).ConfigureAwait(false);
 
-                var jitter = Random.Shared.Next(0, 100);
+                var jitter = CompatibilityBcl.RandomNext(0, 100);
                 await Task.Delay(RetryDelayMs + jitter, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Dekaf/Security/Sasl/AwsCredentials.cs
+++ b/src/Dekaf/Security/Sasl/AwsCredentials.cs
@@ -14,8 +14,8 @@ public sealed class AwsCredentials
         string? sessionToken = null,
         DateTimeOffset? expiration = null)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(accessKeyId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(secretAccessKey);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(accessKeyId);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(secretAccessKey);
 
         AccessKeyId = accessKeyId;
         SecretAccessKey = secretAccessKey;

--- a/src/Dekaf/Security/Sasl/AwsMskIamAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamAuthenticator.cs
@@ -24,7 +24,7 @@ public sealed class AwsMskIamAuthenticator : ISaslAuthenticator
     public AwsMskIamAuthenticator(AwsMskIamConfig? config, string host)
     {
         _config = config ?? DefaultConfig;
-        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(host);
         _host = host;
         _credentialsProvider = _config.CreateCredentialsProvider();
     }
@@ -58,7 +58,7 @@ public sealed class AwsMskIamAuthenticator : ISaslAuthenticator
             credentials,
             _host,
             region,
-            string.IsNullOrWhiteSpace(_config.UserAgent) ? "dekaf" : _config.UserAgent,
+            string.IsNullOrWhiteSpace(_config.UserAgent) ? "dekaf" : _config.UserAgent!,
             DateTimeOffset.UtcNow,
             _config.AuthenticationPayloadExpiration);
 
@@ -108,7 +108,11 @@ internal static class AwsMskIamRegionResolver
 {
     public static string? TryResolveFromHost(string host)
     {
-        var labels = host.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var labels = host
+            .Split(['.'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(static label => label.Trim())
+            .Where(static label => label.Length > 0)
+            .ToArray();
         for (var i = 0; i < labels.Length; i++)
         {
             if (!IsAmazonAwsSuffix(labels, i) || i < 2)
@@ -154,7 +158,7 @@ internal static class AwsMskIamRegionResolver
 
     private static bool LooksLikeRegion(string value)
     {
-        var parts = value.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        var parts = value.Split(['-'], StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length < 3)
             return false;
 

--- a/src/Dekaf/Security/Sasl/AwsMskIamDefaultCredentialsProvider.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamDefaultCredentialsProvider.cs
@@ -30,7 +30,7 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
 
     internal AwsMskIamDefaultCredentialsProvider(HttpClient httpClient, string? profileName = null, string? region = null)
     {
-        ArgumentNullException.ThrowIfNull(httpClient);
+        CompatibilityThrowHelpers.ThrowIfNull(httpClient);
 
         _httpClient = httpClient;
         _profileName = profileName;
@@ -95,7 +95,11 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
         if (string.IsNullOrWhiteSpace(roleArn) || string.IsNullOrWhiteSpace(tokenFile) || !File.Exists(tokenFile))
             return null;
 
+#if NETSTANDARD2_0
+        var webIdentityToken = await Task.Run(() => File.ReadAllText(tokenFile), cancellationToken).ConfigureAwait(false);
+#else
         var webIdentityToken = await File.ReadAllTextAsync(tokenFile, cancellationToken).ConfigureAwait(false);
+#endif
         var sessionName = Environment.GetEnvironmentVariable("AWS_ROLE_SESSION_NAME") ?? _webIdentitySessionName;
         var endpoint = BuildStsEndpoint(ResolveStsRegion());
 
@@ -247,13 +251,16 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
             if (string.IsNullOrWhiteSpace(roleName))
                 return null;
 
-            roleName = roleName.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)[0];
+            roleName = roleName!
+                .Split(['\n'], StringSplitOptions.RemoveEmptyEntries)
+                .Select(static line => line.Trim())
+                .First(static line => line.Length > 0);
             var json = await GetImdsStringAsync(
                 "http://169.254.169.254/latest/meta-data/iam/security-credentials/" + Uri.EscapeDataString(roleName),
                 token,
                 cancellationToken).ConfigureAwait(false);
 
-            return string.IsNullOrWhiteSpace(json) ? null : ParseJsonCredentials(json);
+            return string.IsNullOrWhiteSpace(json) ? null : ParseJsonCredentials(json!);
         }
         catch (HttpRequestException)
         {

--- a/src/Dekaf/Security/Sasl/AwsMskIamSignedPayload.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamSignedPayload.cs
@@ -12,7 +12,7 @@ internal static class AwsMskIamSignedPayload
     private const string Service = "kafka-cluster";
     private const string Version = "2020_10_22";
     private const string SignedHeaders = "host";
-    private static readonly byte[] EmptyPayloadHash = SHA256.HashData([]);
+    private static readonly byte[] EmptyPayloadHash = CompatibilityBcl.Sha256HashData([]);
 
     public static string Create(
         AwsCredentials credentials,
@@ -22,10 +22,10 @@ internal static class AwsMskIamSignedPayload
         DateTimeOffset now,
         TimeSpan expiration)
     {
-        ArgumentNullException.ThrowIfNull(credentials);
-        ArgumentException.ThrowIfNullOrWhiteSpace(host);
-        ArgumentException.ThrowIfNullOrWhiteSpace(region);
-        ArgumentException.ThrowIfNullOrWhiteSpace(userAgent);
+        CompatibilityThrowHelpers.ThrowIfNull(credentials);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(host);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(region);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(userAgent);
 
         if (expiration <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(expiration), "Expiration must be positive");
@@ -54,11 +54,11 @@ internal static class AwsMskIamSignedPayload
 
         var canonicalRequest = CreateCanonicalRequest(queryParameters, host);
         var stringToSign = string.Join(
-            '\n',
+            "\n",
             Algorithm,
             amzDate,
             credentialScope,
-            Hex(SHA256.HashData(Encoding.UTF8.GetBytes(canonicalRequest))));
+            Hex(CompatibilityBcl.Sha256HashData(Encoding.UTF8.GetBytes(canonicalRequest))));
 
         var signature = CalculateSignature(credentials.SecretAccessKey, dateStamp, region, stringToSign);
 
@@ -89,11 +89,11 @@ internal static class AwsMskIamSignedPayload
         string host)
     {
         var canonicalQuery = string.Join(
-            '&',
+            "&",
             queryParameters.Select(pair => $"{UriEncode(pair.Key)}={UriEncode(pair.Value)}"));
 
         return string.Join(
-            '\n',
+            "\n",
             "GET",
             "/",
             canonicalQuery,
@@ -116,11 +116,11 @@ internal static class AwsMskIamSignedPayload
     }
 
     private static byte[] Hmac(byte[] key, string message)
-        => HMACSHA256.HashData(key, Encoding.UTF8.GetBytes(message));
+        => CompatibilityBcl.HmacSha256HashData(key, Encoding.UTF8.GetBytes(message));
 
     private static string Hex(ReadOnlySpan<byte> bytes)
     {
-        return Convert.ToHexString(bytes).ToLowerInvariant();
+        return CompatibilityBcl.ToHexStringLower(bytes);
     }
 
     private static string UriEncode(string value)

--- a/src/Dekaf/Security/Sasl/GssapiConfig.cs
+++ b/src/Dekaf/Security/Sasl/GssapiConfig.cs
@@ -64,22 +64,22 @@ public sealed class GssapiConfig
 
     internal void Validate()
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(ServiceName);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(ServiceName);
 
         if (Principal is not null)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(Principal);
+            CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(Principal);
         }
 
         if (Realm is not null)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(Realm);
+            CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(Realm);
         }
 
         if (KeytabPath is not null)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(KeytabPath);
-            if (OperatingSystem.IsWindows())
+            CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(KeytabPath);
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
             {
                 throw new NotSupportedException(
                     "GSSAPI KeytabPath is not supported on Windows by .NET NegotiateAuthentication. " +
@@ -152,7 +152,7 @@ public sealed class GssapiConfig
 
     internal string BuildSpn(string targetHost)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(targetHost);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(targetHost);
 
         var spn = $"{ServiceName}/{targetHost}";
         return Realm is null ? spn : $"{spn}@{Realm}";

--- a/src/Dekaf/Security/Sasl/OAuthBearerAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerAuthenticator.cs
@@ -20,7 +20,7 @@ public sealed class OAuthBearerAuthenticator : ISaslAuthenticator
     /// <param name="token">The OAuth bearer token to use.</param>
     public OAuthBearerAuthenticator(OAuthBearerToken token)
     {
-        ArgumentNullException.ThrowIfNull(token);
+        CompatibilityThrowHelpers.ThrowIfNull(token);
         _currentToken = token;
         _tokenProvider = _ => new ValueTask<OAuthBearerToken>(token);
     }
@@ -143,7 +143,7 @@ public sealed class OAuthBearerAuthenticator : ISaslAuthenticator
             var errorResponse = Encoding.UTF8.GetString(challenge);
 
             // If the response starts with '{', it's a JSON error
-            if (errorResponse.StartsWith('{'))
+            if (StartsWithJsonObject(errorResponse))
             {
                 throw new AuthenticationException($"OAUTHBEARER authentication failed: {errorResponse}");
             }
@@ -151,5 +151,14 @@ public sealed class OAuthBearerAuthenticator : ISaslAuthenticator
 
         _complete = true;
         return null;
+    }
+
+    private static bool StartsWithJsonObject(string value)
+    {
+#if NETSTANDARD2_0
+        return value.StartsWith("{", StringComparison.Ordinal);
+#else
+        return value.StartsWith('{');
+#endif
     }
 }

--- a/src/Dekaf/Security/Sasl/OAuthBearerJwtAssertion.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerJwtAssertion.cs
@@ -66,14 +66,14 @@ internal static class OAuthBearerJwtAssertion
 
         var signingInput = $"{header}.{payload}";
         var signature = Sign(privateKey, algorithm, Encoding.ASCII.GetBytes(signingInput));
-        return $"{signingInput}.{Base64Url.EncodeToString(signature)}";
+        return $"{signingInput}.{CompatibilityBcl.Base64UrlEncode(signature)}";
     }
 
     private static string Required(string? value, string message)
     {
         if (string.IsNullOrWhiteSpace(value))
             throw new InvalidOperationException(message);
-        return value;
+        return value!;
     }
 
     private static void ValidateAdditionalClaims(IReadOnlyDictionary<string, object?>? claims)
@@ -176,7 +176,7 @@ internal static class OAuthBearerJwtAssertion
 
     private static void WriteAdditionalClaimNumberValue(Utf8JsonWriter writer, string claimName, float value)
     {
-        if (!float.IsFinite(value))
+        if (!CompatibilityBcl.IsFinite(value))
             throw UnsupportedAdditionalClaimValue(claimName, value);
 
         writer.WriteNumberValue(value);
@@ -184,7 +184,7 @@ internal static class OAuthBearerJwtAssertion
 
     private static void WriteAdditionalClaimNumberValue(Utf8JsonWriter writer, string claimName, double value)
     {
-        if (!double.IsFinite(value))
+        if (!CompatibilityBcl.IsFinite(value))
             throw UnsupportedAdditionalClaimValue(claimName, value);
 
         writer.WriteNumberValue(value);
@@ -221,7 +221,7 @@ internal static class OAuthBearerJwtAssertion
             writer.WriteEndObject();
         }
 
-        return Base64Url.EncodeToString(buffer.WrittenSpan);
+        return CompatibilityBcl.Base64UrlEncode(buffer.WrittenSpan);
     }
 
     private static OAuthBearerJwtSigningAlgorithm ResolveAlgorithm(
@@ -292,6 +292,76 @@ internal static class OAuthBearerJwtAssertion
         if (key is not ECDsa ecdsa)
             throw new InvalidOperationException("Selected JWT-bearer signing algorithm requires an ECDSA private key");
 
+#if NETSTANDARD2_0
+        var derSignature = ecdsa.SignData(signingInput, hashAlgorithm);
+        return DerEcdsaSignatureToIeeeP1363(derSignature, (ecdsa.KeySize + 7) / 8);
+#else
         return ecdsa.SignData(signingInput, hashAlgorithm, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+#endif
     }
+
+#if NETSTANDARD2_0
+    private static byte[] DerEcdsaSignatureToIeeeP1363(byte[] derSignature, int fieldLength)
+    {
+        var offset = 0;
+        if (ReadByte(derSignature, ref offset) != 0x30)
+            throw new InvalidOperationException("ECDSA signature was not encoded as a DER sequence.");
+
+        ReadDerLength(derSignature, ref offset);
+        var r = ReadDerInteger(derSignature, ref offset);
+        var s = ReadDerInteger(derSignature, ref offset);
+        var result = new byte[fieldLength * 2];
+        CopyIntegerToFixedField(r, result.AsSpan(0, fieldLength));
+        CopyIntegerToFixedField(s, result.AsSpan(fieldLength, fieldLength));
+        return result;
+    }
+
+    private static ReadOnlySpan<byte> ReadDerInteger(byte[] der, ref int offset)
+    {
+        if (ReadByte(der, ref offset) != 0x02)
+            throw new InvalidOperationException("ECDSA signature DER integer expected.");
+
+        var length = ReadDerLength(der, ref offset);
+        var value = der.AsSpan(offset, length);
+        offset += length;
+        return value!;
+    }
+
+    private static int ReadDerLength(byte[] der, ref int offset)
+    {
+        var first = ReadByte(der, ref offset);
+        if ((first & 0x80) == 0)
+            return first;
+
+        var lengthBytes = first & 0x7F;
+        var length = 0;
+        for (var i = 0; i < lengthBytes; i++)
+        {
+            length = (length << 8) | ReadByte(der, ref offset);
+        }
+
+        return length;
+    }
+
+    private static byte ReadByte(byte[] der, ref int offset)
+    {
+        if ((uint)offset >= (uint)der.Length)
+            throw new InvalidOperationException("ECDSA signature DER data ended unexpectedly.");
+
+        return der[offset++];
+    }
+
+    private static void CopyIntegerToFixedField(ReadOnlySpan<byte> integer, Span<byte> destination)
+    {
+        while (integer.Length > 0 && integer[0] == 0)
+        {
+            integer = integer[1..];
+        }
+
+        if (integer.Length > destination.Length)
+            throw new InvalidOperationException("ECDSA signature integer is larger than the expected key size.");
+
+        integer.CopyTo(destination[(destination.Length - integer.Length)..]);
+    }
+#endif
 }

--- a/src/Dekaf/Security/Sasl/OAuthBearerJwtBearerOptions.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerJwtBearerOptions.cs
@@ -104,7 +104,7 @@ public sealed class OAuthBearerJwtBearerOptions
             GrantType = OAuthBearerGrantType.JwtBearer,
             TokenEndpointUrl = options.TokenEndpoint!,
             ClientId = options.ClientId!,
-            Scope = options.Scopes is { Count: > 0 } ? string.Join(' ', options.Scopes) : null,
+            Scope = options.Scopes is { Count: > 0 } ? string.Join(" ", options.Scopes) : null,
             AdditionalParameters = options.AdditionalParameters,
             JwtBearer = options,
             TokenRefreshBufferSeconds = TokenRefreshBufferSeconds
@@ -121,8 +121,12 @@ public sealed class OAuthBearerJwtBearerOptions
         Subject = Subject,
         KeyId = KeyId,
         Scopes = Scopes is null ? null : Scopes.ToArray(),
-        AdditionalClaims = AdditionalClaims is null ? null : new Dictionary<string, object?>(AdditionalClaims, StringComparer.Ordinal),
-        AdditionalParameters = AdditionalParameters is null ? null : new Dictionary<string, string>(AdditionalParameters, StringComparer.Ordinal),
+        AdditionalClaims = AdditionalClaims is null
+            ? null
+            : AdditionalClaims.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal),
+        AdditionalParameters = AdditionalParameters is null
+            ? null
+            : AdditionalParameters.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal),
         AssertionLifetime = AssertionLifetime,
         TokenRefreshBufferSeconds = TokenRefreshBufferSeconds,
         SigningAlgorithm = SigningAlgorithm

--- a/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
@@ -115,14 +115,14 @@ public sealed class OAuthBearerTokenProvider : IDisposable
 
         if (!string.IsNullOrEmpty(_config.Scope))
         {
-            body["scope"] = _config.Scope;
+            body["scope"] = _config.Scope!;
         }
 
         if (_config.AdditionalParameters is not null)
         {
             foreach (var (key, value) in _config.AdditionalParameters)
             {
-                body[key] = value;
+                body[key] = value!;
             }
         }
 
@@ -196,7 +196,7 @@ public sealed class OAuthBearerTokenProvider : IDisposable
         {
             var sub = subElement.GetString();
             if (!string.IsNullOrEmpty(sub))
-                return sub;
+                return sub!;
         }
 
         // Try to decode JWT and extract subject claim
@@ -229,7 +229,7 @@ public sealed class OAuthBearerTokenProvider : IDisposable
                     {
                         var value = claimElement.GetString();
                         if (!string.IsNullOrEmpty(value))
-                            return value;
+                            return value!;
                     }
                 }
             }

--- a/src/Dekaf/Security/Sasl/SaslCredentialBuffers.cs
+++ b/src/Dekaf/Security/Sasl/SaslCredentialBuffers.cs
@@ -7,6 +7,6 @@ internal static class SaslCredentialBuffers
     public static void Clear(byte[]? buffer)
     {
         if (buffer is { Length: > 0 })
-            CryptographicOperations.ZeroMemory(buffer);
+            CompatibilityBcl.ZeroMemory(buffer);
     }
 }

--- a/src/Dekaf/Security/Sasl/SaslSessionState.cs
+++ b/src/Dekaf/Security/Sasl/SaslSessionState.cs
@@ -26,7 +26,7 @@ internal sealed class SaslSessionState
         SaslReauthenticationConfig config,
         DateTimeOffset? authenticationTime = null)
     {
-        ArgumentNullException.ThrowIfNull(config);
+        CompatibilityThrowHelpers.ThrowIfNull(config);
 
         _sessionLifetimeMs = sessionLifetimeMs;
         _reauthenticationThreshold = config.ReauthenticationThreshold;

--- a/src/Dekaf/Security/Sasl/ScramAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/ScramAuthenticator.cs
@@ -134,7 +134,7 @@ public sealed class ScramAuthenticator : ISaslAuthenticator
         var salt = Convert.FromBase64String(saltBase64);
 
         // Compute salted password using PBKDF2
-        _saltedPassword = Rfc2898DeriveBytes.Pbkdf2(
+        _saltedPassword = CompatibilityBcl.Pbkdf2(
             Encoding.UTF8.GetBytes(_password),
             salt,
             iterations,
@@ -183,7 +183,7 @@ public sealed class ScramAuthenticator : ISaslAuthenticator
         var expectedServerSignature = Hmac(serverKey, _authMessage!);
         var actualServerSignature = Convert.FromBase64String(serverSignatureBase64);
 
-        if (!CryptographicOperations.FixedTimeEquals(expectedServerSignature, actualServerSignature))
+        if (!CompatibilityBcl.FixedTimeEquals(expectedServerSignature, actualServerSignature))
         {
             throw new AuthenticationException("Server signature verification failed");
         }
@@ -210,7 +210,7 @@ public sealed class ScramAuthenticator : ISaslAuthenticator
 
     private static string GenerateNonce()
     {
-        var bytes = RandomNumberGenerator.GetBytes(24);
+        var bytes = CompatibilityBcl.GetRandomBytes(24);
         return Convert.ToBase64String(bytes);
     }
 
@@ -229,15 +229,15 @@ public sealed class ScramAuthenticator : ISaslAuthenticator
     private byte[] Hmac(byte[] key, byte[] message)
     {
         return _hashAlgorithm == HashAlgorithmName.SHA256
-            ? HMACSHA256.HashData(key, message)
-            : HMACSHA512.HashData(key, message);
+            ? CompatibilityBcl.HmacSha256HashData(key, message)
+            : CompatibilityBcl.HmacSha512HashData(key, message);
     }
 
     private byte[] Hash(byte[] data)
     {
         return _hashAlgorithm == HashAlgorithmName.SHA256
-            ? SHA256.HashData(data)
-            : SHA512.HashData(data);
+            ? CompatibilityBcl.Sha256HashData(data)
+            : CompatibilityBcl.Sha512HashData(data);
     }
 
     private static byte[] Xor(byte[] a, byte[] b)

--- a/src/Dekaf/Serialization/BuiltInSerializers.cs
+++ b/src/Dekaf/Serialization/BuiltInSerializers.cs
@@ -107,8 +107,13 @@ public readonly struct Ignore;
 
 internal sealed class ByteArraySerde : ISerde<byte[]>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(byte[] value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(byte[] value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         var span = destination.GetSpan(value.Length);
         value.CopyTo(span);
@@ -123,8 +128,13 @@ internal sealed class ByteArraySerde : ISerde<byte[]>
 
 internal sealed class StringSerde : ISerde<string>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         var span = destination.GetSpan(checked(value.Length * 3));
         var bytesWritten = Encoding.UTF8.GetBytes(value, span);
@@ -139,8 +149,13 @@ internal sealed class StringSerde : ISerde<string>
 
 internal sealed class NullableStringSerde : ISerde<string?>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(string? value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(string? value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         if (value is null)
             return;
@@ -164,8 +179,13 @@ internal sealed class NullableStringSerde : ISerde<string?>
 
 internal sealed class Int32Serde : ISerde<int>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(int value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(int value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         var span = destination.GetSpan(4);
         BinaryPrimitives.WriteInt32BigEndian(span, value);
@@ -180,8 +200,13 @@ internal sealed class Int32Serde : ISerde<int>
 
 internal sealed class Int64Serde : ISerde<long>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(long value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(long value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         var span = destination.GetSpan(8);
         BinaryPrimitives.WriteInt64BigEndian(span, value);
@@ -196,56 +221,76 @@ internal sealed class Int64Serde : ISerde<long>
 
 internal sealed class GuidSerde : ISerde<Guid>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(Guid value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(Guid value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         var span = destination.GetSpan(16);
-        value.TryWriteBytes(span, bigEndian: true, out _);
+        CompatibilityBcl.TryWriteGuidBigEndian(value, span);
         destination.Advance(16);
     }
 
     public Guid Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
     {
-        return new Guid(data.Span, bigEndian: true);
+        return CompatibilityBcl.ReadGuidBigEndian(data.Span);
     }
 }
 
 internal sealed class DoubleSerde : ISerde<double>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(double value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(double value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         var span = destination.GetSpan(8);
-        BinaryPrimitives.WriteDoubleBigEndian(span, value);
+        CompatibilityBcl.WriteDoubleBigEndian(span, value);
         destination.Advance(8);
     }
 
     public double Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
     {
-        return BinaryPrimitives.ReadDoubleBigEndian(data.Span);
+        return CompatibilityBcl.ReadDoubleBigEndian(data.Span);
     }
 }
 
 internal sealed class FloatSerde : ISerde<float>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(float value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(float value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         var span = destination.GetSpan(4);
-        BinaryPrimitives.WriteSingleBigEndian(span, value);
+        CompatibilityBcl.WriteSingleBigEndian(span, value);
         destination.Advance(4);
     }
 
     public float Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
     {
-        return BinaryPrimitives.ReadSingleBigEndian(data.Span);
+        return CompatibilityBcl.ReadSingleBigEndian(data.Span);
     }
 }
 
 internal sealed class DateTimeSerde : ISerde<DateTime>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(DateTime value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(DateTime value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         var span = destination.GetSpan(8);
         BinaryPrimitives.WriteInt64BigEndian(span, value.ToUniversalTime().Ticks);
@@ -261,8 +306,13 @@ internal sealed class DateTimeSerde : ISerde<DateTime>
 
 internal sealed class DateTimeOffsetSerde : ISerde<DateTimeOffset>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(DateTimeOffset value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(DateTimeOffset value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         var span = destination.GetSpan(10);
         BinaryPrimitives.WriteInt64BigEndian(span, value.UtcTicks);
@@ -282,8 +332,13 @@ internal sealed class DateTimeOffsetSerde : ISerde<DateTimeOffset>
 
 internal sealed class TimeSpanSerde : ISerde<TimeSpan>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(TimeSpan value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(TimeSpan value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         var span = destination.GetSpan(8);
         BinaryPrimitives.WriteInt64BigEndian(span, value.Ticks);
@@ -299,8 +354,13 @@ internal sealed class TimeSpanSerde : ISerde<TimeSpan>
 
 internal sealed class NullSerde<T> : ISerde<T?> where T : class
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(T? value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(T? value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         // No-op
     }
@@ -313,8 +373,13 @@ internal sealed class NullSerde<T> : ISerde<T?> where T : class
 
 internal sealed class IgnoreSerde : ISerde<Ignore>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(Ignore value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(Ignore value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         // No-op
     }
@@ -335,8 +400,13 @@ internal sealed class IgnoreSerde : ISerde<Ignore>
 /// </remarks>
 internal sealed class RawBytesSerde : ISerde<ReadOnlyMemory<byte>>
 {
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(ReadOnlyMemory<byte> value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(ReadOnlyMemory<byte> value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
+#endif
     {
         var span = destination.GetSpan(value.Length);
         value.Span.CopyTo(span);

--- a/src/Dekaf/Serialization/CachingStringKeyDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringKeyDeserializer.cs
@@ -29,8 +29,13 @@ internal sealed class CachingStringKeyDeserializer : ISerde<string>
         _inner = inner;
     }
 
+#if NETSTANDARD2_0
+    public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
+        where TWriter : System.Buffers.IBufferWriter<byte>
+#else
     public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
         where TWriter : System.Buffers.IBufferWriter<byte>, allows ref struct
+#endif
     {
         _inner.Serialize(value, ref destination, context);
     }

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -212,7 +212,7 @@ public sealed class Headers : IEnumerable<Header>
     {
         if (!string.IsNullOrEmpty(value))
         {
-            Add(key, value);
+            Add(key, value!);
         }
         return this;
     }
@@ -398,7 +398,7 @@ public readonly record struct Header
     {
         // ASCII keys (99%+ of cases): byte count == char count. Ascii.IsValid is
         // SIMD-optimized and much cheaper than UTF8.GetByteCount for this case.
-        var keyBytes = Ascii.IsValid(Key) ? Key.Length : Encoding.UTF8.GetByteCount(Key);
+        var keyBytes = Key.All(static c => c <= 0x7F) ? Key.Length : Encoding.UTF8.GetByteCount(Key);
         var size = Record.VarIntSize(keyBytes) + keyBytes;
 
         if (IsValueNull)

--- a/src/Dekaf/Serialization/ISerializer.cs
+++ b/src/Dekaf/Serialization/ISerializer.cs
@@ -15,8 +15,13 @@ public interface ISerializer<in T>
     /// <param name="value">The value to serialize.</param>
     /// <param name="destination">The buffer to write serialized bytes to. Passed by ref to support ref struct writers.</param>
     /// <param name="context">Serialization context with topic and header information.</param>
+#if NETSTANDARD2_0
+    void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>;
+#else
     void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct;
+#endif
 }
 
 /// <summary>

--- a/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
@@ -1,3 +1,11 @@
+#if NETSTANDARD2_0
+using TopicNameSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using TopicNameSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
+
 namespace Dekaf.ShareConsumer;
 
 /// <summary>
@@ -17,12 +25,12 @@ public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, 
     /// <summary>
     /// Gets the current topic subscription.
     /// </summary>
-    IReadOnlySet<string> Subscription { get; }
+    TopicNameSet Subscription { get; }
 
     /// <summary>
     /// Gets the current partition assignment from the share group coordinator.
     /// </summary>
-    IReadOnlySet<TopicPartition> Assignment { get; }
+    TopicPartitionSet Assignment { get; }
 
     /// <summary>
     /// Gets the member ID (client-generated UUID) if part of a share group.

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -8,6 +8,13 @@ using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 using Microsoft.Extensions.Logging;
+#if NETSTANDARD2_0
+using TopicNameSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using TopicNameSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
 
 namespace Dekaf.ShareConsumer;
 
@@ -34,8 +41,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     [ThreadStatic]
     private static SerializationContext t_serializationContext;
 
-    private volatile IReadOnlySet<string> _subscriptionSnapshot = new HashSet<string>();
-    private volatile IReadOnlySet<TopicPartition> _assignmentSnapshot = new HashSet<TopicPartition>();
+    private volatile TopicNameSet _subscriptionSnapshot = new HashSet<string>();
+    private volatile TopicPartitionSet _assignmentSnapshot = new HashSet<TopicPartition>();
 
     private readonly SemaphoreSlim _initLock = new(1, 1);
     private volatile bool _initialized;
@@ -132,8 +139,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             loggerFactory?.CreateLogger<ShareConsumerCoordinator>());
     }
 
-    public IReadOnlySet<string> Subscription => _subscriptionSnapshot;
-    public IReadOnlySet<TopicPartition> Assignment => _assignmentSnapshot;
+    public TopicNameSet Subscription => _subscriptionSnapshot;
+    public TopicPartitionSet Assignment => _assignmentSnapshot;
     public string? MemberId => _coordinator.MemberId;
 
     public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)
@@ -510,7 +517,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             foreach (var batch in batches)
             {
                 var types = new byte[batch.AcknowledgeTypes.Length];
-                Array.Fill(types, (byte)AcknowledgeType.Release);
+                CompatibilityBcl.FillArray(types, (byte)AcknowledgeType.Release);
                 releasedBatches.Add(new AcknowledgementBatchData(batch.FirstOffset, batch.LastOffset, types));
             }
             released[tp] = releasedBatches;
@@ -664,7 +671,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     /// Groups assigned partitions by their leader broker.
     /// </summary>
     private Dictionary<int, List<TopicPartition>> GroupPartitionsByLeader(
-        IReadOnlySet<TopicPartition> assignment)
+        TopicPartitionSet assignment)
     {
         var result = new Dictionary<int, List<TopicPartition>>();
 

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -6,6 +6,13 @@ using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Consumer;
 using Microsoft.Extensions.Logging;
+#if NETSTANDARD2_0
+using TopicNameSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using TopicNameSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
 
 namespace Dekaf.ShareConsumer;
 
@@ -39,7 +46,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
 
     private volatile int _heartbeatIntervalMs;
     private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
-    private volatile IReadOnlySet<string>? _subscribedTopics;
+    private volatile TopicNameSet? _subscribedTopics;
 
     internal static int GetCoordinationConnectionIndex(int connectionsPerBroker)
         => connectionsPerBroker - 1;
@@ -64,7 +71,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     public string? MemberId => _memberId;
     public int MemberEpoch => _memberEpoch;
     public CoordinatorState State => _state;
-    public IReadOnlySet<TopicPartition> Assignment => _assignedPartitions;
+    public TopicPartitionSet Assignment => _assignedPartitions;
 
     /// <summary>
     /// Forces the coordinator to rejoin the group on the next
@@ -79,7 +86,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     /// Ensures the share consumer has joined the group.
     /// </summary>
     public async ValueTask EnsureActiveGroupAsync(
-        IReadOnlySet<string> topics,
+        TopicNameSet topics,
         CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _disposed) != 0)
@@ -357,7 +364,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     /// Ensures the share consumer has joined the group using the ShareGroupHeartbeat API.
     /// </summary>
     private async ValueTask EnsureActiveGroupCoreAsync(
-        IReadOnlySet<string> topics,
+        TopicNameSet topics,
         CancellationToken cancellationToken)
     {
         if (!_metadataManager.HasApiKey(ApiKey.ShareGroupHeartbeat))
@@ -386,11 +393,11 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
 
             while (_state != CoordinatorState.Stable)
             {
-                if (Stopwatch.GetElapsedTime(startedAt) > timeout)
+                if (CompatibilityBcl.GetElapsedTime(startedAt) > timeout)
                 {
                     throw new KafkaTimeoutException(
                         TimeoutKind.Rebalance,
-                        Stopwatch.GetElapsedTime(startedAt),
+                        CompatibilityBcl.GetElapsedTime(startedAt),
                         timeout,
                         $"Failed to join share group '{_options.GroupId}' within timeout ({_options.SessionTimeoutMs}ms)");
                 }
@@ -546,8 +553,8 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
 
             var request = new ShareGroupHeartbeatRequest
             {
-                GroupId = _options.GroupId,
-                MemberId = _memberId,
+                GroupId = _options.GroupId!,
+                MemberId = _memberId!,
                 MemberEpoch = -1
             };
 

--- a/src/Dekaf/Telemetry/ApplicationTelemetryMetric.cs
+++ b/src/Dekaf/Telemetry/ApplicationTelemetryMetric.cs
@@ -39,8 +39,8 @@ public sealed class ApplicationTelemetryMetric
         Func<double> observe,
         IReadOnlyDictionary<string, string>? attributes = null)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(name);
-        ArgumentNullException.ThrowIfNull(observe);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(name);
+        CompatibilityThrowHelpers.ThrowIfNull(observe);
 
         Name = name;
         Kind = kind;

--- a/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
@@ -81,14 +81,14 @@ internal sealed class ClientTelemetryMetricCollector
 
     public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
     {
-        ArgumentNullException.ThrowIfNull(metric);
+        CompatibilityThrowHelpers.ThrowIfNull(metric);
         _applicationMetrics[metric.Name] = metric;
         _applicationCounterPreviousValues.TryRemove(metric.Name, out _);
     }
 
     public void RegisterMetricsForSubscription(IEnumerable<ApplicationTelemetryMetric> metrics)
     {
-        ArgumentNullException.ThrowIfNull(metrics);
+        CompatibilityThrowHelpers.ThrowIfNull(metrics);
 
         foreach (var metric in metrics)
         {
@@ -98,7 +98,7 @@ internal sealed class ClientTelemetryMetricCollector
 
     public void UnregisterMetricFromSubscription(string name)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        CompatibilityThrowHelpers.ThrowIfNullOrWhiteSpace(name);
         _applicationMetrics.TryRemove(name, out _);
         _applicationCounterPreviousValues.TryRemove(name, out _);
     }
@@ -262,7 +262,7 @@ internal sealed class ClientTelemetryMetricCollector
                 continue;
             }
 
-            if (!double.IsFinite(value))
+            if (!CompatibilityBcl.IsFinite(value))
             {
                 continue;
             }

--- a/src/Dekaf/Telemetry/ClientTelemetryPayloadProvider.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryPayloadProvider.cs
@@ -148,7 +148,7 @@ internal sealed class ClientTelemetryPayloadProvider : IClientTelemetryPayloadPr
         WriteTag(writer, fieldNumber, WireLengthDelimited);
         WriteVarint(writer, (ulong)byteCount);
         var span = writer.GetSpan(byteCount);
-        var written = System.Text.Encoding.UTF8.GetBytes(value, span);
+        var written = CompatibilityBcl.GetUtf8Bytes(value, span);
         writer.Advance(written);
     }
 
@@ -168,7 +168,7 @@ internal sealed class ClientTelemetryPayloadProvider : IClientTelemetryPayloadPr
 
     private static void WriteDoubleField(IBufferWriter<byte> writer, int fieldNumber, double value)
     {
-        WriteFixed64Field(writer, fieldNumber, (ulong)BitConverter.DoubleToInt64Bits(value));
+        WriteFixed64Field(writer, fieldNumber, (ulong)CompatibilityBcl.DoubleToInt64Bits(value));
     }
 
     private static void WriteTag(IBufferWriter<byte> writer, int fieldNumber, int wireType) =>
@@ -201,7 +201,7 @@ internal sealed class ClientTelemetryPayloadProvider : IClientTelemetryPayloadPr
 
     private static long GetUnixTimeNanoseconds()
     {
-        var ticksSinceUnixEpoch = DateTimeOffset.UtcNow.UtcTicks - DateTime.UnixEpoch.Ticks;
+        var ticksSinceUnixEpoch = DateTimeOffset.UtcNow.UtcTicks - CompatibilityBcl.UnixEpoch.Ticks;
         return checked(ticksSinceUnixEpoch * 100);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Internal/CompatibilityBclTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/CompatibilityBclTests.cs
@@ -1,0 +1,44 @@
+using System.Security.Cryptography;
+using System.Text;
+using Dekaf.Internal;
+
+namespace Dekaf.Tests.Unit.Internal;
+
+public class CompatibilityBclTests
+{
+    [Test]
+    public async Task GuidBigEndian_RoundTripsNetworkOrder()
+    {
+        var guid = new Guid("00112233-4455-6677-8899-aabbccddeeff");
+        var bytes = new byte[16];
+
+        var written = CompatibilityBcl.TryWriteGuidBigEndian(guid, bytes);
+        var parsed = CompatibilityBcl.ReadGuidBigEndian(bytes);
+
+        await Assert.That(written).IsTrue();
+        await Assert.That(Convert.ToHexString(bytes)).IsEqualTo("00112233445566778899AABBCCDDEEFF");
+        await Assert.That(parsed).IsEqualTo(guid);
+    }
+
+    [Test]
+    public async Task Pbkdf2_Sha256_MatchesKnownVector()
+    {
+        var result = CompatibilityBcl.Pbkdf2(
+            Encoding.ASCII.GetBytes("password"),
+            Encoding.ASCII.GetBytes("salt"),
+            iterations: 1,
+            HashAlgorithmName.SHA256,
+            outputLength: 32);
+
+        await Assert.That(Convert.ToHexString(result)).IsEqualTo(
+            "120FB6CFFCF8B32C43E7225256C4F837A86548C92CCC35480805987CB70BE17B");
+    }
+
+    [Test]
+    public async Task Base64UrlEncode_UsesUrlAlphabetAndOmitsPadding()
+    {
+        var encoded = CompatibilityBcl.Base64UrlEncode([0xfb, 0xff]);
+
+        await Assert.That(encoded).IsEqualTo("-_8");
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Networking/ClientDnsLookupTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ClientDnsLookupTests.cs
@@ -68,7 +68,7 @@ public sealed class ClientDnsLookupTests
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
         var acceptTask = listener.AcceptSocketAsync();
         var resolver = new ClientDnsEndpointResolver(new StubDnsLookup(
-            addresses: [IPAddress.Parse("127.0.0.2"), IPAddress.Loopback]));
+            addresses: [IPAddress.IPv6Loopback, IPAddress.Loopback]));
 
         await using var connection = new KafkaConnection(
             "multi.example",

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
@@ -171,11 +171,11 @@ public class StickyPartitionerTests
     {
         var partitioner = new StickyPartitioner();
 
-        // Set counter to near uint.MaxValue using reflection
+        // Counter is stored as int for Interlocked compatibility, then interpreted as uint for modulo.
         var counterField = typeof(StickyPartitioner).GetField("_counter",
             BindingFlags.NonPublic | BindingFlags.Instance);
         await Assert.That(counterField).IsNotNull();
-        counterField!.SetValue(partitioner, uint.MaxValue - 100);
+        counterField!.SetValue(partitioner, unchecked((int)(uint.MaxValue - 100)));
 
         // Call partition and OnBatchComplete many times around the overflow point
         for (var i = 0; i < 200; i++)
@@ -195,11 +195,11 @@ public class StickyPartitionerTests
         var partitioner = new StickyPartitioner();
         const int partitionCount = 10;
 
-        // Set counter to uint.MaxValue - 1
+        // Counter is stored as int for Interlocked compatibility, then interpreted as uint for modulo.
         var counterField = typeof(StickyPartitioner).GetField("_counter",
             BindingFlags.NonPublic | BindingFlags.Instance);
         await Assert.That(counterField).IsNotNull();
-        counterField!.SetValue(partitioner, uint.MaxValue - 1);
+        counterField!.SetValue(partitioner, unchecked((int)(uint.MaxValue - 1)));
 
         // Trigger overflow with OnBatchComplete
         partitioner.OnBatchComplete("test-topic", partitionCount);


### PR DESCRIPTION
## Summary
- add netstandard2.0 BCL/compiler compatibility helpers and target-specific fallbacks for core paths
- keep net10 paths on modern APIs while the forced netstandard2.0 core probe compiles clean
- document target-specific limitations and add focused helper tests

## Test plan
- [x] dotnet build src\Dekaf\Dekaf.csproj --configuration Release -p:TargetFramework=netstandard2.0 -p:TargetFrameworks=netstandard2.0 --no-incremental -v:minimal
- [x] dotnet build src\Dekaf\Dekaf.csproj --configuration Release --no-incremental -v:minimal
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release -v:minimal
- [x] tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe
- [x] npm run build --prefix docs
- [x] git diff --check

Closes #1300