### PR TITLE
fix(benchmarks): stabilize FnF baseline

### DIFF
--- a/tests/Dekaf.Tests.Integration/PartitionedProcessingIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/PartitionedProcessingIntegrationTests.cs
@@ -92,7 +92,13 @@ public sealed class PartitionedProcessingIntegrationTests(KafkaTestContainer kaf
 
         releaseFirstPartition.SetResult();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () => await runTask.ConfigureAwait(false));
+        try
+        {
+            await runTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+        }
 
         await Assert.That(Snapshot(processed, 0)).IsEquivalentTo([0L, 1L, 2L]);
         await Assert.That(Snapshot(processed, 1)).IsEquivalentTo([0L, 1L, 2L]);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Threading;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
@@ -20,8 +21,13 @@ public class ProducerBenchmarks
     private KafkaTestEnvironment _kafka = null!;
     private DekafProducer.IKafkaProducer<string, string> _dekafProducer = null!;
     private Confluent.Kafka.IProducer<string, string> _confluentProducer = null!;
+    private Confluent.Kafka.IProducer<string, string> _confluentFireAndForgetProducer = null!;
 
     private const string Topic = "benchmark-producer";
+    // Keep librdkafka's local queue byte-bound, not message-count-bound, during bursty fire-and-forget runs.
+    private const int ConfluentQueueBufferingMaxKbytes = 1024 * 1024;
+    private const int ConfluentQueueBufferingMaxMessages = 10_000_000;
+    private static readonly TimeSpan QueueFullRetryTimeout = TimeSpan.FromSeconds(30);
     private string _messageValue = null!;
 
     [Params(100, 1000)]
@@ -47,19 +53,29 @@ public class ProducerBenchmarks
             .BuildAsync()
             .ConfigureAwait(false);
 
-        var confluentConfig = new Confluent.Kafka.ProducerConfig
-        {
-            BootstrapServers = _kafka.BootstrapServers,
-            ClientId = "confluent-benchmark",
-            Acks = Confluent.Kafka.Acks.Leader,
-            LingerMs = 5,
-            BatchSize = 16384,
-            QueueBufferingMaxMessages = 1000000
-        };
-        _confluentProducer = new Confluent.Kafka.ProducerBuilder<string, string>(confluentConfig).Build();
+        _confluentProducer = new Confluent.Kafka.ProducerBuilder<string, string>(
+            CreateConfluentConfig("confluent-benchmark", enableDeliveryReports: true))
+            .Build();
+
+        _confluentFireAndForgetProducer = new Confluent.Kafka.ProducerBuilder<string, string>(
+            CreateConfluentConfig("confluent-benchmark-fnf", enableDeliveryReports: false))
+            .Build();
 
         await WarmupAsync().ConfigureAwait(false);
     }
+
+    private Confluent.Kafka.ProducerConfig CreateConfluentConfig(string clientId, bool enableDeliveryReports)
+        => new()
+        {
+            BootstrapServers = _kafka.BootstrapServers,
+            ClientId = clientId,
+            Acks = Confluent.Kafka.Acks.Leader,
+            LingerMs = 5,
+            BatchSize = 16384,
+            QueueBufferingMaxKbytes = ConfluentQueueBufferingMaxKbytes,
+            QueueBufferingMaxMessages = ConfluentQueueBufferingMaxMessages,
+            EnableDeliveryReports = enableDeliveryReports
+        };
 
     private async Task WarmupAsync()
     {
@@ -77,10 +93,13 @@ public class ProducerBenchmarks
                 Key = "warmup",
                 Value = "warmup"
             }).ConfigureAwait(false);
+
+            ProduceConfluentFireAndForget("warmup", "warmup");
         }
 
         await _dekafProducer.FlushAsync().ConfigureAwait(false);
         _confluentProducer.Flush(TimeSpan.FromSeconds(5));
+        _confluentFireAndForgetProducer.Flush(TimeSpan.FromSeconds(5));
     }
 
     [GlobalCleanup]
@@ -96,9 +115,11 @@ public class ProducerBenchmarks
             // Ignore flush errors during cleanup
         }
         _confluentProducer.Flush(TimeSpan.FromSeconds(60));
+        _confluentFireAndForgetProducer.Flush(TimeSpan.FromSeconds(60));
 
         await _dekafProducer.DisposeAsync().ConfigureAwait(false);
         _confluentProducer.Dispose();
+        _confluentFireAndForgetProducer.Dispose();
         await _kafka.DisposeAsync().ConfigureAwait(false);
     }
 
@@ -174,11 +195,32 @@ public class ProducerBenchmarks
     {
         for (var i = 0; i < BatchSize; i++)
         {
-            _confluentProducer.Produce(Topic, new Confluent.Kafka.Message<string, string>
+            ProduceConfluentFireAndForget($"key-{i}", _messageValue);
+        }
+    }
+
+    private void ProduceConfluentFireAndForget(string key, string value)
+    {
+        var message = new Confluent.Kafka.Message<string, string>
+        {
+            Key = key,
+            Value = value
+        };
+        var startedAt = Stopwatch.GetTimestamp();
+
+        while (true)
+        {
+            try
             {
-                Key = $"key-{i}",
-                Value = _messageValue
-            });
+                _confluentFireAndForgetProducer.Produce(Topic, message);
+                return;
+            }
+            catch (Confluent.Kafka.ProduceException<string, string> ex)
+                when (ex.Error.Code == Confluent.Kafka.ErrorCode.Local_QueueFull &&
+                      Stopwatch.GetElapsedTime(startedAt) < QueueFullRetryTimeout)
+            {
+                Thread.Sleep(1);
+            }
         }
     }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs
@@ -1,9 +1,9 @@
-using System.Diagnostics;
 using System.Threading;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;
 using Dekaf.Benchmarks.Infrastructure;
+using Dekaf.Tooling;
 using DekafProducer = Dekaf.Producer;
 
 namespace Dekaf.Benchmarks.Benchmarks.Client;
@@ -24,9 +24,6 @@ public class ProducerBenchmarks
     private Confluent.Kafka.IProducer<string, string> _confluentFireAndForgetProducer = null!;
 
     private const string Topic = "benchmark-producer";
-    // Keep librdkafka's local queue byte-bound, not message-count-bound, during bursty fire-and-forget runs.
-    private const int ConfluentQueueBufferingMaxKbytes = 1024 * 1024;
-    private const int ConfluentQueueBufferingMaxMessages = 10_000_000;
     private static readonly TimeSpan QueueFullRetryTimeout = TimeSpan.FromSeconds(30);
     private string _messageValue = null!;
 
@@ -58,24 +55,35 @@ public class ProducerBenchmarks
             .Build();
 
         _confluentFireAndForgetProducer = new Confluent.Kafka.ProducerBuilder<string, string>(
-            CreateConfluentConfig("confluent-benchmark-fnf", enableDeliveryReports: false))
+            CreateConfluentConfig(
+                "confluent-benchmark-fnf",
+                enableDeliveryReports: false,
+                queueBufferingMaxMessages: ConfluentProducerBackpressure.QueueBufferingMaxMessages))
             .Build();
 
         await WarmupAsync().ConfigureAwait(false);
     }
 
-    private Confluent.Kafka.ProducerConfig CreateConfluentConfig(string clientId, bool enableDeliveryReports)
-        => new()
+    private Confluent.Kafka.ProducerConfig CreateConfluentConfig(
+        string clientId,
+        bool enableDeliveryReports,
+        int? queueBufferingMaxMessages = null)
+    {
+        var config = new Confluent.Kafka.ProducerConfig
         {
             BootstrapServers = _kafka.BootstrapServers,
             ClientId = clientId,
             Acks = Confluent.Kafka.Acks.Leader,
             LingerMs = 5,
             BatchSize = 16384,
-            QueueBufferingMaxKbytes = ConfluentQueueBufferingMaxKbytes,
-            QueueBufferingMaxMessages = ConfluentQueueBufferingMaxMessages,
             EnableDeliveryReports = enableDeliveryReports
         };
+
+        if (queueBufferingMaxMessages is { } maxMessages)
+            config.QueueBufferingMaxMessages = maxMessages;
+
+        return config;
+    }
 
     private async Task WarmupAsync()
     {
@@ -206,22 +214,14 @@ public class ProducerBenchmarks
             Key = key,
             Value = value
         };
-        var startedAt = Stopwatch.GetTimestamp();
 
-        while (true)
-        {
-            try
-            {
-                _confluentFireAndForgetProducer.Produce(Topic, message);
-                return;
-            }
-            catch (Confluent.Kafka.ProduceException<string, string> ex)
-                when (ex.Error.Code == Confluent.Kafka.ErrorCode.Local_QueueFull &&
-                      Stopwatch.GetElapsedTime(startedAt) < QueueFullRetryTimeout)
-            {
-                Thread.Sleep(1);
-            }
-        }
+        ConfluentProducerBackpressure.ProduceWithBackpressure(
+            _confluentFireAndForgetProducer,
+            Topic,
+            message,
+            deliveryHandler: null,
+            cancellationToken: CancellationToken.None,
+            retryTimeout: QueueFullRetryTimeout);
     }
 
     [BenchmarkCategory("FireAndForget")]

--- a/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
+++ b/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="Testcontainers.Kafka" Version="4.13.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\ConfluentProducerBackpressure.cs" Link="Shared\ConfluentProducerBackpressure.cs" />
+  </ItemGroup>
+
 </Project>

--- a/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
+++ b/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
@@ -24,4 +24,8 @@
     <PackageReference Include="Testcontainers.Kafka" Version="4.13.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\ConfluentProducerBackpressure.cs" Link="Shared\ConfluentProducerBackpressure.cs" />
+  </ItemGroup>
+
 </Project>

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Dekaf.StressTests.Metrics;
+using Dekaf.Tooling;
 using ConfluentKafka = Confluent.Kafka;
 
 namespace Dekaf.StressTests.Scenarios;
@@ -18,7 +19,7 @@ internal static class ConfluentStressTestHelpers
     /// matching Dekaf's bytes-only BufferMemory regardless of --message-size (the
     /// default 100k count cap would bind first for messages under ~10 KB).
     /// </summary>
-    internal const int QueueBufferingMaxMessages = 10_000_000;
+    internal const int QueueBufferingMaxMessages = ConfluentProducerBackpressure.QueueBufferingMaxMessages;
 
     // --- Consumer fetch sizing -------------------------------------------------------------
     // Mirrors Dekaf's ConsumerBuilder.ForHighThroughput() preset (src/Dekaf/Builders.cs) so the
@@ -113,24 +114,12 @@ internal static class ConfluentStressTestHelpers
         ConfluentKafka.Message<string, string> message,
         Action<ConfluentKafka.DeliveryReport<string, string>>? deliveryHandler,
         CancellationToken cancellationToken)
-    {
-        while (true)
-        {
-            try
-            {
-                producer.Produce(topic, message, deliveryHandler);
-                return;
-            }
-            catch (ConfluentKafka.ProduceException<string, string> ex)
-                when (ex.Error.Code == ConfluentKafka.ErrorCode.Local_QueueFull)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                // The background poll thread drains the queue; a short sleep is the
-                // idiomatic librdkafka backpressure wait.
-                Thread.Sleep(1);
-            }
-        }
-    }
+        => ConfluentProducerBackpressure.ProduceWithBackpressure(
+            producer,
+            topic,
+            message,
+            deliveryHandler,
+            cancellationToken);
 
     /// <summary>
     /// Produces one message and records the full delivery round-trip into

--- a/tools/Shared/ConfluentProducerBackpressure.cs
+++ b/tools/Shared/ConfluentProducerBackpressure.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+using ConfluentKafka = Confluent.Kafka;
+
+namespace Dekaf.Tooling;
+
+internal static class ConfluentProducerBackpressure
+{
+    internal const int QueueBufferingMaxMessages = 10_000_000;
+
+    internal static void ProduceWithBackpressure(
+        ConfluentKafka.IProducer<string, string> producer,
+        string topic,
+        ConfluentKafka.Message<string, string> message,
+        Action<ConfluentKafka.DeliveryReport<string, string>>? deliveryHandler,
+        CancellationToken cancellationToken,
+        TimeSpan? retryTimeout = null)
+    {
+        var startedAt = retryTimeout.HasValue ? Stopwatch.GetTimestamp() : 0;
+
+        while (true)
+        {
+            try
+            {
+                producer.Produce(topic, message, deliveryHandler);
+                return;
+            }
+            catch (ConfluentKafka.ProduceException<string, string> ex)
+                when (ex.Error.Code == ConfluentKafka.ErrorCode.Local_QueueFull &&
+                      ShouldRetry(startedAt, retryTimeout))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                // Background poll thread drains the local queue; short sleep is librdkafka's backpressure wait.
+                Thread.Sleep(1);
+            }
+        }
+    }
+
+    private static bool ShouldRetry(long startedAt, TimeSpan? retryTimeout)
+        => !retryTimeout.HasValue || Stopwatch.GetElapsedTime(startedAt) < retryTimeout.Value;
+}


### PR DESCRIPTION
## Summary
- Use a dedicated Confluent fire-and-forget producer with delivery reports disabled.
- Raise librdkafka queue bounds so bursty benchmark loops are byte-bound, not message-count-bound.
- Retry `Local_QueueFull` with bounded 1 ms backoff instead of letting the benchmark cell become `NA`.

## Tests
- dotnet build tools/Dekaf.Benchmarks --configuration Release
- dotnet run --project tools/Dekaf.Benchmarks --configuration Release --no-build -- --filter "*ProducerBenchmarks.Confluent_FireAndForget*" *(attempted; local Windows/Testcontainers Kafka setup failed before workloads with `Failed to refresh metadata from any broker`, so no benchmark results were produced)*

Closes #1398