### PR TITLE
fix(protocol): validate lengths before allocation

### DIFF
--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -624,10 +624,10 @@ public ref struct KafkaProtocolReader
         if (length == 0)
             return string.Empty;
 
+        ValidateReadableLength(length);
+
         if (_isContiguous)
         {
-            if (length < 0 || _position > _span.Length - length)
-                ThrowInsufficientData();
             var result = Encoding.UTF8.GetString(_span.Slice(_position, length));
             _position += length;
             return result;
@@ -691,11 +691,11 @@ public ref struct KafkaProtocolReader
 
     private byte[] ReadBytesContent(int length)
     {
+        ValidateReadableLength(length);
+
         var result = new byte[length];
         if (_isContiguous)
         {
-            if (length < 0 || _position > _span.Length - length)
-                ThrowInsufficientData();
             _span.Slice(_position, length).CopyTo(result);
             _position += length;
             return result;
@@ -733,6 +733,9 @@ public ref struct KafkaProtocolReader
     {
         if (count == 0)
             return [];
+
+        ValidateReadableLength(count);
+
         var result = new byte[count];
         ReadRawBytes(result);
         return result;
@@ -748,11 +751,11 @@ public ref struct KafkaProtocolReader
         if (count == 0)
             return ReadOnlyMemory<byte>.Empty;
 
+        ValidateReadableLength(count);
+
         // Fast path: Return a slice of the backing memory (zero-allocation)
         if (_isContiguous && _hasMemory)
         {
-            if (count < 0 || _position > _span.Length - count)
-                ThrowInsufficientData();
             var result = _memory.Slice(_position, count);
             _position += count;
             return result;
@@ -761,8 +764,6 @@ public ref struct KafkaProtocolReader
         // Fallback for span-only mode: must allocate since spans can't become Memory
         if (_isContiguous)
         {
-            if (count < 0 || _position > _span.Length - count)
-                ThrowInsufficientData();
             var result = _span.Slice(_position, count).ToArray();
             _position += count;
             return result;
@@ -796,6 +797,8 @@ public ref struct KafkaProtocolReader
         if (length <= 0)
             return [];
 
+        ValidateReadableLength(length);
+
         var result = new T[length];
         for (var i = 0; i < length; i++)
         {
@@ -812,6 +815,8 @@ public ref struct KafkaProtocolReader
         var length = ReadUnsignedVarInt() - 1;
         if (length <= 0)
             return [];
+
+        ValidateReadableLength(length);
 
         var result = new T[length];
         for (var i = 0; i < length; i++)
@@ -832,6 +837,8 @@ public ref struct KafkaProtocolReader
 
         if (length == 0)
             return [];
+
+        ValidateReadableLength(length);
 
         var result = new T[length];
         for (var i = 0; i < length; i++)
@@ -906,6 +913,8 @@ public ref struct KafkaProtocolReader
         if (length <= 0)
             return [];
 
+        ValidateReadableLength(length);
+
         var result = new T[length];
         for (var i = 0; i < length; i++)
         {
@@ -923,6 +932,8 @@ public ref struct KafkaProtocolReader
         var length = ReadUnsignedVarInt() - 1;
         if (length <= 0)
             return [];
+
+        ValidateReadableLength(length);
 
         var result = new T[length];
         for (var i = 0; i < length; i++)
@@ -945,6 +956,8 @@ public ref struct KafkaProtocolReader
         if (length == 0)
             return [];
 
+        ValidateReadableLength(length);
+
         var result = new T[length];
         for (var i = 0; i < length; i++)
         {
@@ -964,6 +977,8 @@ public ref struct KafkaProtocolReader
         if (length <= 0)
             return 0;
 
+        ValidateReadableLength(length);
+
         for (var i = 0; i < length; i++)
         {
             destination.Add(readItem(ref this, state));
@@ -982,6 +997,8 @@ public ref struct KafkaProtocolReader
         if (length <= 0)
             return 0;
 
+        ValidateReadableLength(length);
+
         for (var i = 0; i < length; i++)
         {
             destination.Add(readItem(ref this, state));
@@ -999,6 +1016,15 @@ public ref struct KafkaProtocolReader
     /// </summary>
     public delegate T ReadFunc<out T, in TState>(ref KafkaProtocolReader reader, TState state);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private readonly void ValidateReadableLength(int length)
+    {
+        if (length < 0 || Remaining < length)
+        {
+            ThrowInvalidLength(length, Remaining);
+        }
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowInsufficientData()
     {
@@ -1015,5 +1041,12 @@ public ref struct KafkaProtocolReader
     private static void ThrowInvalidProtocolData()
     {
         throw new MalformedProtocolDataException("Invalid protocol data: unsigned varint exceeds Int32 range");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowInvalidLength(int length, long remaining)
+    {
+        throw new MalformedProtocolDataException(
+            $"Invalid protocol data: claimed length {length} exceeds remaining data {remaining}");
     }
 }

--- a/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolReaderTests.cs
@@ -140,7 +140,7 @@ public class KafkaProtocolReaderTests
     public async Task ReadBytes_MultiSegmentClaimedLengthExceedsRemaining_ThrowsMalformedProtocolDataException()
     {
         var data = new byte[] { 0x00, 0x00, 0x00, 0x05, 0x01, 0x02 };
-        var sequence = CreateMultiSegmentSequence(data, splitAt: 2);
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(data, splitAt: 2);
 
         var exception = ReadThrowsMalformed(sequence, static (ref KafkaProtocolReader reader) => reader.ReadBytes());
 
@@ -160,7 +160,7 @@ public class KafkaProtocolReaderTests
     [Test]
     public async Task ReadMemorySlice_MultiSegmentClaimedLengthExceedsRemaining_ThrowsMalformedProtocolDataException()
     {
-        var sequence = CreateMultiSegmentSequence(new byte[] { 0x01, 0x02 }, splitAt: 1);
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(new byte[] { 0x01, 0x02 }, splitAt: 1);
 
         var exception = ReadThrowsMalformed(sequence, static (ref KafkaProtocolReader reader) => reader.ReadMemorySlice(3));
 
@@ -265,32 +265,6 @@ public class KafkaProtocolReaderTests
         }
 
         throw new InvalidOperationException("Expected MalformedProtocolDataException");
-    }
-
-    private static ReadOnlySequence<byte> CreateMultiSegmentSequence(byte[] data, int splitAt)
-    {
-        if (splitAt <= 0 || splitAt >= data.Length)
-            throw new ArgumentException("Split position must be within data bounds", nameof(splitAt));
-
-        var first = new TestSegment(data.AsMemory(0, splitAt));
-        var second = new TestSegment(data.AsMemory(splitAt));
-        first.SetNext(second);
-
-        return new ReadOnlySequence<byte>(first, 0, second, second.Memory.Length);
-    }
-
-    private sealed class TestSegment : ReadOnlySequenceSegment<byte>
-    {
-        public TestSegment(ReadOnlyMemory<byte> memory)
-        {
-            Memory = memory;
-        }
-
-        public void SetNext(TestSegment next)
-        {
-            Next = next;
-            next.RunningIndex = RunningIndex + Memory.Length;
-        }
     }
 
     private delegate void ReadAction(ref KafkaProtocolReader reader);

--- a/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolReaderTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using Dekaf.Protocol;
 
 namespace Dekaf.Tests.Unit.Protocol;
@@ -136,11 +137,32 @@ public class KafkaProtocolReaderTests
     }
 
     [Test]
+    public async Task ReadBytes_MultiSegmentClaimedLengthExceedsRemaining_ThrowsMalformedProtocolDataException()
+    {
+        var data = new byte[] { 0x00, 0x00, 0x00, 0x05, 0x01, 0x02 };
+        var sequence = CreateMultiSegmentSequence(data, splitAt: 2);
+
+        var exception = ReadThrowsMalformed(sequence, static (ref KafkaProtocolReader reader) => reader.ReadBytes());
+
+        await Assert.That(exception.Message).Contains("claimed length");
+    }
+
+    [Test]
     public async Task ReadRawBytes_ClaimedLengthExceedsRemaining_ThrowsMalformedProtocolDataException()
     {
         var data = Array.Empty<byte>();
 
         var exception = ReadThrowsMalformed(data, static (ref KafkaProtocolReader reader) => reader.ReadRawBytes(int.MaxValue));
+
+        await Assert.That(exception.Message).Contains("claimed length");
+    }
+
+    [Test]
+    public async Task ReadMemorySlice_MultiSegmentClaimedLengthExceedsRemaining_ThrowsMalformedProtocolDataException()
+    {
+        var sequence = CreateMultiSegmentSequence(new byte[] { 0x01, 0x02 }, splitAt: 1);
+
+        var exception = ReadThrowsMalformed(sequence, static (ref KafkaProtocolReader reader) => reader.ReadMemorySlice(3));
 
         await Assert.That(exception.Message).Contains("claimed length");
     }
@@ -153,6 +175,16 @@ public class KafkaProtocolReaderTests
         var exception = ReadThrowsMalformed(
             data,
             static (ref KafkaProtocolReader reader) => reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt8()));
+
+        await Assert.That(exception.Message).Contains("claimed length");
+    }
+
+    [Test]
+    public async Task ReadString_ClaimedLengthExceedsRemaining_ThrowsMalformedProtocolDataException()
+    {
+        var data = new byte[] { 0x00, 0x05, (byte)'a', (byte)'b' };
+
+        var exception = ReadThrowsMalformed(data, static (ref KafkaProtocolReader reader) => reader.ReadString());
 
         await Assert.That(exception.Message).Contains("claimed length");
     }
@@ -216,6 +248,49 @@ public class KafkaProtocolReaderTests
         }
 
         throw new InvalidOperationException("Expected MalformedProtocolDataException");
+    }
+
+    private static MalformedProtocolDataException ReadThrowsMalformed(
+        ReadOnlySequence<byte> data,
+        ReadAction read)
+    {
+        try
+        {
+            var reader = new KafkaProtocolReader(data);
+            read(ref reader);
+        }
+        catch (MalformedProtocolDataException exception)
+        {
+            return exception;
+        }
+
+        throw new InvalidOperationException("Expected MalformedProtocolDataException");
+    }
+
+    private static ReadOnlySequence<byte> CreateMultiSegmentSequence(byte[] data, int splitAt)
+    {
+        if (splitAt <= 0 || splitAt >= data.Length)
+            throw new ArgumentException("Split position must be within data bounds", nameof(splitAt));
+
+        var first = new TestSegment(data.AsMemory(0, splitAt));
+        var second = new TestSegment(data.AsMemory(splitAt));
+        first.SetNext(second);
+
+        return new ReadOnlySequence<byte>(first, 0, second, second.Memory.Length);
+    }
+
+    private sealed class TestSegment : ReadOnlySequenceSegment<byte>
+    {
+        public TestSegment(ReadOnlyMemory<byte> memory)
+        {
+            Memory = memory;
+        }
+
+        public void SetNext(TestSegment next)
+        {
+            Next = next;
+            next.RunningIndex = RunningIndex + Memory.Length;
+        }
     }
 
     private delegate void ReadAction(ref KafkaProtocolReader reader);

--- a/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolReaderTests.cs
@@ -126,6 +126,38 @@ public class KafkaProtocolReaderTests
     }
 
     [Test]
+    public async Task ReadBytes_ClaimedLengthExceedsRemaining_ThrowsMalformedProtocolDataException()
+    {
+        var data = new byte[] { 0x7F, 0xFF, 0xFF, 0xFF };
+
+        var exception = ReadThrowsMalformed(data, static (ref KafkaProtocolReader reader) => reader.ReadBytes());
+
+        await Assert.That(exception.Message).Contains("claimed length");
+    }
+
+    [Test]
+    public async Task ReadRawBytes_ClaimedLengthExceedsRemaining_ThrowsMalformedProtocolDataException()
+    {
+        var data = Array.Empty<byte>();
+
+        var exception = ReadThrowsMalformed(data, static (ref KafkaProtocolReader reader) => reader.ReadRawBytes(int.MaxValue));
+
+        await Assert.That(exception.Message).Contains("claimed length");
+    }
+
+    [Test]
+    public async Task ReadCompactArray_ClaimedLengthExceedsRemaining_ThrowsMalformedProtocolDataException()
+    {
+        var data = new byte[] { 0x04 };
+
+        var exception = ReadThrowsMalformed(
+            data,
+            static (ref KafkaProtocolReader reader) => reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt8()));
+
+        await Assert.That(exception.Message).Contains("claimed length");
+    }
+
+    [Test]
     public async Task ReadBoolean_ReadsTrue()
     {
         var data = new byte[] { 0x01 };
@@ -168,4 +200,23 @@ public class KafkaProtocolReaderTests
 
         await Assert.That(reader.Remaining).IsEqualTo(2);
     }
+
+    private static MalformedProtocolDataException ReadThrowsMalformed(
+        byte[] data,
+        ReadAction read)
+    {
+        try
+        {
+            var reader = new KafkaProtocolReader(data);
+            read(ref reader);
+        }
+        catch (MalformedProtocolDataException exception)
+        {
+            return exception;
+        }
+
+        throw new InvalidOperationException("Expected MalformedProtocolDataException");
+    }
+
+    private delegate void ReadAction(ref KafkaProtocolReader reader);
 }

--- a/tests/Dekaf.Tests.Unit/Protocol/PrimitiveEncodingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/PrimitiveEncodingTests.cs
@@ -264,39 +264,6 @@ public class PrimitiveEncodingTests
 
     #region Multi-Segment Sequence Tests (Slow Path)
 
-    /// <summary>
-    /// Creates a multi-segment ReadOnlySequence by splitting data at the specified position.
-    /// This forces the reader to use the slow path that handles data spanning multiple segments.
-    /// </summary>
-    private static ReadOnlySequence<byte> CreateMultiSegmentSequence(byte[] data, int splitAt)
-    {
-        if (splitAt <= 0 || splitAt >= data.Length)
-            throw new ArgumentException("Split position must be within data bounds", nameof(splitAt));
-
-        var segment1 = new TestSegment(data.AsMemory(0, splitAt));
-        var segment2 = new TestSegment(data.AsMemory(splitAt));
-        segment1.SetNext(segment2);
-
-        return new ReadOnlySequence<byte>(segment1, 0, segment2, segment2.Memory.Length);
-    }
-
-    /// <summary>
-    /// Helper class to create a linked list of memory segments for multi-segment sequences.
-    /// </summary>
-    private sealed class TestSegment : ReadOnlySequenceSegment<byte>
-    {
-        public TestSegment(ReadOnlyMemory<byte> memory)
-        {
-            Memory = memory;
-        }
-
-        public void SetNext(TestSegment next)
-        {
-            Next = next;
-            next.RunningIndex = RunningIndex + Memory.Length;
-        }
-    }
-
     [Test]
     public async Task Int16_MultiSegment_ReadsCorrectly()
     {
@@ -306,7 +273,7 @@ public class PrimitiveEncodingTests
         writer.WriteInt16(0x1234);
 
         // Split after first byte to force slow path
-        var sequence = CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 1);
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 1);
         var reader = new KafkaProtocolReader(sequence);
 
         await Assert.That(reader.ReadInt16()).IsEqualTo((short)0x1234);
@@ -321,7 +288,7 @@ public class PrimitiveEncodingTests
         writer.WriteInt32(0x12345678);
 
         // Split in the middle to force slow path
-        var sequence = CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 2);
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 2);
         var reader = new KafkaProtocolReader(sequence);
 
         await Assert.That(reader.ReadInt32()).IsEqualTo(0x12345678);
@@ -336,7 +303,7 @@ public class PrimitiveEncodingTests
         writer.WriteInt64(0x123456789ABCDEF0);
 
         // Split in the middle to force slow path
-        var sequence = CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 4);
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 4);
         var reader = new KafkaProtocolReader(sequence);
 
         await Assert.That(reader.ReadInt64()).IsEqualTo(0x123456789ABCDEF0);
@@ -349,7 +316,7 @@ public class PrimitiveEncodingTests
         var writer = new KafkaProtocolWriter(buffer);
         writer.WriteUInt16(0xABCD);
 
-        var sequence = CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 1);
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 1);
         var reader = new KafkaProtocolReader(sequence);
 
         await Assert.That(reader.ReadUInt16()).IsEqualTo((ushort)0xABCD);
@@ -362,7 +329,7 @@ public class PrimitiveEncodingTests
         var writer = new KafkaProtocolWriter(buffer);
         writer.WriteUInt32(0xDEADBEEF);
 
-        var sequence = CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 2);
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 2);
         var reader = new KafkaProtocolReader(sequence);
 
         await Assert.That(reader.ReadUInt32()).IsEqualTo(0xDEADBEEF);
@@ -375,7 +342,7 @@ public class PrimitiveEncodingTests
         var writer = new KafkaProtocolWriter(buffer);
         writer.WriteFloat64(Math.E);
 
-        var sequence = CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 3);
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 3);
         var reader = new KafkaProtocolReader(sequence);
 
         await Assert.That(reader.ReadFloat64()).IsEqualTo(Math.E);
@@ -390,7 +357,7 @@ public class PrimitiveEncodingTests
         writer.WriteUuid(uuid);
 
         // Split in the middle of the 16-byte UUID
-        var sequence = CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 8);
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 8);
         var reader = new KafkaProtocolReader(sequence);
 
         await Assert.That(reader.ReadUuid()).IsEqualTo(uuid);
@@ -407,7 +374,7 @@ public class PrimitiveEncodingTests
         writer.WriteInt64(0x0102030405060708);
 
         // Split at position 3 (middle of the Int32)
-        var sequence = CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 3);
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), 3);
         var reader = new KafkaProtocolReader(sequence);
 
         // Read all values first (ref struct cannot be preserved across await)

--- a/tests/Dekaf.Tests.Unit/Protocol/SequenceTestHelpers.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/SequenceTestHelpers.cs
@@ -1,0 +1,32 @@
+using System.Buffers;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+internal static class SequenceTestHelpers
+{
+    public static ReadOnlySequence<byte> CreateMultiSegmentSequence(byte[] data, int splitAt)
+    {
+        if (splitAt <= 0 || splitAt >= data.Length)
+            throw new ArgumentException("Split position must be within data bounds", nameof(splitAt));
+
+        var first = new TestSegment(data.AsMemory(0, splitAt));
+        var second = new TestSegment(data.AsMemory(splitAt));
+        first.SetNext(second);
+
+        return new ReadOnlySequence<byte>(first, 0, second, second.Memory.Length);
+    }
+
+    private sealed class TestSegment : ReadOnlySequenceSegment<byte>
+    {
+        public TestSegment(ReadOnlyMemory<byte> memory)
+        {
+            Memory = memory;
+        }
+
+        public void SetNext(TestSegment next)
+        {
+            Next = next;
+            next.RunningIndex = RunningIndex + Memory.Length;
+        }
+    }
+}


### PR DESCRIPTION
Summary:
- validate claimed byte/string/array lengths before allocating buffers/arrays
- throw `MalformedProtocolDataException` for claimed lengths beyond remaining frame data
- add regression tests for bytes, raw bytes, and compact arrays

Test plan:
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-incremental -v:minimal`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaProtocolReaderTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ArrayEncodingTests/*"`
- [x] `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --no-incremental -v:minimal`
- [x] `git diff --check`

Closes #1342