### PR TITLE
ci(aot): publish NativeAOT smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,38 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  nativeaot-smoke:
+    name: NativeAOT Smoke
+    needs: build-and-unit-test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-quality: 'preview'
+
+      - name: Install NativeAOT prerequisites
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Publish NativeAOT smoke apps
+        run: |
+          set -euo pipefail
+          dotnet publish tests/Dekaf.Tests.Aot/Dekaf.Tests.Aot.csproj --configuration Release --runtime linux-x64 --output artifacts/nativeaot/Dekaf.Tests.Aot
+          dotnet publish tests/Dekaf.Tests.Aot.DependencyInjection/Dekaf.Tests.Aot.DependencyInjection.csproj --configuration Release --runtime linux-x64 --output artifacts/nativeaot/Dekaf.Tests.Aot.DependencyInjection
+
+      - name: Run published NativeAOT smoke apps
+        run: |
+          set -euo pipefail
+          ./artifacts/nativeaot/Dekaf.Tests.Aot/Dekaf.Tests.Aot
+          ./artifacts/nativeaot/Dekaf.Tests.Aot.DependencyInjection/Dekaf.Tests.Aot.DependencyInjection
+
   integration-tests:
     name: Integration Tests (${{ matrix.category }})
     needs: build-and-unit-test

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -64,3 +64,16 @@ Register `ISerializer<T>` and `IDeserializer<T>` in DI when your application use
 `InMemoryAdminClient` supports common unit-test operations such as creating, deleting, listing, and describing topics, altering/listing group offsets, deleting records, creating partitions, and listing offsets. Broker-only APIs such as ACL, SCRAM, and config mutation are accepted as no-ops or return empty results.
 
 Use Testcontainers or another real broker for protocol compatibility and integration coverage.
+
+## NativeAOT smoke
+
+CI publishes and runs the NativeAOT smoke executables on `linux-x64` for pull requests. Run the same checks locally with:
+
+```bash
+dotnet publish tests/Dekaf.Tests.Aot/Dekaf.Tests.Aot.csproj --configuration Release --runtime linux-x64 --output artifacts/nativeaot/Dekaf.Tests.Aot
+dotnet publish tests/Dekaf.Tests.Aot.DependencyInjection/Dekaf.Tests.Aot.DependencyInjection.csproj --configuration Release --runtime linux-x64 --output artifacts/nativeaot/Dekaf.Tests.Aot.DependencyInjection
+./artifacts/nativeaot/Dekaf.Tests.Aot/Dekaf.Tests.Aot
+./artifacts/nativeaot/Dekaf.Tests.Aot.DependencyInjection/Dekaf.Tests.Aot.DependencyInjection
+```
+
+Use the matching RID and executable name for non-Linux hosts, for example `win-x64` and `Dekaf.Tests.Aot.exe` on Windows. NativeAOT publish requires the platform native toolchain.

--- a/tests/Dekaf.Tests.Aot/Dekaf.Tests.Aot.csproj
+++ b/tests/Dekaf.Tests.Aot/Dekaf.Tests.Aot.csproj
@@ -10,6 +10,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Serialization.Json\Dekaf.Serialization.Json.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dekaf.Tests.Aot/Program.cs
+++ b/tests/Dekaf.Tests.Aot/Program.cs
@@ -1,6 +1,11 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Globalization;
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json.Serialization;
+using Dekaf.SchemaRegistry;
 using Dekaf.Serialization;
 using Dekaf.Security.Sasl;
 
@@ -20,6 +25,54 @@ internal static class AotSmoke
         var headers = Headers.Create("aot", "ok");
         Require(headers.Count == 1, "Header smoke failed.");
         Require(headers[0].Key == "aot", "Header key mismatch.");
+
+        RunJsonSerializationSmoke();
+        await RunJsonSchemaRegistrySmokeAsync();
+    }
+
+    private static void RunJsonSerializationSmoke()
+    {
+        var serializer = new Dekaf.Serialization.Json.JsonSerializer<AotOrder>(
+            AotJsonContext.Default.AotOrder);
+        var context = new SerializationContext
+        {
+            Topic = "aot-orders",
+            Component = SerializationComponent.Value
+        };
+        var expected = new AotOrder(42, "native");
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(expected, ref buffer, context);
+        var actual = serializer.Deserialize(buffer.WrittenMemory, context);
+
+        Require(actual == expected, "JSON source-generated serde roundtrip failed.");
+    }
+
+    private static async Task RunJsonSchemaRegistrySmokeAsync()
+    {
+        using var registry = new InMemorySchemaRegistryClient();
+        await using var serializer = new JsonSchemaRegistrySerializer<AotOrder>(
+            registry,
+            AotOrderSchema,
+            AotJsonContext.Default.AotOrder);
+        await using var deserializer = new JsonSchemaRegistryDeserializer<AotOrder>(
+            registry,
+            AotJsonContext.Default.AotOrder);
+        var context = new SerializationContext
+        {
+            Topic = "aot-orders",
+            Component = SerializationComponent.Value
+        };
+        var expected = new AotOrder(7, "schema-registry");
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(expected, ref buffer, context);
+        var actual = deserializer.Deserialize(buffer.WrittenMemory, context);
+        var schemaId = BinaryPrimitives.ReadInt32BigEndian(buffer.WrittenSpan.Slice(1, 4));
+
+        Require(buffer.WrittenSpan[0] == 0, "Schema Registry magic byte mismatch.");
+        Require(schemaId > 0, "Schema Registry schema ID missing.");
+        Require(actual == expected, "JSON Schema Registry source-generated roundtrip failed.");
     }
 
     private static OAuthBearerConfig CreateJwtBearerConfig(RSA rsa) =>
@@ -59,6 +112,17 @@ internal static class AotSmoke
             throw new InvalidOperationException(message);
     }
 
+    private const string AotOrderSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "id": { "type": "integer" },
+            "customer": { "type": "string" }
+          },
+          "required": ["id", "customer"]
+        }
+        """;
+
     private sealed class TokenEndpointHandler : HttpMessageHandler
     {
         protected override async Task<HttpResponseMessage> SendAsync(
@@ -77,4 +141,165 @@ internal static class AotSmoke
             };
         }
     }
+
+    private sealed class InMemorySchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistryCache
+    {
+        private readonly Dictionary<int, Schema> _schemasById = [];
+        private readonly Dictionary<string, List<RegisteredSchema>> _schemasBySubject = [];
+        private int _nextId = 1;
+        private bool _disposed;
+
+        public Task<int> RegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            if (!_schemasBySubject.TryGetValue(subject, out var schemas))
+            {
+                schemas = [];
+                _schemasBySubject[subject] = schemas;
+            }
+
+            var id = _nextId++;
+            var registered = new RegisteredSchema
+            {
+                Id = id,
+                Subject = subject,
+                Version = schemas.Count + 1,
+                Schema = schema
+            };
+
+            _schemasById[id] = schema;
+            schemas.Add(registered);
+            return Task.FromResult(id);
+        }
+
+        public Task<Schema> GetSchemaAsync(int id, CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            if (_schemasById.TryGetValue(id, out var schema))
+                return Task.FromResult(schema);
+
+            throw new InvalidOperationException($"Schema {id} not found.");
+        }
+
+        public bool TryGetCachedSchema(int id, out Schema schema)
+        {
+            ThrowIfDisposed();
+            return _schemasById.TryGetValue(id, out schema!);
+        }
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version = "latest",
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            var registered = FindSchemaBySubject(subject, version);
+            return Task.FromResult(registered);
+        }
+
+        public Task<int> GetOrRegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            if (_schemasBySubject.TryGetValue(subject, out var schemas))
+            {
+                foreach (var registered in schemas)
+                {
+                    if (registered.Schema.SchemaType == schema.SchemaType
+                        && string.Equals(registered.Schema.SchemaString, schema.SchemaString, StringComparison.Ordinal))
+                    {
+                        return Task.FromResult(registered.Id);
+                    }
+                }
+            }
+
+            return RegisterSchemaAsync(subject, schema, cancellationToken);
+        }
+
+        public Task<IReadOnlyList<string>> GetAllSubjectsAsync(CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            return Task.FromResult<IReadOnlyList<string>>([.. _schemasBySubject.Keys]);
+        }
+
+        public Task<IReadOnlyList<int>> GetVersionsAsync(
+            string subject,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            if (!_schemasBySubject.TryGetValue(subject, out var schemas))
+                throw new InvalidOperationException($"Subject '{subject}' not found.");
+
+            return Task.FromResult<IReadOnlyList<int>>([.. schemas.Select(static schema => schema.Version)]);
+        }
+
+        public Task<bool> IsCompatibleAsync(
+            string subject,
+            Schema schema,
+            string version = "latest",
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            return Task.FromResult(true);
+        }
+
+        public Task<IReadOnlyList<int>> DeleteSubjectAsync(
+            string subject,
+            bool permanent = false,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+
+            if (!_schemasBySubject.Remove(subject, out var schemas))
+                throw new InvalidOperationException($"Subject '{subject}' not found.");
+
+            foreach (var registered in schemas)
+            {
+                _schemasById.Remove(registered.Id);
+            }
+
+            return Task.FromResult<IReadOnlyList<int>>([.. schemas.Select(static schema => schema.Version)]);
+        }
+
+        public void Dispose()
+        {
+            _disposed = true;
+        }
+
+        private RegisteredSchema FindSchemaBySubject(string subject, string version)
+        {
+            if (!_schemasBySubject.TryGetValue(subject, out var schemas) || schemas.Count == 0)
+                throw new InvalidOperationException($"Subject '{subject}' not found.");
+
+            if (string.Equals(version, "latest", StringComparison.Ordinal))
+                return schemas[^1];
+
+            if (!int.TryParse(version, NumberStyles.None, CultureInfo.InvariantCulture, out var requestedVersion))
+                throw new InvalidOperationException($"Schema version '{version}' is invalid.");
+
+            foreach (var schema in schemas)
+            {
+                if (schema.Version == requestedVersion)
+                    return schema;
+            }
+
+            throw new InvalidOperationException($"Version '{version}' not found for subject '{subject}'.");
+        }
+
+        private void ThrowIfDisposed()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+        }
+    }
 }
+
+internal sealed record AotOrder(int Id, string Customer);
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(AotOrder))]
+internal sealed partial class AotJsonContext : JsonSerializerContext;


### PR DESCRIPTION
## Summary
- add a CI NativeAOT smoke job that publishes and runs both smoke executables on linux-x64
- expand the core AOT smoke app to cover source-generated JSON and JSON Schema Registry roundtrips
- document local NativeAOT publish/run commands

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Aot\Dekaf.Tests.Aot.csproj --configuration Release
- [x] dotnet run --project tests\Dekaf.Tests.Aot\Dekaf.Tests.Aot.csproj --configuration Release --no-build
- [x] dotnet build tests\Dekaf.Tests.Aot.DependencyInjection\Dekaf.Tests.Aot.DependencyInjection.csproj --configuration Release
- [x] dotnet run --project tests\Dekaf.Tests.Aot.DependencyInjection\Dekaf.Tests.Aot.DependencyInjection.csproj --configuration Release --no-build
- [x] npm run build --prefix docs
- [x] git diff --check

Local win-x64 NativeAOT publish reached ILCompiler but stopped because this machine lacks the Windows platform linker / Visual Studio C++ workload. The CI job installs clang/zlib and runs the linux-x64 publish.

Closes #1306
