### PR TITLE
fix(admin): tolerate applied retry results

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -170,11 +170,20 @@ public sealed class AdminClient : IAdminClient
                 CreateTopicsRequest.LowestSupportedVersion,
                 CreateTopicsRequest.HighestSupportedVersion);
 
-            createMayHaveApplied = !opts.ValidateOnly;
-            var response = await controller.SendAsync<CreateTopicsRequest, CreateTopicsResponse>(
-                request,
-                apiVersion,
-                cancellationToken).ConfigureAwait(false);
+            CreateTopicsResponse response;
+            try
+            {
+                response = await controller.SendAsync<CreateTopicsRequest, CreateTopicsResponse>(
+                    request,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                if (!opts.ValidateOnly)
+                    createMayHaveApplied = true;
+                throw;
+            }
 
             // Check for errors
             var createdTopicNames = new List<string>(response.Topics.Count);
@@ -197,6 +206,7 @@ public sealed class AdminClient : IAdminClient
             // MetadataManager.GetTopicMetadataSlowAsync.
             if (!opts.ValidateOnly)
             {
+                createMayHaveApplied = true;
                 await WaitForTopicLeadersAsync(createdTopicNames, cancellationToken).ConfigureAwait(false);
             }
         }, cancellationToken).ConfigureAwait(false);
@@ -1164,11 +1174,19 @@ public sealed class AdminClient : IAdminClient
                     GroupsNames = groups
                 };
 
-                deleteMayHaveApplied = true;
-                var response = await connection.SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
-                    request,
-                    apiVersion,
-                    cancellationToken).ConfigureAwait(false);
+                DeleteGroupsResponse response;
+                try
+                {
+                    response = await connection.SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+                        request,
+                        apiVersion,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    deleteMayHaveApplied = true;
+                    throw;
+                }
 
                 foreach (var groupResult in response.Results)
                 {
@@ -1419,11 +1437,19 @@ public sealed class AdminClient : IAdminClient
                 CreatePartitionsRequest.LowestSupportedVersion,
                 CreatePartitionsRequest.HighestSupportedVersion);
 
-            createPartitionsMayHaveApplied = true;
-            var response = await controller.SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(
-                request,
-                apiVersion,
-                cancellationToken).ConfigureAwait(false);
+            CreatePartitionsResponse response;
+            try
+            {
+                response = await controller.SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(
+                    request,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                createPartitionsMayHaveApplied = true;
+                throw;
+            }
 
             foreach (var topicResult in response.Results)
             {
@@ -1484,11 +1510,19 @@ public sealed class AdminClient : IAdminClient
                 AlterPartitionReassignmentsRequest.LowestSupportedVersion,
                 AlterPartitionReassignmentsRequest.HighestSupportedVersion);
 
-            alterMayHaveApplied = true;
-            var response = await controller.SendAsync<AlterPartitionReassignmentsRequest, AlterPartitionReassignmentsResponse>(
-                request,
-                apiVersion,
-                cancellationToken).ConfigureAwait(false);
+            AlterPartitionReassignmentsResponse response;
+            try
+            {
+                response = await controller.SendAsync<AlterPartitionReassignmentsRequest, AlterPartitionReassignmentsResponse>(
+                    request,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                alterMayHaveApplied = true;
+                throw;
+            }
 
             if (response.ErrorCode != Protocol.ErrorCode.None)
             {
@@ -2644,11 +2678,19 @@ public sealed class AdminClient : IAdminClient
                 OffsetDeleteRequest.LowestSupportedVersion,
                 OffsetDeleteRequest.HighestSupportedVersion);
 
-            deleteMayHaveApplied = true;
-            var response = await connection.SendAsync<OffsetDeleteRequest, OffsetDeleteResponse>(
-                request,
-                apiVersion,
-                cancellationToken).ConfigureAwait(false);
+            OffsetDeleteResponse response;
+            try
+            {
+                response = await connection.SendAsync<OffsetDeleteRequest, OffsetDeleteResponse>(
+                    request,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                deleteMayHaveApplied = true;
+                throw;
+            }
 
             // Check for top-level error
             if (response.ErrorCode != Protocol.ErrorCode.None)
@@ -2821,11 +2863,8 @@ public sealed class AdminClient : IAdminClient
             }
         }
 
-        var electionMayHaveApplied = false;
-
         return await WithRetryAsync<IReadOnlyDictionary<TopicPartition, ElectLeadersResultInfo>>(async () =>
         {
-            var isRetryAttempt = electionMayHaveApplied;
             var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
 
             var request = new ElectLeadersRequest
@@ -2840,7 +2879,6 @@ public sealed class AdminClient : IAdminClient
                 ElectLeadersRequest.LowestSupportedVersion,
                 ElectLeadersRequest.HighestSupportedVersion);
 
-            electionMayHaveApplied = true;
             var response = await controller.SendAsync<ElectLeadersRequest, ElectLeadersResponse>(
                 request,
                 apiVersion,
@@ -2859,7 +2897,7 @@ public sealed class AdminClient : IAdminClient
                 foreach (var partition in topic.PartitionResult)
                 {
                     var tp = new TopicPartition(topic.Topic, partition.PartitionId);
-                    var errorCode = isRetryAttempt && partition.ErrorCode == Protocol.ErrorCode.ElectionNotNeeded
+                    var errorCode = partition.ErrorCode == Protocol.ErrorCode.ElectionNotNeeded
                         ? Protocol.ErrorCode.None
                         : partition.ErrorCode;
 
@@ -3490,11 +3528,19 @@ public sealed class AdminClient : IAdminClient
                 DeleteShareGroupOffsetsRequest.LowestSupportedVersion,
                 DeleteShareGroupOffsetsRequest.HighestSupportedVersion);
 
-            deleteMayHaveApplied = true;
-            var response = await connection.SendAsync<DeleteShareGroupOffsetsRequest, DeleteShareGroupOffsetsResponse>(
-                request,
-                apiVersion,
-                cancellationToken).ConfigureAwait(false);
+            DeleteShareGroupOffsetsResponse response;
+            try
+            {
+                response = await connection.SendAsync<DeleteShareGroupOffsetsRequest, DeleteShareGroupOffsetsResponse>(
+                    request,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                deleteMayHaveApplied = true;
+                throw;
+            }
 
             if (response.ErrorCode != Protocol.ErrorCode.None)
             {

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -251,6 +251,20 @@ public sealed class AdminClient : IAdminClient
             $"Topic(s) {string.Join(", ", topicNames)} did not have all partition leaders elected after {leaderWaitRetries * RetryHelper.RetryDelayMs}ms");
     }
 
+    private async ValueTask<bool> TopicHasAtLeastPartitionCountAsync(
+        string topicName,
+        int partitionCount,
+        CancellationToken cancellationToken)
+    {
+        await _metadataManager.RefreshMetadataAsync(
+            [topicName],
+            forceRefresh: true,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var topic = _metadataManager.Metadata.GetTopic(topicName);
+        return topic is { ErrorCode: Protocol.ErrorCode.None } && topic.PartitionCount >= partitionCount;
+    }
+
     public async ValueTask DeleteTopicsAsync(
         IEnumerable<string> topicNames,
         DeleteTopicsOptions? options = null,
@@ -260,9 +274,11 @@ public sealed class AdminClient : IAdminClient
 
         var opts = options ?? new DeleteTopicsOptions();
         var names = topicNames.ToList();
+        var deleteMayHaveApplied = false;
 
         await WithRetryAsync(async () =>
         {
+            var isRetryAttempt = deleteMayHaveApplied;
             var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
@@ -290,6 +306,7 @@ public sealed class AdminClient : IAdminClient
                 };
             }
 
+            deleteMayHaveApplied = true;
             var response = await controller.SendAsync<DeleteTopicsRequest, DeleteTopicsResponse>(
                 request,
                 apiVersion,
@@ -298,7 +315,8 @@ public sealed class AdminClient : IAdminClient
             // Check for errors
             foreach (var topic in response.Responses)
             {
-                if (topic.ErrorCode != Protocol.ErrorCode.None)
+                if (topic.ErrorCode != Protocol.ErrorCode.None &&
+                    !(isRetryAttempt && topic.ErrorCode == Protocol.ErrorCode.UnknownTopicOrPartition))
                 {
                     throw new KafkaException(topic.ErrorCode,
                         $"Failed to delete topic '{topic.Name}': {topic.ErrorMessage ?? topic.ErrorCode.ToString()}");
@@ -1106,9 +1124,11 @@ public sealed class AdminClient : IAdminClient
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
         var groupIdList = groupIds.ToList();
+        var deleteMayHaveApplied = false;
 
         await WithRetryAsync(async () =>
         {
+            var isRetryAttempt = deleteMayHaveApplied;
             // Find coordinator for each group and batch by coordinator
             var groupsByCoordinator = new Dictionary<int, List<string>>();
             foreach (var groupId in groupIdList)
@@ -1136,6 +1156,7 @@ public sealed class AdminClient : IAdminClient
                     GroupsNames = groups
                 };
 
+                deleteMayHaveApplied = true;
                 var response = await connection.SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
                     request,
                     apiVersion,
@@ -1143,7 +1164,8 @@ public sealed class AdminClient : IAdminClient
 
                 foreach (var groupResult in response.Results)
                 {
-                    if (groupResult.ErrorCode != Protocol.ErrorCode.None)
+                    if (groupResult.ErrorCode != Protocol.ErrorCode.None &&
+                        !(isRetryAttempt && groupResult.ErrorCode == Protocol.ErrorCode.GroupIdNotFound))
                     {
                         throw new Errors.GroupException(groupResult.ErrorCode,
                             $"DeleteConsumerGroups failed for group '{groupResult.GroupId}': {groupResult.ErrorCode}")
@@ -1372,9 +1394,11 @@ public sealed class AdminClient : IAdminClient
             Name = kvp.Key,
             Count = kvp.Value
         }).ToList();
+        var createPartitionsMayHaveApplied = false;
 
         await WithRetryAsync(async () =>
         {
+            var isRetryAttempt = createPartitionsMayHaveApplied;
             var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
 
             var request = new CreatePartitionsRequest
@@ -1387,6 +1411,7 @@ public sealed class AdminClient : IAdminClient
                 CreatePartitionsRequest.LowestSupportedVersion,
                 CreatePartitionsRequest.HighestSupportedVersion);
 
+            createPartitionsMayHaveApplied = true;
             var response = await controller.SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(
                 request,
                 apiVersion,
@@ -1396,6 +1421,16 @@ public sealed class AdminClient : IAdminClient
             {
                 if (topicResult.ErrorCode != Protocol.ErrorCode.None)
                 {
+                    if (isRetryAttempt &&
+                        topicResult.ErrorCode == Protocol.ErrorCode.InvalidPartitions &&
+                        await TopicHasAtLeastPartitionCountAsync(
+                            topicResult.Name,
+                            newPartitionCounts[topicResult.Name],
+                            cancellationToken).ConfigureAwait(false))
+                    {
+                        continue;
+                    }
+
                     throw new KafkaException(topicResult.ErrorCode,
                         $"CreatePartitions failed for topic '{topicResult.Name}': {topicResult.ErrorMessage ?? topicResult.ErrorCode.ToString()}");
                 }
@@ -2582,9 +2617,11 @@ public sealed class AdminClient : IAdminClient
                 }).ToList()
             })
             .ToList();
+        var deleteMayHaveApplied = false;
 
         await WithRetryAsync(async () =>
         {
+            var isRetryAttempt = deleteMayHaveApplied;
             var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
             var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
 
@@ -2599,6 +2636,7 @@ public sealed class AdminClient : IAdminClient
                 OffsetDeleteRequest.LowestSupportedVersion,
                 OffsetDeleteRequest.HighestSupportedVersion);
 
+            deleteMayHaveApplied = true;
             var response = await connection.SendAsync<OffsetDeleteRequest, OffsetDeleteResponse>(
                 request,
                 apiVersion,
@@ -2607,6 +2645,9 @@ public sealed class AdminClient : IAdminClient
             // Check for top-level error
             if (response.ErrorCode != Protocol.ErrorCode.None)
             {
+                if (isRetryAttempt && response.ErrorCode == Protocol.ErrorCode.GroupIdNotFound)
+                    return;
+
                 throw new Errors.GroupException(response.ErrorCode,
                     $"DeleteConsumerGroupOffsets failed for group '{groupId}': {response.ErrorCode}")
                 {
@@ -2772,8 +2813,11 @@ public sealed class AdminClient : IAdminClient
             }
         }
 
+        var electionMayHaveApplied = false;
+
         return await WithRetryAsync<IReadOnlyDictionary<TopicPartition, ElectLeadersResultInfo>>(async () =>
         {
+            var isRetryAttempt = electionMayHaveApplied;
             var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
 
             var request = new ElectLeadersRequest
@@ -2788,6 +2832,7 @@ public sealed class AdminClient : IAdminClient
                 ElectLeadersRequest.LowestSupportedVersion,
                 ElectLeadersRequest.HighestSupportedVersion);
 
+            electionMayHaveApplied = true;
             var response = await controller.SendAsync<ElectLeadersRequest, ElectLeadersResponse>(
                 request,
                 apiVersion,
@@ -2806,11 +2851,15 @@ public sealed class AdminClient : IAdminClient
                 foreach (var partition in topic.PartitionResult)
                 {
                     var tp = new TopicPartition(topic.Topic, partition.PartitionId);
+                    var errorCode = isRetryAttempt && partition.ErrorCode == Protocol.ErrorCode.ElectionNotNeeded
+                        ? Protocol.ErrorCode.None
+                        : partition.ErrorCode;
+
                     results[tp] = new ElectLeadersResultInfo
                     {
                         TopicPartition = tp,
-                        ErrorCode = partition.ErrorCode,
-                        ErrorMessage = partition.ErrorMessage
+                        ErrorCode = errorCode,
+                        ErrorMessage = errorCode == Protocol.ErrorCode.None ? null : partition.ErrorMessage
                     };
                 }
             }
@@ -3414,9 +3463,11 @@ public sealed class AdminClient : IAdminClient
         var topicData = topics
             .Select(t => new DeleteShareGroupOffsetsRequestTopic { TopicName = t })
             .ToList();
+        var deleteMayHaveApplied = false;
 
         await WithRetryAsync(async () =>
         {
+            var isRetryAttempt = deleteMayHaveApplied;
             var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
             var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
 
@@ -3431,6 +3482,7 @@ public sealed class AdminClient : IAdminClient
                 DeleteShareGroupOffsetsRequest.LowestSupportedVersion,
                 DeleteShareGroupOffsetsRequest.HighestSupportedVersion);
 
+            deleteMayHaveApplied = true;
             var response = await connection.SendAsync<DeleteShareGroupOffsetsRequest, DeleteShareGroupOffsetsResponse>(
                 request,
                 apiVersion,
@@ -3438,6 +3490,9 @@ public sealed class AdminClient : IAdminClient
 
             if (response.ErrorCode != Protocol.ErrorCode.None)
             {
+                if (isRetryAttempt && response.ErrorCode == Protocol.ErrorCode.GroupIdNotFound)
+                    return;
+
                 throw new Errors.GroupException(response.ErrorCode,
                     $"DeleteShareGroupOffsets failed for group '{groupId}': {response.ErrorCode}")
                 {

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -306,11 +306,19 @@ public sealed class AdminClient : IAdminClient
                 };
             }
 
-            deleteMayHaveApplied = true;
-            var response = await controller.SendAsync<DeleteTopicsRequest, DeleteTopicsResponse>(
-                request,
-                apiVersion,
-                cancellationToken).ConfigureAwait(false);
+            DeleteTopicsResponse response;
+            try
+            {
+                response = await controller.SendAsync<DeleteTopicsRequest, DeleteTopicsResponse>(
+                    request,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                deleteMayHaveApplied = true;
+                throw;
+            }
 
             // Check for errors
             foreach (var topic in response.Responses)

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientCreateTopicsRetryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientCreateTopicsRetryTests.cs
@@ -96,6 +96,37 @@ public sealed class AdminClientCreateTopicsRetryTests
     }
 
     [Test]
+    public async Task CreateTopicsAsync_TopicAlreadyExistsAfterNonAmbiguousRetry_Throws()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection();
+        var createCalls = 0;
+
+        connection.SendAsync<CreateTopicsRequest, CreateTopicsResponse>(
+                Arg.Any<CreateTopicsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(new CreateTopicsResponse
+            {
+                Topics =
+                [
+                    new CreateTopicsResponseTopic
+                    {
+                        Name = TopicName,
+                        ErrorCode = Interlocked.Increment(ref createCalls) == 1
+                            ? ErrorCode.NotController
+                            : ErrorCode.TopicAlreadyExists
+                    }
+                ]
+            }));
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await admin.CreateTopicsAsync([new NewTopic { Name = TopicName, NumPartitions = 1 }]));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.TopicAlreadyExists);
+        await Assert.That(createCalls).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task CreateTopicsAsync_TopicAlreadyExistsOnFirstAttempt_Throws()
     {
         var (admin, connection) = CreateAdminWithMockConnection();

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientIdempotentRetryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientIdempotentRetryTests.cs
@@ -1,0 +1,350 @@
+using Dekaf.Admin;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public sealed class AdminClientIdempotentRetryTests
+{
+    private const string TopicName = "retry-topic";
+    private const string GroupId = "retry-group";
+
+    [Test]
+    public async Task DeleteTopicsAsync_UnknownTopicOnRetry_TreatedAsSuccess()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection(ApiKey.DeleteTopics);
+        var calls = 0;
+
+        connection.SendAsync<DeleteTopicsRequest, DeleteTopicsResponse>(
+                Arg.Any<DeleteTopicsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                    throw new KafkaException(ErrorCode.RequestTimedOut, "simulated timeout");
+
+                return ValueTask.FromResult(new DeleteTopicsResponse
+                {
+                    Responses =
+                    [
+                        new DeleteTopicsResponseTopic
+                        {
+                            Name = TopicName,
+                            ErrorCode = ErrorCode.UnknownTopicOrPartition
+                        }
+                    ]
+                });
+            });
+
+        await admin.DeleteTopicsAsync([TopicName]);
+
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task DeleteConsumerGroupsAsync_GroupIdNotFoundOnRetry_TreatedAsSuccess()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection(ApiKey.DeleteGroups);
+        SetupFindCoordinator(connection);
+        var calls = 0;
+
+        connection.SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+                Arg.Any<DeleteGroupsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                    throw new KafkaException(ErrorCode.RequestTimedOut, "simulated timeout");
+
+                return ValueTask.FromResult(new DeleteGroupsResponse
+                {
+                    Results =
+                    [
+                        new DeleteGroupsResponseResult
+                        {
+                            GroupId = GroupId,
+                            ErrorCode = ErrorCode.GroupIdNotFound
+                        }
+                    ]
+                });
+            });
+
+        await admin.DeleteConsumerGroupsAsync([GroupId]);
+
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task CreatePartitionsAsync_InvalidPartitionsOnRetry_WhenMetadataShowsTarget_TreatedAsSuccess()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection(ApiKey.CreatePartitions);
+        var calls = 0;
+
+        connection.SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(
+                Arg.Any<CreatePartitionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                    throw new KafkaException(ErrorCode.RequestTimedOut, "simulated timeout");
+
+                return ValueTask.FromResult(new CreatePartitionsResponse
+                {
+                    Results =
+                    [
+                        new CreatePartitionsResponseResult
+                        {
+                            Name = TopicName,
+                            ErrorCode = ErrorCode.InvalidPartitions
+                        }
+                    ]
+                });
+            });
+
+        await admin.CreatePartitionsAsync(new Dictionary<string, int>
+        {
+            [TopicName] = 3
+        });
+
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task DeleteConsumerGroupOffsetsAsync_GroupIdNotFoundOnRetry_TreatedAsSuccess()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection(ApiKey.OffsetDelete);
+        SetupFindCoordinator(connection);
+        var calls = 0;
+
+        connection.SendAsync<OffsetDeleteRequest, OffsetDeleteResponse>(
+                Arg.Any<OffsetDeleteRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                    throw new KafkaException(ErrorCode.RequestTimedOut, "simulated timeout");
+
+                return ValueTask.FromResult(new OffsetDeleteResponse
+                {
+                    ErrorCode = ErrorCode.GroupIdNotFound,
+                    Topics = []
+                });
+            });
+
+        await admin.DeleteConsumerGroupOffsetsAsync(GroupId, [new TopicPartition(TopicName, 0)]);
+
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task DeleteShareGroupOffsetsAsync_GroupIdNotFoundOnRetry_TreatedAsSuccess()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection(ApiKey.DeleteShareGroupOffsets);
+        SetupFindCoordinator(connection);
+        var calls = 0;
+
+        connection.SendAsync<DeleteShareGroupOffsetsRequest, DeleteShareGroupOffsetsResponse>(
+                Arg.Any<DeleteShareGroupOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                    throw new KafkaException(ErrorCode.RequestTimedOut, "simulated timeout");
+
+                return ValueTask.FromResult(new DeleteShareGroupOffsetsResponse
+                {
+                    ErrorCode = ErrorCode.GroupIdNotFound,
+                    Responses = []
+                });
+            });
+
+        await admin.DeleteShareGroupOffsetsAsync(GroupId, [TopicName]);
+
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ElectLeadersAsync_ElectionNotNeededOnRetry_TreatedAsSuccess()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection(ApiKey.ElectLeaders);
+        var calls = 0;
+
+        connection.SendAsync<ElectLeadersRequest, ElectLeadersResponse>(
+                Arg.Any<ElectLeadersRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                    throw new KafkaException(ErrorCode.RequestTimedOut, "simulated timeout");
+
+                return ValueTask.FromResult(new ElectLeadersResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    ReplicaElectionResults =
+                    [
+                        new ElectLeadersResponseTopic
+                        {
+                            Topic = TopicName,
+                            PartitionResult =
+                            [
+                                new ElectLeadersResponsePartition
+                                {
+                                    PartitionId = 0,
+                                    ErrorCode = ErrorCode.ElectionNotNeeded,
+                                    ErrorMessage = "already leader"
+                                }
+                            ]
+                        }
+                    ]
+                });
+            });
+
+        var results = await admin.ElectLeadersAsync(
+            ElectionType.Preferred,
+            [new TopicPartition(TopicName, 0)]);
+
+        await Assert.That(calls).IsEqualTo(2);
+        await Assert.That(results[new TopicPartition(TopicName, 0)].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(results[new TopicPartition(TopicName, 0)].ErrorMessage).IsNull();
+    }
+
+    private static void SetupFindCoordinator(IKafkaConnection connection)
+    {
+        connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                Coordinators =
+                [
+                    new Coordinator
+                    {
+                        Key = GroupId,
+                        NodeId = 1,
+                        Host = "localhost",
+                        Port = 9092,
+                        ErrorCode = ErrorCode.None
+                    }
+                ]
+            }));
+    }
+
+    private static (AdminClient Admin, IKafkaConnection Connection) CreateAdminWithMockConnection(
+        params ApiKey[] extraApiKeys)
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.BrokerId.Returns(1);
+        connection.Host.Returns("localhost");
+        connection.Port.Returns(9092);
+        connection.IsConnected.Returns(true);
+
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.Metadata.Update(CreateMetadataResponse());
+        metadataManager.SetApiVersion(ApiKey.Metadata, 9, 13);
+        metadataManager.SetApiVersion(ApiKey.FindCoordinator, 4, 5);
+
+        foreach (var apiKey in extraApiKeys)
+            metadataManager.SetApiVersion(apiKey, 0, 99);
+
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateMetadataResponse()));
+
+        connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys = extraApiKeys
+                    .Append(ApiKey.Metadata)
+                    .Append(ApiKey.FindCoordinator)
+                    .Distinct()
+                    .Select(apiKey => new ApiVersion(apiKey, 0, 99))
+                    .ToList()
+            }));
+
+        var admin = new AdminClient(
+            new AdminClientOptions { BootstrapServers = ["localhost:9092"] },
+            pool,
+            metadataManager);
+
+        return (admin, connection);
+    }
+
+    private static MetadataResponse CreateMetadataResponse() => new()
+    {
+        Brokers =
+        [
+            new BrokerMetadata
+            {
+                NodeId = 1,
+                Host = "localhost",
+                Port = 9092
+            }
+        ],
+        ClusterId = "test-cluster",
+        ControllerId = 1,
+        Topics =
+        [
+            new TopicMetadata
+            {
+                Name = TopicName,
+                ErrorCode = ErrorCode.None,
+                Partitions =
+                [
+                    new PartitionMetadata
+                    {
+                        PartitionIndex = 0,
+                        LeaderId = 1,
+                        LeaderEpoch = 1,
+                        ReplicaNodes = [1],
+                        IsrNodes = [1],
+                        OfflineReplicas = [],
+                        ErrorCode = ErrorCode.None
+                    },
+                    new PartitionMetadata
+                    {
+                        PartitionIndex = 1,
+                        LeaderId = 1,
+                        LeaderEpoch = 1,
+                        ReplicaNodes = [1],
+                        IsrNodes = [1],
+                        OfflineReplicas = [],
+                        ErrorCode = ErrorCode.None
+                    },
+                    new PartitionMetadata
+                    {
+                        PartitionIndex = 2,
+                        LeaderId = 1,
+                        LeaderEpoch = 1,
+                        ReplicaNodes = [1],
+                        IsrNodes = [1],
+                        OfflineReplicas = [],
+                        ErrorCode = ErrorCode.None
+                    }
+                ]
+            }
+        ]
+    };
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientIdempotentRetryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientIdempotentRetryTests.cs
@@ -94,6 +94,38 @@ public sealed class AdminClientIdempotentRetryTests
     }
 
     [Test]
+    public async Task DeleteConsumerGroupsAsync_GroupIdNotFoundAfterNonAmbiguousRetry_Throws()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection(ApiKey.DeleteGroups);
+        SetupFindCoordinator(connection);
+        var calls = 0;
+
+        connection.SendAsync<DeleteGroupsRequest, DeleteGroupsResponse>(
+                Arg.Any<DeleteGroupsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(new DeleteGroupsResponse
+            {
+                Results =
+                [
+                    new DeleteGroupsResponseResult
+                    {
+                        GroupId = GroupId,
+                        ErrorCode = Interlocked.Increment(ref calls) == 1
+                            ? ErrorCode.NotCoordinator
+                            : ErrorCode.GroupIdNotFound
+                    }
+                ]
+            }));
+
+        var exception = await Assert.ThrowsAsync<GroupException>(async () =>
+            await admin.DeleteConsumerGroupsAsync([GroupId]));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.GroupIdNotFound);
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task CreatePartitionsAsync_InvalidPartitionsOnRetry_WhenMetadataShowsTarget_TreatedAsSuccess()
     {
         var (admin, connection) = CreateAdminWithMockConnection(ApiKey.CreatePartitions);
@@ -130,6 +162,40 @@ public sealed class AdminClientIdempotentRetryTests
     }
 
     [Test]
+    public async Task CreatePartitionsAsync_InvalidPartitionsAfterNonAmbiguousRetry_Throws()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection(ApiKey.CreatePartitions);
+        var calls = 0;
+
+        connection.SendAsync<CreatePartitionsRequest, CreatePartitionsResponse>(
+                Arg.Any<CreatePartitionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(new CreatePartitionsResponse
+            {
+                Results =
+                [
+                    new CreatePartitionsResponseResult
+                    {
+                        Name = TopicName,
+                        ErrorCode = Interlocked.Increment(ref calls) == 1
+                            ? ErrorCode.NotController
+                            : ErrorCode.InvalidPartitions
+                    }
+                ]
+            }));
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await admin.CreatePartitionsAsync(new Dictionary<string, int>
+            {
+                [TopicName] = 3
+            }));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.InvalidPartitions);
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task DeleteConsumerGroupOffsetsAsync_GroupIdNotFoundOnRetry_TreatedAsSuccess()
     {
         var (admin, connection) = CreateAdminWithMockConnection(ApiKey.OffsetDelete);
@@ -158,6 +224,32 @@ public sealed class AdminClientIdempotentRetryTests
     }
 
     [Test]
+    public async Task DeleteConsumerGroupOffsetsAsync_GroupIdNotFoundAfterNonAmbiguousRetry_Throws()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection(ApiKey.OffsetDelete);
+        SetupFindCoordinator(connection);
+        var calls = 0;
+
+        connection.SendAsync<OffsetDeleteRequest, OffsetDeleteResponse>(
+                Arg.Any<OffsetDeleteRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(new OffsetDeleteResponse
+            {
+                ErrorCode = Interlocked.Increment(ref calls) == 1
+                    ? ErrorCode.NotCoordinator
+                    : ErrorCode.GroupIdNotFound,
+                Topics = []
+            }));
+
+        var exception = await Assert.ThrowsAsync<GroupException>(async () =>
+            await admin.DeleteConsumerGroupOffsetsAsync(GroupId, [new TopicPartition(TopicName, 0)]));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.GroupIdNotFound);
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task DeleteShareGroupOffsetsAsync_GroupIdNotFoundOnRetry_TreatedAsSuccess()
     {
         var (admin, connection) = CreateAdminWithMockConnection(ApiKey.DeleteShareGroupOffsets);
@@ -182,6 +274,32 @@ public sealed class AdminClientIdempotentRetryTests
 
         await admin.DeleteShareGroupOffsetsAsync(GroupId, [TopicName]);
 
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task DeleteShareGroupOffsetsAsync_GroupIdNotFoundAfterNonAmbiguousRetry_Throws()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection(ApiKey.DeleteShareGroupOffsets);
+        SetupFindCoordinator(connection);
+        var calls = 0;
+
+        connection.SendAsync<DeleteShareGroupOffsetsRequest, DeleteShareGroupOffsetsResponse>(
+                Arg.Any<DeleteShareGroupOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(new DeleteShareGroupOffsetsResponse
+            {
+                ErrorCode = Interlocked.Increment(ref calls) == 1
+                    ? ErrorCode.NotCoordinator
+                    : ErrorCode.GroupIdNotFound,
+                Responses = []
+            }));
+
+        var exception = await Assert.ThrowsAsync<GroupException>(async () =>
+            await admin.DeleteShareGroupOffsetsAsync(GroupId, [TopicName]));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.GroupIdNotFound);
         await Assert.That(calls).IsEqualTo(2);
     }
 
@@ -227,6 +345,44 @@ public sealed class AdminClientIdempotentRetryTests
             [new TopicPartition(TopicName, 0)]);
 
         await Assert.That(calls).IsEqualTo(2);
+        await Assert.That(results[new TopicPartition(TopicName, 0)].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(results[new TopicPartition(TopicName, 0)].ErrorMessage).IsNull();
+    }
+
+    [Test]
+    public async Task ElectLeadersAsync_ElectionNotNeededWithoutPriorRetry_TreatedAsSuccess()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection(ApiKey.ElectLeaders);
+
+        connection.SendAsync<ElectLeadersRequest, ElectLeadersResponse>(
+                Arg.Any<ElectLeadersRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ElectLeadersResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ReplicaElectionResults =
+                [
+                    new ElectLeadersResponseTopic
+                    {
+                        Topic = TopicName,
+                        PartitionResult =
+                        [
+                            new ElectLeadersResponsePartition
+                            {
+                                PartitionId = 0,
+                                ErrorCode = ErrorCode.ElectionNotNeeded,
+                                ErrorMessage = "already leader"
+                            }
+                        ]
+                    }
+                ]
+            }));
+
+        var results = await admin.ElectLeadersAsync(
+            ElectionType.Preferred,
+            [new TopicPartition(TopicName, 0)]);
+
         await Assert.That(results[new TopicPartition(TopicName, 0)].ErrorCode).IsEqualTo(ErrorCode.None);
         await Assert.That(results[new TopicPartition(TopicName, 0)].ErrorMessage).IsNull();
     }

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientIdempotentRetryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientIdempotentRetryTests.cs
@@ -28,22 +28,35 @@ public sealed class AdminClientIdempotentRetryTests
                 if (Interlocked.Increment(ref calls) == 1)
                     throw new KafkaException(ErrorCode.RequestTimedOut, "simulated timeout");
 
-                return ValueTask.FromResult(new DeleteTopicsResponse
-                {
-                    Responses =
-                    [
-                        new DeleteTopicsResponseTopic
-                        {
-                            Name = TopicName,
-                            ErrorCode = ErrorCode.UnknownTopicOrPartition
-                        }
-                    ]
-                });
+                return ValueTask.FromResult(CreateUnknownTopicResponse());
             });
 
         await admin.DeleteTopicsAsync([TopicName]);
 
         await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task DeleteTopicsAsync_UnknownTopicWithoutPriorSendFailure_Throws()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection(ApiKey.DeleteTopics);
+        var calls = 0;
+
+        connection.SendAsync<DeleteTopicsRequest, DeleteTopicsResponse>(
+                Arg.Any<DeleteTopicsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref calls);
+                return ValueTask.FromResult(CreateUnknownTopicResponse());
+            });
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await admin.DeleteTopicsAsync([TopicName]));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.UnknownTopicOrPartition);
+        await Assert.That(calls).IsEqualTo(4);
     }
 
     [Test]
@@ -239,6 +252,18 @@ public sealed class AdminClientIdempotentRetryTests
                 ]
             }));
     }
+
+    private static DeleteTopicsResponse CreateUnknownTopicResponse() => new()
+    {
+        Responses =
+        [
+            new DeleteTopicsResponseTopic
+            {
+                Name = TopicName,
+                ErrorCode = ErrorCode.UnknownTopicOrPartition
+            }
+        ]
+    };
 
     private static (AdminClient Admin, IKafkaConnection Connection) CreateAdminWithMockConnection(
         params ApiKey[] extraApiKeys)

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientPartitionReassignmentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientPartitionReassignmentTests.cs
@@ -107,6 +107,32 @@ public sealed class AdminClientPartitionReassignmentTests
     }
 
     [Test]
+    public async Task AlterPartitionReassignmentsAsync_AlreadyAppliedAfterNonAmbiguousRetry_Throws()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection();
+        var sendCalls = 0;
+
+        connection.SendAsync<AlterPartitionReassignmentsRequest, AlterPartitionReassignmentsResponse>(
+                Arg.Any<AlterPartitionReassignmentsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(CreateAlterResponse(
+                Interlocked.Increment(ref sendCalls) == 1
+                    ? ErrorCode.NotController
+                    : ErrorCode.ReassignmentInProgress)));
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await admin.AlterPartitionReassignmentsAsync(
+                new Dictionary<TopicPartition, Optional<NewPartitionReassignment>>
+                {
+                    [new("test-topic", 0)] = NewPartitionReassignment.ToReplicas(1, 2)
+                }));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.ReassignmentInProgress);
+        await Assert.That(sendCalls).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task ListPartitionReassignmentsAsync_MapsResponseToResult()
     {
         var (admin, connection) = CreateAdminWithMockConnection();


### PR DESCRIPTION
## Summary
- Treat already-applied retry results as success for non-idempotent admin mutations.
- Verify `CreatePartitions` retry success via refreshed metadata before swallowing `InvalidPartitions`.
- Add regression coverage for DeleteTopics, DeleteConsumerGroups, CreatePartitions, offset deletes, and ElectLeaders retry ambiguity.

## Tests
- dotnet build tests/Dekaf.Tests.Unit --configuration Release
- dotnet build src/Dekaf/Dekaf.csproj --configuration Release
- ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter '/*/*/AdminClientIdempotentRetryTests/*'
- ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter '/*/*/AdminClient*Tests/*'

Closes #1341