### PR TITLE
perf(consumer): batch partition runtime ingest

### DIFF
--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -267,6 +267,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
     private readonly HashSet<TopicPartition> _pendingIgnoreRestarts = [];
     private readonly Dictionary<TopicPartition, int> _ignoreRestartFailures = [];
     private readonly ConcurrentDictionary<Task, byte> _ignoreRestartTasks = [];
+    private readonly List<TopicPartition> _partitionsToStop = [];
     private readonly Channel<RuntimeCommand<TKey, TValue>> _commands;
     private readonly CancellationTokenSource _failureCancellation = new();
     private readonly CancellationTokenSource _restartCancellation = new();
@@ -303,25 +304,103 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         try
         {
             await SyncAssignmentAsync(linkedCancellation.Token).ConfigureAwait(false);
+            using var consumeCancellation = CancellationTokenSource.CreateLinkedTokenSource(linkedCancellation.Token);
+            var batchEnumerator = _consumer
+                .ConsumeBatchAsync(consumeCancellation.Token)
+                .GetAsyncEnumerator(consumeCancellation.Token);
+            Task<bool>? pendingBatchMove = null;
+            Task<bool>? pendingCommandWait = null;
 
-            while (true)
+            try
             {
-                linkedCancellation.Token.ThrowIfCancellationRequested();
+                while (true)
+                {
+                    linkedCancellation.Token.ThrowIfCancellationRequested();
 
-                await DrainCommandsAsync(linkedCancellation.Token).ConfigureAwait(false);
-                ThrowIfFailed();
-                await CommitPeriodicallyAsync(linkedCancellation.Token).ConfigureAwait(false);
+                    await DrainCommandsAsync(linkedCancellation.Token).ConfigureAwait(false);
+                    ThrowIfFailed();
+                    await CommitPeriodicallyAsync(linkedCancellation.Token).ConfigureAwait(false);
 
-                var result = await _consumer.ConsumeOneAsync(
-                    ConsumePollTimeout,
-                    linkedCancellation.Token).ConfigureAwait(false);
+                    if (pendingBatchMove is null)
+                    {
+                        var moveNext = batchEnumerator.MoveNextAsync();
+                        if (moveNext.IsCompleted)
+                        {
+                            if (!await moveNext.ConfigureAwait(false))
+                                break;
 
-                await DrainCommandsAsync(linkedCancellation.Token).ConfigureAwait(false);
-                ThrowIfFailed();
-                await SyncAssignmentAsync(linkedCancellation.Token).ConfigureAwait(false);
+                            await DrainCommandsAsync(linkedCancellation.Token).ConfigureAwait(false);
+                            ThrowIfFailed();
+                            await RouteBatchAsync(batchEnumerator.Current, linkedCancellation.Token).ConfigureAwait(false);
+                            continue;
+                        }
 
-                if (result.HasValue && !result.Value.IsPartitionEof)
-                    await RouteAsync(result.Value, linkedCancellation.Token).ConfigureAwait(false);
+                        pendingBatchMove = moveNext.AsTask();
+                    }
+
+                    if (pendingBatchMove.IsCompleted)
+                    {
+                        if (!await pendingBatchMove.ConfigureAwait(false))
+                            break;
+
+                        pendingBatchMove = null;
+                        await DrainCommandsAsync(linkedCancellation.Token).ConfigureAwait(false);
+                        ThrowIfFailed();
+                        await RouteBatchAsync(batchEnumerator.Current, linkedCancellation.Token).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    if (pendingCommandWait is null)
+                    {
+                        var waitToRead = _commands.Reader.WaitToReadAsync(linkedCancellation.Token);
+                        if (waitToRead.IsCompleted)
+                        {
+                            if (!await waitToRead.ConfigureAwait(false))
+                                break;
+
+                            continue;
+                        }
+
+                        pendingCommandWait = waitToRead.AsTask();
+                    }
+
+                    if (pendingCommandWait.IsCompleted)
+                    {
+                        if (!await pendingCommandWait.ConfigureAwait(false))
+                            break;
+
+                        pendingCommandWait = null;
+                        continue;
+                    }
+
+                    var delay = Task.Delay(ConsumePollTimeout, linkedCancellation.Token);
+                    var completed = await Task.WhenAny(
+                        pendingBatchMove,
+                        pendingCommandWait,
+                        delay).ConfigureAwait(false);
+
+                    if (completed == pendingBatchMove || completed == pendingCommandWait)
+                        continue;
+
+                    await SyncAssignmentAsync(linkedCancellation.Token).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                consumeCancellation.Cancel();
+
+                if (pendingBatchMove is not null)
+                {
+                    try
+                    {
+                        await pendingBatchMove.ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (consumeCancellation.IsCancellationRequested)
+                    {
+                    }
+                }
+
+                await batchEnumerator.DisposeAsync().ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException) when (_failure is not null)
@@ -421,50 +500,83 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
     {
         var assignment = _consumer.Partitions.Assignment;
 
-        foreach (var partition in _stoppedByFailure.Where(partition => !assignment.Contains(partition)).ToArray())
+        RemoveUnassigned(_stoppedByFailure, assignment, removePause: true);
+        RemoveUnassigned(_pendingIgnoreRestarts, assignment, removePause: false);
+
+        _partitionsToStop.Clear();
+        foreach (var partition in _lanes.Keys)
         {
-            _stoppedByFailure.Remove(partition);
-            _pausedByRuntime.Remove(partition);
-            _ignoreRestartFailures.Remove(partition);
+            if (!AssignmentContains(assignment, partition))
+                _partitionsToStop.Add(partition);
         }
 
-        foreach (var partition in _pendingIgnoreRestarts.Where(partition => !assignment.Contains(partition)).ToArray())
-        {
-            _pendingIgnoreRestarts.Remove(partition);
-            _ignoreRestartFailures.Remove(partition);
-        }
-
-        foreach (var partition in _lanes.Keys.Where(partition => !assignment.Contains(partition)).ToArray())
+        for (var i = 0; i < _partitionsToStop.Count; i++)
         {
             await StopPartitionAsync(
-                partition,
+                _partitionsToStop[i],
                 PartitionStopReason.Revoke,
                 cancellationToken).ConfigureAwait(false);
         }
+        _partitionsToStop.Clear();
 
         StartAssignedPartitions(assignment);
     }
 
-    private async ValueTask RouteAsync(
-        ConsumeResult<TKey, TValue> result,
+    private void RemoveUnassigned(
+        HashSet<TopicPartition> partitions,
+        IEnumerable<TopicPartition> assignment,
+        bool removePause)
+    {
+        _partitionsToStop.Clear();
+        foreach (var partition in partitions)
+        {
+            if (!AssignmentContains(assignment, partition))
+                _partitionsToStop.Add(partition);
+        }
+
+        for (var i = 0; i < _partitionsToStop.Count; i++)
+        {
+            var partition = _partitionsToStop[i];
+            partitions.Remove(partition);
+            if (removePause)
+                _pausedByRuntime.Remove(partition);
+            _ignoreRestartFailures.Remove(partition);
+        }
+        _partitionsToStop.Clear();
+    }
+
+    private static bool AssignmentContains(
+        IEnumerable<TopicPartition> assignment,
+        TopicPartition partition)
+    {
+        return assignment is ICollection<TopicPartition> collection
+            ? collection.Contains(partition)
+            : assignment.Contains(partition);
+    }
+
+    private async ValueTask RouteBatchAsync(
+        ConsumeBatch<TKey, TValue> batch,
         CancellationToken cancellationToken)
     {
-        var partition = new TopicPartition(result.Topic, result.Partition);
+        var partition = batch.TopicPartition;
         if (!_lanes.TryGetValue(partition, out var lane))
             return;
 
-        while (!lane.TryEnqueue(result))
+        foreach (var result in batch)
         {
+            while (!lane.TryEnqueue(result))
+            {
+                PauseIfNeeded(lane);
+                var canWrite = await lane.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
+                await DrainCommandsAsync(cancellationToken).ConfigureAwait(false);
+                ThrowIfFailed();
+
+                if (!canWrite || !_lanes.TryGetValue(partition, out lane))
+                    return;
+            }
+
             PauseIfNeeded(lane);
-            var canWrite = await lane.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
-            await DrainCommandsAsync(cancellationToken).ConfigureAwait(false);
-            ThrowIfFailed();
-
-            if (!canWrite || !_lanes.TryGetValue(partition, out lane))
-                return;
         }
-
-        PauseIfNeeded(lane);
     }
 
     private void StartLane(TopicPartition partition)

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -3,6 +3,11 @@ using System.Runtime.ExceptionServices;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+#if NETSTANDARD2_0
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
 
 namespace Dekaf.Consumer;
 
@@ -389,16 +394,9 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             {
                 consumeCancellation.Cancel();
 
-                if (pendingBatchMove is not null)
-                {
-                    try
-                    {
-                        await pendingBatchMove.ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException) when (consumeCancellation.IsCancellationRequested)
-                    {
-                    }
-                }
+                await ObserveAbandonedTaskAsync(pendingBatchMove).ConfigureAwait(false);
+                if (pendingCommandWait is { IsCompleted: true })
+                    await ObserveAbandonedTaskAsync(pendingCommandWait).ConfigureAwait(false);
 
                 await batchEnumerator.DisposeAsync().ConfigureAwait(false);
             }
@@ -424,6 +422,21 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         }
 
         ThrowIfFailed();
+    }
+
+    private static async ValueTask ObserveAbandonedTaskAsync(Task<bool>? task)
+    {
+        if (task is null)
+            return;
+
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch
+        {
+            // Cleanup only observes abandoned work; preserve the exception already leaving RunAsync.
+        }
     }
 
     private IDisposable? RegisterRebalanceListener()
@@ -506,7 +519,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         _partitionsToStop.Clear();
         foreach (var partition in _lanes.Keys)
         {
-            if (!AssignmentContains(assignment, partition))
+            if (!assignment.Contains(partition))
                 _partitionsToStop.Add(partition);
         }
 
@@ -524,13 +537,13 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
 
     private void RemoveUnassigned(
         HashSet<TopicPartition> partitions,
-        IEnumerable<TopicPartition> assignment,
+        TopicPartitionSet assignment,
         bool removePause)
     {
         _partitionsToStop.Clear();
         foreach (var partition in partitions)
         {
-            if (!AssignmentContains(assignment, partition))
+            if (!assignment.Contains(partition))
                 _partitionsToStop.Add(partition);
         }
 
@@ -543,15 +556,6 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             _ignoreRestartFailures.Remove(partition);
         }
         _partitionsToStop.Clear();
-    }
-
-    private static bool AssignmentContains(
-        IEnumerable<TopicPartition> assignment,
-        TopicPartition partition)
-    {
-        return assignment is ICollection<TopicPartition> collection
-            ? collection.Contains(partition)
-            : assignment.Contains(partition);
     }
 
     private async ValueTask RouteBatchAsync(

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Dekaf.Consumer;
 using Dekaf.Producer;
+using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
@@ -61,6 +62,41 @@ public sealed class PartitionedConsumerRuntimeTests
 
         await Assert.That(() => Snapshot(processed, firstPartition))
             .Eventually(offsets => offsets.IsEquivalentTo(new long[] { 0, 1 }), TimeSpan.FromSeconds(5));
+
+        await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_RoutesViaConsumeBatchAsync()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var consumer = new TestConsumer();
+        consumer.SetAssignment(partition);
+        var processed = new ConcurrentBag<long>();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            async (context, cancellationToken) =>
+            {
+                await foreach (var message in context.Messages.WithCancellation(cancellationToken))
+                {
+                    processed.Add(message.Offset);
+                    context.MarkProcessed(message);
+                }
+            },
+            new PartitionedProcessingOptions { MaxBufferedRecordsPerPartition = 8 },
+            cts.Token).AsTask();
+
+        consumer.Enqueue(
+            CreateResult(partition, 0),
+            CreateResult(partition, 1),
+            CreateResult(partition, 2));
+
+        await Assert.That(() => processed.Count)
+            .Eventually(count => count.IsEqualTo(3), TimeSpan.FromSeconds(5));
+
+        await Assert.That(consumer.ConsumeOneCalls).IsEqualTo(0);
+        await Assert.That(consumer.ConsumeBatchCalls).IsGreaterThan(0);
 
         await StopRuntimeAsync(cts, runTask).ConfigureAwait(false);
     }
@@ -675,6 +711,8 @@ public sealed class PartitionedConsumerRuntimeTests
         private readonly HashSet<TopicPartition> _paused = [];
         private readonly List<IRebalanceListener> _rebalanceListeners = [];
         private readonly SemaphoreSlim _changed = new(0);
+        private int _consumeOneCalls;
+        private int _consumeBatchCalls;
 
         public IReadOnlySet<string> Subscription => new HashSet<string>(StringComparer.Ordinal);
 
@@ -718,6 +756,10 @@ public sealed class PartitionedConsumerRuntimeTests
         public List<TopicPartition[]> ResumeCalls { get; } = [];
 
         public List<TopicPartitionOffset[]> CommitCalls { get; } = [];
+
+        public int ConsumeOneCalls => Volatile.Read(ref _consumeOneCalls);
+
+        public int ConsumeBatchCalls => Volatile.Read(ref _consumeBatchCalls);
 
         public TaskCompletionSource? CommitStarted { get; init; }
 
@@ -767,6 +809,8 @@ public sealed class PartitionedConsumerRuntimeTests
             TimeSpan timeout,
             CancellationToken cancellationToken = default)
         {
+            Interlocked.Increment(ref _consumeOneCalls);
+
             var deadline = timeout == Timeout.InfiniteTimeSpan
                 ? DateTimeOffset.MaxValue
                 : DateTimeOffset.UtcNow.Add(timeout);
@@ -799,12 +843,23 @@ public sealed class PartitionedConsumerRuntimeTests
         public async IAsyncEnumerable<ConsumeBatch<string, string>> ConsumeBatchAsync(
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            await Task.CompletedTask.ConfigureAwait(false);
-            throw new NotSupportedException();
-#pragma warning disable CS0162
-            yield break;
-#pragma warning restore CS0162
+            Interlocked.Increment(ref _consumeBatchCalls);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                if (!TryDequeueBatch(out var results))
+                {
+                    await _changed.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                using var pending = CreatePendingFetchData(results);
+                yield return new ConsumeBatch<string, string>(
+                    pending,
+                    Serializers.String,
+                    Serializers.String,
+                    IsAssigned);
+            }
         }
 
         public async IAsyncEnumerable<ConsumeRawBatch> ConsumeRawBatchAsync(
@@ -1009,6 +1064,83 @@ public sealed class PartitionedConsumerRuntimeTests
 
             result = default;
             return false;
+        }
+
+        private bool TryDequeueBatch(out List<ConsumeResult<string, string>> results)
+        {
+            lock (_gate)
+            {
+                var count = _records.Count;
+                TopicPartition batchPartition = default;
+                var hasBatchPartition = false;
+                results = [];
+
+                for (var i = 0; i < count; i++)
+                {
+                    var candidate = _records.Dequeue();
+                    var partition = new TopicPartition(candidate.Topic, candidate.Partition);
+                    if (_assignment.Contains(partition)
+                        && !_paused.Contains(partition)
+                        && (!hasBatchPartition || partition == batchPartition))
+                    {
+                        if (!hasBatchPartition)
+                        {
+                            batchPartition = partition;
+                            hasBatchPartition = true;
+                        }
+
+                        results.Add(candidate);
+                        continue;
+                    }
+
+                    _records.Enqueue(candidate);
+                }
+
+                return results.Count != 0;
+            }
+        }
+
+        private bool IsAssigned(TopicPartition partition)
+        {
+            lock (_gate)
+                return _assignment.Contains(partition);
+        }
+
+        private static PendingFetchData CreatePendingFetchData(IReadOnlyList<ConsumeResult<string, string>> results)
+        {
+            var first = results[0];
+            var baseOffset = first.Offset;
+            var baseTimestamp = first.TimestampMs;
+            var records = new Record[results.Count];
+
+            for (var i = 0; i < results.Count; i++)
+            {
+                var result = results[i];
+                records[i] = new Record
+                {
+                    OffsetDelta = checked((int)(result.Offset - baseOffset)),
+                    TimestampDelta = result.TimestampMs - baseTimestamp,
+                    IsKeyNull = true,
+                    IsValueNull = true
+                };
+            }
+
+            var recordBatch = new RecordBatch
+            {
+                BaseOffset = baseOffset,
+                BaseTimestamp = baseTimestamp,
+                MaxTimestamp = results[^1].TimestampMs,
+                LastOffsetDelta = records[^1].OffsetDelta,
+                PartitionLeaderEpoch = first.LeaderEpoch ?? -1,
+                Records = records
+            };
+
+            var pending = PendingFetchData.Create(
+                first.Topic,
+                first.Partition,
+                new List<RecordBatch> { recordBatch });
+            pending.EagerParseAll();
+            return pending;
         }
 
         private void RemoveAssignment(params TopicPartition[] partitions)


### PR DESCRIPTION
Summary:
- drive partitioned runtime ingestion from `ConsumeBatchAsync` instead of per-record `ConsumeOneAsync`
- keep command draining and periodic maintenance active while a batch read is pending
- make assignment cleanup timer/event driven and replace per-record LINQ scans with imperative loops
- add runtime test coverage proving the batch path is used

Test plan:
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-incremental -v:minimal`
- [x] `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --no-incremental -v:minimal`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PartitionedConsumerRuntimeTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumeBatchTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumeOneFastPathTests/*"`
- [x] `git diff --check`

Closes #1351