### PR TITLE
fix(schemaregistry): unwrap protobuf lookup faults

### DIFF
--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -119,7 +119,7 @@ public sealed class ProtobufSchemaRegistrySerializer<
         if (_config.UseLatestVersion)
         {
             task = _schemaRegistry.GetSchemaBySubjectAsync(subject)
-                .ContinueWith(t => t.Result.Id, TaskScheduler.Default);
+                .ContinueWith(static t => t.GetAwaiter().GetResult().Id, TaskScheduler.Default);
         }
         else if (_config.AutoRegisterSchemas)
         {
@@ -128,7 +128,7 @@ public sealed class ProtobufSchemaRegistrySerializer<
         else
         {
             task = _schemaRegistry.GetSchemaBySubjectAsync(subject)
-                .ContinueWith(t => t.Result.Id, TaskScheduler.Default);
+                .ContinueWith(static t => t.GetAwaiter().GetResult().Id, TaskScheduler.Default);
         }
 
         // Add timeout to prevent indefinite blocking

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
@@ -211,6 +211,45 @@ public class ProtobufSchemaRegistrySerializerTests
     }
 
     [Test]
+    public async Task Serialize_DisablesAutoRegisterSchemas_WhenLookupFaults_ThrowsSchemaRegistryException()
+    {
+        await AssertLookupFaultThrowsSchemaRegistryExceptionAsync(
+            new ProtobufSerializerConfig { AutoRegisterSchemas = false },
+            50001);
+    }
+
+    [Test]
+    public async Task Serialize_UseLatestVersion_WhenLookupFaults_ThrowsSchemaRegistryException()
+    {
+        await AssertLookupFaultThrowsSchemaRegistryExceptionAsync(
+            new ProtobufSerializerConfig { UseLatestVersion = true },
+            50002);
+    }
+
+    private static async Task AssertLookupFaultThrowsSchemaRegistryExceptionAsync(
+        ProtobufSerializerConfig config,
+        int errorCode)
+    {
+        var schemaRegistry = Substitute.For<ISchemaRegistryClient>();
+        schemaRegistry.GetSchemaBySubjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<RegisteredSchema>(new SchemaRegistryException(errorCode, "lookup failed")));
+
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(schemaRegistry, config);
+
+        var message = new TestMessage { Id = 1, Name = "Test", Value = 3.14 };
+        var buffer = new ArrayBufferWriter<byte>();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<SchemaRegistryException>(() =>
+        {
+            serializer.Serialize(message, ref buffer, CreateContext());
+            return Task.CompletedTask;
+        });
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(errorCode);
+    }
+
+    [Test]
     public async Task DisposeAsync_DisposesOwnedClient()
     {
         // Arrange


### PR DESCRIPTION
Fixes #1379.

Changes:
- Match the base/JSON schema registry serializers by using `GetAwaiter().GetResult()` inside the Protobuf schema lookup continuations.
- Make the continuations `static`.
- Add regression coverage for both `AutoRegisterSchemas = false` and `UseLatestVersion = true` lookup-fault paths, asserting `SchemaRegistryException` is surfaced directly.

Validation:
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter '/*/*/ProtobufSchemaRegistrySerializerTests/*'` (11/11 passed)
- `./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter '/*/*/(SchemaRegistry*Tests|AvroSerializerTests|ProtobufSchemaRegistry*Tests|JsonSchemaRegistry*Tests|SubjectNameStrategyTests)/*'` (84/84 passed)