### PR TITLE
perf(producer): make default partitioner sticky

### DIFF
--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -189,8 +189,8 @@ Enable message compression:
 Control how messages are assigned to partitions:
 
 ```csharp
-.WithPartitioner(PartitionerType.Default)     // Hash key or round-robin
-.WithPartitioner(PartitionerType.Sticky)      // Stick to partition for batching
+.WithPartitioner(PartitionerType.Default)     // Hash key or sticky null keys
+.WithPartitioner(PartitionerType.Sticky)      // Stick null keys for batching
 .WithPartitioner(PartitionerType.RoundRobin)  // Even distribution
 ```
 

--- a/docs/docs/producer/partitioning.md
+++ b/docs/docs/producer/partitioning.md
@@ -12,7 +12,7 @@ When you send a message, Dekaf determines which partition it goes to:
 
 1. **Explicit partition** - If you specify a partition, that's where it goes
 2. **Key-based** - If you provide a key, it's hashed to determine the partition
-3. **Round-robin** - If no key, messages are distributed across partitions
+3. **Sticky null-key partitioning** - If no key, messages stick to one partition until the current batch completes, then rotate
 
 ## Key-Based Partitioning
 
@@ -55,10 +55,10 @@ Using explicit partitions couples your code to the topic's partition count. If t
 
 ## Null Keys
 
-When you don't provide a key (or it's null), the partitioner distributes messages across partitions:
+When you don't provide a key (or it's null), the default partitioner sticks to one partition while the current batch is open, then rotates after the batch completes:
 
 ```csharp
-// These messages may go to different partitions
+// These messages can batch together on the same partition
 await producer.ProduceAsync("events", null, "event1");
 await producer.ProduceAsync("events", null, "event2");
 await producer.ProduceAsync("events", null, "event3");
@@ -79,13 +79,13 @@ var producer = await Kafka.CreateProducer<string, string>()
 
 | Partitioner | Behavior |
 |-------------|----------|
-| `Default` | Hash key for keyed messages, round-robin for null keys |
-| `Sticky` | Sticks to one partition for null keys until batch is full |
+| `Default` | Hash key for keyed messages, sticks null keys until batch completion |
+| `Sticky` | Sticks to one partition for null keys until batch completion |
 | `RoundRobin` | Distributes all messages evenly |
 
-### Sticky Partitioner
+### Default and Sticky Partitioners
 
-The sticky partitioner improves batching efficiency for null-key messages:
+The default partitioner uses sticky null-key partitioning to improve batching efficiency. You can also select `Sticky` explicitly:
 
 ```csharp
 using Dekaf;

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -20,69 +20,29 @@ internal interface IBatchCompletionAwarePartitioner
     void OnBatchComplete(string topic, int partitionCount);
 }
 
-/// <summary>
-/// Default partitioner - uses murmur2 hash of key, or round-robin for null keys.
-/// </summary>
-public sealed class DefaultPartitioner : IPartitioner
+internal sealed class StickyPartitionTracker
 {
-    // Non-atomic increment is intentional: avoids Interlocked cache line contention across threads.
-    // Two threads may occasionally read the same counter value (benign — just means two messages
-    // land on the same partition), but distribution remains even over time.
-    private uint _counter;
-
-    public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
-    {
-        if (keyIsNull || key.Length == 0)
-        {
-            return (int)(++_counter % (uint)partitionCount);
-        }
-
-        // Kafka-compatible Murmur2 partitioning for keyed messages.
-        return Murmur2.Partition(key, partitionCount);
-    }
-}
-
-/// <summary>
-/// Sticky partitioner - sticks to a partition for null keys until batch is full.
-/// Uses ConcurrentDictionary for lock-free read access in the hot path.
-/// </summary>
-public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwarePartitioner
-{
-    private readonly ConcurrentDictionary<string, int> _stickyPartitions = new();
+    private readonly ConcurrentDictionary<string, int> _partitions = new();
 #if NETSTANDARD2_0
     private int _counter;
 #else
     private uint _counter;
 #endif
 
-    public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+    public int GetOrAssign(string topic, int partitionCount)
     {
-        if (keyIsNull || key.Length == 0)
+        if (_partitions.TryGetValue(topic, out var partition))
         {
-            // Hot path: TryGetValue is lock-free for reads in ConcurrentDictionary
-            if (_stickyPartitions.TryGetValue(topic, out var partition))
-            {
-                return partition;
-            }
-
-            // Cold path: topic not yet seen, compute and add a partition.
-            // Use uint to avoid overflow to negative values.
-            // GetOrAdd handles the race condition - if another thread added first, we use their value.
-            var newPartition = NextPartition(partitionCount);
-            return _stickyPartitions.GetOrAdd(topic, newPartition);
+            return partition;
         }
 
-        return Murmur2.Partition(key, partitionCount);
+        var newPartition = NextPartition(partitionCount);
+        return _partitions.GetOrAdd(topic, newPartition);
     }
 
-    /// <summary>
-    /// Called when a batch is sent to switch to a new partition.
-    /// </summary>
-    public void OnBatchComplete(string topic, int partitionCount)
+    public void Rotate(string topic, int partitionCount)
     {
-        // Use AddOrUpdate for thread-safe update that doesn't race with concurrent TryGetValue.
-        // Use uint to avoid overflow to negative values.
-        _stickyPartitions.AddOrUpdate(
+        _partitions.AddOrUpdate(
             topic,
             _ => NextPartition(partitionCount),
             (_, _) => NextPartition(partitionCount));
@@ -98,11 +58,66 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
 }
 
 /// <summary>
+/// Default partitioner - uses murmur2 hash of key, or sticky partitioning for null keys.
+/// </summary>
+public sealed class DefaultPartitioner : IPartitioner, IBatchCompletionAwarePartitioner
+{
+    private readonly StickyPartitionTracker _stickyPartitionTracker = new();
+
+    public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+    {
+        if (keyIsNull || key.Length == 0)
+        {
+            return _stickyPartitionTracker.GetOrAssign(topic, partitionCount);
+        }
+
+        // Kafka-compatible Murmur2 partitioning for keyed messages.
+        return Murmur2.Partition(key, partitionCount);
+    }
+
+    /// <summary>
+    /// Called when a batch is sent to switch to a new partition.
+    /// </summary>
+    public void OnBatchComplete(string topic, int partitionCount)
+    {
+        _stickyPartitionTracker.Rotate(topic, partitionCount);
+    }
+}
+
+/// <summary>
+/// Sticky partitioner - sticks to a partition for null keys until batch is full.
+/// Uses ConcurrentDictionary for lock-free read access in the hot path.
+/// </summary>
+public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwarePartitioner
+{
+    private readonly StickyPartitionTracker _stickyPartitionTracker = new();
+
+    public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+    {
+        if (keyIsNull || key.Length == 0)
+        {
+            return _stickyPartitionTracker.GetOrAssign(topic, partitionCount);
+        }
+
+        return Murmur2.Partition(key, partitionCount);
+    }
+
+    /// <summary>
+    /// Called when a batch is sent to switch to a new partition.
+    /// </summary>
+    public void OnBatchComplete(string topic, int partitionCount)
+    {
+        _stickyPartitionTracker.Rotate(topic, partitionCount);
+    }
+}
+
+/// <summary>
 /// Round-robin partitioner - cycles through partitions.
 /// </summary>
 public sealed class RoundRobinPartitioner : IPartitioner
 {
-    // Non-atomic increment — see DefaultPartitioner comment for rationale.
+    // Non-atomic increment is intentional: occasional duplicate reads are benign,
+    // and distribution remains even over time without Interlocked contention.
     private uint _counter;
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -493,7 +493,7 @@ public enum Acks
 public enum PartitionerType
 {
     /// <summary>
-    /// Default partitioner (hash key or round-robin).
+    /// Default partitioner (hash key or sticky null keys).
     /// </summary>
     Default,
 

--- a/tests/Dekaf.Tests.Integration/ProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTests.cs
@@ -346,6 +346,56 @@ public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
     }
 
     [Test]
+    public async Task Producer_WithDefaultPartitioner_SticksNullKeysBeforeBatchCompletes()
+    {
+        // Arrange
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 3);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer-default-sticky")
+            .WithLinger(TimeSpan.FromSeconds(5))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        // Act - fire-and-forget callbacks avoid awaited-produce micro-linger, so the
+        // configured linger keeps the current batch open while all partition choices happen.
+        var results = new RecordMetadata?[10];
+        var callbackCount = 0;
+        var callbacksCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        for (var i = 0; i < 10; i++)
+        {
+            var index = i;
+            await producer.FireAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = null,
+                Value = $"value-{i}"
+            }, (metadata, error) =>
+            {
+                if (error is not null)
+                {
+                    callbacksCompleted.TrySetException(error);
+                    return;
+                }
+
+                results[index] = metadata;
+                if (Interlocked.Increment(ref callbackCount) == results.Length)
+                    callbacksCompleted.TrySetResult();
+            });
+        }
+
+        await producer.FlushWithTimeoutAsync();
+        await callbacksCompleted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Assert - default partitioner sticks null-key messages before batch completion.
+        await Assert.That(results.Any(static result => !result.HasValue)).IsFalse();
+        var partitions = results.Select(static result => result.GetValueOrDefault().Partition).Distinct().ToList();
+        await Assert.That(partitions.Count).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Producer_WithStickyPartitioner_SticksMessagesBeforeBatchCompletes()
     {
         // Arrange

--- a/tests/Dekaf.Tests.Unit/Producer/Murmur2Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Murmur2Tests.cs
@@ -165,27 +165,38 @@ public class Murmur2Tests
     }
 
     [Test]
-    public async Task DefaultPartitioner_WithNullKey_UsesRoundRobin()
+    public async Task DefaultPartitioner_WithNullKey_SticksToSamePartition()
     {
         var partitioner = new DefaultPartitioner();
 
         var partition1 = partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, true, 10);
         var partition2 = partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, true, 10);
 
-        // Round-robin should produce incrementing partitions (mod count)
-        // They should not be the same (unless wrapping, which won't happen in 2 calls with 10 partitions)
-        await Assert.That(partition1).IsNotEqualTo(partition2);
+        await Assert.That(partition1).IsEqualTo(partition2);
     }
 
     [Test]
-    public async Task DefaultPartitioner_WithEmptyKey_UsesRoundRobin()
+    public async Task DefaultPartitioner_WithEmptyKey_SticksToSamePartition()
     {
         var partitioner = new DefaultPartitioner();
 
         var partition1 = partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, false, 10);
         var partition2 = partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, false, 10);
 
-        // Empty keys also use round-robin
+        await Assert.That(partition1).IsEqualTo(partition2);
+    }
+
+    [Test]
+    public async Task DefaultPartitioner_OnBatchComplete_SwitchesPartition()
+    {
+        var partitioner = new DefaultPartitioner();
+
+        var partition1 = partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, true, 100);
+        partitioner.OnBatchComplete("topic", 100);
+        var partition2 = partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, true, 100);
+
+        await Assert.That(partition1).IsGreaterThanOrEqualTo(0);
+        await Assert.That(partition2).IsGreaterThanOrEqualTo(0);
         await Assert.That(partition1).IsNotEqualTo(partition2);
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
@@ -3,6 +3,31 @@ using Dekaf.Producer;
 
 namespace Dekaf.Tests.Unit.Producer;
 
+internal static class StickyPartitionerTestHelpers
+{
+    public static void SetCounter(object partitioner, uint value)
+    {
+        var trackerField = partitioner.GetType().GetField("_stickyPartitionTracker",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new MissingFieldException(partitioner.GetType().Name, "_stickyPartitionTracker");
+
+        var tracker = trackerField.GetValue(partitioner)
+            ?? throw new InvalidOperationException("_stickyPartitionTracker was null.");
+
+        var counterField = tracker.GetType().GetField("_counter",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new MissingFieldException(tracker.GetType().Name, "_counter");
+
+        if (counterField.FieldType == typeof(int))
+        {
+            counterField.SetValue(tracker, unchecked((int)value));
+            return;
+        }
+
+        counterField.SetValue(tracker, value);
+    }
+}
+
 public class DefaultPartitionerTests
 {
     [Test]
@@ -16,19 +41,29 @@ public class DefaultPartitionerTests
     }
 
     [Test]
-    public async Task Partition_WithNullKey_RoundRobins()
+    public async Task Partition_WithNullKey_SticksToSamePartition()
     {
         var partitioner = new DefaultPartitioner();
-        var partitions = new HashSet<int>();
 
-        // Call enough times to cycle through all partitions
-        for (var i = 0; i < 10; i++)
-        {
-            var partition = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, 3);
-            partitions.Add(partition);
-        }
+        var partition1 = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, 5);
+        var partition2 = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, 5);
+        var partition3 = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, 5);
 
-        await Assert.That(partitions.Count).IsEqualTo(3);
+        await Assert.That(partition1).IsEqualTo(partition2);
+        await Assert.That(partition2).IsEqualTo(partition3);
+    }
+
+    [Test]
+    public async Task OnBatchComplete_ChangesPartition()
+    {
+        var partitioner = new DefaultPartitioner();
+        const int partitionCount = 5;
+
+        var partition1 = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, partitionCount);
+        partitioner.OnBatchComplete("test-topic", partitionCount);
+        var partition2 = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, partitionCount);
+
+        await Assert.That(partition1).IsNotEqualTo(partition2);
     }
 
     [Test]
@@ -50,19 +85,17 @@ public class DefaultPartitionerTests
     public async Task Partition_NearUIntMaxValue_NeverReturnsNegative()
     {
         var partitioner = new DefaultPartitioner();
+        StickyPartitionerTestHelpers.SetCounter(partitioner, uint.MaxValue - 100);
 
-        // Set counter to near uint.MaxValue using reflection
-        var counterField = typeof(DefaultPartitioner).GetField("_counter",
-            BindingFlags.NonPublic | BindingFlags.Instance);
-        await Assert.That(counterField).IsNotNull();
-        counterField!.SetValue(partitioner, uint.MaxValue - 100);
-
-        // Call partition many times around the overflow point
+        // Call partition and OnBatchComplete many times around the overflow point
         for (var i = 0; i < 200; i++)
         {
-            var partition = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, 7);
+            var topicName = $"test-topic-{i}";
+            var partition = partitioner.Partition(topicName, ReadOnlySpan<byte>.Empty, true, 7);
             await Assert.That(partition).IsGreaterThanOrEqualTo(0);
             await Assert.That(partition).IsLessThan(7);
+
+            partitioner.OnBatchComplete(topicName, 7);
         }
     }
 
@@ -72,26 +105,17 @@ public class DefaultPartitionerTests
         var partitioner = new DefaultPartitioner();
         const int partitionCount = 10;
 
-        // Set counter to uint.MaxValue - 1 so next increment wraps to 0
-        var counterField = typeof(DefaultPartitioner).GetField("_counter",
-            BindingFlags.NonPublic | BindingFlags.Instance);
-        await Assert.That(counterField).IsNotNull();
-        counterField!.SetValue(partitioner, uint.MaxValue - 1);
+        StickyPartitionerTestHelpers.SetCounter(partitioner, uint.MaxValue - 1);
 
-        // Get partition right before overflow
-        var beforeOverflow = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, partitionCount);
-        await Assert.That(beforeOverflow).IsGreaterThanOrEqualTo(0);
-        await Assert.That(beforeOverflow).IsLessThan(partitionCount);
+        partitioner.OnBatchComplete("test-topic", partitionCount);
+        var partition = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, partitionCount);
+        await Assert.That(partition).IsGreaterThanOrEqualTo(0);
+        await Assert.That(partition).IsLessThan(partitionCount);
 
-        // Get partition at overflow (counter wraps from uint.MaxValue to 0)
-        var atOverflow = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, partitionCount);
-        await Assert.That(atOverflow).IsGreaterThanOrEqualTo(0);
-        await Assert.That(atOverflow).IsLessThan(partitionCount);
-
-        // Get partition after overflow
-        var afterOverflow = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, partitionCount);
-        await Assert.That(afterOverflow).IsGreaterThanOrEqualTo(0);
-        await Assert.That(afterOverflow).IsLessThan(partitionCount);
+        partitioner.OnBatchComplete("test-topic", partitionCount);
+        partition = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, partitionCount);
+        await Assert.That(partition).IsGreaterThanOrEqualTo(0);
+        await Assert.That(partition).IsLessThan(partitionCount);
     }
 }
 
@@ -170,12 +194,7 @@ public class StickyPartitionerTests
     public async Task Partition_NearUIntMaxValue_NeverReturnsNegative()
     {
         var partitioner = new StickyPartitioner();
-
-        // Set counter to near uint.MaxValue using reflection
-        var counterField = typeof(StickyPartitioner).GetField("_counter",
-            BindingFlags.NonPublic | BindingFlags.Instance);
-        await Assert.That(counterField).IsNotNull();
-        counterField!.SetValue(partitioner, uint.MaxValue - 100);
+        StickyPartitionerTestHelpers.SetCounter(partitioner, uint.MaxValue - 100);
 
         // Call partition and OnBatchComplete many times around the overflow point
         for (var i = 0; i < 200; i++)
@@ -195,11 +214,7 @@ public class StickyPartitionerTests
         var partitioner = new StickyPartitioner();
         const int partitionCount = 10;
 
-        // Set counter to uint.MaxValue - 1
-        var counterField = typeof(StickyPartitioner).GetField("_counter",
-            BindingFlags.NonPublic | BindingFlags.Instance);
-        await Assert.That(counterField).IsNotNull();
-        counterField!.SetValue(partitioner, uint.MaxValue - 1);
+        StickyPartitionerTestHelpers.SetCounter(partitioner, uint.MaxValue - 1);
 
         // Trigger overflow with OnBatchComplete
         partitioner.OnBatchComplete("test-topic", partitionCount);


### PR DESCRIPTION
## Summary
- make the default partitioner sticky for null and empty keys while keeping Murmur2 keyed routing
- wire default partitioning into batch-completion rotation through the existing callback path
- update unit/integration coverage and partitioning docs

## Test plan
- [x] `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --no-incremental -v:minimal`
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-incremental -v:minimal`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/DefaultPartitionerTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/Murmur2Tests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/StickyPartitionerTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RoundRobinPartitionerTests/*"`
- [x] `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release --no-incremental -v:minimal`
- [x] `tests\Dekaf.Tests.Integration\bin\Release\net10.0\Dekaf.Tests.Integration.exe --treenode-filter "/*/*/ProducerTests/Producer_WithDefaultPartitioner_SticksNullKeysBeforeBatchCompletes"`
- [x] `npm run build --prefix docs`
- [x] `git diff --check`

Closes #1363
