### PR TITLE
feat(security): add TLS hostname toggle

### DIFF
--- a/docs/docs/security/tls.md
+++ b/docs/docs/security/tls.md
@@ -82,8 +82,11 @@ var tlsConfig = new TlsConfig
     ClientKeyPath = "/path/to/client.key",
     ClientKeyPassword = "password",
 
-    // Skip server certificate validation (NOT recommended for production)
-    SkipServerCertificateValidation = false,
+    // Validate the broker certificate chain
+    ValidateServerCertificate = true,
+
+    // Verify that the certificate matches the connection host name
+    ValidateServerCertificateHostName = true,
 
     // Allowed TLS protocols
     EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13
@@ -134,13 +137,26 @@ Solutions:
 2. Check certificate chain is complete
 3. Verify server hostname matches certificate
 
+### Host Name Mismatch Only
+
+If the broker certificate chain is trusted but the certificate host name does not match the address used by clients, disable only host-name verification:
+
+```csharp
+var tlsConfig = new TlsConfig
+{
+    CaCertificatePath = "/path/to/ca.crt",
+    ValidateServerCertificate = true,
+    ValidateServerCertificateHostName = false
+};
+```
+
 ### For Development Only
 
 ```csharp
 // ⚠️ NEVER use in production
 var tlsConfig = new TlsConfig
 {
-    SkipServerCertificateValidation = true
+    ValidateServerCertificate = false
 };
 ```
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1692,6 +1692,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
     {
         var tlsConfig = _options.TlsConfig;
         var callback = _options.RemoteCertificateValidationCallback;
+        var validateServerCertificateHostName = tlsConfig?.ValidateServerCertificateHostName ?? true;
 
         // Configure server certificate validation
         if (tlsConfig is not null && !tlsConfig.ValidateServerCertificate)
@@ -1703,15 +1704,40 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 #pragma warning restore CA5359
         }
 
-        if (callback is null && HasCustomCaCertificate(tlsConfig))
+        if (callback is not null)
+        {
+            return callback;
+        }
+
+        if (HasCustomCaCertificate(tlsConfig))
         {
             // Custom CA certificate validation
             var caCertificates = LoadCaCertificatesWithOwnership(tlsConfig!);
             return (_, certificate, chain, sslPolicyErrors) =>
-                ValidateServerCertificate(certificate, chain, sslPolicyErrors, caCertificates);
+                ValidateServerCertificate(
+                    certificate,
+                    chain,
+                    ApplyServerCertificateHostNamePolicy(sslPolicyErrors, validateServerCertificateHostName),
+                    caCertificates);
         }
 
-        return callback;
+        if (!validateServerCertificateHostName)
+        {
+            return static (_, _, _, sslPolicyErrors) =>
+                ApplyServerCertificateHostNamePolicy(sslPolicyErrors, validateServerCertificateHostName: false) ==
+                SslPolicyErrors.None;
+        }
+
+        return null;
+    }
+
+    internal static SslPolicyErrors ApplyServerCertificateHostNamePolicy(
+        SslPolicyErrors sslPolicyErrors,
+        bool validateServerCertificateHostName)
+    {
+        return validateServerCertificateHostName
+            ? sslPolicyErrors
+            : sslPolicyErrors & ~SslPolicyErrors.RemoteCertificateNameMismatch;
     }
 
     private X509CertificateCollection? BuildClientCertificates(TlsConfig? tlsConfig)

--- a/src/Dekaf/Security/TlsConfig.cs
+++ b/src/Dekaf/Security/TlsConfig.cs
@@ -56,6 +56,13 @@ public sealed class TlsConfig
     public bool ValidateServerCertificate { get; init; } = true;
 
     /// <summary>
+    /// Whether to verify that the server certificate matches the connection host name.
+    /// Set to false to ignore only host-name mismatches while still validating the certificate chain.
+    /// Default is true.
+    /// </summary>
+    public bool ValidateServerCertificateHostName { get; init; } = true;
+
+    /// <summary>
     /// The expected host name in the server's certificate.
     /// If null, the connection host name is used.
     /// </summary>

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -1,10 +1,12 @@
 using System.Buffers.Binary;
 using System.Net;
+using System.Net.Security;
 using System.Net.Sockets;
 using System.Reflection;
 using Dekaf.Errors;
 using Dekaf.Networking;
 using Dekaf.Protocol.Messages;
+using Dekaf.Security;
 
 namespace Dekaf.Tests.Unit.Networking;
 
@@ -411,6 +413,81 @@ public sealed class KafkaConnectionTests
         await Assert.That(stream.ReadCalls).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task BuildRemoteCertificateValidationCallback_WhenHostNameValidationDisabled_IgnoresNameMismatchOnly()
+    {
+        await using var connection = new KafkaConnection(
+            "localhost",
+            9092,
+            options: new ConnectionOptions
+            {
+                TlsConfig = new TlsConfig
+                {
+                    ValidateServerCertificateHostName = false
+                }
+            });
+
+        var callback = InvokeBuildRemoteCertificateValidationCallback(connection);
+
+        await Assert.That(callback).IsNotNull();
+        await Assert.That(callback!(connection, null, null, SslPolicyErrors.RemoteCertificateNameMismatch)).IsTrue();
+        await Assert.That(callback(
+                connection,
+                null,
+                null,
+                SslPolicyErrors.RemoteCertificateNameMismatch | SslPolicyErrors.RemoteCertificateChainErrors))
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task BuildRemoteCertificateValidationCallback_WhenHostNameValidationEnabledWithoutCustomPolicy_ReturnsNull()
+    {
+        await using var connection = new KafkaConnection(
+            "localhost",
+            9092,
+            options: new ConnectionOptions { TlsConfig = new TlsConfig() });
+
+        var callback = InvokeBuildRemoteCertificateValidationCallback(connection);
+
+        await Assert.That(callback).IsNull();
+    }
+
+    [Test]
+    public async Task ApplyServerCertificateHostNamePolicy_WhenEnabled_PreservesNameMismatch()
+    {
+        const SslPolicyErrors errors =
+            SslPolicyErrors.RemoteCertificateNameMismatch | SslPolicyErrors.RemoteCertificateChainErrors;
+
+        var result = KafkaConnection.ApplyServerCertificateHostNamePolicy(
+            errors,
+            validateServerCertificateHostName: true);
+
+        await Assert.That(result).IsEqualTo(errors);
+    }
+
+    [Test]
+    public async Task ApplyServerCertificateHostNamePolicy_WhenDisabled_RemovesOnlyNameMismatch()
+    {
+        const SslPolicyErrors errors =
+            SslPolicyErrors.RemoteCertificateNameMismatch | SslPolicyErrors.RemoteCertificateChainErrors;
+
+        var result = KafkaConnection.ApplyServerCertificateHostNamePolicy(
+            errors,
+            validateServerCertificateHostName: false);
+
+        await Assert.That(result).IsEqualTo(SslPolicyErrors.RemoteCertificateChainErrors);
+    }
+
+    [Test]
+    public async Task ApplyServerCertificateHostNamePolicy_WhenDisabled_AcceptsNameMismatchOnly()
+    {
+        var result = KafkaConnection.ApplyServerCertificateHostNamePolicy(
+            SslPolicyErrors.RemoteCertificateNameMismatch,
+            validateServerCertificateHostName: false);
+
+        await Assert.That(result).IsEqualTo(SslPolicyErrors.None);
+    }
+
     private static async Task<byte[]> ReadRequestFrameAsync(NetworkStream stream, CancellationToken cancellationToken)
     {
         var lengthBuffer = new byte[4];
@@ -471,6 +548,18 @@ public sealed class KafkaConnectionTests
         ]);
 
         await ((ValueTask<SaslHandshakeResponse>)result!).ConfigureAwait(false);
+    }
+
+    private static RemoteCertificateValidationCallback? InvokeBuildRemoteCertificateValidationCallback(
+        KafkaConnection connection)
+    {
+        var method = typeof(KafkaConnection).GetMethod(
+            "BuildRemoteCertificateValidationCallback",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        if (method is null)
+            throw new InvalidOperationException("BuildRemoteCertificateValidationCallback was not found.");
+
+        return (RemoteCertificateValidationCallback?)method.Invoke(connection, null);
     }
 
     private static T GetPrivateField<T>(KafkaConnection connection, string name)

--- a/tests/Dekaf.Tests.Unit/Security/TlsConfigTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/TlsConfigTests.cs
@@ -13,6 +13,7 @@ public class TlsConfigTests
         var config = new TlsConfig();
 
         await Assert.That(config.ValidateServerCertificate).IsTrue();
+        await Assert.That(config.ValidateServerCertificateHostName).IsTrue();
         await Assert.That(config.CheckCertificateRevocation).IsFalse();
         await Assert.That(config.CaCertificatePath).IsNull();
         await Assert.That(config.CaCertificateObject).IsNull();
@@ -112,6 +113,17 @@ public class TlsConfigTests
         };
 
         await Assert.That(config.ValidateServerCertificate).IsFalse();
+    }
+
+    [Test]
+    public async Task Config_CanDisableServerCertificateHostNameValidation()
+    {
+        var config = new TlsConfig
+        {
+            ValidateServerCertificateHostName = false
+        };
+
+        await Assert.That(config.ValidateServerCertificateHostName).IsFalse();
     }
 
     [Test]


### PR DESCRIPTION
Closes #1393

## Summary
- Add `TlsConfig.ValidateServerCertificateHostName` to ignore only TLS host-name mismatches.
- Apply the policy before system/custom CA validation so chain errors still fail.
- Document the option and cover config/callback behavior with unit tests.

## Tests
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -v:minimal`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/TlsConfigTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaConnectionTests/*"`