### PR TITLE
feat(schemaregistry): add bearer auth and mTLS

### DIFF
--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -83,13 +83,14 @@ var config = new SchemaRegistryConfig
 {
     Url = "http://localhost:8081",
 
-    // Authentication
+    // Choose one authentication source:
     BasicAuthUserInfo = "username:password",
+    BearerAuthToken = "eyJhbGciOi...",
+    OAuthBearerConfig = oauthConfig,
+    OAuthBearerTokenProvider = GetSchemaRegistryTokenAsync,
 
-    // SSL
-    SslCaLocation = "/path/to/ca.crt",
-    SslKeystoreLocation = "/path/to/keystore.p12",
-    SslKeystorePassword = "password"
+    // Optional mTLS client certificate
+    ClientCertificate = certificate
 };
 
 var schemaRegistry = new CachedSchemaRegistryClient(config);

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryAuthenticationHandler.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryAuthenticationHandler.cs
@@ -1,0 +1,75 @@
+using System.Net.Http.Headers;
+using System.Text;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.SchemaRegistry;
+
+internal sealed class SchemaRegistryAuthenticationHandler : DelegatingHandler
+{
+    private readonly AuthenticationHeaderValue? _staticAuthorization;
+    private readonly OAuthBearerAuthenticator? _oauthAuthenticator;
+    private readonly OAuthBearerTokenProvider? _ownedTokenProvider;
+
+    internal SchemaRegistryAuthenticationHandler(
+        HttpMessageHandler innerHandler,
+        SchemaRegistryConfig config,
+        Func<OAuthBearerConfig, Func<CancellationToken, ValueTask<OAuthBearerToken>>>? oauthBearerTokenProviderFactory = null)
+        : base(innerHandler)
+    {
+        if (config.OAuthBearerTokenProvider is not null)
+        {
+            _oauthAuthenticator = new OAuthBearerAuthenticator(config.OAuthBearerTokenProvider);
+        }
+        else if (!string.IsNullOrEmpty(config.BearerAuthToken))
+        {
+            _staticAuthorization = new AuthenticationHeaderValue("Bearer", config.BearerAuthToken);
+        }
+        else if (config.OAuthBearerConfig is not null)
+        {
+            Func<CancellationToken, ValueTask<OAuthBearerToken>> tokenProvider;
+            if (oauthBearerTokenProviderFactory is not null)
+            {
+                tokenProvider = oauthBearerTokenProviderFactory(config.OAuthBearerConfig);
+            }
+            else
+            {
+                _ownedTokenProvider = new OAuthBearerTokenProvider(config.OAuthBearerConfig);
+                tokenProvider = _ownedTokenProvider.GetTokenAsync;
+            }
+
+            _oauthAuthenticator = new OAuthBearerAuthenticator(tokenProvider);
+        }
+        else if (!string.IsNullOrEmpty(config.BasicAuthUserInfo))
+        {
+            var authBytes = Encoding.UTF8.GetBytes(config.BasicAuthUserInfo);
+            _staticAuthorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
+        }
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (_oauthAuthenticator is not null)
+        {
+            var token = await _oauthAuthenticator.GetTokenAsync(cancellationToken).ConfigureAwait(false);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.TokenValue);
+        }
+        else if (_staticAuthorization is not null)
+        {
+            request.Headers.Authorization = _staticAuthorization;
+        }
+
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _ownedTokenProvider?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -2,7 +2,8 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Text;
+using System.Security.Cryptography.X509Certificates;
+using Dekaf.Security.Sasl;
 
 namespace Dekaf.SchemaRegistry;
 
@@ -22,11 +23,24 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
     private bool _disposed;
 
     public SchemaRegistryClient(SchemaRegistryConfig config)
+        : this(config, CreateHttpHandler(config?.ClientCertificate))
+    {
+    }
+
+    internal SchemaRegistryClient(
+        SchemaRegistryConfig config,
+        HttpMessageHandler handler,
+        Func<OAuthBearerConfig, Func<CancellationToken, ValueTask<OAuthBearerToken>>>? oauthBearerTokenProviderFactory = null)
     {
         _config = config ?? throw new ArgumentNullException(nameof(config));
         _maxCachedSchemas = Math.Max(0, config.MaxCachedSchemas);
 
-        _httpClient = new HttpClient(CreateHttpHandler(), disposeHandler: true)
+        var authHandler = new SchemaRegistryAuthenticationHandler(
+            handler,
+            config,
+            oauthBearerTokenProviderFactory);
+
+        _httpClient = new HttpClient(authHandler, disposeHandler: true)
         {
             BaseAddress = new Uri(config.Url.TrimEnd('/') + "/"),
             Timeout = TimeSpan.FromMilliseconds(config.RequestTimeoutMs)
@@ -34,22 +48,28 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 
         _httpClient.DefaultRequestHeaders.Accept.Add(
             new MediaTypeWithQualityHeaderValue("application/vnd.schemaregistry.v1+json"));
-
-        if (!string.IsNullOrEmpty(config.BasicAuthUserInfo))
-        {
-            var authBytes = Encoding.UTF8.GetBytes(config.BasicAuthUserInfo);
-            _httpClient.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
-        }
     }
 
     internal int CachedSchemaByIdCount => _schemaByIdCache.Count;
     internal int CachedSchemaIdCount => _idBySchemaCache.Count;
 
-    internal static SocketsHttpHandler CreateHttpHandler() => new()
+    internal static SocketsHttpHandler CreateHttpHandler(X509Certificate2? clientCertificate = null)
     {
-        PooledConnectionLifetime = PooledConnectionLifetime
-    };
+        var handler = new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = PooledConnectionLifetime
+        };
+
+        if (clientCertificate is not null)
+        {
+            handler.SslOptions.ClientCertificates = new X509CertificateCollection
+            {
+                clientCertificate
+            };
+        }
+
+        return handler;
+    }
 
     public async Task<int> RegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default)
     {
@@ -341,6 +361,29 @@ public sealed class SchemaRegistryConfig
     /// Basic auth credentials in format "username:password".
     /// </summary>
     public string? BasicAuthUserInfo { get; init; }
+
+    /// <summary>
+    /// Static bearer token for Schema Registry requests. Takes precedence over
+    /// <see cref="BasicAuthUserInfo"/> and <see cref="OAuthBearerConfig"/>.
+    /// </summary>
+    public string? BearerAuthToken { get; init; }
+
+    /// <summary>
+    /// OAuth 2.0 / OIDC client-credentials configuration used to fetch Schema
+    /// Registry bearer tokens.
+    /// </summary>
+    public OAuthBearerConfig? OAuthBearerConfig { get; init; }
+
+    /// <summary>
+    /// Custom bearer token provider for Schema Registry requests. Takes
+    /// precedence over static tokens and <see cref="OAuthBearerConfig"/>.
+    /// </summary>
+    public Func<CancellationToken, ValueTask<OAuthBearerToken>>? OAuthBearerTokenProvider { get; init; }
+
+    /// <summary>
+    /// Client certificate presented during TLS handshake for mutual TLS.
+    /// </summary>
+    public X509Certificate2? ClientCertificate { get; init; }
 
     /// <summary>
     /// Request timeout in milliseconds.

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -23,7 +23,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
     private bool _disposed;
 
     public SchemaRegistryClient(SchemaRegistryConfig config)
-        : this(config, CreateHttpHandler(config?.ClientCertificate))
+        : this(config, CreateConfiguredHttpHandler(config))
     {
     }
 
@@ -69,6 +69,12 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         }
 
         return handler;
+    }
+
+    private static SocketsHttpHandler CreateConfiguredHttpHandler(SchemaRegistryConfig? config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        return CreateHttpHandler(config.ClientCertificate);
     }
 
     public async Task<int> RegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default)

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAuthenticationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAuthenticationTests.cs
@@ -62,6 +62,51 @@ public sealed class SchemaRegistryAuthenticationTests
     }
 
     [Test]
+    public async Task Client_CustomBearerTokenProvider_TakesPrecedenceOverStaticBearerToken()
+    {
+        var handler = new CapturingSchemaRegistryHandler();
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local",
+            BearerAuthToken = "static-token",
+            OAuthBearerTokenProvider = _ => ValueTask.FromResult(NewToken("provider-token"))
+        }, handler);
+
+        _ = await client.GetAllSubjectsAsync();
+
+        var authorization = handler.AuthorizationHeaders[0];
+        await Assert.That(authorization?.Scheme).IsEqualTo("Bearer");
+        await Assert.That(authorization?.Parameter).IsEqualTo("provider-token");
+    }
+
+    [Test]
+    public async Task Client_BearerToken_TakesPrecedenceOverOAuthConfig()
+    {
+        OAuthBearerConfig? capturedConfig = null;
+        var handler = new CapturingSchemaRegistryHandler();
+        using var client = new SchemaRegistryClient(
+            new SchemaRegistryConfig
+            {
+                Url = "http://schema-registry.local",
+                BearerAuthToken = "static-token",
+                OAuthBearerConfig = NewOAuthConfig()
+            },
+            handler,
+            oauthBearerTokenProviderFactory: oauthConfig =>
+            {
+                capturedConfig = oauthConfig;
+                return _ => ValueTask.FromResult(NewToken("oidc-token"));
+            });
+
+        _ = await client.GetAllSubjectsAsync();
+
+        await Assert.That(capturedConfig).IsNull();
+        var authorization = handler.AuthorizationHeaders[0];
+        await Assert.That(authorization?.Scheme).IsEqualTo("Bearer");
+        await Assert.That(authorization?.Parameter).IsEqualTo("static-token");
+    }
+
+    [Test]
     public async Task Client_UsesCustomBearerTokenProvider_WhenConfigured()
     {
         var providerCalls = 0;
@@ -96,12 +141,7 @@ public sealed class SchemaRegistryAuthenticationTests
         var config = new SchemaRegistryConfig
         {
             Url = "http://schema-registry.local",
-            OAuthBearerConfig = new OAuthBearerConfig
-            {
-                TokenEndpointUrl = "https://auth.local/token",
-                ClientId = "schema-registry-client",
-                ClientSecret = "secret"
-            }
+            OAuthBearerConfig = NewOAuthConfig()
         };
 
         using var client = new SchemaRegistryClient(
@@ -116,6 +156,27 @@ public sealed class SchemaRegistryAuthenticationTests
         _ = await client.GetAllSubjectsAsync();
 
         await Assert.That(capturedConfig).IsSameReferenceAs(config.OAuthBearerConfig);
+        var authorization = handler.AuthorizationHeaders[0];
+        await Assert.That(authorization?.Scheme).IsEqualTo("Bearer");
+        await Assert.That(authorization?.Parameter).IsEqualTo("oidc-token");
+    }
+
+    [Test]
+    public async Task Client_OAuthConfig_TakesPrecedenceOverBasicAuth()
+    {
+        var handler = new CapturingSchemaRegistryHandler();
+        using var client = new SchemaRegistryClient(
+            new SchemaRegistryConfig
+            {
+                Url = "http://schema-registry.local",
+                BasicAuthUserInfo = "user:secret",
+                OAuthBearerConfig = NewOAuthConfig()
+            },
+            handler,
+            oauthBearerTokenProviderFactory: _ => _ => ValueTask.FromResult(NewToken("oidc-token")));
+
+        _ = await client.GetAllSubjectsAsync();
+
         var authorization = handler.AuthorizationHeaders[0];
         await Assert.That(authorization?.Scheme).IsEqualTo("Bearer");
         await Assert.That(authorization?.Parameter).IsEqualTo("oidc-token");
@@ -138,6 +199,13 @@ public sealed class SchemaRegistryAuthenticationTests
         TokenValue = tokenValue,
         Expiration = DateTimeOffset.UtcNow.AddHours(1),
         PrincipalName = "schema-registry"
+    };
+
+    private static OAuthBearerConfig NewOAuthConfig() => new()
+    {
+        TokenEndpointUrl = "https://auth.local/token",
+        ClientId = "schema-registry-client",
+        ClientSecret = "secret"
     };
 
     private static X509Certificate2 CreateSelfSignedCertificate()

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAuthenticationTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryAuthenticationTests.cs
@@ -1,0 +1,172 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Dekaf.SchemaRegistry;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class SchemaRegistryAuthenticationTests
+{
+    [Test]
+    public async Task Client_UsesBasicAuth_WhenConfigured()
+    {
+        var handler = new CapturingSchemaRegistryHandler();
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local",
+            BasicAuthUserInfo = "user:secret"
+        }, handler);
+
+        _ = await client.GetAllSubjectsAsync();
+
+        var authorization = handler.AuthorizationHeaders[0];
+        await Assert.That(authorization?.Scheme).IsEqualTo("Basic");
+        await Assert.That(authorization?.Parameter).IsEqualTo("dXNlcjpzZWNyZXQ=");
+    }
+
+    [Test]
+    public async Task Client_UsesStaticBearerToken_WhenConfigured()
+    {
+        var handler = new CapturingSchemaRegistryHandler();
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local",
+            BearerAuthToken = "static-token"
+        }, handler);
+
+        _ = await client.GetAllSubjectsAsync();
+
+        var authorization = handler.AuthorizationHeaders[0];
+        await Assert.That(authorization?.Scheme).IsEqualTo("Bearer");
+        await Assert.That(authorization?.Parameter).IsEqualTo("static-token");
+    }
+
+    [Test]
+    public async Task Client_BearerToken_TakesPrecedenceOverBasicAuth()
+    {
+        var handler = new CapturingSchemaRegistryHandler();
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local",
+            BasicAuthUserInfo = "user:secret",
+            BearerAuthToken = "static-token"
+        }, handler);
+
+        _ = await client.GetAllSubjectsAsync();
+
+        var authorization = handler.AuthorizationHeaders[0];
+        await Assert.That(authorization?.Scheme).IsEqualTo("Bearer");
+        await Assert.That(authorization?.Parameter).IsEqualTo("static-token");
+    }
+
+    [Test]
+    public async Task Client_UsesCustomBearerTokenProvider_WhenConfigured()
+    {
+        var providerCalls = 0;
+        var handler = new CapturingSchemaRegistryHandler();
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local",
+            OAuthBearerTokenProvider = _ =>
+            {
+                providerCalls++;
+                return ValueTask.FromResult(NewToken("provider-token"));
+            }
+        }, handler);
+
+        _ = await client.GetAllSubjectsAsync();
+        _ = await client.GetAllSubjectsAsync();
+
+        await Assert.That(providerCalls).IsEqualTo(1);
+        await Assert.That(handler.AuthorizationHeaders.Count).IsEqualTo(2);
+        foreach (var authorization in handler.AuthorizationHeaders)
+        {
+            await Assert.That(authorization?.Scheme).IsEqualTo("Bearer");
+            await Assert.That(authorization?.Parameter).IsEqualTo("provider-token");
+        }
+    }
+
+    [Test]
+    public async Task Client_UsesOAuthConfigProvider_WhenConfigured()
+    {
+        OAuthBearerConfig? capturedConfig = null;
+        var handler = new CapturingSchemaRegistryHandler();
+        var config = new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local",
+            OAuthBearerConfig = new OAuthBearerConfig
+            {
+                TokenEndpointUrl = "https://auth.local/token",
+                ClientId = "schema-registry-client",
+                ClientSecret = "secret"
+            }
+        };
+
+        using var client = new SchemaRegistryClient(
+            config,
+            handler,
+            oauthBearerTokenProviderFactory: oauthConfig =>
+            {
+                capturedConfig = oauthConfig;
+                return _ => ValueTask.FromResult(NewToken("oidc-token"));
+            });
+
+        _ = await client.GetAllSubjectsAsync();
+
+        await Assert.That(capturedConfig).IsSameReferenceAs(config.OAuthBearerConfig);
+        var authorization = handler.AuthorizationHeaders[0];
+        await Assert.That(authorization?.Scheme).IsEqualTo("Bearer");
+        await Assert.That(authorization?.Parameter).IsEqualTo("oidc-token");
+    }
+
+    [Test]
+    public async Task CreateHttpHandler_AddsClientCertificate()
+    {
+        using var certificate = CreateSelfSignedCertificate();
+        using var handler = SchemaRegistryClient.CreateHttpHandler(certificate);
+
+        var certificates = handler.SslOptions.ClientCertificates;
+        await Assert.That(certificates).IsNotNull();
+        await Assert.That(certificates!.Count).IsEqualTo(1);
+        await Assert.That(certificates![0]).IsSameReferenceAs(certificate);
+    }
+
+    private static OAuthBearerToken NewToken(string tokenValue) => new()
+    {
+        TokenValue = tokenValue,
+        Expiration = DateTimeOffset.UtcNow.AddHours(1),
+        PrincipalName = "schema-registry"
+    };
+
+    private static X509Certificate2 CreateSelfSignedCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=schema-registry-client",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        return request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddMinutes(-1),
+            DateTimeOffset.UtcNow.AddMinutes(5));
+    }
+
+    private sealed class CapturingSchemaRegistryHandler : HttpMessageHandler
+    {
+        public List<AuthenticationHeaderValue?> AuthorizationHeaders { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            AuthorizationHeaders.Add(request.Headers.Authorization);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]")
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Schema Registry bearer auth support for static tokens, custom token providers, and OAuth/OIDC client-credentials via the existing OAuthBearerConfig provider
- add optional client certificate wiring for mTLS
- keep Basic auth support through the same per-request auth handler
- document the new SchemaRegistryConfig auth options

## Validation
- dotnet build src\Dekaf.SchemaRegistry\Dekaf.SchemaRegistry.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -v:minimal
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -v:minimal
- .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/SchemaRegistryAuthenticationTests/*" --disable-logo --no-ansi --no-progress

Closes #1381
