### PR TITLE
feat(schemaregistry): add rule payload hooks

### DIFF
--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -115,7 +115,23 @@ public sealed class AvroSchemaRegistryDeserializer<
         var writerSchema = GetWriterSchemaCached(schemaId);
 
         // Extract Avro payload using pooled buffer to avoid allocation
-        var payload = span.Slice(5);
+        var payloadMemory = data.Slice(5);
+        if (_config.RuleExecutor is not null)
+        {
+            var schema = _schemaRegistry.GetSchemaSync(schemaId, SchemaRegistryTimeout);
+            payloadMemory = _config.RuleExecutor.TransformDeserializedPayload(
+                payloadMemory,
+                new SchemaRegistryRuleContext
+                {
+                    Topic = context.Topic,
+                    Component = context.Component,
+                    SchemaId = schemaId,
+                    Schema = schema,
+                    PayloadFormat = SchemaRegistryPayloadFormat.Avro
+                });
+        }
+
+        var payload = payloadMemory.Span;
         var codecState = AvroCodecThreadStateCache.Deserialization ??= new AvroDeserializationThreadState();
         var memoryStream = codecState.Stream;
         var rentedBuffer = ArrayPool<byte>.Shared.Rent(payload.Length);

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -126,14 +126,35 @@ public sealed class AvroSchemaRegistrySerializer<
             encoder.Flush();
 
             var avroPayloadLength = (int)memoryStream.Position;
+            var payload = new ReadOnlyMemory<byte>(memoryStream.GetBuffer(), 0, avroPayloadLength);
+            if (_config.RuleExecutor is not null)
+            {
+                var isKey = context.Component == SerializationComponent.Key;
+                var subject = GetSubjectName(context.Topic, isKey);
+                payload = _config.RuleExecutor.TransformSerializedPayload(
+                    payload,
+                    new SchemaRegistryRuleContext
+                    {
+                        Topic = context.Topic,
+                        Component = context.Component,
+                        SchemaId = schemaId,
+                        Subject = subject,
+                        Schema = new RegistrySchema
+                        {
+                            SchemaType = SchemaType.Avro,
+                            SchemaString = GetSchemaFromValue(value).ToString()
+                        },
+                        PayloadFormat = SchemaRegistryPayloadFormat.Avro
+                    });
+            }
 
             // Write wire format: [0x00] [schema ID] [Avro payload]
-            var totalSize = 1 + 4 + avroPayloadLength;
+            var totalSize = 1 + 4 + payload.Length;
             var span = destination.GetSpan(totalSize);
 
             span[0] = MagicByte;
             BinaryPrimitives.WriteInt32BigEndian(span.Slice(1, 4), schemaId);
-            memoryStream.GetBuffer().AsSpan(0, avroPayloadLength).CopyTo(span.Slice(5));
+            payload.Span.CopyTo(span.Slice(5));
 
             destination.Advance(totalSize);
         }

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -90,8 +90,9 @@ public sealed class AvroSchemaRegistrySerializer<
     {
         ArgumentNullException.ThrowIfNull(value);
         var subject = GetSubjectName(topic, isKey);
-        var schemaId = await GetOrFetchSchemaIdAsync(subject, value, cancellationToken).ConfigureAwait(false);
-        CacheSubjectSchemaId(topic, isKey, schemaId);
+        var schema = CreateRegistrySchema(value);
+        var schemaId = await GetOrFetchSchemaIdAsync(subject, schema, cancellationToken).ConfigureAwait(false);
+        CacheSubjectSchemaId(topic, isKey, subject, schemaId, schema);
         return schemaId;
     }
 
@@ -110,7 +111,8 @@ public sealed class AvroSchemaRegistrySerializer<
     {
         ArgumentNullException.ThrowIfNull(value);
 
-        var schemaId = GetSchemaIdForContext(context.Topic, context.Component == SerializationComponent.Key, value);
+        var schemaEntry = GetSchemaForContext(context.Topic, context.Component == SerializationComponent.Key, value);
+        var schemaId = schemaEntry.SchemaId;
 
         var codecState = AvroCodecThreadStateCache.Serialization ??= new AvroSerializationThreadState();
         var memoryStream = codecState.Stream;
@@ -129,8 +131,6 @@ public sealed class AvroSchemaRegistrySerializer<
             var payload = new ReadOnlyMemory<byte>(memoryStream.GetBuffer(), 0, avroPayloadLength);
             if (_config.RuleExecutor is not null)
             {
-                var isKey = context.Component == SerializationComponent.Key;
-                var subject = GetSubjectName(context.Topic, isKey);
                 payload = _config.RuleExecutor.TransformSerializedPayload(
                     payload,
                     new SchemaRegistryRuleContext
@@ -138,12 +138,8 @@ public sealed class AvroSchemaRegistrySerializer<
                         Topic = context.Topic,
                         Component = context.Component,
                         SchemaId = schemaId,
-                        Subject = subject,
-                        Schema = new RegistrySchema
-                        {
-                            SchemaType = SchemaType.Avro,
-                            SchemaString = GetSchemaFromValue(value).ToString()
-                        },
+                        Subject = schemaEntry.Subject,
+                        Schema = schemaEntry.Schema,
                         PayloadFormat = SchemaRegistryPayloadFormat.Avro
                     });
             }
@@ -165,18 +161,24 @@ public sealed class AvroSchemaRegistrySerializer<
         }
     }
 
-    private int GetSchemaIdForContext(string topic, bool isKey, T value)
+    private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry GetSchemaForContext(string topic, bool isKey, T value)
         => _subjectSchemaIdCache.GetOrAdd(
             topic,
             isKey,
             new SubjectSchemaIdState(this, value),
             static (state, topic, isKey) => state.Serializer.GetSubjectName(topic, isKey),
-            static (state, subject) => state.Serializer.GetSchemaIdCached(subject, state.Value));
+            static (state, subject) => state.Serializer.GetSchemaIdCacheValue(subject, state.Value));
 
-    private int CacheSubjectSchemaId(string topic, bool isKey, int schemaId)
-        => _subjectSchemaIdCache.Cache(topic, isKey, schemaId);
+    private int CacheSubjectSchemaId(string topic, bool isKey, string subject, int schemaId, RegistrySchema schema)
+        => _subjectSchemaIdCache.Cache(topic, isKey, subject, schemaId, schema);
 
     private readonly record struct SubjectSchemaIdState(AvroSchemaRegistrySerializer<T> Serializer, T Value);
+
+    private SubjectSchemaIdCache.SubjectSchemaIdCacheValue GetSchemaIdCacheValue(string subject, T value)
+    {
+        var schema = CreateRegistrySchema(value);
+        return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(GetSchemaIdCached(subject, schema), schema);
+    }
 
     private void WriteAvroValue(T value, BinaryEncoder encoder)
     {
@@ -202,9 +204,9 @@ public sealed class AvroSchemaRegistrySerializer<
         }
     }
 
-    private int GetSchemaIdCached(string subject, T value)
+    private int GetSchemaIdCached(string subject, RegistrySchema schema)
     {
-        var lazyTask = GetOrAddSchemaIdLazy(subject, value, cancellationToken: default);
+        var lazyTask = GetOrAddSchemaIdLazy(subject, schema, cancellationToken: default);
 
         // If the task is already completed, this returns immediately without blocking.
         // If this is the first access, it will block waiting for the schema fetch.
@@ -223,44 +225,40 @@ public sealed class AvroSchemaRegistrySerializer<
         return task.WaitAsync(SchemaRegistryTimeout).ConfigureAwait(false).GetAwaiter().GetResult();
     }
 
-    private async Task<int> GetOrFetchSchemaIdAsync(string subject, T value, CancellationToken cancellationToken = default)
+    private async Task<int> GetOrFetchSchemaIdAsync(
+        string subject,
+        RegistrySchema schema,
+        CancellationToken cancellationToken = default)
     {
-        var lazyTask = GetOrAddSchemaIdLazy(subject, value, cancellationToken);
+        var lazyTask = GetOrAddSchemaIdLazy(subject, schema, cancellationToken);
 
         return await lazyTask.Value.ConfigureAwait(false);
     }
 
-    private Lazy<Task<int>> GetOrAddSchemaIdLazy(string subject, T value, CancellationToken cancellationToken)
+    private Lazy<Task<int>> GetOrAddSchemaIdLazy(string subject, RegistrySchema schema, CancellationToken cancellationToken)
     {
         if (_schemaIdCache.TryGetValue(subject, out var cached))
             return cached;
 
         return _schemaIdCache.GetOrAdd(
             subject,
-            static (key, state) => state.Serializer.CreateSchemaIdLazy(key, state.Value, state.CancellationToken),
-            new SchemaIdFetchState(this, value, cancellationToken));
+            static (key, state) => state.Serializer.CreateSchemaIdLazy(key, state.Schema, state.CancellationToken),
+            new SchemaIdFetchState(this, schema, cancellationToken));
     }
 
-    private Lazy<Task<int>> CreateSchemaIdLazy(string subject, T value, CancellationToken cancellationToken) =>
-        new(() => FetchSchemaIdAsync(subject, value, cancellationToken));
+    private Lazy<Task<int>> CreateSchemaIdLazy(string subject, RegistrySchema schema, CancellationToken cancellationToken) =>
+        new(() => FetchSchemaIdAsync(subject, schema, cancellationToken));
 
     private readonly record struct SchemaIdFetchState(
         AvroSchemaRegistrySerializer<T> Serializer,
-        T Value,
+        RegistrySchema Schema,
         CancellationToken CancellationToken);
 
-    private async Task<int> FetchSchemaIdAsync(string subject, T value, CancellationToken cancellationToken = default)
+    private async Task<int> FetchSchemaIdAsync(
+        string subject,
+        RegistrySchema registrySchema,
+        CancellationToken cancellationToken = default)
     {
-        // Get schema from value or type
-        var avroSchema = GetSchemaFromValue(value);
-        var schemaString = avroSchema.ToString();
-
-        var registrySchema = new RegistrySchema
-        {
-            SchemaType = SchemaType.Avro,
-            SchemaString = schemaString
-        };
-
         if (_config.UseLatestVersion)
         {
             // Use latest schema from registry
@@ -280,6 +278,16 @@ public sealed class AvroSchemaRegistrySerializer<
         var existing = await _schemaRegistry.GetSchemaBySubjectAsync(subject, "latest", cancellationToken)
             .ConfigureAwait(false);
         return existing.Id;
+    }
+
+    private RegistrySchema CreateRegistrySchema(T value)
+    {
+        var avroSchema = GetSchemaFromValue(value);
+        return new RegistrySchema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = avroSchema.ToString()
+        };
     }
 
     private AvroSchema GetSchemaFromValue(T value)

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSerializerConfig.cs
@@ -32,6 +32,10 @@ public sealed class AvroSerializerConfig
     /// </summary>
     public bool UseLatestVersion { get; init; }
 
+    /// <summary>
+    /// Optional rule executor applied to Avro payload bytes before the Schema Registry envelope is written.
+    /// </summary>
+    public ISchemaRegistryRuleExecutor? RuleExecutor { get; init; }
 }
 
 /// <summary>
@@ -44,4 +48,9 @@ public sealed class AvroDeserializerConfig
     /// When null, the reader schema is derived from the type T.
     /// </summary>
     public string? ReaderSchema { get; init; }
+
+    /// <summary>
+    /// Optional rule executor applied to Avro payload bytes after the Schema Registry envelope is read.
+    /// </summary>
+    public ISchemaRegistryRuleExecutor? RuleExecutor { get; init; }
 }

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufDeserializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufDeserializerConfig.cs
@@ -17,4 +17,10 @@ public sealed class ProtobufDeserializerConfig
     /// Default is false.
     /// </summary>
     public bool SkipSchemaValidation { get; init; }
+
+    /// <summary>
+    /// Optional rule executor applied to Protobuf message bytes after the Schema Registry envelope is read.
+    /// The Protobuf message-index prefix is not transformed.
+    /// </summary>
+    public ISchemaRegistryRuleExecutor? RuleExecutor { get; init; }
 }

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistryDeserializer.cs
@@ -62,15 +62,17 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
         var schemaId = BinaryPrimitives.ReadInt32BigEndian(span.Slice(1, 4));
 
         // Optionally validate the schema exists (with timeout to prevent indefinite hang)
+        Schema? schema = null;
         if (!_config.SkipSchemaValidation)
         {
-            var schema = _schemaRegistry.GetSchemaSync(schemaId, SchemaRegistryTimeout);
+            schema = _schemaRegistry.GetSchemaSync(schemaId, SchemaRegistryTimeout);
             if (schema.SchemaType != SchemaType.Protobuf)
                 throw new InvalidOperationException($"Schema {schemaId} is not a Protobuf schema (type: {schema.SchemaType})");
         }
 
         // Read the message indexes (varints)
-        var payload = span.Slice(5);
+        var payloadMemory = data.Slice(5);
+        var payload = payloadMemory.Span;
         var (indexCount, bytesRead) = ReadVarint(payload, _config.UseDeprecatedFormat);
         if (indexCount < 0)
             throw new InvalidOperationException("Message index array length cannot be negative");
@@ -85,11 +87,24 @@ public sealed class ProtobufSchemaRegistryDeserializer<T> : IDeserializer<T>, IA
         }
 
         // The rest is the protobuf message
-        var protobufData = payload.Slice(bytesRead);
+        var protobufData = payloadMemory.Slice(bytesRead);
+        if (_config.RuleExecutor is not null)
+        {
+            protobufData = _config.RuleExecutor.TransformDeserializedPayload(
+                protobufData,
+                new SchemaRegistryRuleContext
+                {
+                    Topic = context.Topic,
+                    Component = context.Component,
+                    SchemaId = schemaId,
+                    Schema = schema,
+                    PayloadFormat = SchemaRegistryPayloadFormat.Protobuf
+                });
+        }
 
         // Parse directly from span — zero allocation (Google.Protobuf 3.21+).
         // IBufferMessage constraint is enforced at compile time.
-        return _parser.ParseFrom(protobufData);
+        return _parser.ParseFrom(protobufData.Span);
     }
 
     private static (int value, int bytesRead) ReadVarint(ReadOnlySpan<byte> data, bool useDeprecatedFormat)

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -81,9 +81,25 @@ public sealed class ProtobufSchemaRegistrySerializer<
         var schemaId = GetSchemaIdForContext(context.Topic, context.Component == SerializationComponent.Key);
 
         var protoSize = value.CalculateSize();
+        ReadOnlyMemory<byte> transformedPayload = default;
+        if (_config.RuleExecutor is not null)
+        {
+            transformedPayload = _config.RuleExecutor.TransformSerializedPayload(
+                value.ToByteArray(),
+                new SchemaRegistryRuleContext
+                {
+                    Topic = context.Topic,
+                    Component = context.Component,
+                    SchemaId = schemaId,
+                    Subject = GetSubjectName(context.Topic, context.Component == SerializationComponent.Key),
+                    Schema = _schema,
+                    PayloadFormat = SchemaRegistryPayloadFormat.Protobuf
+                });
+        }
 
         // Total size: magic byte + schema ID + indexes + message
-        var totalSize = 1 + 4 + _encodedMessageIndexes.Length + protoSize;
+        var protobufPayloadLength = _config.RuleExecutor is null ? protoSize : transformedPayload.Length;
+        var totalSize = 1 + 4 + _encodedMessageIndexes.Length + protobufPayloadLength;
         var span = destination.GetSpan(totalSize);
 
         // Write magic byte
@@ -97,7 +113,10 @@ public sealed class ProtobufSchemaRegistrySerializer<
         offset += _encodedMessageIndexes.Length;
 
         // Write the protobuf message
-        value.WriteTo(span.Slice(offset, protoSize));
+        if (_config.RuleExecutor is null)
+            value.WriteTo(span.Slice(offset, protoSize));
+        else
+            transformedPayload.Span.CopyTo(span.Slice(offset, transformedPayload.Length));
 
         destination.Advance(totalSize);
     }

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -78,7 +78,8 @@ public sealed class ProtobufSchemaRegistrySerializer<
     {
         ArgumentNullException.ThrowIfNull(value);
 
-        var schemaId = GetSchemaIdForContext(context.Topic, context.Component == SerializationComponent.Key);
+        var schemaEntry = GetSchemaForContext(context.Topic, context.Component == SerializationComponent.Key);
+        var schemaId = schemaEntry.SchemaId;
 
         var protoSize = value.CalculateSize();
         ReadOnlyMemory<byte> transformedPayload = default;
@@ -91,8 +92,8 @@ public sealed class ProtobufSchemaRegistrySerializer<
                     Topic = context.Topic,
                     Component = context.Component,
                     SchemaId = schemaId,
-                    Subject = GetSubjectName(context.Topic, context.Component == SerializationComponent.Key),
-                    Schema = _schema,
+                    Subject = schemaEntry.Subject,
+                    Schema = schemaEntry.Schema,
                     PayloadFormat = SchemaRegistryPayloadFormat.Protobuf
                 });
         }
@@ -121,13 +122,15 @@ public sealed class ProtobufSchemaRegistrySerializer<
         destination.Advance(totalSize);
     }
 
-    private int GetSchemaIdForContext(string topic, bool isKey)
+    private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry GetSchemaForContext(string topic, bool isKey)
         => _subjectSchemaIdCache.GetOrAdd(
             topic,
             isKey,
             this,
             static (serializer, topic, isKey) => serializer.GetSubjectName(topic, isKey),
-            static (serializer, subject) => serializer.GetSchemaIdSync(subject));
+            static (serializer, subject) => new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(
+                serializer.GetSchemaIdSync(subject),
+                serializer._schema));
 
     private int GetSchemaIdSync(string subject)
     {

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
@@ -57,6 +57,12 @@ public sealed class ProtobufSerializerConfig
     /// Default is <see cref="ReferenceSubjectNameStrategy.ReferenceName"/>.
     /// </summary>
     public ReferenceSubjectNameStrategy ReferenceSubjectNameStrategy { get; init; } = ReferenceSubjectNameStrategy.ReferenceName;
+
+    /// <summary>
+    /// Optional rule executor applied to Protobuf message bytes before the Schema Registry envelope is written.
+    /// The Protobuf message-index prefix is not transformed.
+    /// </summary>
+    public ISchemaRegistryRuleExecutor? RuleExecutor { get; init; }
 }
 
 /// <summary>

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -182,7 +182,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
     {
-        var schemaId = GetSchemaIdForContext(context.Topic, context.Component == SerializationComponent.Key);
+        var schemaEntry = GetSchemaForContext(context.Topic, context.Component == SerializationComponent.Key);
+        var schemaId = schemaEntry.SchemaId;
 
         var payloadBuffer = SchemaRegistryBuffers.PayloadBuffer ??= new ArrayBufferWriter<byte>(initialCapacity: 4096);
         payloadBuffer.ResetWrittenCount();
@@ -212,7 +213,6 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         var payload = payloadBuffer.WrittenMemory;
         if (_ruleExecutor is not null)
         {
-            var isKey = context.Component == SerializationComponent.Key;
             payload = _ruleExecutor.TransformSerializedPayload(
                 payload,
                 new SchemaRegistryRuleContext
@@ -220,8 +220,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
                     Topic = context.Topic,
                     Component = context.Component,
                     SchemaId = schemaId,
-                    Subject = GetSubjectName(context.Topic, isKey),
-                    Schema = _schema,
+                    Subject = schemaEntry.Subject,
+                    Schema = schemaEntry.Schema,
                     PayloadFormat = SchemaRegistryPayloadFormat.Json
                 });
         }
@@ -243,13 +243,15 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         }
     }
 
-    private int GetSchemaIdForContext(string topic, bool isKey)
+    private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry GetSchemaForContext(string topic, bool isKey)
         => _subjectSchemaIdCache.GetOrAdd(
             topic,
             isKey,
             this,
             static (serializer, topic, isKey) => serializer.GetSubjectName(topic, isKey),
-            static (serializer, subject) => serializer.GetSchemaIdSync(subject));
+            static (serializer, subject) => new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(
+                serializer.GetSchemaIdSync(subject),
+                serializer._schema));
 
     private int GetSchemaIdSync(string subject)
     {

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -42,6 +42,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     private readonly bool _autoRegisterSchemas;
     private readonly Schema _schema;
     private readonly bool _ownsClient;
+    private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
 
     private readonly ConcurrentDictionary<string, int> _schemaIdCache = new();
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
@@ -63,7 +64,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         JsonSerializerOptions? jsonOptions = null,
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true,
-        bool ownsClient = false)
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _jsonOptions = CreateJsonOptions(jsonOptions);
@@ -71,6 +73,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         _subjectNameStrategy = subjectNameStrategy;
         _autoRegisterSchemas = autoRegisterSchemas;
         _ownsClient = ownsClient;
+        _ruleExecutor = ruleExecutor;
         _schema = new Schema
         {
             SchemaType = SchemaType.Json,
@@ -93,7 +96,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         JsonTypeInfo<T> jsonTypeInfo,
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true,
-        bool ownsClient = false)
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _jsonTypeInfo = jsonTypeInfo ?? throw new ArgumentNullException(nameof(jsonTypeInfo));
@@ -101,6 +105,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         _subjectNameStrategy = subjectNameStrategy;
         _autoRegisterSchemas = autoRegisterSchemas;
         _ownsClient = ownsClient;
+        _ruleExecutor = ruleExecutor;
         _schema = new Schema
         {
             SchemaType = SchemaType.Json,
@@ -125,7 +130,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         ISubjectNameStrategy customSubjectNameStrategy,
         JsonSerializerOptions? jsonOptions = null,
         bool autoRegisterSchemas = true,
-        bool ownsClient = false)
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _customSubjectNameStrategy = customSubjectNameStrategy ?? throw new ArgumentNullException(nameof(customSubjectNameStrategy));
@@ -133,6 +139,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         _serializePayload = SerializeWithOptions;
         _autoRegisterSchemas = autoRegisterSchemas;
         _ownsClient = ownsClient;
+        _ruleExecutor = ruleExecutor;
         _schema = new Schema
         {
             SchemaType = SchemaType.Json,
@@ -155,7 +162,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         ISubjectNameStrategy customSubjectNameStrategy,
         JsonTypeInfo<T> jsonTypeInfo,
         bool autoRegisterSchemas = true,
-        bool ownsClient = false)
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _customSubjectNameStrategy = customSubjectNameStrategy ?? throw new ArgumentNullException(nameof(customSubjectNameStrategy));
@@ -163,6 +171,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         _serializePayload = SerializeWithTypeInfo;
         _autoRegisterSchemas = autoRegisterSchemas;
         _ownsClient = ownsClient;
+        _ruleExecutor = ruleExecutor;
         _schema = new Schema
         {
             SchemaType = SchemaType.Json,
@@ -200,13 +209,30 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
             throw;
         }
 
+        var payload = payloadBuffer.WrittenMemory;
+        if (_ruleExecutor is not null)
+        {
+            var isKey = context.Component == SerializationComponent.Key;
+            payload = _ruleExecutor.TransformSerializedPayload(
+                payload,
+                new SchemaRegistryRuleContext
+                {
+                    Topic = context.Topic,
+                    Component = context.Component,
+                    SchemaId = schemaId,
+                    Subject = GetSubjectName(context.Topic, isKey),
+                    Schema = _schema,
+                    PayloadFormat = SchemaRegistryPayloadFormat.Json
+                });
+        }
+
         // Write wire format: [0x00] [schema ID] [JSON payload]
-        var totalSize = 1 + 4 + payloadBuffer.WrittenCount;
+        var totalSize = 1 + 4 + payload.Length;
         var span = destination.GetSpan(totalSize);
 
         span[0] = MagicByte;
         BinaryPrimitives.WriteInt32BigEndian(span.Slice(1, 4), schemaId);
-        payloadBuffer.WrittenSpan.CopyTo(span.Slice(5));
+        payload.Span.CopyTo(span.Slice(5));
 
         destination.Advance(totalSize);
 
@@ -311,6 +337,7 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
     private readonly JsonSerializerOptions? _jsonOptions;
     private readonly JsonTypeInfo<T>? _jsonTypeInfo;
     private readonly bool _ownsClient;
+    private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
 
     /// <summary>
     /// Creates a new JSON Schema Registry deserializer.
@@ -323,12 +350,14 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
     public JsonSchemaRegistryDeserializer(
         ISchemaRegistryClient schemaRegistry,
         JsonSerializerOptions? jsonOptions = null,
-        bool ownsClient = false)
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _jsonOptions = CreateJsonOptions(jsonOptions);
         _deserializePayload = DeserializeWithOptions;
         _ownsClient = ownsClient;
+        _ruleExecutor = ruleExecutor;
     }
 
     /// <summary>
@@ -340,12 +369,14 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
     public JsonSchemaRegistryDeserializer(
         ISchemaRegistryClient schemaRegistry,
         JsonTypeInfo<T> jsonTypeInfo,
-        bool ownsClient = false)
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _jsonTypeInfo = jsonTypeInfo ?? throw new ArgumentNullException(nameof(jsonTypeInfo));
         _deserializePayload = DeserializeWithTypeInfo;
         _ownsClient = ownsClient;
+        _ruleExecutor = ruleExecutor;
     }
 
     public T Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
@@ -361,10 +392,25 @@ public sealed class JsonSchemaRegistryDeserializer<T> : IDeserializer<T>, IAsync
         var schemaId = BinaryPrimitives.ReadInt32BigEndian(span.Slice(1, 4));
 
         // Verify the schema exists. Cache hits avoid Task allocation and sync-over-async.
-        _ = _schemaRegistry.GetSchemaSync(schemaId, SchemaRegistryTimeout);
+        var schema = _schemaRegistry.GetSchemaSync(schemaId, SchemaRegistryTimeout);
 
         // Extract JSON payload and deserialize
-        return _deserializePayload(span.Slice(5));
+        var payload = data.Slice(5);
+        if (_ruleExecutor is not null)
+        {
+            payload = _ruleExecutor.TransformDeserializedPayload(
+                payload,
+                new SchemaRegistryRuleContext
+                {
+                    Topic = context.Topic,
+                    Component = context.Component,
+                    SchemaId = schemaId,
+                    Schema = schema,
+                    PayloadFormat = SchemaRegistryPayloadFormat.Json
+                });
+        }
+
+        return _deserializePayload(payload.Span);
     }
 
     public ValueTask DisposeAsync()

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
@@ -54,7 +54,8 @@ public sealed class SchemaRegistryRuleContext
     public string? Subject { get; init; }
 
     /// <summary>
-    /// Gets the Schema Registry schema when available.
+    /// Gets the Schema Registry schema when available. This can be <see langword="null" />
+    /// when a deserializer skips schema validation or when the subject is unknown.
     /// </summary>
     public Schema? Schema { get; init; }
 
@@ -76,6 +77,10 @@ public interface ISchemaRegistryRuleExecutor
     /// <summary>
     /// Transforms the codec payload immediately before it is written to the Schema Registry wire envelope.
     /// </summary>
+    /// <remarks>
+    /// The <paramref name="payload" /> memory is valid only for the synchronous duration of this call.
+    /// Implementations that retain the bytes or use them after returning must copy the payload.
+    /// </remarks>
     ReadOnlyMemory<byte> TransformSerializedPayload(
         ReadOnlyMemory<byte> payload,
         SchemaRegistryRuleContext context);
@@ -83,6 +88,12 @@ public interface ISchemaRegistryRuleExecutor
     /// <summary>
     /// Transforms the codec payload immediately after it is read from the Schema Registry wire envelope.
     /// </summary>
+    /// <remarks>
+    /// The <paramref name="payload" /> memory is valid only for the synchronous duration of this call.
+    /// Implementations that retain the bytes or use them after returning must copy the payload.
+    /// The <see cref="SchemaRegistryRuleContext.Schema" /> property can be <see langword="null" />
+    /// when deserializer schema validation is skipped.
+    /// </remarks>
     ReadOnlyMemory<byte> TransformDeserializedPayload(
         ReadOnlyMemory<byte> payload,
         SchemaRegistryRuleContext context);

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
@@ -1,0 +1,89 @@
+using Dekaf.Serialization;
+
+namespace Dekaf.SchemaRegistry;
+
+/// <summary>
+/// Schema Registry payload format exposed to rule executors.
+/// </summary>
+public enum SchemaRegistryPayloadFormat
+{
+    /// <summary>
+    /// Custom Schema Registry serializer payload.
+    /// </summary>
+    Custom,
+
+    /// <summary>
+    /// JSON Schema payload.
+    /// </summary>
+    Json,
+
+    /// <summary>
+    /// Avro binary payload.
+    /// </summary>
+    Avro,
+
+    /// <summary>
+    /// Protobuf message payload.
+    /// </summary>
+    Protobuf
+}
+
+/// <summary>
+/// Context passed to Schema Registry payload rule executors.
+/// </summary>
+public sealed class SchemaRegistryRuleContext
+{
+    /// <summary>
+    /// Gets the Kafka topic.
+    /// </summary>
+    public required string Topic { get; init; }
+
+    /// <summary>
+    /// Gets whether the payload is for the key or value component.
+    /// </summary>
+    public required SerializationComponent Component { get; init; }
+
+    /// <summary>
+    /// Gets the Schema Registry schema ID from the wire envelope.
+    /// </summary>
+    public required int SchemaId { get; init; }
+
+    /// <summary>
+    /// Gets the Schema Registry subject when known.
+    /// </summary>
+    public string? Subject { get; init; }
+
+    /// <summary>
+    /// Gets the Schema Registry schema when available.
+    /// </summary>
+    public Schema? Schema { get; init; }
+
+    /// <summary>
+    /// Gets the codec payload format.
+    /// </summary>
+    public required SchemaRegistryPayloadFormat PayloadFormat { get; init; }
+}
+
+/// <summary>
+/// Executes Schema Registry payload rules such as encryption or other data-contract transforms.
+/// </summary>
+/// <remarks>
+/// Implementations receive only the codec payload bytes. The Schema Registry magic byte,
+/// schema ID, and Protobuf message-index prefix remain owned by the serializer.
+/// </remarks>
+public interface ISchemaRegistryRuleExecutor
+{
+    /// <summary>
+    /// Transforms the codec payload immediately before it is written to the Schema Registry wire envelope.
+    /// </summary>
+    ReadOnlyMemory<byte> TransformSerializedPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext context);
+
+    /// <summary>
+    /// Transforms the codec payload immediately after it is read from the Schema Registry wire envelope.
+    /// </summary>
+    ReadOnlyMemory<byte> TransformDeserializedPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext context);
+}

--- a/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
@@ -38,6 +38,7 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     private readonly ISubjectNameStrategy? _customSubjectNameStrategy;
     private readonly bool _autoRegisterSchemas;
     private readonly bool _ownsClient;
+    private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
 
     private readonly ConcurrentDictionary<string, int> _schemaIdCache = new();
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
@@ -57,7 +58,8 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         Func<string, Schema> getSchema,
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true,
-        bool ownsClient = false)
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _serialize = serialize ?? throw new ArgumentNullException(nameof(serialize));
@@ -65,6 +67,7 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         _subjectNameStrategy = subjectNameStrategy;
         _autoRegisterSchemas = autoRegisterSchemas;
         _ownsClient = ownsClient;
+        _ruleExecutor = ruleExecutor;
     }
 
     /// <summary>
@@ -82,7 +85,8 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         Func<string, Schema> getSchema,
         ISubjectNameStrategy customSubjectNameStrategy,
         bool autoRegisterSchemas = true,
-        bool ownsClient = false)
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _serialize = serialize ?? throw new ArgumentNullException(nameof(serialize));
@@ -90,6 +94,7 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         _customSubjectNameStrategy = customSubjectNameStrategy ?? throw new ArgumentNullException(nameof(customSubjectNameStrategy));
         _autoRegisterSchemas = autoRegisterSchemas;
         _ownsClient = ownsClient;
+        _ruleExecutor = ruleExecutor;
     }
 
     public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
@@ -104,13 +109,31 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         if (payloadBuffer.Capacity > 1024 * 1024)
             SchemaRegistryBuffers.PayloadBuffer = null;
 
+        var payload = payloadBuffer.WrittenMemory;
+        if (_ruleExecutor is not null)
+        {
+            var isKey = context.Component == SerializationComponent.Key;
+            var subject = GetSubjectName(context.Topic, isKey);
+            payload = _ruleExecutor.TransformSerializedPayload(
+                payload,
+                new SchemaRegistryRuleContext
+                {
+                    Topic = context.Topic,
+                    Component = context.Component,
+                    SchemaId = schemaId,
+                    Subject = subject,
+                    Schema = _getSchema(subject),
+                    PayloadFormat = SchemaRegistryPayloadFormat.Custom
+                });
+        }
+
         // Write wire format: [0x00] [schema ID] [payload]
-        var totalSize = 1 + 4 + payloadBuffer.WrittenCount;
+        var totalSize = 1 + 4 + payload.Length;
         var span = destination.GetSpan(totalSize);
 
         span[0] = MagicByte;
         BinaryPrimitives.WriteInt32BigEndian(span.Slice(1, 4), schemaId);
-        payloadBuffer.WrittenSpan.CopyTo(span.Slice(5));
+        payload.Span.CopyTo(span.Slice(5));
 
         destination.Advance(totalSize);
     }
@@ -204,6 +227,7 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
     private readonly ISchemaRegistryClient _schemaRegistry;
     private readonly Func<ReadOnlyMemory<byte>, Schema, T> _deserialize;
     private readonly bool _ownsClient;
+    private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
 
     /// <summary>
     /// Creates a new Schema Registry deserializer.
@@ -214,11 +238,13 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
     public SchemaRegistryDeserializer(
         ISchemaRegistryClient schemaRegistry,
         Func<byte[], Schema, T> deserialize,
-        bool ownsClient = false)
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null)
         : this(
             schemaRegistry,
             (ReadOnlyMemory<byte> payload, Schema schema) => deserialize(payload.ToArray(), schema),
-            ownsClient)
+            ownsClient,
+            ruleExecutor)
     {
     }
 
@@ -231,11 +257,13 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
     internal SchemaRegistryDeserializer(
         ISchemaRegistryClient schemaRegistry,
         Func<ReadOnlyMemory<byte>, Schema, T> deserialize,
-        bool ownsClient)
+        bool ownsClient,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _deserialize = deserialize ?? throw new ArgumentNullException(nameof(deserialize));
         _ownsClient = ownsClient;
+        _ruleExecutor = ruleExecutor;
     }
 
     public T Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
@@ -252,6 +280,19 @@ public sealed class SchemaRegistryDeserializer<T> : IDeserializer<T>, IAsyncDisp
 
         var schema = _schemaRegistry.GetSchemaSync(schemaId, SchemaRegistryTimeout);
         var payload = data.Slice(5);
+        if (_ruleExecutor is not null)
+        {
+            payload = _ruleExecutor.TransformDeserializedPayload(
+                payload,
+                new SchemaRegistryRuleContext
+                {
+                    Topic = context.Topic,
+                    Component = context.Component,
+                    SchemaId = schemaId,
+                    Schema = schema,
+                    PayloadFormat = SchemaRegistryPayloadFormat.Custom
+                });
+        }
 
         return _deserialize(payload, schema);
     }
@@ -280,8 +321,9 @@ public static class SchemaRegistryDeserializer
     public static SchemaRegistryDeserializer<T> Create<T>(
         ISchemaRegistryClient schemaRegistry,
         Func<ReadOnlyMemory<byte>, Schema, T> deserialize,
-        bool ownsClient = false)
-        => new(schemaRegistry, deserialize, ownsClient);
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null)
+        => new(schemaRegistry, deserialize, ownsClient, ruleExecutor);
 }
 
 /// <summary>

--- a/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
@@ -100,7 +100,8 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
         where TWriter : IBufferWriter<byte>, allows ref struct
     {
-        var schemaId = GetSchemaIdForContext(context.Topic, context.Component == SerializationComponent.Key);
+        var schemaEntry = GetSchemaForContext(context.Topic, context.Component == SerializationComponent.Key);
+        var schemaId = schemaEntry.SchemaId;
 
         var payloadBuffer = SchemaRegistryBuffers.PayloadBuffer ??= new ArrayBufferWriter<byte>(initialCapacity: 4096);
         payloadBuffer.ResetWrittenCount();
@@ -112,8 +113,6 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         var payload = payloadBuffer.WrittenMemory;
         if (_ruleExecutor is not null)
         {
-            var isKey = context.Component == SerializationComponent.Key;
-            var subject = GetSubjectName(context.Topic, isKey);
             payload = _ruleExecutor.TransformSerializedPayload(
                 payload,
                 new SchemaRegistryRuleContext
@@ -121,8 +120,8 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
                     Topic = context.Topic,
                     Component = context.Component,
                     SchemaId = schemaId,
-                    Subject = subject,
-                    Schema = _getSchema(subject),
+                    Subject = schemaEntry.Subject,
+                    Schema = schemaEntry.Schema,
                     PayloadFormat = SchemaRegistryPayloadFormat.Custom
                 });
         }
@@ -138,7 +137,7 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         destination.Advance(totalSize);
     }
 
-    private int GetSchemaIdForContext(string topic, bool isKey)
+    private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry GetSchemaForContext(string topic, bool isKey)
         => _subjectSchemaIdCache.GetOrAdd(
             topic,
             isKey,
@@ -147,7 +146,9 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
             static (serializer, subject) =>
             {
                 var schema = serializer._getSchema(subject);
-                return serializer.GetSchemaIdSync(subject, schema);
+                return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(
+                    serializer.GetSchemaIdSync(subject, schema),
+                    schema);
             });
 
     private int GetSchemaIdSync(string subject, Schema schema)

--- a/src/Dekaf.SchemaRegistry/SubjectSchemaIdCache.cs
+++ b/src/Dekaf.SchemaRegistry/SubjectSchemaIdCache.cs
@@ -14,62 +14,62 @@ internal sealed class SubjectSchemaIdCache
 
     internal int CachedEntryCount => Volatile.Read(ref _cacheCount);
 
-    public int GetOrAdd<TState>(
+    internal SubjectSchemaIdCacheEntry GetOrAdd<TState>(
         string topic,
         bool isKey,
         TState state,
         Func<TState, string, bool, string> getSubjectName,
-        Func<TState, string, int> getSchemaId)
+        Func<TState, string, SubjectSchemaIdCacheValue> getSchema)
     {
         var key = new SubjectSchemaIdCacheKey(topic, isKey);
         var last = Volatile.Read(ref _last);
         if (last is not null && last.Key.Equals(key))
-            return last.SchemaId;
+            return last;
 
         if (_cache.TryGetValue(key, out var cached))
         {
             Volatile.Write(ref _last, cached);
-            return cached.SchemaId;
+            return cached;
         }
 
         var subject = getSubjectName(state, topic, isKey);
-        var schemaId = getSchemaId(state, subject);
-        return Cache(key, schemaId);
+        var schema = getSchema(state, subject);
+        return Cache(key, subject, schema.SchemaId, schema.Schema);
     }
 
-    public int Cache(string topic, bool isKey, int schemaId) =>
-        Cache(new SubjectSchemaIdCacheKey(topic, isKey), schemaId);
+    internal int Cache(string topic, bool isKey, string subject, int schemaId, Schema? schema) =>
+        Cache(new SubjectSchemaIdCacheKey(topic, isKey), subject, schemaId, schema).SchemaId;
 
-    private int Cache(SubjectSchemaIdCacheKey key, int schemaId)
+    private SubjectSchemaIdCacheEntry Cache(SubjectSchemaIdCacheKey key, string? subject, int schemaId, Schema? schema)
     {
         if (_cache.TryGetValue(key, out var existing))
         {
             Volatile.Write(ref _last, existing);
-            return existing.SchemaId;
+            return existing;
         }
 
-        var entry = new SubjectSchemaIdCacheEntry(key, schemaId);
+        var entry = new SubjectSchemaIdCacheEntry(key, subject, schemaId, schema);
         if (!TryReserveSlot())
         {
             Volatile.Write(ref _last, entry);
-            return schemaId;
+            return entry;
         }
 
         if (_cache.TryAdd(key, entry))
         {
             Volatile.Write(ref _last, entry);
-            return schemaId;
+            return entry;
         }
 
         Interlocked.Decrement(ref _cacheCount);
         if (_cache.TryGetValue(key, out existing))
         {
             Volatile.Write(ref _last, existing);
-            return existing.SchemaId;
+            return existing;
         }
 
         Volatile.Write(ref _last, entry);
-        return schemaId;
+        return entry;
     }
 
     private bool TryReserveSlot()
@@ -85,7 +85,13 @@ internal sealed class SubjectSchemaIdCache
         }
     }
 
-    private readonly record struct SubjectSchemaIdCacheKey(string Topic, bool IsKey);
+    internal readonly record struct SubjectSchemaIdCacheKey(string Topic, bool IsKey);
 
-    private sealed record SubjectSchemaIdCacheEntry(SubjectSchemaIdCacheKey Key, int SchemaId);
+    internal readonly record struct SubjectSchemaIdCacheValue(int SchemaId, Schema? Schema);
+
+    internal sealed record SubjectSchemaIdCacheEntry(
+        SubjectSchemaIdCacheKey Key,
+        string? Subject,
+        int SchemaId,
+        Schema? Schema);
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -44,6 +44,30 @@ public sealed class AvroSerializerTests
         return ms.ToArray();
     }
 
+    private sealed class CapturingRuleExecutor(
+        byte[]? serializedPayload = null,
+        byte[]? deserializedPayload = null) : ISchemaRegistryRuleExecutor
+    {
+        public SchemaRegistryRuleContext? SerializeContext { get; private set; }
+        public SchemaRegistryRuleContext? DeserializeContext { get; private set; }
+
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context)
+        {
+            SerializeContext = context;
+            return serializedPayload ?? payload;
+        }
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context)
+        {
+            DeserializeContext = context;
+            return deserializedPayload ?? payload;
+        }
+    }
+
     [Test]
     public async Task Serializer_SerializesGenericRecord_WithWireFormat()
     {
@@ -71,6 +95,36 @@ public sealed class AvroSerializerTests
 
         var schemaId = BinaryPrimitives.ReadInt32BigEndian(data.Span.Slice(1, 4));
         await Assert.That(schemaId).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Serializer_RuleExecutor_TransformsAvroPayload()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        var schema = AvroSchema.Parse(SimpleRecordSchema) as Avro.RecordSchema;
+        var record = new GenericRecord(schema!);
+        record.Add("id", 42);
+        record.Add("name", "plain");
+
+        var replacement = new GenericRecord(schema!);
+        replacement.Add("id", 99);
+        replacement.Add("name", "encrypted");
+        var replacementPayload = SerializeAvroRecord(replacement, schema!);
+        var executor = new CapturingRuleExecutor(serializedPayload: replacementPayload);
+        var config = new AvroSerializerConfig { RuleExecutor = executor };
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry, config);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize(record, ref buffer, CreateContext());
+
+        await Assert.That(buffer.WrittenSpan.Slice(5).ToArray()).IsEquivalentTo(replacementPayload);
+        await Assert.That(executor.SerializeContext).IsNotNull();
+        await Assert.That(executor.SerializeContext!.PayloadFormat).IsEqualTo(SchemaRegistryPayloadFormat.Avro);
+        await Assert.That(executor.SerializeContext.Subject).IsEqualTo("test-topic-value");
+        await Assert.That(executor.SerializeContext.SchemaId).IsGreaterThan(0);
+        await Assert.That(executor.SerializeContext.Schema).IsNotNull();
+        await Assert.That(executor.SerializeContext.Schema!.SchemaType).IsEqualTo(SchemaType.Avro);
+        await Assert.That(executor.SerializeContext.Schema.SchemaString).IsEqualTo(schema!.ToString());
     }
 
     [Test]
@@ -114,6 +168,37 @@ public sealed class AvroSerializerTests
         await Assert.That(result).IsNotNull();
         await Assert.That((int)result["id"]!).IsEqualTo(42);
         await Assert.That((string)result["name"]!).IsEqualTo("test");
+    }
+
+    [Test]
+    public async Task Deserializer_RuleExecutor_TransformsAvroPayload()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        var schemaObj = new RegistrySchema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = SimpleRecordSchema
+        };
+        var schemaId = await schemaRegistry.RegisterSchemaAsync("test-topic-value", schemaObj);
+
+        var avroSchema = AvroSchema.Parse(SimpleRecordSchema) as Avro.RecordSchema;
+        var replacement = new GenericRecord(avroSchema!);
+        replacement.Add("id", 7);
+        replacement.Add("name", "plain");
+        var replacementPayload = SerializeAvroRecord(replacement, avroSchema!);
+        var wireFormat = CreateWireFormat(schemaId, "encrypted"u8.ToArray());
+        var executor = new CapturingRuleExecutor(deserializedPayload: replacementPayload);
+        var config = new AvroDeserializerConfig { RuleExecutor = executor };
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(schemaRegistry, config);
+
+        var result = deserializer.Deserialize(wireFormat, CreateContext());
+
+        await Assert.That((int)result["id"]!).IsEqualTo(7);
+        await Assert.That((string)result["name"]!).IsEqualTo("plain");
+        await Assert.That(executor.DeserializeContext).IsNotNull();
+        await Assert.That(executor.DeserializeContext!.PayloadFormat).IsEqualTo(SchemaRegistryPayloadFormat.Avro);
+        await Assert.That(executor.DeserializeContext.SchemaId).IsEqualTo(schemaId);
+        await Assert.That(executor.DeserializeContext.Schema).IsSameReferenceAs(schemaObj);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistryDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistryDeserializerTests.cs
@@ -12,6 +12,35 @@ public class ProtobufSchemaRegistryDeserializerTests
     private static SerializationContext CreateContext(string topic = "test-topic", bool isKey = false) =>
         new() { Topic = topic, Component = isKey ? SerializationComponent.Key : SerializationComponent.Value };
 
+    private sealed class CapturingRuleExecutor(byte[]? deserializedPayload = null) : ISchemaRegistryRuleExecutor
+    {
+        public SchemaRegistryRuleContext? Context { get; private set; }
+
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context)
+            => payload;
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context)
+        {
+            Context = context;
+            return deserializedPayload ?? payload;
+        }
+    }
+
+    private static byte[] CreateWireBytes(int schemaId, TestMessage message)
+    {
+        var protoBytes = message.ToByteArray();
+        var wireBytes = new byte[1 + 4 + 1 + protoBytes.Length];
+        wireBytes[0] = 0x00;
+        BinaryPrimitives.WriteInt32BigEndian(wireBytes.AsSpan(1, 4), schemaId);
+        wireBytes[5] = 0;
+        protoBytes.CopyTo(wireBytes.AsSpan(6));
+        return wireBytes;
+    }
+
     [Test]
     public async Task Deserialize_ReadsCorrectWireFormat()
     {
@@ -76,6 +105,33 @@ public class ProtobufSchemaRegistryDeserializerTests
         await Assert.That(result.Id).IsEqualTo(42);
         await Assert.That(schemaRegistry.TryGetCachedSchemaCallCount).IsEqualTo(1);
         await Assert.That(schemaRegistry.GetSchemaCallCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Deserialize_RuleExecutor_TransformsMessageBytes_AfterMessageIndexes()
+    {
+        var schemaRegistry = new MockSchemaRegistryClient();
+        var schema = new Schema
+        {
+            SchemaType = SchemaType.Protobuf,
+            SchemaString = "syntax = \"proto3\";"
+        };
+        var schemaId = await schemaRegistry.RegisterSchemaAsync("test-topic-value", schema);
+        var replacement = new TestMessage { Id = 9, Name = "Plain", Value = 1.25 };
+        var executor = new CapturingRuleExecutor(replacement.ToByteArray());
+        var config = new ProtobufDeserializerConfig { RuleExecutor = executor };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(schemaRegistry, config);
+        var wireBytes = CreateWireBytes(schemaId, new TestMessage { Id = 1, Name = "Encrypted", Value = 3.14 });
+
+        var result = deserializer.Deserialize(wireBytes, CreateContext());
+
+        await Assert.That(result.Id).IsEqualTo(replacement.Id);
+        await Assert.That(result.Name).IsEqualTo(replacement.Name);
+        await Assert.That(result.Value).IsEqualTo(replacement.Value);
+        await Assert.That(executor.Context).IsNotNull();
+        await Assert.That(executor.Context!.PayloadFormat).IsEqualTo(SchemaRegistryPayloadFormat.Protobuf);
+        await Assert.That(executor.Context.SchemaId).IsEqualTo(schemaId);
+        await Assert.That(executor.Context.Schema).IsSameReferenceAs(schema);
     }
 
     [Test]
@@ -157,6 +213,28 @@ public class ProtobufSchemaRegistryDeserializerTests
         // Assert - schema registry should not be called
         await schemaRegistry.DidNotReceive().GetSchemaAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
         await Assert.That(result.Id).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Deserialize_RuleExecutor_SkipSchemaValidation_PassesNullSchema()
+    {
+        var schemaRegistry = Substitute.For<ISchemaRegistryClient>();
+        var executor = new CapturingRuleExecutor();
+        var config = new ProtobufDeserializerConfig
+        {
+            SkipSchemaValidation = true,
+            RuleExecutor = executor
+        };
+        await using var deserializer = new ProtobufSchemaRegistryDeserializer<TestMessage>(schemaRegistry, config);
+        var wireBytes = CreateWireBytes(123, new TestMessage { Id = 42, Name = "Hello", Value = 3.14 });
+
+        var result = deserializer.Deserialize(wireBytes, CreateContext());
+
+        await schemaRegistry.DidNotReceive().GetSchemaAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await Assert.That(result.Id).IsEqualTo(42);
+        await Assert.That(executor.Context).IsNotNull();
+        await Assert.That(executor.Context!.SchemaId).IsEqualTo(123);
+        await Assert.That(executor.Context.Schema).IsNull();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
@@ -13,6 +13,24 @@ public class ProtobufSchemaRegistrySerializerTests
     private static SerializationContext CreateContext(string topic = "test-topic", bool isKey = false) =>
         new() { Topic = topic, Component = isKey ? SerializationComponent.Key : SerializationComponent.Value };
 
+    private sealed class ReplacingRuleExecutor(byte[] serializedPayload) : ISchemaRegistryRuleExecutor
+    {
+        public SchemaRegistryRuleContext? Context { get; private set; }
+
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context)
+        {
+            Context = context;
+            return serializedPayload;
+        }
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context)
+            => payload;
+    }
+
     [Test]
     public async Task Serialize_WritesCorrectWireFormat()
     {
@@ -45,6 +63,31 @@ public class ProtobufSchemaRegistrySerializerTests
         var expectedPayload = message.ToByteArray();
         await Assert.That(written.AsSpan(6).ToArray()).IsEquivalentTo(expectedPayload);
     }
+
+    [Test]
+    public async Task Serialize_RuleExecutor_TransformsMessageBytes_AfterMessageIndexes()
+    {
+        var schemaRegistry = Substitute.For<ISchemaRegistryClient>();
+        schemaRegistry.GetOrRegisterSchemaAsync(Arg.Any<string>(), Arg.Any<Schema>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(42));
+
+        var replacement = new TestMessage { Id = 9, Name = "Encrypted", Value = 1.25 };
+        var executor = new ReplacingRuleExecutor(replacement.ToByteArray());
+        var config = new ProtobufSerializerConfig { RuleExecutor = executor };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(schemaRegistry, config);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize(new TestMessage { Id = 1, Name = "Plain", Value = 3.14 }, ref buffer, CreateContext());
+
+        var written = buffer.WrittenMemory.ToArray();
+        await Assert.That(written[5]).IsEqualTo((byte)0);
+        await Assert.That(written.AsSpan(6).ToArray()).IsEquivalentTo(replacement.ToByteArray());
+        await Assert.That(executor.Context).IsNotNull();
+        await Assert.That(executor.Context!.PayloadFormat).IsEqualTo(SchemaRegistryPayloadFormat.Protobuf);
+        await Assert.That(executor.Context.Subject).IsEqualTo("test-topic-value");
+        await Assert.That(executor.Context.SchemaId).IsEqualTo(42);
+    }
+
 
     [Test]
     public async Task Serialize_CachesSchemaId()

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
@@ -121,6 +121,30 @@ public sealed class SchemaRegistryCacheTests
         }
     }
 
+    private sealed class ReplacingRuleExecutor(
+        byte[]? serializedPayload = null,
+        byte[]? deserializedPayload = null) : ISchemaRegistryRuleExecutor
+    {
+        public SchemaRegistryRuleContext? SerializeContext { get; private set; }
+        public SchemaRegistryRuleContext? DeserializeContext { get; private set; }
+
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context)
+        {
+            SerializeContext = context;
+            return serializedPayload ?? payload;
+        }
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleContext context)
+        {
+            DeserializeContext = context;
+            return deserializedPayload ?? payload;
+        }
+    }
+
     private static SerializationContext CreateContext(string topic = "topic", bool isKey = false) =>
         new()
         {
@@ -221,6 +245,62 @@ public sealed class SchemaRegistryCacheTests
         await Assert.That(strategy.CallCount).IsEqualTo(1);
         await Assert.That(schemaFactoryCalls).IsEqualTo(1);
         await Assert.That(registry.GetCallCount("topic-value")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Serializer_RuleExecutor_TransformsSerializedPayload()
+    {
+        var registry = new CountingSchemaRegistryClient();
+        var schema = new Schema { SchemaType = SchemaType.Json, SchemaString = """{ "type": "string" }""" };
+        var executor = new ReplacingRuleExecutor(serializedPayload: "encrypted"u8.ToArray());
+
+        await using var serializer = new SchemaRegistrySerializer<string>(
+            registry,
+            serialize: static (value, writer) =>
+            {
+                var byteCount = Encoding.UTF8.GetByteCount(value);
+                Encoding.UTF8.GetBytes(value, writer.GetSpan(byteCount));
+                writer.Advance(byteCount);
+            },
+            getSchema: _ => schema,
+            ruleExecutor: executor);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize("plain", ref buffer, CreateContext());
+
+        await Assert.That(Encoding.UTF8.GetString(buffer.WrittenSpan.Slice(5))).IsEqualTo("encrypted");
+        await Assert.That(executor.SerializeContext).IsNotNull();
+        await Assert.That(executor.SerializeContext!.Subject).IsEqualTo("topic-value");
+        await Assert.That(executor.SerializeContext.PayloadFormat).IsEqualTo(SchemaRegistryPayloadFormat.Custom);
+        await Assert.That(executor.SerializeContext.SchemaId).IsEqualTo(registry.GetSchemaId("topic-value"));
+        await Assert.That(executor.SerializeContext.Schema).IsSameReferenceAs(schema);
+    }
+
+    [Test]
+    public async Task Deserializer_RuleExecutor_TransformsDeserializedPayload()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schema = new Schema { SchemaType = SchemaType.Json, SchemaString = """{ "type": "string" }""" };
+        var schemaId = await registry.RegisterSchemaAsync("topic-value", schema);
+        var cipherText = "encrypted"u8.ToArray();
+        var wireBytes = new byte[5 + cipherText.Length];
+        wireBytes[0] = 0;
+        BinaryPrimitives.WriteInt32BigEndian(wireBytes.AsSpan(1, 4), schemaId);
+        cipherText.CopyTo(wireBytes.AsSpan(5));
+
+        var executor = new ReplacingRuleExecutor(deserializedPayload: "plain"u8.ToArray());
+        await using var deserializer = SchemaRegistryDeserializer.Create(
+            registry,
+            static (ReadOnlyMemory<byte> payload, Schema _) => Encoding.UTF8.GetString(payload.Span),
+            ruleExecutor: executor);
+
+        var result = deserializer.Deserialize(wireBytes, CreateContext());
+
+        await Assert.That(result).IsEqualTo("plain");
+        await Assert.That(executor.DeserializeContext).IsNotNull();
+        await Assert.That(executor.DeserializeContext!.PayloadFormat).IsEqualTo(SchemaRegistryPayloadFormat.Custom);
+        await Assert.That(executor.DeserializeContext.SchemaId).IsEqualTo(schemaId);
+        await Assert.That(executor.DeserializeContext.Schema).IsSameReferenceAs(schema);
     }
 
     [Test]
@@ -351,6 +431,33 @@ public sealed class SchemaRegistryCacheTests
         var expectedPayload = JsonSerializer.SerializeToUtf8Bytes(payload, CamelCaseJsonOptions);
         await Assert.That(actualPayload).IsEquivalentTo(expectedPayload);
         await Assert.That(registry.GetCallCount("topic-value")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task JsonSerializer_RuleExecutor_TransformsPayload()
+    {
+        var registry = new CountingSchemaRegistryClient();
+        var executor = new ReplacingRuleExecutor(serializedPayload: "encrypted-json"u8.ToArray());
+        await using var serializer = new JsonSchemaRegistrySerializer<JsonPayload>(
+            registry,
+            """
+            {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer" },
+                    "name": { "type": "string" }
+                }
+            }
+            """,
+            ruleExecutor: executor);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize(new JsonPayload(7, "Test"), ref buffer, CreateContext());
+
+        await Assert.That(Encoding.UTF8.GetString(buffer.WrittenSpan.Slice(5))).IsEqualTo("encrypted-json");
+        await Assert.That(executor.SerializeContext).IsNotNull();
+        await Assert.That(executor.SerializeContext!.PayloadFormat).IsEqualTo(SchemaRegistryPayloadFormat.Json);
+        await Assert.That(executor.SerializeContext.Subject).IsEqualTo("topic-value");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
@@ -164,7 +164,7 @@ public sealed class SchemaRegistryCacheTests
                 isKey: false,
                 state: 0,
                 static (_, topic, isKey) => topic + (isKey ? "-key" : "-value"),
-                static (_, subject) => subject.Length);
+                static (_, subject) => new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(subject.Length, null));
         }
 
         await Assert.That(cache.CachedEntryCount).IsEqualTo(SubjectSchemaIdCache.MaxCachedEntries);
@@ -253,6 +253,7 @@ public sealed class SchemaRegistryCacheTests
         var registry = new CountingSchemaRegistryClient();
         var schema = new Schema { SchemaType = SchemaType.Json, SchemaString = """{ "type": "string" }""" };
         var executor = new ReplacingRuleExecutor(serializedPayload: "encrypted"u8.ToArray());
+        var schemaFactoryCalls = 0;
 
         await using var serializer = new SchemaRegistrySerializer<string>(
             registry,
@@ -262,18 +263,28 @@ public sealed class SchemaRegistryCacheTests
                 Encoding.UTF8.GetBytes(value, writer.GetSpan(byteCount));
                 writer.Advance(byteCount);
             },
-            getSchema: _ => schema,
+            getSchema: _ =>
+            {
+                schemaFactoryCalls++;
+                return schema;
+            },
             ruleExecutor: executor);
 
         var buffer = new ArrayBufferWriter<byte>();
         serializer.Serialize("plain", ref buffer, CreateContext());
 
+        var buffer2 = new ArrayBufferWriter<byte>();
+        serializer.Serialize("plain-again", ref buffer2, CreateContext());
+
         await Assert.That(Encoding.UTF8.GetString(buffer.WrittenSpan.Slice(5))).IsEqualTo("encrypted");
+        await Assert.That(Encoding.UTF8.GetString(buffer2.WrittenSpan.Slice(5))).IsEqualTo("encrypted");
         await Assert.That(executor.SerializeContext).IsNotNull();
         await Assert.That(executor.SerializeContext!.Subject).IsEqualTo("topic-value");
         await Assert.That(executor.SerializeContext.PayloadFormat).IsEqualTo(SchemaRegistryPayloadFormat.Custom);
         await Assert.That(executor.SerializeContext.SchemaId).IsEqualTo(registry.GetSchemaId("topic-value"));
         await Assert.That(executor.SerializeContext.Schema).IsSameReferenceAs(schema);
+        await Assert.That(schemaFactoryCalls).IsEqualTo(1);
+        await Assert.That(registry.GetCallCount("topic-value")).IsEqualTo(1);
     }
 
     [Test]
@@ -437,6 +448,7 @@ public sealed class SchemaRegistryCacheTests
     public async Task JsonSerializer_RuleExecutor_TransformsPayload()
     {
         var registry = new CountingSchemaRegistryClient();
+        var strategy = new CountingSubjectNameStrategy();
         var executor = new ReplacingRuleExecutor(serializedPayload: "encrypted-json"u8.ToArray());
         await using var serializer = new JsonSchemaRegistrySerializer<JsonPayload>(
             registry,
@@ -449,15 +461,22 @@ public sealed class SchemaRegistryCacheTests
                 }
             }
             """,
+            strategy,
             ruleExecutor: executor);
 
         var buffer = new ArrayBufferWriter<byte>();
         serializer.Serialize(new JsonPayload(7, "Test"), ref buffer, CreateContext());
 
+        var buffer2 = new ArrayBufferWriter<byte>();
+        serializer.Serialize(new JsonPayload(8, "Test"), ref buffer2, CreateContext());
+
         await Assert.That(Encoding.UTF8.GetString(buffer.WrittenSpan.Slice(5))).IsEqualTo("encrypted-json");
+        await Assert.That(Encoding.UTF8.GetString(buffer2.WrittenSpan.Slice(5))).IsEqualTo("encrypted-json");
         await Assert.That(executor.SerializeContext).IsNotNull();
         await Assert.That(executor.SerializeContext!.PayloadFormat).IsEqualTo(SchemaRegistryPayloadFormat.Json);
         await Assert.That(executor.SerializeContext.Subject).IsEqualTo("topic-value");
+        await Assert.That(strategy.CallCount).IsEqualTo(1);
+        await Assert.That(registry.GetCallCount("topic-value")).IsEqualTo(1);
     }
 
     [Test]
@@ -582,6 +601,33 @@ public sealed class SchemaRegistryCacheTests
         await Assert.That(result).IsEqualTo("hello");
         await Assert.That(registry.TryGetCachedSchemaCallCount).IsEqualTo(1);
         await Assert.That(registry.GetSchemaCallCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task JsonDeserializer_RuleExecutor_TransformsPayload()
+    {
+        var registry = new MockSchemaRegistryClient();
+        var schema = new Schema { SchemaType = SchemaType.Json, SchemaString = """{ "type": "string" }""" };
+        var schemaId = await registry.RegisterSchemaAsync("topic-value", schema);
+        var cipherText = "encrypted-json"u8.ToArray();
+        var wireBytes = new byte[5 + cipherText.Length];
+        wireBytes[0] = 0;
+        BinaryPrimitives.WriteInt32BigEndian(wireBytes.AsSpan(1, 4), schemaId);
+        cipherText.CopyTo(wireBytes.AsSpan(5));
+
+        var plainJson = JsonSerializer.SerializeToUtf8Bytes("plain");
+        var executor = new ReplacingRuleExecutor(deserializedPayload: plainJson);
+        await using var deserializer = new JsonSchemaRegistryDeserializer<string>(
+            registry,
+            ruleExecutor: executor);
+
+        var result = deserializer.Deserialize(wireBytes, CreateContext());
+
+        await Assert.That(result).IsEqualTo("plain");
+        await Assert.That(executor.DeserializeContext).IsNotNull();
+        await Assert.That(executor.DeserializeContext!.PayloadFormat).IsEqualTo(SchemaRegistryPayloadFormat.Json);
+        await Assert.That(executor.DeserializeContext.SchemaId).IsEqualTo(schemaId);
+        await Assert.That(executor.DeserializeContext.Schema).IsSameReferenceAs(schema);
     }
 
     private static Schema NewSchema(int id) => new()


### PR DESCRIPTION
Refs #1382.

This is the first staged slice for Schema Registry data-contract/CSFLE support. It adds rule-executor payload hooks across the existing Schema Registry serdes without implementing KMS drivers or CEL yet.

Changes:
- add `ISchemaRegistryRuleExecutor`, `SchemaRegistryRuleContext`, and payload-format metadata
- wire serialize/deserialize payload transforms for generic Schema Registry, JSON Schema, Avro, and Protobuf serdes
- keep the Schema Registry envelope out of the transformed bytes; Protobuf message indexes also stay outside the transformed payload
- add unit coverage for base/JSON/Protobuf hook behavior and context metadata

Validation:
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet build src\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet build src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet build src\Dekaf.SchemaRegistry.Protobuf\Dekaf.SchemaRegistry.Protobuf.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -v:minimal`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --disable-logo --no-ansi --treenode-filter "/*/*/SchemaRegistryCacheTests/*" --minimum-expected-tests 17`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --disable-logo --no-ansi --treenode-filter "/*/*/ProtobufSchemaRegistrySerializerTests/*" --minimum-expected-tests 12`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --disable-logo --no-ansi --treenode-filter "/*/*/AvroSerializerTests/*" --minimum-expected-tests 15`