### PR TITLE
fix(producer): mask Murmur2 sign bit

### DIFF
--- a/docs/docs/producer/partitioning.md
+++ b/docs/docs/producer/partitioning.md
@@ -27,6 +27,8 @@ await producer.ProduceAsync("orders", "order-123", event3);
 
 This guarantees ordering for messages with the same key - they'll be consumed in the order they were produced.
 
+Dekaf uses Kafka's Murmur2 positive-hash partition reduction for keyed messages, matching the Java client and librdkafka/Confluent.Kafka. This preserves key-to-partition assignments when migrating producers or running mixed client fleets.
+
 :::tip
 Use meaningful keys like user IDs, order IDs, or entity IDs to keep related messages together.
 :::

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -37,8 +37,8 @@ public sealed class DefaultPartitioner : IPartitioner
             return (int)(++_counter % (uint)partitionCount);
         }
 
-        // Murmur2 hash for consistent partitioning
-        return (int)(Murmur2.Hash(key) % partitionCount);
+        // Kafka-compatible Murmur2 partitioning for keyed messages.
+        return Murmur2.Partition(key, partitionCount);
     }
 }
 
@@ -72,7 +72,7 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
             return _stickyPartitions.GetOrAdd(topic, newPartition);
         }
 
-        return (int)(Murmur2.Hash(key) % partitionCount);
+        return Murmur2.Partition(key, partitionCount);
     }
 
     /// <summary>
@@ -119,6 +119,12 @@ internal static class Murmur2
     private const uint Seed = 0x9747b28c;
     private const int M = 0x5bd1e995;
     private const int R = 24;
+    private const uint PositiveMask = 0x7fff_ffff;
+
+    public static int Partition(ReadOnlySpan<byte> key, int partitionCount)
+    {
+        return (int)((Hash(key) & PositiveMask) % (uint)partitionCount);
+    }
 
     public static uint Hash(ReadOnlySpan<byte> data)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/Murmur2Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Murmur2Tests.cs
@@ -5,6 +5,15 @@ namespace Dekaf.Tests.Unit.Producer;
 
 public class Murmur2Tests
 {
+    private static readonly JavaPartitionVector[] JavaPartitionVectors =
+    [
+        new("user-123", 0xa87c3114u, 10, 8),
+        new("order-123", 0xc7f202c1u, 12, 1),
+        new("tenant-a", 0xe20b7283u, 50, 29),
+        new("a", 0xa2d0b27cu, 6, 4),
+        new("kafka", 0xd067cf64u, 100, 80)
+    ];
+
     #region Consistency Tests
 
     [Test]
@@ -106,13 +115,35 @@ public class Murmur2Tests
     }
 
     [Test]
+    public async Task Hash_JavaPartitionVectors_MatchExpectedHashes()
+    {
+        foreach (var vector in JavaPartitionVectors)
+        {
+            var key = Encoding.UTF8.GetBytes(vector.Key);
+
+            await Assert.That(Murmur2.Hash(key)).IsEqualTo(vector.Hash);
+        }
+    }
+
+    [Test]
+    public async Task Partition_JavaPartitionVectors_MatchPositiveHashReduction()
+    {
+        foreach (var vector in JavaPartitionVectors)
+        {
+            var key = Encoding.UTF8.GetBytes(vector.Key);
+
+            await Assert.That(Murmur2.Partition(key, vector.PartitionCount)).IsEqualTo(vector.ExpectedPartition);
+        }
+    }
+
+    [Test]
     public async Task Hash_PartitionConsistency_SameKeyAlwaysMapsToSamePartition()
     {
         const int partitionCount = 10;
         var key = Encoding.UTF8.GetBytes("user-123");
 
-        var partition1 = (int)(Murmur2.Hash(key) % partitionCount);
-        var partition2 = (int)(Murmur2.Hash(key) % partitionCount);
+        var partition1 = Murmur2.Partition(key, partitionCount);
+        var partition2 = Murmur2.Partition(key, partitionCount);
 
         await Assert.That(partition1).IsEqualTo(partition2);
     }
@@ -172,6 +203,21 @@ public class Murmur2Tests
         }
     }
 
+    [Test]
+    public async Task DefaultPartitioner_WithKey_MatchesJavaPartitionVectors()
+    {
+        var partitioner = new DefaultPartitioner();
+
+        foreach (var vector in JavaPartitionVectors)
+        {
+            var key = Encoding.UTF8.GetBytes(vector.Key);
+
+            var partition = partitioner.Partition("topic", key, false, vector.PartitionCount);
+
+            await Assert.That(partition).IsEqualTo(vector.ExpectedPartition);
+        }
+    }
+
     #endregion
 
     #region RoundRobinPartitioner Tests
@@ -222,6 +268,21 @@ public class Murmur2Tests
     }
 
     [Test]
+    public async Task StickyPartitioner_WithKey_MatchesJavaPartitionVectors()
+    {
+        var partitioner = new StickyPartitioner();
+
+        foreach (var vector in JavaPartitionVectors)
+        {
+            var key = Encoding.UTF8.GetBytes(vector.Key);
+
+            var partition = partitioner.Partition("topic", key, false, vector.PartitionCount);
+
+            await Assert.That(partition).IsEqualTo(vector.ExpectedPartition);
+        }
+    }
+
+    [Test]
     public async Task StickyPartitioner_WithNullKey_SticksToSamePartition()
     {
         var partitioner = new StickyPartitioner();
@@ -249,4 +310,10 @@ public class Murmur2Tests
     }
 
     #endregion
+
+    private sealed record JavaPartitionVector(
+        string Key,
+        uint Hash,
+        int PartitionCount,
+        int ExpectedPartition);
 }


### PR DESCRIPTION
## Summary
- Match Java/librdkafka keyed partitioning by masking the Murmur2 sign bit before modulo
- Add fixed Java compatibility vectors for Murmur2 hashes and partition assignments
- Document keyed partition compatibility for migrations and mixed producer fleets

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit --configuration Release
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit
- [x] npm run build --prefix docs

Closes #1336
