### PR TITLE
fix(core): unblock netstandard compile

### DIFF
--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -61,15 +61,25 @@ dotnet build src/Dekaf/Dekaf.csproj --configuration Release `
   -p:TargetFramework=netstandard2.0
 ```
 
-The probe is still expected to fail until #1300 removes or isolates the remaining core API blockers. Current blocker categories:
+The #1300 pass removes the core compile blocker layer. The forced probe now builds cleanly:
 
-- Runtime intrinsics: `System.Runtime.Intrinsics` is not available as a `netstandard2.0` package, so the CRC/vectorized record batch paths need conditional fallbacks.
-- Modern collection and threading APIs: `IReadOnlySet<T>`, `System.Threading.Lock`, `PeriodicTimer`, non-generic `TaskCompletionSource`, and `Task.WaitAsync`.
-- Runtime feature constraints: static abstract interface members, by-ref-like generics, and ref fields are not supported by the `netstandard2.0` target runtime.
-- Buffer and stream APIs: `SequenceReader<T>`, `ArrayBufferWriter<T>`, and span-based `Stream.Write(ReadOnlySpan<byte>)` need compatibility paths.
-- TLS/GSSAPI APIs: `SslClientAuthenticationOptions`, `NegotiateAuthentication`, and `NegotiateAuthenticationClientOptions` need target-specific handling.
+```bash
+dotnet build src/Dekaf/Dekaf.csproj --configuration Release `
+  -p:TargetFrameworks=netstandard2.0 `
+  -p:TargetFramework=netstandard2.0
+```
 
-This baseline does not declare package support for `netstandard2.0`; it only makes the next compile-blocker work measurable.
+This pass includes:
+
+- CRC32C hardware intrinsics are guarded so `netstandard2.0` uses the existing software CRC path.
+- `IReadOnlySet<T>` public and internal surfaces are target-aliased to `IReadOnlyCollection<T>` for `netstandard2.0`.
+- `System.Threading.Lock`, `PeriodicTimer`, non-generic `TaskCompletionSource`, `Task.WaitAsync`, `CancellationTokenSource.CancelAsync`, `ArrayBufferWriter<T>`, `SequenceReader<T>`, `Index`, `Range`, `HashCode`, `ValueTask.CompletedTask`, and related BCL helpers have conditional compatibility shims.
+- Span-based compression stream APIs use array-based stream calls on `netstandard2.0`.
+- Generic protocol send/read paths no longer require static abstract interface members for `netstandard2.0`; `net10.0` keeps static interface dispatch through the metadata helper.
+- TLS authentication uses the older `SslStream.AuthenticateAsClientAsync` overload on `netstandard2.0`.
+- GSSAPI remains part of the API surface, but using it on `netstandard2.0` throws `PlatformNotSupportedException` because `NegotiateAuthentication` is unavailable there.
+
+This baseline does not declare package support for `netstandard2.0`; it makes the core compile state clean so packaging and runtime validation can proceed separately.
 
 ## Blocker Categories
 

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1672,7 +1672,7 @@ public sealed class AdminClient : IAdminClient
                     break;
 
                 case UserScramCredentialUpsertion upsertion:
-                    var salt = upsertion.Salt ?? RandomNumberGenerator.GetBytes(32);
+                    var salt = upsertion.Salt ?? Dekaf.Compatibility.RandomNumberGeneratorCompat.GetBytes(32);
                     var saltedPassword = ComputeSaltedPassword(
                         upsertion.Password,
                         salt,

--- a/src/Dekaf/Compatibility/Net10CompatibilityForwarders.cs
+++ b/src/Dekaf/Compatibility/Net10CompatibilityForwarders.cs
@@ -1,0 +1,31 @@
+#if !NETSTANDARD2_0
+using System.Security.Cryptography;
+
+namespace Dekaf.Compatibility;
+
+internal static class EnvironmentCompat
+{
+    public static long TickCount64 => Environment.TickCount64;
+}
+
+internal static class ObjectDisposedExceptionCompat
+{
+    public static void ThrowIf(bool condition, object? instance)
+        => ObjectDisposedException.ThrowIf(condition, instance!);
+}
+
+internal static class RandomNumberGeneratorCompat
+{
+    public static byte[] GetBytes(int count)
+        => RandomNumberGenerator.GetBytes(count);
+}
+
+internal static class GuidCompatibility
+{
+    public static Guid ReadBigEndian(ReadOnlySpan<byte> source)
+        => new(source, bigEndian: true);
+
+    public static void WriteBigEndian(Guid value, Span<byte> destination)
+        => value.TryWriteBytes(destination, bigEndian: true, out _);
+}
+#endif

--- a/src/Dekaf/Compatibility/Net10ValueTaskForwarders.cs
+++ b/src/Dekaf/Compatibility/Net10ValueTaskForwarders.cs
@@ -1,0 +1,11 @@
+#if !NETSTANDARD2_0
+namespace System.Threading.Tasks;
+
+internal static class ValueTaskCompatibility
+{
+    public static ValueTask CompletedTask => ValueTask.CompletedTask;
+
+    public static ValueTask<T> FromException<T>(Exception exception)
+        => ValueTask.FromException<T>(exception);
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20Base64Url.cs
+++ b/src/Dekaf/Compatibility/NetStandard20Base64Url.cs
@@ -1,0 +1,12 @@
+#if NETSTANDARD2_0
+namespace System.Buffers.Text;
+
+internal static class Base64Url
+{
+    public static string EncodeToString(ReadOnlySpan<byte> bytes)
+    {
+        var text = Convert.ToBase64String(bytes.ToArray());
+        return text.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20BufferShims.cs
+++ b/src/Dekaf/Compatibility/NetStandard20BufferShims.cs
@@ -67,7 +67,7 @@ namespace System.Buffers
 
             var currentLength = _buffer.Length;
             var growBy = Math.Max(sizeHint, currentLength);
-            var newSize = currentLength == 0 ? growBy : currentLength + growBy;
+            var newSize = currentLength == 0 ? Math.Max(growBy, DefaultInitialBufferSize) : currentLength + growBy;
             if ((uint)newSize > ArrayMaxLength)
             {
                 newSize = Math.Max(currentLength + sizeHint, ArrayMaxLength);
@@ -97,7 +97,7 @@ namespace System.Buffers
         public readonly long Remaining => _sequence.Length - _consumed;
         public readonly bool End => Remaining == 0;
         public readonly ReadOnlySequence<T> UnreadSequence => _sequence.Slice(_position);
-        public readonly ReadOnlySpan<T> UnreadSpan => UnreadSequence.First.Span;
+        public readonly ReadOnlySpan<T> UnreadSpan => GetUnreadSpan(_sequence, _position);
 
         public bool TryRead(out T value)
         {
@@ -107,8 +107,7 @@ namespace System.Buffers
                 return false;
             }
 
-            var span = UnreadSpan;
-            if (span.Length == 0)
+            if (!TryMoveToNonEmptySpan(out var span))
             {
                 value = default!;
                 return false;
@@ -135,6 +134,37 @@ namespace System.Buffers
 
             _position = _sequence.GetPosition(count, _position);
             _consumed += count;
+        }
+
+        private bool TryMoveToNonEmptySpan(out ReadOnlySpan<T> span)
+        {
+            var current = _position;
+            var next = current;
+            while (_sequence.TryGet(ref next, out var memory))
+            {
+                if (memory.Length != 0)
+                {
+                    span = memory.Span;
+                    _position = current;
+                    return true;
+                }
+
+                current = next;
+            }
+
+            span = default;
+            return false;
+        }
+
+        private static ReadOnlySpan<T> GetUnreadSpan(ReadOnlySequence<T> sequence, SequencePosition position)
+        {
+            while (sequence.TryGet(ref position, out var memory))
+            {
+                if (memory.Length != 0)
+                    return memory.Span;
+            }
+
+            return default;
         }
     }
 }

--- a/src/Dekaf/Compatibility/NetStandard20BufferShims.cs
+++ b/src/Dekaf/Compatibility/NetStandard20BufferShims.cs
@@ -1,0 +1,141 @@
+#if NETSTANDARD2_0
+namespace System.Buffers
+{
+    internal sealed class ArrayBufferWriter<T> : IBufferWriter<T>
+    {
+        private const int DefaultInitialBufferSize = 256;
+        private const int ArrayMaxLength = 0x7FFFFFC7;
+
+        private T[] _buffer;
+        private int _index;
+
+        public ArrayBufferWriter()
+            : this(DefaultInitialBufferSize)
+        {
+        }
+
+        public ArrayBufferWriter(int initialCapacity)
+        {
+            if (initialCapacity < 0)
+                throw new ArgumentOutOfRangeException(nameof(initialCapacity));
+
+            _buffer = initialCapacity == 0 ? Array.Empty<T>() : new T[initialCapacity];
+        }
+
+        public ReadOnlyMemory<T> WrittenMemory => _buffer.AsMemory(0, _index);
+        public ReadOnlySpan<T> WrittenSpan => _buffer.AsSpan(0, _index);
+        public int WrittenCount => _index;
+        public int Capacity => _buffer.Length;
+        public int FreeCapacity => _buffer.Length - _index;
+
+        public void Advance(int count)
+        {
+            if ((uint)count > (uint)FreeCapacity)
+                throw new ArgumentException("Cannot advance past the end of the buffer.", nameof(count));
+
+            _index += count;
+        }
+
+        public Memory<T> GetMemory(int sizeHint = 0)
+        {
+            CheckAndResizeBuffer(sizeHint);
+            return _buffer.AsMemory(_index);
+        }
+
+        public Span<T> GetSpan(int sizeHint = 0)
+        {
+            CheckAndResizeBuffer(sizeHint);
+            return _buffer.AsSpan(_index);
+        }
+
+        public void Clear()
+        {
+            _buffer.AsSpan(0, _index).Clear();
+            _index = 0;
+        }
+
+        private void CheckAndResizeBuffer(int sizeHint)
+        {
+            if (sizeHint < 0)
+                throw new ArgumentOutOfRangeException(nameof(sizeHint));
+
+            if (sizeHint == 0)
+                sizeHint = 1;
+
+            if (sizeHint <= FreeCapacity)
+                return;
+
+            var currentLength = _buffer.Length;
+            var growBy = Math.Max(sizeHint, currentLength);
+            var newSize = currentLength == 0 ? growBy : currentLength + growBy;
+            if ((uint)newSize > ArrayMaxLength)
+            {
+                newSize = Math.Max(currentLength + sizeHint, ArrayMaxLength);
+            }
+
+            if (newSize < currentLength + sizeHint)
+                throw new InvalidOperationException("Cannot grow buffer: maximum size reached.");
+
+            Array.Resize(ref _buffer, newSize);
+        }
+    }
+
+    internal ref struct SequenceReader<T>
+    {
+        private readonly ReadOnlySequence<T> _sequence;
+        private SequencePosition _position;
+        private long _consumed;
+
+        public SequenceReader(ReadOnlySequence<T> sequence)
+        {
+            _sequence = sequence;
+            _position = sequence.Start;
+            _consumed = 0;
+        }
+
+        public readonly long Consumed => _consumed;
+        public readonly long Remaining => _sequence.Length - _consumed;
+        public readonly bool End => Remaining == 0;
+        public readonly ReadOnlySequence<T> UnreadSequence => _sequence.Slice(_position);
+        public readonly ReadOnlySpan<T> UnreadSpan => UnreadSequence.First.Span;
+
+        public bool TryRead(out T value)
+        {
+            if (End)
+            {
+                value = default!;
+                return false;
+            }
+
+            var span = UnreadSpan;
+            if (span.Length == 0)
+            {
+                value = default!;
+                return false;
+            }
+
+            value = span[0];
+            Advance(1);
+            return true;
+        }
+
+        public readonly bool TryCopyTo(Span<T> destination)
+        {
+            if (Remaining < destination.Length)
+                return false;
+
+            UnreadSequence.Slice(0, destination.Length).CopyTo(destination);
+            return true;
+        }
+
+        public void Advance(long count)
+        {
+            if ((ulong)count > (ulong)Remaining)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
+            _position = _sequence.GetPosition(count, _position);
+            _consumed += count;
+        }
+    }
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20CollectionExtensions.cs
+++ b/src/Dekaf/Compatibility/NetStandard20CollectionExtensions.cs
@@ -1,0 +1,65 @@
+#if NETSTANDARD2_0
+namespace System.Collections.Generic;
+
+internal static class KeyValuePairCompatibilityExtensions
+{
+    public static void Deconstruct<TKey, TValue>(
+        this KeyValuePair<TKey, TValue> pair,
+        out TKey key,
+        out TValue value)
+    {
+        key = pair.Key;
+        value = pair.Value;
+    }
+
+    public static bool TryDequeue<T>(this Queue<T> queue, out T result)
+    {
+        if (queue.Count == 0)
+        {
+            result = default!;
+            return false;
+        }
+
+        result = queue.Dequeue();
+        return true;
+    }
+
+    public static TValue? GetValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key)
+        where TKey : notnull
+        => dictionary.TryGetValue(key, out var value) ? value : default;
+
+    public static TValue GetValueOrDefault<TKey, TValue>(
+        this Dictionary<TKey, TValue> dictionary,
+        TKey key,
+        TValue defaultValue)
+        where TKey : notnull
+        => dictionary.TryGetValue(key, out var value) ? value : defaultValue;
+
+    public static bool TryAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        where TKey : notnull
+    {
+        if (dictionary.ContainsKey(key))
+            return false;
+
+        dictionary.Add(key, value);
+        return true;
+    }
+
+    public static bool Remove<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, out TValue value)
+        where TKey : notnull
+    {
+        if (!dictionary.TryGetValue(key, out value!))
+            return false;
+
+        dictionary.Remove(key);
+        return true;
+    }
+
+    public static int EnsureCapacity<T>(this List<T> list, int capacity)
+    {
+        if (list.Capacity < capacity)
+            list.Capacity = capacity;
+        return list.Capacity;
+    }
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20CompatCore.cs
+++ b/src/Dekaf/Compatibility/NetStandard20CompatCore.cs
@@ -1,0 +1,570 @@
+#if NETSTANDARD2_0
+namespace Dekaf.Compatibility;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+
+internal class ArgumentExceptionCompat : System.ArgumentException
+{
+    public ArgumentExceptionCompat()
+    {
+    }
+
+    public ArgumentExceptionCompat(string? message)
+        : base(message)
+    {
+    }
+
+    public ArgumentExceptionCompat(string? message, string? paramName)
+        : base(message, paramName)
+    {
+    }
+
+    public static void ThrowIfNullOrEmpty([NotNull] string? argument, string? paramName = null)
+    {
+        if (argument is null)
+            throw new System.ArgumentNullException(paramName);
+        if (argument.Length == 0)
+            throw new System.ArgumentException("Value cannot be empty.", paramName);
+    }
+
+    public static void ThrowIfNullOrWhiteSpace([NotNull] string? argument, string? paramName = null)
+    {
+        if (argument is null)
+            throw new System.ArgumentNullException(paramName);
+        if (string.IsNullOrWhiteSpace(argument))
+            throw new System.ArgumentException("Value cannot be empty or whitespace.", paramName);
+    }
+}
+
+internal class ArgumentNullExceptionCompat : System.ArgumentNullException
+{
+    public ArgumentNullExceptionCompat()
+    {
+    }
+
+    public ArgumentNullExceptionCompat(string? paramName)
+        : base(paramName)
+    {
+    }
+
+    public ArgumentNullExceptionCompat(string? paramName, string? message)
+        : base(paramName, message)
+    {
+    }
+
+    public static void ThrowIfNull([NotNull] object? argument, string? paramName = null)
+    {
+        if (argument is null)
+            throw new System.ArgumentNullException(paramName);
+    }
+
+    public static void ThrowIfNullOrEmpty([NotNull] string? argument, string? paramName = null)
+        => ArgumentExceptionCompat.ThrowIfNullOrEmpty(argument, paramName);
+}
+
+internal class ArgumentOutOfRangeExceptionCompat : System.ArgumentOutOfRangeException
+{
+    public ArgumentOutOfRangeExceptionCompat()
+    {
+    }
+
+    public ArgumentOutOfRangeExceptionCompat(string? paramName)
+        : base(paramName)
+    {
+    }
+
+    public ArgumentOutOfRangeExceptionCompat(string? paramName, string? message)
+        : base(paramName, message)
+    {
+    }
+
+    public ArgumentOutOfRangeExceptionCompat(string? paramName, object? actualValue, string? message)
+        : base(paramName, actualValue, message)
+    {
+    }
+
+    public static void ThrowIfGreaterThan<T>(T value, T other, string? paramName = null)
+        where T : IComparable<T>
+    {
+        if (value.CompareTo(other) > 0)
+            throw new System.ArgumentOutOfRangeException(paramName, value, $"Value must be less than or equal to {other}.");
+    }
+
+    public static void ThrowIfGreaterThanOrEqual<T>(T value, T other, string? paramName = null)
+        where T : IComparable<T>
+    {
+        if (value.CompareTo(other) >= 0)
+            throw new System.ArgumentOutOfRangeException(paramName, value, $"Value must be less than {other}.");
+    }
+
+    public static void ThrowIfLessThan<T>(T value, T other, string? paramName = null)
+        where T : IComparable<T>
+    {
+        if (value.CompareTo(other) < 0)
+            throw new System.ArgumentOutOfRangeException(paramName, value, $"Value must be greater than or equal to {other}.");
+    }
+
+    public static void ThrowIfNegative<T>(T value, string? paramName = null)
+        where T : struct, IComparable<T>
+    {
+        if (value.CompareTo(default) < 0)
+            throw new System.ArgumentOutOfRangeException(paramName, value, "Value must be non-negative.");
+    }
+
+    public static void ThrowIfNegativeOrZero<T>(T value, string? paramName = null)
+        where T : struct, IComparable<T>
+    {
+        if (value.CompareTo(default) <= 0)
+            throw new System.ArgumentOutOfRangeException(paramName, value, "Value must be positive.");
+    }
+
+    public static void ThrowIfZero<T>(T value, string? paramName = null)
+        where T : struct, IComparable<T>
+    {
+        if (value.CompareTo(default) == 0)
+            throw new System.ArgumentOutOfRangeException(paramName, value, "Value must be non-zero.");
+    }
+}
+
+internal static class ArrayCompat
+{
+    public const int MaxLength = 0x7FFFFFC7;
+
+    public static T[] Empty<T>() => System.Array.Empty<T>();
+
+    public static void Resize<T>(ref T[] array, int newSize) => System.Array.Resize(ref array, newSize);
+
+    public static void Copy(System.Array sourceArray, System.Array destinationArray, int length)
+        => System.Array.Copy(sourceArray, destinationArray, length);
+
+    public static void Copy(System.Array sourceArray, int sourceIndex, System.Array destinationArray, int destinationIndex, int length)
+        => System.Array.Copy(sourceArray, sourceIndex, destinationArray, destinationIndex, length);
+
+    public static int FindIndex<T>(T[] array, Predicate<T> match) => System.Array.FindIndex(array, match);
+
+    public static void Clear(System.Array array) => System.Array.Clear(array, 0, array.Length);
+
+    public static void Clear(System.Array array, int index, int length) => System.Array.Clear(array, index, length);
+
+    public static void Fill<T>(T[] array, T value)
+    {
+        for (var i = 0; i < array.Length; i++)
+            array[i] = value;
+    }
+}
+
+internal static class BinaryPrimitivesCompat
+{
+    public static short ReadInt16BigEndian(ReadOnlySpan<byte> source)
+        => System.Buffers.Binary.BinaryPrimitives.ReadInt16BigEndian(source);
+
+    public static int ReadInt32BigEndian(ReadOnlySpan<byte> source)
+        => System.Buffers.Binary.BinaryPrimitives.ReadInt32BigEndian(source);
+
+    public static int ReadInt32LittleEndian(ReadOnlySpan<byte> source)
+        => System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(source);
+
+    public static long ReadInt64BigEndian(ReadOnlySpan<byte> source)
+        => System.Buffers.Binary.BinaryPrimitives.ReadInt64BigEndian(source);
+
+    public static ushort ReadUInt16BigEndian(ReadOnlySpan<byte> source)
+        => System.Buffers.Binary.BinaryPrimitives.ReadUInt16BigEndian(source);
+
+    public static uint ReadUInt32BigEndian(ReadOnlySpan<byte> source)
+        => System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(source);
+
+    public static uint ReadUInt32LittleEndian(ReadOnlySpan<byte> source)
+        => System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(source);
+
+    public static ulong ReadUInt64LittleEndian(ReadOnlySpan<byte> source)
+        => System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(source);
+
+    public static float ReadSingleBigEndian(ReadOnlySpan<byte> source)
+        => BitConverter.ToSingle(ToEndianBytes(source, sizeof(float)), 0);
+
+    public static double ReadDoubleBigEndian(ReadOnlySpan<byte> source)
+        => BitConverter.ToDouble(ToEndianBytes(source, sizeof(double)), 0);
+
+    public static void WriteInt16BigEndian(Span<byte> destination, short value)
+        => System.Buffers.Binary.BinaryPrimitives.WriteInt16BigEndian(destination, value);
+
+    public static void WriteInt32BigEndian(Span<byte> destination, int value)
+        => System.Buffers.Binary.BinaryPrimitives.WriteInt32BigEndian(destination, value);
+
+    public static void WriteInt64BigEndian(Span<byte> destination, long value)
+        => System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(destination, value);
+
+    public static void WriteUInt16BigEndian(Span<byte> destination, ushort value)
+        => System.Buffers.Binary.BinaryPrimitives.WriteUInt16BigEndian(destination, value);
+
+    public static void WriteUInt32BigEndian(Span<byte> destination, uint value)
+        => System.Buffers.Binary.BinaryPrimitives.WriteUInt32BigEndian(destination, value);
+
+    public static void WriteUInt64LittleEndian(Span<byte> destination, ulong value)
+        => System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(destination, value);
+
+    public static void WriteSingleBigEndian(Span<byte> destination, float value)
+        => WriteEndianBytes(destination, BitConverter.GetBytes(value));
+
+    public static void WriteDoubleBigEndian(Span<byte> destination, double value)
+        => WriteEndianBytes(destination, BitConverter.GetBytes(value));
+
+    private static byte[] ToEndianBytes(ReadOnlySpan<byte> source, int length)
+    {
+        var bytes = source.Slice(0, length).ToArray();
+        if (BitConverter.IsLittleEndian)
+            System.Array.Reverse(bytes);
+        return bytes;
+    }
+
+    private static void WriteEndianBytes(Span<byte> destination, byte[] bytes)
+    {
+        if (BitConverter.IsLittleEndian)
+            System.Array.Reverse(bytes);
+        bytes.AsSpan().CopyTo(destination);
+    }
+}
+
+internal static class BitOperationsCompat
+{
+    public static int Log2(uint value)
+    {
+        var result = 0;
+        while ((value >>= 1) != 0)
+            result++;
+        return result;
+    }
+
+    public static int Log2(ulong value)
+    {
+        var result = 0;
+        while ((value >>= 1) != 0)
+            result++;
+        return result;
+    }
+
+    public static int RoundUpToPowerOf2(int value)
+    {
+        if (value <= 1)
+            return 1;
+
+        var current = (uint)value - 1;
+        current |= current >> 1;
+        current |= current >> 2;
+        current |= current >> 4;
+        current |= current >> 8;
+        current |= current >> 16;
+        return (int)(current + 1);
+    }
+
+    public static uint RoundUpToPowerOf2(uint value)
+    {
+        if (value <= 1)
+            return 1;
+
+        value--;
+        value |= value >> 1;
+        value |= value >> 2;
+        value |= value >> 4;
+        value |= value >> 8;
+        value |= value >> 16;
+        return value + 1;
+    }
+}
+
+internal static class GuidCompatibility
+{
+    public static Guid ReadBigEndian(ReadOnlySpan<byte> source)
+    {
+        Span<byte> bytes = stackalloc byte[16];
+        bytes[0] = source[3];
+        bytes[1] = source[2];
+        bytes[2] = source[1];
+        bytes[3] = source[0];
+        bytes[4] = source[5];
+        bytes[5] = source[4];
+        bytes[6] = source[7];
+        bytes[7] = source[6];
+        source.Slice(8, 8).CopyTo(bytes.Slice(8));
+        return new Guid(bytes.ToArray());
+    }
+
+    public static void WriteBigEndian(Guid value, Span<byte> destination)
+    {
+        var bytes = value.ToByteArray();
+        destination[0] = bytes[3];
+        destination[1] = bytes[2];
+        destination[2] = bytes[1];
+        destination[3] = bytes[0];
+        destination[4] = bytes[5];
+        destination[5] = bytes[4];
+        destination[6] = bytes[7];
+        destination[7] = bytes[6];
+        bytes.AsSpan(8, 8).CopyTo(destination.Slice(8));
+    }
+}
+
+internal static class ConvertCompat
+{
+    public static byte[] FromBase64String(string s) => System.Convert.FromBase64String(s);
+
+    public static string ToBase64String(byte[] inArray) => System.Convert.ToBase64String(inArray);
+
+    public static string ToHexString(ReadOnlySpan<byte> bytes)
+    {
+        var chars = new char[bytes.Length * 2];
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            var b = bytes[i];
+            chars[i * 2] = GetHexChar(b >> 4);
+            chars[(i * 2) + 1] = GetHexChar(b & 0xF);
+        }
+
+        return new string(chars);
+    }
+
+    private static char GetHexChar(int value)
+        => (char)(value < 10 ? '0' + value : 'A' + (value - 10));
+}
+
+internal static class DnsCompat
+{
+    public static Task<IPAddress[]> GetHostAddressesAsync(string hostNameOrAddress, CancellationToken cancellationToken)
+        => System.Net.Dns.GetHostAddressesAsync(hostNameOrAddress).WaitAsync(cancellationToken);
+
+    public static Task<IPHostEntry> GetHostEntryAsync(string hostNameOrAddress, CancellationToken cancellationToken)
+        => System.Net.Dns.GetHostEntryAsync(hostNameOrAddress).WaitAsync(cancellationToken);
+}
+
+internal static class FileCompat
+{
+    public static bool Exists(string? path) => System.IO.File.Exists(path);
+
+    public static string ReadAllText(string path) => System.IO.File.ReadAllText(path);
+
+    public static async Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken = default)
+    {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        var read = reader.ReadToEndAsync();
+        await read.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return await read.ConfigureAwait(false);
+    }
+
+    public static IEnumerable<string> ReadLines(string path) => System.IO.File.ReadLines(path);
+}
+
+internal static class GCCompat
+{
+    public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) => new T[length];
+
+    public static GCMemoryInfoCompat GetGCMemoryInfo()
+        => new((long)System.Math.Min(long.MaxValue, (double)System.Environment.WorkingSet + (1024.0 * 1024.0 * 1024.0)));
+}
+
+internal readonly struct GCMemoryInfoCompat
+{
+    public GCMemoryInfoCompat(long totalAvailableMemoryBytes)
+    {
+        TotalAvailableMemoryBytes = totalAvailableMemoryBytes;
+    }
+
+    public long TotalAvailableMemoryBytes { get; }
+}
+
+internal static class HMACSHA256Compat
+{
+    public static byte[] HashData(byte[] key, byte[] source)
+    {
+        using var hmac = new System.Security.Cryptography.HMACSHA256(key);
+        return hmac.ComputeHash(source);
+    }
+}
+
+internal static class HMACSHA512Compat
+{
+    public static byte[] HashData(byte[] key, byte[] source)
+    {
+        using var hmac = new System.Security.Cryptography.HMACSHA512(key);
+        return hmac.ComputeHash(source);
+    }
+}
+
+internal static class MathCompat
+{
+    public static short Max(short val1, short val2) => val1 > val2 ? val1 : val2;
+    public static uint Max(uint val1, uint val2) => val1 > val2 ? val1 : val2;
+    public static ulong Max(ulong val1, ulong val2) => val1 > val2 ? val1 : val2;
+    public static int Max(int val1, int val2) => System.Math.Max(val1, val2);
+    public static long Max(long val1, long val2) => System.Math.Max(val1, val2);
+    public static double Max(double val1, double val2) => System.Math.Max(val1, val2);
+    public static short Min(short val1, short val2) => val1 < val2 ? val1 : val2;
+    public static uint Min(uint val1, uint val2) => val1 < val2 ? val1 : val2;
+    public static ulong Min(ulong val1, ulong val2) => val1 < val2 ? val1 : val2;
+    public static int Min(int val1, int val2) => System.Math.Min(val1, val2);
+    public static long Min(long val1, long val2) => System.Math.Min(val1, val2);
+    public static double Min(double val1, double val2) => System.Math.Min(val1, val2);
+    public static double Ceiling(double a) => System.Math.Ceiling(a);
+    public static double Pow(double x, double y) => System.Math.Pow(x, y);
+    public static int Clamp(int value, int min, int max) => value < min ? min : value > max ? max : value;
+    public static long Clamp(long value, long min, long max) => value < min ? min : value > max ? max : value;
+    public static double Clamp(double value, double min, double max) => value < min ? min : value > max ? max : value;
+}
+
+internal static class EnvironmentCompat
+{
+    public static long TickCount64
+        => (long)(
+            System.Diagnostics.Stopwatch.GetTimestamp()
+            * 1000.0
+            / System.Diagnostics.Stopwatch.Frequency);
+}
+
+internal static class ObjectDisposedExceptionCompat
+{
+    public static void ThrowIf(bool condition, object? instance)
+    {
+        if (condition)
+            throw new ObjectDisposedException(instance?.GetType().FullName);
+    }
+}
+
+internal static class OperatingSystemCompat
+{
+    public static bool IsWindows()
+        => System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.Windows);
+}
+
+internal static class RandomCompat
+{
+    public static ThreadSafeRandom Shared { get; } = new();
+
+    internal sealed class ThreadSafeRandom
+    {
+        private int _seed = System.Environment.TickCount;
+        private readonly ThreadLocal<System.Random> _local;
+
+        public ThreadSafeRandom()
+        {
+            _local = new ThreadLocal<System.Random>(() => new System.Random(Interlocked.Increment(ref _seed)));
+        }
+
+        public int Next(int maxValue) => _local.Value!.Next(maxValue);
+
+        public int Next(int minValue, int maxValue) => _local.Value!.Next(minValue, maxValue);
+
+        public double NextDouble() => _local.Value!.NextDouble();
+    }
+}
+
+internal static class RandomNumberGeneratorCompat
+{
+    public static byte[] GetBytes(int count)
+    {
+        var bytes = new byte[count];
+        using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
+        rng.GetBytes(bytes);
+        return bytes;
+    }
+}
+
+internal static class Rfc2898DeriveBytesCompat
+{
+    public static byte[] Pbkdf2(
+        byte[] password,
+        byte[] salt,
+        int iterations,
+        HashAlgorithmName hashAlgorithm,
+        int outputLength)
+    {
+        if (iterations <= 0)
+            throw new System.ArgumentOutOfRangeException(nameof(iterations));
+
+        using var hmac = CreateHmac(hashAlgorithm, password);
+        var result = new byte[outputLength];
+        var block = new byte[hmac.HashSize / 8];
+        var saltAndBlock = new byte[salt.Length + 4];
+        salt.CopyTo(saltAndBlock, 0);
+
+        var offset = 0;
+        for (var blockIndex = 1; offset < outputLength; blockIndex++)
+        {
+            saltAndBlock[salt.Length] = (byte)(blockIndex >> 24);
+            saltAndBlock[salt.Length + 1] = (byte)(blockIndex >> 16);
+            saltAndBlock[salt.Length + 2] = (byte)(blockIndex >> 8);
+            saltAndBlock[salt.Length + 3] = (byte)blockIndex;
+
+            var u = hmac.ComputeHash(saltAndBlock);
+            u.CopyTo(block, 0);
+            for (var i = 1; i < iterations; i++)
+            {
+                u = hmac.ComputeHash(u);
+                for (var j = 0; j < block.Length; j++)
+                    block[j] ^= u[j];
+            }
+
+            var count = System.Math.Min(block.Length, outputLength - offset);
+            System.Array.Copy(block, 0, result, offset, count);
+            offset += count;
+        }
+
+        return result;
+    }
+
+    private static HMAC CreateHmac(HashAlgorithmName hashAlgorithm, byte[] key)
+    {
+        if (hashAlgorithm == HashAlgorithmName.SHA256)
+            return new System.Security.Cryptography.HMACSHA256(key);
+        if (hashAlgorithm == HashAlgorithmName.SHA512)
+            return new System.Security.Cryptography.HMACSHA512(key);
+
+        throw new NotSupportedException($"PBKDF2 hash algorithm '{hashAlgorithm.Name}' is not supported.");
+    }
+}
+
+internal static class SHA256Compat
+{
+    public static byte[] HashData(byte[] source)
+    {
+        using var hash = System.Security.Cryptography.SHA256.Create();
+        return hash.ComputeHash(source);
+    }
+
+    public static byte[] HashData(ReadOnlySpan<byte> source) => HashData(source.ToArray());
+}
+
+internal static class SHA512Compat
+{
+    public static byte[] HashData(byte[] source)
+    {
+        using var hash = System.Security.Cryptography.SHA512.Create();
+        return hash.ComputeHash(source);
+    }
+}
+
+internal static class StopwatchCompat
+{
+    public static readonly long Frequency = System.Diagnostics.Stopwatch.Frequency;
+
+    public static long GetTimestamp() => System.Diagnostics.Stopwatch.GetTimestamp();
+
+    public static TimeSpan GetElapsedTime(long startingTimestamp)
+        => GetElapsedTime(startingTimestamp, GetTimestamp());
+
+    public static TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp)
+    {
+        var ticks = (endingTimestamp - startingTimestamp) * (double)TimeSpan.TicksPerSecond / Frequency;
+        return new TimeSpan((long)ticks);
+    }
+}
+
+internal static class ThreadCompat
+{
+    public static int GetCurrentProcessorId() => System.Environment.CurrentManagedThreadId;
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20CompatCore.cs
+++ b/src/Dekaf/Compatibility/NetStandard20CompatCore.cs
@@ -362,8 +362,9 @@ internal static class GCCompat
 {
     public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) => new T[length];
 
+    // No portable netstandard2.0 cgroup/system-memory API exists; report unknown so callers use fixed fallback budgets.
     public static GCMemoryInfoCompat GetGCMemoryInfo()
-        => new((long)System.Math.Min(long.MaxValue, (double)System.Environment.WorkingSet + (1024.0 * 1024.0 * 1024.0)));
+        => new(0);
 }
 
 internal readonly struct GCMemoryInfoCompat

--- a/src/Dekaf/Compatibility/NetStandard20CompilerAttributes.cs
+++ b/src/Dekaf/Compatibility/NetStandard20CompilerAttributes.cs
@@ -1,0 +1,21 @@
+#if NETSTANDARD2_0
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Field, Inherited = false)]
+    internal sealed class NotNullAttribute : Attribute;
+}
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    internal sealed class CallerArgumentExpressionAttribute : Attribute
+    {
+        public CallerArgumentExpressionAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        public string ParameterName { get; }
+    }
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20ConcurrentExtensions.cs
+++ b/src/Dekaf/Compatibility/NetStandard20ConcurrentExtensions.cs
@@ -1,0 +1,56 @@
+#if NETSTANDARD2_0
+namespace System.Collections.Concurrent;
+
+internal static class ConcurrentCollectionCompatibilityExtensions
+{
+    public static TValue? GetValueOrDefault<TKey, TValue>(
+        this ConcurrentDictionary<TKey, TValue> dictionary,
+        TKey key)
+        where TKey : notnull
+        => dictionary.TryGetValue(key, out var value) ? value : default;
+
+    public static TValue GetValueOrDefault<TKey, TValue>(
+        this ConcurrentDictionary<TKey, TValue> dictionary,
+        TKey key,
+        TValue defaultValue)
+        where TKey : notnull
+        => dictionary.TryGetValue(key, out var value) ? value : defaultValue;
+
+    public static void Clear<T>(this ConcurrentQueue<T> queue)
+    {
+        while (queue.TryDequeue(out _))
+        {
+        }
+    }
+
+    public static bool TryRemove<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> dictionary, TKey key)
+        where TKey : notnull
+        => dictionary.TryRemove(key, out _);
+
+    public static bool TryRemove<TKey, TValue>(
+        this ConcurrentDictionary<TKey, TValue> dictionary,
+        KeyValuePair<TKey, TValue> item)
+        where TKey : notnull
+        => ((ICollection<KeyValuePair<TKey, TValue>>)dictionary).Remove(item);
+
+    public static TValue GetOrAdd<TKey, TValue, TArg>(
+        this ConcurrentDictionary<TKey, TValue> dictionary,
+        TKey key,
+        Func<TKey, TArg, TValue> valueFactory,
+        TArg factoryArgument)
+        where TKey : notnull
+        => dictionary.GetOrAdd(key, k => valueFactory(k, factoryArgument));
+
+    public static TValue AddOrUpdate<TKey, TValue, TArg>(
+        this ConcurrentDictionary<TKey, TValue> dictionary,
+        TKey key,
+        Func<TKey, TArg, TValue> addValueFactory,
+        Func<TKey, TValue, TArg, TValue> updateValueFactory,
+        TArg factoryArgument)
+        where TKey : notnull
+        => dictionary.AddOrUpdate(
+            key,
+            k => addValueFactory(k, factoryArgument),
+            (k, existing) => updateValueFactory(k, existing, factoryArgument));
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20CryptoExtensions.cs
+++ b/src/Dekaf/Compatibility/NetStandard20CryptoExtensions.cs
@@ -1,0 +1,20 @@
+#if NETSTANDARD2_0
+namespace System.Security.Cryptography;
+
+internal static class CryptographicOperations
+{
+    public static bool FixedTimeEquals(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
+    {
+        if (left.Length != right.Length)
+            return false;
+
+        var diff = 0;
+        for (var i = 0; i < left.Length; i++)
+            diff |= left[i] ^ right[i];
+
+        return diff == 0;
+    }
+
+    public static void ZeroMemory(Span<byte> buffer) => buffer.Clear();
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20HttpExtensions.cs
+++ b/src/Dekaf/Compatibility/NetStandard20HttpExtensions.cs
@@ -1,0 +1,9 @@
+#if NETSTANDARD2_0
+namespace System.Net.Http;
+
+internal static class HttpContentCompatibilityExtensions
+{
+    public static Task<string> ReadAsStringAsync(this HttpContent content, CancellationToken cancellationToken)
+        => content.ReadAsStringAsync().WaitAsync(cancellationToken);
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20IoExtensions.cs
+++ b/src/Dekaf/Compatibility/NetStandard20IoExtensions.cs
@@ -1,0 +1,53 @@
+#if NETSTANDARD2_0
+namespace System.IO;
+
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+internal static class StreamCompatibilityExtensions
+{
+    public static async ValueTask<int> ReadAsync(this Stream stream, Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (MemoryMarshal.TryGetArray<byte>(buffer, out var segment))
+            return await stream.ReadAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken).ConfigureAwait(false);
+
+        var rented = ArrayPool<byte>.Shared.Rent(buffer.Length);
+        try
+        {
+            var read = await stream.ReadAsync(rented, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            rented.AsSpan(0, read).CopyTo(buffer.Span);
+            return read;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    public static async Task WriteAsync(this Stream stream, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (MemoryMarshal.TryGetArray<byte>(buffer, out var segment))
+        {
+            await stream.WriteAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var rented = ArrayPool<byte>.Shared.Rent(buffer.Length);
+        try
+        {
+            buffer.Span.CopyTo(rented);
+            await stream.WriteAsync(rented, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    public static ValueTask DisposeAsync(this Stream stream)
+    {
+        stream.Dispose();
+        return default;
+    }
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20LinqExtensions.cs
+++ b/src/Dekaf/Compatibility/NetStandard20LinqExtensions.cs
@@ -1,0 +1,28 @@
+#if NETSTANDARD2_0
+namespace System.Linq;
+
+internal static class LinqCompatibilityExtensions
+{
+    public static IOrderedEnumerable<T> Order<T>(this IEnumerable<T> source) => source.OrderBy(static item => item);
+
+    public static bool TryGetNonEnumeratedCount<T>(this IEnumerable<T> source, out int count)
+    {
+        if (source is ICollection<T> collection)
+        {
+            count = collection.Count;
+            return true;
+        }
+
+        if (source is IReadOnlyCollection<T> readOnlyCollection)
+        {
+            count = readOnlyCollection.Count;
+            return true;
+        }
+
+        count = 0;
+        return false;
+    }
+
+    public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source) => new(source);
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20RuntimeShims.cs
+++ b/src/Dekaf/Compatibility/NetStandard20RuntimeShims.cs
@@ -1,0 +1,199 @@
+#if NETSTANDARD2_0
+namespace System.Threading
+{
+    internal sealed class Lock
+    {
+        private readonly object _gate = new();
+
+        public Scope EnterScope()
+        {
+            Monitor.Enter(_gate);
+            return new Scope(_gate);
+        }
+
+        public readonly ref struct Scope
+        {
+            private readonly object _gate;
+
+            internal Scope(object gate)
+            {
+                _gate = gate;
+            }
+
+            public void Dispose()
+            {
+                Monitor.Exit(_gate);
+            }
+        }
+    }
+
+    internal sealed class PeriodicTimer : IDisposable
+    {
+        private readonly TimeSpan _period;
+        private readonly CancellationTokenSource _disposed = new();
+
+        public PeriodicTimer(TimeSpan period)
+        {
+            _period = period;
+        }
+
+        public async ValueTask<bool> WaitForNextTickAsync(CancellationToken cancellationToken = default)
+        {
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposed.Token);
+            try
+            {
+                await Task.Delay(_period, linked.Token).ConfigureAwait(false);
+                return !_disposed.IsCancellationRequested;
+            }
+            catch (OperationCanceledException) when (_disposed.IsCancellationRequested)
+            {
+                return false;
+            }
+        }
+
+        public void Dispose()
+        {
+            _disposed.Cancel();
+            _disposed.Dispose();
+        }
+    }
+
+    internal static class CancellationTokenSourceCompatibilityExtensions
+    {
+        public static Task CancelAsync(this CancellationTokenSource source)
+        {
+            source.Cancel();
+            return Task.CompletedTask;
+        }
+    }
+}
+
+namespace System.Threading.Tasks
+{
+    internal sealed class TaskCompletionSource
+    {
+        private readonly TaskCompletionSource<bool> _inner;
+
+        public TaskCompletionSource()
+            : this(TaskCreationOptions.None)
+        {
+        }
+
+        public TaskCompletionSource(TaskCreationOptions creationOptions)
+        {
+            _inner = new TaskCompletionSource<bool>(creationOptions);
+        }
+
+        public Task Task => _inner.Task;
+
+        public void SetResult()
+        {
+            _inner.SetResult(true);
+        }
+
+        public bool TrySetResult()
+        {
+            return _inner.TrySetResult(true);
+        }
+
+        public bool TrySetCanceled()
+        {
+            return _inner.TrySetCanceled();
+        }
+
+        public bool TrySetCanceled(CancellationToken cancellationToken)
+        {
+            return _inner.TrySetCanceled(cancellationToken);
+        }
+
+        public bool TrySetException(Exception exception)
+        {
+            return _inner.TrySetException(exception);
+        }
+
+        public bool TrySetException(IEnumerable<Exception> exceptions)
+        {
+            return _inner.TrySetException(exceptions);
+        }
+    }
+
+    internal static class TaskWaitAsyncCompatibilityExtensions
+    {
+        public static Task WaitAsync(this Task task, CancellationToken cancellationToken)
+            => WaitAsyncCore(task, Timeout.InfiniteTimeSpan, hasTimeout: false, cancellationToken);
+
+        public static Task WaitAsync(this Task task, TimeSpan timeout)
+            => WaitAsyncCore(task, timeout, hasTimeout: true, CancellationToken.None);
+
+        public static Task WaitAsync(this Task task, TimeSpan timeout, CancellationToken cancellationToken)
+            => WaitAsyncCore(task, timeout, hasTimeout: true, cancellationToken);
+
+        public static async Task<TResult> WaitAsync<TResult>(this Task<TResult> task, CancellationToken cancellationToken)
+        {
+            await WaitAsync((Task)task, cancellationToken).ConfigureAwait(false);
+            return await task.ConfigureAwait(false);
+        }
+
+        public static async Task<TResult> WaitAsync<TResult>(this Task<TResult> task, TimeSpan timeout)
+        {
+            await WaitAsync((Task)task, timeout).ConfigureAwait(false);
+            return await task.ConfigureAwait(false);
+        }
+
+        public static async Task<TResult> WaitAsync<TResult>(
+            this Task<TResult> task,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+            await WaitAsync((Task)task, timeout, cancellationToken).ConfigureAwait(false);
+            return await task.ConfigureAwait(false);
+        }
+
+        private static async Task WaitAsyncCore(
+            Task task,
+            TimeSpan timeout,
+            bool hasTimeout,
+            CancellationToken cancellationToken)
+        {
+            if (task.IsCompleted)
+            {
+                await task.ConfigureAwait(false);
+                return;
+            }
+
+            using var timeoutCts = hasTimeout ? new CancellationTokenSource() : null;
+            using var linkedCts = CreateLinkedCancellationTokenSource(timeoutCts, hasTimeout, cancellationToken);
+            var delay = Task.Delay(hasTimeout ? timeout : Timeout.InfiniteTimeSpan, linkedCts.Token);
+
+            var completed = await Task.WhenAny(task, delay).ConfigureAwait(false);
+            if (ReferenceEquals(completed, task))
+            {
+                timeoutCts?.Cancel();
+                await task.ConfigureAwait(false);
+                return;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new TimeoutException();
+        }
+
+        private static CancellationTokenSource CreateLinkedCancellationTokenSource(
+            CancellationTokenSource? timeoutCts,
+            bool hasTimeout,
+            CancellationToken cancellationToken)
+        {
+            if (hasTimeout && cancellationToken.CanBeCanceled)
+            {
+                return CancellationTokenSource.CreateLinkedTokenSource(timeoutCts!.Token, cancellationToken);
+            }
+
+            if (hasTimeout)
+            {
+                return CancellationTokenSource.CreateLinkedTokenSource(timeoutCts!.Token);
+            }
+
+            return CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        }
+    }
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20RuntimeShims.cs
+++ b/src/Dekaf/Compatibility/NetStandard20RuntimeShims.cs
@@ -61,10 +61,10 @@ namespace System.Threading
     internal static class CancellationTokenSourceCompatibilityExtensions
     {
         public static Task CancelAsync(this CancellationTokenSource source)
-        {
-            source.Cancel();
-            return Task.CompletedTask;
-        }
+            => Task.Factory.StartNew(static state =>
+            {
+                ((CancellationTokenSource)state!).Cancel();
+            }, source, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
     }
 }
 

--- a/src/Dekaf/Compatibility/NetStandard20SocketExtensions.cs
+++ b/src/Dekaf/Compatibility/NetStandard20SocketExtensions.cs
@@ -1,0 +1,33 @@
+#if NETSTANDARD2_0
+namespace System.Net.Sockets;
+
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+internal static class SocketCompatibilityExtensions
+{
+    public static async ValueTask<int> ReceiveAsync(this Socket socket, Memory<byte> buffer, SocketFlags socketFlags)
+    {
+        if (MemoryMarshal.TryGetArray<byte>(buffer, out var segment))
+            return await socket.ReceiveAsync(segment, socketFlags).ConfigureAwait(false);
+
+        var rented = ArrayPool<byte>.Shared.Rent(buffer.Length);
+        try
+        {
+            var read = await socket.ReceiveAsync(new ArraySegment<byte>(rented, 0, buffer.Length), socketFlags).ConfigureAwait(false);
+            rented.AsSpan(0, read).CopyTo(buffer.Span);
+            return read;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    public static async Task ConnectAsync(this Socket socket, EndPoint remoteEndPoint, CancellationToken cancellationToken)
+    {
+        var connect = socket.ConnectAsync(remoteEndPoint);
+        await connect.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20SystemTypes.cs
+++ b/src/Dekaf/Compatibility/NetStandard20SystemTypes.cs
@@ -1,0 +1,75 @@
+#if NETSTANDARD2_0
+namespace System;
+
+internal readonly struct Index
+{
+    private readonly int _value;
+
+    public Index(int value, bool fromEnd = false)
+    {
+        if (value < 0)
+            throw new ArgumentOutOfRangeException(nameof(value));
+
+        _value = fromEnd ? ~value : value;
+    }
+
+    private Index(int value)
+    {
+        _value = value;
+    }
+
+    public int Value => _value < 0 ? ~_value : _value;
+    public bool IsFromEnd => _value < 0;
+    public static Index Start => new(0);
+    public static Index End => new(~0);
+    public static implicit operator Index(int value) => new(value);
+    public int GetOffset(int length) => IsFromEnd ? length - Value : Value;
+}
+
+internal readonly struct Range
+{
+    public Range(Index start, Index end)
+    {
+        Start = start;
+        End = end;
+    }
+
+    public Index Start { get; }
+    public Index End { get; }
+    public static Range All => new(Index.Start, Index.End);
+    public static Range StartAt(Index start) => new(start, Index.End);
+    public static Range EndAt(Index end) => new(Index.Start, end);
+
+    public (int Offset, int Length) GetOffsetAndLength(int length)
+    {
+        var start = Start.GetOffset(length);
+        var end = End.GetOffset(length);
+        if ((uint)end > (uint)length || (uint)start > (uint)end)
+            throw new ArgumentOutOfRangeException(nameof(length));
+        return (start, end - start);
+    }
+}
+
+internal struct HashCode
+{
+    private int _hash;
+
+    public void Add<T>(T value)
+    {
+        _hash = Combine(_hash, value);
+    }
+
+    public int ToHashCode() => _hash;
+
+    public static int Combine<T1, T2>(T1 value1, T2 value2)
+        => Combine(value1?.GetHashCode() ?? 0, value2);
+
+    private static int Combine<T>(int hash, T value)
+    {
+        unchecked
+        {
+            return (hash * 397) ^ (value?.GetHashCode() ?? 0);
+        }
+    }
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20TaskValueTask.cs
+++ b/src/Dekaf/Compatibility/NetStandard20TaskValueTask.cs
@@ -1,0 +1,15 @@
+#if NETSTANDARD2_0
+namespace System.Threading.Tasks;
+
+internal static class ValueTaskCompatibility
+{
+    public static ValueTask CompletedTask => default;
+
+    public static ValueTask<T> FromException<T>(Exception exception)
+    {
+        var source = new TaskCompletionSource<T>();
+        source.SetException(exception);
+        return new ValueTask<T>(source.Task);
+    }
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20TextExtensions.cs
+++ b/src/Dekaf/Compatibility/NetStandard20TextExtensions.cs
@@ -1,0 +1,54 @@
+#if NETSTANDARD2_0
+namespace System.Text;
+
+internal static class EncodingCompatibilityExtensions
+{
+    public static int GetBytes(this Encoding encoding, string text, Span<byte> destination)
+    {
+        var bytes = encoding.GetBytes(text);
+        bytes.AsSpan().CopyTo(destination);
+        return bytes.Length;
+    }
+
+    public static int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> destination)
+    {
+        var text = new string(chars.ToArray());
+        return GetBytes(encoding, text, destination);
+    }
+
+    public static int GetByteCount(this Encoding encoding, ReadOnlySpan<char> chars)
+        => encoding.GetByteCount(chars.ToArray());
+
+    public static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+        => encoding.GetString(bytes.ToArray());
+}
+
+internal static class StringCompatibilityExtensions
+{
+    public static bool Contains(this string text, string value, StringComparison comparisonType)
+        => text.IndexOf(value, comparisonType) >= 0;
+
+    public static bool Contains(this string text, char value, StringComparison comparisonType)
+        => text.IndexOf(value.ToString(), comparisonType) >= 0;
+
+    public static bool StartsWith(this string text, char value)
+        => text.Length > 0 && text[0] == value;
+
+    public static string[] Split(this string text, char separator, StringSplitOptions options)
+        => text.Split(new[] { separator }, options);
+}
+
+internal static class Ascii
+{
+    public static bool IsValid(string value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] > 0x7F)
+                return false;
+        }
+
+        return true;
+    }
+}
+#endif

--- a/src/Dekaf/Compatibility/NetStandard20ThreadingExtensions.cs
+++ b/src/Dekaf/Compatibility/NetStandard20ThreadingExtensions.cs
@@ -1,0 +1,21 @@
+#if NETSTANDARD2_0
+namespace System.Threading;
+
+internal static class CancellationCompatibilityExtensions
+{
+    public static bool TryReset(this CancellationTokenSource source)
+        => !source.IsCancellationRequested;
+
+    public static CancellationTokenRegistration UnsafeRegister(
+        this CancellationToken cancellationToken,
+        Action<object?> callback,
+        object? state)
+        => cancellationToken.Register(callback, state);
+
+    public static CancellationTokenRegistration UnsafeRegister(
+        this CancellationToken cancellationToken,
+        Action<object?, CancellationToken> callback,
+        object? state)
+        => cancellationToken.Register(s => callback(s, cancellationToken), state);
+}
+#endif

--- a/src/Dekaf/Compression/BuiltInCodecs.cs
+++ b/src/Dekaf/Compression/BuiltInCodecs.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.IO.Compression;
+using System.Runtime.InteropServices;
 using Dekaf.Protocol.Records;
 
 namespace Dekaf.Compression;
@@ -67,7 +68,12 @@ public sealed class GzipCompressionCodec : ICompressionCodec
             0 => CompressionLevel.NoCompression,
             >= 1 and <= 3 => CompressionLevel.Fastest,
             >= 4 and <= 6 => CompressionLevel.Optimal,
-            _ => CompressionLevel.SmallestSize
+            _ =>
+#if NETSTANDARD2_0
+                CompressionLevel.Optimal
+#else
+                CompressionLevel.SmallestSize
+#endif
         };
     }
 
@@ -80,7 +86,11 @@ public sealed class GzipCompressionCodec : ICompressionCodec
 
         foreach (var segment in source)
         {
+#if NETSTANDARD2_0
+            WriteSegment(gzipStream, segment);
+#else
             gzipStream.Write(segment.Span);
+#endif
         }
     }
 
@@ -91,6 +101,29 @@ public sealed class GzipCompressionCodec : ICompressionCodec
 
         CompressionStreamCopy.CopyToBufferWriter(gzipStream, destination);
     }
+
+#if NETSTANDARD2_0
+    private static void WriteSegment(Stream stream, ReadOnlyMemory<byte> segment)
+    {
+        if (MemoryMarshal.TryGetArray(segment, out var arraySegment) &&
+            arraySegment.Array is not null)
+        {
+            stream.Write(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
+            return;
+        }
+
+        var rented = ArrayPool<byte>.Shared.Rent(segment.Length);
+        try
+        {
+            segment.Span.CopyTo(rented);
+            stream.Write(rented, 0, segment.Length);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+#endif
 }
 
 internal static class CompressionStreamCopy
@@ -99,6 +132,25 @@ internal static class CompressionStreamCopy
 
     internal static void CopyToBufferWriter(Stream source, IBufferWriter<byte> destination)
     {
+#if NETSTANDARD2_0
+        var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+        try
+        {
+            while (true)
+            {
+                var bytesRead = source.Read(buffer, 0, buffer.Length);
+                if (bytesRead == 0)
+                    break;
+
+                buffer.AsSpan(0, bytesRead).CopyTo(destination.GetSpan(bytesRead));
+                destination.Advance(bytesRead);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+#else
         while (true)
         {
             var span = destination.GetSpan(BufferSize);
@@ -108,6 +160,7 @@ internal static class CompressionStreamCopy
 
             destination.Advance(bytesRead);
         }
+#endif
     }
 }
 
@@ -151,12 +204,14 @@ internal sealed class BufferWriterStream : Stream
         _writer.Advance(count);
     }
 
+#if !NETSTANDARD2_0
     public override void Write(ReadOnlySpan<byte> buffer)
     {
         var span = _writer.GetSpan(buffer.Length);
         buffer.CopyTo(span);
         _writer.Advance(buffer.Length);
     }
+#endif
 }
 
 /// <summary>

--- a/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
+++ b/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
@@ -134,7 +134,7 @@ internal sealed class AdaptiveFetchSizer
         if (fetchDuration <= TimeSpan.Zero)
             return;
 
-        var ratio = processingDuration / fetchDuration;
+        var ratio = processingDuration.TotalSeconds / fetchDuration.TotalSeconds;
         EvaluateAndAdjust(ratio);
     }
 

--- a/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
+++ b/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
@@ -126,7 +126,7 @@ internal sealed class ConsumerConnectionScaler
     private void FireAndObserve(Func<CancellationToken, ValueTask> action)
     {
         var task = action(CancellationToken.None);
-        if (task.IsCompleted)
+        if (task.IsCompletedSuccessfully)
             return;
 
         task.AsTask().ContinueWith(static (t, state) =>

--- a/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
+++ b/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
@@ -126,7 +126,7 @@ internal sealed class ConsumerConnectionScaler
     private void FireAndObserve(Func<CancellationToken, ValueTask> action)
     {
         var task = action(CancellationToken.None);
-        if (task.IsCompletedSuccessfully)
+        if (task.IsCompleted)
             return;
 
         task.AsTask().ContinueWith(static (t, state) =>

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -6,6 +6,13 @@ using Dekaf.Retry;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Microsoft.Extensions.Logging;
+#if NETSTANDARD2_0
+using StringSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using StringSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
 
 namespace Dekaf.Consumer;
 
@@ -48,7 +55,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     // KIP-848 consumer protocol state
     private volatile int _heartbeatIntervalMs;
     private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
-    private volatile IReadOnlySet<string>? _subscribedTopics;
+    private volatile StringSet? _subscribedTopics;
     private volatile string? _subscribedTopicRegex;
 
     internal static int GetCoordinationConnectionIndex(int connectionsPerBroker)
@@ -75,7 +82,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     public string? MemberId => _memberId;
     public int GenerationId => _generationId;
     public CoordinatorState State => _state;
-    public IReadOnlySet<TopicPartition> Assignment => _assignedPartitions;
+    public TopicPartitionSet Assignment => _assignedPartitions;
     internal int AssignmentVersion => Volatile.Read(ref _assignmentVersion);
 
     private static void RemoveEmptyTopicGroups<TItem>(Dictionary<string, List<TItem>> topicGroups)
@@ -114,12 +121,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// Ensures the consumer has joined the group.
     /// </summary>
     public ValueTask EnsureActiveGroupAsync(
-        IReadOnlySet<string> topics,
+        StringSet topics,
         CancellationToken cancellationToken)
         => EnsureActiveGroupAsync(topics, null, cancellationToken);
 
     public async ValueTask EnsureActiveGroupAsync(
-        IReadOnlySet<string> topics,
+        StringSet topics,
         string? subscribedTopicRegex,
         CancellationToken cancellationToken)
     {
@@ -152,7 +159,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             or ErrorCode.CoordinatorNotAvailable
             or ErrorCode.CoordinatorLoadInProgress;
 
-    private static bool SetEquals(IReadOnlySet<string>? current, IReadOnlySet<string> next)
+    private static bool SetEquals(StringSet? current, StringSet next)
     {
         if (ReferenceEquals(current, next))
             return true;
@@ -169,11 +176,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         return true;
     }
 
-    private bool SubscriptionMatches(IReadOnlySet<string> topics, string? subscribedTopicRegex)
+    private bool SubscriptionMatches(StringSet topics, string? subscribedTopicRegex)
         => string.Equals(_subscribedTopicRegex, subscribedTopicRegex, StringComparison.Ordinal) &&
            SetEquals(_subscribedTopics, topics);
 
-    private void UpdateSubscription(IReadOnlySet<string> topics, string? subscribedTopicRegex)
+    private void UpdateSubscription(StringSet topics, string? subscribedTopicRegex)
     {
         if (SubscriptionMatches(topics, subscribedTopicRegex))
             return;
@@ -385,7 +392,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                 var request = new OffsetCommitRequest
                 {
-                    GroupId = _options.GroupId,
+                    GroupId = _options.GroupId!,
                     GenerationIdOrMemberEpoch = _generationId,
                     MemberId = _memberId,
                     GroupInstanceId = _options.GroupInstanceId,
@@ -482,7 +489,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                 var request = new OffsetFetchRequest
                 {
-                    GroupId = _options.GroupId,
+                    GroupId = _options.GroupId!,
                     Topics = topicPartitions
                 };
 
@@ -873,7 +880,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// KIP-848 entry point: ensures the consumer has joined the group using the ConsumerGroupHeartbeat API.
     /// </summary>
     private async ValueTask EnsureActiveGroupConsumerProtocolAsync(
-        IReadOnlySet<string> topics,
+        StringSet topics,
         string? subscribedTopicRegex,
         CancellationToken cancellationToken)
     {

--- a/src/Dekaf/Consumer/FetchSessionHandler.cs
+++ b/src/Dekaf/Consumer/FetchSessionHandler.cs
@@ -216,7 +216,7 @@ internal sealed class FetchSessionHandler
     private static string ResolveTopicName(FetchRequestTopic topic, ClusterMetadata? clusterMetadata)
     {
         if (!string.IsNullOrEmpty(topic.Topic))
-            return topic.Topic;
+            return topic.Topic!;
 
         return topic.TopicId == Guid.Empty
             ? string.Empty

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -1,6 +1,13 @@
 using Dekaf.Producer;
 using Dekaf.Serialization;
 using Dekaf.Telemetry;
+#if NETSTANDARD2_0
+using StringSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using StringSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
 
 namespace Dekaf.Consumer;
 
@@ -14,7 +21,7 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <summary>
     /// Gets the current subscription.
     /// </summary>
-    IReadOnlySet<string> Subscription { get; }
+    StringSet Subscription { get; }
 
     /// <summary>
     /// Gets the current server-side topic regex subscription, if any.
@@ -24,12 +31,12 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <summary>
     /// Gets the current assignment.
     /// </summary>
-    IReadOnlySet<TopicPartition> Assignment { get; }
+    TopicPartitionSet Assignment { get; }
 
     /// <summary>
     /// Gets the paused partitions.
     /// </summary>
-    IReadOnlySet<TopicPartition> Paused { get; }
+    TopicPartitionSet Paused { get; }
 
     /// <summary>
     /// Gets the member ID if part of a consumer group.
@@ -196,12 +203,12 @@ public interface IConsumerPartitions
     /// <summary>
     /// Gets the current assignment.
     /// </summary>
-    IReadOnlySet<TopicPartition> Assignment { get; }
+    TopicPartitionSet Assignment { get; }
 
     /// <summary>
     /// Gets the paused partitions.
     /// </summary>
-    IReadOnlySet<TopicPartition> Paused { get; }
+    TopicPartitionSet Paused { get; }
 
     /// <summary>
     /// Manually assigns partitions.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -17,6 +17,13 @@ using Dekaf.Retry;
 using Dekaf.Serialization;
 using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
+#if NETSTANDARD2_0
+using StringSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using StringSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
 
 namespace Dekaf.Consumer;
 
@@ -600,10 +607,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private readonly ConcurrentDictionary<string, byte> _subscription = new();
     private readonly HashSet<TopicPartition> _assignment = [];
-    private volatile IReadOnlySet<TopicPartition> _assignmentSnapshot = new HashSet<TopicPartition>();
+    private volatile TopicPartitionSet _assignmentSnapshot = new HashSet<TopicPartition>();
     private readonly ConcurrentDictionary<TopicPartition, byte> _paused = new();
-    private volatile IReadOnlySet<string> _subscriptionSnapshot = new HashSet<string>();
-    private volatile IReadOnlySet<TopicPartition> _pausedSnapshot = new HashSet<TopicPartition>();
+    private volatile StringSet _subscriptionSnapshot = new HashSet<string>();
+    private volatile TopicPartitionSet _pausedSnapshot = new HashSet<TopicPartition>();
 
     // Pattern subscription support
     private volatile Func<string, bool>? _topicFilter;
@@ -937,11 +944,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         Diagnostics.DekafMetrics.RegisterConsumerLagCallback(ObserveConsumerLag);
     }
 
-    public IReadOnlySet<string> Subscription => _subscriptionSnapshot;
+    public StringSet Subscription => _subscriptionSnapshot;
     public string? SubscriptionPattern => _topicPattern;
-    public IReadOnlySet<TopicPartition> Assignment => _assignmentSnapshot;
+    public TopicPartitionSet Assignment => _assignmentSnapshot;
     public string? MemberId => _coordinator?.MemberId;
-    public IReadOnlySet<TopicPartition> Paused => _pausedSnapshot;
+    public TopicPartitionSet Paused => _pausedSnapshot;
     public IConsumerPositions Positions => this;
     public IConsumerPartitions Partitions => this;
     public IConsumerOffsets Offsets => this;
@@ -979,11 +986,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         get
         {
             // Return null if not part of a consumer group
-            if (_coordinator is null || string.IsNullOrEmpty(_options.GroupId))
+            var groupId = _options.GroupId;
+            if (_coordinator is null || string.IsNullOrEmpty(groupId))
                 return null;
 
             // Return null if not yet joined (no member ID assigned)
-            if (string.IsNullOrEmpty(_coordinator.MemberId))
+            var memberId = _coordinator.MemberId;
+            if (string.IsNullOrEmpty(memberId))
                 return null;
 
             // Return null if generation ID is invalid (not yet in a stable group)
@@ -992,9 +1001,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             return new ConsumerGroupMetadata
             {
-                GroupId = _options.GroupId,
+                GroupId = groupId!,
                 GenerationId = _coordinator.GenerationId,
-                MemberId = _coordinator.MemberId,
+                MemberId = memberId!,
                 GroupInstanceId = _options.GroupInstanceId
             };
         }
@@ -1332,7 +1341,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     var pending = _pendingFetches.Peek();
                     var pendingFetchesVersion = Volatile.Read(ref _pendingFetchesVersion);
                     long? batchProcessingStarted = _adaptiveFetchSizer is not null
-                        ? System.Diagnostics.Stopwatch.GetTimestamp() : null;
+                        ? Stopwatch.GetTimestamp() : null;
 
                     // Eagerly parse all records in this fetch's batches upfront.
                     // This converts per-record lazy parse overhead (disposed check +
@@ -1477,7 +1486,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Report batch processing time to the adaptive fetch sizer (per-batch, not per-message)
                     if (batchProcessingStarted.HasValue)
                     {
-                        var processingDuration = System.Diagnostics.Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
+                        var processingDuration = Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
                         _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
                     }
 
@@ -1615,7 +1624,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                 PendingFetchData pending = _pendingFetches.Dequeue();
                 long? batchProcessingStarted = _adaptiveFetchSizer is not null
-                    ? System.Diagnostics.Stopwatch.GetTimestamp() : null;
+                    ? Stopwatch.GetTimestamp() : null;
 
                 try
                 {
@@ -1642,7 +1651,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Report batch processing time to the adaptive fetch sizer
                     if (batchProcessingStarted.HasValue)
                     {
-                        TimeSpan processingDuration = System.Diagnostics.Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
+                        TimeSpan processingDuration = Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
                         _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
                     }
                 }
@@ -1762,7 +1771,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                 PendingFetchData pending = _pendingFetches.Dequeue();
                 long? batchProcessingStarted = _adaptiveFetchSizer is not null
-                    ? System.Diagnostics.Stopwatch.GetTimestamp() : null;
+                    ? Stopwatch.GetTimestamp() : null;
 
                 try
                 {
@@ -1785,7 +1794,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Report batch processing time to the adaptive fetch sizer
                     if (batchProcessingStarted.HasValue)
                     {
-                        TimeSpan processingDuration = System.Diagnostics.Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
+                        TimeSpan processingDuration = Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
                         _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
                     }
                 }
@@ -1953,8 +1962,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // the bottleneck (slowest broker) which is the right signal for adaptive sizing.
                 _adaptiveFetchSizer?.RecordFetchStart();
 
+#if NETSTANDARD2_0
+                await Task.WhenAll(fetchTasks.Take(taskCount)).ConfigureAwait(false);
+#else
                 // ReadOnlySpan overload (.NET 9+) avoids internal array copy and ArraySegment boxing
                 await Task.WhenAll(new ReadOnlySpan<Task>(fetchTasks, 0, taskCount)).ConfigureAwait(false);
+#endif
 
                 _adaptiveFetchSizer?.RecordFetchEnd();
             }
@@ -2103,7 +2116,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             request.SessionId = fetchSessionBuild?.SessionId ?? 0;
             request.SessionEpoch = fetchSessionBuild?.SessionEpoch ?? -1;
 
-            var fetchStarted = System.Diagnostics.Stopwatch.GetTimestamp();
+            var fetchStarted = Stopwatch.GetTimestamp();
 
             FetchResponse response;
             try
@@ -2632,7 +2645,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             var pending = _pendingFetches.Peek();
             long? batchProcessingStarted = _adaptiveFetchSizer is not null
-                ? System.Diagnostics.Stopwatch.GetTimestamp() : null;
+                ? Stopwatch.GetTimestamp() : null;
 
             pending.EagerParseAll();
 
@@ -2715,7 +2728,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             if (batchProcessingStarted.HasValue)
             {
-                var processingDuration = System.Diagnostics.Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
+                var processingDuration = Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
                 _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
             }
 
@@ -3365,7 +3378,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         const long refreshIntervalTicks = 30 * TimeSpan.TicksPerSecond;
 
-        var now = Environment.TickCount64;
+        var now = Dekaf.Compatibility.EnvironmentCompat.TickCount64;
         var lastRefresh = Volatile.Read(ref _lastFilterRefreshTicks);
 
         // Rate-limit: skip if we refreshed recently (unless this is the first call)
@@ -3813,8 +3826,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // the bottleneck (slowest broker) which is the right signal for adaptive sizing.
                 _adaptiveFetchSizer?.RecordFetchStart();
 
+#if NETSTANDARD2_0
+                await Task.WhenAll(fetchTasks.Take(taskCount)).ConfigureAwait(false);
+#else
                 // ReadOnlySpan overload: same zero-copy benefit as above
                 await Task.WhenAll(new ReadOnlySpan<Task<List<PendingFetchData>?>>(fetchTasks, 0, taskCount)).ConfigureAwait(false);
+#endif
 
                 _adaptiveFetchSizer?.RecordFetchEnd();
 
@@ -3958,7 +3975,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 brokerTasks[i] = ResolvePartitionFetchBrokerAsync(assignmentArray[i], cancellationToken);
             }
 
+#if NETSTANDARD2_0
+            await Task.WhenAll(brokerTasks.Take(assignmentCount)).ConfigureAwait(false);
+#else
             await Task.WhenAll(new ReadOnlySpan<Task<(TopicPartition Partition, BrokerNode? Broker)>>(brokerTasks, 0, assignmentCount)).ConfigureAwait(false);
+#endif
         }
         finally
         {
@@ -4082,7 +4103,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         request.SessionId = fetchSessionBuild?.SessionId ?? 0;
         request.SessionEpoch = fetchSessionBuild?.SessionEpoch ?? -1;
 
-        var fetchStarted = System.Diagnostics.Stopwatch.GetTimestamp();
+        var fetchStarted = Stopwatch.GetTimestamp();
 
         FetchResponse response;
         try
@@ -4446,7 +4467,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (!updated)
             ScheduleLeaderRefresh(topic);
 
-        return ValueTask.CompletedTask;
+        return ValueTaskCompatibility.CompletedTask;
     }
 
     private void UpdatePreferredReadReplica(string topic, FetchResponsePartition partitionResponse)
@@ -5205,7 +5226,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         else
             _memoryBudget.ReleaseExplicit((ulong)_options.QueuedMaxMessagesKbytes * 1024);
 
-        var disposeStart = System.Diagnostics.Stopwatch.GetTimestamp();
+        var disposeStart = Stopwatch.GetTimestamp();
         LogConsumerDisposing();
 
         // Unregister lag callback so the OTel SDK no longer invokes it on this disposed instance
@@ -5228,7 +5249,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
         }
 
-        var closeElapsedMs = System.Diagnostics.Stopwatch.GetElapsedTime(disposeStart).TotalMilliseconds;
+        var closeElapsedMs = Stopwatch.GetElapsedTime(disposeStart).TotalMilliseconds;
         LogConsumerCloseCompleted(closeElapsedMs);
 
         CancelActiveConsumeOperations();
@@ -5297,7 +5318,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             await _connectionPool.DisposeAsync().ConfigureAwait(false);
         }
 
-        var disposeElapsedMs = System.Diagnostics.Stopwatch.GetElapsedTime(disposeStart).TotalMilliseconds;
+        var disposeElapsedMs = Stopwatch.GetElapsedTime(disposeStart).TotalMilliseconds;
         LogConsumerDisposed(disposeElapsedMs);
     }
 

--- a/src/Dekaf/Dekaf.csproj
+++ b/src/Dekaf/Dekaf.csproj
@@ -24,6 +24,10 @@
     <PackageReference Include="System.IO.Hashing" Version="10.0.9" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
+  </PropertyGroup>
+
   <!-- Compatibility probe dependencies only. Dekaf still defaults to net10.0 until netstandard2.0 support is complete. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.IO.Pipelines" Version="10.0.9" />

--- a/src/Dekaf/Diagnostics/TraceContextPropagator.cs
+++ b/src/Dekaf/Diagnostics/TraceContextPropagator.cs
@@ -36,9 +36,10 @@ internal static class TraceContextPropagator
         var traceparent = $"00-{activity.TraceId}-{activity.SpanId}-{(activity.Recorded ? "01" : "00")}";
         headers.Add(TraceparentHeader, traceparent);
 
-        if (!string.IsNullOrEmpty(activity.TraceStateString))
+        var traceState = activity.TraceStateString;
+        if (!string.IsNullOrEmpty(traceState))
         {
-            headers.Add(TracestateHeader, activity.TraceStateString);
+            headers.Add(TracestateHeader, traceState!);
         }
 
         return headers;

--- a/src/Dekaf/GlobalUsings.cs
+++ b/src/Dekaf/GlobalUsings.cs
@@ -1,1 +1,25 @@
 global using KafkaException = Dekaf.Errors.KafkaException;
+
+#if NETSTANDARD2_0
+global using System.Text;
+global using ArgumentException = Dekaf.Compatibility.ArgumentExceptionCompat;
+global using ArgumentNullException = Dekaf.Compatibility.ArgumentNullExceptionCompat;
+global using ArgumentOutOfRangeException = Dekaf.Compatibility.ArgumentOutOfRangeExceptionCompat;
+global using Array = Dekaf.Compatibility.ArrayCompat;
+global using BinaryPrimitives = Dekaf.Compatibility.BinaryPrimitivesCompat;
+global using BitOperations = Dekaf.Compatibility.BitOperationsCompat;
+global using Convert = Dekaf.Compatibility.ConvertCompat;
+global using Dns = Dekaf.Compatibility.DnsCompat;
+global using File = Dekaf.Compatibility.FileCompat;
+global using GC = Dekaf.Compatibility.GCCompat;
+global using HMACSHA256 = Dekaf.Compatibility.HMACSHA256Compat;
+global using HMACSHA512 = Dekaf.Compatibility.HMACSHA512Compat;
+global using Math = Dekaf.Compatibility.MathCompat;
+global using OperatingSystem = Dekaf.Compatibility.OperatingSystemCompat;
+global using Random = Dekaf.Compatibility.RandomCompat;
+global using Rfc2898DeriveBytes = Dekaf.Compatibility.Rfc2898DeriveBytesCompat;
+global using SHA256 = Dekaf.Compatibility.SHA256Compat;
+global using SHA512 = Dekaf.Compatibility.SHA512Compat;
+global using Stopwatch = Dekaf.Compatibility.StopwatchCompat;
+global using Thread = Dekaf.Compatibility.ThreadCompat;
+#endif

--- a/src/Dekaf/Metadata/ClusterMetadata.cs
+++ b/src/Dekaf/Metadata/ClusterMetadata.cs
@@ -272,7 +272,7 @@ public sealed class ClusterMetadata
             if (currentPartition.LeaderEpoch >= 0 && leaderEpoch <= currentPartition.LeaderEpoch)
                 return false;
 
-            var brokers = new Dictionary<int, BrokerNode>(existing.Brokers);
+            var brokers = existing.Brokers.ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value);
             if (leaderEndpoint is not null)
             {
                 if (leaderEndpoint.NodeId != leaderId)
@@ -312,8 +312,8 @@ public sealed class ClusterMetadata
             if (!updated)
                 return false;
 
-            var topics = new Dictionary<string, TopicInfo>(existing.Topics);
-            var topicsById = new Dictionary<Guid, TopicInfo>(existing.TopicsById);
+            var topics = existing.Topics.ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value);
+            var topicsById = existing.TopicsById.ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value);
             var updatedTopic = new TopicInfo
             {
                 Name = topic.Name,

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -126,9 +126,12 @@ public sealed partial class MetadataManager : IAsyncDisposable
             var colonIndex = server.IndexOf(':');
             if (colonIndex > 0 && colonIndex < server.Length - 1)
             {
-                var host = server[..colonIndex];
-                // Use span-based parsing to avoid string allocation for port
+                var host = server.Substring(0, colonIndex);
+#if NETSTANDARD2_0
+                if (int.TryParse(server.Substring(colonIndex + 1), out var port))
+#else
                 if (int.TryParse(server.AsSpan(colonIndex + 1), out var port))
+#endif
                 {
                     _bootstrapEndpoints.Add((host, port));
                     _originalBootstrapHostnames.Add(server);
@@ -671,7 +674,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// </summary>
     internal async ValueTask<bool> TryRebootstrapAsync(IEnumerable<string>? topics, CancellationToken cancellationToken)
     {
-        var now = Environment.TickCount64;
+        var now = Dekaf.Compatibility.EnvironmentCompat.TickCount64;
 
         // Atomically set the timestamp only if it hasn't been set yet (compare-and-set from 0)
         if (Interlocked.CompareExchange(ref _allBrokersUnavailableSince, now, 0) == 0)
@@ -944,8 +947,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 currentBrokers.Count + _bootstrapEndpoints.Count);
 
             // First try known brokers, tracking seen endpoints for O(1) dedup
-            var seen = new HashSet<(string Host, int Port)>(
-                currentBrokers.Count + _bootstrapEndpoints.Count);
+            var seen = new HashSet<(string Host, int Port)>();
 
             foreach (var broker in currentBrokers)
             {

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -442,7 +442,7 @@ public sealed partial class ConnectionPool : IConnectionPool
     {
         foreach (var task in tasks)
         {
-            if (task is not null && task.IsCompletedSuccessfully)
+            if (task is not null && task.Status == TaskStatus.RanToCompletion)
             {
                 try { await task.Result.DisposeAsync().ConfigureAwait(false); }
                 catch { /* best-effort cleanup */ }
@@ -1031,7 +1031,7 @@ public sealed partial class ConnectionPool : IConnectionPool
             if (Volatile.Read(ref _disposed) != 0)
                 return 0;
 
-            var now = Environment.TickCount64;
+            var now = Dekaf.Compatibility.EnvironmentCompat.TickCount64;
             var reaped = 0;
 
             foreach (var (endpoint, connection) in _connectionsByEndpoint.ToArray())

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -191,7 +191,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
     private OAuthBearerTokenProvider? _ownedTokenProvider;
     private int _disposed;
     private int _connected;
-    private long _lastUsedTimestampMs = Environment.TickCount64;
+    private long _lastUsedTimestampMs = Dekaf.Compatibility.EnvironmentCompat.TickCount64;
     private readonly SemaphoreSlim _connectLock = new(1, 1);
 
     // SASL re-authentication (KIP-368)
@@ -377,11 +377,23 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         if (_options.UseTls || _options.TlsConfig is not null)
         {
+#if NETSTANDARD2_0
+            var sslStream = new SslStream(
+                networkStream,
+                leaveInnerStreamOpen: false,
+                BuildRemoteCertificateValidationCallback());
+#else
             var sslStream = new SslStream(networkStream, leaveInnerStreamOpen: false);
-            var sslOptions = BuildSslClientAuthenticationOptions(targetHost);
+#endif
             try
             {
+#if NETSTANDARD2_0
+                await AuthenticateAsClientNetStandardAsync(sslStream, targetHost, cancellationToken)
+                    .ConfigureAwait(false);
+#else
+                var sslOptions = BuildSslClientAuthenticationOptions(targetHost);
                 await sslStream.AuthenticateAsClientAsync(sslOptions, cancellationToken).ConfigureAwait(false);
+#endif
             }
             catch (System.Security.Authentication.AuthenticationException ex)
             {
@@ -548,8 +560,8 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         Touch();
         var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
-        var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
-        var responseHeaderVersion = TRequest.GetResponseHeaderVersion(apiVersion);
+        var headerVersion = KafkaMessageMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
+        var responseHeaderVersion = KafkaMessageMetadata<TRequest, TResponse>.GetResponseHeaderVersion(apiVersion);
 
         await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
         var pending = _pendingRequestPool.Rent();
@@ -572,7 +584,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             var telemetryStartTimestamp = _telemetryMetricCollector is null ? 0 : Stopwatch.GetTimestamp();
 
             // Write phase
-            LogSendingRequest(TRequest.ApiKey, correlationId, apiVersion, _host, _port);
+            LogSendingRequest(KafkaMessageMetadata<TRequest, TResponse>.ApiKey, correlationId, apiVersion, _host, _port);
 
             await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken)
                 .ConfigureAwait(false);
@@ -643,11 +655,11 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         Touch();
         var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
-        var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
+        var headerVersion = KafkaMessageMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
 
         // Don't register a pending request - we won't receive a response
 
-        LogSendingFireAndForgetRequest(TRequest.ApiKey, correlationId, apiVersion, _host, _port);
+        LogSendingFireAndForgetRequest(KafkaMessageMetadata<TRequest, TResponse>.ApiKey, correlationId, apiVersion, _host, _port);
 
         await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken, callerOwnsTimeout)
             .ConfigureAwait(false);
@@ -699,8 +711,8 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         Touch();
         var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
-        var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
-        var responseHeaderVersion = TRequest.GetResponseHeaderVersion(apiVersion);
+        var headerVersion = KafkaMessageMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
+        var responseHeaderVersion = KafkaMessageMetadata<TRequest, TResponse>.GetResponseHeaderVersion(apiVersion);
 
         await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
         var pending = _pendingRequestPool.Rent();
@@ -772,7 +784,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    throw CreateResponseTimeoutException(TRequest.ApiKey, correlationId);
+                    throw CreateResponseTimeoutException(KafkaMessageMetadata<TRequest, TResponse>.ApiKey, correlationId);
                 }
                 finally
                 {
@@ -798,7 +810,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 }
                 catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
-                    throw CreateResponseTimeoutException(TRequest.ApiKey, correlationId);
+                    throw CreateResponseTimeoutException(KafkaMessageMetadata<TRequest, TResponse>.ApiKey, correlationId);
                 }
                 finally
                 {
@@ -810,7 +822,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
             LogResponseReceived(correlationId);
 
-            var isFetchResponse = TRequest.ApiKey == ApiKey.Fetch;
+            var isFetchResponse = KafkaMessageMetadata<TRequest, TResponse>.ApiKey == ApiKey.Fetch;
 
             if (isFetchResponse)
             {
@@ -818,7 +830,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 using var parsingScope = ResponseParsingContext.SetPooledMemory(memoryOwner);
 
                 var reader = new KafkaProtocolReader(pooledBuffer.Data);
-                var response = (TResponse)TResponse.Read(ref reader, apiVersion);
+                var response = KafkaMessageMetadata<TRequest, TResponse>.ReadResponse(ref reader, apiVersion);
 
                 if (ResponseParsingContext.WasMemoryUsed)
                 {
@@ -844,7 +856,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 try
                 {
                     var reader = new KafkaProtocolReader(pooledBuffer.Data);
-                    return (TResponse)TResponse.Read(ref reader, apiVersion);
+                    return KafkaMessageMetadata<TRequest, TResponse>.ReadResponse(ref reader, apiVersion);
                 }
                 finally
                 {
@@ -900,7 +912,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         var bodyWriter = new KafkaProtocolWriter(writer);
         var header = new RequestHeader
         {
-            ApiKey = TRequest.ApiKey,
+            ApiKey = KafkaMessageMetadata<TRequest, TResponse>.ApiKey,
             ApiVersion = apiVersion,
             CorrelationId = correlationId,
             ClientId = _clientId,
@@ -935,7 +947,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         where TResponse : IKafkaResponse
     {
         var (serializedArray, serializedLength) = PreSerializeRequest<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion);
-        var clearSerializedArray = TRequest.ApiKey == ApiKey.SaslAuthenticate;
+        var clearSerializedArray = KafkaMessageMetadata<TRequest, TResponse>.ApiKey == ApiKey.SaslAuthenticate;
         byte[]? arrayToReturn = serializedArray;
         try
         {
@@ -1223,7 +1235,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             if (_pendingRequestSlots.Wait(0, cancellationToken))
             {
                 if (Volatile.Read(ref _disposed) == 0)
-                    return ValueTask.CompletedTask;
+                    return ValueTaskCompatibility.CompletedTask;
 
                 _pendingRequestSlots.Release();
                 throw new ObjectDisposedException(nameof(KafkaConnection));
@@ -1415,7 +1427,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         return count;
     }
 
-    private void Touch() => Volatile.Write(ref _lastUsedTimestampMs, Environment.TickCount64);
+    private void Touch() => Volatile.Write(ref _lastUsedTimestampMs, Dekaf.Compatibility.EnvironmentCompat.TickCount64);
 
     private bool TryReadResponse(
         ref ReadOnlySequence<byte> buffer,
@@ -1473,7 +1485,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         correlationId = 0;
         responseData = default;
 
-        var span = buffer.FirstSpan;
+        var span = buffer.First.Span;
 
         // Read size prefix directly from span
         var size = BinaryPrimitives.ReadInt32BigEndian(span);
@@ -1590,13 +1602,36 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         ReleasePendingRequestSlots(releasedSlots);
     }
 
+#if NETSTANDARD2_0
+    private async ValueTask AuthenticateAsClientNetStandardAsync(
+        SslStream sslStream,
+        string targetHost,
+        CancellationToken cancellationToken)
+    {
+        var tlsConfig = _options.TlsConfig;
+        var clientCertificates = BuildClientCertificates(tlsConfig);
+        var enabledProtocols = tlsConfig?.EnabledSslProtocols ?? System.Security.Authentication.SslProtocols.None;
+        var checkCertificateRevocation = tlsConfig?.CheckCertificateRevocation ?? false;
+
+        await sslStream
+            .AuthenticateAsClientAsync(
+                tlsConfig?.TargetHost ?? targetHost,
+                clientCertificates,
+                enabledProtocols,
+                checkCertificateRevocation)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+#endif
+
+#if !NETSTANDARD2_0
     private SslClientAuthenticationOptions BuildSslClientAuthenticationOptions(string targetHost)
     {
         var tlsConfig = _options.TlsConfig;
         var options = new SslClientAuthenticationOptions
         {
             TargetHost = tlsConfig?.TargetHost ?? targetHost,
-            RemoteCertificateValidationCallback = _options.RemoteCertificateValidationCallback
+            RemoteCertificateValidationCallback = BuildRemoteCertificateValidationCallback()
         };
 
         // Configure enabled SSL protocols if specified
@@ -1613,34 +1648,55 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 : X509RevocationMode.NoCheck;
         }
 
+        // Configure client certificate for mTLS
+        var clientCertificates = BuildClientCertificates(tlsConfig);
+        if (clientCertificates is not null)
+        {
+            options.ClientCertificates = clientCertificates;
+        }
+
+        return options;
+    }
+#endif
+
+    private RemoteCertificateValidationCallback? BuildRemoteCertificateValidationCallback()
+    {
+        var tlsConfig = _options.TlsConfig;
+        var callback = _options.RemoteCertificateValidationCallback;
+
         // Configure server certificate validation
         if (tlsConfig is not null && !tlsConfig.ValidateServerCertificate)
         {
             // Disable server certificate validation (not recommended for production)
             // This is intentional when user explicitly sets ValidateServerCertificate = false
 #pragma warning disable CA5359 // Do not disable certificate validation
-            options.RemoteCertificateValidationCallback = (_, _, _, _) => true;
+            return (_, _, _, _) => true;
 #pragma warning restore CA5359
         }
-        else if (options.RemoteCertificateValidationCallback is null && HasCustomCaCertificate(tlsConfig))
+
+        if (callback is null && HasCustomCaCertificate(tlsConfig))
         {
             // Custom CA certificate validation
             var caCertificates = LoadCaCertificatesWithOwnership(tlsConfig!);
-            options.RemoteCertificateValidationCallback = (_, certificate, chain, sslPolicyErrors) =>
+            return (_, certificate, chain, sslPolicyErrors) =>
                 ValidateServerCertificate(certificate, chain, sslPolicyErrors, caCertificates);
         }
 
-        // Configure client certificate for mTLS
-        if (tlsConfig is not null)
-        {
-            var clientCert = LoadClientCertificateWithOwnership(tlsConfig);
-            if (clientCert is not null)
-            {
-                options.ClientCertificates = [clientCert];
-            }
-        }
+        return callback;
+    }
 
-        return options;
+    private X509CertificateCollection? BuildClientCertificates(TlsConfig? tlsConfig)
+    {
+        if (tlsConfig is null)
+            return null;
+
+        var clientCert = LoadClientCertificateWithOwnership(tlsConfig);
+        if (clientCert is null)
+            return null;
+
+        var certificates = new X509CertificateCollection();
+        certificates.Add(clientCert);
+        return certificates;
     }
 
     private void ConfigureTcpKeepAlive(Socket socket)
@@ -1650,6 +1706,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         TrySetSocketOption(socket, SocketOptionLevel.Socket, SocketOptionName.KeepAlive, 1);
 
+#if !NETSTANDARD2_0
         var keepAliveTimeSeconds = ToPositiveSeconds(_options.TcpKeepAliveTime);
         if (keepAliveTimeSeconds > 0)
             TrySetSocketOption(socket, SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, keepAliveTimeSeconds);
@@ -1660,6 +1717,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         if (_options.TcpKeepAliveRetryCount > 0)
             TrySetSocketOption(socket, SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, _options.TcpKeepAliveRetryCount);
+#endif
     }
 
     private static int ToPositiveSeconds(TimeSpan value)
@@ -1734,13 +1792,23 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         if (extension is ".pfx" or ".p12")
         {
+#if NETSTANDARD2_0
+#pragma warning disable SYSLIB0057
+            collection.Add(new X509Certificate2(path));
+#pragma warning restore SYSLIB0057
+#else
             // Load PFX/PKCS12 file using modern API
             collection.Add(X509CertificateLoader.LoadPkcs12FromFile(path, password: null));
+#endif
         }
         else
         {
+#if NETSTANDARD2_0
+            throw new PlatformNotSupportedException("PEM CA certificate files require net10.0 or later. Use a PFX/P12 CA file for netstandard2.0.");
+#else
             // Assume PEM format - can contain multiple certificates
             collection.ImportFromPemFile(path);
+#endif
         }
 
         return collection;
@@ -1768,13 +1836,24 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             X509Certificate2 cert;
             if (extension is ".pfx" or ".p12")
             {
+#if NETSTANDARD2_0
+#pragma warning disable SYSLIB0057
+                cert = string.IsNullOrEmpty(tlsConfig.ClientKeyPassword)
+                    ? new X509Certificate2(certPath)
+                    : new X509Certificate2(certPath, tlsConfig.ClientKeyPassword);
+#pragma warning restore SYSLIB0057
+#else
                 // Load PFX/PKCS12 file (contains both certificate and private key) using modern API
                 cert = X509CertificateLoader.LoadPkcs12FromFile(
                     certPath,
                     string.IsNullOrEmpty(tlsConfig.ClientKeyPassword) ? null : tlsConfig.ClientKeyPassword);
+#endif
             }
             else
             {
+#if NETSTANDARD2_0
+                throw new PlatformNotSupportedException("PEM client certificates require net10.0 or later. Use a PFX/P12 client certificate for netstandard2.0.");
+#else
                 // PEM format - need separate key file
                 if (tlsConfig.ClientKeyPath is null)
                 {
@@ -1785,6 +1864,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 cert = string.IsNullOrEmpty(tlsConfig.ClientKeyPassword)
                     ? X509Certificate2.CreateFromPemFile(certPath, tlsConfig.ClientKeyPath)
                     : X509Certificate2.CreateFromEncryptedPemFile(certPath, tlsConfig.ClientKeyPassword, tlsConfig.ClientKeyPath);
+#endif
             }
 
             _loadedClientCertificate = cert;
@@ -1810,6 +1890,9 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         // If the only error is an untrusted root, validate against our custom CA
         if (sslPolicyErrors == SslPolicyErrors.RemoteCertificateChainErrors && chain is not null)
         {
+#if NETSTANDARD2_0
+            return false;
+#else
             // Track if we created a new certificate to dispose it later
             X509Certificate2? ownedCert = null;
             try
@@ -1852,6 +1935,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             {
                 ownedCert?.Dispose();
             }
+#endif
         }
 
         return false;
@@ -2225,7 +2309,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             throw new InvalidOperationException("Not connected");
 
         var correlationId = Interlocked.Increment(ref s_globalCorrelationId);
-        var headerVersion = TRequest.GetRequestHeaderVersion(apiVersion);
+        var headerVersion = KafkaMessageMetadata<TRequest, TResponse>.GetRequestHeaderVersion(apiVersion);
 
         // Write to stream directly (no pipe yet). Use the pooled serializer path instead
         // of the thread-local SASL buffer so credential-bearing requests can be cleared.
@@ -2234,7 +2318,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             correlationId,
             apiVersion,
             headerVersion);
-        var clearSerializedArray = TRequest.ApiKey == ApiKey.SaslAuthenticate;
+        var clearSerializedArray = KafkaMessageMetadata<TRequest, TResponse>.ApiKey == ApiKey.SaslAuthenticate;
         try
         {
             await _stream.WriteAsync(buffer.AsMemory(0, totalSize), cancellationToken).ConfigureAwait(false);
@@ -2266,7 +2350,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 }
 
                 // Skip response header and parse body
-                var responseHeaderVersion = TRequest.GetResponseHeaderVersion(apiVersion);
+                var responseHeaderVersion = KafkaMessageMetadata<TRequest, TResponse>.GetResponseHeaderVersion(apiVersion);
                 var offset = 4; // Correlation ID
 
                 if (responseHeaderVersion >= 1)
@@ -2304,7 +2388,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 }
 
                 var reader = new KafkaProtocolReader(responseBuffer.AsMemory(offset, responseSize - offset));
-                return (TResponse)TResponse.Read(ref reader, apiVersion);
+                return KafkaMessageMetadata<TRequest, TResponse>.ReadResponse(ref reader, apiVersion);
             }
             finally
             {
@@ -2627,7 +2711,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             var destination = context.Buffer.AsSpan(context.Offset, available);
 
             if (buffer.IsSingleSegment)
-                buffer.FirstSpan.Slice(0, available).CopyTo(destination);
+                buffer.First.Span.Slice(0, available).CopyTo(destination);
             else
                 buffer.Slice(0, available).CopyTo(destination);
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1890,9 +1890,6 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         // If the only error is an untrusted root, validate against our custom CA
         if (sslPolicyErrors == SslPolicyErrors.RemoteCertificateChainErrors && chain is not null)
         {
-#if NETSTANDARD2_0
-            return false;
-#else
             // Track if we created a new certificate to dispose it later
             X509Certificate2? ownedCert = null;
             try
@@ -1903,39 +1900,55 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                 using var customChain = new X509Chain();
                 customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
                 customChain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
+#if NETSTANDARD2_0
+                foreach (var caCert in trustedCaCertificates)
+                {
+                    customChain.ChainPolicy.ExtraStore.Add(caCert);
+                }
+#else
                 customChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
 
                 foreach (var caCert in trustedCaCertificates)
                 {
                     customChain.ChainPolicy.CustomTrustStore.Add(caCert);
                 }
+#endif
 
                 if (customChain.Build(cert2))
                 {
-                    // Check chain status for errors other than UntrustedRoot
-                    foreach (var status in customChain.ChainStatus)
-                    {
-                        if (status.Status != X509ChainStatusFlags.UntrustedRoot &&
-                            status.Status != X509ChainStatusFlags.NoError)
-                        {
-                            return false;
-                        }
-                    }
-
-                    // Verify the chain ends with one of our trusted CAs
-                    var rootCert = customChain.ChainElements[^1].Certificate;
-                    foreach (var caCert in trustedCaCertificates)
-                    {
-                        if (rootCert.Thumbprint == caCert.Thumbprint)
-                            return true;
-                    }
+                    return IsChainRootedInTrustedCa(customChain, trustedCaCertificates);
                 }
             }
             finally
             {
                 ownedCert?.Dispose();
             }
-#endif
+        }
+
+        return false;
+    }
+
+    private static bool IsChainRootedInTrustedCa(
+        X509Chain chain,
+        X509Certificate2Collection trustedCaCertificates)
+    {
+        foreach (var status in chain.ChainStatus)
+        {
+            if (status.Status != X509ChainStatusFlags.UntrustedRoot &&
+                status.Status != X509ChainStatusFlags.NoError)
+            {
+                return false;
+            }
+        }
+
+        if (chain.ChainElements.Count == 0)
+            return false;
+
+        var rootCert = chain.ChainElements[chain.ChainElements.Count - 1].Certificate;
+        foreach (var caCert in trustedCaCertificates)
+        {
+            if (string.Equals(rootCert.Thumbprint, caCert.Thumbprint, StringComparison.OrdinalIgnoreCase))
+                return true;
         }
 
         return false;

--- a/src/Dekaf/Networking/PipeMemoryPool.cs
+++ b/src/Dekaf/Networking/PipeMemoryPool.cs
@@ -81,7 +81,7 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
 
     public override IMemoryOwner<byte> Rent(int minBufferSize = -1)
     {
-        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        Dekaf.Compatibility.ObjectDisposedExceptionCompat.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
 
         if (minBufferSize < 0)
             minBufferSize = 4096;
@@ -172,7 +172,7 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
             get
             {
                 var array = _array;
-                ObjectDisposedException.ThrowIf(array is null, this);
+                Dekaf.Compatibility.ObjectDisposedExceptionCompat.ThrowIf(array is null, this);
                 return array;
             }
         }

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2293,6 +2293,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
         }
 
+#if NETSTANDARD2_0
+        private sealed class ReadyBatchTopicComparer : IComparer<ReadyBatch>
+        {
+            public static readonly ReadyBatchTopicComparer Instance = new();
+
+            public int Compare(ReadyBatch? x, ReadyBatch? y)
+                => string.Compare(x?.TopicPartition.Topic, y?.TopicPartition.Topic, StringComparison.Ordinal);
+        }
+#endif
+
         /// <summary>
         /// Populates the reusable request from the given batches. Returns the same
         /// ProduceRequest instance each time — callers must not hold references past
@@ -2330,8 +2340,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // batches are rare; the common case (single topic or already sorted) skips the sort.
             if (!alreadySorted)
             {
+#if NETSTANDARD2_0
+                System.Array.Sort(batches, 0, count, ReadyBatchTopicComparer.Instance);
+#else
                 batchesSpan.Sort(static (a, b) =>
                     string.Compare(a.TopicPartition.Topic, b.TopicPartition.Topic, StringComparison.Ordinal));
+#endif
 
                 // Discard the partial topicCount from the pre-scan and recount from scratch.
                 // Post-sort, topics are contiguous so simple != equality suffices (no need for
@@ -2775,7 +2789,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // After the send loop exits, these won't be polled by MaybeScaleConnections.
         if (_pendingShrinkTask is not null)
         {
-            if (_pendingShrinkTask.IsCompletedSuccessfully)
+            if (_pendingShrinkTask.Status == TaskStatus.RanToCompletion)
             {
                 var removedConn = _pendingShrinkTask.Result;
                 if (removedConn is not null)
@@ -2869,7 +2883,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var task = _pendingScaleTask;
             _pendingScaleTask = null;
 
-            if (task.IsCompletedSuccessfully)
+            if (task.Status == TaskStatus.RanToCompletion)
             {
                 var actualCount = task.Result;
                 if (actualCount > _connectionCount)
@@ -2894,7 +2908,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var task = _pendingShrinkTask;
             _pendingShrinkTask = null;
 
-            if (task.IsCompletedSuccessfully)
+            if (task.Status == TaskStatus.RanToCompletion)
             {
                 var removedConnection = task.Result;
                 if (removedConnection is not null)
@@ -2910,7 +2924,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return 0;
         }
 
-        var now = Environment.TickCount64;
+        var now = Dekaf.Compatibility.EnvironmentCompat.TickCount64;
 
         // Cooldown applies to both scale-up and scale-down
         if (now - _lastScaleTimeTicks < ScaleCooldownMs)

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -840,7 +840,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 var appendResult = SerializeAndAppendFromSpansAsync(message.Topic, message.Key, message.Value, message.Headers, message.Partition, message.Timestamp, topicInfo!, null);
 
-                if (appendResult.IsCompletedSuccessfully)
+                if (appendResult.IsCompleted)
                 {
                     // Hot path complete — fully synchronous, zero allocation
                     if (!appendResult.Result)
@@ -898,7 +898,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 var appendResult = SerializeAndAppendFromSpansAsync(topic, key, value, null, null, null, topicInfo!, null);
 
-                if (appendResult.IsCompletedSuccessfully)
+                if (appendResult.IsCompleted)
                 {
                     if (!appendResult.Result)
                         throw new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>));
@@ -936,7 +936,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // Check if cache is for this metadata manager, topic, and still valid
         // Use signed comparison to handle TickCount64 wraparound (every ~292 million years)
         var cache = GetOrCreateCache();
-        var currentTicks = Environment.TickCount64;
+        var currentTicks = Dekaf.Compatibility.EnvironmentCompat.TickCount64;
         if (cache.CachedMetadataManager == _metadataManager &&
             cache.CachedTopicName == topic &&
             cache.CachedTopicInfo is not null &&
@@ -963,7 +963,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         cache.CachedTopicInfo = topicInfo;
         // Cache valid for ~1 second (1000 ticks) - enough for high-throughput bursts
         // while still detecting stale metadata reasonably quickly
-        cache.CachedTopicValidUntilTicks = Environment.TickCount64 + 1000;
+        cache.CachedTopicValidUntilTicks = Dekaf.Compatibility.EnvironmentCompat.TickCount64 + 1000;
     }
 
     /// <summary>
@@ -1244,7 +1244,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 var appendResult = SerializeAndAppendFromSpansAsync(message.Topic, message.Key, message.Value, message.Headers, message.Partition, message.Timestamp, topicInfo!, deliveryHandler);
 
-                if (appendResult.IsCompletedSuccessfully)
+                if (appendResult.IsCompleted)
                 {
                     // Hot path complete — fully synchronous, zero allocation
                     if (!appendResult.Result)
@@ -1440,7 +1440,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         ThrowIfNotInitialized();
 
         if ((options & PurgeOptions.All) == PurgeOptions.None)
-            return ValueTask.CompletedTask;
+            return ValueTaskCompatibility.CompletedTask;
 
         ThrowIfPurgeCannotRun();
 
@@ -1449,7 +1449,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             "Produce operation was purged before delivery completed.");
 
         _accumulator.Purge(options, exception, CompleteInflightEntry);
-        return ValueTask.CompletedTask;
+        return ValueTaskCompatibility.CompletedTask;
     }
 
     private void ThrowIfPurgeCannotRun()
@@ -3104,10 +3104,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     {
         var cache = GetOrCreateCache();
 
-        // Use Environment.TickCount64 (cheap counter) to determine if we need to refresh.
+        // Use Dekaf.Compatibility.EnvironmentCompat.TickCount64 (cheap counter) to determine if we need to refresh.
         // TickCount64 increments every ~15.6ms on Windows, ~1ms on Linux, but checking
         // the difference is still much cheaper than calling DateTimeOffset.UtcNow.
-        var currentTicks = Environment.TickCount64;
+        var currentTicks = Dekaf.Compatibility.EnvironmentCompat.TickCount64;
 
         // Refresh if more than ~1ms has passed (or on first call when CachedTimestampTicks is 0)
         if (currentTicks - cache.CachedTimestampTicks > 1 || cache.CachedTimestampTicks == 0)
@@ -3685,7 +3685,11 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
 /// Used with thread-local buffers to avoid per-message ArrayPool rentals.
 /// After serialization, ToPooledMemory() copies data to a right-sized pooled buffer.
 /// </summary>
+#if NETSTANDARD2_0
+internal struct ReusableBufferWriter : IBufferWriter<byte>
+#else
 internal ref struct ReusableBufferWriter : IBufferWriter<byte>
+#endif
 {
     private byte[] _buffer;
     private int _written;

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -49,7 +49,11 @@ public sealed class DefaultPartitioner : IPartitioner
 public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwarePartitioner
 {
     private readonly ConcurrentDictionary<string, int> _stickyPartitions = new();
+#if NETSTANDARD2_0
+    private int _counter;
+#else
     private uint _counter;
+#endif
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
@@ -64,7 +68,7 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
             // Cold path: topic not yet seen, compute and add a partition.
             // Use uint to avoid overflow to negative values.
             // GetOrAdd handles the race condition - if another thread added first, we use their value.
-            var newPartition = (int)(Interlocked.Increment(ref _counter) % (uint)partitionCount);
+            var newPartition = NextPartition(partitionCount);
             return _stickyPartitions.GetOrAdd(topic, newPartition);
         }
 
@@ -80,9 +84,17 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
         // Use uint to avoid overflow to negative values.
         _stickyPartitions.AddOrUpdate(
             topic,
-            _ => (int)(Interlocked.Increment(ref _counter) % (uint)partitionCount),
-            (_, _) => (int)(Interlocked.Increment(ref _counter) % (uint)partitionCount));
+            _ => NextPartition(partitionCount),
+            (_, _) => NextPartition(partitionCount));
     }
+
+#if NETSTANDARD2_0
+    private int NextPartition(int partitionCount)
+        => (int)((uint)Interlocked.Increment(ref _counter) % (uint)partitionCount);
+#else
+    private int NextPartition(int partitionCount)
+        => (int)(Interlocked.Increment(ref _counter) % (uint)partitionCount);
+#endif
 }
 
 /// <summary>

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -132,7 +132,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _pool = pool;
 
         // Arm timeout timer. Compute remaining ms from deadline.
-        var remainingMs = deadlineTickCount - Environment.TickCount64;
+        var remainingMs = deadlineTickCount - Dekaf.Compatibility.EnvironmentCompat.TickCount64;
         if (remainingMs > 0)
         {
             _timer.Change(remainingMs, Timeout.Infinite);
@@ -220,7 +220,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     private void OnTimeout()
     {
         var configured = TimeSpan.FromMilliseconds(_accumulator.MaxBlockMsOption);
-        var elapsed = TimeSpan.FromMilliseconds(Environment.TickCount64 - _startTicks);
+        var elapsed = TimeSpan.FromMilliseconds(Dekaf.Compatibility.EnvironmentCompat.TickCount64 - _startTicks);
 
         var exception = new KafkaTimeoutException(
             TimeoutKind.MaxBlock,

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -14,13 +14,61 @@ using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 using Microsoft.Extensions.Logging;
+#if NETSTANDARD2_0
+using SpinLock = Dekaf.Producer.CompatibilitySpinLock;
+#endif
 
 namespace Dekaf.Producer;
+
+#if NETSTANDARD2_0
+internal sealed class CompatibilitySpinLock
+{
+    private readonly object _gate = new();
+
+    public CompatibilitySpinLock(bool enableThreadOwnerTracking = false)
+    {
+        _ = enableThreadOwnerTracking;
+    }
+
+    public void Enter(ref bool lockTaken)
+    {
+        Monitor.Enter(_gate);
+        lockTaken = true;
+    }
+
+    public void Exit()
+    {
+        Monitor.Exit(_gate);
+    }
+}
+#endif
 
 /// <summary>
 /// RAII guard for SpinLock that ensures Exit() is called on dispose.
 /// Must be used with <c>using var guard = new SpinLockGuard(ref spinLock);</c>.
 /// </summary>
+#if NETSTANDARD2_0
+internal readonly struct SpinLockGuard : IDisposable
+{
+    private readonly SpinLock _lock;
+    private readonly bool _taken;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public SpinLockGuard(ref SpinLock spinLock)
+    {
+        _lock = spinLock;
+        var taken = false;
+        _lock.Enter(ref taken);
+        _taken = taken;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Dispose()
+    {
+        if (_taken) _lock.Exit();
+    }
+}
+#else
 internal ref struct SpinLockGuard
 {
     private ref SpinLock _lock;
@@ -40,6 +88,7 @@ internal ref struct SpinLockGuard
         if (_taken) _lock.Exit();
     }
 }
+#endif
 
 
 /// <summary>
@@ -2280,7 +2329,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             key.Return();
             value.Return();
             ReturnPooledHeaders(headers);
-            return ValueTask.FromException<bool>(new ObjectDisposedException(nameof(RecordAccumulator)));
+            return ValueTaskCompatibility.FromException<bool>(new ObjectDisposedException(nameof(RecordAccumulator)));
         }
 
         if (cancellationToken.IsCancellationRequested)
@@ -2288,7 +2337,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             key.Return();
             value.Return();
             ReturnPooledHeaders(headers);
-            return ValueTask.FromException<bool>(new OperationCanceledException(cancellationToken));
+            return ValueTaskCompatibility.FromException<bool>(new OperationCanceledException(cancellationToken));
         }
 
         var (startTicks, deadline) = BeginReservationWait(recordSize);
@@ -2310,7 +2359,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 // Caller gets a pre-built exception ValueTask, so nobody will call GetResult
                 // on this op. Manually return it to the pool to avoid leaking.
                 op.ReturnToPoolAfterTryFail();
-                return ValueTask.FromException<bool>(disposedException);
+                return ValueTaskCompatibility.FromException<bool>(disposedException);
             }
         }
 
@@ -2965,7 +3014,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var currentBufferedBytes = Volatile.Read(ref _bufferedBytes);
         var currentMaxBufferMemory = (ulong)Volatile.Read(ref _maxBufferMemory);
         LogBufferMemoryWaiting(recordSize, currentBufferedBytes, currentMaxBufferMemory);
-        var currentTicks = Environment.TickCount64;
+        var currentTicks = Dekaf.Compatibility.EnvironmentCompat.TickCount64;
         var deadline = (long.MaxValue - currentTicks > _options.MaxBlockMs)
             ? currentTicks + _options.MaxBlockMs
             : long.MaxValue;
@@ -2995,7 +3044,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var remainingMs = deadline - Environment.TickCount64;
+            var remainingMs = deadline - Dekaf.Compatibility.EnvironmentCompat.TickCount64;
             if (remainingMs <= 0)
                 ThrowBufferMemoryTimeout(recordSize, startTicks);
 
@@ -3074,7 +3123,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private void ThrowBufferMemoryTimeout(int recordSize, long startTicks)
     {
         var configured = TimeSpan.FromMilliseconds(_options.MaxBlockMs);
-        var elapsed = TimeSpan.FromMilliseconds(Environment.TickCount64 - startTicks);
+        var elapsed = TimeSpan.FromMilliseconds(Dekaf.Compatibility.EnvironmentCompat.TickCount64 - startTicks);
         throw new KafkaTimeoutException(
             TimeoutKind.MaxBlock,
             elapsed,
@@ -3195,7 +3244,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             // Reset oldest batch tracking since there are no batches
             Volatile.Write(ref _oldestBatchCreatedTicks, long.MaxValue);
-            return ValueTask.CompletedTask;
+            return ValueTaskCompatibility.CompletedTask;
         }
 
         // Fast path 2: if the oldest batch hasn't reached linger time yet AND there are no
@@ -3210,7 +3259,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 if (millisSinceOldest < _options.LingerMs)
                 {
                     // No batch is old enough to flush yet.
-                    return ValueTask.CompletedTask;
+                    return ValueTaskCompatibility.CompletedTask;
                 }
             }
         }
@@ -3894,7 +3943,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // Fast path: no unsealed batches AND no in-flight batches - avoid async overhead entirely
         if (!HasUnsealedBatches() && Volatile.Read(ref _inFlightBatchCount) == 0)
         {
-            return ValueTask.CompletedTask;
+            return ValueTaskCompatibility.CompletedTask;
         }
 
         return FlushAsyncCore(cancellationToken);

--- a/src/Dekaf/Producer/ValueTaskSourcePool.cs
+++ b/src/Dekaf/Producer/ValueTaskSourcePool.cs
@@ -137,10 +137,10 @@ public sealed class ValueTaskSourcePool<T> : IAsyncDisposable
     public ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
-            return ValueTask.CompletedTask;
+            return ValueTaskCompatibility.CompletedTask;
 
         _stack.Clear();
 
-        return ValueTask.CompletedTask;
+        return ValueTaskCompatibility.CompletedTask;
     }
 }

--- a/src/Dekaf/Protocol/IKafkaMessage.cs
+++ b/src/Dekaf/Protocol/IKafkaMessage.cs
@@ -5,6 +5,7 @@ namespace Dekaf.Protocol;
 /// </summary>
 public interface IKafkaMessage
 {
+#if !NETSTANDARD2_0
     /// <summary>
     /// The API key for this message type.
     /// </summary>
@@ -19,6 +20,7 @@ public interface IKafkaMessage
     /// The highest supported API version.
     /// </summary>
     static abstract short HighestSupportedVersion { get; }
+#endif
 }
 
 /// <summary>
@@ -36,6 +38,7 @@ public interface IKafkaRequest<TResponse> : IKafkaMessage
     /// Returns true if this API version uses flexible encoding.
     /// With Kafka 4.0+ all supported versions are flexible.
     /// </summary>
+#if !NETSTANDARD2_0
     static virtual bool IsFlexibleVersion(short version) => true;
 
     /// <summary>
@@ -49,6 +52,7 @@ public interface IKafkaRequest<TResponse> : IKafkaMessage
     /// With Kafka 4.0+ all responses use header v1.
     /// </summary>
     static virtual short GetResponseHeaderVersion(short version) => 1;
+#endif
 }
 
 /// <summary>
@@ -56,8 +60,10 @@ public interface IKafkaRequest<TResponse> : IKafkaMessage
 /// </summary>
 public interface IKafkaResponse : IKafkaMessage
 {
+#if !NETSTANDARD2_0
     /// <summary>
     /// Reads the response body from the protocol reader.
     /// </summary>
     static abstract IKafkaResponse Read(ref KafkaProtocolReader reader, short version);
+#endif
 }

--- a/src/Dekaf/Protocol/KafkaMessageMetadata.cs
+++ b/src/Dekaf/Protocol/KafkaMessageMetadata.cs
@@ -1,0 +1,86 @@
+using System.Reflection;
+
+namespace Dekaf.Protocol;
+
+internal static class KafkaMessageMetadata<TRequest, TResponse>
+    where TRequest : IKafkaRequest<TResponse>
+    where TResponse : IKafkaResponse
+{
+#if !NETSTANDARD2_0
+    public static ApiKey ApiKey => TRequest.ApiKey;
+
+    public static short GetRequestHeaderVersion(short version) => TRequest.GetRequestHeaderVersion(version);
+
+    public static short GetResponseHeaderVersion(short version) => TRequest.GetResponseHeaderVersion(version);
+
+    public static TResponse ReadResponse(ref KafkaProtocolReader reader, short version)
+        => (TResponse)TResponse.Read(ref reader, version);
+#else
+    private delegate short HeaderVersionDelegate(short version);
+    private delegate IKafkaResponse ReadResponseDelegate(ref KafkaProtocolReader reader, short version);
+
+    private static readonly HeaderVersionDelegate? s_getRequestHeaderVersion =
+        CreateHeaderVersionDelegate(nameof(GetRequestHeaderVersion));
+    private static readonly HeaderVersionDelegate? s_getResponseHeaderVersion =
+        CreateHeaderVersionDelegate(nameof(GetResponseHeaderVersion));
+    private static readonly ReadResponseDelegate s_readResponse = CreateReadResponseDelegate();
+
+    public static ApiKey ApiKey { get; } = ReadApiKey();
+
+    public static short GetRequestHeaderVersion(short version)
+        => s_getRequestHeaderVersion?.Invoke(version) ?? 2;
+
+    public static short GetResponseHeaderVersion(short version)
+        => s_getResponseHeaderVersion?.Invoke(version) ?? 1;
+
+    public static TResponse ReadResponse(ref KafkaProtocolReader reader, short version)
+        => (TResponse)s_readResponse(ref reader, version);
+
+    private static ApiKey ReadApiKey()
+    {
+        var property = typeof(TRequest).GetProperty(
+            nameof(ApiKey),
+            BindingFlags.Public | BindingFlags.Static);
+
+        if (property is null || property.GetValue(null) is not ApiKey apiKey)
+        {
+            throw new InvalidOperationException(
+                $"{typeof(TRequest).FullName} must expose a public static ApiKey property.");
+        }
+
+        return apiKey;
+    }
+
+    private static HeaderVersionDelegate? CreateHeaderVersionDelegate(string name)
+    {
+        var method = typeof(TRequest).GetMethod(
+            name,
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: [typeof(short)],
+            modifiers: null);
+
+        return method is null
+            ? null
+            : (HeaderVersionDelegate)Delegate.CreateDelegate(typeof(HeaderVersionDelegate), method);
+    }
+
+    private static ReadResponseDelegate CreateReadResponseDelegate()
+    {
+        var method = typeof(TResponse).GetMethod(
+            "Read",
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: [typeof(KafkaProtocolReader).MakeByRefType(), typeof(short)],
+            modifiers: null);
+
+        if (method is null)
+        {
+            throw new InvalidOperationException(
+                $"{typeof(TResponse).FullName} must expose a public static Read(ref KafkaProtocolReader, short) method.");
+        }
+
+        return (ReadResponseDelegate)Delegate.CreateDelegate(typeof(ReadResponseDelegate), method);
+    }
+#endif
+}

--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -68,7 +68,7 @@ public ref struct KafkaProtocolReader
         if (buffer.IsSingleSegment)
         {
             // Fast path: Single segment - use direct span access
-            _span = buffer.FirstSpan;
+            _span = buffer.First.Span;
             _memory = buffer.First;
             _hasMemory = true;
             _position = 0;
@@ -302,7 +302,7 @@ public ref struct KafkaProtocolReader
         {
             if (_position + 16 > _span.Length)
                 ThrowInsufficientData();
-            var result = new Guid(_span.Slice(_position, 16), bigEndian: true);
+            var result = Dekaf.Compatibility.GuidCompatibility.ReadBigEndian(_span.Slice(_position, 16));
             _position += 16;
             return result;
         }
@@ -314,7 +314,7 @@ public ref struct KafkaProtocolReader
     {
         if (_reader.UnreadSpan.Length >= 16)
         {
-            var result = new Guid(_reader.UnreadSpan[..16], bigEndian: true);
+            var result = Dekaf.Compatibility.GuidCompatibility.ReadBigEndian(_reader.UnreadSpan[..16]);
             _reader.Advance(16);
             return result;
         }
@@ -322,7 +322,7 @@ public ref struct KafkaProtocolReader
         if (!_reader.TryCopyTo(buffer))
             ThrowInsufficientData();
         _reader.Advance(16);
-        return new Guid(buffer, bigEndian: true);
+        return Dekaf.Compatibility.GuidCompatibility.ReadBigEndian(buffer);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Protocol/KafkaProtocolWriter.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolWriter.cs
@@ -94,7 +94,7 @@ public ref struct KafkaProtocolWriter
     public void WriteUuid(Guid value)
     {
         var span = _output.GetSpan(16);
-        value.TryWriteBytes(span, bigEndian: true, out _);
+        Dekaf.Compatibility.GuidCompatibility.WriteBigEndian(value, span);
         _output.Advance(16);
         _bytesWritten += 16;
     }

--- a/src/Dekaf/Protocol/Messages/FetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FetchResponse.cs
@@ -52,7 +52,7 @@ public sealed class FetchResponse : IKafkaResponse
     {
         get
         {
-            ObjectDisposedException.ThrowIf(Volatile.Read(ref _pooled) != 0, this);
+            Dekaf.Compatibility.ObjectDisposedExceptionCompat.ThrowIf(Volatile.Read(ref _pooled) != 0, this);
             return _responses;
         }
         internal set => _responses = value;
@@ -195,7 +195,7 @@ public sealed class FetchResponseTopic
     {
         get
         {
-            ObjectDisposedException.ThrowIf(Volatile.Read(ref _pooled) != 0, this);
+            Dekaf.Compatibility.ObjectDisposedExceptionCompat.ThrowIf(Volatile.Read(ref _pooled) != 0, this);
             return _partitions;
         }
         internal set => _partitions = value;
@@ -349,7 +349,7 @@ public sealed class FetchResponsePartition
     {
         get
         {
-            ObjectDisposedException.ThrowIf(Volatile.Read(ref _pooled) != 0, this);
+            Dekaf.Compatibility.ObjectDisposedExceptionCompat.ThrowIf(Volatile.Read(ref _pooled) != 0, this);
             return _abortedTransactions;
         }
         internal set => _abortedTransactions = value;
@@ -367,7 +367,7 @@ public sealed class FetchResponsePartition
     {
         get
         {
-            ObjectDisposedException.ThrowIf(Volatile.Read(ref _pooled) != 0, this);
+            Dekaf.Compatibility.ObjectDisposedExceptionCompat.ThrowIf(Volatile.Read(ref _pooled) != 0, this);
             return _records;
         }
         internal set => _records = value;

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -2,8 +2,10 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+#if !NETSTANDARD2_0
 using System.Runtime.Intrinsics.X86;
 using ArmCrc32 = System.Runtime.Intrinsics.Arm.Crc32;
+#endif
 using Dekaf.Compression;
 using Dekaf.Internal;
 using Dekaf.Producer;
@@ -1356,12 +1358,16 @@ internal static class Crc32C
 {
     private const int TableSize = 256;
     private const int SliceCount = 8;
+#if !NETSTANDARD2_0
     private const int X86ParallelChunkSize = 512;
     private const int X86ParallelBlockSize = X86ParallelChunkSize * 3;
+#endif
 
     private static readonly uint[] Table = GenerateTable();
+#if !NETSTANDARD2_0
     private static readonly uint[] X86ShiftChunk = CreateShiftOperator(X86ParallelChunkSize);
     private static readonly uint[] X86ShiftTwoChunks = CreateShiftOperator(X86ParallelChunkSize * 2);
+#endif
 
     private static uint[] GenerateTable()
     {
@@ -1396,6 +1402,7 @@ internal static class Crc32C
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static uint Compute(ReadOnlySpan<byte> data)
     {
+#if !NETSTANDARD2_0
         if (Sse42.IsSupported)
         {
             return ComputeHardwareX86(data);
@@ -1405,10 +1412,12 @@ internal static class Crc32C
         {
             return ComputeHardwareArm(data);
         }
+#endif
 
         return ComputeSoftware(data);
     }
 
+#if !NETSTANDARD2_0
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static uint ComputeHardwareX86(ReadOnlySpan<byte> data)
     {
@@ -1532,6 +1541,7 @@ internal static class Crc32C
 
         return crc ^ 0xFFFFFFFFu;
     }
+#endif
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     internal static uint ComputeSoftware(ReadOnlySpan<byte> data)

--- a/src/Dekaf/Security/Sasl/AwsMskIamAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamAuthenticator.cs
@@ -54,11 +54,12 @@ public sealed class AwsMskIamAuthenticator : ISaslAuthenticator
             ?? throw new InvalidOperationException("AWS credentials are not available. Call GetCredentialsAsync before authentication.");
 
         var region = ResolveRegion();
+        var userAgent = string.IsNullOrWhiteSpace(_config.UserAgent) ? "dekaf" : _config.UserAgent!;
         var payload = AwsMskIamSignedPayload.Create(
             credentials,
             _host,
             region,
-            string.IsNullOrWhiteSpace(_config.UserAgent) ? "dekaf" : _config.UserAgent,
+            userAgent,
             DateTimeOffset.UtcNow,
             _config.AuthenticationPayloadExpiration);
 
@@ -108,7 +109,10 @@ internal static class AwsMskIamRegionResolver
 {
     public static string? TryResolveFromHost(string host)
     {
-        var labels = host.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var labels = host.Split('.', StringSplitOptions.RemoveEmptyEntries)
+            .Select(static label => label.Trim())
+            .Where(static label => label.Length > 0)
+            .ToArray();
         for (var i = 0; i < labels.Length; i++)
         {
             if (!IsAmazonAwsSuffix(labels, i) || i < 2)

--- a/src/Dekaf/Security/Sasl/AwsMskIamDefaultCredentialsProvider.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamDefaultCredentialsProvider.cs
@@ -247,13 +247,15 @@ public sealed class AwsMskIamDefaultCredentialsProvider : IAwsCredentialsProvide
             if (string.IsNullOrWhiteSpace(roleName))
                 return null;
 
-            roleName = roleName.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)[0];
+            roleName = roleName!.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Select(static line => line.Trim())
+                .First(static line => line.Length > 0);
             var json = await GetImdsStringAsync(
                 "http://169.254.169.254/latest/meta-data/iam/security-credentials/" + Uri.EscapeDataString(roleName),
                 token,
                 cancellationToken).ConfigureAwait(false);
 
-            return string.IsNullOrWhiteSpace(json) ? null : ParseJsonCredentials(json);
+            return string.IsNullOrWhiteSpace(json) ? null : ParseJsonCredentials(json!);
         }
         catch (HttpRequestException)
         {

--- a/src/Dekaf/Security/Sasl/AwsMskIamSignedPayload.cs
+++ b/src/Dekaf/Security/Sasl/AwsMskIamSignedPayload.cs
@@ -54,7 +54,7 @@ internal static class AwsMskIamSignedPayload
 
         var canonicalRequest = CreateCanonicalRequest(queryParameters, host);
         var stringToSign = string.Join(
-            '\n',
+            "\n",
             Algorithm,
             amzDate,
             credentialScope,
@@ -89,11 +89,11 @@ internal static class AwsMskIamSignedPayload
         string host)
     {
         var canonicalQuery = string.Join(
-            '&',
+            "&",
             queryParameters.Select(pair => $"{UriEncode(pair.Key)}={UriEncode(pair.Value)}"));
 
         return string.Join(
-            '\n',
+            "\n",
             "GET",
             "/",
             canonicalQuery,

--- a/src/Dekaf/Security/Sasl/GssapiAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/GssapiAuthenticator.cs
@@ -1,4 +1,6 @@
+#if !NETSTANDARD2_0
 using System.Net.Security;
+#endif
 using Dekaf.Errors;
 
 namespace Dekaf.Security.Sasl;
@@ -21,9 +23,11 @@ namespace Dekaf.Security.Sasl;
 /// </remarks>
 public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
 {
+#if !NETSTANDARD2_0
     private readonly GssapiConfig _config;
     private readonly string _targetHost;
     private NegotiateAuthentication? _auth;
+#endif
     private GssapiState _state = GssapiState.Initial;
     private bool _disposed;
 
@@ -41,9 +45,15 @@ public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
     /// <param name="targetHost">The target broker hostname for SPN construction.</param>
     public GssapiAuthenticator(GssapiConfig config, string targetHost)
     {
+#if NETSTANDARD2_0
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(targetHost);
+        config.Validate();
+#else
         _config = config ?? throw new ArgumentNullException(nameof(config));
         _targetHost = targetHost ?? throw new ArgumentNullException(nameof(targetHost));
         _config.Validate();
+#endif
     }
 
     /// <inheritdoc />
@@ -55,6 +65,10 @@ public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
     /// <inheritdoc />
     public byte[] GetInitialResponse()
     {
+#if NETSTANDARD2_0
+        throw new PlatformNotSupportedException(
+            "SASL GSSAPI requires System.Net.Security.NegotiateAuthentication, which is not available on netstandard2.0.");
+#else
         if (_state != GssapiState.Initial)
         {
             throw new InvalidOperationException("GetInitialResponse can only be called once");
@@ -83,11 +97,16 @@ public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
         }
 
         return outgoingBlob ?? [];
+#endif
     }
 
     /// <inheritdoc />
     public byte[]? EvaluateChallenge(byte[] challenge)
     {
+#if NETSTANDARD2_0
+        throw new PlatformNotSupportedException(
+            "SASL GSSAPI requires System.Net.Security.NegotiateAuthentication, which is not available on netstandard2.0.");
+#else
         if (_auth is null)
         {
             throw new InvalidOperationException("GetInitialResponse must be called before EvaluateChallenge");
@@ -113,6 +132,7 @@ public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
         }
 
         throw new AuthenticationException($"GSSAPI authentication failed: {statusCode}");
+#endif
     }
 
     /// <inheritdoc />
@@ -123,7 +143,9 @@ public sealed class GssapiAuthenticator : ISaslAuthenticator, IDisposable
             return;
         }
 
+#if !NETSTANDARD2_0
         _auth?.Dispose();
+#endif
         _disposed = true;
     }
 }

--- a/src/Dekaf/Security/Sasl/GssapiConfig.cs
+++ b/src/Dekaf/Security/Sasl/GssapiConfig.cs
@@ -1,5 +1,7 @@
 using System.Net;
+#if !NETSTANDARD2_0
 using System.Net.Security;
+#endif
 using System.Security.Principal;
 
 namespace Dekaf.Security.Sasl;
@@ -94,6 +96,7 @@ public sealed class GssapiConfig
         }
     }
 
+#if !NETSTANDARD2_0
     internal NegotiateAuthenticationClientOptions CreateClientOptions(string targetHost)
     {
         Validate();
@@ -114,6 +117,7 @@ public sealed class GssapiConfig
 
         return options;
     }
+#endif
 
     internal void ApplyKeytabEnvironment()
     {

--- a/src/Dekaf/Security/Sasl/OAuthBearerJwtAssertion.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerJwtAssertion.cs
@@ -73,7 +73,7 @@ internal static class OAuthBearerJwtAssertion
     {
         if (string.IsNullOrWhiteSpace(value))
             throw new InvalidOperationException(message);
-        return value;
+        return value!;
     }
 
     private static void ValidateAdditionalClaims(IReadOnlyDictionary<string, object?>? claims)
@@ -176,7 +176,7 @@ internal static class OAuthBearerJwtAssertion
 
     private static void WriteAdditionalClaimNumberValue(Utf8JsonWriter writer, string claimName, float value)
     {
-        if (!float.IsFinite(value))
+        if (float.IsNaN(value) || float.IsInfinity(value))
             throw UnsupportedAdditionalClaimValue(claimName, value);
 
         writer.WriteNumberValue(value);
@@ -184,7 +184,7 @@ internal static class OAuthBearerJwtAssertion
 
     private static void WriteAdditionalClaimNumberValue(Utf8JsonWriter writer, string claimName, double value)
     {
-        if (!double.IsFinite(value))
+        if (double.IsNaN(value) || double.IsInfinity(value))
             throw UnsupportedAdditionalClaimValue(claimName, value);
 
         writer.WriteNumberValue(value);
@@ -289,9 +289,13 @@ internal static class OAuthBearerJwtAssertion
         byte[] signingInput,
         HashAlgorithmName hashAlgorithm)
     {
+#if NETSTANDARD2_0
+        throw new PlatformNotSupportedException("ECDSA JWT-bearer assertions require .NET APIs that are not available on netstandard2.0.");
+#else
         if (key is not ECDsa ecdsa)
             throw new InvalidOperationException("Selected JWT-bearer signing algorithm requires an ECDSA private key");
 
         return ecdsa.SignData(signingInput, hashAlgorithm, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+#endif
     }
 }

--- a/src/Dekaf/Security/Sasl/OAuthBearerJwtBearerOptions.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerJwtBearerOptions.cs
@@ -104,7 +104,7 @@ public sealed class OAuthBearerJwtBearerOptions
             GrantType = OAuthBearerGrantType.JwtBearer,
             TokenEndpointUrl = options.TokenEndpoint!,
             ClientId = options.ClientId!,
-            Scope = options.Scopes is { Count: > 0 } ? string.Join(' ', options.Scopes) : null,
+            Scope = options.Scopes is { Count: > 0 } ? string.Join(" ", options.Scopes) : null,
             AdditionalParameters = options.AdditionalParameters,
             JwtBearer = options,
             TokenRefreshBufferSeconds = TokenRefreshBufferSeconds
@@ -121,8 +121,12 @@ public sealed class OAuthBearerJwtBearerOptions
         Subject = Subject,
         KeyId = KeyId,
         Scopes = Scopes is null ? null : Scopes.ToArray(),
-        AdditionalClaims = AdditionalClaims is null ? null : new Dictionary<string, object?>(AdditionalClaims, StringComparer.Ordinal),
-        AdditionalParameters = AdditionalParameters is null ? null : new Dictionary<string, string>(AdditionalParameters, StringComparer.Ordinal),
+        AdditionalClaims = AdditionalClaims is null
+            ? null
+            : AdditionalClaims.ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value, StringComparer.Ordinal),
+        AdditionalParameters = AdditionalParameters is null
+            ? null
+            : AdditionalParameters.ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value, StringComparer.Ordinal),
         AssertionLifetime = AssertionLifetime,
         TokenRefreshBufferSeconds = TokenRefreshBufferSeconds,
         SigningAlgorithm = SigningAlgorithm

--- a/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
@@ -113,9 +113,10 @@ public sealed class OAuthBearerTokenProvider : IDisposable
             _ => throw new InvalidOperationException($"Unsupported OAuth bearer grant type: {_config.GrantType}")
         };
 
-        if (!string.IsNullOrEmpty(_config.Scope))
+        var scope = _config.Scope;
+        if (!string.IsNullOrEmpty(scope))
         {
-            body["scope"] = _config.Scope;
+            body["scope"] = scope!;
         }
 
         if (_config.AdditionalParameters is not null)
@@ -196,7 +197,7 @@ public sealed class OAuthBearerTokenProvider : IDisposable
         {
             var sub = subElement.GetString();
             if (!string.IsNullOrEmpty(sub))
-                return sub;
+                return sub!;
         }
 
         // Try to decode JWT and extract subject claim
@@ -229,7 +230,7 @@ public sealed class OAuthBearerTokenProvider : IDisposable
                     {
                         var value = claimElement.GetString();
                         if (!string.IsNullOrEmpty(value))
-                            return value;
+                            return value!;
                     }
                 }
             }

--- a/src/Dekaf/Security/Sasl/ScramAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/ScramAuthenticator.cs
@@ -210,7 +210,7 @@ public sealed class ScramAuthenticator : ISaslAuthenticator
 
     private static string GenerateNonce()
     {
-        var bytes = RandomNumberGenerator.GetBytes(24);
+        var bytes = Dekaf.Compatibility.RandomNumberGeneratorCompat.GetBytes(24);
         return Convert.ToBase64String(bytes);
     }
 

--- a/src/Dekaf/Serialization/BuiltInSerializers.cs
+++ b/src/Dekaf/Serialization/BuiltInSerializers.cs
@@ -108,7 +108,10 @@ public readonly struct Ignore;
 internal sealed class ByteArraySerde : ISerde<byte[]>
 {
     public void Serialize<TWriter>(byte[] value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         var span = destination.GetSpan(value.Length);
         value.CopyTo(span);
@@ -124,7 +127,10 @@ internal sealed class ByteArraySerde : ISerde<byte[]>
 internal sealed class StringSerde : ISerde<string>
 {
     public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         var span = destination.GetSpan(checked(value.Length * 3));
         var bytesWritten = Encoding.UTF8.GetBytes(value, span);
@@ -140,7 +146,10 @@ internal sealed class StringSerde : ISerde<string>
 internal sealed class NullableStringSerde : ISerde<string?>
 {
     public void Serialize<TWriter>(string? value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         if (value is null)
             return;
@@ -165,7 +174,10 @@ internal sealed class NullableStringSerde : ISerde<string?>
 internal sealed class Int32Serde : ISerde<int>
 {
     public void Serialize<TWriter>(int value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         var span = destination.GetSpan(4);
         BinaryPrimitives.WriteInt32BigEndian(span, value);
@@ -181,7 +193,10 @@ internal sealed class Int32Serde : ISerde<int>
 internal sealed class Int64Serde : ISerde<long>
 {
     public void Serialize<TWriter>(long value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         var span = destination.GetSpan(8);
         BinaryPrimitives.WriteInt64BigEndian(span, value);
@@ -197,23 +212,29 @@ internal sealed class Int64Serde : ISerde<long>
 internal sealed class GuidSerde : ISerde<Guid>
 {
     public void Serialize<TWriter>(Guid value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         var span = destination.GetSpan(16);
-        value.TryWriteBytes(span, bigEndian: true, out _);
+        Dekaf.Compatibility.GuidCompatibility.WriteBigEndian(value, span);
         destination.Advance(16);
     }
 
     public Guid Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
     {
-        return new Guid(data.Span, bigEndian: true);
+        return Dekaf.Compatibility.GuidCompatibility.ReadBigEndian(data.Span);
     }
 }
 
 internal sealed class DoubleSerde : ISerde<double>
 {
     public void Serialize<TWriter>(double value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         var span = destination.GetSpan(8);
         BinaryPrimitives.WriteDoubleBigEndian(span, value);
@@ -229,7 +250,10 @@ internal sealed class DoubleSerde : ISerde<double>
 internal sealed class FloatSerde : ISerde<float>
 {
     public void Serialize<TWriter>(float value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         var span = destination.GetSpan(4);
         BinaryPrimitives.WriteSingleBigEndian(span, value);
@@ -245,7 +269,10 @@ internal sealed class FloatSerde : ISerde<float>
 internal sealed class DateTimeSerde : ISerde<DateTime>
 {
     public void Serialize<TWriter>(DateTime value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         var span = destination.GetSpan(8);
         BinaryPrimitives.WriteInt64BigEndian(span, value.ToUniversalTime().Ticks);
@@ -262,7 +289,10 @@ internal sealed class DateTimeSerde : ISerde<DateTime>
 internal sealed class DateTimeOffsetSerde : ISerde<DateTimeOffset>
 {
     public void Serialize<TWriter>(DateTimeOffset value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         var span = destination.GetSpan(10);
         BinaryPrimitives.WriteInt64BigEndian(span, value.UtcTicks);
@@ -283,7 +313,10 @@ internal sealed class DateTimeOffsetSerde : ISerde<DateTimeOffset>
 internal sealed class TimeSpanSerde : ISerde<TimeSpan>
 {
     public void Serialize<TWriter>(TimeSpan value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         var span = destination.GetSpan(8);
         BinaryPrimitives.WriteInt64BigEndian(span, value.Ticks);
@@ -300,7 +333,10 @@ internal sealed class TimeSpanSerde : ISerde<TimeSpan>
 internal sealed class NullSerde<T> : ISerde<T?> where T : class
 {
     public void Serialize<TWriter>(T? value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         // No-op
     }
@@ -314,7 +350,10 @@ internal sealed class NullSerde<T> : ISerde<T?> where T : class
 internal sealed class IgnoreSerde : ISerde<Ignore>
 {
     public void Serialize<TWriter>(Ignore value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         // No-op
     }
@@ -336,7 +375,10 @@ internal sealed class IgnoreSerde : ISerde<Ignore>
 internal sealed class RawBytesSerde : ISerde<ReadOnlyMemory<byte>>
 {
     public void Serialize<TWriter>(ReadOnlyMemory<byte> value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         var span = destination.GetSpan(value.Length);
         value.Span.CopyTo(span);

--- a/src/Dekaf/Serialization/CachingStringKeyDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringKeyDeserializer.cs
@@ -30,7 +30,10 @@ internal sealed class CachingStringKeyDeserializer : ISerde<string>
     }
 
     public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
-        where TWriter : System.Buffers.IBufferWriter<byte>, allows ref struct
+        where TWriter : System.Buffers.IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
     {
         _inner.Serialize(value, ref destination, context);
     }

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -212,7 +212,7 @@ public sealed class Headers : IEnumerable<Header>
     {
         if (!string.IsNullOrEmpty(value))
         {
-            Add(key, value);
+            Add(key, value!);
         }
         return this;
     }

--- a/src/Dekaf/Serialization/ISerializer.cs
+++ b/src/Dekaf/Serialization/ISerializer.cs
@@ -16,7 +16,11 @@ public interface ISerializer<in T>
     /// <param name="destination">The buffer to write serialized bytes to. Passed by ref to support ref struct writers.</param>
     /// <param name="context">Serialization context with topic and header information.</param>
     void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct;
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
+        ;
 }
 
 /// <summary>

--- a/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
@@ -1,3 +1,11 @@
+#if NETSTANDARD2_0
+using StringSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using StringSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
+
 namespace Dekaf.ShareConsumer;
 
 /// <summary>
@@ -17,12 +25,12 @@ public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, 
     /// <summary>
     /// Gets the current topic subscription.
     /// </summary>
-    IReadOnlySet<string> Subscription { get; }
+    StringSet Subscription { get; }
 
     /// <summary>
     /// Gets the current partition assignment from the share group coordinator.
     /// </summary>
-    IReadOnlySet<TopicPartition> Assignment { get; }
+    TopicPartitionSet Assignment { get; }
 
     /// <summary>
     /// Gets the member ID (client-generated UUID) if part of a share group.

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -8,6 +8,13 @@ using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 using Microsoft.Extensions.Logging;
+#if NETSTANDARD2_0
+using StringSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using StringSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
 
 namespace Dekaf.ShareConsumer;
 
@@ -34,8 +41,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     [ThreadStatic]
     private static SerializationContext t_serializationContext;
 
-    private volatile IReadOnlySet<string> _subscriptionSnapshot = new HashSet<string>();
-    private volatile IReadOnlySet<TopicPartition> _assignmentSnapshot = new HashSet<TopicPartition>();
+    private volatile StringSet _subscriptionSnapshot = new HashSet<string>();
+    private volatile TopicPartitionSet _assignmentSnapshot = new HashSet<TopicPartition>();
 
     private readonly SemaphoreSlim _initLock = new(1, 1);
     private volatile bool _initialized;
@@ -132,8 +139,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             loggerFactory?.CreateLogger<ShareConsumerCoordinator>());
     }
 
-    public IReadOnlySet<string> Subscription => _subscriptionSnapshot;
-    public IReadOnlySet<TopicPartition> Assignment => _assignmentSnapshot;
+    public StringSet Subscription => _subscriptionSnapshot;
+    public TopicPartitionSet Assignment => _assignmentSnapshot;
     public string? MemberId => _coordinator.MemberId;
 
     public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)
@@ -664,7 +671,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     /// Groups assigned partitions by their leader broker.
     /// </summary>
     private Dictionary<int, List<TopicPartition>> GroupPartitionsByLeader(
-        IReadOnlySet<TopicPartition> assignment)
+        TopicPartitionSet assignment)
     {
         var result = new Dictionary<int, List<TopicPartition>>();
 

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -6,6 +6,13 @@ using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Consumer;
 using Microsoft.Extensions.Logging;
+#if NETSTANDARD2_0
+using StringSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using StringSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
 
 namespace Dekaf.ShareConsumer;
 
@@ -39,7 +46,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
 
     private volatile int _heartbeatIntervalMs;
     private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
-    private volatile IReadOnlySet<string>? _subscribedTopics;
+    private volatile StringSet? _subscribedTopics;
 
     internal static int GetCoordinationConnectionIndex(int connectionsPerBroker)
         => connectionsPerBroker - 1;
@@ -64,7 +71,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     public string? MemberId => _memberId;
     public int MemberEpoch => _memberEpoch;
     public CoordinatorState State => _state;
-    public IReadOnlySet<TopicPartition> Assignment => _assignedPartitions;
+    public TopicPartitionSet Assignment => _assignedPartitions;
 
     /// <summary>
     /// Forces the coordinator to rejoin the group on the next
@@ -79,7 +86,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     /// Ensures the share consumer has joined the group.
     /// </summary>
     public async ValueTask EnsureActiveGroupAsync(
-        IReadOnlySet<string> topics,
+        StringSet topics,
         CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _disposed) != 0)
@@ -357,7 +364,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     /// Ensures the share consumer has joined the group using the ShareGroupHeartbeat API.
     /// </summary>
     private async ValueTask EnsureActiveGroupCoreAsync(
-        IReadOnlySet<string> topics,
+        StringSet topics,
         CancellationToken cancellationToken)
     {
         if (!_metadataManager.HasApiKey(ApiKey.ShareGroupHeartbeat))
@@ -532,7 +539,8 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
         if (Volatile.Read(ref _disposed) != 0)
             return;
 
-        if (string.IsNullOrEmpty(_memberId))
+        var memberId = _memberId;
+        if (string.IsNullOrEmpty(memberId))
             return;
 
         if (_coordinatorId < 0)
@@ -547,7 +555,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
             var request = new ShareGroupHeartbeatRequest
             {
                 GroupId = _options.GroupId,
-                MemberId = _memberId,
+                MemberId = memberId!,
                 MemberEpoch = -1
             };
 

--- a/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
@@ -262,7 +262,7 @@ internal sealed class ClientTelemetryMetricCollector
                 continue;
             }
 
-            if (!double.IsFinite(value))
+            if (double.IsNaN(value) || double.IsInfinity(value))
             {
                 continue;
             }

--- a/src/Dekaf/Telemetry/ClientTelemetryPayloadProvider.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryPayloadProvider.cs
@@ -12,6 +12,7 @@ internal sealed class ClientTelemetryPayloadProvider : IClientTelemetryPayloadPr
     private const int WireLengthDelimited = 2;
     private const int AggregationTemporalityDelta = 1;
     private const int AggregationTemporalityCumulative = 2;
+    private const long UnixEpochTicks = 621355968000000000L;
 
     private readonly CompressionCodecRegistry _compressionCodecs;
     private readonly Func<long> _unixNanoClock;
@@ -201,7 +202,7 @@ internal sealed class ClientTelemetryPayloadProvider : IClientTelemetryPayloadPr
 
     private static long GetUnixTimeNanoseconds()
     {
-        var ticksSinceUnixEpoch = DateTimeOffset.UtcNow.UtcTicks - 621355968000000000L;
+        var ticksSinceUnixEpoch = DateTimeOffset.UtcNow.UtcTicks - UnixEpochTicks;
         return checked(ticksSinceUnixEpoch * 100);
     }
 }

--- a/src/Dekaf/Telemetry/ClientTelemetryPayloadProvider.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryPayloadProvider.cs
@@ -201,7 +201,7 @@ internal sealed class ClientTelemetryPayloadProvider : IClientTelemetryPayloadPr
 
     private static long GetUnixTimeNanoseconds()
     {
-        var ticksSinceUnixEpoch = DateTimeOffset.UtcNow.UtcTicks - DateTime.UnixEpoch.Ticks;
+        var ticksSinceUnixEpoch = DateTimeOffset.UtcNow.UtcTicks - 621355968000000000L;
         return checked(ticksSinceUnixEpoch * 100);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Consumer;
+using Dekaf.Tests.Unit;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
@@ -153,6 +154,26 @@ public sealed class ConsumerConnectionScalerTests
         scaler.ReportPipelineUtilization(3, 3);
         scaler.MaybeScale();
         await Assert.That(scaleUpCount).IsEqualTo(0); // Cannot scale
+    }
+
+    [Test]
+    public async Task MaybeScale_SynchronousScaleFailure_LogsError()
+    {
+        var exception = new InvalidOperationException("scale failed");
+        Exception? logged = null;
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 4,
+            scaleUpAsync: _ => ValueTask.FromException(exception),
+            scaleDownAsync: _ => ValueTask.CompletedTask,
+            logError: ex => logged = ex);
+
+        scaler.ReportPipelineUtilization(3, 3);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+        scaler.MaybeScale();
+
+        await TestWait.UntilAsync(() => logged is not null, TimeSpan.FromSeconds(5));
+        await Assert.That(logged).IsSameReferenceAs(exception);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add netstandard2.0 compatibility shims for core BCL, threading, buffering, crypto, stream/socket, and ValueTask gaps
- route protocol metadata through a helper so netstandard avoids static abstract interface dispatch while net10 keeps the fast path
- guard net10-only TLS/GSSAPI/compression/intrinsics paths and document the clean forced probe state

## Test plan
- [x] `dotnet build src\Dekaf\Dekaf.csproj --configuration Release -f net10.0`
- [x] `dotnet build src\Dekaf\Dekaf.csproj --configuration Release -p:TargetFrameworks=netstandard2.0 -p:TargetFramework=netstandard2.0`
- [x] `dotnet build tests\Dekaf.Tests.Unit --configuration Release`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/StickyPartitionerTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ClientDnsLookupTests/KafkaConnection_ConnectAsync_TriesAllResolvedAddresses"`
- [ ] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe` full suite: 4124/4125 passed locally; `KafkaConnection_ConnectAsync_TriesAllResolvedAddresses` canceled once, then passed when run focused after confirming `ConnectSocketAsync` matches `origin/main` in that path.

Closes #1300
