### PR TITLE
docs(consumer): document partitioned processing

### DIFF
--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -82,38 +82,42 @@ Get notified when partitions are assigned, revoked, lost, or stopped during grac
 ```csharp
 using Dekaf;
 
-public class MyRebalanceListener : IRebalanceListener, IPartitionStopListener
+public sealed class MyRebalanceListener : IRebalanceListener, IPartitionStopListener
 {
-    public async ValueTask OnPartitionsAssignedAsync(
+    public ValueTask OnPartitionsAssignedAsync(
         IEnumerable<TopicPartition> partitions,
         CancellationToken ct)
     {
         Console.WriteLine($"Assigned: {string.Join(", ", partitions)}");
         // Initialize resources for these partitions
+        return ValueTask.CompletedTask;
     }
 
-    public async ValueTask OnPartitionsRevokedAsync(
+    public ValueTask OnPartitionsRevokedAsync(
         IEnumerable<TopicPartition> partitions,
         CancellationToken ct)
     {
         Console.WriteLine($"Revoked: {string.Join(", ", partitions)}");
-        // Commit offsets, clean up resources
+        // Commit completed offsets, clean up resources
+        return ValueTask.CompletedTask;
     }
 
-    public async ValueTask OnPartitionsLostAsync(
+    public ValueTask OnPartitionsLostAsync(
         IEnumerable<TopicPartition> partitions,
         CancellationToken ct)
     {
         Console.WriteLine($"Lost: {string.Join(", ", partitions)}");
-        // Partitions were taken away (e.g., due to timeout)
+        // Partitions were taken away. Do not commit offsets here.
+        return ValueTask.CompletedTask;
     }
 
-    public async ValueTask OnPartitionsStoppedAsync(
+    public ValueTask OnPartitionsStoppedAsync(
         IEnumerable<TopicPartition> partitions,
         CancellationToken ct)
     {
         Console.WriteLine($"Stopped: {string.Join(", ", partitions)}");
         // Normal shutdown: drain and dispose partition-scoped resources
+        return ValueTask.CompletedTask;
     }
 }
 
@@ -126,11 +130,95 @@ var consumer = await Kafka.CreateConsumer<string, string>()
 
 Callback semantics:
 
-- `OnPartitionsAssignedAsync` runs after the group assigns partitions to this consumer.
-- `OnPartitionsRevokedAsync` runs during cooperative rebalance before ownership is transferred.
-- `OnPartitionsLostAsync` runs when ownership was lost involuntarily, such as heartbeat timeout; do not commit offsets for lost partitions unless you know they are still owned.
-- `OnPartitionsStoppedAsync` runs only for graceful `CloseAsync` or `DisposeAsync`, after heartbeat, leader-refresh, auto-commit, and prefetch tasks stop and before final auto-commit, `LeaveGroup`, assignment cleanup, and resource disposal.
-- Non-cancellation callback exceptions are logged and suppressed. `OperationCanceledException` follows the supplied cancellation token.
+| Callback | When it runs | Offset rule |
+| --- | --- | --- |
+| `OnPartitionsAssignedAsync` | After the group assigns partitions to this consumer. | Initialize partition-scoped state before records are processed. |
+| `OnPartitionsRevokedAsync` | During cooperative rebalance before ownership is transferred. | Commit only offsets for records that have completed processing, then dispose partition-scoped state. |
+| `OnPartitionsLostAsync` | After ownership was lost involuntarily, such as heartbeat timeout or unknown member recovery. | Do not commit offsets for lost partitions unless your application has a separate ownership guarantee. |
+| `OnPartitionsStoppedAsync` | During graceful `CloseAsync` or `DisposeAsync`, after heartbeat, leader-refresh, auto-commit, and prefetch tasks stop and before final auto-commit, `LeaveGroup`, assignment cleanup, and resource disposal. | Drain local work if needed, commit completed offsets, then release resources. |
+
+Non-cancellation callback exceptions are logged and suppressed. `OperationCanceledException` follows the supplied cancellation token.
+
+For low-level consumers, track completed offsets only after durable processing.
+On revoke or graceful stop, commit those completed offsets. On lost, remove local
+state without committing:
+
+```csharp
+using System.Collections.Concurrent;
+using Dekaf;
+
+public sealed class RebalanceCommitListener(
+    ConcurrentDictionary<TopicPartition, TopicPartitionOffset> completedOffsets,
+    Func<IReadOnlyCollection<TopicPartitionOffset>, CancellationToken, ValueTask> commitCompletedAsync)
+    : IRebalanceListener, IPartitionStopListener
+{
+    public ValueTask OnPartitionsAssignedAsync(
+        IEnumerable<TopicPartition> partitions,
+        CancellationToken ct)
+    {
+        foreach (var partition in partitions)
+            completedOffsets.TryRemove(partition, out _);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask OnPartitionsRevokedAsync(
+        IEnumerable<TopicPartition> partitions,
+        CancellationToken ct)
+    {
+        await CommitCompletedForAsync(partitions, ct);
+    }
+
+    public ValueTask OnPartitionsLostAsync(
+        IEnumerable<TopicPartition> partitions,
+        CancellationToken ct)
+    {
+        foreach (var partition in partitions)
+            completedOffsets.TryRemove(partition, out _);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask OnPartitionsStoppedAsync(
+        IEnumerable<TopicPartition> partitions,
+        CancellationToken ct)
+    {
+        await CommitCompletedForAsync(partitions, ct);
+    }
+
+    private async ValueTask CommitCompletedForAsync(
+        IEnumerable<TopicPartition> partitions,
+        CancellationToken ct)
+    {
+        var offsets = new List<TopicPartitionOffset>();
+
+        foreach (var partition in partitions)
+        {
+            if (completedOffsets.TryRemove(partition, out var offset))
+                offsets.Add(offset);
+        }
+
+        if (offsets.Count > 0)
+            await commitCompletedAsync(offsets, ct);
+    }
+}
+```
+
+Update the tracker from the consume loop after work succeeds:
+
+```csharp
+completedOffsets[new TopicPartition(message.Topic, message.Partition)] =
+    new TopicPartitionOffset(
+        message.Topic,
+        message.Partition,
+        message.Offset + 1,
+        message.LeaderEpoch ?? -1);
+```
+
+For the built-in partitioned runtime, prefer
+[`RunPartitionedAsync`](./partitioned-processing-api.md). It owns the
+channel-per-partition pattern, bounded queues, pause/resume backpressure, and
+revoke/lost/shutdown commits for you.
 
 ### Cooperative Rebalancing
 

--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -4,119 +4,24 @@ sidebar_position: 6
 
 # Partitioned Async Processing
 
-:::info
-This page records the first public runtime API. Expanded user-facing docs and samples are tracked by #1269.
-:::
+`RunPartitionedAsync` is the high-level consumer API for work that must stay
+ordered within each Kafka partition but can run in parallel across partitions.
 
-Dekaf already exposes the low-level pieces needed for partition-aware consumers: `ConsumeAsync`, manual commits, `consumer.Partitions.Pause` / `consumer.Partitions.Resume`, and `IRebalanceListener`. The partitioned processing API makes the common advanced model first-class:
+Use it when:
 
-- one ordered async lane per assigned `TopicPartition`
-- parallel processing across partitions
-- bounded per-partition buffers
-- deterministic assignment, revoke, lost, and graceful stop behavior
-- offset commits based on completed processing, not fetched records
+- a key, customer, tenant, aggregate, or stream shard must be processed in offset order
+- different partitions can run at the same time
+- offset commits must reflect completed processing, not just fetched records
+- partition revoke, lost, and shutdown behavior must be explicit
 
-## API Shape
+The method owns the consume loop while it runs. Do not call `ConsumeAsync`,
+`ConsumeBatchAsync`, `ConsumeRawBatchAsync`, `consumer.Partitions.Assign`,
+`consumer.Partitions.Unassign`, `consumer.Partitions.Pause`, or
+`consumer.Partitions.Resume` concurrently on the same consumer.
 
-Add an extension method on `IKafkaConsumer<TKey, TValue>`:
+## Basic Usage
 
-```csharp
-await consumer.RunPartitionedAsync(
-    ProcessPartitionAsync,
-    new PartitionedProcessingOptions
-    {
-        MaxBufferedRecordsPerPartition = 256,
-        BackpressureMode = PartitionBackpressureMode.PauseResume,
-        StopPolicy = PartitionStopPolicy.Drain,
-        ErrorPolicy = PartitionWorkerErrorPolicy.StopConsumer,
-        CommitPolicy = PartitionCommitPolicy.CommitCompletedOnRevoke
-    },
-    cancellationToken);
-
-static async ValueTask ProcessPartitionAsync(
-    PartitionProcessorContext<string, Order> partition,
-    CancellationToken cancellationToken)
-{
-    await foreach (var message in partition.Messages.WithCancellation(cancellationToken))
-    {
-        await SaveOrderAsync(message.Value, cancellationToken);
-        partition.MarkProcessed(message);
-    }
-}
-```
-
-The method owns the consume loop while it runs. Applications should not call `ConsumeAsync`, `ConsumeBatchAsync`, `ConsumeRawBatchAsync`, `consumer.Partitions.Assign`, `consumer.Partitions.Unassign`, `consumer.Partitions.Pause`, or `consumer.Partitions.Resume` concurrently with `RunPartitionedAsync` on the same consumer.
-
-## Public Types
-
-```csharp
-public static class PartitionedConsumerExtensions
-{
-    public static ValueTask RunPartitionedAsync<TKey, TValue>(
-        this IKafkaConsumer<TKey, TValue> consumer,
-        PartitionProcessor<TKey, TValue> processor,
-        PartitionedProcessingOptions? options = null,
-        CancellationToken cancellationToken = default);
-}
-
-public delegate ValueTask PartitionProcessor<TKey, TValue>(
-    PartitionProcessorContext<TKey, TValue> context,
-    CancellationToken cancellationToken);
-
-public sealed class PartitionProcessorContext<TKey, TValue>
-{
-    public TopicPartition TopicPartition { get; }
-    public IAsyncEnumerable<ConsumeResult<TKey, TValue>> Messages { get; }
-    public CancellationToken StoppingToken { get; }
-
-    public void MarkProcessed(ConsumeResult<TKey, TValue> message);
-    public ValueTask CommitProcessedAsync(CancellationToken cancellationToken = default);
-    public long? LastProcessedOffset { get; }
-}
-
-public sealed class PartitionedProcessingOptions
-{
-    public int MaxBufferedRecordsPerPartition { get; init; } = 256;
-    public PartitionBackpressureMode BackpressureMode { get; init; } = PartitionBackpressureMode.PauseResume;
-    public PartitionStopPolicy StopPolicy { get; init; } = PartitionStopPolicy.Drain;
-    public TimeSpan StopTimeout { get; init; } = TimeSpan.FromSeconds(30);
-    public PartitionWorkerErrorPolicy ErrorPolicy { get; init; } = PartitionWorkerErrorPolicy.StopConsumer;
-    public TimeSpan IgnoreRestartBackoff { get; init; } = TimeSpan.FromMilliseconds(100);
-    public TimeSpan IgnoreRestartBackoffMax { get; init; } = TimeSpan.FromSeconds(5);
-    public PartitionCommitPolicy CommitPolicy { get; init; } = PartitionCommitPolicy.CommitCompletedOnRevoke;
-    public TimeSpan CommitInterval { get; init; } = TimeSpan.FromSeconds(5);
-}
-
-public enum PartitionBackpressureMode
-{
-    PauseResume,
-    AwaitCapacity
-}
-
-public enum PartitionStopPolicy
-{
-    Drain,
-    Cancel
-}
-
-public enum PartitionWorkerErrorPolicy
-{
-    StopConsumer,
-    StopPartition,
-    Ignore
-}
-
-public enum PartitionCommitPolicy
-{
-    UserManaged,
-    CommitCompletedOnRevoke,
-    CommitCompletedPeriodically
-}
-```
-
-The context is intentionally partition-scoped. It exposes only the messages for one partition and commit helpers for offsets completed by that lane. It does not expose the global consumer because direct consumer mutation would bypass the runtime's ownership checks.
-
-## Basic Example
+Use manual offset commits for at-least-once partitioned processing:
 
 ```csharp
 await using var consumer = await Kafka.CreateConsumer<string, Order>()
@@ -125,6 +30,14 @@ await using var consumer = await Kafka.CreateConsumer<string, Order>()
     .WithOffsetCommitMode(OffsetCommitMode.Manual)
     .SubscribeTo("orders")
     .BuildAsync();
+
+var options = new PartitionedProcessingOptions
+{
+    MaxBufferedRecordsPerPartition = 256,
+    BackpressureMode = PartitionBackpressureMode.PauseResume,
+    StopPolicy = PartitionStopPolicy.Drain,
+    CommitPolicy = PartitionCommitPolicy.CommitCompletedOnRevoke
+};
 
 await consumer.RunPartitionedAsync(
     async (partition, ct) =>
@@ -135,163 +48,228 @@ await consumer.RunPartitionedAsync(
             partition.MarkProcessed(message);
         }
     },
+    options,
+    stoppingToken);
+```
+
+Dekaf starts one processor invocation for each assigned `TopicPartition`. Each
+processor receives only the ordered stream for that partition. Processors for
+different partitions run concurrently.
+
+## Ordering And Parallelism
+
+The processor callback is long-lived. It starts when a partition is assigned and
+ends when the partition is revoked, lost, stopped, failed, or when the whole
+consumer shuts down.
+
+Within one partition:
+
+- messages are yielded in Kafka offset order
+- at most one processor invocation is active
+- `MarkProcessed` records the highest completed offset for that partition
+
+Across partitions:
+
+- processors run independently
+- slow partitions do not block processing already queued for other partitions
+- shared application state must still be protected by your code
+
+```csharp
+await consumer.RunPartitionedAsync(
+    async (partition, ct) =>
+    {
+        var topicPartition = partition.TopicPartition;
+
+        await foreach (var message in partition.Messages.WithCancellation(ct))
+        {
+            await HandlePartitionRecordAsync(
+                topicPartition,
+                message.Offset,
+                message.Value,
+                ct);
+
+            partition.MarkProcessed(message);
+        }
+    },
     cancellationToken: stoppingToken);
 ```
 
-This preserves order for each partition while different partitions run concurrently.
+This pattern lets partition `orders-0` continue in offset order while
+`orders-1`, `orders-2`, and other assigned partitions run their own ordered
+lanes at the same time.
 
-## Advanced Example
+## Commit Semantics
+
+`MarkProcessed(message)` marks `message.Offset + 1` as eligible for commit for
+the current partition. Dekaf never commits a record merely because it was
+fetched or yielded.
+
+Commit policies:
+
+| Policy | Behavior |
+| --- | --- |
+| `UserManaged` | Dekaf tracks processed offsets, but only your code calls `CommitProcessedAsync` or another commit mechanism. |
+| `CommitCompletedOnRevoke` | Dekaf commits completed offsets when a partition is revoked and during graceful shutdown. This is the default. |
+| `CommitCompletedPeriodically` | Dekaf commits completed offsets on `CommitInterval`, then again on revoke and graceful shutdown. |
+
+Manual per-partition commits are useful when you want a tighter commit cadence
+without waiting for a rebalance:
 
 ```csharp
-var options = new PartitionedProcessingOptions
-{
-    MaxBufferedRecordsPerPartition = 1024,
-    BackpressureMode = PartitionBackpressureMode.PauseResume,
-    StopPolicy = PartitionStopPolicy.Drain,
-    StopTimeout = TimeSpan.FromSeconds(20),
-    ErrorPolicy = PartitionWorkerErrorPolicy.StopConsumer,
-    CommitPolicy = PartitionCommitPolicy.CommitCompletedOnRevoke
-};
-
 await consumer.RunPartitionedAsync(
     async (partition, ct) =>
     {
         await foreach (var message in partition.Messages.WithCancellation(ct))
         {
-            using var activity = Telemetry.StartPartitionWork(partition.TopicPartition, message.Offset);
-
-            await HandleAsync(message.Value, ct);
+            await SaveAsync(message.Value, ct);
             partition.MarkProcessed(message);
 
-            if (ShouldFlush(partition.LastProcessedOffset))
-            {
+            if (ShouldFlushOffset(partition.LastProcessedOffset))
                 await partition.CommitProcessedAsync(ct);
-            }
         }
     },
-    options,
+    new PartitionedProcessingOptions
+    {
+        CommitPolicy = PartitionCommitPolicy.UserManaged
+    },
     stoppingToken);
 ```
 
-## Threading And Ordering Guarantees
+`CommitProcessedAsync` commits only the current partition's completed offset.
+Runtime-managed revoke and shutdown commits may batch completed offsets for
+multiple partitions into one `CommitAsync` call.
 
-For each assigned partition, the runtime starts at most one active processor invocation. Messages for that partition are delivered to that processor in Kafka offset order.
+If the consumer uses auto commit mode, use `PartitionCommitPolicy.UserManaged`
+and understand that auto commit can commit consumed positions before partition
+processing finishes. For at-least-once partitioned processing, prefer
+`OffsetCommitMode.Manual`.
 
-Different partitions may run concurrently. User code must protect shared application state the same way it would when running multiple tasks.
+Transactions remain user-managed. If a processor writes transactionally, send
+the processed offsets to that transaction and do not also let the partitioned
+runtime commit them outside the transaction.
 
-The runtime owns the consume loop internally and routes each record to exactly one partition lane. It must not process a later offset for a partition until every earlier yielded offset for that partition has been delivered to the same lane.
+## Assignment Lifecycle
 
-The processor callback is long-lived. It starts when a partition is assigned and ends when that partition is revoked, lost, stopped, or when the whole consumer fails or is cancelled.
+When partitions are assigned, Dekaf creates partition state, starts exactly one
+processor lane per partition, then routes records to those lanes.
 
-## Backpressure And Memory Behavior
+When partitions are revoked during cooperative rebalance, Dekaf:
 
-Each partition lane has a bounded queue. `MaxBufferedRecordsPerPartition` is the maximum number of records the runtime may buffer for a single partition before applying backpressure.
+1. Stops routing new records to the revoked partitions.
+2. Removes queued or prefetched records for partitions no longer assigned.
+3. Applies `StopPolicy`.
+4. Commits only offsets that were marked processed when the commit policy allows it.
+5. Disposes partition state and completes the partition message stream.
 
-Default backpressure mode is `PauseResume`:
+When partitions are lost involuntarily, such as after a heartbeat timeout, Dekaf
+cancels those partition lanes and completes their streams. It does not commit
+offsets for lost partitions because ownership is no longer guaranteed.
 
-- when a partition queue is full, the runtime pauses that partition
-- when queue capacity returns, the runtime resumes that partition
-- pause and resume are owned by the partitioned runtime while it is active
+## Shutdown
 
-`AwaitCapacity` is useful for simpler runtimes or tests. It waits for lane capacity before routing more records. This is easier to reason about but can reduce fairness when one slow partition blocks dispatch.
+Cancelling the token passed to `RunPartitionedAsync` stops the consume loop and
+then stops all active partition lanes.
 
-Memory is bounded by:
+`PartitionStopPolicy.Drain`:
+
+- completes each partition message stream
+- lets the processor finish already queued records
+- waits up to `StopTimeout`
+- commits completed offsets during graceful shutdown when the commit policy allows it
+
+`PartitionStopPolicy.Cancel`:
+
+- cancels each processor's token immediately
+- does not wait for the remaining queued records to be processed
+- commits only offsets already marked processed when the commit policy allows it
+
+The `CancellationToken` passed to the processor is the partition stopping token.
+With `Drain`, the normal signal is stream completion. With `Cancel`, lost
+partitions, processor failure cleanup, or drain timeout, the token is cancelled.
+
+If a processor does not finish within `StopTimeout`, Dekaf treats the timeout as
+fatal because it can no longer guarantee a single active processor for that
+partition. During shutdown, `StopTimeout` also bounds the final runtime-managed
+commit attempt.
+
+## Backpressure
+
+Each partition lane has a bounded queue. `MaxBufferedRecordsPerPartition` limits
+how many records Dekaf buffers for one partition after fetching and before your
+processor handles them.
+
+Memory for partition lanes is bounded by:
 
 ```text
 assigned partition count * MaxBufferedRecordsPerPartition * average record size
 ```
 
-The runtime should also respect existing consumer prefetch limits such as `QueuedMaxMessagesKbytes`. Bounded lane queues do not replace the consumer's fetch buffer limit; they add an application-processing boundary after fetch.
+Backpressure modes:
 
-## Assignment Lifecycle
+| Mode | Behavior | Use when |
+| --- | --- | --- |
+| `PauseResume` | Dekaf pauses a partition when its lane is full and resumes it when capacity returns. | Production default. It isolates slow partitions and keeps the shared consume loop fair. |
+| `AwaitCapacity` | Dekaf waits for queue capacity without changing the consumer pause state. | Tests or simple deployments where pause/resume side effects are undesirable. |
 
-When partitions are assigned:
+While `RunPartitionedAsync` is active, Dekaf owns pause and resume for its
+backpressure. Do not manually pause or resume partitions on the same consumer.
 
-1. Create partition state before routing records.
-2. Start exactly one processor lane per partition.
-3. Begin routing records only after lane startup succeeds.
-
-If startup fails, apply `ErrorPolicy`. The default should fail the whole partitioned run because a partition without a processor cannot make progress safely.
-
-## Revoke Lifecycle
-
-When partitions are revoked during cooperative rebalance:
-
-1. Stop routing new records to revoked partitions.
-2. Remove queued or prefetched records for revoked partitions before yielding more records. This depends on #1265.
-3. Apply `StopPolicy`.
-4. If draining, wait until completed records are marked processed or until `StopTimeout`.
-5. Commit only offsets that have completed processing when `CommitPolicy` allows runtime-managed commits.
-6. Dispose partition state and complete that partition's message stream.
-
-The runtime must never commit offsets for records that were fetched but not marked processed.
-
-## Lost Lifecycle
-
-When Dekaf's built-in `KafkaConsumer` reports partitions lost involuntarily through the coordinator rebalance callback, the runtime cancels those partition lanes and completes their streams. It does not commit offsets for lost partitions because ownership is no longer guaranteed.
-
-Manual assignment changes and custom `IKafkaConsumer` implementations that do not expose coordinator rebalance events cannot identify involuntary loss separately from ordinary assignment removal.
-
-Applications that write idempotently may still persist their own external offsets, but the runtime-managed Kafka commit policy should remain conservative.
-
-## Graceful Stop Lifecycle
-
-On `RunPartitionedAsync` cancellation or consumer close:
-
-1. Stop consuming new records.
-2. Stop routing records into partition queues.
-3. Apply `StopPolicy` to all active lanes.
-4. Commit completed offsets when `CommitPolicy` permits it.
-5. Dispose partition state.
-
-The partitioned runtime owns this lifecycle internally. The lower-level #1266 partition stop callback remains available for consumers that do not use `RunPartitionedAsync`.
+Bounded partition queues do not replace Kafka fetch limits such as
+`QueuedMaxMessagesKbytes`; they add an application-processing boundary after
+records have been fetched.
 
 ## Error Policy
 
-Default behavior is fail-fast:
+`PartitionWorkerErrorPolicy.StopConsumer` is the default. A processor exception
+stops the whole partitioned run and propagates from `RunPartitionedAsync`.
 
-- processor exception stops the partitioned run
-- all active lanes are cancelled or drained according to stop policy
-- the exception is propagated from `RunPartitionedAsync`
+`StopPartition` stops only the failed partition and pauses it while it remains
+assigned. Use this only when operations can tolerate lag on that partition until
+the next revoke or reassignment.
 
-`StopPartition` is available for advanced users, but it needs careful operational handling because a stopped partition that remains assigned can cause lag.
+`Ignore` logs the exception, waits with exponential backoff, and restarts the
+failed lane while healthy partitions keep running. Prefer handling retries and
+dead-letter routing inside your processor so unexpected exceptions remain
+visible.
 
-When `StopPartition` stops a failed partition, the runtime logs the processor exception and pauses the partition while it remains assigned. A later revoke/lost event clears that stopped state so a legitimate reassignment can start a fresh lane.
+## Low-Level Rebalance Callbacks
 
-`Ignore` is opt-in only. It logs the processor exception, waits with exponential backoff between restarts, restarts the partition lane, and keeps the rest of the run active. The restart wait is scheduled outside the shared poll/command loop, so healthy partitions continue to fetch and route while the failed partition backs off. `IgnoreRestartBackoff` controls the first delay and must be greater than zero; `IgnoreRestartBackoffMax` caps the delay. Prefer handling retries and dead-letter routing inside the processor so unexpected exceptions remain visible.
+`RunPartitionedAsync` builds on the lower-level rebalance lifecycle described in
+[consumer groups](./consumer-groups.md#rebalance-listener). For most partitioned
+work, use `RunPartitionedAsync` instead of writing your own channel-per-partition
+dispatcher.
 
-If a processor does not stop within `StopTimeout`, the runtime treats that timeout as fatal because it can no longer guarantee one active processor per partition.
+Use `IRebalanceListener` directly when you need full control over assignment
+state, custom queues, or integration with an existing processing runtime. The
+same safety rule applies: commit completed offsets on revoke or graceful stop,
+but do not commit offsets for lost partitions unless your application has a
+separate ownership guarantee.
 
-## Commit Semantics
+## Migrating From Other APIs
 
-The runtime tracks completed offsets per partition. Calling `MarkProcessed(message)` marks `message.Offset + 1` as eligible for commit for that partition.
+### Confluent.Kafka
 
-Runtime-managed Kafka commits require manual offset mode:
+Map Confluent rebalance handlers to Dekaf callbacks:
 
-```csharp
-.WithOffsetCommitMode(OffsetCommitMode.Manual)
-```
+| Confluent.Kafka | Dekaf |
+| --- | --- |
+| `SetPartitionsAssignedHandler` | `IRebalanceListener.OnPartitionsAssignedAsync` |
+| `SetPartitionsRevokedHandler` | `IRebalanceListener.OnPartitionsRevokedAsync` |
+| `SetPartitionsLostHandler` | `IRebalanceListener.OnPartitionsLostAsync` |
 
-If the consumer uses auto commit mode, use `PartitionCommitPolicy.UserManaged`. Auto commit can commit fetched or yielded positions before partition processing completes, which conflicts with at-least-once partitioned processing.
+If your Confluent consumer starts one task or channel per assigned partition,
+replace that dispatcher with `RunPartitionedAsync`. Move the per-partition work
+into the processor callback, call `MarkProcessed` after durable processing, and
+let `CommitPolicy` handle revoke and shutdown commits.
 
-`CommitProcessedAsync` commits only the calling partition's completed offset. Revoke and graceful stop commits may batch completed offsets for multiple partitions into one `CommitAsync` call.
+### Akka.Streams.Kafka
 
-Transactions remain user-managed. When a processor writes to Kafka transactionally, it should use `SendOffsetsToTransactionAsync` with offsets derived from `MarkProcessed` state, and the runtime should not also commit those offsets outside the transaction.
+`RunPartitionedAsync` maps most closely to partitioned sources where each
+assigned partition becomes an ordered substream. The processor callback is the
+substream body, `partition.Messages` is the ordered stream, and `MarkProcessed`
+is the point where a committable offset becomes eligible for commit.
 
-## Compatibility
-
-`ConsumeAsync`, `ConsumeBatchAsync`, and `ConsumeRawBatchAsync` remain the low-level APIs. `RunPartitionedAsync` is a higher-level owner of the consume loop and should not be mixed with them on the same consumer while active.
-
-`KafkaConsumerService<TKey, TValue>` can compose in two ways:
-
-- add a new `PartitionedKafkaConsumerService<TKey, TValue>` base class
-- add an opt-in service option that runs `RunPartitionedAsync` instead of `ConsumeAsync`
-
-The separate base class is the clearer first version because it keeps existing hosted service behavior unchanged.
-
-## Prerequisites
-
-- #1265: coordinator-driven revocation must discard queued and prefetched records for removed partitions before any consume API yields them.
-- #1266: graceful partition stop semantics are available for the low-level listener path.
-- #1268: implements the partitioned runtime.
-- #1269: replaces this API page with full user-facing docs and samples.
+If your Akka.Streams.Kafka flow commits offsets in a partition handler during
+revoke, use `CommitCompletedOnRevoke` or call `CommitProcessedAsync` inside the
+Dekaf processor. Keep per-partition ordering assumptions inside one processor
+invocation, not in shared mutable state.


### PR DESCRIPTION
Summary:
- Replace partitioned async processing design notes with user-facing docs for ordering, commits, shutdown, backpressure, errors, and migrations.
- Expand consumer group rebalance docs with assigned/revoked/lost/stopped semantics and completed-offset revoke/stop guidance.

Tests:
- git diff --check
- npm run build --prefix docs

Closes #1269