### PR TITLE
fix(ci): allow positive review headings

### DIFF
--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -15,11 +15,30 @@ function Get-ActionableReviewBodyReason {
         "|$previouslyResolvedHeading"
     $actionableHeadingWord = 'Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Design|Leak|Leaks|Gap|Gaps|Silently|(?<!not )(?<!non-)Blocking|(?<!not )(?<!non-)Blocker|Test coverage gap|Required|Must fix'
     $categoryOnlyHeading = '(?:correctness|design|architecture)(?:\s*/\s*(?:correctness|design|architecture))*'
+    $positiveCategorySection =
+        '\bno\s+(?:\w+\s+){0,5}(?:bugs?|issues?|concerns?|blockers?|findings?|problems?)\b(?:\s+(?:found|detected|identified|seen|remain|remaining))?'
+
+    $categoryHeadingPattern = "(?im)^\s*#{2,4}\s+($categoryOnlyHeading)\s*:?\s*$"
+    foreach ($heading in [regex]::Matches($Body, $categoryHeadingPattern)) {
+        $sectionStart = $heading.Index + $heading.Length
+        $sectionRemainder = $Body.Substring($sectionStart)
+        $nextHeading = [regex]::Match($sectionRemainder, '(?m)^\s*#{2,4}\s+')
+        $sectionBody = if ($nextHeading.Success) {
+            $sectionRemainder.Substring(0, $nextHeading.Index)
+        } else {
+            $sectionRemainder
+        }
+        $firstParagraph = [regex]::Match($sectionBody, '(?ms)\S.*?(?:\r?\n\s*\r?\n|$)').Value
+
+        if ($firstParagraph -notmatch $positiveCategorySection) {
+            return "actionable category heading: $($heading.Value.Trim())"
+        }
+    }
 
     $patterns = @(
         @{
             Reason = 'actionable heading'
-            Pattern = "(?im)^\s*#{2,4}\s+(?!$nonActionableHeading)(?!$categoryOnlyHeading\s*$).*\b($actionableHeadingWord)\b"
+            Pattern = "(?im)^\s*#{2,4}\s+(?!$nonActionableHeading)(?!$categoryOnlyHeading\s*:?\s*$).*\b($actionableHeadingWord)\b"
         },
         @{
             Reason = 'numbered finding heading'

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -14,11 +14,12 @@ function Get-ActionableReviewBodyReason {
         '(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking)\b' +
         "|$previouslyResolvedHeading"
     $actionableHeadingWord = 'Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Design|Leak|Leaks|Gap|Gaps|Silently|(?<!not )(?<!non-)Blocking|(?<!not )(?<!non-)Blocker|Test coverage gap|Required|Must fix'
+    $categoryOnlyHeading = '(?:correctness|design|architecture)(?:\s*/\s*(?:correctness|design|architecture))*'
 
     $patterns = @(
         @{
             Reason = 'actionable heading'
-            Pattern = "(?im)^\s*#{2,4}\s+(?!$nonActionableHeading).*\b($actionableHeadingWord)\b"
+            Pattern = "(?im)^\s*#{2,4}\s+(?!$nonActionableHeading)(?!$categoryOnlyHeading\s*$).*\b($actionableHeadingWord)\b"
         },
         @{
             Reason = 'numbered finding heading'

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -64,6 +64,27 @@ Scope check passed.
         Blocks = $false
     },
     @{
+        Name = 'allows positive category section headings'
+        Body = @'
+## Review
+
+### Correctness
+No bugs found. This is a faithful refactor.
+
+### Design / architecture
+This is a genuine improvement, not just churn.
+
+### Zero-allocation / hot path
+No concerns.
+
+### Test coverage
+Existing tests cover the behavior.
+
+No blocking issues.
+'@
+        Blocks = $false
+    },
+    @{
         Name = 'allows optional follow-up'
         Body = @'
 ## Review

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -72,7 +72,7 @@ Scope check passed.
 No bugs found. This is a faithful refactor.
 
 ### Design / architecture
-This is a genuine improvement, not just churn.
+No design issues found. This is a genuine improvement, not just churn.
 
 ### Zero-allocation / hot path
 No concerns.
@@ -83,6 +83,43 @@ Existing tests cover the behavior.
 No blocking issues.
 '@
         Blocks = $false
+    },
+    @{
+        Name = 'allows positive category section heading with colon'
+        Body = @'
+## Review
+
+### Correctness:
+No issues found.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'blocks category section heading with finding body'
+        Body = @'
+## Review
+
+### Correctness
+`MetadataManager.RefreshAsync` leaks the cached `Task` when the request is
+cancelled, causing a slow unbounded memory leak in long-running consumers.
+
+### Design
+The retry loop duplicates logic already present in `BackoffPolicy` and
+should be consolidated.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks category section when all-clear is not first paragraph'
+        Body = @'
+## Review
+
+### Correctness
+This leaks cached tasks under cancellation.
+
+No issues found after that.
+'@
+        Blocks = $true
     },
     @{
         Name = 'allows optional follow-up'


### PR DESCRIPTION
## Summary
- allow category-only review headings like `### Correctness` and `### Design / architecture`
- keep concrete finding headings blocking
- add regression coverage for positive sectioned reviews

## Test plan
- [x] `pwsh scripts\Test-AssertPrGreenReviewHeuristics.ps1`
- [x] `pwsh scripts\Assert-PrGreen.ps1 -Pr 1333`
- [x] `git diff --check`

Closes #1399
