### PR TITLE
test(compat): smoke netstandard package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
+      - name: Run netstandard2.0 package smoke
+        shell: pwsh
+        run: ./scripts/RunNetStandardPackageSmoke.ps1
+
       - name: Upload HangDump artifacts
         uses: actions/upload-artifact@v7
         if: always()

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Compatibility
 
-Dekaf currently targets `net10.0`.
+Dekaf's core package targets `net10.0` and `netstandard2.0`. The extension, serialization, compression, Schema Registry, testing, and tool packages still target `net10.0`.
 
 The project is open to broader target-framework support when it does not regress the `net10.0` performance path. `netstandard2.0` support is tracked by #1224 and split into staged child issues so compatibility work can land without weakening the current package.
 
@@ -12,7 +12,7 @@ The project is open to broader target-framework support when it does not regress
 
 | Area | Status |
 | --- | --- |
-| Core package (`Dekaf`) | `net10.0` |
+| Core package (`Dekaf`) | `net10.0`, `netstandard2.0` |
 | Compression packages | `net10.0` |
 | Serialization packages | `net10.0` |
 | Schema Registry packages | `net10.0` |
@@ -79,7 +79,7 @@ This pass includes:
 - TLS authentication uses the older `SslStream.AuthenticateAsClientAsync` overload on `netstandard2.0`.
 - GSSAPI remains part of the API surface, but using it on `netstandard2.0` throws `PlatformNotSupportedException` because `NegotiateAuthentication` is unavailable there.
 
-This baseline does not declare package support for `netstandard2.0`; it makes the core compile state clean so packaging and runtime validation can proceed separately.
+The #1301 package pass declares `netstandard2.0` support for the core `Dekaf` package only. CI packs the package with both `lib/net10.0/Dekaf.dll` and `lib/netstandard2.0/Dekaf.dll`, then restores a sample `netstandard2.0` library from the local `.nupkg` and runs it through a `net10.0` console host.
 
 ## Blocker Categories
 
@@ -120,9 +120,9 @@ Each replacement needs performance review. The `net10.0` hot path should keep mo
 
 ### Package Matrix
 
-Not every package has to multi-target at the same time. The likely sequence is:
+Not every package has to multi-target at the same time. The current sequence is:
 
-1. `Dekaf`
+1. `Dekaf` - shipped as `net10.0` and `netstandard2.0`
 2. serialization and compression packages that can compile without framework-specific hosting dependencies
 3. Schema Registry packages
 4. extensions packages where their `Microsoft.Extensions.*` dependencies support the chosen older target
@@ -141,6 +141,12 @@ Compatibility support is not complete until these checks exist:
 - Any compatibility helper has focused tests or compile canaries.
 
 Integration tests should keep using the existing runtime target unless a specific compatibility runtime issue requires a separate run.
+
+Run the package smoke locally after packing:
+
+```powershell
+./scripts/RunNetStandardPackageSmoke.ps1
+```
 
 ## Non-goals
 

--- a/samples/PackageSmoke/Dekaf.PackageSmoke.NetStandard20/Dekaf.PackageSmoke.NetStandard20.csproj
+++ b/samples/PackageSmoke/Dekaf.PackageSmoke.NetStandard20/Dekaf.PackageSmoke.NetStandard20.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <DekafPackageVersion Condition="'$(DekafPackageVersion)' == ''">0.0.1-local</DekafPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dekaf" Version="$(DekafPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/samples/PackageSmoke/Dekaf.PackageSmoke.NetStandard20/NetStandardPackageSmoke.cs
+++ b/samples/PackageSmoke/Dekaf.PackageSmoke.NetStandard20/NetStandardPackageSmoke.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Text;
+using Dekaf;
+using Dekaf.Consumer;
+using Dekaf.Retry;
+using Dekaf.Serialization;
+
+namespace Dekaf.PackageSmoke.NetStandard20;
+
+public static class NetStandardPackageSmoke
+{
+    public static string Run()
+    {
+        var headers = Headers
+            .Create("source", "netstandard2.0")
+            .AddIfNotNull("package", "Dekaf");
+
+        var context = new SerializationContext
+        {
+            Topic = "package-smoke",
+            Component = SerializationComponent.Value,
+            Headers = headers
+        };
+
+        var payload = Encoding.UTF8.GetBytes("dekaf");
+        var decoded = Serializers.String.Deserialize(new ReadOnlyMemory<byte>(payload), context);
+
+        var producerBuilder = new ProducerBuilder<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithClientId("package-smoke-producer")
+            .WithLinger(TimeSpan.FromMilliseconds(5))
+            .WithKeySerializer(Serializers.String)
+            .WithValueSerializer(Serializers.String)
+            .WithRetryPolicy(NoRetryPolicy.Instance);
+
+        var consumerBuilder = new ConsumerBuilder<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithClientId("package-smoke-consumer")
+            .WithGroupId("package-smoke")
+            .SubscribeTo("package-smoke")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithKeyDeserializer(Serializers.String)
+            .WithValueDeserializer(Serializers.String)
+            .WithRetryPolicy(NoRetryPolicy.Instance);
+
+        return $"{decoded}:{headers.Count}:{producerBuilder.GetType().Name}:{consumerBuilder.GetType().Name}";
+    }
+}

--- a/samples/PackageSmoke/Dekaf.PackageSmoke.Runner/Dekaf.PackageSmoke.Runner.csproj
+++ b/samples/PackageSmoke/Dekaf.PackageSmoke.Runner/Dekaf.PackageSmoke.Runner.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dekaf.PackageSmoke.NetStandard20\Dekaf.PackageSmoke.NetStandard20.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/PackageSmoke/Dekaf.PackageSmoke.Runner/Program.cs
+++ b/samples/PackageSmoke/Dekaf.PackageSmoke.Runner/Program.cs
@@ -1,0 +1,10 @@
+using Dekaf.PackageSmoke.NetStandard20;
+
+var result = NetStandardPackageSmoke.Run();
+
+if (!result.StartsWith("dekaf:", StringComparison.Ordinal))
+{
+    throw new InvalidOperationException($"Unexpected package smoke result: {result}");
+}
+
+Console.WriteLine(result);

--- a/scripts/RunNetStandardPackageSmoke.ps1
+++ b/scripts/RunNetStandardPackageSmoke.ps1
@@ -1,0 +1,143 @@
+[CmdletBinding()]
+param(
+    [string]$PackageVersion = '',
+    [string]$Configuration = 'Release'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-DotNet {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory)]
+        [string]$Step
+    )
+
+    & dotnet @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Step failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Get-PackageVersionFromFile {
+    param([Parameter(Mandatory)][System.IO.FileInfo]$PackageFile)
+
+    $prefix = 'Dekaf.'
+    $suffix = '.nupkg'
+    return $PackageFile.Name.Substring($prefix.Length, $PackageFile.Name.Length - $prefix.Length - $suffix.Length)
+}
+
+function Assert-PackageEntry {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Entries,
+        [Parameter(Mandatory)]
+        [string]$Entry,
+        [Parameter(Mandatory)]
+        [string]$PackagePath
+    )
+
+    if ($Entries -notcontains $Entry) {
+        throw "Package '$PackagePath' is missing '$Entry'"
+    }
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$packageSource = Join-Path $repoRoot "src/Dekaf/bin/$Configuration"
+
+if (-not (Test-Path -LiteralPath $packageSource)) {
+    throw "Package source directory not found: $packageSource"
+}
+
+if ($PackageVersion) {
+    $packagePath = Join-Path $packageSource "Dekaf.$PackageVersion.nupkg"
+    if (-not (Test-Path -LiteralPath $packagePath)) {
+        throw "Dekaf package not found: $packagePath"
+    }
+
+    $corePackage = Get-Item -LiteralPath $packagePath
+}
+else {
+    $corePackage = Get-ChildItem -LiteralPath $packageSource -Filter 'Dekaf.*.nupkg' |
+        Sort-Object LastWriteTimeUtc -Descending |
+        Select-Object -First 1
+
+    if (-not $corePackage) {
+        throw "No Dekaf package found under $packageSource"
+    }
+
+    $PackageVersion = Get-PackageVersionFromFile $corePackage
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$zip = [System.IO.Compression.ZipFile]::OpenRead($corePackage.FullName)
+try {
+    $entries = [string[]]$zip.Entries.FullName
+    Assert-PackageEntry -Entries $entries -Entry 'lib/net10.0/Dekaf.dll' -PackagePath $corePackage.FullName
+    Assert-PackageEntry -Entries $entries -Entry 'lib/netstandard2.0/Dekaf.dll' -PackagePath $corePackage.FullName
+}
+finally {
+    $zip.Dispose()
+}
+
+$otherPackages = Get-ChildItem -Path (Join-Path $repoRoot 'src') -Recurse -Filter 'Dekaf*.nupkg' |
+    Where-Object { $_.FullName -ne $corePackage.FullName }
+
+foreach ($package in $otherPackages) {
+    $otherZip = [System.IO.Compression.ZipFile]::OpenRead($package.FullName)
+    try {
+        if ($otherZip.Entries.FullName -like 'lib/netstandard2.0/*') {
+            throw "Only the Dekaf core package should contain a netstandard2.0 asset for this validation pass: $($package.FullName)"
+        }
+    }
+    finally {
+        $otherZip.Dispose()
+    }
+}
+
+$smokeProject = Join-Path $repoRoot 'samples/PackageSmoke/Dekaf.PackageSmoke.Runner/Dekaf.PackageSmoke.Runner.csproj'
+if (-not (Test-Path -LiteralPath $smokeProject)) {
+    throw "Package smoke project not found: $smokeProject"
+}
+
+$artifactsDir = Join-Path $repoRoot 'artifacts/package-smoke'
+$nugetPackages = Join-Path $artifactsDir 'nuget-cache'
+New-Item -ItemType Directory -Force $nugetPackages | Out-Null
+
+$previousNuGetPackages = $env:NUGET_PACKAGES
+$env:NUGET_PACKAGES = $nugetPackages
+
+try {
+    Invoke-DotNet -Step 'package smoke restore' -Arguments @(
+        'restore',
+        $smokeProject,
+        "-p:DekafPackageVersion=$PackageVersion",
+        "-p:RestoreAdditionalProjectSources=$packageSource"
+    )
+
+    Invoke-DotNet -Step 'package smoke build' -Arguments @(
+        'build',
+        $smokeProject,
+        '--configuration',
+        $Configuration,
+        '--no-restore',
+        "-p:DekafPackageVersion=$PackageVersion",
+        '-p:TreatWarningsAsErrors=true'
+    )
+
+    Invoke-DotNet -Step 'package smoke run' -Arguments @(
+        'run',
+        '--project',
+        $smokeProject,
+        '--configuration',
+        $Configuration,
+        '--framework',
+        'net10.0',
+        '--no-build'
+    )
+}
+finally {
+    $env:NUGET_PACKAGES = $previousNuGetPackages
+}

--- a/src/Dekaf/Compatibility/Net10ValueTaskForwarders.cs
+++ b/src/Dekaf/Compatibility/Net10ValueTaskForwarders.cs
@@ -5,6 +5,12 @@ internal static class ValueTaskCompatibility
 {
     public static ValueTask CompletedTask => ValueTask.CompletedTask;
 
+    public static ValueTask FromCanceled(System.Threading.CancellationToken cancellationToken)
+        => ValueTask.FromCanceled(cancellationToken);
+
+    public static ValueTask FromException(Exception exception)
+        => ValueTask.FromException(exception);
+
     public static ValueTask<T> FromException<T>(Exception exception)
         => ValueTask.FromException<T>(exception);
 }

--- a/src/Dekaf/Compatibility/NetStandard20TaskValueTask.cs
+++ b/src/Dekaf/Compatibility/NetStandard20TaskValueTask.cs
@@ -5,6 +5,20 @@ internal static class ValueTaskCompatibility
 {
     public static ValueTask CompletedTask => default;
 
+    public static ValueTask FromCanceled(System.Threading.CancellationToken cancellationToken)
+    {
+        var source = new TaskCompletionSource<bool>();
+        source.TrySetCanceled(cancellationToken);
+        return new ValueTask(source.Task);
+    }
+
+    public static ValueTask FromException(Exception exception)
+    {
+        var source = new TaskCompletionSource<bool>();
+        source.SetException(exception);
+        return new ValueTask(source.Task);
+    }
+
     public static ValueTask<T> FromException<T>(Exception exception)
     {
         var source = new TaskCompletionSource<T>();

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -379,7 +379,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         {
             cancellationToken.ThrowIfCancellationRequested();
             runtime.QueueAssignedPartitions(partitions);
-            return ValueTask.CompletedTask;
+            return ValueTaskCompatibility.CompletedTask;
         }
 
         public ValueTask OnPartitionsRevokedAsync(
@@ -388,7 +388,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         {
             cancellationToken.ThrowIfCancellationRequested();
             runtime.QueueStoppedPartitions(partitions, PartitionStopReason.Revoke);
-            return ValueTask.CompletedTask;
+            return ValueTaskCompatibility.CompletedTask;
         }
 
         public ValueTask OnPartitionsLostAsync(
@@ -397,7 +397,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         {
             cancellationToken.ThrowIfCancellationRequested();
             runtime.QueueStoppedPartitions(partitions, PartitionStopReason.Lost);
-            return ValueTask.CompletedTask;
+            return ValueTaskCompatibility.CompletedTask;
         }
     }
 
@@ -406,13 +406,13 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         CancellationToken cancellationToken)
     {
         if (cancellationToken.IsCancellationRequested)
-            return ValueTask.FromCanceled(cancellationToken);
+            return ValueTaskCompatibility.FromCanceled(cancellationToken);
 
         var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var command = RuntimeCommand<TKey, TValue>.Commit(lane, completion, cancellationToken);
 
         if (!_commands.Writer.TryWrite(command))
-            return ValueTask.FromException(new InvalidOperationException("Partitioned processing runtime is not accepting commit requests."));
+            return ValueTaskCompatibility.FromException(new InvalidOperationException("Partitioned processing runtime is not accepting commit requests."));
 
         return new ValueTask(completion.Task.WaitAsync(cancellationToken));
     }

--- a/src/Dekaf/Dekaf.csproj
+++ b/src/Dekaf/Dekaf.csproj
@@ -1,5 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="PublishAot">
 
+  <!-- CI AOT publishes pass PublishAot globally; let netstandard2.0 inner builds override it. -->
   <PropertyGroup>
     <!-- Directory.Build.props sets a default TargetFramework before project properties; clear it so TargetFrameworks drives package assets. -->
     <TargetFramework></TargetFramework>
@@ -29,6 +30,7 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
+    <PublishAot>false</PublishAot>
   </PropertyGroup>
 
   <!-- Compatibility dependencies for the package's netstandard2.0 asset. -->

--- a/src/Dekaf/Dekaf.csproj
+++ b/src/Dekaf/Dekaf.csproj
@@ -1,8 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Directory.Build.props sets a default TargetFramework before project properties; clear it so TargetFrameworks drives package assets. -->
+    <TargetFramework></TargetFramework>
+    <TargetFrameworks>net10.0;netstandard2.0</TargetFrameworks>
     <PackageId>Dekaf</PackageId>
-    <Description>High-performance, pure C# Apache Kafka client library for .NET 10</Description>
+    <Description>High-performance, pure C# Apache Kafka client library for .NET</Description>
     <PackageTags>kafka;messaging;streaming;producer;consumer;pubsub</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -28,7 +31,7 @@
     <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
   </PropertyGroup>
 
-  <!-- Compatibility probe dependencies only. Dekaf still defaults to net10.0 until netstandard2.0 support is complete. -->
+  <!-- Compatibility dependencies for the package's netstandard2.0 asset. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.IO.Pipelines" Version="10.0.9" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />


### PR DESCRIPTION
## Summary

- Ship the core `Dekaf` package with `net10.0` and `netstandard2.0` assets.
- Add package smoke sample projects that restore `Dekaf` from the local `.nupkg`, build a `netstandard2.0` library, and run it from a `net10.0` host.
- Wire the smoke into CI after packing and document the supported package matrix.
- Add `ValueTaskCompatibility` helpers needed by the partitioned consumer runtime after #1315 landed.

Closes #1301

## Validation

- `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --no-incremental -v:minimal`
- `dotnet pack src\Dekaf\Dekaf.csproj --configuration Release --no-build -p:Version=0.0.1-local -p:PackageVersion=0.0.1-local -v:minimal`
- `pwsh scripts\RunNetStandardPackageSmoke.ps1 -PackageVersion 0.0.1-local`
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-incremental -v:minimal`
- `git diff --check`
- Full unit suite was run twice locally; each run hit one different timing-sensitive test, and focused reruns passed:
  - `ClientDnsLookupTests`: passed focused rerun
  - `RecordAccumulatorTests/Purge_Queue_FailsPendingAppendBlockedOnBufferMemory`: passed focused rerun