### PR TITLE
feat(schemaregistry): add failover and normalize

### DIFF
--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -343,8 +343,16 @@ public sealed class AvroSchemaRegistrySerializer<
             if (_config.AutoRegisterSchemas)
             {
                 // Register schema if auto-register is enabled
-                return await _schemaRegistry.GetOrRegisterSchemaAsync(subject, registrySchema, CancellationToken.None)
-                    .ConfigureAwait(false);
+                return _config.NormalizeSchemas
+                    ? await _schemaRegistry.GetOrRegisterSchemaAsync(
+                        subject,
+                        registrySchema,
+                        normalize: true,
+                        CancellationToken.None).ConfigureAwait(false)
+                    : await _schemaRegistry.GetOrRegisterSchemaAsync(
+                        subject,
+                        registrySchema,
+                        CancellationToken.None).ConfigureAwait(false);
             }
 
             // Get existing schema ID from registry

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSerializerConfig.cs
@@ -33,6 +33,12 @@ public sealed class AvroSerializerConfig
     public bool UseLatestVersion { get; init; }
 
     /// <summary>
+    /// Whether schema registration and lookup requests should include normalize=true.
+    /// Default is false.
+    /// </summary>
+    public bool NormalizeSchemas { get; init; }
+
+    /// <summary>
     /// Optional rule executor applied to Avro payload bytes before the Schema Registry envelope is written.
     /// </summary>
     public ISchemaRegistryRuleExecutor? RuleExecutor { get; init; }

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -145,7 +145,9 @@ public sealed class ProtobufSchemaRegistrySerializer<
         }
         else if (_config.AutoRegisterSchemas)
         {
-            task = _schemaRegistry.GetOrRegisterSchemaAsync(subject, _schema);
+            task = _config.NormalizeSchemas
+                ? _schemaRegistry.GetOrRegisterSchemaAsync(subject, _schema, normalize: true)
+                : _schemaRegistry.GetOrRegisterSchemaAsync(subject, _schema);
         }
         else
         {

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
@@ -34,6 +34,12 @@ public sealed class ProtobufSerializerConfig
     public bool UseLatestVersion { get; init; }
 
     /// <summary>
+    /// Whether schema registration and lookup requests should include normalize=true.
+    /// Default is false.
+    /// </summary>
+    public bool NormalizeSchemas { get; init; }
+
+    /// <summary>
     /// Whether to use the deprecated unsigned Protobuf message-index encoding.
     /// This also preserves the previous RecordName subject naming format without a -key/-value suffix.
     /// Default is false.

--- a/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
@@ -13,7 +13,25 @@ public interface ISchemaRegistryClient : IDisposable
     /// <param name="schema">The schema to register.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The schema ID.</returns>
-    Task<int> RegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default);
+    Task<int> RegisterSchemaAsync(
+        string subject,
+        Schema schema,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Registers a schema under a subject, optionally requesting Schema Registry normalization.
+    /// </summary>
+    /// <param name="subject">The subject name (typically topic-key or topic-value).</param>
+    /// <param name="schema">The schema to register.</param>
+    /// <param name="normalize">Whether to request Schema Registry normalization.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The schema ID.</returns>
+    Task<int> RegisterSchemaAsync(
+        string subject,
+        Schema schema,
+        bool normalize,
+        CancellationToken cancellationToken = default)
+        => RegisterSchemaAsync(subject, schema, cancellationToken);
 
     /// <summary>
     /// Gets a schema by its global ID.
@@ -40,7 +58,25 @@ public interface ISchemaRegistryClient : IDisposable
     /// <param name="schema">The schema.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The schema ID.</returns>
-    Task<int> GetOrRegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default);
+    Task<int> GetOrRegisterSchemaAsync(
+        string subject,
+        Schema schema,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets or registers a schema, optionally requesting Schema Registry normalization.
+    /// </summary>
+    /// <param name="subject">The subject name.</param>
+    /// <param name="schema">The schema.</param>
+    /// <param name="normalize">Whether to request Schema Registry normalization.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The schema ID.</returns>
+    Task<int> GetOrRegisterSchemaAsync(
+        string subject,
+        Schema schema,
+        bool normalize,
+        CancellationToken cancellationToken = default)
+        => GetOrRegisterSchemaAsync(subject, schema, cancellationToken);
 
     /// <summary>
     /// Lists all subjects.
@@ -65,7 +101,28 @@ public interface ISchemaRegistryClient : IDisposable
     /// <param name="version">The version to check against (default: latest).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>True if compatible.</returns>
-    Task<bool> IsCompatibleAsync(string subject, Schema schema, string version = "latest", CancellationToken cancellationToken = default);
+    Task<bool> IsCompatibleAsync(
+        string subject,
+        Schema schema,
+        string version = "latest",
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks schema compatibility, optionally requesting Schema Registry normalization.
+    /// </summary>
+    /// <param name="subject">The subject name.</param>
+    /// <param name="schema">The schema to check.</param>
+    /// <param name="version">The version to check against.</param>
+    /// <param name="normalize">Whether to request Schema Registry normalization.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if compatible.</returns>
+    Task<bool> IsCompatibleAsync(
+        string subject,
+        Schema schema,
+        string version,
+        bool normalize,
+        CancellationToken cancellationToken = default)
+        => IsCompatibleAsync(subject, schema, version, cancellationToken);
 
     /// <summary>
     /// Deletes a subject and all associated schemas.

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -40,6 +40,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     private readonly SubjectNameStrategy _subjectNameStrategy;
     private readonly ISubjectNameStrategy? _customSubjectNameStrategy;
     private readonly bool _autoRegisterSchemas;
+    private readonly bool _normalizeSchemas;
     private readonly Schema _schema;
     private readonly bool _ownsClient;
     private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
@@ -56,6 +57,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     /// <param name="subjectNameStrategy">Strategy for determining subject names.</param>
     /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
     /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
+    /// <param name="ruleExecutor">Optional rule executor applied to JSON payload bytes.</param>
+    /// <param name="normalizeSchemas">Whether to normalize schemas during registration.</param>
     [RequiresUnreferencedCode("JsonSerializerOptions-based JSON serialization uses reflection. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
     [RequiresDynamicCode("JsonSerializerOptions-based JSON serialization may require runtime code generation. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
     public JsonSchemaRegistrySerializer(
@@ -65,13 +68,15 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true,
         bool ownsClient = false,
-        ISchemaRegistryRuleExecutor? ruleExecutor = null)
+        ISchemaRegistryRuleExecutor? ruleExecutor = null,
+        bool normalizeSchemas = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _jsonOptions = CreateJsonOptions(jsonOptions);
         _serializePayload = SerializeWithOptions;
         _subjectNameStrategy = subjectNameStrategy;
         _autoRegisterSchemas = autoRegisterSchemas;
+        _normalizeSchemas = normalizeSchemas;
         _ownsClient = ownsClient;
         _ruleExecutor = ruleExecutor;
         _schema = new Schema
@@ -90,6 +95,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     /// <param name="subjectNameStrategy">Strategy for determining subject names.</param>
     /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
     /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
+    /// <param name="ruleExecutor">Optional rule executor applied to JSON payload bytes.</param>
+    /// <param name="normalizeSchemas">Whether to normalize schemas during registration.</param>
     public JsonSchemaRegistrySerializer(
         ISchemaRegistryClient schemaRegistry,
         string jsonSchema,
@@ -97,13 +104,15 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true,
         bool ownsClient = false,
-        ISchemaRegistryRuleExecutor? ruleExecutor = null)
+        ISchemaRegistryRuleExecutor? ruleExecutor = null,
+        bool normalizeSchemas = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _jsonTypeInfo = jsonTypeInfo ?? throw new ArgumentNullException(nameof(jsonTypeInfo));
         _serializePayload = SerializeWithTypeInfo;
         _subjectNameStrategy = subjectNameStrategy;
         _autoRegisterSchemas = autoRegisterSchemas;
+        _normalizeSchemas = normalizeSchemas;
         _ownsClient = ownsClient;
         _ruleExecutor = ruleExecutor;
         _schema = new Schema
@@ -122,6 +131,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     /// <param name="jsonOptions">JSON serializer options.</param>
     /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
     /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
+    /// <param name="ruleExecutor">Optional rule executor applied to JSON payload bytes.</param>
+    /// <param name="normalizeSchemas">Whether to normalize schemas during registration.</param>
     [RequiresUnreferencedCode("JsonSerializerOptions-based JSON serialization uses reflection. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
     [RequiresDynamicCode("JsonSerializerOptions-based JSON serialization may require runtime code generation. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
     public JsonSchemaRegistrySerializer(
@@ -131,13 +142,15 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         JsonSerializerOptions? jsonOptions = null,
         bool autoRegisterSchemas = true,
         bool ownsClient = false,
-        ISchemaRegistryRuleExecutor? ruleExecutor = null)
+        ISchemaRegistryRuleExecutor? ruleExecutor = null,
+        bool normalizeSchemas = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _customSubjectNameStrategy = customSubjectNameStrategy ?? throw new ArgumentNullException(nameof(customSubjectNameStrategy));
         _jsonOptions = CreateJsonOptions(jsonOptions);
         _serializePayload = SerializeWithOptions;
         _autoRegisterSchemas = autoRegisterSchemas;
+        _normalizeSchemas = normalizeSchemas;
         _ownsClient = ownsClient;
         _ruleExecutor = ruleExecutor;
         _schema = new Schema
@@ -156,6 +169,8 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     /// <param name="jsonTypeInfo">Source-generated metadata for type T.</param>
     /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
     /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
+    /// <param name="ruleExecutor">Optional rule executor applied to JSON payload bytes.</param>
+    /// <param name="normalizeSchemas">Whether to normalize schemas during registration.</param>
     public JsonSchemaRegistrySerializer(
         ISchemaRegistryClient schemaRegistry,
         string jsonSchema,
@@ -163,13 +178,15 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         JsonTypeInfo<T> jsonTypeInfo,
         bool autoRegisterSchemas = true,
         bool ownsClient = false,
-        ISchemaRegistryRuleExecutor? ruleExecutor = null)
+        ISchemaRegistryRuleExecutor? ruleExecutor = null,
+        bool normalizeSchemas = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _customSubjectNameStrategy = customSubjectNameStrategy ?? throw new ArgumentNullException(nameof(customSubjectNameStrategy));
         _jsonTypeInfo = jsonTypeInfo ?? throw new ArgumentNullException(nameof(jsonTypeInfo));
         _serializePayload = SerializeWithTypeInfo;
         _autoRegisterSchemas = autoRegisterSchemas;
+        _normalizeSchemas = normalizeSchemas;
         _ownsClient = ownsClient;
         _ruleExecutor = ruleExecutor;
         _schema = new Schema
@@ -258,10 +275,18 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         if (_schemaIdCache.TryGetValue(subject, out var cachedId))
             return cachedId;
 
-        var task = _autoRegisterSchemas
-            ? _schemaRegistry.GetOrRegisterSchemaAsync(subject, _schema)
-            : _schemaRegistry.GetSchemaBySubjectAsync(subject).ContinueWith(
+        Task<int> task;
+        if (_autoRegisterSchemas)
+        {
+            task = _normalizeSchemas
+                ? _schemaRegistry.GetOrRegisterSchemaAsync(subject, _schema, normalize: true)
+                : _schemaRegistry.GetOrRegisterSchemaAsync(subject, _schema);
+        }
+        else
+        {
+            task = _schemaRegistry.GetSchemaBySubjectAsync(subject).ContinueWith(
                 static t => t.GetAwaiter().GetResult().Id, TaskScheduler.Default);
+        }
 
         // Add timeout to prevent indefinite blocking
         var id = task.WaitAsync(SchemaRegistryTimeout).ConfigureAwait(false).GetAwaiter().GetResult();

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -18,7 +18,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
     private readonly HttpClient _httpClient;
     private readonly SchemaRegistryConfig _config;
     private readonly ConcurrentDictionary<int, Schema> _schemaByIdCache = new();
-    private readonly ConcurrentDictionary<(string Subject, Schema Schema), int> _idBySchemaCache = new();
+    private readonly ConcurrentDictionary<(string Subject, Schema Schema, bool Normalize), int> _idBySchemaCache = new();
     private readonly object _cacheLock = new();
     private readonly int _maxCachedSchemas;
     private readonly Uri[] _baseUris;
@@ -145,7 +145,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 
                 response.Dispose();
             }
-            catch (Exception ex) when (IsRetriableException(ex, cancellationToken) && attempt < _baseUris.Length - 1)
+            catch (Exception ex) when (IsRetriableException(ex, cancellationToken))
             {
                 lastException = ex;
             }
@@ -177,7 +177,8 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         bool normalize,
         CancellationToken cancellationToken = default)
     {
-        var cacheKey = (subject, schema);
+        var effectiveNormalize = normalize || _config.NormalizeSchemas;
+        var cacheKey = (subject, schema, effectiveNormalize);
         if (_idBySchemaCache.TryGetValue(cacheKey, out var cachedId))
             return cachedId;
 
@@ -194,7 +195,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         };
 
         using var response = await PostAsJsonWithFailoverAsync(
-            WithNormalizeQuery($"subjects/{Uri.EscapeDataString(subject)}/versions", normalize || _config.NormalizeSchemas),
+            WithNormalizeQuery($"subjects/{Uri.EscapeDataString(subject)}/versions", effectiveNormalize),
             request,
             SchemaRegistryJsonContext.Default.RegisterSchemaRequest,
             cancellationToken).ConfigureAwait(false);
@@ -206,7 +207,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 
         var id = result!.Id;
 
-        CacheSchema(id, subject, schema);
+        CacheSchema(id, subject, schema, effectiveNormalize);
 
         return id;
     }
@@ -290,7 +291,8 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         bool normalize,
         CancellationToken cancellationToken = default)
     {
-        var cacheKey = (subject, schema);
+        var effectiveNormalize = normalize || _config.NormalizeSchemas;
+        var cacheKey = (subject, schema, effectiveNormalize);
         if (_idBySchemaCache.TryGetValue(cacheKey, out var cachedId))
             return cachedId;
 
@@ -308,7 +310,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         };
 
         using var response = await PostAsJsonWithFailoverAsync(
-            WithNormalizeQuery($"subjects/{Uri.EscapeDataString(subject)}", normalize || _config.NormalizeSchemas),
+            WithNormalizeQuery($"subjects/{Uri.EscapeDataString(subject)}", effectiveNormalize),
             request,
             SchemaRegistryJsonContext.Default.RegisterSchemaRequest,
             cancellationToken).ConfigureAwait(false);
@@ -319,7 +321,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             return await RegisterSchemaAsync(
                 subject,
                 schema,
-                normalize,
+                effectiveNormalize,
                 cancellationToken).ConfigureAwait(false);
         }
 
@@ -330,12 +332,12 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 
         var id = result!.Id;
 
-        CacheSchema(id, subject, schema);
+        CacheSchema(id, subject, schema, effectiveNormalize);
 
         return id;
     }
 
-    internal void CacheSchema(int id, string? subject, Schema schema)
+    internal void CacheSchema(int id, string? subject, Schema schema, bool normalize = false)
     {
         if (_maxCachedSchemas == 0)
             return;
@@ -351,7 +353,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             _schemaByIdCache.TryAdd(id, schema);
             if (subject is not null)
             {
-                _idBySchemaCache.TryAdd((subject, schema), id);
+                _idBySchemaCache.TryAdd((subject, schema, normalize), id);
             }
         }
     }

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.Json.Serialization.Metadata;
 using Dekaf.Security.Sasl;
 
 namespace Dekaf.SchemaRegistry;
@@ -20,6 +21,8 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
     private readonly ConcurrentDictionary<(string Subject, Schema Schema), int> _idBySchemaCache = new();
     private readonly object _cacheLock = new();
     private readonly int _maxCachedSchemas;
+    private readonly Uri[] _baseUris;
+    private int _activeBaseUriIndex;
     private bool _disposed;
 
     public SchemaRegistryClient(SchemaRegistryConfig config)
@@ -34,6 +37,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
     {
         _config = config ?? throw new ArgumentNullException(nameof(config));
         _maxCachedSchemas = Math.Max(0, config.MaxCachedSchemas);
+        _baseUris = ResolveBaseUris(config);
 
         var authHandler = new SchemaRegistryAuthenticationHandler(
             handler,
@@ -42,7 +46,6 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 
         _httpClient = new HttpClient(authHandler, disposeHandler: true)
         {
-            BaseAddress = new Uri(config.Url.TrimEnd('/') + "/"),
             Timeout = TimeSpan.FromMilliseconds(config.RequestTimeoutMs)
         };
 
@@ -77,7 +80,102 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         return CreateHttpHandler(config.ClientCertificate);
     }
 
-    public async Task<int> RegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default)
+    private static Uri[] ResolveBaseUris(SchemaRegistryConfig config)
+    {
+        var urls = config.Urls is { Count: > 0 }
+            ? config.Urls
+            : config.Url.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var baseUris = urls
+            .Select(static url => new Uri(url.TrimEnd('/') + "/", UriKind.Absolute))
+            .ToArray();
+
+        if (baseUris.Length == 0)
+            throw new ArgumentException("At least one Schema Registry URL is required.", nameof(config));
+
+        return baseUris;
+    }
+
+    private static string WithNormalizeQuery(string path, bool normalize)
+    {
+        if (!normalize)
+            return path;
+
+        return path.Contains('?', StringComparison.Ordinal)
+            ? path + "&normalize=true"
+            : path + "?normalize=true";
+    }
+
+    private Task<HttpResponseMessage> GetWithFailoverAsync(string path, CancellationToken cancellationToken) =>
+        SendWithFailoverAsync(baseUri => _httpClient.GetAsync(new Uri(baseUri, path), cancellationToken), cancellationToken);
+
+    private Task<HttpResponseMessage> DeleteWithFailoverAsync(string path, CancellationToken cancellationToken) =>
+        SendWithFailoverAsync(baseUri => _httpClient.DeleteAsync(new Uri(baseUri, path), cancellationToken), cancellationToken);
+
+    private Task<HttpResponseMessage> PostAsJsonWithFailoverAsync<T>(
+        string path,
+        T value,
+        JsonTypeInfo<T> jsonTypeInfo,
+        CancellationToken cancellationToken) =>
+        SendWithFailoverAsync(
+            baseUri => _httpClient.PostAsJsonAsync(new Uri(baseUri, path), value, jsonTypeInfo, cancellationToken),
+            cancellationToken);
+
+    private async Task<HttpResponseMessage> SendWithFailoverAsync(
+        Func<Uri, Task<HttpResponseMessage>> sendAsync,
+        CancellationToken cancellationToken)
+    {
+        var startIndex = Volatile.Read(ref _activeBaseUriIndex);
+        Exception? lastException = null;
+
+        for (var attempt = 0; attempt < _baseUris.Length; attempt++)
+        {
+            var index = (startIndex + attempt) % _baseUris.Length;
+            try
+            {
+                var response = await sendAsync(_baseUris[index]).ConfigureAwait(false);
+                if (!IsRetriableStatus(response.StatusCode))
+                {
+                    Volatile.Write(ref _activeBaseUriIndex, index);
+                    return response;
+                }
+
+                if (attempt == _baseUris.Length - 1)
+                    return response;
+
+                response.Dispose();
+            }
+            catch (Exception ex) when (IsRetriableException(ex, cancellationToken) && attempt < _baseUris.Length - 1)
+            {
+                lastException = ex;
+            }
+        }
+
+        if (lastException is not null)
+            throw lastException;
+
+        throw new SchemaRegistryException(0, "Schema Registry request failed before receiving a response.");
+    }
+
+    private static bool IsRetriableStatus(HttpStatusCode statusCode) =>
+        statusCode is HttpStatusCode.RequestTimeout or (HttpStatusCode)429 ||
+        (int)statusCode >= 500;
+
+    private static bool IsRetriableException(Exception exception, CancellationToken cancellationToken) =>
+        exception is HttpRequestException ||
+        (exception is TaskCanceledException && !cancellationToken.IsCancellationRequested);
+
+    public Task<int> RegisterSchemaAsync(
+        string subject,
+        Schema schema,
+        CancellationToken cancellationToken = default) =>
+        RegisterSchemaAsync(subject, schema, normalize: false, cancellationToken);
+
+    public async Task<int> RegisterSchemaAsync(
+        string subject,
+        Schema schema,
+        bool normalize,
+        CancellationToken cancellationToken = default)
     {
         var cacheKey = (subject, schema);
         if (_idBySchemaCache.TryGetValue(cacheKey, out var cachedId))
@@ -95,8 +193,8 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             }).ToList()
         };
 
-        using var response = await _httpClient.PostAsJsonAsync(
-            $"subjects/{Uri.EscapeDataString(subject)}/versions",
+        using var response = await PostAsJsonWithFailoverAsync(
+            WithNormalizeQuery($"subjects/{Uri.EscapeDataString(subject)}/versions", normalize || _config.NormalizeSchemas),
             request,
             SchemaRegistryJsonContext.Default.RegisterSchemaRequest,
             cancellationToken).ConfigureAwait(false);
@@ -118,7 +216,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         if (_schemaByIdCache.TryGetValue(id, out var cached))
             return cached;
 
-        using var response = await _httpClient.GetAsync(
+        using var response = await GetWithFailoverAsync(
             $"schemas/ids/{id}",
             cancellationToken).ConfigureAwait(false);
 
@@ -148,7 +246,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 
     public async Task<RegisteredSchema> GetSchemaBySubjectAsync(string subject, string version = "latest", CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync(
+        using var response = await GetWithFailoverAsync(
             $"subjects/{Uri.EscapeDataString(subject)}/versions/{Uri.EscapeDataString(version)}",
             cancellationToken).ConfigureAwait(false);
 
@@ -180,7 +278,17 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         };
     }
 
-    public async Task<int> GetOrRegisterSchemaAsync(string subject, Schema schema, CancellationToken cancellationToken = default)
+    public Task<int> GetOrRegisterSchemaAsync(
+        string subject,
+        Schema schema,
+        CancellationToken cancellationToken = default) =>
+        GetOrRegisterSchemaAsync(subject, schema, normalize: false, cancellationToken);
+
+    public async Task<int> GetOrRegisterSchemaAsync(
+        string subject,
+        Schema schema,
+        bool normalize,
+        CancellationToken cancellationToken = default)
     {
         var cacheKey = (subject, schema);
         if (_idBySchemaCache.TryGetValue(cacheKey, out var cachedId))
@@ -199,8 +307,8 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             }).ToList()
         };
 
-        using var response = await _httpClient.PostAsJsonAsync(
-            $"subjects/{Uri.EscapeDataString(subject)}",
+        using var response = await PostAsJsonWithFailoverAsync(
+            WithNormalizeQuery($"subjects/{Uri.EscapeDataString(subject)}", normalize || _config.NormalizeSchemas),
             request,
             SchemaRegistryJsonContext.Default.RegisterSchemaRequest,
             cancellationToken).ConfigureAwait(false);
@@ -208,7 +316,11 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
             // Schema doesn't exist, register it
-            return await RegisterSchemaAsync(subject, schema, cancellationToken).ConfigureAwait(false);
+            return await RegisterSchemaAsync(
+                subject,
+                schema,
+                normalize,
+                cancellationToken).ConfigureAwait(false);
         }
 
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -246,7 +358,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 
     public async Task<IReadOnlyList<string>> GetAllSubjectsAsync(CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync("subjects", cancellationToken).ConfigureAwait(false);
+        using var response = await GetWithFailoverAsync("subjects", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content.ReadFromJsonAsync<List<string>>(
@@ -255,7 +367,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 
     public async Task<IReadOnlyList<int>> GetVersionsAsync(string subject, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync(
+        using var response = await GetWithFailoverAsync(
             $"subjects/{Uri.EscapeDataString(subject)}/versions",
             cancellationToken).ConfigureAwait(false);
 
@@ -265,7 +377,19 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             SchemaRegistryJsonContext.Default.ListInt32, cancellationToken).ConfigureAwait(false) ?? [];
     }
 
-    public async Task<bool> IsCompatibleAsync(string subject, Schema schema, string version = "latest", CancellationToken cancellationToken = default)
+    public Task<bool> IsCompatibleAsync(
+        string subject,
+        Schema schema,
+        string version = "latest",
+        CancellationToken cancellationToken = default) =>
+        IsCompatibleAsync(subject, schema, version, normalize: false, cancellationToken);
+
+    public async Task<bool> IsCompatibleAsync(
+        string subject,
+        Schema schema,
+        string version,
+        bool normalize,
+        CancellationToken cancellationToken = default)
     {
         var request = new RegisterSchemaRequest
         {
@@ -279,8 +403,10 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             }).ToList()
         };
 
-        using var response = await _httpClient.PostAsJsonAsync(
-            $"compatibility/subjects/{Uri.EscapeDataString(subject)}/versions/{Uri.EscapeDataString(version)}",
+        using var response = await PostAsJsonWithFailoverAsync(
+            WithNormalizeQuery(
+                $"compatibility/subjects/{Uri.EscapeDataString(subject)}/versions/{Uri.EscapeDataString(version)}",
+                normalize || _config.NormalizeSchemas),
             request,
             SchemaRegistryJsonContext.Default.RegisterSchemaRequest,
             cancellationToken).ConfigureAwait(false);
@@ -302,7 +428,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         if (permanent)
             url += "?permanent=true";
 
-        using var response = await _httpClient.DeleteAsync(url, cancellationToken).ConfigureAwait(false);
+        using var response = await DeleteWithFailoverAsync(url, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content.ReadFromJsonAsync<List<int>>(
@@ -359,9 +485,16 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 public sealed class SchemaRegistryConfig
 {
     /// <summary>
-    /// Schema Registry URL.
+    /// Schema Registry URL. Multiple failover URLs may be provided as a
+    /// comma-separated list.
     /// </summary>
     public required string Url { get; init; }
+
+    /// <summary>
+    /// Optional Schema Registry failover URLs. When set, this takes precedence
+    /// over <see cref="Url"/>.
+    /// </summary>
+    public IReadOnlyList<string>? Urls { get; init; }
 
     /// <summary>
     /// Basic auth credentials in format "username:password".
@@ -400,6 +533,12 @@ public sealed class SchemaRegistryConfig
     /// Maximum number of schemas to cache.
     /// </summary>
     public int MaxCachedSchemas { get; init; } = 1000;
+
+    /// <summary>
+    /// Whether schema registration, lookup, and compatibility requests should
+    /// include normalize=true.
+    /// </summary>
+    public bool NormalizeSchemas { get; init; }
 }
 
 /// <summary>

--- a/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
@@ -37,6 +37,7 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     private readonly SubjectNameStrategy _subjectNameStrategy;
     private readonly ISubjectNameStrategy? _customSubjectNameStrategy;
     private readonly bool _autoRegisterSchemas;
+    private readonly bool _normalizeSchemas;
     private readonly bool _ownsClient;
     private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
 
@@ -52,6 +53,8 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     /// <param name="subjectNameStrategy">Strategy for determining subject names.</param>
     /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
     /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
+    /// <param name="ruleExecutor">Optional rule executor applied to payload bytes.</param>
+    /// <param name="normalizeSchemas">Whether to normalize schemas during registration.</param>
     public SchemaRegistrySerializer(
         ISchemaRegistryClient schemaRegistry,
         Action<T, IBufferWriter<byte>> serialize,
@@ -59,13 +62,15 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true,
         bool ownsClient = false,
-        ISchemaRegistryRuleExecutor? ruleExecutor = null)
+        ISchemaRegistryRuleExecutor? ruleExecutor = null,
+        bool normalizeSchemas = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _serialize = serialize ?? throw new ArgumentNullException(nameof(serialize));
         _getSchema = getSchema ?? throw new ArgumentNullException(nameof(getSchema));
         _subjectNameStrategy = subjectNameStrategy;
         _autoRegisterSchemas = autoRegisterSchemas;
+        _normalizeSchemas = normalizeSchemas;
         _ownsClient = ownsClient;
         _ruleExecutor = ruleExecutor;
     }
@@ -79,6 +84,8 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     /// <param name="customSubjectNameStrategy">Custom strategy for determining subject names.</param>
     /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
     /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
+    /// <param name="ruleExecutor">Optional rule executor applied to payload bytes.</param>
+    /// <param name="normalizeSchemas">Whether to normalize schemas during registration.</param>
     public SchemaRegistrySerializer(
         ISchemaRegistryClient schemaRegistry,
         Action<T, IBufferWriter<byte>> serialize,
@@ -86,13 +93,15 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         ISubjectNameStrategy customSubjectNameStrategy,
         bool autoRegisterSchemas = true,
         bool ownsClient = false,
-        ISchemaRegistryRuleExecutor? ruleExecutor = null)
+        ISchemaRegistryRuleExecutor? ruleExecutor = null,
+        bool normalizeSchemas = false)
     {
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _serialize = serialize ?? throw new ArgumentNullException(nameof(serialize));
         _getSchema = getSchema ?? throw new ArgumentNullException(nameof(getSchema));
         _customSubjectNameStrategy = customSubjectNameStrategy ?? throw new ArgumentNullException(nameof(customSubjectNameStrategy));
         _autoRegisterSchemas = autoRegisterSchemas;
+        _normalizeSchemas = normalizeSchemas;
         _ownsClient = ownsClient;
         _ruleExecutor = ruleExecutor;
     }
@@ -158,10 +167,18 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
 
         // Cache miss — fetch from registry. May race under contention for a new subject;
         // this is safe because schema registration is idempotent (same subject always returns same ID).
-        var task = _autoRegisterSchemas
-            ? _schemaRegistry.GetOrRegisterSchemaAsync(subject, schema)
-            : _schemaRegistry.GetSchemaBySubjectAsync(subject).ContinueWith(
+        Task<int> task;
+        if (_autoRegisterSchemas)
+        {
+            task = _normalizeSchemas
+                ? _schemaRegistry.GetOrRegisterSchemaAsync(subject, schema, normalize: true)
+                : _schemaRegistry.GetOrRegisterSchemaAsync(subject, schema);
+        }
+        else
+        {
+            task = _schemaRegistry.GetSchemaBySubjectAsync(subject).ContinueWith(
                 static t => t.GetAwaiter().GetResult().Id, TaskScheduler.Default);
+        }
 
         var fetchedId = task.WaitAsync(SchemaRegistryTimeout).ConfigureAwait(false).GetAwaiter().GetResult();
         return _schemaIdCache.GetOrAdd(subject, fetchedId);

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -5,6 +5,7 @@ using Avro.IO;
 using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Avro;
 using Dekaf.Serialization;
+using NSubstitute;
 using AvroSchema = Avro.Schema;
 using RegistrySchema = Dekaf.SchemaRegistry.Schema;
 
@@ -306,6 +307,33 @@ public sealed class AvroSerializerTests
         var schemaId1 = BinaryPrimitives.ReadInt32BigEndian(buffer1.WrittenSpan.Slice(1, 4));
         var schemaId2 = BinaryPrimitives.ReadInt32BigEndian(buffer2.WrittenSpan.Slice(1, 4));
         await Assert.That(schemaId1).IsEqualTo(schemaId2);
+    }
+
+    [Test]
+    public async Task Serializer_NormalizeSchemas_PassesNormalizeToRegistry()
+    {
+        var schemaRegistry = Substitute.For<ISchemaRegistryClient>();
+        schemaRegistry.GetOrRegisterSchemaAsync(
+                Arg.Any<string>(),
+                Arg.Any<RegistrySchema>(),
+                true,
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(123));
+        var config = new AvroSerializerConfig { NormalizeSchemas = true };
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry, config);
+        var schema = AvroSchema.Parse(SimpleRecordSchema) as Avro.RecordSchema;
+        var record = new GenericRecord(schema!);
+        record.Add("id", 1);
+        record.Add("name", "normalized");
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize(record, ref buffer, CreateContext());
+
+        await schemaRegistry.Received(1).GetOrRegisterSchemaAsync(
+            Arg.Any<string>(),
+            Arg.Any<RegistrySchema>(),
+            true,
+            Arg.Any<CancellationToken>());
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
@@ -254,6 +254,35 @@ public class ProtobufSchemaRegistrySerializerTests
     }
 
     [Test]
+    public async Task Serialize_NormalizeSchemas_PassesNormalizeToRegistry()
+    {
+        // Arrange
+        var schemaRegistry = Substitute.For<ISchemaRegistryClient>();
+        schemaRegistry.GetOrRegisterSchemaAsync(
+                Arg.Any<string>(),
+                Arg.Any<Schema>(),
+                true,
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(123));
+
+        var config = new ProtobufSerializerConfig { NormalizeSchemas = true };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(schemaRegistry, config);
+
+        var message = new TestMessage { Id = 1, Name = "Test", Value = 3.14 };
+
+        // Act
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize(message, ref buffer, CreateContext());
+
+        // Assert
+        await schemaRegistry.Received(1).GetOrRegisterSchemaAsync(
+            Arg.Any<string>(),
+            Arg.Any<Schema>(),
+            true,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task Serialize_DisablesAutoRegisterSchemas_WhenLookupFaults_ThrowsSchemaRegistryException()
     {
         await AssertLookupFaultThrowsSchemaRegistryExceptionAsync(

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
@@ -10,6 +10,7 @@ using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Avro;
 using Dekaf.SchemaRegistry.Protobuf;
 using Dekaf.Serialization;
+using NSubstitute;
 using AvroSchema = Avro.Schema;
 
 namespace Dekaf.Tests.Unit.SchemaRegistry;
@@ -289,6 +290,39 @@ public sealed class SchemaRegistryCacheTests
     }
 
     [Test]
+    public async Task Serializer_NormalizeSchemas_PassesNormalizeToRegistry()
+    {
+        var registry = Substitute.For<ISchemaRegistryClient>();
+        registry.GetOrRegisterSchemaAsync(
+                Arg.Any<string>(),
+                Arg.Any<Schema>(),
+                true,
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(123));
+        var schema = new Schema { SchemaType = SchemaType.Json, SchemaString = """{ "type": "string" }""" };
+
+        await using var serializer = new SchemaRegistrySerializer<string>(
+            registry,
+            serialize: static (value, writer) =>
+            {
+                var byteCount = Encoding.UTF8.GetByteCount(value);
+                Encoding.UTF8.GetBytes(value, writer.GetSpan(byteCount));
+                writer.Advance(byteCount);
+            },
+            getSchema: _ => schema,
+            normalizeSchemas: true);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize("msg", ref buffer, CreateContext());
+
+        await registry.Received(1).GetOrRegisterSchemaAsync(
+            Arg.Any<string>(),
+            Arg.Any<Schema>(),
+            true,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task Deserializer_RuleExecutor_TransformsDeserializedPayload()
     {
         var registry = new MockSchemaRegistryClient();
@@ -336,6 +370,32 @@ public sealed class SchemaRegistryCacheTests
 
         await Assert.That(strategy.CallCount).IsEqualTo(1);
         await Assert.That(registry.GetCallCount("topic-value")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task JsonSerializer_NormalizeSchemas_PassesNormalizeToRegistry()
+    {
+        var registry = Substitute.For<ISchemaRegistryClient>();
+        registry.GetOrRegisterSchemaAsync(
+                Arg.Any<string>(),
+                Arg.Any<Schema>(),
+                true,
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(123));
+
+        await using var serializer = new JsonSchemaRegistrySerializer<string>(
+            registry,
+            """{ "type": "string" }""",
+            normalizeSchemas: true);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize("msg", ref buffer, CreateContext());
+
+        await registry.Received(1).GetOrRegisterSchemaAsync(
+            Arg.Any<string>(),
+            Arg.Any<Schema>(),
+            true,
+            Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -580,6 +640,50 @@ public sealed class SchemaRegistryCacheTests
     }
 
     [Test]
+    public async Task Client_RegisterSchema_CacheKeyIncludesNormalizeFlag()
+    {
+        using var handler = new QueueingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.OK, """{ "id": 41 }""")
+            .Enqueue(HttpStatusCode.OK, """{ "id": 42 }""");
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://registry:8081"
+        }, handler);
+        var schema = NewSchema(1);
+
+        var firstId = await client.RegisterSchemaAsync("topic-value", schema, normalize: false);
+        var secondId = await client.RegisterSchemaAsync("topic-value", schema, normalize: true);
+
+        await Assert.That(firstId).IsEqualTo(41);
+        await Assert.That(secondId).IsEqualTo(42);
+        await Assert.That(handler.RequestUris).Count().IsEqualTo(2);
+        await Assert.That(handler.RequestUris[0].Query).IsEqualTo("");
+        await Assert.That(handler.RequestUris[1].Query).IsEqualTo("?normalize=true");
+    }
+
+    [Test]
+    public async Task Client_GetOrRegisterSchema_CacheKeyIncludesNormalizeFlag()
+    {
+        using var handler = new QueueingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.OK, RegisteredSchemaJson(41))
+            .Enqueue(HttpStatusCode.OK, RegisteredSchemaJson(42));
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://registry:8081"
+        }, handler);
+        var schema = NewSchema(1);
+
+        var firstId = await client.GetOrRegisterSchemaAsync("topic-value", schema, normalize: false);
+        var secondId = await client.GetOrRegisterSchemaAsync("topic-value", schema, normalize: true);
+
+        await Assert.That(firstId).IsEqualTo(41);
+        await Assert.That(secondId).IsEqualTo(42);
+        await Assert.That(handler.RequestUris).Count().IsEqualTo(2);
+        await Assert.That(handler.RequestUris[0].Query).IsEqualTo("");
+        await Assert.That(handler.RequestUris[1].Query).IsEqualTo("?normalize=true");
+    }
+
+    [Test]
     public async Task Deserializer_UsesCachedSchema_AndPassesPayloadWithoutCopy()
     {
         var registry = new MockSchemaRegistryClient();
@@ -691,6 +795,17 @@ public sealed class SchemaRegistryCacheTests
         SchemaType = SchemaType.Json,
         SchemaString = $$"""{ "type": "string", "title": "schema-{{id}}" }"""
     };
+
+    private static string RegisteredSchemaJson(int id) =>
+        $$"""
+        {
+          "subject": "topic-value",
+          "version": 1,
+          "id": {{id}},
+          "schema": "{ \"type\": \"string\" }",
+          "schemaType": "JSON"
+        }
+        """;
 
     private sealed class QueueingSchemaRegistryHandler : HttpMessageHandler
     {

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryCacheTests.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.Net;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
@@ -524,6 +525,61 @@ public sealed class SchemaRegistryCacheTests
     }
 
     [Test]
+    public async Task Client_FailsOverToNextUrl_OnRetriableStatus()
+    {
+        using var handler = new QueueingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.ServiceUnavailable, "{}")
+            .Enqueue(HttpStatusCode.OK, "[]");
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://primary:8081, http://secondary:8081"
+        }, handler);
+
+        var subjects = await client.GetAllSubjectsAsync();
+
+        await Assert.That(subjects).IsEmpty();
+        await Assert.That(handler.RequestUris).Count().IsEqualTo(2);
+        await Assert.That(handler.RequestUris[0].Host).IsEqualTo("primary");
+        await Assert.That(handler.RequestUris[1].Host).IsEqualTo("secondary");
+    }
+
+    [Test]
+    public async Task Client_DoesNotFailOver_OnSchemaRegistryClientError()
+    {
+        using var handler = new QueueingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.NotFound, """{ "error_code": 40401, "message": "not found" }""")
+            .Enqueue(HttpStatusCode.OK, "[]");
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Urls = ["http://primary:8081", "http://secondary:8081"],
+            Url = "http://ignored:8081"
+        }, handler);
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryException>(() => client.GetAllSubjectsAsync());
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(40401);
+        await Assert.That(handler.RequestUris).Count().IsEqualTo(1);
+        await Assert.That(handler.RequestUris[0].Host).IsEqualTo("primary");
+    }
+
+    [Test]
+    public async Task Client_AddsNormalizeQuery_WhenConfigured()
+    {
+        using var handler = new QueueingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.OK, """{ "id": 42 }""");
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://registry:8081",
+            NormalizeSchemas = true
+        }, handler);
+
+        var schemaId = await client.RegisterSchemaAsync("topic-value", NewSchema(1));
+
+        await Assert.That(schemaId).IsEqualTo(42);
+        await Assert.That(handler.RequestUris[0].Query).IsEqualTo("?normalize=true");
+    }
+
+    [Test]
     public async Task Deserializer_UsesCachedSchema_AndPassesPayloadWithoutCopy()
     {
         var registry = new MockSchemaRegistryClient();
@@ -635,6 +691,34 @@ public sealed class SchemaRegistryCacheTests
         SchemaType = SchemaType.Json,
         SchemaString = $$"""{ "type": "string", "title": "schema-{{id}}" }"""
     };
+
+    private sealed class QueueingSchemaRegistryHandler : HttpMessageHandler
+    {
+        private readonly Queue<(HttpStatusCode StatusCode, string Content)> _responses = new();
+
+        public List<Uri> RequestUris { get; } = [];
+
+        public QueueingSchemaRegistryHandler Enqueue(HttpStatusCode statusCode, string content)
+        {
+            _responses.Enqueue((statusCode, content));
+            return this;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestUris.Add(request.RequestUri!);
+            (HttpStatusCode StatusCode, string Content) response = _responses.Count > 0
+                ? _responses.Dequeue()
+                : (HttpStatusCode.OK, "[]");
+
+            return Task.FromResult(new HttpResponseMessage(response.StatusCode)
+            {
+                Content = new StringContent(response.Content, Encoding.UTF8)
+            });
+        }
+    }
 
     private static GenericRecord CreateAvroRecord()
     {


### PR DESCRIPTION
## Summary
- add Schema Registry multi-URL failover via comma-separated `Url` or `Urls`
- retry failover only for transport errors, timeouts, 408, 429, and 5xx responses
- add `normalize=true` support on client requests plus Avro/Protobuf/JSON serializer configs
- keep existing `UseLatestVersion` serializer support unchanged

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -v:minimal`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/SchemaRegistryCacheTests/*" --disable-logo --no-ansi --no-progress`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ProtobufSchemaRegistrySerializerTests/*" --disable-logo --no-ansi --no-progress`
- [ ] Full unit executable timed out after 180s locally; process was stopped.

Closes #1396