### PR TITLE
fix(producer): cap coalesced batches

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -797,13 +797,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 {
                     CoalesceBatch(drainList[i], coalescedBatches, ref coalescedCount,
                         coalescedPartitions, carryOver);
-
-                    if (coalescedCount >= maxCoalesce)
-                    {
-                        for (var j = i + 1; j < drainList.Count; j++)
-                            carryOver.Add(drainList[j]);
-                        break;
-                    }
                 }
 
                 // Read from the event channel lazily during coalescing (like main reads

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -794,8 +794,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     carryOver.DrainTo(drainList);
 
                 for (var i = 0; i < drainList.Count; i++)
+                {
                     CoalesceBatch(drainList[i], coalescedBatches, ref coalescedCount,
                         coalescedPartitions, carryOver);
+
+                    if (coalescedCount >= maxCoalesce)
+                    {
+                        for (var j = i + 1; j < drainList.Count; j++)
+                            carryOver.Add(drainList[j]);
+                        break;
+                    }
+                }
 
                 // Read from the event channel lazily during coalescing (like main reads
                 // from its bounded batch channel). Non-batch events are consumed as signals.
@@ -808,7 +817,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     var carryOverBudget = maxCoalesce - carryOver.Count;
                     var channelReads = 0;
                     var channelCarryOvers = 0;
-                    while (channelReads < maxCoalesce && eventReader.TryRead(out var evt))
+                    while (coalescedCount < maxCoalesce
+                        && channelReads < maxCoalesce
+                        && eventReader.TryRead(out var evt))
                     {
                         if (evt.Type == SendLoopEventType.NewBatch)
                         {
@@ -843,12 +854,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // the spin pure waste. This is especially important for single-partition topics
                 // where coalescedCount is always 1 and every MicroLinger iteration is wasted.
                 if (coalescedCount > 0 && coalescedCount <= MicroLingerBatchThreshold
+                    && coalescedCount < maxCoalesce
                     && coalescedPartitions.Count < _knownPartitions.Count
                     && carryOver.Count == 0
                     && Volatile.Read(ref _totalPendingResponseCount) < _totalMaxInFlight)
                 {
                     var spinWait = new SpinWait();
-                    for (var spin = 0; spin < MicroLingerMaxSpins; spin++)
+                    for (var spin = 0; spin < MicroLingerMaxSpins && coalescedCount < maxCoalesce; spin++)
                     {
                         if (!eventReader.TryRead(out var evt))
                         {
@@ -1296,6 +1308,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // carry-over — they must retain their retry state and mute status.
             batch.RetryNotBefore = 0;
 
+            if (CarryOverIfCoalescedFull(batch, coalescedBatches, coalescedCount, carryOver))
+                return;
+
             if (!coalescedPartitions.Add(batch.TopicPartition))
             {
                 // Same partition already in this request (shouldn't happen — only one
@@ -1304,9 +1319,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 return;
             }
 
-            batch.AppendDiag('C');
-            coalescedBatches[coalescedCount] = batch;
-            coalescedCount++;
+            AddCoalescedBatch(batch, coalescedBatches, ref coalescedCount);
             return;
         }
 
@@ -1319,6 +1332,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return;
         }
 
+        if (CarryOverIfCoalescedFull(batch, coalescedBatches, coalescedCount, carryOver))
+            return;
+
         // Ensure at most one batch per partition per coalesced request
         if (!coalescedPartitions.Add(batch.TopicPartition))
         {
@@ -1327,6 +1343,30 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return;
         }
 
+        AddCoalescedBatch(batch, coalescedBatches, ref coalescedCount);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool CarryOverIfCoalescedFull(
+        ReadyBatch batch,
+        ReadyBatch[] coalescedBatches,
+        int coalescedCount,
+        PartitionCarryOver carryOver)
+    {
+        if (coalescedCount < coalescedBatches.Length)
+            return false;
+
+        batch.AppendDiag('O');
+        carryOver.Add(batch);
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AddCoalescedBatch(
+        ReadyBatch batch,
+        ReadyBatch[] coalescedBatches,
+        ref int coalescedCount)
+    {
         batch.AppendDiag('C');
         coalescedBatches[coalescedCount] = batch;
         coalescedCount++;

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Reflection;
 using Dekaf.Compression;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -21,6 +22,14 @@ namespace Dekaf.Tests.Unit.Producer;
 /// </summary>
 public sealed class BrokerSenderMuteOrderingTests
 {
+    private static readonly MethodInfo CoalesceBatchMethod = typeof(BrokerSender).GetMethod(
+        "CoalesceBatch",
+        BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static readonly Type PartitionCarryOverType = typeof(BrokerSender).GetNestedType(
+        "PartitionCarryOver",
+        BindingFlags.NonPublic)!;
+
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 0, int retryBackoffMaxMs = 0,
         int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000) => new()
@@ -205,6 +214,120 @@ public sealed class BrokerSenderMuteOrderingTests
             rerouteBatch: rerouteBatch,
             onAcknowledgement: onAcknowledgement,
             logger: null);
+
+    private static object CreateCarryOver()
+    {
+        return Activator.CreateInstance(PartitionCarryOverType)!;
+    }
+
+    private static int GetCarryOverCount(object carryOver)
+    {
+        return (int)PartitionCarryOverType.GetProperty("Count")!.GetValue(carryOver)!;
+    }
+
+    private static void InvokeCoalesceBatch(
+        BrokerSender sender,
+        ReadyBatch batch,
+        ReadyBatch[] coalescedBatches,
+        ref int coalescedCount,
+        HashSet<TopicPartition> coalescedPartitions,
+        object carryOver)
+    {
+        var args = new object?[]
+        {
+            batch,
+            coalescedBatches,
+            coalescedCount,
+            coalescedPartitions,
+            carryOver
+        };
+
+        CoalesceBatchMethod.Invoke(sender, args);
+        coalescedCount = (int)args[2]!;
+    }
+
+    [Test]
+    public async Task CoalesceBatch_WhenFull_CarriesOverNormalBatch()
+    {
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
+        var (pool, _) = CreateMockConnection(responseQueue);
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            var firstBatch = CreateTestBatch(vtPool, "test-topic", 0);
+            var overflowBatch = CreateTestBatch(vtPool, "test-topic", 1);
+            var coalescedBatches = new[] { firstBatch };
+            var coalescedCount = 1;
+            var coalescedPartitions = new HashSet<TopicPartition> { firstBatch.TopicPartition };
+            var carryOver = CreateCarryOver();
+
+            InvokeCoalesceBatch(
+                sender,
+                overflowBatch,
+                coalescedBatches,
+                ref coalescedCount,
+                coalescedPartitions,
+                carryOver);
+
+            await Assert.That(coalescedCount).IsEqualTo(1);
+            await Assert.That(coalescedBatches[0]).IsSameReferenceAs(firstBatch);
+            await Assert.That(GetCarryOverCount(carryOver)).IsEqualTo(1);
+            await Assert.That(coalescedPartitions.Contains(overflowBatch.TopicPartition)).IsFalse();
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task CoalesceBatch_WhenFull_CarriesOverRetryBatchWithoutClearingRetryState()
+    {
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
+        var (pool, _) = CreateMockConnection(responseQueue);
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            var firstBatch = CreateTestBatch(vtPool, "test-topic", 0);
+            var overflowBatch = CreateTestBatch(vtPool, "test-topic", 1);
+            overflowBatch.IsRetry = true;
+
+            var coalescedBatches = new[] { firstBatch };
+            var coalescedCount = 1;
+            var coalescedPartitions = new HashSet<TopicPartition> { firstBatch.TopicPartition };
+            var carryOver = CreateCarryOver();
+
+            InvokeCoalesceBatch(
+                sender,
+                overflowBatch,
+                coalescedBatches,
+                ref coalescedCount,
+                coalescedPartitions,
+                carryOver);
+
+            await Assert.That(coalescedCount).IsEqualTo(1);
+            await Assert.That(coalescedBatches[0]).IsSameReferenceAs(firstBatch);
+            await Assert.That(GetCarryOverCount(carryOver)).IsEqualTo(1);
+            await Assert.That(overflowBatch.IsRetry).IsTrue();
+            await Assert.That(coalescedPartitions.Contains(overflowBatch.TopicPartition)).IsFalse();
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
 
     [Test]
     [Timeout(60_000)]


### PR DESCRIPTION
## Summary
- Carry overflow coalesce candidates into the per-partition carry-over queue before the request array can overflow
- Stop draining new channel events and micro-linger reads once the coalesced request is full
- Add regression coverage for full-array normal and retry coalescing paths

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit --configuration Release
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter '/*/*/BrokerSenderMuteOrderingTests/*'
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter '/*/*/BrokerSender*/*'
- [x] dotnet build src/Dekaf/Dekaf.csproj --configuration Release
- [ ] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit (failed in unrelated networking DNS test KafkaConnection_ConnectAsync_TriesAllResolvedAddresses with local cancellation after ~6s)

Closes #1338
