### PR TITLE
ci(stress): add consumer allocation probes

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -8,6 +8,9 @@ SCENARIO_TITLES = {
     'producer-async': 'Producer (Async)',
     'producer-async-idempotent': 'Producer (Async, Idempotent)',
     'consumer': 'Consumer',
+    'consumer-batch': 'Consumer (Batch)',
+    'consumer-raw': 'Consumer (Raw Bytes)',
+    'consumer-raw-batch': 'Consumer (Raw Batch)',
 }
 
 
@@ -35,6 +38,8 @@ def scenario_title(scenario_key, fallback_prefix=''):
 
 def format_bytes(num_bytes):
     """Format a byte count as a human-readable string."""
+    if num_bytes is None:
+        return 'N/A'
     if num_bytes < 1024:
         return f"{num_bytes} B"
     elif num_bytes < 1024 * 1024:
@@ -71,6 +76,20 @@ def effective_mb_rate(result):
     if rate is not None:
         return rate
     return result.get('throughput', {}).get('averageMegabytesPerSecond', 0)
+
+
+def allocated_per_message(result):
+    """Heap allocation per application message, or None when unavailable."""
+    serialized = result.get('allocatedBytesPerMessage')
+    if serialized is not None:
+        return serialized
+
+    gc = result.get('gcStats', {})
+    allocated = gc.get('allocatedBytes')
+    total_messages = result.get('throughput', {}).get('totalMessages', 0)
+    if allocated is None or not total_messages:
+        return None
+    return allocated / total_messages
 
 
 def find_confluent_baseline(results):
@@ -174,18 +193,24 @@ def format_gc_table(results, title="GC Statistics"):
     lines = []
     lines.append(f"## {title}")
     lines.append("")
-    lines.append("| Client | Scenario | Gen0 | Gen1 | Gen2 | Total Allocated |")
-    lines.append("|--------|----------|------|------|------|-----------------|")
+    lines.append("| Client | Scenario | Gen0 | Gen1 | Gen2 | Total Allocated | Alloc/msg |")
+    lines.append("|--------|----------|------|------|------|-----------------|-----------|")
 
     for r in sorted(results, key=lambda x: (x.get('client', ''), x.get('scenario', ''), x.get('brokerCount', 1))):
         client = r.get('client', 'Unknown')
         scenario_key = (r.get('scenario', 'Unknown'), r.get('brokerCount', 1))
         label = scenario_title(scenario_key)
         gc = r.get('gcStats', {})
-        alloc_str = format_bytes(gc.get('allocatedBytes', 0))
-        lines.append(f"| {client} | {label} | {gc.get('gen0Collections', 0)} | {gc.get('gen1Collections', 0)} | {gc.get('gen2Collections', 0)} | {alloc_str} |")
+        allocated = gc.get('allocatedBytes')
+        alloc_str = format_bytes(allocated)
+        alloc_msg = allocated_per_message(r)
+        alloc_msg_str = format_bytes(round(alloc_msg)) if alloc_msg is not None else 'N/A'
+        lines.append(f"| {client} | {label} | {gc.get('gen0Collections', 0)} | {gc.get('gen1Collections', 0)} | {gc.get('gen2Collections', 0)} | {alloc_str} | {alloc_msg_str} |")
 
     lines.append("")
+    if any(r.get('client', '').lower() == 'confluent' for r in results):
+        lines.append("*Confluent.Kafka uses native librdkafka; .NET GC allocation counters exclude unmanaged allocations.*")
+        lines.append("")
     return lines
 
 

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -61,6 +61,18 @@ jobs:
             client: confluent
             brokers: 1
             name: Confluent Consumer
+          - scenario: consumer-batch
+            client: dekaf
+            brokers: 1
+            name: Dekaf Consumer Batch
+          - scenario: consumer-raw
+            client: dekaf
+            brokers: 1
+            name: Dekaf Consumer Raw
+          - scenario: consumer-raw-batch
+            client: dekaf
+            brokers: 1
+            name: Dekaf Consumer Raw Batch
           # Multi-broker: producer scenarios only — consumer throughput is unaffected by
           # replication factor since Acks only applies to producers.
           - scenario: producer

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -34,6 +34,12 @@ internal static class MarkdownReporter
             GenerateGcTable(sb, groupResults, $"GC Statistics - {label}");
         }
 
+        if (results.Results.Any(r => r.Client.Equals("Confluent", StringComparison.OrdinalIgnoreCase)))
+        {
+            sb.AppendLine("*Confluent.Kafka uses native librdkafka; .NET GC allocation counters exclude unmanaged allocations.*");
+            sb.AppendLine();
+        }
+
         return sb.ToString();
     }
 
@@ -126,12 +132,15 @@ internal static class MarkdownReporter
 
         sb.AppendLine($"## {title}");
         sb.AppendLine();
-        sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Gen0 | Gen1 | Gen2 | Total Allocated |");
-        sb.AppendLine($"|{new string('-', clientWidth + 2)}|------|------|------|-----------------|");
+        sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Gen0 | Gen1 | Gen2 | Total Allocated | Alloc/msg |");
+        sb.AppendLine($"|{new string('-', clientWidth + 2)}|------|------|------|-----------------|-----------|");
 
         foreach (var result in results.OrderBy(r => r.Client))
         {
-            sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {result.GcStats.Gen0Collections,4} | {result.GcStats.Gen1Collections,4} | {result.GcStats.Gen2Collections,4} | {result.GcStats.FormatAllocatedBytes(),9} |");
+            var allocatedPerMessage = result.AllocatedBytesPerMessage is { } bytes
+                ? FormatBytes((long)Math.Round(bytes))
+                : "N/A";
+            sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {result.GcStats.Gen0Collections,4} | {result.GcStats.Gen1Collections,4} | {result.GcStats.Gen2Collections,4} | {result.GcStats.FormatAllocatedBytes(),9} | {allocatedPerMessage,9} |");
         }
 
         sb.AppendLine();
@@ -144,6 +153,9 @@ internal static class MarkdownReporter
         "producer-async" => "Producer (Async) Throughput",
         "producer-async-idempotent" => "Producer (Async, Idempotent) Throughput",
         "consumer" => "Consumer Throughput",
+        "consumer-batch" => "Consumer (Batch) Throughput",
+        "consumer-raw" => "Consumer (Raw Bytes) Throughput",
+        "consumer-raw-batch" => "Consumer (Raw Batch) Throughput",
         _ => $"{scenario} Throughput"
     };
 
@@ -154,7 +166,18 @@ internal static class MarkdownReporter
         "producer-async" => "Async",
         "producer-async-idempotent" => "Async (Idempotent)",
         "consumer" => "Consumer",
+        "consumer-batch" => "Consumer (Batch)",
+        "consumer-raw" => "Consumer (Raw Bytes)",
+        "consumer-raw-batch" => "Consumer (Raw Batch)",
         _ => scenario
+    };
+
+    private static string FormatBytes(long numBytes) => numBytes switch
+    {
+        < 1024 => $"{numBytes} B",
+        < 1024 * 1024 => $"{numBytes / 1024.0:F2} KB",
+        < 1024 * 1024 * 1024 => $"{numBytes / (1024.0 * 1024):F2} MB",
+        _ => $"{numBytes / (1024.0 * 1024 * 1024):F2} GB"
     };
 
     private static string FormatLatencyUs(double us)

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -77,6 +77,11 @@ internal sealed class StressTestResult
             ? cpu / Throughput.ElapsedSeconds
             : null;
 
+    public double? AllocatedBytesPerMessage =>
+        GcStats.AllocatedBytes is { } allocated && Throughput.TotalMessages > 0
+            ? (double)allocated / Throughput.TotalMessages
+            : null;
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,


### PR DESCRIPTION
## Summary
- add weekly Dekaf consumer-batch, consumer-raw, and consumer-raw-batch stress jobs
- report allocated bytes per message in Python and C# stress reports
- note that Confluent.Kafka native librdkafka allocations are outside .NET GC counters

## Validation
- dotnet build tools\Dekaf.StressTests\Dekaf.StressTests.csproj --configuration Release -v:minimal
- dotnet format tools\Dekaf.StressTests\Dekaf.StressTests.csproj --verify-no-changes -v minimal --include tools\Dekaf.StressTests\Reporting\StressTestResult.cs tools\Dekaf.StressTests\Reporting\MarkdownReporter.cs
- python -m py_compile .github\scripts\stress_report.py
- git diff --check HEAD~1..HEAD

Closes #1353