### PR TITLE
feat(consumer): add manual offset store

### DIFF
--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -845,6 +845,7 @@ internal static class DekafOptionsBinding
             builder.WithClientRack(options.ClientRack);
         builder.WithOffsetCommitMode(options.OffsetCommitMode);
         builder.WithAutoCommitInterval(TimeSpan.FromMilliseconds(options.AutoCommitIntervalMs));
+        builder.WithAutoOffsetStore(options.EnableAutoOffsetStore);
         if (options.AutoOffsetReset == AutoOffsetReset.ByDuration)
             builder.WithAutoOffsetResetByDuration(options.AutoOffsetResetDuration ?? TimeSpan.Zero);
         else
@@ -1133,6 +1134,8 @@ internal static class DekafConfigurationBinding
             builder.WithOffsetCommitMode(offsetCommitMode);
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.AutoCommitIntervalMs), out var autoCommitIntervalMs))
             builder.WithAutoCommitInterval(TimeSpan.FromMilliseconds(autoCommitIntervalMs));
+        if (TryGetValue<bool>(configuration, nameof(ConsumerOptions.EnableAutoOffsetStore), out var enableAutoOffsetStore))
+            builder.WithAutoOffsetStore(enableAutoOffsetStore);
         if (TryGetAutoOffsetReset(configuration, out var autoOffsetReset, out var autoOffsetResetDuration))
         {
             if (autoOffsetReset == AutoOffsetReset.ByDuration)

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -301,7 +301,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         ThrowIfDisposed();
 
         lock (_gate)
-            CommitCurrentOffsets();
+            CommitStoredOffsets();
 
         return ValueTask.CompletedTask;
     }
@@ -398,7 +398,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         {
             var partition = new TopicPartition(offset.Topic, offset.Partition);
             _positions[partition] = offset.Offset;
-            _storedOffsets[partition] = offset.Offset;
+            if (_options.EnableAutoOffsetStore)
+                _storedOffsets[partition] = offset.Offset;
         }
     }
 
@@ -413,7 +414,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             {
                 var position = _cluster.GetWatermarks(partition).Low;
                 _positions[partition] = position;
-                _storedOffsets[partition] = position;
+                if (_options.EnableAutoOffsetStore)
+                    _storedOffsets[partition] = position;
             }
         }
     }
@@ -429,7 +431,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             {
                 var position = _cluster.GetWatermarks(partition).High;
                 _positions[partition] = position;
-                _storedOffsets[partition] = position;
+                if (_options.EnableAutoOffsetStore)
+                    _storedOffsets[partition] = position;
             }
         }
     }
@@ -662,9 +665,6 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     private void CommitStoredOffsets()
         => CommitOffsetsFrom(_storedOffsets);
-
-    private void CommitCurrentOffsets()
-        => CommitOffsetsFrom(_positions);
 
     private void CommitOffsetsFrom(Dictionary<TopicPartition, long> positions)
     {

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -25,6 +25,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private readonly HashSet<TopicPartition> _assignment = [];
     private readonly HashSet<TopicPartition> _paused = [];
     private readonly Dictionary<TopicPartition, long> _positions = [];
+    private readonly Dictionary<TopicPartition, long> _storedOffsets = [];
     private readonly string? _memberId;
     private string? _subscriptionPattern;
     private bool _disposed;
@@ -206,6 +207,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _assignment.Clear();
             _paused.Clear();
             _positions.Clear();
+            _storedOffsets.Clear();
             UnregisterConsumerGroupMemberUnderLock();
         }
     }
@@ -318,6 +320,27 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         return ValueTask.CompletedTask;
     }
 
+    public void StoreOffset(ConsumeResult<TKey, TValue> result)
+    {
+        ThrowIfDisposed();
+        if (result.IsPartitionEof)
+            return;
+
+        StoreOffset(new TopicPartitionOffset(
+            result.Topic,
+            result.Partition,
+            checked(result.Offset + 1),
+            result.LeaderEpoch ?? -1));
+    }
+
+    public void StoreOffset(TopicPartitionOffset offset)
+    {
+        ThrowIfDisposed();
+
+        lock (_gate)
+            _storedOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
+    }
+
     public ValueTask CloseAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -331,7 +354,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 return ValueTask.CompletedTask;
 
             if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
-                CommitCurrentOffsets();
+                CommitStoredOffsets();
 
             UnregisterConsumerGroupMemberUnderLock();
             _disposed = true;
@@ -372,7 +395,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         ThrowIfDisposed();
 
         lock (_gate)
-            _positions[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
+        {
+            var partition = new TopicPartition(offset.Topic, offset.Partition);
+            _positions[partition] = offset.Offset;
+            _storedOffsets[partition] = offset.Offset;
+        }
     }
 
     public void SeekToBeginning(params TopicPartition[] partitions)
@@ -383,7 +410,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         lock (_gate)
         {
             foreach (var partition in SelectTargetPartitions(partitions))
-                _positions[partition] = _cluster.GetWatermarks(partition).Low;
+            {
+                var position = _cluster.GetWatermarks(partition).Low;
+                _positions[partition] = position;
+                _storedOffsets[partition] = position;
+            }
         }
     }
 
@@ -395,7 +426,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         lock (_gate)
         {
             foreach (var partition in SelectTargetPartitions(partitions))
-                _positions[partition] = _cluster.GetWatermarks(partition).High;
+            {
+                var position = _cluster.GetWatermarks(partition).High;
+                _positions[partition] = position;
+                _storedOffsets[partition] = position;
+            }
         }
     }
 
@@ -422,6 +457,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _assignment.Clear();
             _paused.Clear();
             _positions.Clear();
+            _storedOffsets.Clear();
             UnregisterConsumerGroupMemberUnderLock();
         }
     }
@@ -457,6 +493,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 _assignment.Remove(partition);
                 _paused.Remove(partition);
                 _positions.Remove(partition);
+                _storedOffsets.Remove(partition);
             }
 
             RegisterConsumerGroupMemberUnderLock();
@@ -538,8 +575,10 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 selected = record;
                 selectedPartition = partition;
                 _positions[partition] = record.Offset + 1;
+                if (_options.EnableAutoOffsetStore)
+                    _storedOffsets[partition] = record.Offset + 1;
                 if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
-                    CommitCurrentOffsets();
+                    CommitStoredOffsets();
                 break;
             }
         }
@@ -581,6 +620,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         _assignment.Clear();
         _paused.Clear();
         _positions.Clear();
+        _storedOffsets.Clear();
 
         foreach (var (partition, position) in nextPositions)
         {
@@ -620,13 +660,19 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         return match.Success && match.Index == 0 && match.Length == topic.Length;
     }
 
+    private void CommitStoredOffsets()
+        => CommitOffsetsFrom(_storedOffsets);
+
     private void CommitCurrentOffsets()
+        => CommitOffsetsFrom(_positions);
+
+    private void CommitOffsetsFrom(Dictionary<TopicPartition, long> positions)
     {
         if (_options.GroupId is null)
             return;
 
         var assignment = GetCurrentAssignmentUnderLock();
-        var offsets = _positions
+        var offsets = positions
             .Where(item => assignment.Contains(item.Key))
             .Select(item => new TopicPartitionOffset(
                 item.Key.Topic,

--- a/src/Dekaf.Testing/InMemoryConsumerOptions.cs
+++ b/src/Dekaf.Testing/InMemoryConsumerOptions.cs
@@ -28,6 +28,12 @@ public sealed class InMemoryConsumerOptions
     public OffsetCommitMode OffsetCommitMode { get; init; } = OffsetCommitMode.Auto;
 
     /// <summary>
+    /// Automatically stores each consumed message's next offset for auto-commit.
+    /// Disable to call <c>StoreOffset</c> after processing succeeds.
+    /// </summary>
+    public bool EnableAutoOffsetStore { get; init; } = true;
+
+    /// <summary>
     /// Member ID reported by the fake consumer.
     /// </summary>
     public string? MemberId { get; init; }

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1145,6 +1145,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private string? _clientRack;
     private OffsetCommitMode _offsetCommitMode = OffsetCommitMode.Auto;
     private int _autoCommitIntervalMs = 5000;
+    private bool _enableAutoOffsetStore = true;
     private AutoOffsetReset _autoOffsetReset = AutoOffsetReset.Latest;
     private TimeSpan? _autoOffsetResetDuration;
     private int _fetchMinBytes = 1;
@@ -1337,6 +1338,17 @@ public sealed class ConsumerBuilder<TKey, TValue>
     public ConsumerBuilder<TKey, TValue> WithOffsetCommitMode(OffsetCommitMode mode)
     {
         _offsetCommitMode = mode;
+        return this;
+    }
+
+    /// <summary>
+    /// Controls whether consumed offsets are stored automatically for background auto-commit.
+    /// Disable this and call <see cref="IKafkaConsumer{TKey,TValue}.StoreOffset(ConsumeResult{TKey,TValue})"/>
+    /// after processing succeeds to get Confluent-style manual offset store with auto-commit.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithAutoOffsetStore(bool enabled = true)
+    {
+        _enableAutoOffsetStore = enabled;
         return this;
     }
 
@@ -2184,6 +2196,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             ClientRack = _clientRack,
             OffsetCommitMode = _offsetCommitMode,
             AutoCommitIntervalMs = _autoCommitIntervalMs,
+            EnableAutoOffsetStore = _enableAutoOffsetStore,
             AutoOffsetReset = _autoOffsetReset,
             AutoOffsetResetDuration = _autoOffsetResetDuration,
             FetchMinBytes = _fetchMinBytes,

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -77,6 +77,13 @@ public sealed class ConsumerOptions
     public int AutoCommitIntervalMs { get; init; } = 5000;
 
     /// <summary>
+    /// Automatically stores each consumed message's next offset for auto-commit.
+    /// Disable to call <c>StoreOffset</c> after processing succeeds while keeping
+    /// automatic background commits enabled.
+    /// </summary>
+    public bool EnableAutoOffsetStore { get; init; } = true;
+
+    /// <summary>
     /// Auto offset reset behavior.
     /// </summary>
     public AutoOffsetReset AutoOffsetReset { get; init; } = AutoOffsetReset.Latest;

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -141,6 +141,18 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     ValueTask CommitAsync(IEnumerable<TopicPartitionOffset> offsets, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Stores the consumed message's next offset for the automatic commit loop.
+    /// Use with <see cref="ConsumerOptions.EnableAutoOffsetStore"/> disabled to store offsets only
+    /// after message processing succeeds.
+    /// </summary>
+    void StoreOffset(ConsumeResult<TKey, TValue> result);
+
+    /// <summary>
+    /// Stores an offset for the automatic commit loop.
+    /// </summary>
+    void StoreOffset(TopicPartitionOffset offset);
+
+    /// <summary>
     /// Gracefully closes the consumer: stops background tasks (heartbeat, auto-commit, prefetch),
     /// notifies <see cref="IPartitionStopListener"/> when configured, commits pending offsets,
     /// leaves the consumer group, and releases resources.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -642,8 +642,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     //   a single fetch using a stale position before being updated by the next operation.
     //   Adding locks would defeat the purpose of lock-free consumption.
     private readonly ConcurrentDictionary<TopicPartition, long> _positions = new();      // Consumed position (what app has seen)
-    private readonly ConcurrentDictionary<TopicPartition, long> _dirtyPositions = new(); // Consumed positions changed since last successful commit
-    private readonly ConcurrentDictionary<TopicPartition, long> _storedOffsets = new();  // Offsets staged for auto-commit
+    private readonly ConcurrentDictionary<TopicPartition, long> _storedOffsets = new();  // Offsets staged for commit
     private readonly ConcurrentDictionary<TopicPartition, long> _dirtyStoredOffsets = new(); // Stored offsets changed since last successful commit
     private readonly ConcurrentDictionary<TopicPartition, int> _storedOffsetLeaderEpochs = new();
     private readonly ConcurrentDictionary<TopicPartition, long> _fetchPositions = new(); // Fetch position (what to fetch next)
@@ -2371,12 +2370,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _positions[partition] = position;
         if (dirty)
         {
-            _dirtyPositions[partition] = position;
-            StoreOffsetCore(partition, position, GetLastConsumedLeaderEpoch(partition));
+            if (_options.EnableAutoOffsetStore)
+                StoreOffsetCore(partition, position, GetLastConsumedLeaderEpoch(partition));
         }
         else
         {
-            _dirtyPositions.TryRemove(partition, out _);
             ClearStoredOffset(partition);
         }
     }
@@ -2385,7 +2383,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         _positions[partition] = position;
         SetLastConsumedLeaderEpoch(partition, leaderEpoch);
-        _dirtyPositions[partition] = position;
         if (_options.EnableAutoOffsetStore)
             StoreOffsetCore(partition, position, leaderEpoch);
     }
@@ -2424,11 +2421,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _lastConsumedLeaderEpochs.TryRemove(partition, out _);
     }
 
-    private void ClearDirtyPositionIfCommitted(TopicPartition partition, long committedOffset)
-    {
-        _dirtyPositions.TryRemove(new KeyValuePair<TopicPartition, long>(partition, committedOffset));
-    }
-
     private void ClearDirtyStoredOffsetIfCommitted(TopicPartition partition, long committedOffset)
     {
         _dirtyStoredOffsets.TryRemove(new KeyValuePair<TopicPartition, long>(partition, committedOffset));
@@ -2437,7 +2429,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private void MarkOffsetCommitted(TopicPartition partition, long committedOffset)
     {
         _committed[partition] = committedOffset;
-        ClearDirtyPositionIfCommitted(partition, committedOffset);
         ClearDirtyStoredOffsetIfCommitted(partition, committedOffset);
     }
 
@@ -2813,15 +2804,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private async ValueTask CommitStoredOffsetsAsync(CancellationToken cancellationToken)
     {
-        await CommitDirtyOffsetsAsync(_dirtyStoredOffsets.ToArray(), GetStoredOffsetLeaderEpoch, cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    private async ValueTask CommitDirtyOffsetsAsync(
-        KeyValuePair<TopicPartition, long>[] dirtyOffsetsSnapshot,
-        Func<TopicPartition, int> getLeaderEpoch,
-        CancellationToken cancellationToken)
-    {
         if (_coordinator is null)
             return;
 
@@ -2831,6 +2813,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             // Commit only offsets that changed since the last successful commit.
             // Snapshot the concurrent dictionary to avoid race conditions during enumeration
+            var dirtyOffsetsSnapshot = _dirtyStoredOffsets.ToArray();
             offsetCount = dirtyOffsetsSnapshot.Length;
             if (offsetCount == 0)
                 return;
@@ -2848,7 +2831,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         kvp.Key.Topic,
                         kvp.Key.Partition,
                         kvp.Value,
-                        getLeaderEpoch(kvp.Key));
+                        GetStoredOffsetLeaderEpoch(kvp.Key));
                 }
 
                 // Create array segment to pass only the used portion
@@ -3038,7 +3021,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         foreach (var partition in partitions)
         {
             _positions.TryRemove(partition, out _);
-            _dirtyPositions.TryRemove(partition, out _);
             ClearStoredOffset(partition);
             _fetchPositions.TryRemove(partition, out _);
             _lastConsumedLeaderEpochs.TryRemove(partition, out _);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -642,7 +642,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     //   a single fetch using a stale position before being updated by the next operation.
     //   Adding locks would defeat the purpose of lock-free consumption.
     private readonly ConcurrentDictionary<TopicPartition, long> _positions = new();      // Consumed position (what app has seen)
-    private readonly ConcurrentDictionary<TopicPartition, long> _dirtyPositions = new(); // Positions changed since last successful commit
+    private readonly ConcurrentDictionary<TopicPartition, long> _dirtyPositions = new(); // Consumed positions changed since last successful commit
+    private readonly ConcurrentDictionary<TopicPartition, long> _storedOffsets = new();  // Offsets staged for auto-commit
+    private readonly ConcurrentDictionary<TopicPartition, long> _dirtyStoredOffsets = new(); // Stored offsets changed since last successful commit
+    private readonly ConcurrentDictionary<TopicPartition, int> _storedOffsetLeaderEpochs = new();
     private readonly ConcurrentDictionary<TopicPartition, long> _fetchPositions = new(); // Fetch position (what to fetch next)
     // Last consumed record-batch leader epoch, sent as FetchRequest.LastFetchedEpoch.
     private readonly ConcurrentDictionary<TopicPartition, int> _lastConsumedLeaderEpochs = new();
@@ -2303,8 +2306,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (!TryGetConsumedPosition(pending, out var tp, out var nextOffset, out var leaderEpoch))
             return;
 
-        SetPosition(tp, nextOffset, dirty: true);
-        SetLastConsumedLeaderEpoch(tp, leaderEpoch);
+        RecordConsumedPosition(tp, nextOffset, leaderEpoch);
 
         if (!_prefetchEnabled)
         {
@@ -2320,8 +2322,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var pending = _pendingFetches.Peek();
         if (TryGetConsumedPosition(pending, out var tp, out var nextOffset, out var leaderEpoch))
         {
-            SetPosition(tp, nextOffset, dirty: true);
-            SetLastConsumedLeaderEpoch(tp, leaderEpoch);
+            RecordConsumedPosition(tp, nextOffset, leaderEpoch);
         }
     }
 
@@ -2369,9 +2370,42 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         _positions[partition] = position;
         if (dirty)
+        {
             _dirtyPositions[partition] = position;
+            StoreOffsetCore(partition, position, GetLastConsumedLeaderEpoch(partition));
+        }
         else
+        {
             _dirtyPositions.TryRemove(partition, out _);
+            ClearStoredOffset(partition);
+        }
+    }
+
+    private void RecordConsumedPosition(TopicPartition partition, long position, int leaderEpoch)
+    {
+        _positions[partition] = position;
+        SetLastConsumedLeaderEpoch(partition, leaderEpoch);
+        _dirtyPositions[partition] = position;
+        if (_options.EnableAutoOffsetStore)
+            StoreOffsetCore(partition, position, leaderEpoch);
+    }
+
+    private void StoreOffsetCore(TopicPartition partition, long offset, int leaderEpoch)
+    {
+        _storedOffsets[partition] = offset;
+        _dirtyStoredOffsets[partition] = offset;
+
+        if (leaderEpoch >= 0)
+            _storedOffsetLeaderEpochs[partition] = leaderEpoch;
+        else
+            _storedOffsetLeaderEpochs.TryRemove(partition, out _);
+    }
+
+    private void ClearStoredOffset(TopicPartition partition)
+    {
+        _storedOffsets.TryRemove(partition, out _);
+        _dirtyStoredOffsets.TryRemove(partition, out _);
+        _storedOffsetLeaderEpochs.TryRemove(partition, out _);
     }
 
     private void SetLastConsumedLeaderEpoch(TopicPartition partition, int leaderEpoch)
@@ -2395,10 +2429,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _dirtyPositions.TryRemove(new KeyValuePair<TopicPartition, long>(partition, committedOffset));
     }
 
+    private void ClearDirtyStoredOffsetIfCommitted(TopicPartition partition, long committedOffset)
+    {
+        _dirtyStoredOffsets.TryRemove(new KeyValuePair<TopicPartition, long>(partition, committedOffset));
+    }
+
     private void MarkOffsetCommitted(TopicPartition partition, long committedOffset)
     {
         _committed[partition] = committedOffset;
         ClearDirtyPositionIfCommitted(partition, committedOffset);
+        ClearDirtyStoredOffsetIfCommitted(partition, committedOffset);
     }
 
     private void UpdateFetchPositionsFromPrefetch(PendingFetchData pending)
@@ -2767,6 +2807,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (_options.OffsetCommitMode == OffsetCommitMode.Manual)
             FlushActiveConsumedPosition();
 
+        await CommitStoredOffsetsAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async ValueTask CommitStoredOffsetsAsync(CancellationToken cancellationToken)
+    {
+        await CommitDirtyOffsetsAsync(_dirtyStoredOffsets.ToArray(), GetStoredOffsetLeaderEpoch, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async ValueTask CommitDirtyOffsetsAsync(
+        KeyValuePair<TopicPartition, long>[] dirtyOffsetsSnapshot,
+        Func<TopicPartition, int> getLeaderEpoch,
+        CancellationToken cancellationToken)
+    {
         if (_coordinator is null)
             return;
 
@@ -2774,10 +2829,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int offsetCount;
 
         {
-            // Commit only positions that changed since the last successful commit.
+            // Commit only offsets that changed since the last successful commit.
             // Snapshot the concurrent dictionary to avoid race conditions during enumeration
-            var dirtyPositionsSnapshot = _dirtyPositions.ToArray();
-            offsetCount = dirtyPositionsSnapshot.Length;
+            offsetCount = dirtyOffsetsSnapshot.Length;
             if (offsetCount == 0)
                 return;
 
@@ -2788,13 +2842,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             try
             {
                 int index = 0;
-                foreach (var kvp in dirtyPositionsSnapshot)
+                foreach (var kvp in dirtyOffsetsSnapshot)
                 {
                     offsetsArray[index++] = new TopicPartitionOffset(
                         kvp.Key.Topic,
                         kvp.Key.Partition,
                         kvp.Value,
-                        GetLastConsumedLeaderEpoch(kvp.Key));
+                        getLeaderEpoch(kvp.Key));
                 }
 
                 // Create array segment to pass only the used portion
@@ -2839,6 +2893,23 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         InvokeOnCommitInterceptors(offsetsList);
     }
 
+    public void StoreOffset(ConsumeResult<TKey, TValue> result)
+    {
+        if (result.IsPartitionEof)
+            return;
+
+        StoreOffset(new TopicPartitionOffset(
+            result.Topic,
+            result.Partition,
+            checked(result.Offset + 1),
+            result.LeaderEpoch ?? -1));
+    }
+
+    public void StoreOffset(TopicPartitionOffset offset)
+    {
+        StoreOffsetCore(new TopicPartition(offset.Topic, offset.Partition), offset.Offset, offset.LeaderEpoch);
+    }
+
     public async ValueTask<long?> GetCommittedOffsetAsync(TopicPartition partition, CancellationToken cancellationToken = default)
     {
         if (_committed.TryGetValue(partition, out var offset))
@@ -2867,8 +2938,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (_options.OffsetCommitMode == OffsetCommitMode.Manual
             && TryGetActiveConsumedPosition(partition, out var activePosition, out var leaderEpoch))
         {
-            SetPosition(partition, activePosition, dirty: true);
-            SetLastConsumedLeaderEpoch(partition, leaderEpoch);
+            RecordConsumedPosition(partition, activePosition, leaderEpoch);
             return activePosition;
         }
 
@@ -2910,11 +2980,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         LogSeek(offset.Topic, offset.Partition, offset.Offset);
         var tp = new TopicPartition(offset.Topic, offset.Partition);
         // Update positions (thread-safe with ConcurrentDictionary)
-        SetPosition(tp, offset.Offset, dirty: true);
         if (offset.LeaderEpoch >= 0)
             SetLastConsumedLeaderEpoch(tp, offset.LeaderEpoch);
         else
             ClearLastConsumedLeaderEpoch(tp);
+        SetPosition(tp, offset.Offset, dirty: true);
         _fetchPositions[tp] = offset.Offset;
 
         // Reset EOF state for this partition so it can fire again
@@ -2927,8 +2997,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Update positions (thread-safe with ConcurrentDictionary)
         foreach (var partition in partitions)
         {
-            SetPosition(partition, 0, dirty: true);
             ClearLastConsumedLeaderEpoch(partition);
+            SetPosition(partition, 0, dirty: true);
             _fetchPositions[partition] = 0;
         }
 
@@ -2945,8 +3015,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Update positions (thread-safe with ConcurrentDictionary)
         foreach (var partition in partitions)
         {
-            SetPosition(partition, -1, dirty: true); // Special value meaning end
             ClearLastConsumedLeaderEpoch(partition);
+            SetPosition(partition, -1, dirty: true); // Special value meaning end
             _fetchPositions[partition] = -1; // Special value meaning end
         }
 
@@ -2969,6 +3039,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             _positions.TryRemove(partition, out _);
             _dirtyPositions.TryRemove(partition, out _);
+            ClearStoredOffset(partition);
             _fetchPositions.TryRemove(partition, out _);
             _lastConsumedLeaderEpochs.TryRemove(partition, out _);
             _committed.TryRemove(partition, out _);
@@ -4412,6 +4483,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private int GetLastConsumedLeaderEpoch(TopicPartition partition) =>
         _lastConsumedLeaderEpochs.GetValueOrDefault(partition, -1);
 
+    private int GetStoredOffsetLeaderEpoch(TopicPartition partition) =>
+        _storedOffsetLeaderEpochs.GetValueOrDefault(partition, -1);
+
     private void ThrowPendingFetchException()
     {
         if (_pendingFetchExceptions.TryDequeue(out var exception))
@@ -4927,7 +5001,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 if (_coordinator is null || _coordinator.State != CoordinatorState.Stable)
                     continue;
 
-                await CommitAsync(cancellationToken).ConfigureAwait(false);
+                await CommitStoredOffsetsAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -4939,7 +5013,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 try
                 {
                     await Task.Delay(200, cancellationToken).ConfigureAwait(false);
-                    await CommitAsync(cancellationToken).ConfigureAwait(false);
+                    await CommitStoredOffsetsAsync(cancellationToken).ConfigureAwait(false);
                 }
                 catch { /* Best effort — will retry on next interval */ }
             }
@@ -5013,13 +5087,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var partitionStopCancellation = await InvokePartitionStopListenerAsync(cancellationToken).ConfigureAwait(false);
 
         // Step 6: Commit pending offsets (if auto-commit enabled and we have a coordinator)
-        if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null && !_dirtyPositions.IsEmpty)
+        if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null && !_dirtyStoredOffsets.IsEmpty)
         {
             for (var attempt = 0; attempt < 3; attempt++)
             {
                 try
                 {
-                    await CommitAsync(cancellationToken).ConfigureAwait(false);
+                    await CommitStoredOffsetsAsync(cancellationToken).ConfigureAwait(false);
                     LogCommittedPendingOffsets();
                     break;
                 }

--- a/tests/Dekaf.Tests.Integration/PartitionedProcessingIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/PartitionedProcessingIntegrationTests.cs
@@ -92,7 +92,13 @@ public sealed class PartitionedProcessingIntegrationTests(KafkaTestContainer kaf
 
         releaseFirstPartition.SetResult();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () => await runTask.ConfigureAwait(false));
+        try
+        {
+            await runTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+        }
 
         await Assert.That(Snapshot(processed, 0)).IsEquivalentTo([0L, 1L, 2L]);
         await Assert.That(Snapshot(processed, 1)).IsEquivalentTo([0L, 1L, 2L]);

--- a/tests/Dekaf.Tests.Integration/StoreOffsetTests.cs
+++ b/tests/Dekaf.Tests.Integration/StoreOffsetTests.cs
@@ -452,4 +452,73 @@ public class OffsetCommitModeTests(KafkaTestContainer kafka) : KafkaIntegrationT
             await Assert.That(committedValue!.Value).IsGreaterThanOrEqualTo(3);
         }
     }
+
+    [Test]
+    public async Task OffsetCommitMode_Auto_WithManualOffsetStore_CommitsOnlyStoredOffset()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        var groupId = $"test-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        for (var i = 0; i < 3; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = $"key-{i}",
+                Value = $"value-{i}"
+            }, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-consumer")
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithAutoCommitInterval(TimeSpan.FromMilliseconds(100))
+            .WithSessionTimeout(TimeSpan.FromMilliseconds(10000))
+            .WithOffsetCommitMode(OffsetCommitMode.Auto)
+            .WithAutoOffsetStore(false)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var consumeCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var first = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), consumeCts.Token).ConfigureAwait(false);
+        var second = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), consumeCts.Token).ConfigureAwait(false);
+
+        await Assert.That(first).IsNotNull();
+        await Assert.That(second).IsNotNull();
+        consumer.StoreOffset(first!.Value);
+
+        var tp = new TopicPartition(topic, 0);
+        using var commitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        long? committedOffset = null;
+        while (!commitCts.Token.IsCancellationRequested)
+        {
+            try
+            {
+                var committed = await consumer.GetCommittedOffsetAsync(tp).ConfigureAwait(false);
+                if (committed is not null)
+                {
+                    committedOffset = committed;
+                    break;
+                }
+            }
+            catch (IOException ex)
+            {
+                TestContext.Current?.OutputWriter?.WriteLine($"Manual offset store polling: IOException caught, retrying: {ex.Message}");
+            }
+
+            await Task.Delay(100).ConfigureAwait(false);
+        }
+
+        await Assert.That(committedOffset).IsEqualTo(1);
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -157,6 +157,26 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task WithAutoOffsetStore_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+        var result = builder.WithAutoOffsetStore(false);
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithAutoOffsetStore_DisablesOption()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithAutoOffsetStore(false)
+            .Build();
+
+        var options = GetConsumerOptions(consumer);
+        await Assert.That(options.EnableAutoOffsetStore).IsFalse();
+    }
+
+    [Test]
     public async Task WithAutoOffsetReset_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateConsumer<string, string>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -193,6 +193,36 @@ public sealed class ConsumerDirtyCommitTests
         ]);
     }
 
+    [Test]
+    [Arguments("Seek")]
+    [Arguments("SeekToBeginning")]
+    [Arguments("SeekToEnd")]
+    public async Task CommitAsync_WhenAutoOffsetStoreDisabled_DoesNotCommitSeekedPositionUntilStored(string seekOperation)
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            OffsetCommitMode.Manual,
+            enableAutoOffsetStore: false);
+        var partition = new TopicPartition("topic-a", 0);
+
+        ApplySeek(consumer, seekOperation, partition);
+
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(requests).IsEmpty();
+
+        consumer.StoreOffset(new TopicPartitionOffset("topic-a", 0, 10, leaderEpoch: 3));
+
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(GetCommittedOffsets(requests.Single())).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 0, 10, leaderEpoch: 3)
+        ]);
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer(
         List<OffsetCommitRequest> requests,
         ErrorCode responseError,
@@ -260,6 +290,27 @@ public sealed class ConsumerDirtyCommitTests
             BindingFlags.NonPublic | BindingFlags.Instance)!;
 
         method.Invoke(consumer, [partition, position, dirty]);
+    }
+
+    private static void ApplySeek(
+        KafkaConsumer<string, string> consumer,
+        string seekOperation,
+        TopicPartition partition)
+    {
+        switch (seekOperation)
+        {
+            case "Seek":
+                consumer.Seek(new TopicPartitionOffset(partition.Topic, partition.Partition, 10, leaderEpoch: 3));
+                break;
+            case "SeekToBeginning":
+                consumer.SeekToBeginning(partition);
+                break;
+            case "SeekToEnd":
+                consumer.SeekToEnd(partition);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(seekOperation), seekOperation, null);
+        }
     }
 
     private static void RecordConsumedPosition(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -109,14 +109,106 @@ public sealed class ConsumerDirtyCommitTests
         await Assert.That(partition.CommittedLeaderEpoch).IsEqualTo(7);
     }
 
-    private static KafkaConsumer<string, string> CreateConsumer(
-        List<OffsetCommitRequest> requests,
-        ErrorCode responseError)
-        => CreateConsumer(requests, new Queue<ErrorCode>([responseError]));
+    [Test]
+    public async Task StoreOffset_AutoCommit_CommitsNextOffset()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            OffsetCommitMode.Auto,
+            enableAutoOffsetStore: false);
+
+        consumer.StoreOffset(CreateConsumeResult(offset: 41, leaderEpoch: 7));
+
+        await CommitStoredOffsetsAsync(consumer);
+
+        await Assert.That(GetCommittedOffsets(requests.Single())).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 0, 42, leaderEpoch: 7)
+        ]);
+    }
+
+    [Test]
+    public async Task AutoCommit_WhenAutoOffsetStoreDisabled_DoesNotCommitConsumedPosition()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            OffsetCommitMode.Auto,
+            enableAutoOffsetStore: false);
+
+        RecordConsumedPosition(consumer, new TopicPartition("topic-a", 0), 10, leaderEpoch: 3);
+
+        await CommitStoredOffsetsAsync(consumer);
+
+        await Assert.That(requests).IsEmpty();
+    }
+
+    [Test]
+    public async Task AutoCommit_WhenAutoOffsetStoreEnabled_CommitsConsumedPosition()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            OffsetCommitMode.Auto,
+            enableAutoOffsetStore: true);
+
+        RecordConsumedPosition(consumer, new TopicPartition("topic-a", 0), 10, leaderEpoch: 3);
+
+        await CommitStoredOffsetsAsync(consumer);
+
+        await Assert.That(GetCommittedOffsets(requests.Single())).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 0, 10, leaderEpoch: 3)
+        ]);
+    }
+
+    [Test]
+    public async Task CommitAsync_WhenAutoOffsetStoreDisabled_CommitsOnlyStoredOffset()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            OffsetCommitMode.Manual,
+            enableAutoOffsetStore: false);
+        var partition = new TopicPartition("topic-a", 0);
+
+        RecordConsumedPosition(consumer, partition, 10, leaderEpoch: 3);
+
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(requests).IsEmpty();
+
+        consumer.StoreOffset(new TopicPartitionOffset("topic-a", 0, 10, leaderEpoch: 3));
+
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(GetCommittedOffsets(requests.Single())).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 0, 10, leaderEpoch: 3)
+        ]);
+    }
 
     private static KafkaConsumer<string, string> CreateConsumer(
         List<OffsetCommitRequest> requests,
-        Queue<ErrorCode> responseErrors)
+        ErrorCode responseError,
+        OffsetCommitMode offsetCommitMode = OffsetCommitMode.Manual,
+        bool enableAutoOffsetStore = true)
+        => CreateConsumer(
+            requests,
+            new Queue<ErrorCode>([responseError]),
+            offsetCommitMode,
+            enableAutoOffsetStore);
+
+    private static KafkaConsumer<string, string> CreateConsumer(
+        List<OffsetCommitRequest> requests,
+        Queue<ErrorCode> responseErrors,
+        OffsetCommitMode offsetCommitMode = OffsetCommitMode.Manual,
+        bool enableAutoOffsetStore = true)
     {
         var connectionPool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
@@ -148,7 +240,8 @@ public sealed class ConsumerDirtyCommitTests
             {
                 BootstrapServers = ["localhost:9092"],
                 GroupId = "group-a",
-                OffsetCommitMode = OffsetCommitMode.Manual
+                OffsetCommitMode = offsetCommitMode,
+                EnableAutoOffsetStore = enableAutoOffsetStore
             },
             Serializers.String,
             Serializers.String,
@@ -167,6 +260,47 @@ public sealed class ConsumerDirtyCommitTests
             BindingFlags.NonPublic | BindingFlags.Instance)!;
 
         method.Invoke(consumer, [partition, position, dirty]);
+    }
+
+    private static void RecordConsumedPosition(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition partition,
+        long position,
+        int leaderEpoch)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "RecordConsumedPosition",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        method.Invoke(consumer, [partition, position, leaderEpoch]);
+    }
+
+    private static async Task CommitStoredOffsetsAsync(KafkaConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "CommitStoredOffsetsAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        var commit = (ValueTask)method.Invoke(consumer, [CancellationToken.None])!;
+        await commit.ConfigureAwait(false);
+    }
+
+    private static ConsumeResult<string, string> CreateConsumeResult(long offset, int leaderEpoch)
+    {
+        return new ConsumeResult<string, string>(
+            topic: "topic-a",
+            partition: 0,
+            offset: offset,
+            keyData: ReadOnlyMemory<byte>.Empty,
+            isKeyNull: true,
+            valueData: ReadOnlyMemory<byte>.Empty,
+            isValueNull: true,
+            headers: null,
+            timestampMs: 0,
+            timestampType: TimestampType.NotAvailable,
+            leaderEpoch: leaderEpoch,
+            keyDeserializer: null,
+            valueDeserializer: null);
     }
 
     private static OffsetCommitRequest CloneRequest(OffsetCommitRequest request)

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetCommitModeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetCommitModeTests.cs
@@ -18,6 +18,17 @@ public class OffsetCommitModeTests
     }
 
     [Test]
+    public async Task ConsumerBuilder_WithAutoOffsetStore_ConfiguresOption()
+    {
+        var builder = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithAutoOffsetStore(false)
+            .WithAutoOffsetStore(true);
+
+        await Assert.That(builder).IsNotNull();
+    }
+
+    [Test]
     public async Task ConsumerBuilder_OffsetCommitMode_DefaultIsAuto()
     {
         // The default should be Auto
@@ -76,9 +87,17 @@ public class OffsetCommitModeTests
         var commitAsyncWithOffsets = interfaceType.GetMethod(
             nameof(IKafkaConsumer<string, string>.CommitAsync),
             [typeof(IEnumerable<TopicPartitionOffset>), typeof(CancellationToken)]);
+        var storeOffset = interfaceType.GetMethod(
+            nameof(IKafkaConsumer<string, string>.StoreOffset),
+            [typeof(ConsumeResult<string, string>)]);
+        var storeSpecificOffset = interfaceType.GetMethod(
+            nameof(IKafkaConsumer<string, string>.StoreOffset),
+            [typeof(TopicPartitionOffset)]);
 
         await Assert.That(commitAsyncNoArgs).IsNotNull();
         await Assert.That(commitAsyncWithOffsets).IsNotNull();
+        await Assert.That(storeOffset).IsNotNull();
+        await Assert.That(storeSpecificOffset).IsNotNull();
     }
 
     [Test]
@@ -92,6 +111,17 @@ public class OffsetCommitModeTests
 
         // Default should be Auto
         await Assert.That(options.OffsetCommitMode).IsEqualTo(OffsetCommitMode.Auto);
+    }
+
+    [Test]
+    public async Task ConsumerOptions_EnableAutoOffsetStore_DefaultValue()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"]
+        };
+
+        await Assert.That(options.EnableAutoOffsetStore).IsTrue();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -902,6 +902,14 @@ public sealed class PartitionedConsumerRuntimeTests
                 CommitCalls.Add(offsets.ToArray());
         }
 
+        public void StoreOffset(ConsumeResult<string, string> result)
+        {
+        }
+
+        public void StoreOffset(TopicPartitionOffset offset)
+        {
+        }
+
         public ValueTask CloseAsync(CancellationToken cancellationToken = default)
             => ValueTask.CompletedTask;
 

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -656,6 +656,7 @@ public class DependencyInjectionTests
             ["Kafka:Consumers:Orders:GroupRemoteAssignor"] = "uniform",
             ["Kafka:Consumers:Orders:OffsetCommitMode"] = "Manual",
             ["Kafka:Consumers:Orders:AutoCommitIntervalMs"] = "2000",
+            ["Kafka:Consumers:Orders:EnableAutoOffsetStore"] = "false",
             ["Kafka:Consumers:Orders:AutoOffsetReset"] = "Earliest",
             ["Kafka:Consumers:Orders:FetchMinBytes"] = "1024",
             ["Kafka:Consumers:Orders:FetchMaxBytes"] = "2097152",
@@ -713,6 +714,7 @@ public class DependencyInjectionTests
         await Assert.That(options.GroupRemoteAssignor).IsEqualTo("uniform");
         await Assert.That(options.OffsetCommitMode).IsEqualTo(OffsetCommitMode.Manual);
         await Assert.That(options.AutoCommitIntervalMs).IsEqualTo(2000);
+        await Assert.That(options.EnableAutoOffsetStore).IsFalse();
         await Assert.That(options.AutoOffsetReset).IsEqualTo(AutoOffsetReset.Earliest);
         await Assert.That(options.FetchMinBytes).IsEqualTo(1024);
         await Assert.That(options.FetchMaxBytes).IsEqualTo(2097152);

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -80,6 +80,36 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task Consumer_ManualOffsetStore_WithAutoCommit_CommitsStoredOffset()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                EnableAutoOffsetStore = false
+            });
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("jobs", 0);
+
+        await producer.ProduceAsync("jobs", "a", "one");
+        consumer.Subscribe("jobs");
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+        var offsetsBeforeStore = await admin.ListConsumerGroupOffsetsAsync("workers");
+        consumer.StoreOffset(result!.Value);
+        await consumer.CloseAsync();
+        var offsetsAfterStore = await admin.ListConsumerGroupOffsetsAsync("workers");
+
+        await Assert.That(offsetsBeforeStore.ContainsKey(partition)).IsFalse();
+        await Assert.That(offsetsAfterStore[partition]).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Admin_CreatesDescribesAndDeletesTopics()
     {
         var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions { AutoCreateTopics = false });

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -110,6 +110,45 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    [Arguments("Seek")]
+    [Arguments("SeekToBeginning")]
+    [Arguments("SeekToEnd")]
+    public async Task Consumer_ManualOffsetStore_CommitAsyncDoesNotCommitSeekedPositionUntilStored(string seekOperation)
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                EnableAutoOffsetStore = false
+            });
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("jobs", 0);
+
+        await producer.ProduceAsync("jobs", "a", "one");
+        await producer.ProduceAsync("jobs", "b", "two");
+        consumer.Subscribe("jobs");
+        ApplySeek(consumer, seekOperation, partition);
+
+        await consumer.CommitAsync();
+
+        var offsetsBeforeStore = await admin.ListConsumerGroupOffsetsAsync("workers");
+
+        consumer.StoreOffset(new TopicPartitionOffset("jobs", 0, 1));
+
+        await consumer.CommitAsync();
+
+        var offsetsAfterStore = await admin.ListConsumerGroupOffsetsAsync("workers");
+
+        await Assert.That(offsetsBeforeStore.ContainsKey(partition)).IsFalse();
+        await Assert.That(offsetsAfterStore[partition]).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Admin_CreatesDescribesAndDeletesTopics()
     {
         var cluster = new InMemoryKafkaCluster(new InMemoryKafkaClusterOptions { AutoCreateTopics = false });
@@ -636,5 +675,26 @@ public sealed class InMemoryKafkaClusterTests
             BindingFlags.Instance | BindingFlags.NonPublic)!;
 
         return (Task)method.Invoke(cluster, [timeout, cancellationToken])!;
+    }
+
+    private static void ApplySeek(
+        InMemoryConsumer<string, string> consumer,
+        string seekOperation,
+        TopicPartition partition)
+    {
+        switch (seekOperation)
+        {
+            case "Seek":
+                consumer.Seek(new TopicPartitionOffset(partition.Topic, partition.Partition, 1));
+                break;
+            case "SeekToBeginning":
+                consumer.SeekToBeginning(partition);
+                break;
+            case "SeekToEnd":
+                consumer.SeekToEnd(partition);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(seekOperation), seekOperation, null);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `EnableAutoOffsetStore` and `StoreOffset` APIs for consumers
- make auto-commit use stored offsets while `CommitAsync()` preserves consumed-position commits
- mirror manual offset store behavior in the in-memory consumer and DI/builder binding
- cover unit and integration behavior, including auto-commit storing only processed offsets

## Validation
- `dotnet build src\Dekaf\Dekaf.csproj -c Release`
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj -c Release`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe`
- `tests\Dekaf.Tests.Integration\bin\Release\net10.0\Dekaf.Tests.Integration.exe --treenode-filter "/*/*/*/OffsetCommitMode_Auto_WithManualOffsetStore_CommitsOnlyStoredOffset" --minimum-expected-tests 1`
- `git diff origin/main..HEAD --check`

Closes #1384