### PR TITLE
feat(admin): add transaction remediation APIs

### DIFF
--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -659,6 +659,47 @@ public sealed class InMemoryAdminClient : IAdminClient
         return ValueTask.FromResult<IReadOnlyDictionary<TopicPartition, DescribeProducersResultInfo>>(result);
     }
 
+    public ValueTask<IReadOnlyDictionary<string, FenceProducersResultInfo>> FenceProducersAsync(
+        IEnumerable<string> transactionalIds,
+        FenceProducersOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(transactionalIds);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var result = transactionalIds.ToDictionary(
+            transactionalId => transactionalId,
+            transactionalId => new FenceProducersResultInfo
+            {
+                TransactionalId = transactionalId,
+                ErrorCode = ErrorCode.TransactionalIdNotFound
+            },
+            StringComparer.Ordinal);
+
+        return ValueTask.FromResult<IReadOnlyDictionary<string, FenceProducersResultInfo>>(result);
+    }
+
+    public ValueTask<AbortTransactionResultInfo> AbortTransactionAsync(
+        AbortTransactionSpec transaction,
+        AbortTransactionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(transaction);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        ValidateTopicPartition(transaction.TopicPartition);
+
+        return ValueTask.FromResult(new AbortTransactionResultInfo
+        {
+            TopicPartition = transaction.TopicPartition,
+            ProducerId = transaction.ProducerId,
+            ProducerEpoch = transaction.ProducerEpoch,
+            CoordinatorEpoch = transaction.CoordinatorEpoch,
+            ErrorCode = ErrorCode.None
+        });
+    }
+
     public ValueTask<IReadOnlyDictionary<int, IReadOnlyDictionary<string, LogDirDescription>>> DescribeLogDirsAsync(
         IEnumerable<int> brokerIds,
         IEnumerable<TopicPartition>? partitions = null,

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1099,6 +1099,177 @@ public sealed class AdminClient : IAdminClient
         }, cancellationToken).ConfigureAwait(false);
     }
 
+    public async ValueTask<IReadOnlyDictionary<string, FenceProducersResultInfo>> FenceProducersAsync(
+        IEnumerable<string> transactionalIds,
+        FenceProducersOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(transactionalIds);
+
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!SupportsApiRange(
+            Protocol.ApiKey.InitProducerId,
+            InitProducerIdRequest.LowestSupportedVersion,
+            InitProducerIdRequest.HighestSupportedVersion))
+        {
+            throw new Errors.BrokerVersionException("Broker does not support InitProducerId (API key 22).");
+        }
+
+        var transactionalIdList = transactionalIds.ToList();
+        if (transactionalIdList.Count == 0)
+        {
+            return new Dictionary<string, FenceProducersResultInfo>();
+        }
+
+        var transactionTimeoutMs = options?.TimeoutMs ?? _options.RequestTimeoutMs;
+
+        return await WithRetryAsync<IReadOnlyDictionary<string, FenceProducersResultInfo>>(async () =>
+        {
+            var idsByCoordinator = new Dictionary<int, List<string>>();
+            foreach (var transactionalId in transactionalIdList)
+            {
+                var coordinatorId = await FindTransactionCoordinatorAsync(transactionalId, cancellationToken).ConfigureAwait(false);
+                if (!idsByCoordinator.TryGetValue(coordinatorId, out var ids))
+                {
+                    ids = [];
+                    idsByCoordinator[coordinatorId] = ids;
+                }
+
+                ids.Add(transactionalId);
+            }
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.InitProducerId,
+                InitProducerIdRequest.LowestSupportedVersion,
+                InitProducerIdRequest.HighestSupportedVersion);
+
+            var result = new Dictionary<string, FenceProducersResultInfo>(StringComparer.Ordinal);
+
+            foreach (var (coordinatorId, ids) in idsByCoordinator)
+            {
+                var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+
+                foreach (var transactionalId in ids)
+                {
+                    var request = new InitProducerIdRequest
+                    {
+                        TransactionalId = transactionalId,
+                        TransactionTimeoutMs = transactionTimeoutMs,
+                        ProducerId = -1,
+                        ProducerEpoch = -1
+                    };
+
+                    var response = await connection.SendAsync<InitProducerIdRequest, InitProducerIdResponse>(
+                        request,
+                        apiVersion,
+                        cancellationToken).ConfigureAwait(false);
+
+                    if (response.ErrorCode == Protocol.ErrorCode.ConcurrentTransactions)
+                    {
+                        throw new KafkaException(response.ErrorCode,
+                            $"FenceProducers is waiting for a concurrent transaction on transactional ID '{transactionalId}'.",
+                            isRetriable: true);
+                    }
+
+                    if (response.ErrorCode.IsRetriable() || response.ErrorCode.RequiresMetadataRefresh())
+                    {
+                        throw new KafkaException(response.ErrorCode,
+                            $"FenceProducers failed for transactional ID '{transactionalId}': {response.ErrorCode}");
+                    }
+
+                    result[transactionalId] = new FenceProducersResultInfo
+                    {
+                        TransactionalId = transactionalId,
+                        ErrorCode = response.ErrorCode,
+                        ProducerId = response.ProducerId,
+                        ProducerEpoch = response.ProducerEpoch
+                    };
+                }
+            }
+
+            return result;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<AbortTransactionResultInfo> AbortTransactionAsync(
+        AbortTransactionSpec transaction,
+        AbortTransactionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(transaction);
+
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!SupportsApiRange(
+            Protocol.ApiKey.WriteTxnMarkers,
+            WriteTxnMarkersRequest.LowestSupportedVersion,
+            WriteTxnMarkersRequest.HighestSupportedVersion))
+        {
+            throw new Errors.BrokerVersionException("Broker does not support WriteTxnMarkers (API key 27).");
+        }
+
+        return await WithRetryAsync(async () =>
+        {
+            var topicPartition = transaction.TopicPartition;
+            var leaderNode = _metadataManager.Metadata.GetPartitionLeader(topicPartition.Topic, topicPartition.Partition);
+            if (leaderNode is null)
+            {
+                throw new KafkaException(Protocol.ErrorCode.LeaderNotAvailable,
+                    $"No leader available for {topicPartition.Topic}-{topicPartition.Partition}");
+            }
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.WriteTxnMarkers,
+                WriteTxnMarkersRequest.LowestSupportedVersion,
+                WriteTxnMarkersRequest.HighestSupportedVersion);
+
+            var request = new WriteTxnMarkersRequest
+            {
+                Markers =
+                [
+                    new WriteTxnMarkersRequestMarker
+                    {
+                        ProducerId = transaction.ProducerId,
+                        ProducerEpoch = transaction.ProducerEpoch,
+                        TransactionResult = false,
+                        CoordinatorEpoch = transaction.CoordinatorEpoch,
+                        Topics =
+                        [
+                            new WriteTxnMarkersRequestTopic
+                            {
+                                Name = topicPartition.Topic,
+                                PartitionIndexes = [topicPartition.Partition]
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            var connection = await _connectionPool.GetConnectionAsync(leaderNode.NodeId, cancellationToken).ConfigureAwait(false);
+            var response = await connection.SendAsync<WriteTxnMarkersRequest, WriteTxnMarkersResponse>(
+                request,
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            var partitionResult = FindAbortTransactionPartition(response, transaction);
+            if (partitionResult.ErrorCode.IsRetriable() || partitionResult.ErrorCode.RequiresMetadataRefresh())
+            {
+                throw new KafkaException(partitionResult.ErrorCode,
+                    $"AbortTransaction failed for {topicPartition.Topic}-{topicPartition.Partition}: {partitionResult.ErrorCode}");
+            }
+
+            return new AbortTransactionResultInfo
+            {
+                TopicPartition = topicPartition,
+                ProducerId = transaction.ProducerId,
+                ProducerEpoch = transaction.ProducerEpoch,
+                CoordinatorEpoch = transaction.CoordinatorEpoch,
+                ErrorCode = partitionResult.ErrorCode
+            };
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
     public async ValueTask DeleteConsumerGroupsAsync(
         IEnumerable<string> groupIds,
         CancellationToken cancellationToken = default)
@@ -3495,6 +3666,48 @@ public sealed class AdminClient : IAdminClient
 
     private ValueTask<T> WithRetryAsync<T>(Func<ValueTask<T>> operation, CancellationToken cancellationToken)
         => RetryHelper.WithRetryAsync(operation, _metadataManager, cancellationToken);
+
+    private bool SupportsApiRange(Protocol.ApiKey apiKey, short lowestSupportedVersion, short highestSupportedVersion)
+    {
+        if (!_metadataManager.HasApiKey(apiKey))
+            return false;
+
+        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            apiKey,
+            lowestSupportedVersion,
+            highestSupportedVersion);
+
+        return apiVersion >= lowestSupportedVersion &&
+               apiVersion <= highestSupportedVersion &&
+               _metadataManager.SupportsApiVersion(apiKey, apiVersion);
+    }
+
+    private static WriteTxnMarkersResponsePartition FindAbortTransactionPartition(
+        WriteTxnMarkersResponse response,
+        AbortTransactionSpec transaction)
+    {
+        var topicPartition = transaction.TopicPartition;
+        foreach (var marker in response.Markers)
+        {
+            if (marker.ProducerId != transaction.ProducerId)
+                continue;
+
+            foreach (var topic in marker.Topics)
+            {
+                if (!string.Equals(topic.Name, topicPartition.Topic, StringComparison.Ordinal))
+                    continue;
+
+                foreach (var partition in topic.Partitions)
+                {
+                    if (partition.PartitionIndex == topicPartition.Partition)
+                        return partition;
+                }
+            }
+        }
+
+        throw new KafkaException(Protocol.ErrorCode.UnknownServerError,
+            $"WriteTxnMarkers response did not include {topicPartition.Topic}-{topicPartition.Partition} for producer {transaction.ProducerId}.");
+    }
 
     private async ValueTask<IKafkaConnection> GetControllerAsync(CancellationToken cancellationToken)
     {

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -96,6 +96,22 @@ public interface IAdminClient : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Fences active producers for transactional IDs by initializing new producer epochs.
+    /// </summary>
+    ValueTask<IReadOnlyDictionary<string, FenceProducersResultInfo>> FenceProducersAsync(
+        IEnumerable<string> transactionalIds,
+        FenceProducersOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Forcefully aborts an open transaction on a topic partition.
+    /// </summary>
+    ValueTask<AbortTransactionResultInfo> AbortTransactionAsync(
+        AbortTransactionSpec transaction,
+        AbortTransactionOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Deletes consumer groups.
     /// </summary>
     ValueTask DeleteConsumerGroupsAsync(IEnumerable<string> groupIds, CancellationToken cancellationToken = default);
@@ -657,6 +673,63 @@ public sealed class ActiveProducerDescription
     public long LastTimestamp { get; init; }
     public int CoordinatorEpoch { get; init; }
     public long CurrentTransactionStartOffset { get; init; }
+}
+
+/// <summary>
+/// Options for fencing transactional producers.
+/// </summary>
+public sealed class FenceProducersOptions
+{
+    /// <summary>
+    /// Timeout in milliseconds used by the transaction coordinator while fencing.
+    /// </summary>
+    public int TimeoutMs { get; init; } = 30000;
+}
+
+/// <summary>
+/// Result of fencing producers for a transactional ID.
+/// </summary>
+public sealed class FenceProducersResultInfo
+{
+    public required string TransactionalId { get; init; }
+    public Protocol.ErrorCode ErrorCode { get; init; }
+    public long ProducerId { get; init; } = -1;
+    public short ProducerEpoch { get; init; } = -1;
+}
+
+/// <summary>
+/// Specification for forcefully aborting an open transaction on a topic partition.
+/// </summary>
+public sealed class AbortTransactionSpec
+{
+    public required TopicPartition TopicPartition { get; init; }
+    public long ProducerId { get; init; }
+    public short ProducerEpoch { get; init; }
+
+    /// <summary>
+    /// Transaction coordinator epoch. The default -1 matches admin abort semantics when
+    /// the caller wants the broker to validate producer state without coordinator fencing.
+    /// </summary>
+    public int CoordinatorEpoch { get; init; } = -1;
+}
+
+/// <summary>
+/// Options for forcefully aborting a transaction.
+/// </summary>
+public sealed class AbortTransactionOptions
+{
+}
+
+/// <summary>
+/// Result of forcefully aborting a transaction.
+/// </summary>
+public sealed class AbortTransactionResultInfo
+{
+    public required TopicPartition TopicPartition { get; init; }
+    public long ProducerId { get; init; }
+    public short ProducerEpoch { get; init; }
+    public int CoordinatorEpoch { get; init; }
+    public Protocol.ErrorCode ErrorCode { get; init; }
 }
 
 /// <summary>

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -703,14 +703,13 @@ public sealed class FenceProducersResultInfo
 public sealed class AbortTransactionSpec
 {
     public required TopicPartition TopicPartition { get; init; }
-    public long ProducerId { get; init; }
-    public short ProducerEpoch { get; init; }
+    public required long ProducerId { get; init; }
+    public required short ProducerEpoch { get; init; }
 
     /// <summary>
-    /// Transaction coordinator epoch. The default -1 matches admin abort semantics when
-    /// the caller wants the broker to validate producer state without coordinator fencing.
+    /// Transaction coordinator epoch returned by DescribeProducers for the active producer.
     /// </summary>
-    public int CoordinatorEpoch { get; init; } = -1;
+    public required int CoordinatorEpoch { get; init; }
 }
 
 /// <summary>

--- a/src/Dekaf/Protocol/Messages/WriteTxnMarkersRequest.cs
+++ b/src/Dekaf/Protocol/Messages/WriteTxnMarkersRequest.cs
@@ -1,0 +1,77 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// WriteTxnMarkers request (API key 27).
+/// Writes transaction commit or abort markers to topic partitions.
+/// </summary>
+public sealed class WriteTxnMarkersRequest : IKafkaRequest<WriteTxnMarkersResponse>
+{
+    public static ApiKey ApiKey => ApiKey.WriteTxnMarkers;
+    public static short LowestSupportedVersion => 1;
+    public static short HighestSupportedVersion => 2;
+
+    public required IReadOnlyList<WriteTxnMarkersRequestMarker> Markers { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactArray(
+            Markers,
+            static (ref KafkaProtocolWriter w, WriteTxnMarkersRequestMarker marker, short v) => marker.Write(ref w, v),
+            version);
+
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// Transaction marker in a WriteTxnMarkers request.
+/// </summary>
+public sealed class WriteTxnMarkersRequestMarker
+{
+    public long ProducerId { get; init; }
+    public short ProducerEpoch { get; init; }
+    public bool TransactionResult { get; init; }
+    public required IReadOnlyList<WriteTxnMarkersRequestTopic> Topics { get; init; }
+    public int CoordinatorEpoch { get; init; }
+    public sbyte TransactionVersion { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteInt64(ProducerId);
+        writer.WriteInt16(ProducerEpoch);
+        writer.WriteBoolean(TransactionResult);
+
+        writer.WriteCompactArray(
+            Topics,
+            static (ref KafkaProtocolWriter w, WriteTxnMarkersRequestTopic topic) => topic.Write(ref w));
+
+        writer.WriteInt32(CoordinatorEpoch);
+
+        if (version >= 2)
+        {
+            writer.WriteInt8(TransactionVersion);
+        }
+
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// Topic in a WriteTxnMarkers request marker.
+/// </summary>
+public sealed class WriteTxnMarkersRequestTopic
+{
+    public required string Name { get; init; }
+    public required IReadOnlyList<int> PartitionIndexes { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(Name);
+
+        writer.WriteCompactArray(
+            PartitionIndexes,
+            static (ref KafkaProtocolWriter w, int partitionIndex) => w.WriteInt32(partitionIndex));
+
+        writer.WriteEmptyTaggedFields();
+    }
+}

--- a/src/Dekaf/Protocol/Messages/WriteTxnMarkersResponse.cs
+++ b/src/Dekaf/Protocol/Messages/WriteTxnMarkersResponse.cs
@@ -1,0 +1,101 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// WriteTxnMarkers response (API key 27).
+/// Contains per-partition transaction marker write results.
+/// </summary>
+public sealed class WriteTxnMarkersResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.WriteTxnMarkers;
+    public static short LowestSupportedVersion => 1;
+    public static short HighestSupportedVersion => 2;
+
+    public required IReadOnlyList<WriteTxnMarkersResponseMarker> Markers { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var markers = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => WriteTxnMarkersResponseMarker.Read(ref r, v),
+            version);
+
+        reader.SkipTaggedFields();
+
+        return new WriteTxnMarkersResponse
+        {
+            Markers = markers
+        };
+    }
+}
+
+/// <summary>
+/// Transaction marker result in a WriteTxnMarkers response.
+/// </summary>
+public sealed class WriteTxnMarkersResponseMarker
+{
+    public long ProducerId { get; init; }
+    public required IReadOnlyList<WriteTxnMarkersResponseTopic> Topics { get; init; }
+
+    public static WriteTxnMarkersResponseMarker Read(ref KafkaProtocolReader reader, short version)
+    {
+        var producerId = reader.ReadInt64();
+        var topics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => WriteTxnMarkersResponseTopic.Read(ref r, v),
+            version);
+
+        reader.SkipTaggedFields();
+
+        return new WriteTxnMarkersResponseMarker
+        {
+            ProducerId = producerId,
+            Topics = topics
+        };
+    }
+}
+
+/// <summary>
+/// Topic result in a WriteTxnMarkers response marker.
+/// </summary>
+public sealed class WriteTxnMarkersResponseTopic
+{
+    public required string Name { get; init; }
+    public required IReadOnlyList<WriteTxnMarkersResponsePartition> Partitions { get; init; }
+
+    public static WriteTxnMarkersResponseTopic Read(ref KafkaProtocolReader reader, short version)
+    {
+        var name = reader.ReadCompactNonNullableString();
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => WriteTxnMarkersResponsePartition.Read(ref r, v),
+            version);
+
+        reader.SkipTaggedFields();
+
+        return new WriteTxnMarkersResponseTopic
+        {
+            Name = name,
+            Partitions = partitions
+        };
+    }
+}
+
+/// <summary>
+/// Partition result in a WriteTxnMarkers response topic.
+/// </summary>
+public sealed class WriteTxnMarkersResponsePartition
+{
+    public int PartitionIndex { get; init; }
+    public ErrorCode ErrorCode { get; init; }
+
+    public static WriteTxnMarkersResponsePartition Read(ref KafkaProtocolReader reader, short version)
+    {
+        var partitionIndex = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+
+        reader.SkipTaggedFields();
+
+        return new WriteTxnMarkersResponsePartition
+        {
+            PartitionIndex = partitionIndex,
+            ErrorCode = errorCode
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Integration/AdminTransactionRemediationTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminTransactionRemediationTests.cs
@@ -1,0 +1,138 @@
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Transaction")]
+public sealed class AdminTransactionRemediationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task FenceProducersAsync_FencesActiveTransactionalProducer()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var txnId = $"admin-fence-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId(txnId)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.InitTransactionsAsync();
+        await using var transaction = producer.BeginTransaction();
+
+        await transaction.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "fenced-key",
+            Value = "fenced-value"
+        }, CancellationToken.None);
+
+        await using var admin = KafkaContainer.CreateAdminClient();
+        var results = await admin.FenceProducersAsync([txnId]);
+
+        await Assert.That(results[txnId].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(results[txnId].ProducerId).IsGreaterThanOrEqualTo(0);
+
+        var commit = () => transaction.CommitAsync().AsTask();
+        await Assert.That(commit).Throws<FatalTransactionException>();
+    }
+
+    [Test]
+    public async Task AbortTransactionAsync_WritesAbortMarkerForOpenTransaction()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var topicPartition = new TopicPartition(topic, 0);
+        var hungTxnId = $"admin-abort-hung-{Guid.NewGuid():N}";
+        var laterTxnId = $"admin-abort-later-{Guid.NewGuid():N}";
+
+        await using var hungProducer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId(hungTxnId)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await hungProducer.InitTransactionsAsync();
+        var hungTransaction = hungProducer.BeginTransaction();
+
+        try
+        {
+            await hungTransaction.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = "aborted-key",
+                Value = "aborted-value"
+            }, CancellationToken.None);
+
+            await using var admin = KafkaContainer.CreateAdminClient();
+            var producerState = await admin.DescribeProducersAsync([topicPartition]);
+            var activeProducer = producerState[topicPartition].ActiveProducers
+                .Single(producer => producer.CurrentTransactionStartOffset >= 0);
+
+            var abortResult = await admin.AbortTransactionAsync(new AbortTransactionSpec
+            {
+                TopicPartition = topicPartition,
+                ProducerId = activeProducer.ProducerId,
+                ProducerEpoch = checked((short)activeProducer.ProducerEpoch),
+                CoordinatorEpoch = activeProducer.CoordinatorEpoch
+            });
+
+            await Assert.That(abortResult.ErrorCode).IsEqualTo(ErrorCode.None);
+
+            await using var laterProducer = await Kafka.CreateProducer<string, string>()
+                .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                .WithTransactionalId(laterTxnId)
+                .WithAcks(Acks.All)
+                .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+                .BuildAsync();
+
+            await laterProducer.InitTransactionsAsync();
+            await using (var laterTransaction = laterProducer.BeginTransaction())
+            {
+                await laterTransaction.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Partition = 0,
+                    Key = "later-key",
+                    Value = "later-value"
+                }, CancellationToken.None);
+                await laterTransaction.CommitAsync();
+            }
+
+            await using var consumer = await Kafka.CreateConsumer<string, string>()
+                .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                .WithGroupId($"admin-abort-verify-{Guid.NewGuid():N}")
+                .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+                .WithIsolationLevel(IsolationLevel.ReadCommitted)
+                .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+                .BuildAsync();
+
+            consumer.Subscribe(topic);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!.Value.Key).IsEqualTo("later-key");
+            await Assert.That(result.Value.Value).IsEqualTo("later-value");
+        }
+        finally
+        {
+            try
+            {
+                await hungTransaction.DisposeAsync();
+            }
+            catch (TransactionException)
+            {
+                // Best-effort cleanup after the admin abort has already ended the broker transaction.
+            }
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientTransactionIntrospectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientTransactionIntrospectionTests.cs
@@ -558,7 +558,8 @@ public sealed class AdminClientTransactionIntrospectionTests
             {
                 TopicPartition = new TopicPartition("orders", 0),
                 ProducerId = 101,
-                ProducerEpoch = 3
+                ProducerEpoch = 3,
+                CoordinatorEpoch = 5
             });
         }).Throws<BrokerVersionException>();
     }

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientTransactionIntrospectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientTransactionIntrospectionTests.cs
@@ -349,6 +349,220 @@ public sealed class AdminClientTransactionIntrospectionTests
         }).Throws<KafkaException>();
     }
 
+    [Test]
+    public async Task FenceProducersAsync_UsesTransactionCoordinatorsAndMapsProducerIds()
+    {
+        var (admin, connections) = CreateAdminWithMockConnections();
+
+        connections[1].SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<FindCoordinatorRequest>();
+                var coordinatorId = request.Key == "tx-b" ? 2 : 1;
+
+                return ValueTask.FromResult(new FindCoordinatorResponse
+                {
+                    Coordinators =
+                    [
+                        new Coordinator
+                        {
+                            Key = request.Key,
+                            NodeId = coordinatorId,
+                            Host = $"broker-{coordinatorId}",
+                            Port = 9090 + coordinatorId,
+                            ErrorCode = ErrorCode.None
+                        }
+                    ]
+                });
+            });
+
+        connections[1].SendAsync<InitProducerIdRequest, InitProducerIdResponse>(
+                Arg.Any<InitProducerIdRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new InitProducerIdResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ProducerId = 101,
+                ProducerEpoch = 3
+            }));
+
+        connections[2].SendAsync<InitProducerIdRequest, InitProducerIdResponse>(
+                Arg.Any<InitProducerIdRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new InitProducerIdResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ProducerId = 202,
+                ProducerEpoch = 4
+            }));
+
+        var result = await admin.FenceProducersAsync(
+            ["tx-a", "tx-b"],
+            new FenceProducersOptions { TimeoutMs = 12345 });
+
+        await Assert.That(result["tx-a"].ProducerId).IsEqualTo(101);
+        await Assert.That(result["tx-a"].ProducerEpoch).IsEqualTo((short)3);
+        await Assert.That(result["tx-b"].ProducerId).IsEqualTo(202);
+        await Assert.That(result["tx-b"].ProducerEpoch).IsEqualTo((short)4);
+
+        await connections[1].Received(1).SendAsync<InitProducerIdRequest, InitProducerIdResponse>(
+            Arg.Is<InitProducerIdRequest>(r =>
+                r.TransactionalId == "tx-a" &&
+                r.TransactionTimeoutMs == 12345 &&
+                r.ProducerId == -1 &&
+                r.ProducerEpoch == -1),
+            5,
+            Arg.Any<CancellationToken>());
+
+        await connections[2].Received(1).SendAsync<InitProducerIdRequest, InitProducerIdResponse>(
+            Arg.Is<InitProducerIdRequest>(r =>
+                r.TransactionalId == "tx-b" &&
+                r.TransactionTimeoutMs == 12345 &&
+                r.ProducerId == -1 &&
+                r.ProducerEpoch == -1),
+            5,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task FenceProducersAsync_ConcurrentTransactions_Retries()
+    {
+        var (admin, connections) = CreateAdminWithMockConnections();
+        SetupTransactionCoordinatorLookup(connections[1], coordinatorId: 1);
+        var attempts = 0;
+
+        connections[1].SendAsync<InitProducerIdRequest, InitProducerIdResponse>(
+                Arg.Any<InitProducerIdRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                attempts++;
+                return ValueTask.FromResult(new InitProducerIdResponse
+                {
+                    ErrorCode = attempts == 1 ? ErrorCode.ConcurrentTransactions : ErrorCode.None,
+                    ProducerId = attempts == 1 ? -1 : 101,
+                    ProducerEpoch = attempts == 1 ? (short)-1 : (short)3
+                });
+            });
+
+        var result = await admin.FenceProducersAsync(["tx-a"]);
+
+        await Assert.That(result["tx-a"].ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(result["tx-a"].ProducerId).IsEqualTo(101);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task FenceProducersAsync_NonRetriableItemError_ReturnsResultError()
+    {
+        var (admin, connections) = CreateAdminWithMockConnections();
+        SetupTransactionCoordinatorLookup(connections[1], coordinatorId: 1);
+        connections[1].SendAsync<InitProducerIdRequest, InitProducerIdResponse>(
+                Arg.Any<InitProducerIdRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new InitProducerIdResponse
+            {
+                ErrorCode = ErrorCode.TransactionalIdAuthorizationFailed
+            }));
+
+        var result = await admin.FenceProducersAsync(["tx-a"]);
+
+        await Assert.That(result["tx-a"].ErrorCode).IsEqualTo(ErrorCode.TransactionalIdAuthorizationFailed);
+    }
+
+    [Test]
+    public async Task FenceProducersAsync_WhenApiKeyMissing_ThrowsBrokerVersionException()
+    {
+        var (admin, _) = CreateAdminWithMockConnections(includeInitProducerIdApi: false);
+
+        await Assert.That(async () =>
+        {
+            await admin.FenceProducersAsync(["tx-a"]);
+        }).Throws<BrokerVersionException>();
+    }
+
+    [Test]
+    public async Task AbortTransactionAsync_SendsAbortMarkerToPartitionLeader()
+    {
+        var (admin, connections) = CreateAdminWithMockConnections();
+
+        connections[2].SendAsync<WriteTxnMarkersRequest, WriteTxnMarkersResponse>(
+                Arg.Any<WriteTxnMarkersRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo => ValueTask.FromResult(CreateWriteTxnMarkersResponse(callInfo.Arg<WriteTxnMarkersRequest>())));
+
+        var result = await admin.AbortTransactionAsync(new AbortTransactionSpec
+        {
+            TopicPartition = new TopicPartition("orders", 1),
+            ProducerId = 202,
+            ProducerEpoch = 4,
+            CoordinatorEpoch = 5
+        });
+
+        await Assert.That(result.ErrorCode).IsEqualTo(ErrorCode.None);
+
+        await connections[2].Received(1).SendAsync<WriteTxnMarkersRequest, WriteTxnMarkersResponse>(
+            Arg.Is<WriteTxnMarkersRequest>(r =>
+                r.Markers.Count == 1 &&
+                r.Markers[0].ProducerId == 202 &&
+                r.Markers[0].ProducerEpoch == 4 &&
+                !r.Markers[0].TransactionResult &&
+                r.Markers[0].CoordinatorEpoch == 5 &&
+                r.Markers[0].Topics.Count == 1 &&
+                r.Markers[0].Topics[0].Name == "orders" &&
+                r.Markers[0].Topics[0].PartitionIndexes.Count == 1 &&
+                r.Markers[0].Topics[0].PartitionIndexes[0] == 1),
+            2,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task AbortTransactionAsync_NonRetriablePartitionError_ReturnsResultError()
+    {
+        var (admin, connections) = CreateAdminWithMockConnections();
+        connections[1].SendAsync<WriteTxnMarkersRequest, WriteTxnMarkersResponse>(
+                Arg.Any<WriteTxnMarkersRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo => ValueTask.FromResult(CreateWriteTxnMarkersResponse(
+                callInfo.Arg<WriteTxnMarkersRequest>(),
+                ErrorCode.InvalidProducerEpoch)));
+
+        var result = await admin.AbortTransactionAsync(new AbortTransactionSpec
+        {
+            TopicPartition = new TopicPartition("orders", 0),
+            ProducerId = 101,
+            ProducerEpoch = 3,
+            CoordinatorEpoch = 5
+        });
+
+        await Assert.That(result.ErrorCode).IsEqualTo(ErrorCode.InvalidProducerEpoch);
+    }
+
+    [Test]
+    public async Task AbortTransactionAsync_WhenApiKeyMissing_ThrowsBrokerVersionException()
+    {
+        var (admin, _) = CreateAdminWithMockConnections(includeWriteTxnMarkersApi: false);
+
+        await Assert.That(async () =>
+        {
+            await admin.AbortTransactionAsync(new AbortTransactionSpec
+            {
+                TopicPartition = new TopicPartition("orders", 0),
+                ProducerId = 101,
+                ProducerEpoch = 3
+            });
+        }).Throws<BrokerVersionException>();
+    }
+
     private static DescribeTransactionsResponse CreateDescribeTransactionsResponse(
         DescribeTransactionsRequest request,
         long producerId,
@@ -420,10 +634,34 @@ public sealed class AdminClientTransactionIntrospectionTests
         ];
     }
 
+    private static WriteTxnMarkersResponse CreateWriteTxnMarkersResponse(
+        WriteTxnMarkersRequest request,
+        ErrorCode errorCode = ErrorCode.None)
+    {
+        return new WriteTxnMarkersResponse
+        {
+            Markers = request.Markers.Select(marker => new WriteTxnMarkersResponseMarker
+            {
+                ProducerId = marker.ProducerId,
+                Topics = marker.Topics.Select(topic => new WriteTxnMarkersResponseTopic
+                {
+                    Name = topic.Name,
+                    Partitions = topic.PartitionIndexes.Select(partition => new WriteTxnMarkersResponsePartition
+                    {
+                        PartitionIndex = partition,
+                        ErrorCode = errorCode
+                    }).ToList()
+                }).ToList()
+            }).ToList()
+        };
+    }
+
     private static (AdminClient Admin, IReadOnlyDictionary<int, IKafkaConnection> Connections) CreateAdminWithMockConnections(
         bool includeListTransactionsApi = true,
         bool includeDescribeTransactionsApi = true,
         bool includeDescribeProducersApi = true,
+        bool includeInitProducerIdApi = true,
+        bool includeWriteTxnMarkersApi = true,
         short listTransactionsMaxVersion = 2)
     {
         var connections = new Dictionary<int, IKafkaConnection>
@@ -456,6 +694,10 @@ public sealed class AdminClientTransactionIntrospectionTests
             metadataManager.SetApiVersion(ApiKey.DescribeTransactions, 0, 0);
         if (includeDescribeProducersApi)
             metadataManager.SetApiVersion(ApiKey.DescribeProducers, 0, 0);
+        if (includeInitProducerIdApi)
+            metadataManager.SetApiVersion(ApiKey.InitProducerId, 2, 5);
+        if (includeWriteTxnMarkersApi)
+            metadataManager.SetApiVersion(ApiKey.WriteTxnMarkers, 1, 2);
 
         var admin = new AdminClient(
             new AdminClientOptions { BootstrapServers = ["localhost:9092"] },

--- a/tests/Dekaf.Tests.Unit/Protocol/TransactionProtocolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/TransactionProtocolTests.cs
@@ -365,6 +365,142 @@ public sealed class TransactionProtocolTests
         await Assert.That(committedLeaderEpoch).IsEqualTo(5);
     }
 
+    [Test]
+    public async Task WriteTxnMarkersRequest_V1_AbortMarker_WritesCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new WriteTxnMarkersRequest
+        {
+            Markers =
+            [
+                new WriteTxnMarkersRequestMarker
+                {
+                    ProducerId = 42,
+                    ProducerEpoch = 7,
+                    TransactionResult = false,
+                    CoordinatorEpoch = 5,
+                    Topics =
+                    [
+                        new WriteTxnMarkersRequestTopic
+                        {
+                            Name = "orders",
+                            PartitionIndexes = [1]
+                        }
+                    ]
+                }
+            ]
+        };
+        request.Write(ref writer, version: 1);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        var markerCount = reader.ReadUnsignedVarInt() - 1;
+        var producerId = reader.ReadInt64();
+        var producerEpoch = reader.ReadInt16();
+        var transactionResult = reader.ReadBoolean();
+        var topicCount = reader.ReadUnsignedVarInt() - 1;
+        var topicName = reader.ReadCompactNonNullableString();
+        var partitionCount = reader.ReadUnsignedVarInt() - 1;
+        var partitionIndex = reader.ReadInt32();
+        reader.SkipTaggedFields();
+        var coordinatorEpoch = reader.ReadInt32();
+        reader.SkipTaggedFields();
+        reader.SkipTaggedFields();
+        var end = reader.End;
+
+        await Assert.That(markerCount).IsEqualTo(1);
+        await Assert.That(producerId).IsEqualTo(42L);
+        await Assert.That(producerEpoch).IsEqualTo((short)7);
+        await Assert.That(transactionResult).IsFalse();
+        await Assert.That(topicCount).IsEqualTo(1);
+        await Assert.That(topicName).IsEqualTo("orders");
+        await Assert.That(partitionCount).IsEqualTo(1);
+        await Assert.That(partitionIndex).IsEqualTo(1);
+        await Assert.That(coordinatorEpoch).IsEqualTo(5);
+        await Assert.That(end).IsTrue();
+    }
+
+    [Test]
+    public async Task WriteTxnMarkersRequest_V2_IncludesTransactionVersion()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new WriteTxnMarkersRequest
+        {
+            Markers =
+            [
+                new WriteTxnMarkersRequestMarker
+                {
+                    ProducerId = 42,
+                    ProducerEpoch = 7,
+                    TransactionResult = false,
+                    CoordinatorEpoch = 5,
+                    TransactionVersion = 2,
+                    Topics =
+                    [
+                        new WriteTxnMarkersRequestTopic
+                        {
+                            Name = "orders",
+                            PartitionIndexes = [1]
+                        }
+                    ]
+                }
+            ]
+        };
+        request.Write(ref writer, version: 2);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        _ = reader.ReadUnsignedVarInt();
+        _ = reader.ReadInt64();
+        _ = reader.ReadInt16();
+        _ = reader.ReadBoolean();
+        _ = reader.ReadUnsignedVarInt();
+        _ = reader.ReadCompactNonNullableString();
+        _ = reader.ReadUnsignedVarInt();
+        _ = reader.ReadInt32();
+        reader.SkipTaggedFields();
+        _ = reader.ReadInt32();
+        var transactionVersion = reader.ReadInt8();
+        reader.SkipTaggedFields();
+        reader.SkipTaggedFields();
+        var end = reader.End;
+
+        await Assert.That(transactionVersion).IsEqualTo((sbyte)2);
+        await Assert.That(end).IsTrue();
+    }
+
+    [Test]
+    public async Task WriteTxnMarkersResponse_V1_ReadsCorrectly()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteInt64(42);
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteCompactString("orders");
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteInt32(1);
+        writer.WriteInt16((short)ErrorCode.InvalidProducerEpoch);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (WriteTxnMarkersResponse)WriteTxnMarkersResponse.Read(ref reader, version: 1);
+
+        await Assert.That(response.Markers.Count).IsEqualTo(1);
+        await Assert.That(response.Markers[0].ProducerId).IsEqualTo(42L);
+        await Assert.That(response.Markers[0].Topics[0].Name).IsEqualTo("orders");
+        await Assert.That(response.Markers[0].Topics[0].Partitions[0].PartitionIndex).IsEqualTo(1);
+        await Assert.That(response.Markers[0].Topics[0].Partitions[0].ErrorCode).IsEqualTo(ErrorCode.InvalidProducerEpoch);
+    }
+
     #region Version Constants Tests
 
     [Test]
@@ -405,6 +541,17 @@ public sealed class TransactionProtocolTests
         await Assert.That(AddOffsetsToTxnRequest.ApiKey).IsEqualTo(ApiKey.AddOffsetsToTxn);
         await Assert.That(AddOffsetsToTxnRequest.LowestSupportedVersion).IsEqualTo((short)3);
         await Assert.That(AddOffsetsToTxnRequest.HighestSupportedVersion).IsEqualTo((short)4);
+    }
+
+    [Test]
+    public async Task WriteTxnMarkersRequest_VersionConstants()
+    {
+        await Assert.That(WriteTxnMarkersRequest.ApiKey).IsEqualTo(ApiKey.WriteTxnMarkers);
+        await Assert.That(WriteTxnMarkersRequest.LowestSupportedVersion).IsEqualTo((short)1);
+        await Assert.That(WriteTxnMarkersRequest.HighestSupportedVersion).IsEqualTo((short)2);
+        await Assert.That(WriteTxnMarkersResponse.ApiKey).IsEqualTo(ApiKey.WriteTxnMarkers);
+        await Assert.That(WriteTxnMarkersResponse.LowestSupportedVersion).IsEqualTo((short)1);
+        await Assert.That(WriteTxnMarkersResponse.HighestSupportedVersion).IsEqualTo((short)2);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- add admin `FenceProducersAsync` and `AbortTransactionAsync` APIs/result types
- wire `WriteTxnMarkers` protocol support plus admin coordinator/leader routing
- cover remediation behavior with unit, protocol, and broker-backed integration tests

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -v:minimal`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --disable-logo --no-ansi --treenode-filter "/*/*/AdminClientTransactionIntrospectionTests/*" --minimum-expected-tests 22`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --disable-logo --no-ansi --treenode-filter "/*/*/TransactionProtocolTests/*" --minimum-expected-tests 18`
- [x] `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --framework netstandard2.0 --no-restore -p:TreatWarningsAsErrors=true --no-incremental -v:minimal`
- [x] `dotnet build src\Dekaf.Testing\Dekaf.Testing.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true --no-incremental -v:minimal`
- [x] `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -v:minimal`
- [x] `tests\Dekaf.Tests.Integration\bin\Release\net10.0\Dekaf.Tests.Integration.exe --disable-logo --no-ansi --treenode-filter "/*/*/AdminTransactionRemediationTests/*" --minimum-expected-tests 2`
- [x] `git diff --check`
- [x] `git diff --check origin/main...HEAD`

Closes #1383
