### PR TITLE
fix(ci): relax resolved review headings

### DIFF
--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -8,10 +8,15 @@ function Get-ActionableReviewBodyReason {
         return $null
     }
 
+    $nonActionableHeading =
+        '(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking)\b' +
+        '|previously[- ]flagged\b.*\b(?:fixed|resolved|addressed|verified)\b'
+    $actionableHeadingWord = 'Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Design|Leak|Leaks|Gap|Gaps|Silently|(?<!not )(?<!non-)Blocking|(?<!not )(?<!non-)Blocker|Test coverage gap|Required|Must fix'
+
     $patterns = @(
         @{
             Reason = 'actionable heading'
-            Pattern = '(?im)^\s*#{2,4}\s+(?!(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking)\b).*\b(Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Design|Leak|Leaks|Gap|Gaps|Silently|(?<!not )(?<!non-)Blocking|(?<!not )(?<!non-)Blocker|Test coverage gap|Required|Must fix)\b'
+            Pattern = "(?im)^\s*#{2,4}\s+(?!$nonActionableHeading).*\b($actionableHeadingWord)\b"
         },
         @{
             Reason = 'numbered finding heading'

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -8,9 +8,11 @@ function Get-ActionableReviewBodyReason {
         return $null
     }
 
+    $previouslyResolvedHeading =
+        'previously[- ]flagged\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun\w+\b).)*\b(?:fixed|resolved|addressed|verified)\b\s*$'
     $nonActionableHeading =
         '(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking)\b' +
-        '|previously[- ]flagged\b.*\b(?:fixed|resolved|addressed|verified)\b'
+        "|$previouslyResolvedHeading"
     $actionableHeadingWord = 'Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Design|Leak|Leaks|Gap|Gaps|Silently|(?<!not )(?<!non-)Blocking|(?<!not )(?<!non-)Blocker|Test coverage gap|Required|Must fix'
 
     $patterns = @(

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -95,6 +95,28 @@ This is optional.
 The prior findings are now resolved.
 '@
         Blocks = $false
+    },
+    @{
+        Name = 'blocks previously flagged issue still not fixed'
+        Body = @'
+## Review
+
+### Previously-flagged issue - still not fixed
+
+The finding remains open.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks previously flagged concerns not yet resolved'
+        Body = @'
+## Review
+
+### Previously flagged concerns, not yet resolved
+
+The finding remains open.
+'@
+        Blocks = $true
     }
 )
 

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -84,6 +84,17 @@ Minor/optional, not blocking:
 This is optional.
 '@
         Blocks = $false
+    },
+    @{
+        Name = 'allows previously flagged issues verified fixed heading'
+        Body = @'
+## Review
+
+### Previously-flagged issues - verified fixed
+
+The prior findings are now resolved.
+'@
+        Blocks = $false
     }
 )
 


### PR DESCRIPTION
## Summary
- allow resolved summary review headings like `Previously-flagged issues - verified fixed` in the merge-gate heuristic
- keep existing actionable-heading and before-merge blocking coverage
- add a regression case for the resolved-heading shape

## Test plan
- [x] `pwsh scripts\Test-AssertPrGreenReviewHeuristics.ps1`

Closes #1326
