### PR TITLE
fix(producer): drain refunds outside lock

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2158,6 +2158,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 var appendSucceeded = false;
                 var disposed = false;
                 var messageTooLarge = false;
+                var memoryToReleaseAfterLock = 0;
 
                 {
                     using var guard = new SpinLockGuard(ref pd.Lock);
@@ -2191,8 +2192,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         if (pd.CurrentBatch is { } currentBatch)
                         {
                             if (TryAppendToBatch(currentBatch, timestamp, key, value, headers, headerCount,
-                                completionSource, callback, recordSize))
+                                completionSource, callback, recordSize, out var overestimatedBytesToRelease))
                             {
+                                memoryToReleaseAfterLock = overestimatedBytesToRelease;
                                 ownsReservation = false;
                                 ownsRecordResources = false;
                                 ownsPendingCount = false;
@@ -2222,8 +2224,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
 
                             if (TryAppendToBatch(newBatch, timestamp, key, value, headers, headerCount,
-                                completionSource, callback, recordSize))
+                                completionSource, callback, recordSize, out var overestimatedBytesToRelease))
                             {
+                                memoryToReleaseAfterLock = overestimatedBytesToRelease;
                                 ownsReservation = false;
                                 ownsRecordResources = false;
                                 ownsPendingCount = false;
@@ -2258,6 +2261,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     if (batchToFail.TrySetMemoryReleased())
                         ReleaseMemory(batchToFail.DataSize);
                 }
+
+                if (memoryToReleaseAfterLock > 0)
+                    ReleaseMemory(memoryToReleaseAfterLock);
 
                 if (disposed)
                 {
@@ -2497,6 +2503,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 var appendSucceeded = false;
                 var disposed = false;
                 var messageTooLarge = false;
+                var memoryToReleaseAfterLock = 0;
 
                 {
                     using var guard = new SpinLockGuard(ref pd.Lock);
@@ -2530,8 +2537,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         if (pd.CurrentBatch is { } currentBatch)
                         {
                             if (TryAppendFromSpansToBatch(currentBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                                headers, headerCount, completionSource, callback, recordSize))
+                                headers, headerCount, completionSource, callback, recordSize, out var overestimatedBytesToRelease))
                             {
+                                memoryToReleaseAfterLock = overestimatedBytesToRelease;
                                 ownsReservation = false;
                                 ownsHeaderResources = false;
                                 ownsPendingCount = false;
@@ -2561,8 +2569,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
 
                             if (TryAppendFromSpansToBatch(newBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                                headers, headerCount, completionSource, callback, recordSize))
+                                headers, headerCount, completionSource, callback, recordSize, out var overestimatedBytesToRelease))
                             {
+                                memoryToReleaseAfterLock = overestimatedBytesToRelease;
                                 ownsReservation = false;
                                 ownsHeaderResources = false;
                                 ownsPendingCount = false;
@@ -2597,6 +2606,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     if (batchToFail.TrySetMemoryReleased())
                         ReleaseMemory(batchToFail.DataSize);
                 }
+
+                if (memoryToReleaseAfterLock > 0)
+                    ReleaseMemory(memoryToReleaseAfterLock);
 
                 if (disposed)
                 {
@@ -2648,7 +2660,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// Helper: tries to append a record to the given batch.
     /// Called under the deque lock.
     /// </summary>
-    private bool TryAppendToBatch(
+    private static bool TryAppendToBatch(
         PartitionBatch batch,
         long timestamp,
         PooledMemory key,
@@ -2657,16 +2669,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int headerCount,
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
-        int estimatedSize)
+        int estimatedSize,
+        out int overestimatedBytesToRelease)
     {
+        overestimatedBytesToRelease = 0;
         var result = batch.TryAppend(timestamp, key, value, headers, headerCount, completionSource, callback);
 
         if (result.Success)
         {
             ProducerDebugCounters.RecordMessageAppended(hasCompletionSource: completionSource is not null);
-            var overestimate = estimatedSize - result.ActualSizeAdded;
-            if (overestimate > 0)
-                ReleaseMemory(overestimate);
+            overestimatedBytesToRelease = Math.Max(0, estimatedSize - result.ActualSizeAdded);
             return true;
         }
 
@@ -2781,7 +2793,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// Helper: tries to append a record from span data to the given batch using arena zero-copy.
     /// Called under the deque lock.
     /// </summary>
-    private bool TryAppendFromSpansToBatch(
+    private static bool TryAppendFromSpansToBatch(
         PartitionBatch batch,
         long timestamp,
         ReadOnlySpan<byte> keyData,
@@ -2792,17 +2804,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int headerCount,
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
-        int estimatedSize)
+        int estimatedSize,
+        out int overestimatedBytesToRelease)
     {
+        overestimatedBytesToRelease = 0;
         var result = batch.TryAppendFromSpans(timestamp, keyData, keyIsNull, valueData, valueIsNull,
             headers, headerCount, completionSource, callback);
 
         if (result.Success)
         {
             ProducerDebugCounters.RecordMessageAppended(hasCompletionSource: completionSource is not null);
-            var overestimate = estimatedSize - result.ActualSizeAdded;
-            if (overestimate > 0)
-                ReleaseMemory(overestimate);
+            overestimatedBytesToRelease = Math.Max(0, estimatedSize - result.ActualSizeAdded);
             return true;
         }
 

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -2545,6 +2545,73 @@ public class RecordAccumulatorTests
         }
     }
 
+    [Test]
+    public async Task AppendFromSpansAsync_HotPathRefund_DrainsPendingAppendAfterPartitionLockReleased()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            BufferMemory = 4096,
+            BatchSize = 4096,
+            LingerMs = 10,
+            MaxBlockMs = 30000
+        };
+        var accumulator = new RecordAccumulator(options);
+        var topicPartition = new TopicPartition("test-topic", 0);
+
+        try
+        {
+            var seedResult = await accumulator.AppendFromSpansAsync(
+                topicPartition.Topic, topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                ReadOnlySpan<byte>.Empty, valueIsNull: true,
+                null, 0, null, CancellationToken.None);
+
+            await Assert.That(seedResult).IsTrue();
+
+            EnableThreadOwnerTrackingForPartitionLock(accumulator, topicPartition);
+
+            var fillSize = checked((int)options.BufferMemory - (int)accumulator.BufferedBytes);
+            await Assert.That(accumulator.TryReserveMemoryForTest(fillSize)).IsTrue();
+
+            var pendingValue = new byte[128];
+            var pendingAppendTask = accumulator.AppendFromSpansAsync(
+                topicPartition.Topic, topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                pendingValue, valueIsNull: false,
+                null, 0, null, CancellationToken.None).AsTask();
+
+            while (accumulator.BufferPressureEvents == 0 && !pendingAppendTask.IsCompleted)
+                await Task.Yield();
+
+            await Assert.That(pendingAppendTask.IsCompleted).IsFalse();
+
+            // Free memory without draining. The next hot-path overestimate refund should
+            // drain the pending append, but only after the partition SpinLock is released.
+            SetBufferedBytesForTest(accumulator, 3000);
+
+            var hotResult = await accumulator.AppendFromSpansAsync(
+                topicPartition.Topic, topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                ReadOnlySpan<byte>.Empty, valueIsNull: true,
+                null, 0, null, CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(hotResult).IsTrue();
+
+            var pendingResult = await pendingAppendTask.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(pendingResult).IsTrue();
+        }
+        finally
+        {
+            var currentBatch = GetCurrentPartitionBatch(accumulator, topicPartition);
+            SetBufferedBytesForTest(accumulator, currentBatch.EstimatedSize);
+            await accumulator.DisposeAsync();
+        }
+    }
+
     #endregion
 
     private static ReadyBatch CompleteCurrentBatch(RecordAccumulator accumulator, TopicPartition topicPartition)
@@ -2577,6 +2644,22 @@ public class RecordAccumulatorTests
             throw new InvalidOperationException("Partition deque was not found.");
 
         return parameters[1]!;
+    }
+
+    private static void EnableThreadOwnerTrackingForPartitionLock(
+        RecordAccumulator accumulator,
+        TopicPartition topicPartition)
+    {
+        var partitionDeque = GetPartitionDeque(accumulator, topicPartition);
+        var lockField = partitionDeque.GetType().GetField("Lock");
+        lockField!.SetValue(partitionDeque, new SpinLock(enableThreadOwnerTracking: true));
+    }
+
+    private static void SetBufferedBytesForTest(RecordAccumulator accumulator, long value)
+    {
+        var bufferedBytesField = typeof(RecordAccumulator).GetField("_bufferedBytes",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        bufferedBytesField!.SetValue(accumulator, value);
     }
 
     private static T GetPrivateField<T>(object instance, string fieldName)

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -2583,8 +2583,9 @@ public class RecordAccumulatorTests
                 pendingValue, valueIsNull: false,
                 null, 0, null, CancellationToken.None).AsTask();
 
-            while (accumulator.BufferPressureEvents == 0 && !pendingAppendTask.IsCompleted)
-                await Task.Yield();
+            await TestWait.UntilAsync(
+                () => accumulator.BufferPressureEvents > 0 || pendingAppendTask.IsCompleted,
+                TimeSpan.FromSeconds(5));
 
             await Assert.That(pendingAppendTask.IsCompleted).IsFalse();
 


### PR DESCRIPTION
## Summary
- release append overestimate refunds after the partition SpinLock scope exits
- keep pending append drain behavior but prevent same-partition reentry during ReleaseMemory
- add regression coverage with owner-tracked SpinLock to catch reentrant drain attempts

## Validation
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -v:minimal
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --minimum-expected-tests 1 --timeout 5m --no-progress
- dotnet format tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --verify-no-changes -v minimal --include src\Dekaf\Producer\RecordAccumulator.cs tests\Dekaf.Tests.Unit\Producer\RecordAccumulatorTests.cs
- git diff --check
- dotnet build src\Dekaf\Dekaf.csproj --configuration Release -v:minimal
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --minimum-expected-tests 1 --treenode-filter "/*/*/RecordAccumulatorTests/AppendFromSpansAsync_HotPathRefund_DrainsPendingAppendAfterPartitionLockReleased" --timeout 1m --no-progress

Closes #1337