### PR TITLE
fix(networking): keep idle connections alive

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1061,15 +1061,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
                     var readHasRequestTimeout = HasPendingRequests();
                     try
                     {
-                        if (!timeoutCts.TryReset())
-                        {
-                            reg.Dispose();
-                            timeoutCts.Dispose();
-                            timeoutCts = _timeoutCtsPool.Rent();
-                            reg = cancellationToken.CanBeCanceled
-                                ? cancellationToken.Register(static s => ((CancellationTokenSource)s!).Cancel(), timeoutCts)
-                                : default;
-                        }
+                        timeoutCts.TryReset();
 
                         // Only arm RequestTimeout while a response is outstanding. Idle
                         // connections are governed by ConnectionsMaxIdleMs instead.

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -176,6 +176,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int _pendingRequestSlotOperationCount;
     private int _pendingRequestSlotsClosed;
+    private int _pendingRequestCount;
     private readonly CancelledCorrelationIdTracker _cancelledCorrelationIds = new(MaxCancelledCorrelationIds);
     private readonly PendingRequestPool _pendingRequestPool;
     private readonly CancellationTokenSourcePool _timeoutCtsPool;
@@ -1047,142 +1048,160 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         try
         {
-            // Rent a single pooled CTS for the entire loop lifetime and register the
-            // connection's cancellation token once. Each iteration reuses the same CTS
-            // via TryReset + CancelAfter, eliminating the per-iteration
-            // CancellationTokenRegistration allocation (see #507).
-            using var timeoutCts = _timeoutCtsPool.Rent();
-            using var reg = cancellationToken.CanBeCanceled
+            var timeoutCts = _timeoutCtsPool.Rent();
+            var reg = cancellationToken.CanBeCanceled
                 ? cancellationToken.Register(static s => ((CancellationTokenSource)s!).Cancel(), timeoutCts)
                 : default;
 
-            while (!cancellationToken.IsCancellationRequested)
+            try
             {
-                ReadResult result;
-                try
+                while (!cancellationToken.IsCancellationRequested)
                 {
-                    // Apply RequestTimeout to each read operation.
-                    // TryReset clears any pending CancelAfter timer from the previous iteration.
-                    // It returns false if the outer cancellationToken fired (via the registration),
-                    // in which case ReadAsync will throw immediately and the while-condition
-                    // will exit before the next iteration.
-                    if (timeoutCts.TryReset())
-                        timeoutCts.CancelAfter(_options.RequestTimeout);
+                    ReadResult result;
+                    var readHasRequestTimeout = HasPendingRequests();
+                    try
+                    {
+                        if (!timeoutCts.TryReset())
+                        {
+                            reg.Dispose();
+                            timeoutCts.Dispose();
+                            timeoutCts = _timeoutCtsPool.Rent();
+                            reg = cancellationToken.CanBeCanceled
+                                ? cancellationToken.Register(static s => ((CancellationTokenSource)s!).Cancel(), timeoutCts)
+                                : default;
+                        }
 
-                    // ReadResult state machine (System.IO.Pipelines):
-                    //
-                    // ReadAsync can complete in three ways:
-                    //
-                    // 1. IsCompleted=false, IsCanceled=false (normal data available):
-                    //    Data is available in result.Buffer. Process all complete responses,
-                    //    then call AdvanceTo to indicate consumed/examined positions.
-                    //
-                    // 2. IsCompleted=true:
-                    //    The PipeWriter was completed (end of stream). For PipeReader.Create(stream),
-                    //    this means the underlying stream reached EOF — the remote peer closed the
-                    //    connection. Any remaining data in the buffer is still valid and must be
-                    //    processed before exiting. We process responses first, then break out of
-                    //    the receive loop.
-                    //
-                    // 3. IsCanceled=true:
-                    //    The read was canceled. With Pipe.Reader (used via SocketPipe/DuplexPipe since
-                    //    PR #458), CancellationToken-based cancellation returns IsCanceled=true instead
-                    //    of throwing OperationCanceledException. Both paths must be handled.
-                    result = await _reader!.ReadAsync(timeoutCts.Token).ConfigureAwait(false);
+                        // Only arm RequestTimeout while a response is outstanding. Idle
+                        // connections are governed by ConnectionsMaxIdleMs instead.
+                        if (readHasRequestTimeout)
+                            timeoutCts.CancelAfter(_options.RequestTimeout);
+
+                        // ReadResult state machine (System.IO.Pipelines):
+                        //
+                        // ReadAsync can complete in three ways:
+                        //
+                        // 1. IsCompleted=false, IsCanceled=false (normal data available):
+                        //    Data is available in result.Buffer. Process all complete responses,
+                        //    then call AdvanceTo to indicate consumed/examined positions.
+                        //
+                        // 2. IsCompleted=true:
+                        //    The PipeWriter was completed (end of stream). For PipeReader.Create(stream),
+                        //    this means the underlying stream reached EOF — the remote peer closed the
+                        //    connection. Any remaining data in the buffer is still valid and must be
+                        //    processed before exiting. We process responses first, then break out of
+                        //    the receive loop.
+                        //
+                        // 3. IsCanceled=true:
+                        //    The read was canceled. With Pipe.Reader (used via SocketPipe/DuplexPipe since
+                        //    PR #458), CancellationToken-based cancellation returns IsCanceled=true instead
+                        //    of throwing OperationCanceledException. Both paths must be handled.
+                        result = await _reader!.ReadAsync(readHasRequestTimeout ? timeoutCts.Token : cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (readHasRequestTimeout && timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                    {
+                        if (!HasPendingRequests())
+                            continue;
+
+                        throw CreateReceiveTimeoutException();
+                    }
+
+                    // Pipe.Reader.ReadAsync returns IsCanceled=true on token cancellation instead of
+                    // throwing OperationCanceledException (unlike PipeReader.Create(Stream)). Without
+                    // this check, timeouts are silently swallowed: the connection stays in the pool
+                    // appearing healthy, and all subsequent requests on it also time out (#670).
+                    if (result.IsCanceled)
+                    {
+                        if (readHasRequestTimeout && timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                        {
+                            if (!HasPendingRequests())
+                            {
+                                _reader!.AdvanceTo(result.Buffer.Start, result.Buffer.Start);
+                                continue;
+                            }
+
+                            throw CreateReceiveTimeoutException();
+                        }
+
+                        if (!cancellationToken.IsCancellationRequested)
+                        {
+                            _reader!.AdvanceTo(result.Buffer.Start, result.Buffer.Start);
+                            continue;
+                        }
+
+                        // Outer cancellation (disposal) — exit cleanly
+                        break;
+                    }
+
+                    var buffer = result.Buffer;
+
+                    LogReceivedBytes(buffer.Length, _host, _port);
+
+                    // Phase 1: Continue assembling a partial frame if one is in progress.
+                    // The partial frame consumes data from the pipe buffer as it copies,
+                    // keeping the buffer below the pause threshold for large responses.
+                    if (_partialFrame.IsActive)
+                    {
+                        if (ContinuePartialFrame(ref buffer, ref _partialFrame))
+                        {
+                            // Frame complete — dispatch it
+                            var responseData = new PooledResponseBuffer(
+                                _partialFrame.Buffer!, _partialFrame.FrameSize,
+                                _partialFrame.IsPooled, pool: _responseBufferPool);
+                            DispatchResponse(_partialFrame.CorrelationId, responseData);
+                            _partialFrame = default;
+                        }
+                    }
+
+                    // Phase 2: Process any complete responses available in the buffer.
+                    // This is the fast path for small responses (e.g., producer acks)
+                    // that fit entirely within the pipe buffer.
+                    if (!_partialFrame.IsActive)
+                    {
+                        while (TryReadResponse(ref buffer, out var correlationId, out var responseData))
+                        {
+                            DispatchResponse(correlationId, responseData);
+                        }
+
+                        // Phase 3: Start incremental assembly for frames that don't fit
+                        // in the current buffer, keeping the pipe below the pause threshold.
+                        if (buffer.Length >= 8)
+                        {
+                            TryStartPartialFrame(ref buffer, ref _partialFrame, _responseBufferPool);
+                        }
+                    }
+
+                    _reader!.AdvanceTo(buffer.Start, buffer.End);
+
+                    // After processing all available responses, check if the stream has ended.
+                    // IsCompleted=true means the remote peer closed the connection (EOF).
+                    // The remote peer closed the connection. Fail any pending requests
+                    // immediately so callers don't hang waiting for responses that will
+                    // never arrive. Without this, pending requests rely on their individual
+                    // RequestTimeout (30s default), which delays error detection and can
+                    // cause indefinite hangs when combined with BrokerSender retry cycles.
+                    if (result.IsCompleted)
+                    {
+                        LogReceiveLoopCompleted(_host, _port);
+                        MarkDisposed(); // Prevent new requests from being queued on a dead connection
+                        FailAllPendingRequests(new KafkaException(
+                            "Connection closed by remote peer (EOF)"));
+                        break;
+                    }
                 }
-                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-                {
-                    LogReceiveTimeout(_options.RequestTimeout.TotalMilliseconds, BrokerId);
 
-                    // Mark connection as failed to trigger reconnection
+                // While loop exited normally (no exception thrown, so no catch block runs).
+                // Two cases: cancellation between iterations, or EOF break (already handled above).
+                if (cancellationToken.IsCancellationRequested)
+                {
                     MarkDisposed();
-
-                    throw new KafkaException(
-                        $"Receive timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms - connection to broker {BrokerId} failed");
-                }
-
-                // Pipe.Reader.ReadAsync returns IsCanceled=true on token cancellation instead of
-                // throwing OperationCanceledException (unlike PipeReader.Create(Stream)). Without
-                // this check, timeouts are silently swallowed: the connection stays in the pool
-                // appearing healthy, and all subsequent requests on it also time out (#670).
-                if (result.IsCanceled)
-                {
-                    if (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-                    {
-                        LogReceiveTimeout(_options.RequestTimeout.TotalMilliseconds, BrokerId);
-                        MarkDisposed();
-
-                        throw new KafkaException(
-                            $"Receive timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms - connection to broker {BrokerId} failed");
-                    }
-
-                    // Outer cancellation (disposal) — exit cleanly
-                    break;
-                }
-
-                var buffer = result.Buffer;
-
-                LogReceivedBytes(buffer.Length, _host, _port);
-
-                // Phase 1: Continue assembling a partial frame if one is in progress.
-                // The partial frame consumes data from the pipe buffer as it copies,
-                // keeping the buffer below the pause threshold for large responses.
-                if (_partialFrame.IsActive)
-                {
-                    if (ContinuePartialFrame(ref buffer, ref _partialFrame))
-                    {
-                        // Frame complete — dispatch it
-                        var responseData = new PooledResponseBuffer(
-                            _partialFrame.Buffer!, _partialFrame.FrameSize,
-                            _partialFrame.IsPooled, pool: _responseBufferPool);
-                        DispatchResponse(_partialFrame.CorrelationId, responseData);
-                        _partialFrame = default;
-                    }
-                }
-
-                // Phase 2: Process any complete responses available in the buffer.
-                // This is the fast path for small responses (e.g., producer acks)
-                // that fit entirely within the pipe buffer.
-                if (!_partialFrame.IsActive)
-                {
-                    while (TryReadResponse(ref buffer, out var correlationId, out var responseData))
-                    {
-                        DispatchResponse(correlationId, responseData);
-                    }
-
-                    // Phase 3: Start incremental assembly for frames that don't fit
-                    // in the current buffer, keeping the pipe below the pause threshold.
-                    if (buffer.Length >= 8)
-                    {
-                        TryStartPartialFrame(ref buffer, ref _partialFrame, _responseBufferPool);
-                    }
-                }
-
-                _reader!.AdvanceTo(buffer.Start, buffer.End);
-
-                // After processing all available responses, check if the stream has ended.
-                // IsCompleted=true means the remote peer closed the connection (EOF).
-                // The remote peer closed the connection. Fail any pending requests
-                // immediately so callers don't hang waiting for responses that will
-                // never arrive. Without this, pending requests rely on their individual
-                // RequestTimeout (30s default), which delays error detection and can
-                // cause indefinite hangs when combined with BrokerSender retry cycles.
-                if (result.IsCompleted)
-                {
-                    LogReceiveLoopCompleted(_host, _port);
-                    MarkDisposed(); // Prevent new requests from being queued on a dead connection
-                    FailAllPendingRequests(new KafkaException(
-                        "Connection closed by remote peer (EOF)"));
-                    break;
+                    FailAllPendingRequests(new OperationCanceledException("Connection closing", cancellationToken));
                 }
             }
-
-            // While loop exited normally (no exception thrown, so no catch block runs).
-            // Two cases: cancellation between iterations, or EOF break (already handled above).
-            if (cancellationToken.IsCancellationRequested)
+            finally
             {
-                MarkDisposed();
-                FailAllPendingRequests(new OperationCanceledException("Connection closing", cancellationToken));
+                reg.Dispose();
+                timeoutCts.Dispose();
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -1197,6 +1216,15 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             MarkDisposed(); // Prevent new requests from being queued on a dead connection
             FailAllPendingRequests(ex);
         }
+    }
+
+    private KafkaException CreateReceiveTimeoutException()
+    {
+        LogReceiveTimeout(_options.RequestTimeout.TotalMilliseconds, BrokerId);
+        MarkDisposed();
+
+        return new KafkaException(
+            $"Receive timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms - connection to broker {BrokerId} failed");
     }
 
     private void DispatchResponse(int correlationId, PooledResponseBuffer responseData)
@@ -1387,6 +1415,9 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             if (!shard.Requests.TryAdd(correlationId, new PendingRequestEntry(request, request.Version)))
                 throw new InvalidOperationException($"Duplicate pending request correlation id {correlationId}.");
         }
+
+        if (Interlocked.Increment(ref _pendingRequestCount) == 1)
+            _reader?.CancelPendingRead();
     }
 
     private bool TryGetPendingRequest(int correlationId, out PendingRequestEntry entry)
@@ -1408,24 +1439,22 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         }
 
         if (removed)
+        {
+            var remaining = Interlocked.Decrement(ref _pendingRequestCount);
+            Debug.Assert(remaining >= 0);
+
+            if (remaining == 0)
+                _reader?.CancelPendingRead();
+
             ReleasePendingRequestSlot();
+        }
 
         return removed;
     }
 
-    private int GetPendingRequestCount()
-    {
-        var count = 0;
-        foreach (var shard in _pendingRequestShards)
-        {
-            lock (shard.Gate)
-            {
-                count += shard.Requests.Count;
-            }
-        }
+    private int GetPendingRequestCount() => Volatile.Read(ref _pendingRequestCount);
 
-        return count;
-    }
+    private bool HasPendingRequests() => Volatile.Read(ref _pendingRequestCount) != 0;
 
     private void Touch() => Volatile.Write(ref _lastUsedTimestampMs, Dekaf.Compatibility.EnvironmentCompat.TickCount64);
 
@@ -1597,6 +1626,12 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
                 shard.Requests.Clear();
             }
+        }
+
+        if (releasedSlots != 0)
+        {
+            var remaining = Interlocked.Add(ref _pendingRequestCount, -releasedSlots);
+            Debug.Assert(remaining >= 0);
         }
 
         ReleasePendingRequestSlots(releasedSlots);

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -213,12 +213,12 @@ public sealed class KafkaConnectionTests
             await using var connection = new KafkaConnection(
                 IPAddress.Loopback.ToString(),
                 port,
-                options: new ConnectionOptions { RequestTimeout = TimeSpan.FromMilliseconds(100) });
+                options: new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(1) });
 
             await connection.ConnectAsync(cancellationToken);
             using var serverClient = await acceptTask.ConfigureAwait(false);
 
-            await Task.Delay(TimeSpan.FromMilliseconds(300), cancellationToken);
+            await Task.Delay(TimeSpan.FromMilliseconds(1500), cancellationToken);
 
             await Assert.That(connection.IsConnected).IsTrue();
         }
@@ -242,7 +242,7 @@ public sealed class KafkaConnectionTests
             await using var connection = new KafkaConnection(
                 IPAddress.Loopback.ToString(),
                 port,
-                options: new ConnectionOptions { RequestTimeout = TimeSpan.FromMilliseconds(100) });
+                options: new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(1) });
 
             await connection.ConnectAsync(cancellationToken);
             using var serverClient = await acceptTask.ConfigureAwait(false);
@@ -262,7 +262,7 @@ public sealed class KafkaConnectionTests
             });
             await Assert.That(thrown!.CancellationToken).IsEqualTo(callerCancellation.Token);
 
-            await Task.Delay(TimeSpan.FromMilliseconds(300), cancellationToken);
+            await Task.Delay(TimeSpan.FromMilliseconds(1500), cancellationToken);
 
             await Assert.That(connection.IsConnected).IsTrue();
         }

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -201,6 +201,79 @@ public sealed class KafkaConnectionTests
 
     [Test]
     [Timeout(10_000)]
+    public async Task ReceiveLoop_IdleLongerThanRequestTimeout_RemainsConnected(CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            await using var connection = new KafkaConnection(
+                IPAddress.Loopback.ToString(),
+                port,
+                options: new ConnectionOptions { RequestTimeout = TimeSpan.FromMilliseconds(100) });
+
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(300), cancellationToken);
+
+            await Assert.That(connection.IsConnected).IsTrue();
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task SendAsync_CallerCanceledRequest_DoesNotFailIdleConnectionAfterRequestTimeout(CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            await using var connection = new KafkaConnection(
+                IPAddress.Loopback.ToString(),
+                port,
+                options: new ConnectionOptions { RequestTimeout = TimeSpan.FromMilliseconds(100) });
+
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+            using var callerCancellation = new CancellationTokenSource();
+
+            var sendTask = connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                apiVersion: 3,
+                callerCancellation.Token).AsTask();
+
+            await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+            await callerCancellation.CancelAsync();
+
+            var thrown = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await sendTask.ConfigureAwait(false);
+            });
+            await Assert.That(thrown!.CancellationToken).IsEqualTo(callerCancellation.Token);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(300), cancellationToken);
+
+            await Assert.That(connection.IsConnected).IsTrue();
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    [Timeout(10_000)]
     public async Task IsConnected_StreamAssignedBeforeConnectionReady_ReturnsFalse(CancellationToken cancellationToken)
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);


### PR DESCRIPTION
Summary:
- only arm the receive-loop `RequestTimeout` while responses are actually pending
- wake the receive loop when pending requests transition between idle and active so timeout state is refreshed
- add regressions for idle connections and caller-canceled requests staying connected past `RequestTimeout`

Test plan:
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-incremental -v:minimal`
- [x] `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --no-incremental -v:minimal`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaConnectionTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConnectionPoolConcurrencyTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PooledPendingRequestTests/*"`
- [x] `git diff --check`

Closes #1339