### PR TITLE
ci(aot): run NativeAOT smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,10 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
             core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
 
-      - name: Install NativeAOT prerequisites
-        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
-
       - name: Run Pipeline
         env:
           SKIP_INTEGRATION_TESTS: 'true'
+          SKIP_AOT_SMOKE_TESTS: 'true'
           NuGet__ShouldPublish: ${{ inputs.publish_nuget == true && 'true' || 'false' }}
           NuGet__ApiKey: ${{ secrets.NUGET__APIKEY }}
         run: dotnet run --project tools/Dekaf.Pipeline
@@ -93,6 +91,50 @@ jobs:
             **/*.dmp
           if-no-files-found: ignore
           retention-days: 7
+
+  native-aot-smoke:
+    name: NativeAOT Smoke (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: core
+            project: tests/Dekaf.Tests.Aot/Dekaf.Tests.Aot.csproj
+            executable: Dekaf.Tests.Aot
+          - name: dependency-injection
+            project: tests/Dekaf.Tests.Aot.DependencyInjection/Dekaf.Tests.Aot.DependencyInjection.csproj
+            executable: Dekaf.Tests.Aot.DependencyInjection
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-quality: 'preview'
+
+      - name: Install NativeAOT prerequisites
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Publish NativeAOT smoke executable
+        run: |
+          dotnet publish "${{ matrix.project }}" \
+            --configuration Release \
+            --framework net10.0 \
+            --runtime linux-x64 \
+            --self-contained true \
+            --output "artifacts/aot/${{ matrix.name }}" \
+            -p:PublishAot=true \
+            -p:ContinuousIntegrationBuild=true \
+            -p:TreatWarningsAsErrors=true
+
+      - name: Run NativeAOT smoke executable
+        run: ./artifacts/aot/${{ matrix.name }}/${{ matrix.executable }}
 
   integration-tests:
     name: Integration Tests (${{ matrix.category }})

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -64,3 +64,38 @@ Register `ISerializer<T>` and `IDeserializer<T>` in DI when your application use
 `InMemoryAdminClient` supports common unit-test operations such as creating, deleting, listing, and describing topics, altering/listing group offsets, deleting records, creating partitions, and listing offsets. Broker-only APIs such as ACL, SCRAM, and config mutation are accepted as no-ops or return empty results.
 
 Use Testcontainers or another real broker for protocol compatibility and integration coverage.
+
+## NativeAOT smoke validation
+
+CI runs a `NativeAOT Smoke` pull-request job for the supported `linux-x64`
+runtime. It publishes each smoke executable with `PublishAot=true` and
+`TreatWarningsAsErrors=true`, then runs the published binary.
+
+Run the same validation locally on Linux after installing the NativeAOT
+toolchain:
+
+```bash
+sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+dotnet publish tests/Dekaf.Tests.Aot/Dekaf.Tests.Aot.csproj \
+  --configuration Release \
+  --framework net10.0 \
+  --runtime linux-x64 \
+  --self-contained true \
+  --output artifacts/aot/core \
+  -p:PublishAot=true \
+  -p:ContinuousIntegrationBuild=true \
+  -p:TreatWarningsAsErrors=true
+./artifacts/aot/core/Dekaf.Tests.Aot
+
+dotnet publish tests/Dekaf.Tests.Aot.DependencyInjection/Dekaf.Tests.Aot.DependencyInjection.csproj \
+  --configuration Release \
+  --framework net10.0 \
+  --runtime linux-x64 \
+  --self-contained true \
+  --output artifacts/aot/dependency-injection \
+  -p:PublishAot=true \
+  -p:ContinuousIntegrationBuild=true \
+  -p:TreatWarningsAsErrors=true
+./artifacts/aot/dependency-injection/Dekaf.Tests.Aot.DependencyInjection
+```

--- a/src/Dekaf.Extensions.DependencyInjection/Dekaf.Extensions.DependencyInjection.csproj
+++ b/src/Dekaf.Extensions.DependencyInjection/Dekaf.Extensions.DependencyInjection.csproj
@@ -4,6 +4,7 @@
     <PackageId>Dekaf.Extensions.DependencyInjection</PackageId>
     <Description>Microsoft.Extensions.DependencyInjection integration for Dekaf Kafka client</Description>
     <PackageTags>kafka;dependency-injection;di</PackageTags>
+    <NoWarn>$(NoWarn);SYSLIB1104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
+++ b/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Dekaf.Consumer;
 using Dekaf.Consumer.DeadLetter;
 using Dekaf.Producer;
@@ -486,7 +487,10 @@ public static class HostingExtensions
     /// <summary>
     /// Adds a Kafka consumer hosted service.
     /// </summary>
-    public static IHostBuilder UseKafkaConsumer<TService, TKey, TValue>(this IHostBuilder builder)
+    public static IHostBuilder UseKafkaConsumer<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TService,
+        TKey,
+        TValue>(this IHostBuilder builder)
         where TService : KafkaConsumerService<TKey, TValue>
     {
         return builder.ConfigureServices((context, services) =>

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaFieldCache.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaFieldCache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Dekaf.SchemaRegistry.Avro;
@@ -21,9 +22,13 @@ internal static class AvroSchemaFieldCache
     /// execute more than once; however, the reflection call is idempotent and only one result is
     /// stored and returned for subsequent lookups.
     /// </remarks>
-    internal static FieldInfo? GetSchemaField(Type type)
+    internal static FieldInfo? GetSchemaField(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type)
     {
-        return s_schemaFieldCache.GetOrAdd(type, static t =>
-            t.GetField("_SCHEMA", BindingFlags.Public | BindingFlags.Static));
+        if (s_schemaFieldCache.TryGetValue(type, out var cached))
+            return cached;
+
+        var field = type.GetField("_SCHEMA", BindingFlags.Public | BindingFlags.Static);
+        return s_schemaFieldCache.GetOrAdd(type, field);
     }
 }

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using Avro.Generic;
 using Avro.IO;
 using Avro.Specific;
@@ -31,7 +32,9 @@ namespace Dekaf.SchemaRegistry.Avro;
 /// </para>
 /// </remarks>
 /// <typeparam name="T">The type to deserialize. Must be either an Avro ISpecificRecord or GenericRecord.</typeparam>
-public sealed class AvroSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisposable
+public sealed class AvroSchemaRegistryDeserializer<
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>
+    : IDeserializer<T>, IAsyncDisposable
 {
     private const byte MagicByte = 0x00;
     private static readonly TimeSpan SchemaRegistryTimeout = TimeSpan.FromSeconds(30);

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -33,7 +33,9 @@ namespace Dekaf.SchemaRegistry.Avro;
 /// </remarks>
 /// <typeparam name="T">The type to deserialize. Must be either an Avro ISpecificRecord or GenericRecord.</typeparam>
 public sealed class AvroSchemaRegistryDeserializer<
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>
+    [DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.PublicFields |
+        DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>
     : IDeserializer<T>, IAsyncDisposable
 {
     private const byte MagicByte = 0x00;

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryExtensions.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Avro.Generic;
 using Avro.Specific;
 
@@ -17,7 +18,9 @@ public static class AvroSchemaRegistryExtensions
     /// <param name="schemaRegistry">The Schema Registry client.</param>
     /// <param name="config">Optional Avro serializer configuration.</param>
     /// <returns>The builder for chaining.</returns>
-    public static ProducerBuilder<TKey, TValue> UseAvroSchemaRegistry<TKey, TValue>(
+    public static ProducerBuilder<TKey, TValue> UseAvroSchemaRegistry<
+        TKey,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
         AvroSerializerConfig? config = null)
@@ -37,7 +40,9 @@ public static class AvroSchemaRegistryExtensions
     /// <param name="schemaRegistry">The Schema Registry client.</param>
     /// <param name="config">Optional Avro serializer configuration.</param>
     /// <returns>The builder for chaining.</returns>
-    public static ProducerBuilder<TKey, TValue> UseAvroSchemaRegistryKey<TKey, TValue>(
+    public static ProducerBuilder<TKey, TValue> UseAvroSchemaRegistryKey<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TKey,
+        TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
         AvroSerializerConfig? config = null)
@@ -57,7 +62,9 @@ public static class AvroSchemaRegistryExtensions
     /// <param name="schemaRegistry">The Schema Registry client.</param>
     /// <param name="config">Optional Avro deserializer configuration.</param>
     /// <returns>The builder for chaining.</returns>
-    public static ConsumerBuilder<TKey, TValue> UseAvroSchemaRegistry<TKey, TValue>(
+    public static ConsumerBuilder<TKey, TValue> UseAvroSchemaRegistry<
+        TKey,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TValue>(
         this ConsumerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
         AvroDeserializerConfig? config = null)
@@ -77,7 +84,9 @@ public static class AvroSchemaRegistryExtensions
     /// <param name="schemaRegistry">The Schema Registry client.</param>
     /// <param name="config">Optional Avro deserializer configuration.</param>
     /// <returns>The builder for chaining.</returns>
-    public static ConsumerBuilder<TKey, TValue> UseAvroSchemaRegistryKey<TKey, TValue>(
+    public static ConsumerBuilder<TKey, TValue> UseAvroSchemaRegistryKey<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TKey,
+        TValue>(
         this ConsumerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
         AvroDeserializerConfig? config = null)
@@ -88,7 +97,8 @@ public static class AvroSchemaRegistryExtensions
         return builder.WithKeyDeserializer(deserializer);
     }
 
-    private static void ValidateAvroType<T>()
+    private static void ValidateAvroType<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>()
     {
         if (!typeof(ISpecificRecord).IsAssignableFrom(typeof(T)) &&
             !typeof(GenericRecord).IsAssignableFrom(typeof(T)))

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryExtensions.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryExtensions.cs
@@ -64,7 +64,9 @@ public static class AvroSchemaRegistryExtensions
     /// <returns>The builder for chaining.</returns>
     public static ConsumerBuilder<TKey, TValue> UseAvroSchemaRegistry<
         TKey,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TValue>(
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicFields |
+            DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TValue>(
         this ConsumerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
         AvroDeserializerConfig? config = null)
@@ -85,7 +87,9 @@ public static class AvroSchemaRegistryExtensions
     /// <param name="config">Optional Avro deserializer configuration.</param>
     /// <returns>The builder for chaining.</returns>
     public static ConsumerBuilder<TKey, TValue> UseAvroSchemaRegistryKey<
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TKey,
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicFields |
+            DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TKey,
         TValue>(
         this ConsumerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using Avro.Generic;
 using Avro.IO;
 using Avro.Specific;
@@ -32,7 +33,9 @@ namespace Dekaf.SchemaRegistry.Avro;
 /// </para>
 /// </remarks>
 /// <typeparam name="T">The type to serialize. Must be either an Avro ISpecificRecord or GenericRecord.</typeparam>
-public sealed class AvroSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposable
+public sealed class AvroSchemaRegistrySerializer<
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>
+    : ISerializer<T>, IAsyncDisposable
 {
     private const byte MagicByte = 0x00;
     private static readonly TimeSpan SchemaRegistryTimeout = TimeSpan.FromSeconds(30);

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryExtensions.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Google.Protobuf;
 
 namespace Dekaf.SchemaRegistry.Protobuf;
@@ -16,7 +17,9 @@ public static class ProtobufSchemaRegistryExtensions
     /// <param name="schemaRegistry">The Schema Registry client.</param>
     /// <param name="config">Optional serializer configuration.</param>
     /// <returns>The builder for chaining.</returns>
-    public static ProducerBuilder<TKey, TValue> UseProtobufSchemaRegistry<TKey, TValue>(
+    public static ProducerBuilder<TKey, TValue> UseProtobufSchemaRegistry<
+        TKey,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
         ProtobufSerializerConfig? config = null)
@@ -39,7 +42,9 @@ public static class ProtobufSchemaRegistryExtensions
     /// <param name="keyConfig">Optional key serializer configuration.</param>
     /// <param name="valueConfig">Optional value serializer configuration.</param>
     /// <returns>The builder for chaining.</returns>
-    public static ProducerBuilder<TKey, TValue> UseProtobufSchemaRegistryForKeyAndValue<TKey, TValue>(
+    public static ProducerBuilder<TKey, TValue> UseProtobufSchemaRegistryForKeyAndValue<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TKey,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
         ProtobufSerializerConfig? keyConfig = null,

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using Dekaf.Serialization;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
@@ -22,7 +23,9 @@ namespace Dekaf.SchemaRegistry.Protobuf;
 /// </para>
 /// </remarks>
 /// <typeparam name="T">The Protobuf message type to serialize.</typeparam>
-public sealed class ProtobufSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposable
+public sealed class ProtobufSchemaRegistrySerializer<
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
+    : ISerializer<T>, IAsyncDisposable
     where T : IMessage<T>
 {
     private const byte MagicByte = 0x00;

--- a/tests/Dekaf.Tests.Aot.DependencyInjection/Dekaf.Tests.Aot.DependencyInjection.csproj
+++ b/tests/Dekaf.Tests.Aot.DependencyInjection/Dekaf.Tests.Aot.DependencyInjection.csproj
@@ -11,6 +11,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dekaf.Extensions.DependencyInjection\Dekaf.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Extensions.HealthChecks\Dekaf.Extensions.HealthChecks.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Extensions.Hosting\Dekaf.Extensions.Hosting.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.OpenTelemetry\Dekaf.OpenTelemetry.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Testing\Dekaf.Testing.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
 

--- a/tests/Dekaf.Tests.Aot.DependencyInjection/Program.cs
+++ b/tests/Dekaf.Tests.Aot.DependencyInjection/Program.cs
@@ -2,8 +2,14 @@ using Dekaf;
 using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Extensions.DependencyInjection;
+using Dekaf.Extensions.HealthChecks;
+using Dekaf.Extensions.Hosting;
 using Dekaf.Producer;
+using Dekaf.Testing;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 var services = new ServiceCollection();
 
@@ -41,6 +47,43 @@ _ = provider.GetRequiredService<IKafkaProducer<string, string>>();
 _ = provider.GetRequiredService<IKafkaConsumer<string, string>>();
 _ = provider.GetRequiredService<IAdminClient>();
 
+await RunTestingAndHealthChecksSmokeAsync();
+RunHostingSmoke();
+RunOpenTelemetrySmoke();
+
+static async Task RunTestingAndHealthChecksSmokeAsync()
+{
+    var services = new ServiceCollection();
+    services.AddLogging();
+    services.AddDekafInMemory(options => options.DefaultPartitionCount = 1);
+    services.AddHealthChecks()
+        .AddDekafProducerHealthCheck<string, string>()
+        .AddDekafBrokerHealthCheck();
+
+    await using var provider = services.BuildServiceProvider();
+    provider.GetRequiredService<InMemoryKafkaCluster>().CreateTopic("aot-topic");
+
+    var producer = provider.GetRequiredService<IKafkaProducer<string, string>>();
+    await producer.ProduceAsync("aot-topic", "key", "value");
+
+    var report = await provider.GetRequiredService<HealthCheckService>().CheckHealthAsync();
+    if (report.Entries.Count != 2)
+        throw new InvalidOperationException("Health check registration smoke failed.");
+}
+
+static void RunHostingSmoke()
+{
+    IHostBuilder hostBuilder = new HostBuilder();
+    hostBuilder.UseKafkaConsumer<AotHostedConsumerService, string, string>();
+    GC.KeepAlive(hostBuilder);
+}
+
+static void RunOpenTelemetrySmoke()
+{
+    GC.KeepAlive(typeof(Dekaf.OpenTelemetry.MeterProviderBuilderExtensions));
+    GC.KeepAlive(typeof(Dekaf.OpenTelemetry.TracerProviderBuilderExtensions));
+}
+
 file sealed class AotProducerInterceptor : IProducerInterceptor<string, string>
 {
     public ProducerMessage<string, string> OnSend(ProducerMessage<string, string> message) => message;
@@ -48,6 +91,19 @@ file sealed class AotProducerInterceptor : IProducerInterceptor<string, string>
     public void OnAcknowledgement(RecordMetadata metadata, Exception? exception)
     {
     }
+}
+
+file sealed class AotHostedConsumerService(
+    IKafkaConsumer<string, string> consumer,
+    ILogger<AotHostedConsumerService> logger)
+    : KafkaConsumerService<string, string>(consumer, logger)
+{
+    protected override IEnumerable<string> Topics => ["aot-topic"];
+
+    protected override ValueTask ProcessAsync(
+        ConsumeResult<string, string> result,
+        CancellationToken cancellationToken)
+        => ValueTask.CompletedTask;
 }
 
 file sealed class AotConsumerInterceptor : IConsumerInterceptor<string, string>

--- a/tests/Dekaf.Tests.Aot/Dekaf.Tests.Aot.csproj
+++ b/tests/Dekaf.Tests.Aot/Dekaf.Tests.Aot.csproj
@@ -6,6 +6,8 @@
     <IsAotCompatible>true</IsAotCompatible>
     <PublishAot>true</PublishAot>
     <SelfContained>true</SelfContained>
+    <!-- Avro/Newtonsoft emit assembly-level summaries when schema-registry smoke paths are rooted. Keep warnings visible. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2104;IL3053</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Dekaf.Tests.Aot/Dekaf.Tests.Aot.csproj
+++ b/tests/Dekaf.Tests.Aot/Dekaf.Tests.Aot.csproj
@@ -9,7 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Dekaf.Compression.Brotli\Dekaf.Compression.Brotli.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Compression.Snappy\Dekaf.Compression.Snappy.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Compression.Zstd\Dekaf.Compression.Zstd.csproj" />
     <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Serialization.Json\Dekaf.Serialization.Json.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dekaf.Tests.Aot/Program.cs
+++ b/tests/Dekaf.Tests.Aot/Program.cs
@@ -3,6 +3,8 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json.Serialization;
+using Avro.Specific;
+using Dekaf;
 using Dekaf.Compression;
 using Dekaf.Compression.Brotli;
 using Dekaf.Compression.Lz4;
@@ -14,6 +16,9 @@ using Dekaf.SchemaRegistry.Protobuf;
 using Dekaf.Security.Sasl;
 using Dekaf.Serialization;
 using Dekaf.Serialization.Json;
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
+using AvroSchema = Avro.Schema;
 using DekafJsonSerializer = Dekaf.Serialization.Json.JsonSerializer<AotPayload>;
 
 await AotSmoke.RunAsync();
@@ -31,7 +36,7 @@ internal static class AotSmoke
         RunCompressionSmoke();
         RunJsonSmoke();
         await RunSchemaRegistrySmokeAsync();
-        RunSchemaRegistryPackageSmoke();
+        await RunSchemaRegistryPackageSmokeAsync();
         await RunCoreSmokeAsync();
     }
 
@@ -105,7 +110,7 @@ internal static class AotSmoke
         Require(roundTrip == payload, "Schema Registry JSON round-trip failed.");
     }
 
-    private static void RunSchemaRegistryPackageSmoke()
+    private static async Task RunSchemaRegistryPackageSmokeAsync()
     {
         var avroSerializerConfig = new AvroSerializerConfig { AutoRegisterSchemas = false };
         var avroDeserializerConfig = new AvroDeserializerConfig();
@@ -123,6 +128,76 @@ internal static class AotSmoke
         Require(avroDeserializerConfig.ReaderSchema is null, "Avro deserializer config smoke failed.");
         Require(!protobufSerializerConfig.AutoRegisterSchemas, "Protobuf config smoke failed.");
         Require(protobufDeserializerConfig.SkipSchemaValidation, "Protobuf deserializer config smoke failed.");
+
+        using var avroRegistry = new InMemorySchemaRegistry();
+        using var protobufRegistry = new InMemorySchemaRegistry();
+        using var builderRegistry = new InMemorySchemaRegistry();
+
+        await RunAvroSchemaRegistryPackageSmokeAsync(avroRegistry);
+        await RunProtobufSchemaRegistryPackageSmokeAsync(protobufRegistry);
+        RunSchemaRegistryBuilderExtensionSmoke(builderRegistry);
+    }
+
+    private static async Task RunAvroSchemaRegistryPackageSmokeAsync(InMemorySchemaRegistry registry)
+    {
+        await using var serializer = new AvroSchemaRegistrySerializer<AotAvroRecord>(registry);
+        await using var deserializer = new AvroSchemaRegistryDeserializer<AotAvroRecord>(registry);
+
+        var payload = new AotAvroRecord { Id = 9, Name = "avro" };
+        var buffer = new ArrayBufferWriter<byte>();
+
+        await serializer.WarmupAsync(ValueContext.Topic, payload);
+        serializer.Serialize(payload, ref buffer, ValueContext);
+
+        var roundTrip = deserializer.Deserialize(buffer.WrittenMemory, ValueContext);
+        Require(roundTrip.Id == payload.Id, "Avro Schema Registry ID mismatch.");
+        Require(roundTrip.Name == payload.Name, "Avro Schema Registry name mismatch.");
+    }
+
+    private static async Task RunProtobufSchemaRegistryPackageSmokeAsync(InMemorySchemaRegistry registry)
+    {
+        await using var serializer = new ProtobufSchemaRegistrySerializer<AotProtobufMessage>(registry);
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<AotProtobufMessage>(registry);
+
+        var payload = new AotProtobufMessage { Id = 10, Name = "protobuf", Value = 11.5 };
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(payload, ref buffer, ValueContext);
+
+        var roundTrip = deserializer.Deserialize(buffer.WrittenMemory, ValueContext);
+        Require(roundTrip.Id == payload.Id, "Protobuf Schema Registry ID mismatch.");
+        Require(roundTrip.Name == payload.Name, "Protobuf Schema Registry name mismatch.");
+        Require(Math.Abs(roundTrip.Value - payload.Value) < 0.0001, "Protobuf Schema Registry value mismatch.");
+    }
+
+    private static void RunSchemaRegistryBuilderExtensionSmoke(InMemorySchemaRegistry registry)
+    {
+        var avroProducer = Kafka.CreateProducer<string, AotAvroRecord>()
+            .UseAvroSchemaRegistry(registry);
+        var avroKeyProducer = Kafka.CreateProducer<AotAvroRecord, string>()
+            .UseAvroSchemaRegistryKey(registry);
+        var avroConsumer = Kafka.CreateConsumer<string, AotAvroRecord>()
+            .UseAvroSchemaRegistry(registry);
+        var avroKeyConsumer = Kafka.CreateConsumer<AotAvroRecord, string>()
+            .UseAvroSchemaRegistryKey(registry);
+
+        var protobufProducer = Kafka.CreateProducer<string, AotProtobufMessage>()
+            .UseProtobufSchemaRegistry(registry);
+        var protobufKeyValueProducer = Kafka.CreateProducer<AotProtobufMessage, AotProtobufMessage>()
+            .UseProtobufSchemaRegistryForKeyAndValue(registry);
+        var protobufConsumer = Kafka.CreateConsumer<string, AotProtobufMessage>()
+            .UseProtobufSchemaRegistry(registry);
+        var protobufKeyValueConsumer = Kafka.CreateConsumer<AotProtobufMessage, AotProtobufMessage>()
+            .UseProtobufSchemaRegistryForKeyAndValue(registry);
+
+        GC.KeepAlive(avroProducer);
+        GC.KeepAlive(avroKeyProducer);
+        GC.KeepAlive(avroConsumer);
+        GC.KeepAlive(avroKeyConsumer);
+        GC.KeepAlive(protobufProducer);
+        GC.KeepAlive(protobufKeyValueProducer);
+        GC.KeepAlive(protobufConsumer);
+        GC.KeepAlive(protobufKeyValueConsumer);
     }
 
     private static OAuthBearerConfig CreateJwtBearerConfig(RSA rsa) =>
@@ -296,6 +371,227 @@ internal static class AotSmoke
 }
 
 internal sealed record AotPayload(int Id, string Name);
+
+internal sealed class AotAvroRecord : ISpecificRecord
+{
+    public static readonly AvroSchema _SCHEMA = AvroSchema.Parse("""
+        {
+          "type": "record",
+          "name": "AotAvroRecord",
+          "fields": [
+            { "name": "id", "type": "int" },
+            { "name": "name", "type": "string" }
+          ]
+        }
+        """);
+
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public AvroSchema Schema => _SCHEMA;
+
+    public object Get(int fieldPos) => fieldPos switch
+    {
+        0 => Id,
+        1 => Name,
+        _ => throw new ArgumentOutOfRangeException(nameof(fieldPos), fieldPos, "Invalid field position.")
+    };
+
+    public void Put(int fieldPos, object fieldValue)
+    {
+        switch (fieldPos)
+        {
+            case 0:
+                Id = (int)fieldValue;
+                break;
+            case 1:
+                Name = fieldValue.ToString() ?? string.Empty;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(fieldPos), fieldPos, "Invalid field position.");
+        }
+    }
+}
+
+internal sealed class AotProtobufMessage : IMessage<AotProtobufMessage>, IBufferMessage
+{
+    private static readonly MessageParser<AotProtobufMessage> ParserInstance = new(() => new AotProtobufMessage());
+    private static readonly MessageDescriptor DescriptorInstance;
+    private UnknownFieldSet? _unknownFields;
+
+    static AotProtobufMessage()
+    {
+        var fileDescriptorProto = new FileDescriptorProto
+        {
+            Name = "aot_message.proto",
+            Package = "dekaf.tests.aot",
+            Syntax = "proto3"
+        };
+
+        fileDescriptorProto.MessageType.Add(new DescriptorProto
+        {
+            Name = "AotProtobufMessage",
+            Field =
+            {
+                new FieldDescriptorProto
+                {
+                    Name = "id",
+                    Number = 1,
+                    Type = FieldDescriptorProto.Types.Type.Int32,
+                    Label = FieldDescriptorProto.Types.Label.Optional
+                },
+                new FieldDescriptorProto
+                {
+                    Name = "name",
+                    Number = 2,
+                    Type = FieldDescriptorProto.Types.Type.String,
+                    Label = FieldDescriptorProto.Types.Label.Optional
+                },
+                new FieldDescriptorProto
+                {
+                    Name = "value",
+                    Number = 3,
+                    Type = FieldDescriptorProto.Types.Type.Double,
+                    Label = FieldDescriptorProto.Types.Label.Optional
+                }
+            }
+        });
+
+        DescriptorInstance = FileDescriptor.BuildFromByteStrings([fileDescriptorProto.ToByteString()])
+            .Single()
+            .MessageTypes[0];
+    }
+
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public double Value { get; set; }
+    public static MessageParser<AotProtobufMessage> Parser => ParserInstance;
+    public static MessageDescriptor Descriptor => DescriptorInstance;
+    MessageDescriptor IMessage.Descriptor => DescriptorInstance;
+
+    public int CalculateSize()
+    {
+        var size = 0;
+        if (Id != 0)
+            size += 1 + CodedOutputStream.ComputeInt32Size(Id);
+        if (!string.IsNullOrEmpty(Name))
+            size += 1 + CodedOutputStream.ComputeStringSize(Name);
+        if (Value != 0)
+            size += 1 + 8;
+        return size;
+    }
+
+    public AotProtobufMessage Clone() => new()
+    {
+        Id = Id,
+        Name = Name,
+        Value = Value
+    };
+
+    public bool Equals(AotProtobufMessage? other)
+        => other is not null && Id == other.Id && Name == other.Name && Value.Equals(other.Value);
+
+    public override bool Equals(object? obj) => Equals(obj as AotProtobufMessage);
+
+    public override int GetHashCode() => HashCode.Combine(Id, Name, Value);
+
+    public void MergeFrom(AotProtobufMessage message)
+    {
+        if (message.Id != 0)
+            Id = message.Id;
+        if (!string.IsNullOrEmpty(message.Name))
+            Name = message.Name;
+        if (message.Value != 0)
+            Value = message.Value;
+    }
+
+    public void MergeFrom(CodedInputStream input)
+    {
+        uint tag;
+        while ((tag = input.ReadTag()) != 0)
+        {
+            switch (tag)
+            {
+                case 8:
+                    Id = input.ReadInt32();
+                    break;
+                case 18:
+                    Name = input.ReadString();
+                    break;
+                case 25:
+                    Value = input.ReadDouble();
+                    break;
+                default:
+                    input.SkipLastField();
+                    break;
+            }
+        }
+    }
+
+    public void WriteTo(CodedOutputStream output)
+    {
+        if (Id != 0)
+        {
+            output.WriteRawTag(8);
+            output.WriteInt32(Id);
+        }
+
+        if (!string.IsNullOrEmpty(Name))
+        {
+            output.WriteRawTag(18);
+            output.WriteString(Name);
+        }
+
+        if (Value != 0)
+        {
+            output.WriteRawTag(25);
+            output.WriteDouble(Value);
+        }
+    }
+
+    void IBufferMessage.InternalMergeFrom(ref ParseContext input)
+    {
+        uint tag;
+        while ((tag = input.ReadTag()) != 0)
+        {
+            switch (tag)
+            {
+                case 8:
+                    Id = input.ReadInt32();
+                    break;
+                case 18:
+                    Name = input.ReadString();
+                    break;
+                case 25:
+                    Value = input.ReadDouble();
+                    break;
+                default:
+                    _unknownFields = UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+                    break;
+            }
+        }
+    }
+
+    void IBufferMessage.InternalWriteTo(ref WriteContext output)
+    {
+        if (Id != 0)
+        {
+            output.WriteRawTag(8);
+            output.WriteInt32(Id);
+        }
+
+        if (!string.IsNullOrEmpty(Name))
+        {
+            output.WriteRawTag(18);
+            output.WriteString(Name);
+        }
+
+        if (Value != 0)
+        {
+            output.WriteRawTag(25);
+            output.WriteDouble(Value);
+        }
+    }
+}
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(AotPayload))]

--- a/tests/Dekaf.Tests.Aot/Program.cs
+++ b/tests/Dekaf.Tests.Aot/Program.cs
@@ -389,6 +389,10 @@ internal sealed class AotAvroRecord : ISpecificRecord
     public string Name { get; set; } = string.Empty;
     public AvroSchema Schema => _SCHEMA;
 
+    public AotAvroRecord()
+    {
+    }
+
     public object Get(int fieldPos) => fieldPos switch
     {
         0 => Id,

--- a/tests/Dekaf.Tests.Aot/Program.cs
+++ b/tests/Dekaf.Tests.Aot/Program.cs
@@ -1,14 +1,41 @@
+using System.Buffers;
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
-using Dekaf.Serialization;
+using System.Text.Json.Serialization;
+using Dekaf.Compression;
+using Dekaf.Compression.Brotli;
+using Dekaf.Compression.Lz4;
+using Dekaf.Compression.Snappy;
+using Dekaf.Compression.Zstd;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Avro;
+using Dekaf.SchemaRegistry.Protobuf;
 using Dekaf.Security.Sasl;
+using Dekaf.Serialization;
+using Dekaf.Serialization.Json;
+using DekafJsonSerializer = Dekaf.Serialization.Json.JsonSerializer<AotPayload>;
 
 await AotSmoke.RunAsync();
 
 internal static class AotSmoke
 {
+    private static readonly SerializationContext ValueContext = new()
+    {
+        Topic = "aot-topic",
+        Component = SerializationComponent.Value
+    };
+
     public static async Task RunAsync()
+    {
+        RunCompressionSmoke();
+        RunJsonSmoke();
+        await RunSchemaRegistrySmokeAsync();
+        RunSchemaRegistryPackageSmoke();
+        await RunCoreSmokeAsync();
+    }
+
+    private static async Task RunCoreSmokeAsync()
     {
         using var rsa = RSA.Create(2048);
         using var provider = new OAuthBearerTokenProvider(CreateJwtBearerConfig(rsa), CreateHttpClient());
@@ -20,6 +47,82 @@ internal static class AotSmoke
         var headers = Headers.Create("aot", "ok");
         Require(headers.Count == 1, "Header smoke failed.");
         Require(headers[0].Key == "aot", "Header key mismatch.");
+    }
+
+    private static void RunCompressionSmoke()
+    {
+        ReadOnlyMemory<byte> payload = Encoding.UTF8.GetBytes("NativeAOT compression smoke payload");
+        ICompressionCodec[] codecs =
+        [
+            new BrotliCompressionCodec(),
+            new Lz4CompressionCodec(),
+            new SnappyCompressionCodec(),
+            new ZstdCompressionCodec()
+        ];
+
+        foreach (var codec in codecs)
+        {
+            var compressed = new ArrayBufferWriter<byte>();
+            codec.Compress(new ReadOnlySequence<byte>(payload), compressed);
+
+            var decompressed = new ArrayBufferWriter<byte>();
+            codec.Decompress(new ReadOnlySequence<byte>(compressed.WrittenMemory), decompressed);
+
+            Require(decompressed.WrittenSpan.SequenceEqual(payload.Span),
+                $"{codec.Type} compression round-trip failed.");
+        }
+    }
+
+    private static void RunJsonSmoke()
+    {
+        var serializer = new DekafJsonSerializer(AotJsonContext.Default.AotPayload);
+        var payload = new AotPayload(7, "json");
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(payload, ref buffer, ValueContext);
+
+        var roundTrip = serializer.Deserialize(buffer.WrittenMemory, ValueContext);
+        Require(roundTrip == payload, "JSON serializer round-trip failed.");
+    }
+
+    private static async Task RunSchemaRegistrySmokeAsync()
+    {
+        using var registry = new InMemorySchemaRegistry();
+        var payload = new AotPayload(8, "schema-registry");
+        var buffer = new ArrayBufferWriter<byte>();
+
+        await using var serializer = new JsonSchemaRegistrySerializer<AotPayload>(
+            registry,
+            AotPayloadJsonSchema,
+            AotJsonContext.Default.AotPayload);
+        await using var deserializer = new JsonSchemaRegistryDeserializer<AotPayload>(
+            registry,
+            AotJsonContext.Default.AotPayload);
+
+        serializer.Serialize(payload, ref buffer, ValueContext);
+
+        var roundTrip = deserializer.Deserialize(buffer.WrittenMemory, ValueContext);
+        Require(roundTrip == payload, "Schema Registry JSON round-trip failed.");
+    }
+
+    private static void RunSchemaRegistryPackageSmoke()
+    {
+        var avroSerializerConfig = new AvroSerializerConfig { AutoRegisterSchemas = false };
+        var avroDeserializerConfig = new AvroDeserializerConfig();
+        var protobufSerializerConfig = new ProtobufSerializerConfig
+        {
+            AutoRegisterSchemas = false,
+            UseSchemaReferences = false
+        };
+        var protobufDeserializerConfig = new ProtobufDeserializerConfig
+        {
+            SkipSchemaValidation = true
+        };
+
+        Require(!avroSerializerConfig.AutoRegisterSchemas, "Avro config smoke failed.");
+        Require(avroDeserializerConfig.ReaderSchema is null, "Avro deserializer config smoke failed.");
+        Require(!protobufSerializerConfig.AutoRegisterSchemas, "Protobuf config smoke failed.");
+        Require(protobufDeserializerConfig.SkipSchemaValidation, "Protobuf deserializer config smoke failed.");
     }
 
     private static OAuthBearerConfig CreateJwtBearerConfig(RSA rsa) =>
@@ -77,4 +180,123 @@ internal static class AotSmoke
             };
         }
     }
+
+    private const string AotPayloadJsonSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "id": { "type": "integer" },
+            "name": { "type": "string" }
+          },
+          "required": [ "id", "name" ]
+        }
+        """;
+
+    private sealed class InMemorySchemaRegistry : ISchemaRegistryClient, ISchemaRegistryCache
+    {
+        private readonly Dictionary<int, Schema> _schemasById = [];
+        private readonly Dictionary<string, RegisteredSchema> _schemasBySubject = new(StringComparer.Ordinal);
+        private int _nextId = 1;
+
+        public Task<int> RegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_schemasBySubject.TryGetValue(subject, out var existing))
+                return Task.FromResult(existing.Id);
+
+            var id = _nextId++;
+            var registered = new RegisteredSchema
+            {
+                Id = id,
+                Subject = subject,
+                Version = 1,
+                Schema = schema
+            };
+            _schemasBySubject[subject] = registered;
+            _schemasById[id] = schema;
+
+            return Task.FromResult(id);
+        }
+
+        public Task<Schema> GetSchemaAsync(int id, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_schemasById[id]);
+        }
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version = "latest",
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_schemasBySubject[subject]);
+        }
+
+        public Task<int> GetOrRegisterSchemaAsync(
+            string subject,
+            Schema schema,
+            CancellationToken cancellationToken = default)
+            => RegisterSchemaAsync(subject, schema, cancellationToken);
+
+        public Task<IReadOnlyList<string>> GetAllSubjectsAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<IReadOnlyList<string>>(_schemasBySubject.Keys.ToArray());
+        }
+
+        public Task<IReadOnlyList<int>> GetVersionsAsync(
+            string subject,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<IReadOnlyList<int>>([_schemasBySubject[subject].Version]);
+        }
+
+        public Task<bool> IsCompatibleAsync(
+            string subject,
+            Schema schema,
+            string version = "latest",
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(true);
+        }
+
+        public Task<IReadOnlyList<int>> DeleteSubjectAsync(
+            string subject,
+            bool permanent = false,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<IReadOnlyList<int>>(
+                _schemasBySubject.Remove(subject, out var registered) ? [registered.Version] : []);
+        }
+
+        public bool TryGetCachedSchema(int id, out Schema schema)
+        {
+            if (_schemasById.TryGetValue(id, out var cached))
+            {
+                schema = cached;
+                return true;
+            }
+
+            schema = null!;
+            return false;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
 }
+
+internal sealed record AotPayload(int Id, string Name);
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(AotPayload))]
+internal sealed partial class AotJsonContext : JsonSerializerContext;

--- a/tools/Dekaf.Pipeline/Modules/RunAotSmokeTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunAotSmokeTestsModule.cs
@@ -14,10 +14,16 @@ namespace Dekaf.Pipeline.Modules;
 [DependsOn<BuildModule>]
 public class RunAotSmokeTestsModule(ICommand command) : Module<IReadOnlyList<CommandResult>>
 {
+    private static readonly AotSmokeProject[] Projects =
+    [
+        new("Dekaf.Tests.Aot.csproj", "core"),
+        new("Dekaf.Tests.Aot.DependencyInjection.csproj", "dependency-injection")
+    ];
+
     protected override ModuleConfiguration Configure()
     {
         return new ModuleConfigurationBuilder()
-            .WithTimeout(TimeSpan.FromMinutes(10))
+            .WithTimeout(TimeSpan.FromMinutes(20))
             .Build();
     }
 
@@ -32,46 +38,58 @@ public class RunAotSmokeTestsModule(ICommand command) : Module<IReadOnlyList<Com
         }
 
         var rootDirectory = context.Git().RootDirectory;
-        var project = rootDirectory.FindFile(x => x.Name == "Dekaf.Tests.Aot.csproj");
-        if (project is null)
+        var results = new List<CommandResult>(Projects.Length * 2);
+
+        foreach (var smokeProject in Projects)
         {
-            throw new InvalidOperationException("Dekaf.Tests.Aot.csproj not found");
+            var project = rootDirectory.FindFile(x => x.Name == smokeProject.ProjectFileName);
+            if (project is null)
+            {
+                throw new InvalidOperationException($"{smokeProject.ProjectFileName} not found");
+            }
+
+            var outputDirectory = Path.Combine(
+                rootDirectory.Path,
+                "artifacts",
+                "aot",
+                smokeProject.OutputName);
+
+            var publishResult = await context.DotNet().Publish(
+                new DotNetPublishOptions
+                {
+                    ProjectSolution = project.Path,
+                    Configuration = "Release",
+                    Framework = "net10.0",
+                    Runtime = "linux-x64",
+                    NoRestore = true,
+                    Output = outputDirectory,
+                    Properties =
+                    [
+                        new KeyValue("PublishAot", "true"),
+                        new KeyValue("SelfContained", "true"),
+                        new KeyValue("ContinuousIntegrationBuild", "true"),
+                        new KeyValue("TreatWarningsAsErrors", "true")
+                    ]
+                },
+                null,
+                cancellationToken);
+            results.Add(publishResult);
+
+            var executablePath = Path.Combine(
+                outputDirectory,
+                Path.GetFileNameWithoutExtension(smokeProject.ProjectFileName));
+            var runResult = await command.ExecuteCommandLineTool(
+                new GenericCommandLineToolOptions(executablePath),
+                new CommandExecutionOptions
+                {
+                    WorkingDirectory = outputDirectory
+                },
+                cancellationToken);
+            results.Add(runResult);
         }
 
-        var outputDirectory = Path.Combine(
-            rootDirectory.Path,
-            "artifacts",
-            "aot",
-            "core");
-
-        var publishResult = await context.DotNet().Publish(
-            new DotNetPublishOptions
-            {
-                ProjectSolution = project.Path,
-                Configuration = "Release",
-                Framework = "net10.0",
-                Runtime = "linux-x64",
-                NoRestore = true,
-                Output = outputDirectory,
-                Properties =
-                [
-                    new KeyValue("PublishAot", "true"),
-                    new KeyValue("SelfContained", "true"),
-                    new KeyValue("ContinuousIntegrationBuild", "true"),
-                    new KeyValue("TreatWarningsAsErrors", "true")
-                ]
-            },
-            null,
-            cancellationToken);
-
-        var runResult = await command.ExecuteCommandLineTool(
-            new GenericCommandLineToolOptions(Path.Combine(outputDirectory, "Dekaf.Tests.Aot")),
-            new CommandExecutionOptions
-            {
-                WorkingDirectory = outputDirectory
-            },
-            cancellationToken);
-
-        return [publishResult, runResult];
+        return results;
     }
+
+    private sealed record AotSmokeProject(string ProjectFileName, string OutputName);
 }


### PR DESCRIPTION
## Summary
- add explicit PR CI matrix job that publishes and runs core/package and DI/package NativeAOT smoke executables on linux-x64
- expand AOT smoke apps to cover core, JSON, schema registry, compression, Avro/Protobuf config, DI, hosting, health checks, OpenTelemetry, and in-memory testing package surfaces
- add trim annotations needed by Avro/Protobuf/hosting package coverage and document local AOT validation commands

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Aot\Dekaf.Tests.Aot.csproj --configuration Release /clp:ErrorsOnly
- [x] dotnet build tests\Dekaf.Tests.Aot.DependencyInjection\Dekaf.Tests.Aot.DependencyInjection.csproj --configuration Release /clp:ErrorsOnly
- [x] dotnet build tools\Dekaf.Pipeline\Dekaf.Pipeline.csproj --configuration Release /p:DisableGitVersionTask=true /clp:ErrorsOnly
- [x] .\tests\Dekaf.Tests.Aot\bin\Release\net10.0\win-x64\Dekaf.Tests.Aot.exe
- [x] .\tests\Dekaf.Tests.Aot.DependencyInjection\bin\Release\net10.0\win-x64\Dekaf.Tests.Aot.DependencyInjection.exe
- [x] dotnet publish tests\Dekaf.Tests.Aot\Dekaf.Tests.Aot.csproj --configuration Release --framework net10.0 --runtime win-x64 --self-contained true -p:PublishAot=true -p:ContinuousIntegrationBuild=true -p:TreatWarningsAsErrors=true (no trim/AOT diagnostics before local missing Windows native linker)
- [x] dotnet publish tests\Dekaf.Tests.Aot.DependencyInjection\Dekaf.Tests.Aot.DependencyInjection.csproj --configuration Release --framework net10.0 --runtime win-x64 --self-contained true -p:PublishAot=true -p:ContinuousIntegrationBuild=true -p:TreatWarningsAsErrors=true (no trim/AOT diagnostics before local missing Windows native linker)
- [x] npm run build --prefix docs
- [x] git diff --check

Closes #1306