### PR TITLE
fix(ci): allow positive category verdicts

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -85,6 +85,7 @@ jobs:
             - When you do find an issue, suggest a concrete better approach and explain WHY it is better, not just WHAT to change.
             - Compare the current state of the PR against any previous PR comments to make sure they have been addressed.
             - Skip minor style/formatting issues unless they impact readability significantly.
+            - End the review body with exactly one literal verdict marker as the final line. Use `<!-- REVIEW_VERDICT: BLOCKING -->` if you reported any actionable issue that should block merge. Use `<!-- REVIEW_VERDICT: CLEAR -->` only when there are zero actionable findings. Do not put the marker in a code block.
             - ALWAYS post your review, even if no issues are found (acknowledge good code). You MUST post using `gh pr review --comment` before finishing, and ONLY that command. Do not also use `gh pr comment` — it posts a separate issue comment, which duplicates the review. Do not just output the review - actually post it to the PR.
 
             Use the code review skill to run this review: /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number || inputs.pr_number }}

--- a/scripts/Assert-PrGreen.ps1
+++ b/scripts/Assert-PrGreen.ps1
@@ -7,7 +7,7 @@
 #   - mergeStateStatus == CLEAN
 #   - every status check is terminal AND passing (CheckRun: status=COMPLETED and
 #     conclusion in SUCCESS/SKIPPED/NEUTRAL; StatusContext: state=SUCCESS)
-#   - no latest top-level review has actionable finding headings
+#   - no current-head top-level review has actionable finding headings
 #   - no unresolved review threads
 #
 # Any other state — pending/queued/in-progress checks, an empty rollup, a failed
@@ -40,7 +40,7 @@ $repoArgs = @()
 if ($Repo) { $repoArgs = @('--repo', $Repo) }
 
 # Re-fetch fresh — survey output goes stale within seconds.
-$raw = gh pr view $Pr @repoArgs --json number,state,mergeable,mergeStateStatus,statusCheckRollup,latestReviews 2>$null
+$raw = gh pr view $Pr @repoArgs --json number,state,mergeable,mergeStateStatus,statusCheckRollup,latestReviews,commits 2>$null
 if ($LASTEXITCODE -ne 0) { Deny "gh pr view failed (exit $LASTEXITCODE)" }
 try {
     $view = $raw | ConvertFrom-Json
@@ -85,9 +85,14 @@ if ($bad.Count -gt 0) {
     Deny ("checks not green: " + ($bad -join '; '))
 }
 
+$headCommit = @($view.commits | Where-Object { $null -ne $_ }) | Select-Object -Last 1
+$headCommittedAt = if ($headCommit) { ConvertTo-UtcDateTimeOffset $headCommit.committedDate } else { $null }
+
 # Top-level review comments are not review threads, so GitHub does not expose a
 # resolved flag for them. Fail closed on common review-finding shapes instead
-# of treating a COMMENTED review as automatically safe.
+# of treating a COMMENTED review as automatically safe. A stale Claude review
+# from before the current head commit is ignored only when the current-head
+# claude-review check completed green.
 $latestReviews = @($view.latestReviews | Where-Object { $null -ne $_ })
 $requestedChanges = @($latestReviews | Where-Object { $_.state -eq 'CHANGES_REQUESTED' })
 if ($requestedChanges.Count -gt 0) {
@@ -98,6 +103,10 @@ if ($requestedChanges.Count -gt 0) {
 $actionableReviews = @()
 foreach ($review in $latestReviews) {
     if ($review.state -ne 'COMMENTED') { continue }
+    if (Test-StaleBotReviewCanBeIgnored -Review $review -HeadCommitCommittedAt $headCommittedAt -Checks $checks) {
+        continue
+    }
+
     $body = [string]$review.body
     $reason = Get-ActionableReviewBodyReason -Body $body
     if ($reason) {

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -1,3 +1,110 @@
+function ConvertTo-UtcDateTimeOffset {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]$Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [DateTimeOffset]) {
+        return ([DateTimeOffset]$Value).ToUniversalTime()
+    }
+
+    if ($Value -is [DateTime]) {
+        return [DateTimeOffset]::new(([DateTime]$Value).ToUniversalTime())
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    try {
+        return [DateTimeOffset]::Parse($text).ToUniversalTime()
+    }
+    catch {
+        return $null
+    }
+}
+
+function Test-ReviewSubmittedBeforeInstant {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]$Review,
+        [AllowNull()]$InstantUtc
+    )
+
+    $instant = ConvertTo-UtcDateTimeOffset $InstantUtc
+    if ($null -eq $instant) {
+        return $false
+    }
+
+    $submittedAt = ConvertTo-UtcDateTimeOffset $Review.submittedAt
+    if ($null -eq $submittedAt) {
+        return $false
+    }
+
+    return $submittedAt -lt $instant
+}
+
+function Test-StatusCheckCompletedAfterInstant {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]$Checks,
+        [Parameter(Mandatory)][string]$Name,
+        [AllowNull()]$InstantUtc
+    )
+
+    $instant = ConvertTo-UtcDateTimeOffset $InstantUtc
+    if ($null -eq $instant) {
+        return $false
+    }
+
+    $allowedConclusions = @('SUCCESS', 'SKIPPED', 'NEUTRAL')
+    foreach ($check in @($Checks | Where-Object { $null -ne $_ })) {
+        if ([string]$check.name -ne $Name) {
+            continue
+        }
+
+        if (($null -ne $check.status) -and ([string]$check.status -ne 'COMPLETED')) {
+            continue
+        }
+
+        if (($null -ne $check.conclusion) -and ($allowedConclusions -notcontains [string]$check.conclusion)) {
+            continue
+        }
+
+        $completedAt = ConvertTo-UtcDateTimeOffset $check.completedAt
+        if ($null -ne $completedAt -and $completedAt -gt $instant) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Test-StaleBotReviewCanBeIgnored {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]$Review,
+        [AllowNull()]$HeadCommitCommittedAt,
+        [AllowNull()]$Checks
+    )
+
+    $author = [string]$Review.author.login
+    if ($author -notmatch '^claude(?:\[bot\])?$') {
+        return $false
+    }
+
+    if (-not (Test-ReviewSubmittedBeforeInstant -Review $Review -InstantUtc $HeadCommitCommittedAt)) {
+        return $false
+    }
+
+    return Test-StatusCheckCompletedAfterInstant -Checks $Checks -Name 'claude-review' -InstantUtc $HeadCommitCommittedAt
+}
+
 function Get-ActionableReviewBodyReason {
     [CmdletBinding()]
     param(

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -24,7 +24,7 @@ function Get-ActionableReviewBodyReason {
     $noCategoryFindings =
         '\bno\s+(?:\w+\s+){0,5}(?:bugs?|issues?|concerns?|blockers?|findings?|problems?)\b(?:\s+(?:found|detected|identified|seen|remain|remaining))?'
     $positiveVerdictBlocker =
-        '\b(?:though|that\s+said|still|incorrectly|miss(?:es|ing)?|deadlocks?|will\s+throw|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|off[- ]by[- ]one|broken|leaks?|race|corrupt(?:s|ion)?|unsafe|real\s+bug|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped))\b'
+        '\b(?:though|that\s+said|still|incorrectly|miss(?:es|ing)?|deadlocks?|will\s+throw|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|broken|leaks?|race|corrupt(?:s|ion)?|unsafe|vulnerabilit(?:y|ies)|injection|hardcoded|guessable|session\s+token|stack\s+overflow|hangs?|forever|real\s+bug|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped))\b'
     $positiveVerdictAlternatives = @(
         "$noCategoryFindings(?:[\s\S]*)?"
         'looks?\s+(?:right|good)'

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -9,9 +9,9 @@ function Get-ActionableReviewBodyReason {
     }
 
     $previouslyResolvedHeading =
-        'previously[- ]flagged\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun(?:fixed|resolved|addressed|verified|handled)\b).)*\b(?:fixed|resolved|addressed|verified)\b\s*$'
+        '(?=.{1,300}\s*$)previously[- ]flagged\b(?![^\r\n]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[^\r\n]*\b(?:fixed|resolved|addressed|verified)\b)[^\r\n]*\s*$'
     $resolvedFindingHeading =
-        '(?:(?:fix|change|commit|follow[- ]up)\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun(?:fixed|resolved|addressed|verified|handled)\b).)*\b(?:fix(?:es|ed)?|resolves?|resolved|addresses?|addressed)\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun(?:fixed|resolved|addressed|verified|handled)\b).)*\b(?:issues?|bugs?|findings?|concerns?|regressions?)|(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun(?:fixed|resolved|addressed|verified|handled)\b).)*\b(?:issues?|bugs?|findings?|concerns?|regressions?)\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun(?:fixed|resolved|addressed|verified|handled)\b).)*\b(?:fixed|resolved|addressed|verified)\b(?:\s+in\s+`?[\w]+`?)?)\s*$'
+        '(?=.{1,300}\s*$)(?![^\r\n]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[^\r\n]*\b(?:fix|fix(?:es|ed)?|change|commit|follow[- ]up|resolves?|resolved|addresses?|addressed|verified)\b)(?=[^\r\n]*\b(?:issues?|bugs?|findings?|concerns?|regressions?)\b)[^\r\n]*\s*$'
     $nonActionableHeading =
         '(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking)\b' +
         '|not\s+a\s+regression\b(?:,\s+just\s+noting\s+scope)?\s*$' +
@@ -24,10 +24,10 @@ function Get-ActionableReviewBodyReason {
     $noCategoryFindings =
         '\bno\s+(?:\w+\s+){0,5}(?:bugs?|issues?|concerns?|blockers?|findings?|problems?)\b(?:\s+(?:found|detected|identified|seen|remain|remaining))?'
     $positiveVerdictDefect =
-        '(?<!not\s)incorrect(?:ly)?|(?<!not\s)(?<!nothing\s)wrong|miss(?:es|ing)?|deadlocks?|will\s+throw|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|broken|leaks?|race|corrupt(?:s|ion)?|vulnerabilit(?:y|ies)|vulnerable|insecure|injection|hardcoded|guessable|session\s+token|stack\s+overflow|hangs?|forever|infinite\s+loop|use[- ]after[- ]free|double[- ]free|(?<!no\s)data\s+loss|silent(?:ly)?\s+drops?(?:\s+\w+){0,2}\s+messages?|real\s+bug|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped)'
+        '(?<!not\s)incorrect(?:ly)?|(?<!not\s)(?<!nothing\s)wrong|miss(?:es|ing)?|deadlocks?|will\s+throw|crash(?:es|ing|ed)?|fixme|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|will\s+allocate|allocate\s+per|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|still\s+broken|remains?\s+broken|is\s+broken|leak(?:s|ing|ed)?|race|corrupt(?:s|ion|ed|ing)?|vulnerabilit(?:y|ies)|vulnerable|insecure|injection|hardcoded|guessable|session\s+token|stack\s+overflow|hang(?:s|ing)?|forever|infinite\s+loop|use[- ]after[- ]free|double[- ]free|(?<!no\s)data\s+loss|silent(?:ly)?\s+drops?(?:\s+\w+){0,2}\s+messages?|skip(?:s|ped|ping)?\s+validation|design\s+risk|risk\s+(?:for|of)|real\s+concerns?|concerns?\s+about|(?:test\s+)?coverage\s+gap|(?<!no\s)(?<!non[- ])block(?:er|ing)|fix\s+is\s+required|required\s+fix|required\s+before|real\s+(?:bug|issue)|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped)'
     $positiveVerdictBlocker = '\b(?:' + $positiveVerdictDefect + ')\b'
     $positiveVerdictContinuationDefect =
-        "$positiveVerdictDefect|(?<!not\s+a\s)(?<!no\s)regressions?|duplicat(?:ed|es|ing|ion)|swallow(?:s|ed|ing)?"
+        "$positiveVerdictDefect|(?<!not\s+a\s)(?<!no\s)regressions?(?!\s+(?:coverage|tests?|risk))|now\s+duplicated|(?<!used\s+to\s+be\s)(?<!previously\s)duplicated\s+across|duplicates?\s+logic|duplication\s+of|swallow(?:s|ed|ing)?"
     $positiveVerdictContinuationBlocker =
         '\b(?:' + $positiveVerdictContinuationDefect + ')\b'
     $positiveVerdictAlternatives = @(
@@ -35,8 +35,8 @@ function Get-ActionableReviewBodyReason {
         'looks?\s+(?:right|good)(?:[\s\S]*)?'
         'verified(?:\s+against\b[\s\S]*)?'
         'confirmed\b(?:[\s\S]*)?'
-        '(?:[\s\S]*\b)?no\s+concerns\b(?:[\s\S]*)?'
-        '(?:[\s\S]*\b)?configureawait\(false\)(?:[\s\S]*\b)?used\s+consistently(?:[\s\S]*)?'
+        'no\s+concerns\b(?:[\s\S]*)?'
+        '`?configureawait\(false\)`?(?:[\s\S]*\b)?used\s+consistently(?:[\s\S]*)?'
         '(?:the\s+)?core\s+fix\s+is\s+(?:sound|correct)(?:[\s\S]*)?'
         'genuine\s+improvement,\s+not\s+just\s+churn(?:[\s\S]*)?'
         'fix\s+is\s+scoped(?:\s+to\b[\s\S]*)?'

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -23,8 +23,11 @@ function Get-ActionableReviewBodyReason {
     $categoryOnlyHeading = "$categoryHeadingTerm(?:$horizontalWhitespace*/$horizontalWhitespace*$categoryHeadingTerm)*"
     $noCategoryFindings =
         '\bno\s+(?:\w+\s+){0,5}(?:bugs?|issues?|concerns?|blockers?|findings?|problems?)\b(?:\s+(?:found|detected|identified|seen|remain|remaining))?'
-    $positiveVerdictBlocker =
-        '\b(?:though|that\s+said|still|incorrectly|miss(?:es|ing)?|deadlocks?|will\s+throw|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|broken|leaks?|race|corrupt(?:s|ion)?|unsafe|vulnerabilit(?:y|ies)|injection|hardcoded|guessable|session\s+token|stack\s+overflow|hangs?|forever|real\s+bug|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped))\b'
+    $positiveVerdictDefect =
+        'incorrectly|miss(?:es|ing)?|deadlocks?|will\s+throw|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|broken|leaks?|race|corrupt(?:s|ion)?|unsafe|vulnerabilit(?:y|ies)|vulnerable|insecure|injection|hardcoded|guessable|session\s+token|stack\s+overflow|hangs?|forever|real\s+bug|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped)'
+    $positiveVerdictBlocker = '\b(?:' + $positiveVerdictDefect + ')\b'
+    $positiveVerdictContinuationBlocker =
+        '\b(?:but|however|although|though|that\s+said|still)\b[\s\S]{0,400}\b(?:' + $positiveVerdictDefect + ')\b'
     $positiveVerdictAlternatives = @(
         "$noCategoryFindings(?:[\s\S]*)?"
         'looks?\s+(?:right|good)'
@@ -64,9 +67,10 @@ function Get-ActionableReviewBodyReason {
         } else {
             $sectionRemainder
         }
-        $firstParagraph = [regex]::Match($sectionBody, '(?ms)\S.*?(?:\r?\n\s*\r?\n|$)').Value
+        $firstVerdictMatch = [regex]::Match($sectionBody, '(?m)\S[^\r\n]*')
+        $firstVerdict = $firstVerdictMatch.Value.Trim()
 
-        if ([string]::IsNullOrWhiteSpace($firstParagraph)) {
+        if ([string]::IsNullOrWhiteSpace($firstVerdict)) {
             if ($headingVerdict) {
                 continue
             }
@@ -74,7 +78,13 @@ function Get-ActionableReviewBodyReason {
             return "actionable category heading: $($heading.Value.Trim())"
         }
 
-        if ($firstParagraph -notmatch $positiveCategorySection) {
+        if ($firstVerdict -notmatch $positiveCategorySection) {
+            return "actionable category heading: $($heading.Value.Trim())"
+        }
+
+        $sectionTailStart = $firstVerdictMatch.Index + $firstVerdictMatch.Length
+        $sectionTail = $sectionBody.Substring($sectionTailStart)
+        if ($sectionTail -match $positiveVerdictContinuationBlocker) {
             return "actionable category heading: $($heading.Value.Trim())"
         }
     }

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -13,7 +13,8 @@ function Get-ActionableReviewBodyReason {
     $resolvedFindingHeading =
         '(?:fix|change|commit|follow[- ]up)\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun\w+\b).)*\b(?:fix(?:es|ed)?|resolves?|resolved|addresses?|addressed)\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun\w+\b).)*\b(?:issues?|bugs?|findings?|concerns?|regressions?)\b\s*$'
     $nonActionableHeading =
-        '(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking|not\s+a\s+regression)\b' +
+        '(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking)\b' +
+        '|not\s+a\s+regression\b(?:,\s+just\s+noting\s+scope)?\s*$' +
         "|$previouslyResolvedHeading" +
         "|$resolvedFindingHeading"
     $actionableHeadingWord = 'Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Design|Leak|Leaks|Gap|Gaps|Silently|(?<!not )(?<!non-)Blocking|(?<!not )(?<!non-)Blocker|Test coverage gap|Required|Must fix'
@@ -22,9 +23,19 @@ function Get-ActionableReviewBodyReason {
     $categoryOnlyHeading = "$categoryHeadingTerm(?:$horizontalWhitespace*/$horizontalWhitespace*$categoryHeadingTerm)*"
     $noCategoryFindings =
         '\bno\s+(?:\w+\s+){0,5}(?:bugs?|issues?|concerns?|blockers?|findings?|problems?)\b(?:\s+(?:found|detected|identified|seen|remain|remaining))?'
+    $positiveVerdictBlocker =
+        '\b(?:but|however|still|incorrectly|miss(?:es|ing)?|leaks?|race|corrupt(?:s|ion)?|unsafe|real\s+bug|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped))\b'
+    $positiveVerdictAlternatives = @(
+        "$noCategoryFindings(?:[\s\S]*)?"
+        'looks?\s+(?:right|good)'
+        '(?:the\s+)?core\s+fix\s+is\s+(?:sound|correct)(?:[\s\S]*)?'
+        'genuine\s+improvement,\s+not\s+just\s+churn(?:[\s\S]*)?'
+        'fix\s+is\s+scoped(?:\s+to\b[\s\S]*)?'
+        '(?:[\s\S]*\b)?allocation[- ]free\s+helper(?:[\s\S]*)?'
+    ) -join '|'
     $positiveCategoryVerdict =
-        "$noCategoryFindings|\b(?:looks?\s+(?:right|good)|core\s+fix\s+is\s+(?:sound|correct)|genuine\s+improvement|not\s+just\s+churn|fix\s+is\s+scoped|allocation[- ]free\s+helper)\b"
-    $positiveCategoryHeadingVerdict = "$positiveCategoryVerdict|\bverified\b"
+        "(?is)^(?!.*$positiveVerdictBlocker)\s*(?:[-*]\s*)?(?:$positiveVerdictAlternatives)\.?\s*$"
+    $positiveCategoryHeadingVerdict = "$positiveCategoryVerdict|(?is)^\s*verified\b[\s\S]*$"
     $positiveCategorySection = $positiveCategoryVerdict
 
     $categoryHeadingWithOptionalVerdict = "$categoryOnlyHeading(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*\S[^\r\n#]*)|(?:$horizontalWhitespace*\([^\r\n#)]*\))|(?:$horizontalWhitespace+\S[^\r\n#]*))?:?"

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -8,15 +8,29 @@ function Get-ActionableReviewBodyReason {
         return $null
     }
 
+    $verdictMarkers = [regex]::Matches($Body, '(?im)^\s*<!--\s*REVIEW_VERDICT:\s*(CLEAR|BLOCKING)\s*-->\s*$')
+    if ($verdictMarkers.Count -gt 0) {
+        foreach ($marker in $verdictMarkers) {
+            if ($marker.Groups[1].Value -eq 'BLOCKING') {
+                return 'review verdict marker: BLOCKING'
+            }
+        }
+
+        return $null
+    }
+
     $previouslyResolvedHeading =
         '(?=.{1,300}\s*$)previously[- ]flagged\b(?![^\r\n]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[^\r\n]*\b(?:fixed|resolved|addressed|verified)\b)[^\r\n]*\s*$'
     $resolvedFindingHeading =
         '(?=.{1,300}\s*$)(?![^\r\n]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[^\r\n]*\b(?:fix|fix(?:es|ed)?|change|commit|follow[- ]up|resolves?|resolved|addresses?|addressed|verified)\b)(?=[^\r\n]*\b(?:issues?|bugs?|findings?|concerns?|regressions?)\b)[^\r\n]*\s*$'
+    $verifiedCleanHeading =
+        '(?=.{1,300}\s*$)merge\s+correctness\b(?=[^\r\n]*\bverified\s+clean\b)[^\r\n]*\s*$'
     $nonActionableHeading =
         '(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking)\b' +
         '|not\s+a\s+regression\b(?:,\s+just\s+noting\s+scope)?\s*$' +
         "|$previouslyResolvedHeading" +
-        "|$resolvedFindingHeading"
+        "|$resolvedFindingHeading" +
+        "|$verifiedCleanHeading"
     $actionableHeadingWord = 'Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Design|Leak|Leaks|Gap|Gaps|Silently|(?<!not )(?<!non-)Blocking|(?<!not )(?<!non-)Blocker|Test coverage gap|Required|Must fix'
     $horizontalWhitespace = '[^\S\r\n]'
     $categoryHeadingTerm = "(?:correctness|security|design|architecture|claude\.md$horizontalWhitespace+(?:compliance|conventions))"
@@ -24,7 +38,7 @@ function Get-ActionableReviewBodyReason {
     $noCategoryFindings =
         '\bno\s+(?:\w+\s+){0,5}(?:bugs?|issues?|concerns?|blockers?|findings?|problems?)\b(?:\s+(?:found|detected|identified|seen|remain|remaining))?'
     $positiveVerdictDefect =
-        '(?<!not\s)incorrect(?:ly)?|(?<!not\s)(?<!nothing\s)wrong|miss(?:es|ing)?|deadlocks?|will\s+throw|crash(?:es|ing|ed)?|fixme|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|will\s+allocate|allocate\s+per|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|still\s+broken|remains?\s+broken|is\s+broken|leak(?:s|ing|ed)?|race|corrupt(?:s|ion|ed|ing)?|vulnerabilit(?:y|ies)|vulnerable|insecure|injection|hardcoded|guessable|session\s+token|stack\s+overflow|hang(?:s|ing)?|forever|infinite\s+loop|use[- ]after[- ]free|double[- ]free|(?<!no\s)data\s+loss|silent(?:ly)?\s+drops?(?:\s+\w+){0,2}\s+messages?|skip(?:s|ped|ping)?\s+validation|design\s+risk|risk\s+(?:for|of)|real\s+concerns?|concerns?\s+about|(?:test\s+)?coverage\s+gap|(?<!no\s)(?<!non[- ])block(?:er|ing)|fix\s+is\s+required|required\s+fix|required\s+before|real\s+(?:bug|issue)|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped)'
+        '(?<!not\s)incorrect(?:ly)?|(?<!not\s)(?<!nothing\s)wrong|miss(?:es|ing)?|deadlocks?|will\s+throw|throws?\s+(?:an?\s+)?exception|crash(?:es|ing|ed)?|fixme|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|will\s+allocate|allocate\s+per|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|still\s+broken|remains?\s+broken|is\s+broken|leak(?:s|ing|ed)?|never\s+disposed|not\s+disposed|race|corrupt(?:s|ion|ed|ing)?|vulnerabilit(?:y|ies)|vulnerable|insecure|injection|hardcoded|guessable|session\s+token|expos(?:es|ed|ing)?\s+(?:credentials?|secrets?|tokens?)|stack\s+overflow|hang(?:s|ing)?|forever|infinite\s+loop|use[- ]after[- ]free|double[- ]free|double[- ]charges?|not\s+idempotent|(?<!no\s)data\s+loss|silent(?:ly)?\s+drops?(?:\s+\w+){0,2}\s+messages?|skip(?:s|ped|ping)?\s+validation|design\s+risk|risk\s+(?:for|of)|real\s+concerns?|concerns?\s+about|(?:test\s+)?coverage\s+gap|(?<!no\s)(?<!non[- ])block(?:er|ing)|fix\s+is\s+required|required\s+fix|required\s+before|real\s+(?:bug|issue)|edge\s+case|go(?:es|ing)?\s+stale|stale\s+(?:cache|entry)|never\s+refresh|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped)'
     $positiveVerdictBlocker = '\b(?:' + $positiveVerdictDefect + ')\b'
     $positiveVerdictContinuationDefect =
         "$positiveVerdictDefect|(?<!not\s+a\s)(?<!no\s)regressions?(?!\s+(?:coverage|tests?|risk))|now\s+duplicated|(?<!used\s+to\s+be\s)(?<!previously\s)duplicated\s+across|duplicates?\s+logic|duplication\s+of|swallow(?:s|ed|ing)?"

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -24,12 +24,12 @@ function Get-ActionableReviewBodyReason {
     $noCategoryFindings =
         '\bno\s+(?:\w+\s+){0,5}(?:bugs?|issues?|concerns?|blockers?|findings?|problems?)\b(?:\s+(?:found|detected|identified|seen|remain|remaining))?'
     $positiveVerdictDefect =
-        'incorrectly|miss(?:es|ing)?|deadlocks?|will\s+throw|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|broken|leaks?|race|corrupt(?:s|ion)?|vulnerabilit(?:y|ies)|vulnerable|insecure|injection|hardcoded|guessable|session\s+token|stack\s+overflow|hangs?|forever|real\s+bug|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped)'
+        '(?<!not\s)incorrect(?:ly)?|(?<!not\s)(?<!nothing\s)wrong|miss(?:es|ing)?|deadlocks?|will\s+throw|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|broken|leaks?|race|corrupt(?:s|ion)?|vulnerabilit(?:y|ies)|vulnerable|insecure|injection|hardcoded|guessable|session\s+token|stack\s+overflow|hangs?|forever|infinite\s+loop|use[- ]after[- ]free|double[- ]free|(?<!no\s)data\s+loss|silent(?:ly)?\s+drops?(?:\s+\w+){0,2}\s+messages?|real\s+bug|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped)'
     $positiveVerdictBlocker = '\b(?:' + $positiveVerdictDefect + ')\b'
     $positiveVerdictContinuationDefect =
         "$positiveVerdictDefect|(?<!not\s+a\s)(?<!no\s)regressions?|duplicat(?:ed|es|ing|ion)|swallow(?:s|ed|ing)?"
     $positiveVerdictContinuationBlocker =
-        '\b(?:but|however|although|though|that\s+said|still)\b[\s\S]{0,400}\b(?:' + $positiveVerdictContinuationDefect + ')\b'
+        '\b(?:' + $positiveVerdictContinuationDefect + ')\b'
     $positiveVerdictAlternatives = @(
         "$noCategoryFindings(?:[\s\S]*)?"
         'looks?\s+(?:right|good)(?:[\s\S]*)?'

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -10,16 +10,37 @@ function Get-ActionableReviewBodyReason {
 
     $previouslyResolvedHeading =
         'previously[- ]flagged\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun\w+\b).)*\b(?:fixed|resolved|addressed|verified)\b\s*$'
+    $resolvedFindingHeading =
+        '(?:fix|change|commit|follow[- ]up)\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun\w+\b).)*\b(?:fix(?:es|ed)?|resolves?|resolved|addresses?|addressed)\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun\w+\b).)*\b(?:issues?|bugs?|findings?|concerns?|regressions?)\b\s*$'
     $nonActionableHeading =
-        '(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking)\b' +
-        "|$previouslyResolvedHeading"
+        '(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking|not\s+a\s+regression)\b' +
+        "|$previouslyResolvedHeading" +
+        "|$resolvedFindingHeading"
     $actionableHeadingWord = 'Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Design|Leak|Leaks|Gap|Gaps|Silently|(?<!not )(?<!non-)Blocking|(?<!not )(?<!non-)Blocker|Test coverage gap|Required|Must fix'
-    $categoryOnlyHeading = '(?:correctness|design|architecture)(?:\s*/\s*(?:correctness|design|architecture))*'
-    $positiveCategorySection =
+    $horizontalWhitespace = '[^\S\r\n]'
+    $categoryHeadingTerm = "(?:correctness|security|design|architecture|claude\.md$horizontalWhitespace+(?:compliance|conventions))"
+    $categoryOnlyHeading = "$categoryHeadingTerm(?:$horizontalWhitespace*/$horizontalWhitespace*$categoryHeadingTerm)*"
+    $noCategoryFindings =
         '\bno\s+(?:\w+\s+){0,5}(?:bugs?|issues?|concerns?|blockers?|findings?|problems?)\b(?:\s+(?:found|detected|identified|seen|remain|remaining))?'
+    $positiveCategoryVerdict =
+        "$noCategoryFindings|\b(?:looks?\s+(?:right|good)|core\s+fix\s+is\s+(?:sound|correct)|genuine\s+improvement|not\s+just\s+churn|fix\s+is\s+scoped|allocation[- ]free\s+helper)\b"
+    $positiveCategoryHeadingVerdict = "$positiveCategoryVerdict|\bverified\b"
+    $positiveCategorySection = $positiveCategoryVerdict
 
-    $categoryHeadingPattern = "(?im)^\s*#{2,4}\s+($categoryOnlyHeading)\s*:?\s*$"
+    $categoryHeadingWithOptionalVerdict = "$categoryOnlyHeading(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*\S[^\r\n#]*)|(?:$horizontalWhitespace*\([^\r\n#)]*\))|(?:$horizontalWhitespace+\S[^\r\n#]*))?:?"
+    $categoryHeadingPattern = "(?im)^$horizontalWhitespace*#{2,4}$horizontalWhitespace+($categoryOnlyHeading)(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*(?<verdict>\S[^\r\n#]*))|(?:$horizontalWhitespace*\((?<parentheticalVerdict>[^)\r\n#]+)\))|(?:$horizontalWhitespace+(?<bareVerdict>\S[^\r\n#]*)))?:?$horizontalWhitespace*\r?$"
     foreach ($heading in [regex]::Matches($Body, $categoryHeadingPattern)) {
+        $headingVerdict = if ($heading.Groups['verdict'].Success) {
+            $heading.Groups['verdict'].Value
+        } elseif ($heading.Groups['bareVerdict'].Success) {
+            $heading.Groups['bareVerdict'].Value
+        } else {
+            $heading.Groups['parentheticalVerdict'].Value
+        }
+        if ($headingVerdict -and $headingVerdict -notmatch $positiveCategoryHeadingVerdict) {
+            return "actionable category heading: $($heading.Value.Trim())"
+        }
+
         $sectionStart = $heading.Index + $heading.Length
         $sectionRemainder = $Body.Substring($sectionStart)
         $nextHeading = [regex]::Match($sectionRemainder, '(?m)^\s*#{2,4}\s+')
@@ -30,7 +51,7 @@ function Get-ActionableReviewBodyReason {
         }
         $firstParagraph = [regex]::Match($sectionBody, '(?ms)\S.*?(?:\r?\n\s*\r?\n|$)').Value
 
-        if ($firstParagraph -notmatch $positiveCategorySection) {
+        if (-not $headingVerdict -and $firstParagraph -notmatch $positiveCategorySection) {
             return "actionable category heading: $($heading.Value.Trim())"
         }
     }
@@ -38,7 +59,7 @@ function Get-ActionableReviewBodyReason {
     $patterns = @(
         @{
             Reason = 'actionable heading'
-            Pattern = "(?im)^\s*#{2,4}\s+(?!$nonActionableHeading)(?!$categoryOnlyHeading\s*:?\s*$).*\b($actionableHeadingWord)\b"
+            Pattern = "(?im)^\s*#{2,4}\s+(?!$nonActionableHeading)(?!$categoryHeadingWithOptionalVerdict\s*$).*\b($actionableHeadingWord)\b"
         },
         @{
             Reason = 'numbered finding heading'

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -9,9 +9,9 @@ function Get-ActionableReviewBodyReason {
     }
 
     $previouslyResolvedHeading =
-        'previously[- ]flagged\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun\w+\b).)*\b(?:fixed|resolved|addressed|verified)\b\s*$'
+        'previously[- ]flagged\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun(?:fixed|resolved|addressed|verified|handled)\b).)*\b(?:fixed|resolved|addressed|verified)\b\s*$'
     $resolvedFindingHeading =
-        '(?:fix|change|commit|follow[- ]up)\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun\w+\b).)*\b(?:fix(?:es|ed)?|resolves?|resolved|addresses?|addressed)\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun\w+\b).)*\b(?:issues?|bugs?|findings?|concerns?|regressions?)\b\s*$'
+        '(?:(?:fix|change|commit|follow[- ]up)\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun(?:fixed|resolved|addressed|verified|handled)\b).)*\b(?:fix(?:es|ed)?|resolves?|resolved|addresses?|addressed)\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun(?:fixed|resolved|addressed|verified|handled)\b).)*\b(?:issues?|bugs?|findings?|concerns?|regressions?)|(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun(?:fixed|resolved|addressed|verified|handled)\b).)*\b(?:issues?|bugs?|findings?|concerns?|regressions?)\b(?:(?!\bnot\b|\bnever\b|\bstill\b|\bun(?:fixed|resolved|addressed|verified|handled)\b).)*\b(?:fixed|resolved|addressed|verified)\b(?:\s+in\s+`?[\w]+`?)?)\s*$'
     $nonActionableHeading =
         '(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking)\b' +
         '|not\s+a\s+regression\b(?:,\s+just\s+noting\s+scope)?\s*$' +
@@ -24,10 +24,14 @@ function Get-ActionableReviewBodyReason {
     $noCategoryFindings =
         '\bno\s+(?:\w+\s+){0,5}(?:bugs?|issues?|concerns?|blockers?|findings?|problems?)\b(?:\s+(?:found|detected|identified|seen|remain|remaining))?'
     $positiveVerdictBlocker =
-        '\b(?:but|however|still|incorrectly|miss(?:es|ing)?|leaks?|race|corrupt(?:s|ion)?|unsafe|real\s+bug|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped))\b'
+        '\b(?:though|that\s+said|still|incorrectly|miss(?:es|ing)?|deadlocks?|will\s+throw|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|off[- ]by[- ]one|broken|leaks?|race|corrupt(?:s|ion)?|unsafe|real\s+bug|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped))\b'
     $positiveVerdictAlternatives = @(
         "$noCategoryFindings(?:[\s\S]*)?"
         'looks?\s+(?:right|good)'
+        'verified(?:\s+against\b[\s\S]*)?'
+        'confirmed\b(?:[\s\S]*)?'
+        '(?:[\s\S]*\b)?no\s+concerns\b(?:[\s\S]*)?'
+        '(?:[\s\S]*\b)?configureawait\(false\)(?:[\s\S]*\b)?used\s+consistently(?:[\s\S]*)?'
         '(?:the\s+)?core\s+fix\s+is\s+(?:sound|correct)(?:[\s\S]*)?'
         'genuine\s+improvement,\s+not\s+just\s+churn(?:[\s\S]*)?'
         'fix\s+is\s+scoped(?:\s+to\b[\s\S]*)?'
@@ -35,7 +39,7 @@ function Get-ActionableReviewBodyReason {
     ) -join '|'
     $positiveCategoryVerdict =
         "(?is)^(?!.*$positiveVerdictBlocker)\s*(?:[-*]\s*)?(?:$positiveVerdictAlternatives)\.?\s*$"
-    $positiveCategoryHeadingVerdict = "$positiveCategoryVerdict|(?is)^\s*verified\b[\s\S]*$"
+    $positiveCategoryHeadingVerdict = $positiveCategoryVerdict
     $positiveCategorySection = $positiveCategoryVerdict
 
     $categoryHeadingWithOptionalVerdict = "$categoryOnlyHeading(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*\S[^\r\n#]*)|(?:$horizontalWhitespace*\([^\r\n#)]*\))|(?:$horizontalWhitespace+\S[^\r\n#]*))?:?"
@@ -62,7 +66,15 @@ function Get-ActionableReviewBodyReason {
         }
         $firstParagraph = [regex]::Match($sectionBody, '(?ms)\S.*?(?:\r?\n\s*\r?\n|$)').Value
 
-        if (-not $headingVerdict -and $firstParagraph -notmatch $positiveCategorySection) {
+        if ([string]::IsNullOrWhiteSpace($firstParagraph)) {
+            if ($headingVerdict) {
+                continue
+            }
+
+            return "actionable category heading: $($heading.Value.Trim())"
+        }
+
+        if ($firstParagraph -notmatch $positiveCategorySection) {
             return "actionable category heading: $($heading.Value.Trim())"
         }
     }

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -24,13 +24,15 @@ function Get-ActionableReviewBodyReason {
     $noCategoryFindings =
         '\bno\s+(?:\w+\s+){0,5}(?:bugs?|issues?|concerns?|blockers?|findings?|problems?)\b(?:\s+(?:found|detected|identified|seen|remain|remaining))?'
     $positiveVerdictDefect =
-        'incorrectly|miss(?:es|ing)?|deadlocks?|will\s+throw|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|broken|leaks?|race|corrupt(?:s|ion)?|unsafe|vulnerabilit(?:y|ies)|vulnerable|insecure|injection|hardcoded|guessable|session\s+token|stack\s+overflow|hangs?|forever|real\s+bug|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped)'
+        'incorrectly|miss(?:es|ing)?|deadlocks?|will\s+throw|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|broken|leaks?|race|corrupt(?:s|ion)?|vulnerabilit(?:y|ies)|vulnerable|insecure|injection|hardcoded|guessable|session\s+token|stack\s+overflow|hangs?|forever|real\s+bug|edge\s+case|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped)'
     $positiveVerdictBlocker = '\b(?:' + $positiveVerdictDefect + ')\b'
+    $positiveVerdictContinuationDefect =
+        "$positiveVerdictDefect|(?<!not\s+a\s)(?<!no\s)regressions?|duplicat(?:ed|es|ing|ion)|swallow(?:s|ed|ing)?"
     $positiveVerdictContinuationBlocker =
-        '\b(?:but|however|although|though|that\s+said|still)\b[\s\S]{0,400}\b(?:' + $positiveVerdictDefect + ')\b'
+        '\b(?:but|however|although|though|that\s+said|still)\b[\s\S]{0,400}\b(?:' + $positiveVerdictContinuationDefect + ')\b'
     $positiveVerdictAlternatives = @(
         "$noCategoryFindings(?:[\s\S]*)?"
-        'looks?\s+(?:right|good)'
+        'looks?\s+(?:right|good)(?:[\s\S]*)?'
         'verified(?:\s+against\b[\s\S]*)?'
         'confirmed\b(?:[\s\S]*)?'
         '(?:[\s\S]*\b)?no\s+concerns\b(?:[\s\S]*)?'
@@ -38,10 +40,10 @@ function Get-ActionableReviewBodyReason {
         '(?:the\s+)?core\s+fix\s+is\s+(?:sound|correct)(?:[\s\S]*)?'
         'genuine\s+improvement,\s+not\s+just\s+churn(?:[\s\S]*)?'
         'fix\s+is\s+scoped(?:\s+to\b[\s\S]*)?'
-        '(?:[\s\S]*\b)?allocation[- ]free\s+helper(?:[\s\S]*)?'
+        '(?:[\s\S]*\b)?allocation[- ]free(?:[\s\S]*)?'
     ) -join '|'
     $positiveCategoryVerdict =
-        "(?is)^(?!.*$positiveVerdictBlocker)\s*(?:[-*]\s*)?(?:$positiveVerdictAlternatives)\.?\s*$"
+        "(?is)^(?!.*$positiveVerdictBlocker)(?!.*$positiveVerdictContinuationBlocker)\s*(?:[-*]\s*)?(?:$positiveVerdictAlternatives)\.?\s*$"
     $positiveCategoryHeadingVerdict = $positiveCategoryVerdict
     $positiveCategorySection = $positiveCategoryVerdict
 

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -245,6 +245,44 @@ Nice allocation-free helper, but it is not thread-safe and will corrupt the buff
         Blocks = $true
     },
     @{
+        Name = 'blocks no-bugs heading followed by though deadlocks'
+        Body = @'
+## Review
+
+### Correctness - no bugs found, though the retry path deadlocks under high load.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks no-bugs paragraph followed by exception'
+        Body = @'
+## Review
+
+### Correctness
+No bugs found. That said, this will throw a NullReferenceException whenever the batch is empty.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks looks-good heading with actionable paragraph'
+        Body = @'
+## Review
+
+### Correctness - looks good
+This introduces a deadlock when Flush and Dispose run concurrently, since both take the same lock without a timeout.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks verified heading followed by blocker text'
+        Body = @'
+## Review
+
+### Correctness - verified, still broken and leaks a connection on every retry
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'blocks category parenthetical finding'
         Body = @'
 ## Review
@@ -357,6 +395,17 @@ The new commit avoids the unsafe queue path.
         Blocks = $false
     },
     @{
+        Name = 'allows regression fixed in commit heading'
+        Body = @'
+## Review
+
+### Self-triggering `UnknownTopicOrPartition` regression (from review #1) - fixed in `bb0f437f`
+
+The regression is covered.
+'@
+        Blocks = $false
+    },
+    @{
         Name = 'blocks previously flagged issue still not fixed'
         Body = @'
 ## Review
@@ -390,6 +439,34 @@ The finding remains open.
         Blocks = $true
     }
 )
+
+$positivePrefixes = @(
+    'No bugs found.'
+    'The core fix is sound:'
+    'Looks good.'
+    'Verified against code.'
+)
+$actionableContinuations = @(
+    'Though the retry path deadlocks under high load.'
+    'That said, this throws a NullReferenceException when the batch is empty.'
+    'But the hot path boxes the partition key per record.'
+    'However, the new index math has an off-by-one error.'
+)
+
+for ($prefixIndex = 0; $prefixIndex -lt $positivePrefixes.Count; $prefixIndex++) {
+    for ($continuationIndex = 0; $continuationIndex -lt $actionableContinuations.Count; $continuationIndex++) {
+        $cases += @{
+            Name = "blocks generated positive prefix $prefixIndex with actionable continuation $continuationIndex"
+            Body = @"
+## Review
+
+### Correctness
+$($positivePrefixes[$prefixIndex]) $($actionableContinuations[$continuationIndex])
+"@
+            Blocks = $true
+        }
+    }
+}
 
 foreach ($case in $cases) {
     $reason = Get-ActionableReviewBodyReason -Body $case.Body

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -283,6 +283,53 @@ This introduces a deadlock when Flush and Dispose run concurrently, since both t
         Blocks = $true
     },
     @{
+        Name = 'blocks confirmed heading followed by security vulnerability'
+        Body = @'
+## Review
+
+### Correctness - confirmed, but this exposes a SQL injection vulnerability in the query builder.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks no-problems paragraph with hardcoded token'
+        Body = @'
+## Review
+
+### Correctness
+No problems found here, although this uses a hardcoded, guessable session token.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks confirmed correct with stack overflow'
+        Body = @'
+## Review
+
+### Correctness - confirmed correct, but there is a stack overflow with deeply nested input.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks no-issues heading with hangs forever'
+        Body = @'
+## Review
+
+### Correctness - no issues found, however this hangs forever if the queue is empty.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks allocation noun in positive design section'
+        Body = @'
+## Review
+
+### Design
+Genuine improvement, not just churn. However this violates the zero-allocation rule with a per-message array allocation.
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'blocks category parenthetical finding'
         Body = @'
 ## Review

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -489,6 +489,108 @@ No issues found, though this silently swallows the exception.
         Blocks = $true
     },
     @{
+        Name = 'blocks positive heading verdict followed by design risk'
+        Body = @'
+## Review
+
+### Correctness - Looks good, though this is a design risk for concurrent readers.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks positive heading verdict followed by release blocker'
+        Body = @'
+## Review
+
+### Correctness - Looks good, but this is a blocker for release.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks positive heading verdict followed by coverage gap'
+        Body = @'
+## Review
+
+### Correctness - No issues found, but this leaves a test coverage gap.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks positive paragraph followed by FIXME crash'
+        Body = @'
+## Review
+
+### Correctness
+Looks good overall and the refactor is clean.
+FIXME this crashes on empty input.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks trailing no-concerns after finding'
+        Body = @'
+## Review
+
+### Correctness
+This skips validation entirely for negative offsets, no concerns.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks leaking inflection after positive opener'
+        Body = @'
+## Review
+
+### Correctness
+No bugs found, though the connection pool is leaking sockets under load.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks allocate base verb after positive opener'
+        Body = @'
+## Review
+
+### Correctness
+No bugs found, but this will allocate per message in the hot path.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks hanging inflection after positive opener'
+        Body = @'
+## Review
+
+### Correctness
+No bugs found, but the shutdown path is hanging under cancellation.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'allows live protocol clean review shape'
+        Body = @'
+## Review
+
+### Correctness / Security
+No bugs found. `ValidateReadableLength` is invoked before every allocation site touched by this PR, including branches that previously had no bounds check at all. Confirmed the boundary condition is correct and there is no overflow risk.
+
+### Design / CLAUDE.md compliance
+`ValidateReadableLength` is a small, allocation-free helper reused consistently across every call site.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows live admin compliance clean review shape'
+        Body = @'
+## Review
+
+### CLAUDE.md compliance
+- `ConfigureAwait(false)` is used consistently on all new/modified `await` calls in `src/`.
+- This is admin/control-plane code, not a hot path per the project's performance guidelines, so the zero-allocation rules don't apply here — no concerns.
+'@
+        Blocks = $false
+    },
+    @{
         Name = 'blocks category parenthetical finding'
         Body = @'
 ## Review
@@ -645,6 +747,12 @@ The finding remains open.
         Blocks = $true
     }
 )
+
+$cases += @{
+    Name = 'blocks long resolved-like heading without catastrophic backtracking'
+    Body = "## Review`n`n### $(('x' * 54000)) issue fixed"
+    Blocks = $true
+}
 
 $positivePrefixes = @(
     'No bugs found.'

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -197,6 +197,54 @@ No outstanding issues.
         Blocks = $false
     },
     @{
+        Name = 'blocks positive phrase followed by incorrect scope'
+        Body = @'
+## Review
+
+### Correctness - fix is scoped incorrectly, still misses the edge case for empty batches
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks genuine improvement followed by race'
+        Body = @'
+## Review
+
+### Design / Architecture
+Genuine improvement in the abstraction, but this introduces a new race condition when two threads call Dispose concurrently.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks sound fix followed by leak'
+        Body = @'
+## Review
+
+### Correctness
+The core fix is sound for the happy path, but it leaks a socket on the cancellation branch.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks allocation-free helper followed by unsafe text'
+        Body = @'
+## Review
+
+### Design / CLAUDE.md compliance
+Nice allocation-free helper, but it is not thread-safe and will corrupt the buffer under concurrent access.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks not-a-regression heading with real bug'
+        Body = @'
+## Review
+
+### Not a regression, but this is a real bug that leaks memory
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'blocks category parenthetical finding'
         Body = @'
 ## Review

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -330,6 +330,39 @@ Genuine improvement, not just churn. However this violates the zero-allocation r
         Blocks = $true
     },
     @{
+        Name = 'blocks multiline bullet after no-bugs opener'
+        Body = @'
+## Review
+
+### Correctness
+- No bugs found.
+- However, this hangs forever if the queue is empty.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks later paragraph after positive opener'
+        Body = @'
+## Review
+
+### Design / Architecture
+Genuine improvement, not just churn.
+
+But this introduces a new race condition when two threads call Dispose concurrently.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks vulnerable adjective'
+        Body = @'
+## Review
+
+### Correctness
+No bugs found, but this code is vulnerable to a timing attack.
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'blocks category parenthetical finding'
         Body = @'
 ## Review

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -277,6 +277,89 @@ No bugs found. That said, this will throw a NullReferenceException whenever the 
         Blocks = $true
     },
     @{
+        Name = 'blocks no-bugs paragraph followed by leak without connector'
+        Body = @'
+## Review
+
+### Correctness
+No bugs found.
+This leaks a socket on the retry path.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks looks-good paragraph followed by deadlock without connector'
+        Body = @'
+## Review
+
+### Correctness
+Looks good.
+
+The retry path deadlocks under high load.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks wrong after positive opener'
+        Body = @'
+## Review
+
+### Correctness
+No issues found, however this uses the wrong offset for negative timestamps.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks use-after-free after positive opener'
+        Body = @'
+## Review
+
+### Correctness
+No issues found. This creates a use-after-free when the callback runs late.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks double free after positive opener'
+        Body = @'
+## Review
+
+### Correctness
+No bugs found. The cleanup path can double free the native handle.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks infinite loop after positive opener'
+        Body = @'
+## Review
+
+### Correctness
+Looks good. The parser enters an infinite loop on empty varints.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks silently drops messages after positive opener'
+        Body = @'
+## Review
+
+### Correctness
+No concerns. The producer silently drops messages after a retriable timeout.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks data loss after positive opener'
+        Body = @'
+## Review
+
+### Correctness
+No problems found. This creates data loss when compaction is enabled.
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'blocks looks-good heading with actionable paragraph'
         Body = @'
 ## Review

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -875,4 +875,74 @@ foreach ($case in $cases) {
     }
 }
 
-Write-Host "OK review heuristic tests passed ($($cases.Count) cases)."
+$staleReviewCases = @(
+    @{
+        Name = 'ignores stale Claude review after current-head review check'
+        Review = [pscustomobject]@{
+            submittedAt = '2026-07-06T01:13:33Z'
+            author = [pscustomobject]@{ login = 'claude' }
+        }
+        HeadCommitCommittedAt = '2026-07-06T01:39:24Z'
+        Checks = @([pscustomobject]@{
+            name = 'claude-review'
+            status = 'COMPLETED'
+            conclusion = 'SUCCESS'
+            completedAt = '2026-07-06T01:40:48Z'
+        })
+        Ignored = $true
+    },
+    @{
+        Name = 'keeps stale Claude review before current-head review check'
+        Review = [pscustomobject]@{
+            submittedAt = '2026-07-06T01:13:33Z'
+            author = [pscustomobject]@{ login = 'claude' }
+        }
+        HeadCommitCommittedAt = '2026-07-06T01:39:24Z'
+        Checks = @([pscustomobject]@{
+            name = 'claude-review'
+            status = 'COMPLETED'
+            conclusion = 'SUCCESS'
+            completedAt = '2026-07-06T01:20:00Z'
+        })
+        Ignored = $false
+    },
+    @{
+        Name = 'keeps human stale review'
+        Review = [pscustomobject]@{
+            submittedAt = '2026-07-06T01:13:33Z'
+            author = [pscustomobject]@{ login = 'alice' }
+        }
+        HeadCommitCommittedAt = '2026-07-06T01:39:24Z'
+        Checks = @([pscustomobject]@{
+            name = 'claude-review'
+            status = 'COMPLETED'
+            conclusion = 'SUCCESS'
+            completedAt = '2026-07-06T01:40:48Z'
+        })
+        Ignored = $false
+    },
+    @{
+        Name = 'keeps current Claude review'
+        Review = [pscustomobject]@{
+            submittedAt = '2026-07-06T01:41:00Z'
+            author = [pscustomobject]@{ login = 'claude[bot]' }
+        }
+        HeadCommitCommittedAt = '2026-07-06T01:39:24Z'
+        Checks = @([pscustomobject]@{
+            name = 'claude-review'
+            status = 'COMPLETED'
+            conclusion = 'SUCCESS'
+            completedAt = '2026-07-06T01:40:48Z'
+        })
+        Ignored = $false
+    }
+)
+
+foreach ($case in $staleReviewCases) {
+    $ignored = Test-StaleBotReviewCanBeIgnored -Review $case.Review -HeadCommitCommittedAt $case.HeadCommitCommittedAt -Checks $case.Checks
+    if ($ignored -ne $case.Ignored) {
+        throw "Case '$($case.Name)' expected Ignored=$($case.Ignored), got Ignored=$ignored"
+    }
+}
+
+Write-Host "OK review heuristic tests passed ($($cases.Count) body cases, $($staleReviewCases.Count) stale review cases)."

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -85,6 +85,30 @@ No blocking issues.
         Blocks = $false
     },
     @{
+        Name = 'allows positive category heading verdict'
+        Body = @"
+## Review
+
+### Correctness $([char]0x2014) looks right
+- The core fix is correct.
+
+No blocking issues found.
+"@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows verified category heading parenthetical'
+        Body = @'
+## Review
+
+### Correctness (verified against code, not just description)
+- Confirmed the fix runs outside the lock.
+
+No blocking issues found.
+'@
+        Blocks = $false
+    },
+    @{
         Name = 'allows positive category section heading with colon'
         Body = @'
 ## Review
@@ -93,6 +117,114 @@ No blocking issues.
 No issues found.
 '@
         Blocks = $false
+    },
+    @{
+        Name = 'allows positive correctness section with sound fix'
+        Body = @'
+## Review
+
+### Correctness
+The core fix is sound: the guard now checks the right invariant.
+
+No blocking issues.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows positive category heading verdict with colon'
+        Body = @'
+## Review
+
+### Correctness: No issues found.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows positive category heading bare verdict'
+        Body = @'
+## Review
+
+### Correctness / Security No bugs found.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows positive design architecture paragraph'
+        Body = @'
+## Review
+
+### Design / Architecture
+Genuine improvement, not just churn: this removes duplicate shim code.
+
+No blocking issues.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows positive design conventions paragraph'
+        Body = @'
+## Review
+
+### Design / CLAUDE.md conventions
+- Fix is scoped to only the paths that needed it.
+
+No blocking issues.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows positive design compliance paragraph'
+        Body = @'
+## Review
+
+### Design / CLAUDE.md compliance
+- Fix is scoped to only the paths that needed it.
+
+No blocking issues.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows allocation-free design compliance paragraph'
+        Body = @'
+## Review
+
+### Design / CLAUDE.md compliance
+`ValidateReadableLength` is a small, allocation-free helper reused consistently.
+
+No outstanding issues.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'blocks category parenthetical finding'
+        Body = @'
+## Review
+
+### Correctness (pool resize drops cached items)
+This needs a fix.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks category bare finding'
+        Body = @'
+## Review
+
+### Correctness / Security leaks buffers
+This needs a fix.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks design conventions finding'
+        Body = @'
+## Review
+
+### Design / CLAUDE.md conventions
+This introduces a broad abstraction that should be fixed.
+'@
+        Blocks = $true
     },
     @{
         Name = 'blocks category section heading with finding body'
@@ -134,6 +266,17 @@ Minor/optional, not blocking:
         Blocks = $false
     },
     @{
+        Name = 'allows not a regression heading'
+        Body = @'
+## Review
+
+### Not a regression, just noting scope
+
+This matches pre-PR behavior.
+'@
+        Blocks = $false
+    },
+    @{
         Name = 'allows numbered non-blocking heading'
         Body = @'
 ## Review
@@ -155,11 +298,33 @@ The prior findings are now resolved.
         Blocks = $false
     },
     @{
+        Name = 'allows fix resolves issue heading'
+        Body = @'
+## Review
+
+### Fix in `62546f5` resolves the concurrency issue
+
+The new commit avoids the unsafe queue path.
+'@
+        Blocks = $false
+    },
+    @{
         Name = 'blocks previously flagged issue still not fixed'
         Body = @'
 ## Review
 
 ### Previously-flagged issue - still not fixed
+
+The finding remains open.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks fix still not resolving issue heading'
+        Body = @'
+## Review
+
+### Fix still does not resolve the concurrency issue
 
 The finding remains open.
 '@

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -197,6 +197,19 @@ No outstanding issues.
         Blocks = $false
     },
     @{
+        Name = 'allows clean unsafe and allocation wording'
+        Body = @'
+## Review
+
+### Correctness
+Looks good. Verified the unsafe pointer arithmetic in KafkaProtocolReader does not allocate.
+
+### Design / CLAUDE.md compliance
+This is still allocation-free and keeps the existing unsafe fast path unchanged.
+'@
+        Blocks = $false
+    },
+    @{
         Name = 'blocks positive phrase followed by incorrect scope'
         Body = @'
 ## Review
@@ -359,6 +372,36 @@ But this introduces a new race condition when two threads call Dispose concurren
 
 ### Correctness
 No bugs found, but this code is vulnerable to a timing attack.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks regression after positive opener'
+        Body = @'
+## Review
+
+### Correctness
+No concerns here, but this is a regression from the previous behavior.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks duplicated logic after positive opener'
+        Body = @'
+## Review
+
+### Correctness
+No bugs found, but the retry logic is now duplicated across three call sites.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks swallowed exception after positive opener'
+        Body = @'
+## Review
+
+### Correctness
+No issues found, though this silently swallows the exception.
 '@
         Blocks = $true
     },

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -64,6 +64,30 @@ Scope check passed.
         Blocks = $false
     },
     @{
+        Name = 'allows explicit clear verdict marker'
+        Body = @'
+## Review
+
+### Correctness
+Legacy prose can mention scary words without blocking when the review posts the
+machine-readable all-clear marker.
+
+<!-- REVIEW_VERDICT: CLEAR -->
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'blocks explicit blocking verdict marker'
+        Body = @'
+## Review
+
+No issues found.
+
+<!-- REVIEW_VERDICT: BLOCKING -->
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'allows positive category section headings'
         Body = @'
 ## Review
@@ -567,6 +591,56 @@ No bugs found, but the shutdown path is hanging under cancellation.
         Blocks = $true
     },
     @{
+        Name = 'blocks non-idempotent positive opener finding'
+        Body = @'
+## Review
+
+### Correctness
+Looks good, but the retry logic is not idempotent and can double-charge.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks never-disposed positive opener finding'
+        Body = @'
+## Review
+
+### Correctness
+Looks good, but the connection is never disposed.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks throws-exception positive opener finding'
+        Body = @'
+## Review
+
+### Correctness
+No issues found, but this throws an exception on empty input.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks credential-exposure positive opener finding'
+        Body = @'
+## Review
+
+### Correctness
+Looks good, but this exposes credentials in the log output.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks stale-cache positive opener finding'
+        Body = @'
+## Review
+
+### Correctness
+No bugs found. The cache entry can go stale and never refresh.
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'allows live protocol clean review shape'
         Body = @'
 ## Review
@@ -699,6 +773,17 @@ The prior findings are now resolved.
 ### Fix in `62546f5` resolves the concurrency issue
 
 The new commit avoids the unsafe queue path.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows merge correctness verified clean heading'
+        Body = @'
+## Review
+
+### Merge correctness — verified clean
+
+Conflict resolution kept both feature sets.
 '@
         Blocks = $false
     },


### PR DESCRIPTION
Fixes #1418.

Changes:
- Route category headings with optional verdict suffixes through the category-specific review heuristic.
- Allow explicit positive/all-clear category verdicts like `Correctness — looks right`, `Correctness (verified...)`, `Correctness: No issues found`, `Correctness / Security No bugs found`, and positive section text like `The core fix is sound`, `Genuine improvement, not just churn`, `Fix is scoped...`, and `allocation-free helper`.
- Allow resolved-review headings like `Fix ... resolves the ... issue` and explicitly non-regression scope notes.
- Keep blocking category headings whose suffix or first paragraph is not an explicit positive verdict, and keep blocking unresolved/still-not-fixed forms.

Validation:
- `pwsh scripts/Test-AssertPrGreenReviewHeuristics.ps1`
- Live latest review bodies for #1409, #1333, #1406, #1405, #1404, and #1403 now return no actionable reason from `Get-ActionableReviewBodyReason`.