### PR TITLE
feat(networking): expose connection tuning

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -98,10 +98,13 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithQueuedMaxMessagesKbytes(...)` | `QueuedMaxMessagesKbytes` | KiB; omit to keep auto-tuning |
 | `WithPrefetchPipelineDepth(...)` | `PrefetchPipelineDepth` | Integer |
 | `WithConnectionsMaxIdle(...)` | `ConnectionsMaxIdleMs` | Milliseconds; `-1` disables |
+| `WithConnectionTimeout(...)` | `ConnectionTimeout` | TimeSpan |
+| `WithTcpKeepAlive(...)` | `EnableTcpKeepAlive`, `TcpKeepAliveTime`, `TcpKeepAliveInterval`, `TcpKeepAliveRetryCount` | Socket keepalive |
 | `WithConnectionsPerBroker(...)` | `ConnectionsPerBroker` | Integer |
 | `WithAdaptiveConnections(...)` | `EnableAdaptiveConnections`, `MaxConnectionsPerBroker` | Set `EnableAdaptiveConnections` to `false` to disable |
 | `WithAdaptiveFetchSizing(...)` | `EnableAdaptiveFetchSizing`, `AdaptiveFetchSizingOptions` | Bind nested adaptive sizing fields |
 | `UseTls(...)` | `UseTls`, `TlsConfig` | `TlsConfig` can bind certificate path fields |
+| `WithRemoteCertificateValidationCallback(...)` | Runtime callback | Custom TLS certificate validation |
 | `WithSaslPlain(...)` / `WithSaslScramSha512(...)` | `SaslMechanism`, `SaslUsername`, `SaslPassword` | `SaslMechanism` values match the enum names |
 | `WithGssapi(...)` | `SaslMechanism`, `GssapiConfig` | Use `SaslMechanism: Gssapi` |
 | `WithOAuthBearer(...)` | `SaslMechanism`, `OAuthBearerConfig` | Use `SaslMechanism: OAuthBearer` |
@@ -282,6 +285,23 @@ Maximum time an unused broker connection stays open before the client closes it:
 
 The default is 9 minutes, slightly below Kafka's broker-side `connections.max.idle.ms` default of 10 minutes. Connections with in-flight requests are not reaped.
 
+### WithConnectionTimeout
+
+Maximum time allowed for socket connection setup, including TLS and SASL handshakes:
+
+```csharp
+.WithConnectionTimeout(TimeSpan.FromSeconds(10))
+```
+
+### WithTcpKeepAlive
+
+Enable, disable, or tune TCP keepalive probes:
+
+```csharp
+.WithTcpKeepAlive(false) // Disable keepalive
+.WithTcpKeepAlive(TimeSpan.FromMinutes(2), TimeSpan.FromSeconds(30), retryCount: 3)
+```
+
 ## Security
 
 ### UseTls
@@ -292,6 +312,13 @@ Enable TLS:
 .UseTls()
 .UseTls(tlsConfig)
 .UseMutualTls(caCert, clientCert, clientKey)
+```
+
+Custom TLS certificate validation can be attached for pinning or private PKI:
+
+```csharp
+.WithRemoteCertificateValidationCallback((sender, cert, chain, errors) =>
+    errors == SslPolicyErrors.None)
 ```
 
 ### SASL Authentication
@@ -378,4 +405,7 @@ For transactional reads:
 | `WithConnectionsMaxIdle` | 540000ms | Close unused broker connections; `Timeout.InfiniteTimeSpan` disables |
 | `WithConnectionsPerBroker` | 2 | TCP connections per broker |
 | `WithAdaptiveConnections` | enabled (max 4) | Auto-scale connections under load |
+| `WithConnectionTimeout` | 30000ms | Socket connection setup timeout |
+| `WithTcpKeepAlive` | enabled | TCP keepalive; 2m idle, 30s interval, 3 retries |
 | `UseTls` | false | Enable TLS |
+| `WithRemoteCertificateValidationCallback` | null | Custom TLS certificate validation |

--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -314,7 +314,8 @@ Enable TLS:
 .UseMutualTls(caCert, clientCert, clientKey)
 ```
 
-Custom TLS certificate validation can be attached for pinning or private PKI:
+Custom TLS certificate validation can be attached for pinning or private PKI.
+Setting a callback enables TLS for the connection.
 
 ```csharp
 .WithRemoteCertificateValidationCallback((sender, cert, chain, errors) =>

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -292,7 +292,8 @@ Enable, disable, or tune TCP keepalive probes:
 
 ### WithRemoteCertificateValidationCallback
 
-Attach a custom TLS certificate validation callback for pinning or private PKI:
+Attach a custom TLS certificate validation callback for pinning or private PKI.
+Setting a callback enables TLS for the connection.
 
 ```csharp
 .WithRemoteCertificateValidationCallback((sender, cert, chain, errors) =>

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -80,6 +80,8 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithRequestTimeout(...)` | `RequestTimeoutMs` | Milliseconds |
 | `WithIdempotence(...)` | `EnableIdempotence` | Boolean |
 | `WithConnectionsMaxIdle(...)` | `ConnectionsMaxIdleMs` | Milliseconds; `-1` disables |
+| `WithConnectionTimeout(...)` | `ConnectionTimeout` | TimeSpan |
+| `WithTcpKeepAlive(...)` | `EnableTcpKeepAlive`, `TcpKeepAliveTime`, `TcpKeepAliveInterval`, `TcpKeepAliveRetryCount` | Socket keepalive |
 | `WithConnectionsPerBroker(...)` | `ConnectionsPerBroker` | Integer |
 | `WithAdaptiveConnections(...)` | `EnableAdaptiveConnections`, `MaxConnectionsPerBroker` | Set `EnableAdaptiveConnections` to `false` to disable |
 | `WithTransactionalId(...)` | `TransactionalId` | String |
@@ -88,6 +90,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithCompressionLevel(...)` | `CompressionLevel` | Codec-specific integer |
 | `WithPartitioner(...)` | `Partitioner` | `Default`, `Sticky`, `RoundRobin` |
 | `UseTls(...)` | `UseTls`, `TlsConfig` | `TlsConfig` can bind certificate path fields |
+| `WithRemoteCertificateValidationCallback(...)` | Runtime callback | Custom TLS certificate validation |
 | `WithSaslPlain(...)` / `WithSaslScramSha512(...)` | `SaslMechanism`, `SaslUsername`, `SaslPassword` | `SaslMechanism` values match the enum names |
 | `WithGssapi(...)` | `SaslMechanism`, `GssapiConfig` | Use `SaslMechanism: Gssapi` |
 | `WithOAuthBearer(...)` | `SaslMechanism`, `OAuthBearerConfig` | Use `SaslMechanism: OAuthBearer` |
@@ -270,6 +273,32 @@ Maximum time an unused broker connection stays open before the client closes it:
 
 The default is 9 minutes, slightly below Kafka's broker-side `connections.max.idle.ms` default of 10 minutes. This lets Dekaf close unused connections first and avoid a request racing a broker idle close.
 
+### WithConnectionTimeout
+
+Maximum time allowed for socket connection setup, including TLS and SASL handshakes:
+
+```csharp
+.WithConnectionTimeout(TimeSpan.FromSeconds(10))
+```
+
+### WithTcpKeepAlive
+
+Enable, disable, or tune TCP keepalive probes:
+
+```csharp
+.WithTcpKeepAlive(false) // Disable keepalive
+.WithTcpKeepAlive(TimeSpan.FromMinutes(2), TimeSpan.FromSeconds(30), retryCount: 3)
+```
+
+### WithRemoteCertificateValidationCallback
+
+Attach a custom TLS certificate validation callback for pinning or private PKI:
+
+```csharp
+.WithRemoteCertificateValidationCallback((sender, cert, chain, errors) =>
+    errors == SslPolicyErrors.None)
+```
+
 ### WithAdaptiveConnections
 
 Configure adaptive connection scaling. When sustained buffer backpressure is detected, the producer automatically adds connections per broker to increase drain throughput:
@@ -344,6 +373,8 @@ Enable logging:
 | `WithPartitioner` | Default | Partition strategy |
 | `WithConnectionsPerBroker` | 1 | TCP connections per broker |
 | `WithConnectionsMaxIdle` | 540000ms | Close unused broker connections; `Timeout.InfiniteTimeSpan` disables |
+| `WithConnectionTimeout` | 30000ms | Socket connection setup timeout |
+| `WithTcpKeepAlive` | enabled | TCP keepalive; 2m idle, 30s interval, 3 retries |
 | `WithAdaptiveConnections` | enabled (max 10) | Auto-scale connections under load |
 | `WithoutAdaptiveConnections` | - | Disable adaptive scaling |
 | `WithBufferMemory` | auto-tuned | Max buffer for unsent messages |
@@ -353,5 +384,6 @@ Enable logging:
 | `WithSocketSendBufferBytes` | OS default | TCP send buffer size |
 | `WithSocketReceiveBufferBytes` | OS default | TCP receive buffer size |
 | `UseTls` | false | Enable TLS |
+| `WithRemoteCertificateValidationCallback` | null | Custom TLS certificate validation |
 | `WithKeySerializer` | inferred | Key serializer |
 | `WithValueSerializer` | inferred | Value serializer |

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -782,6 +782,10 @@ internal static class DekafOptionsBinding
         builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
         builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs));
         builder.WithConnectionsMaxIdle(ToTimeout(options.ConnectionsMaxIdleMs));
+        builder.WithConnectionTimeout(options.ConnectionTimeout);
+        if (options.EnableTcpKeepAlive)
+            builder.WithTcpKeepAlive(options.TcpKeepAliveTime, options.TcpKeepAliveInterval, options.TcpKeepAliveRetryCount);
+        builder.WithTcpKeepAlive(options.EnableTcpKeepAlive);
         builder.WithIdempotence(options.EnableIdempotence);
         builder.WithConnectionsPerBroker(options.ConnectionsPerBroker);
         if (options.TransactionalId is not null)
@@ -797,6 +801,8 @@ internal static class DekafOptionsBinding
         else
             builder.WithPartitioner(options.Partitioner);
         ApplyTls(options.UseTls, options.TlsConfig, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
+        if (options.RemoteCertificateValidationCallback is not null)
+            builder.WithRemoteCertificateValidationCallback(options.RemoteCertificateValidationCallback);
         ApplySasl(
             options.SaslMechanism,
             options.SaslUsername,
@@ -864,8 +870,14 @@ internal static class DekafOptionsBinding
         builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
         builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs));
         builder.WithConnectionsMaxIdle(ToTimeout(options.ConnectionsMaxIdleMs));
+        builder.WithConnectionTimeout(options.ConnectionTimeout);
+        if (options.EnableTcpKeepAlive)
+            builder.WithTcpKeepAlive(options.TcpKeepAliveTime, options.TcpKeepAliveInterval, options.TcpKeepAliveRetryCount);
+        builder.WithTcpKeepAlive(options.EnableTcpKeepAlive);
         builder.WithCheckCrcs(options.CheckCrcs);
         ApplyTls(options.UseTls, options.TlsConfig, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
+        if (options.RemoteCertificateValidationCallback is not null)
+            builder.WithRemoteCertificateValidationCallback(options.RemoteCertificateValidationCallback);
         ApplySasl(
             options.SaslMechanism,
             options.SaslUsername,
@@ -913,7 +925,13 @@ internal static class DekafOptionsBinding
         builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
         builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs));
         builder.WithConnectionsMaxIdle(ToTimeout(options.ConnectionsMaxIdleMs));
+        builder.WithConnectionTimeout(options.ConnectionTimeout);
+        if (options.EnableTcpKeepAlive)
+            builder.WithTcpKeepAlive(options.TcpKeepAliveTime, options.TcpKeepAliveInterval, options.TcpKeepAliveRetryCount);
+        builder.WithTcpKeepAlive(options.EnableTcpKeepAlive);
         ApplyTls(options.UseTls, options.TlsConfig, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
+        if (options.RemoteCertificateValidationCallback is not null)
+            builder.WithRemoteCertificateValidationCallback(options.RemoteCertificateValidationCallback);
         if (options.OAuthBearerTokenProvider is not null)
         {
             builder.WithOAuthBearer(options.OAuthBearerTokenProvider);
@@ -1071,6 +1089,11 @@ internal static class DekafConfigurationBinding
             builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(reconnectBackoffMs));
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.ReconnectBackoffMaxMs), out var reconnectBackoffMaxMs))
             builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(reconnectBackoffMaxMs));
+        ApplySocketConnectionOptions(
+            configuration,
+            builder.WithConnectionTimeout,
+            enabled => builder.WithTcpKeepAlive(enabled),
+            (time, interval, retryCount) => builder.WithTcpKeepAlive(time, interval, retryCount));
         if (TryGetValue<bool>(configuration, nameof(ProducerOptions.EnableIdempotence), out var enableIdempotence))
             builder.WithIdempotence(enableIdempotence);
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.ConnectionsPerBroker), out var connectionsPerBroker))
@@ -1175,6 +1198,11 @@ internal static class DekafConfigurationBinding
             builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(reconnectBackoffMs));
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.ReconnectBackoffMaxMs), out var reconnectBackoffMaxMs))
             builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(reconnectBackoffMaxMs));
+        ApplySocketConnectionOptions(
+            configuration,
+            builder.WithConnectionTimeout,
+            enabled => builder.WithTcpKeepAlive(enabled),
+            (time, interval, retryCount) => builder.WithTcpKeepAlive(time, interval, retryCount));
         if (TryGetValue<bool>(configuration, nameof(ConsumerOptions.CheckCrcs), out var checkCrcs))
             builder.WithCheckCrcs(checkCrcs);
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
@@ -1221,6 +1249,11 @@ internal static class DekafConfigurationBinding
             builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(reconnectBackoffMs));
         if (TryGetValue<int>(configuration, nameof(AdminClientOptions.ReconnectBackoffMaxMs), out var reconnectBackoffMaxMs))
             builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(reconnectBackoffMaxMs));
+        ApplySocketConnectionOptions(
+            configuration,
+            builder.WithConnectionTimeout,
+            enabled => builder.WithTcpKeepAlive(enabled),
+            (time, interval, retryCount) => builder.WithTcpKeepAlive(time, interval, retryCount));
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
         if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth, out var awsMskIam, out var saslScramTokenAuth))
             builder.WithSaslOptions(mechanism, username, password, gssapi, oauth, awsMskIam, saslScramTokenAuth: saslScramTokenAuth);
@@ -1247,6 +1280,50 @@ internal static class DekafConfigurationBinding
         {
             useTls();
         }
+    }
+
+    private static void ApplySocketConnectionOptions<TBuilder>(
+        IConfiguration configuration,
+        Func<TimeSpan, TBuilder> withConnectionTimeout,
+        Func<bool, TBuilder> withTcpKeepAliveEnabled,
+        Func<TimeSpan, TimeSpan, int, TBuilder> withTcpKeepAlive)
+    {
+        if (TryGetValue<TimeSpan>(configuration, nameof(ProducerOptions.ConnectionTimeout), out var connectionTimeout))
+            withConnectionTimeout(connectionTimeout);
+
+        var hasEnableTcpKeepAlive = TryGetValue<bool>(
+            configuration,
+            nameof(ProducerOptions.EnableTcpKeepAlive),
+            out var enableTcpKeepAlive);
+        if (hasEnableTcpKeepAlive && !enableTcpKeepAlive)
+        {
+            withTcpKeepAliveEnabled(false);
+            return;
+        }
+
+        var hasKeepAliveTime = TryGetValue<TimeSpan>(
+            configuration,
+            nameof(ProducerOptions.TcpKeepAliveTime),
+            out var keepAliveTime);
+        var hasKeepAliveInterval = TryGetValue<TimeSpan>(
+            configuration,
+            nameof(ProducerOptions.TcpKeepAliveInterval),
+            out var keepAliveInterval);
+        var hasKeepAliveRetryCount = TryGetValue<int>(
+            configuration,
+            nameof(ProducerOptions.TcpKeepAliveRetryCount),
+            out var keepAliveRetryCount);
+
+        if (hasKeepAliveTime || hasKeepAliveInterval || hasKeepAliveRetryCount)
+        {
+            withTcpKeepAlive(
+                hasKeepAliveTime ? keepAliveTime : TimeSpan.FromMinutes(2),
+                hasKeepAliveInterval ? keepAliveInterval : TimeSpan.FromSeconds(30),
+                hasKeepAliveRetryCount ? keepAliveRetryCount : 3);
+        }
+
+        if (hasEnableTcpKeepAlive)
+            withTcpKeepAliveEnabled(enableTcpKeepAlive);
     }
 
     private static void ApplyAdaptiveConnections<TBuilder>(

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Net.Security;
 using System.Xml;
 
 namespace Dekaf.Extensions.DependencyInjection;
@@ -782,10 +783,15 @@ internal static class DekafOptionsBinding
         builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
         builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs));
         builder.WithConnectionsMaxIdle(ToTimeout(options.ConnectionsMaxIdleMs));
-        builder.WithConnectionTimeout(options.ConnectionTimeout);
-        if (options.EnableTcpKeepAlive)
-            builder.WithTcpKeepAlive(options.TcpKeepAliveTime, options.TcpKeepAliveInterval, options.TcpKeepAliveRetryCount);
-        builder.WithTcpKeepAlive(options.EnableTcpKeepAlive);
+        ApplySocketConnectionOptions(
+            options.ConnectionTimeout,
+            options.EnableTcpKeepAlive,
+            options.TcpKeepAliveTime,
+            options.TcpKeepAliveInterval,
+            options.TcpKeepAliveRetryCount,
+            builder.WithConnectionTimeout,
+            enabled => builder.WithTcpKeepAlive(enabled),
+            (time, interval, retryCount) => builder.WithTcpKeepAlive(time, interval, retryCount));
         builder.WithIdempotence(options.EnableIdempotence);
         builder.WithConnectionsPerBroker(options.ConnectionsPerBroker);
         if (options.TransactionalId is not null)
@@ -801,8 +807,9 @@ internal static class DekafOptionsBinding
         else
             builder.WithPartitioner(options.Partitioner);
         ApplyTls(options.UseTls, options.TlsConfig, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
-        if (options.RemoteCertificateValidationCallback is not null)
-            builder.WithRemoteCertificateValidationCallback(options.RemoteCertificateValidationCallback);
+        ApplyRemoteCertificateValidationCallback(
+            options.RemoteCertificateValidationCallback,
+            builder.WithRemoteCertificateValidationCallback);
         ApplySasl(
             options.SaslMechanism,
             options.SaslUsername,
@@ -870,14 +877,20 @@ internal static class DekafOptionsBinding
         builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
         builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs));
         builder.WithConnectionsMaxIdle(ToTimeout(options.ConnectionsMaxIdleMs));
-        builder.WithConnectionTimeout(options.ConnectionTimeout);
-        if (options.EnableTcpKeepAlive)
-            builder.WithTcpKeepAlive(options.TcpKeepAliveTime, options.TcpKeepAliveInterval, options.TcpKeepAliveRetryCount);
-        builder.WithTcpKeepAlive(options.EnableTcpKeepAlive);
+        ApplySocketConnectionOptions(
+            options.ConnectionTimeout,
+            options.EnableTcpKeepAlive,
+            options.TcpKeepAliveTime,
+            options.TcpKeepAliveInterval,
+            options.TcpKeepAliveRetryCount,
+            builder.WithConnectionTimeout,
+            enabled => builder.WithTcpKeepAlive(enabled),
+            (time, interval, retryCount) => builder.WithTcpKeepAlive(time, interval, retryCount));
         builder.WithCheckCrcs(options.CheckCrcs);
         ApplyTls(options.UseTls, options.TlsConfig, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
-        if (options.RemoteCertificateValidationCallback is not null)
-            builder.WithRemoteCertificateValidationCallback(options.RemoteCertificateValidationCallback);
+        ApplyRemoteCertificateValidationCallback(
+            options.RemoteCertificateValidationCallback,
+            builder.WithRemoteCertificateValidationCallback);
         ApplySasl(
             options.SaslMechanism,
             options.SaslUsername,
@@ -925,13 +938,19 @@ internal static class DekafOptionsBinding
         builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
         builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs));
         builder.WithConnectionsMaxIdle(ToTimeout(options.ConnectionsMaxIdleMs));
-        builder.WithConnectionTimeout(options.ConnectionTimeout);
-        if (options.EnableTcpKeepAlive)
-            builder.WithTcpKeepAlive(options.TcpKeepAliveTime, options.TcpKeepAliveInterval, options.TcpKeepAliveRetryCount);
-        builder.WithTcpKeepAlive(options.EnableTcpKeepAlive);
+        ApplySocketConnectionOptions(
+            options.ConnectionTimeout,
+            options.EnableTcpKeepAlive,
+            options.TcpKeepAliveTime,
+            options.TcpKeepAliveInterval,
+            options.TcpKeepAliveRetryCount,
+            builder.WithConnectionTimeout,
+            enabled => builder.WithTcpKeepAlive(enabled),
+            (time, interval, retryCount) => builder.WithTcpKeepAlive(time, interval, retryCount));
         ApplyTls(options.UseTls, options.TlsConfig, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
-        if (options.RemoteCertificateValidationCallback is not null)
-            builder.WithRemoteCertificateValidationCallback(options.RemoteCertificateValidationCallback);
+        ApplyRemoteCertificateValidationCallback(
+            options.RemoteCertificateValidationCallback,
+            builder.WithRemoteCertificateValidationCallback);
         if (options.OAuthBearerTokenProvider is not null)
         {
             builder.WithOAuthBearer(options.OAuthBearerTokenProvider);
@@ -975,6 +994,32 @@ internal static class DekafOptionsBinding
         {
             useTlsBuilder();
         }
+    }
+
+    private static void ApplySocketConnectionOptions<TBuilder>(
+        TimeSpan connectionTimeout,
+        bool enableTcpKeepAlive,
+        TimeSpan tcpKeepAliveTime,
+        TimeSpan tcpKeepAliveInterval,
+        int tcpKeepAliveRetryCount,
+        Func<TimeSpan, TBuilder> withConnectionTimeout,
+        Func<bool, TBuilder> withTcpKeepAliveEnabled,
+        Func<TimeSpan, TimeSpan, int, TBuilder> withTcpKeepAlive)
+    {
+        withConnectionTimeout(connectionTimeout);
+
+        if (enableTcpKeepAlive)
+            withTcpKeepAlive(tcpKeepAliveTime, tcpKeepAliveInterval, tcpKeepAliveRetryCount);
+        else
+            withTcpKeepAliveEnabled(false);
+    }
+
+    private static void ApplyRemoteCertificateValidationCallback<TBuilder>(
+        RemoteCertificateValidationCallback? remoteCertificateValidationCallback,
+        Func<RemoteCertificateValidationCallback, TBuilder> withRemoteCertificateValidationCallback)
+    {
+        if (remoteCertificateValidationCallback is not null)
+            withRemoteCertificateValidationCallback(remoteCertificateValidationCallback);
     }
 
     private static TimeSpan ToTimeout(int milliseconds) =>
@@ -1317,13 +1362,14 @@ internal static class DekafConfigurationBinding
         if (hasKeepAliveTime || hasKeepAliveInterval || hasKeepAliveRetryCount)
         {
             withTcpKeepAlive(
-                hasKeepAliveTime ? keepAliveTime : TimeSpan.FromMinutes(2),
-                hasKeepAliveInterval ? keepAliveInterval : TimeSpan.FromSeconds(30),
-                hasKeepAliveRetryCount ? keepAliveRetryCount : 3);
+                hasKeepAliveTime ? keepAliveTime : ConnectionOptions.DefaultTcpKeepAliveTime,
+                hasKeepAliveInterval ? keepAliveInterval : ConnectionOptions.DefaultTcpKeepAliveInterval,
+                hasKeepAliveRetryCount ? keepAliveRetryCount : ConnectionOptions.DefaultTcpKeepAliveRetryCount);
         }
-
-        if (hasEnableTcpKeepAlive)
-            withTcpKeepAliveEnabled(enableTcpKeepAlive);
+        else if (hasEnableTcpKeepAlive)
+        {
+            withTcpKeepAliveEnabled(true);
+        }
     }
 
     private static void ApplyAdaptiveConnections<TBuilder>(

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Dekaf;
@@ -45,6 +46,12 @@ public sealed class AdminClient : IAdminClient
             {
                 UseTls = options.UseTls,
                 TlsConfig = options.TlsConfig,
+                RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
+                ConnectionTimeout = options.ConnectionTimeout,
+                EnableTcpKeepAlive = options.EnableTcpKeepAlive,
+                TcpKeepAliveTime = options.TcpKeepAliveTime,
+                TcpKeepAliveInterval = options.TcpKeepAliveInterval,
+                TcpKeepAliveRetryCount = options.TcpKeepAliveRetryCount,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
                 ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
@@ -3888,8 +3895,40 @@ public sealed class AdminClientOptions
     /// </summary>
     public int ConnectionsMaxIdleMs { get; init; } = ConnectionOptions.DefaultConnectionsMaxIdleMs;
 
+    /// <summary>
+    /// Maximum time allowed for socket connection setup, including TLS/SASL handshakes.
+    /// </summary>
+    public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Whether to enable TCP keepalive on broker sockets.
+    /// </summary>
+    public bool EnableTcpKeepAlive { get; init; } = true;
+
+    /// <summary>
+    /// Idle time before TCP keepalive probes start. Unsupported platforms ignore this.
+    /// </summary>
+    public TimeSpan TcpKeepAliveTime { get; init; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Interval between TCP keepalive probes. Unsupported platforms ignore this.
+    /// </summary>
+    public TimeSpan TcpKeepAliveInterval { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Number of TCP keepalive probes before the connection is considered dead.
+    /// Unsupported platforms ignore this.
+    /// </summary>
+    public int TcpKeepAliveRetryCount { get; init; } = 3;
+
     public bool UseTls { get; init; }
     public TlsConfig? TlsConfig { get; init; }
+
+    /// <summary>
+    /// Custom TLS certificate validation callback.
+    /// </summary>
+    public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; init; }
+
     public SaslMechanism SaslMechanism { get; init; } = SaslMechanism.None;
     public string? SaslUsername { get; init; }
     public string? SaslPassword { get; init; }
@@ -3970,6 +4009,12 @@ public sealed class AdminClientBuilder
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
+    private TimeSpan _connectionTimeout = TimeSpan.FromSeconds(30);
+    private bool _enableTcpKeepAlive = true;
+    private TimeSpan _tcpKeepAliveTime = TimeSpan.FromMinutes(2);
+    private TimeSpan _tcpKeepAliveInterval = TimeSpan.FromSeconds(30);
+    private int _tcpKeepAliveRetryCount = 3;
+    private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private AwsMskIamConfig? _awsMskIamConfig;
     private ILoggerFactory? _loggerFactory;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
@@ -4327,6 +4372,59 @@ public sealed class AdminClientBuilder
         return this;
     }
 
+    /// <summary>
+    /// Sets the maximum time allowed for socket connection setup, including TLS/SASL handshakes.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.ms</c>.
+    /// </summary>
+    /// <param name="timeout">The connection setup timeout. Must be positive.</param>
+    public AdminClientBuilder WithConnectionTimeout(TimeSpan timeout)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _connectionTimeout = ConnectionOptionValidation.ValidatePositiveTimeout(
+            timeout,
+            nameof(timeout),
+            "Connection timeout must be positive");
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables TCP keepalive on broker sockets.
+    /// Equivalent to Kafka's <c>socket.keepalive.enable</c>.
+    /// </summary>
+    public AdminClientBuilder WithTcpKeepAlive(bool enabled = true)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _enableTcpKeepAlive = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures TCP keepalive probe timing on broker sockets and enables TCP keepalive.
+    /// Unsupported platforms ignore individual probe options.
+    /// </summary>
+    public AdminClientBuilder WithTcpKeepAlive(TimeSpan time, TimeSpan interval, int retryCount = 3)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ConnectionOptionValidation.ValidateTcpKeepAlive(time, interval, retryCount);
+        _enableTcpKeepAlive = true;
+        _tcpKeepAliveTime = time;
+        _tcpKeepAliveInterval = interval;
+        _tcpKeepAliveRetryCount = retryCount;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a custom TLS certificate validation callback and enables TLS.
+    /// </summary>
+    public AdminClientBuilder WithRemoteCertificateValidationCallback(
+        RemoteCertificateValidationCallback callback)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _useTls = true;
+        _remoteCertificateValidationCallback = callback ?? throw new ArgumentNullException(nameof(callback));
+        return this;
+    }
+
     internal AdminClientBuilder WithSaslOptions(
         SaslMechanism mechanism,
         string? username,
@@ -4364,8 +4462,14 @@ public sealed class AdminClientBuilder
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
+            ConnectionTimeout = _connectionTimeout,
+            EnableTcpKeepAlive = _enableTcpKeepAlive,
+            TcpKeepAliveTime = _tcpKeepAliveTime,
+            TcpKeepAliveInterval = _tcpKeepAliveInterval,
+            TcpKeepAliveRetryCount = _tcpKeepAliveRetryCount,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
+            RemoteCertificateValidationCallback = _remoteCertificateValidationCallback,
             SaslMechanism = _saslMechanism,
             SaslUsername = _saslUsername,
             SaslPassword = _saslPassword,

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -3898,28 +3898,28 @@ public sealed class AdminClientOptions
     /// <summary>
     /// Maximum time allowed for socket connection setup, including TLS/SASL handshakes.
     /// </summary>
-    public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan ConnectionTimeout { get; init; } = ConnectionOptions.DefaultConnectionTimeout;
 
     /// <summary>
     /// Whether to enable TCP keepalive on broker sockets.
     /// </summary>
-    public bool EnableTcpKeepAlive { get; init; } = true;
+    public bool EnableTcpKeepAlive { get; init; } = ConnectionOptions.DefaultEnableTcpKeepAlive;
 
     /// <summary>
     /// Idle time before TCP keepalive probes start. Unsupported platforms ignore this.
     /// </summary>
-    public TimeSpan TcpKeepAliveTime { get; init; } = TimeSpan.FromMinutes(2);
+    public TimeSpan TcpKeepAliveTime { get; init; } = ConnectionOptions.DefaultTcpKeepAliveTime;
 
     /// <summary>
     /// Interval between TCP keepalive probes. Unsupported platforms ignore this.
     /// </summary>
-    public TimeSpan TcpKeepAliveInterval { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan TcpKeepAliveInterval { get; init; } = ConnectionOptions.DefaultTcpKeepAliveInterval;
 
     /// <summary>
     /// Number of TCP keepalive probes before the connection is considered dead.
     /// Unsupported platforms ignore this.
     /// </summary>
-    public int TcpKeepAliveRetryCount { get; init; } = 3;
+    public int TcpKeepAliveRetryCount { get; init; } = ConnectionOptions.DefaultTcpKeepAliveRetryCount;
 
     public bool UseTls { get; init; }
     public TlsConfig? TlsConfig { get; init; }
@@ -4009,11 +4009,11 @@ public sealed class AdminClientBuilder
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
-    private TimeSpan _connectionTimeout = TimeSpan.FromSeconds(30);
-    private bool _enableTcpKeepAlive = true;
-    private TimeSpan _tcpKeepAliveTime = TimeSpan.FromMinutes(2);
-    private TimeSpan _tcpKeepAliveInterval = TimeSpan.FromSeconds(30);
-    private int _tcpKeepAliveRetryCount = 3;
+    private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
+    private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
+    private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
+    private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
+    private int _tcpKeepAliveRetryCount = ConnectionOptions.DefaultTcpKeepAliveRetryCount;
     private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private AwsMskIamConfig? _awsMskIamConfig;
     private ILoggerFactory? _loggerFactory;
@@ -4402,7 +4402,10 @@ public sealed class AdminClientBuilder
     /// Configures TCP keepalive probe timing on broker sockets and enables TCP keepalive.
     /// Unsupported platforms ignore individual probe options.
     /// </summary>
-    public AdminClientBuilder WithTcpKeepAlive(TimeSpan time, TimeSpan interval, int retryCount = 3)
+    public AdminClientBuilder WithTcpKeepAlive(
+        TimeSpan time,
+        TimeSpan interval,
+        int retryCount = ConnectionOptions.DefaultTcpKeepAliveRetryCount)
     {
         ThrowIfClientOwnedConnectionSettings();
         ConnectionOptionValidation.ValidateTcpKeepAlive(time, interval, retryCount);

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -73,11 +73,11 @@ public sealed class ProducerBuilder<TKey, TValue>
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
-    private TimeSpan _connectionTimeout = TimeSpan.FromSeconds(30);
-    private bool _enableTcpKeepAlive = true;
-    private TimeSpan _tcpKeepAliveTime = TimeSpan.FromMinutes(2);
-    private TimeSpan _tcpKeepAliveInterval = TimeSpan.FromSeconds(30);
-    private int _tcpKeepAliveRetryCount = 3;
+    private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
+    private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
+    private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
+    private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
+    private int _tcpKeepAliveRetryCount = ConnectionOptions.DefaultTcpKeepAliveRetryCount;
     private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private IRetryPolicy? _retryPolicy;
     private bool _enableAdaptiveConnections = true;
@@ -319,7 +319,10 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// Configures TCP keepalive probe timing on broker sockets and enables TCP keepalive.
     /// Unsupported platforms ignore individual probe options.
     /// </summary>
-    public ProducerBuilder<TKey, TValue> WithTcpKeepAlive(TimeSpan time, TimeSpan interval, int retryCount = 3)
+    public ProducerBuilder<TKey, TValue> WithTcpKeepAlive(
+        TimeSpan time,
+        TimeSpan interval,
+        int retryCount = ConnectionOptions.DefaultTcpKeepAliveRetryCount)
     {
         ThrowIfClientOwnedConnectionSettings();
         ConnectionOptionValidation.ValidateTcpKeepAlive(time, interval, retryCount);
@@ -1260,11 +1263,11 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
-    private TimeSpan _connectionTimeout = TimeSpan.FromSeconds(30);
-    private bool _enableTcpKeepAlive = true;
-    private TimeSpan _tcpKeepAliveTime = TimeSpan.FromMinutes(2);
-    private TimeSpan _tcpKeepAliveInterval = TimeSpan.FromSeconds(30);
-    private int _tcpKeepAliveRetryCount = 3;
+    private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
+    private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
+    private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
+    private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
+    private int _tcpKeepAliveRetryCount = ConnectionOptions.DefaultTcpKeepAliveRetryCount;
     private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private bool _enableAdaptiveFetchSizing;
     private AdaptiveFetchSizingOptions? _adaptiveFetchSizingOptions;
@@ -2038,7 +2041,10 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// Configures TCP keepalive probe timing on broker sockets and enables TCP keepalive.
     /// Unsupported platforms ignore individual probe options.
     /// </summary>
-    public ConsumerBuilder<TKey, TValue> WithTcpKeepAlive(TimeSpan time, TimeSpan interval, int retryCount = 3)
+    public ConsumerBuilder<TKey, TValue> WithTcpKeepAlive(
+        TimeSpan time,
+        TimeSpan interval,
+        int retryCount = ConnectionOptions.DefaultTcpKeepAliveRetryCount)
     {
         ThrowIfClientOwnedConnectionSettings();
         ConnectionOptionValidation.ValidateTcpKeepAlive(time, interval, retryCount);
@@ -2493,11 +2499,11 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
-    private TimeSpan _connectionTimeout = TimeSpan.FromSeconds(30);
-    private bool _enableTcpKeepAlive = true;
-    private TimeSpan _tcpKeepAliveTime = TimeSpan.FromMinutes(2);
-    private TimeSpan _tcpKeepAliveInterval = TimeSpan.FromSeconds(30);
-    private int _tcpKeepAliveRetryCount = 3;
+    private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
+    private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
+    private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
+    private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
+    private int _tcpKeepAliveRetryCount = ConnectionOptions.DefaultTcpKeepAliveRetryCount;
     private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
     private IRetryPolicy? _retryPolicy;
@@ -2667,7 +2673,10 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     /// Configures TCP keepalive probe timing on broker sockets and enables TCP keepalive.
     /// Unsupported platforms ignore individual probe options.
     /// </summary>
-    public ShareConsumerBuilder<TKey, TValue> WithTcpKeepAlive(TimeSpan time, TimeSpan interval, int retryCount = 3)
+    public ShareConsumerBuilder<TKey, TValue> WithTcpKeepAlive(
+        TimeSpan time,
+        TimeSpan interval,
+        int retryCount = ConnectionOptions.DefaultTcpKeepAliveRetryCount)
     {
         ThrowIfClientOwnedConnectionSettings();
         ConnectionOptionValidation.ValidateTcpKeepAlive(time, interval, retryCount);

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1,3 +1,4 @@
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using Dekaf.Consumer;
 using Dekaf.Internal;
@@ -72,6 +73,12 @@ public sealed class ProducerBuilder<TKey, TValue>
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
+    private TimeSpan _connectionTimeout = TimeSpan.FromSeconds(30);
+    private bool _enableTcpKeepAlive = true;
+    private TimeSpan _tcpKeepAliveTime = TimeSpan.FromMinutes(2);
+    private TimeSpan _tcpKeepAliveInterval = TimeSpan.FromSeconds(30);
+    private int _tcpKeepAliveRetryCount = 3;
+    private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private IRetryPolicy? _retryPolicy;
     private bool _enableAdaptiveConnections = true;
     private int _maxConnectionsPerBroker = 10;
@@ -279,6 +286,59 @@ public sealed class ProducerBuilder<TKey, TValue>
         ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfNegative(bytes);
         _socketReceiveBufferBytes = bytes;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum time allowed for socket connection setup, including TLS/SASL handshakes.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.ms</c>.
+    /// </summary>
+    /// <param name="timeout">The connection setup timeout. Must be positive.</param>
+    public ProducerBuilder<TKey, TValue> WithConnectionTimeout(TimeSpan timeout)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _connectionTimeout = ConnectionOptionValidation.ValidatePositiveTimeout(
+            timeout,
+            nameof(timeout),
+            "Connection timeout must be positive");
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables TCP keepalive on broker sockets.
+    /// Equivalent to Kafka's <c>socket.keepalive.enable</c>.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithTcpKeepAlive(bool enabled = true)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _enableTcpKeepAlive = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures TCP keepalive probe timing on broker sockets and enables TCP keepalive.
+    /// Unsupported platforms ignore individual probe options.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithTcpKeepAlive(TimeSpan time, TimeSpan interval, int retryCount = 3)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ConnectionOptionValidation.ValidateTcpKeepAlive(time, interval, retryCount);
+        _enableTcpKeepAlive = true;
+        _tcpKeepAliveTime = time;
+        _tcpKeepAliveInterval = interval;
+        _tcpKeepAliveRetryCount = retryCount;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a custom TLS certificate validation callback and enables TLS.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithRemoteCertificateValidationCallback(
+        RemoteCertificateValidationCallback callback)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _useTls = true;
+        _remoteCertificateValidationCallback = callback ?? throw new ArgumentNullException(nameof(callback));
         return this;
     }
 
@@ -1006,6 +1066,11 @@ public sealed class ProducerBuilder<TKey, TValue>
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
+            ConnectionTimeout = _connectionTimeout,
+            EnableTcpKeepAlive = _enableTcpKeepAlive,
+            TcpKeepAliveTime = _tcpKeepAliveTime,
+            TcpKeepAliveInterval = _tcpKeepAliveInterval,
+            TcpKeepAliveRetryCount = _tcpKeepAliveRetryCount,
             EnableIdempotence = _enableIdempotence,
             ConnectionsPerBroker = _connectionsPerBroker,
             TransactionalId = _transactionalId,
@@ -1018,6 +1083,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             CustomPartitioner = _customPartitioner,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
+            RemoteCertificateValidationCallback = _remoteCertificateValidationCallback,
             SaslMechanism = _saslMechanism,
             SaslUsername = _saslUsername,
             SaslPassword = _saslPassword,
@@ -1194,6 +1260,12 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
+    private TimeSpan _connectionTimeout = TimeSpan.FromSeconds(30);
+    private bool _enableTcpKeepAlive = true;
+    private TimeSpan _tcpKeepAliveTime = TimeSpan.FromMinutes(2);
+    private TimeSpan _tcpKeepAliveInterval = TimeSpan.FromSeconds(30);
+    private int _tcpKeepAliveRetryCount = 3;
+    private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private bool _enableAdaptiveFetchSizing;
     private AdaptiveFetchSizingOptions? _adaptiveFetchSizingOptions;
     private bool _enableFetchSessions = true;
@@ -1937,6 +2009,59 @@ public sealed class ConsumerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Sets the maximum time allowed for socket connection setup, including TLS/SASL handshakes.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.ms</c>.
+    /// </summary>
+    /// <param name="timeout">The connection setup timeout. Must be positive.</param>
+    public ConsumerBuilder<TKey, TValue> WithConnectionTimeout(TimeSpan timeout)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _connectionTimeout = ConnectionOptionValidation.ValidatePositiveTimeout(
+            timeout,
+            nameof(timeout),
+            "Connection timeout must be positive");
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables TCP keepalive on broker sockets.
+    /// Equivalent to Kafka's <c>socket.keepalive.enable</c>.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithTcpKeepAlive(bool enabled = true)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _enableTcpKeepAlive = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures TCP keepalive probe timing on broker sockets and enables TCP keepalive.
+    /// Unsupported platforms ignore individual probe options.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithTcpKeepAlive(TimeSpan time, TimeSpan interval, int retryCount = 3)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ConnectionOptionValidation.ValidateTcpKeepAlive(time, interval, retryCount);
+        _enableTcpKeepAlive = true;
+        _tcpKeepAliveTime = time;
+        _tcpKeepAliveInterval = interval;
+        _tcpKeepAliveRetryCount = retryCount;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a custom TLS certificate validation callback and enables TLS.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithRemoteCertificateValidationCallback(
+        RemoteCertificateValidationCallback callback)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _useTls = true;
+        _remoteCertificateValidationCallback = callback ?? throw new ArgumentNullException(nameof(callback));
+        return this;
+    }
+
+    /// <summary>
     /// Configures the consumer for high throughput scenarios.
     /// </summary>
     /// <remarks>
@@ -2213,9 +2338,15 @@ public sealed class ConsumerBuilder<TKey, TValue>
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
+            ConnectionTimeout = _connectionTimeout,
+            EnableTcpKeepAlive = _enableTcpKeepAlive,
+            TcpKeepAliveTime = _tcpKeepAliveTime,
+            TcpKeepAliveInterval = _tcpKeepAliveInterval,
+            TcpKeepAliveRetryCount = _tcpKeepAliveRetryCount,
             CheckCrcs = _checkCrcs,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
+            RemoteCertificateValidationCallback = _remoteCertificateValidationCallback,
             SaslMechanism = _saslMechanism,
             SaslUsername = _saslUsername,
             SaslPassword = _saslPassword,
@@ -2362,6 +2493,12 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
+    private TimeSpan _connectionTimeout = TimeSpan.FromSeconds(30);
+    private bool _enableTcpKeepAlive = true;
+    private TimeSpan _tcpKeepAliveTime = TimeSpan.FromMinutes(2);
+    private TimeSpan _tcpKeepAliveInterval = TimeSpan.FromSeconds(30);
+    private int _tcpKeepAliveRetryCount = 3;
+    private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
     private IRetryPolicy? _retryPolicy;
     private readonly List<string> _topicsToSubscribe = [];
@@ -2497,6 +2634,59 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     {
         ThrowIfClientOwnedConnectionSettings();
         _connectionsMaxIdleMs = ConnectionOptions.ToConnectionsMaxIdleMs(idle, nameof(idle));
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum time allowed for socket connection setup, including TLS/SASL handshakes.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.ms</c>.
+    /// </summary>
+    /// <param name="timeout">The connection setup timeout. Must be positive.</param>
+    public ShareConsumerBuilder<TKey, TValue> WithConnectionTimeout(TimeSpan timeout)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _connectionTimeout = ConnectionOptionValidation.ValidatePositiveTimeout(
+            timeout,
+            nameof(timeout),
+            "Connection timeout must be positive");
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables TCP keepalive on broker sockets.
+    /// Equivalent to Kafka's <c>socket.keepalive.enable</c>.
+    /// </summary>
+    public ShareConsumerBuilder<TKey, TValue> WithTcpKeepAlive(bool enabled = true)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _enableTcpKeepAlive = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures TCP keepalive probe timing on broker sockets and enables TCP keepalive.
+    /// Unsupported platforms ignore individual probe options.
+    /// </summary>
+    public ShareConsumerBuilder<TKey, TValue> WithTcpKeepAlive(TimeSpan time, TimeSpan interval, int retryCount = 3)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ConnectionOptionValidation.ValidateTcpKeepAlive(time, interval, retryCount);
+        _enableTcpKeepAlive = true;
+        _tcpKeepAliveTime = time;
+        _tcpKeepAliveInterval = interval;
+        _tcpKeepAliveRetryCount = retryCount;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a custom TLS certificate validation callback and enables TLS.
+    /// </summary>
+    public ShareConsumerBuilder<TKey, TValue> WithRemoteCertificateValidationCallback(
+        RemoteCertificateValidationCallback callback)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _useTls = true;
+        _remoteCertificateValidationCallback = callback ?? throw new ArgumentNullException(nameof(callback));
         return this;
     }
 
@@ -2749,8 +2939,14 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
+            ConnectionTimeout = _connectionTimeout,
+            EnableTcpKeepAlive = _enableTcpKeepAlive,
+            TcpKeepAliveTime = _tcpKeepAliveTime,
+            TcpKeepAliveInterval = _tcpKeepAliveInterval,
+            TcpKeepAliveRetryCount = _tcpKeepAliveRetryCount,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
+            RemoteCertificateValidationCallback = _remoteCertificateValidationCallback,
             SaslMechanism = _saslMechanism,
             SaslUsername = _saslUsername,
             SaslPassword = _saslPassword,

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -176,28 +176,28 @@ public sealed class ConsumerOptions
     /// <summary>
     /// Maximum time allowed for socket connection setup, including TLS/SASL handshakes.
     /// </summary>
-    public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan ConnectionTimeout { get; init; } = ConnectionOptions.DefaultConnectionTimeout;
 
     /// <summary>
     /// Whether to enable TCP keepalive on broker sockets.
     /// </summary>
-    public bool EnableTcpKeepAlive { get; init; } = true;
+    public bool EnableTcpKeepAlive { get; init; } = ConnectionOptions.DefaultEnableTcpKeepAlive;
 
     /// <summary>
     /// Idle time before TCP keepalive probes start. Unsupported platforms ignore this.
     /// </summary>
-    public TimeSpan TcpKeepAliveTime { get; init; } = TimeSpan.FromMinutes(2);
+    public TimeSpan TcpKeepAliveTime { get; init; } = ConnectionOptions.DefaultTcpKeepAliveTime;
 
     /// <summary>
     /// Interval between TCP keepalive probes. Unsupported platforms ignore this.
     /// </summary>
-    public TimeSpan TcpKeepAliveInterval { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan TcpKeepAliveInterval { get; init; } = ConnectionOptions.DefaultTcpKeepAliveInterval;
 
     /// <summary>
     /// Number of TCP keepalive probes before the connection is considered dead.
     /// Unsupported platforms ignore this.
     /// </summary>
-    public int TcpKeepAliveRetryCount { get; init; } = 3;
+    public int TcpKeepAliveRetryCount { get; init; } = ConnectionOptions.DefaultTcpKeepAliveRetryCount;
 
     /// <summary>
     /// Check CRCs.

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -1,3 +1,4 @@
+using System.Net.Security;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol.Messages;
@@ -173,6 +174,32 @@ public sealed class ConsumerOptions
     public int ConnectionsMaxIdleMs { get; init; } = ConnectionOptions.DefaultConnectionsMaxIdleMs;
 
     /// <summary>
+    /// Maximum time allowed for socket connection setup, including TLS/SASL handshakes.
+    /// </summary>
+    public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Whether to enable TCP keepalive on broker sockets.
+    /// </summary>
+    public bool EnableTcpKeepAlive { get; init; } = true;
+
+    /// <summary>
+    /// Idle time before TCP keepalive probes start. Unsupported platforms ignore this.
+    /// </summary>
+    public TimeSpan TcpKeepAliveTime { get; init; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Interval between TCP keepalive probes. Unsupported platforms ignore this.
+    /// </summary>
+    public TimeSpan TcpKeepAliveInterval { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Number of TCP keepalive probes before the connection is considered dead.
+    /// Unsupported platforms ignore this.
+    /// </summary>
+    public int TcpKeepAliveRetryCount { get; init; } = 3;
+
+    /// <summary>
     /// Check CRCs.
     /// </summary>
     public bool CheckCrcs { get; init; }
@@ -187,6 +214,11 @@ public sealed class ConsumerOptions
     /// When set, <see cref="UseTls"/> is automatically enabled.
     /// </summary>
     public TlsConfig? TlsConfig { get; init; }
+
+    /// <summary>
+    /// Custom TLS certificate validation callback.
+    /// </summary>
+    public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; init; }
 
     /// <summary>
     /// SASL authentication mechanism.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -834,6 +834,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 UseTls = options.UseTls,
                 TlsConfig = options.TlsConfig,
+                RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
+                ConnectionTimeout = options.ConnectionTimeout,
+                EnableTcpKeepAlive = options.EnableTcpKeepAlive,
+                TcpKeepAliveTime = options.TcpKeepAliveTime,
+                TcpKeepAliveInterval = options.TcpKeepAliveInterval,
+                TcpKeepAliveRetryCount = options.TcpKeepAliveRetryCount,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
                 ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),

--- a/src/Dekaf/Internal/ConnectionOptionValidation.cs
+++ b/src/Dekaf/Internal/ConnectionOptionValidation.cs
@@ -1,0 +1,20 @@
+namespace Dekaf.Internal;
+
+internal static class ConnectionOptionValidation
+{
+    public static TimeSpan ValidatePositiveTimeout(TimeSpan timeout, string paramName, string message)
+    {
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(paramName, message);
+
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, paramName);
+        return timeout;
+    }
+
+    public static void ValidateTcpKeepAlive(TimeSpan time, TimeSpan interval, int retryCount)
+    {
+        ValidatePositiveTimeout(time, nameof(time), "TCP keepalive time must be positive");
+        ValidatePositiveTimeout(interval, nameof(interval), "TCP keepalive interval must be positive");
+        ArgumentOutOfRangeException.ThrowIfLessThan(retryCount, 1);
+    }
+}

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -99,11 +99,11 @@ public sealed class KafkaClientBuilder
     private int _maxInFlightRequestsPerConnection = 5;
     private int _maxConnectionsPerBroker = 10;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
-    private TimeSpan _connectionTimeout = TimeSpan.FromSeconds(30);
-    private bool _enableTcpKeepAlive = true;
-    private TimeSpan _tcpKeepAliveTime = TimeSpan.FromMinutes(2);
-    private TimeSpan _tcpKeepAliveInterval = TimeSpan.FromSeconds(30);
-    private int _tcpKeepAliveRetryCount = 3;
+    private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
+    private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
+    private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
+    private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
+    private int _tcpKeepAliveRetryCount = ConnectionOptions.DefaultTcpKeepAliveRetryCount;
     private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private TimeSpan? _metadataMaxAge;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
@@ -209,7 +209,10 @@ public sealed class KafkaClientBuilder
     /// Configures TCP keepalive probe timing on broker sockets and enables TCP keepalive.
     /// Unsupported platforms ignore individual probe options.
     /// </summary>
-    public KafkaClientBuilder WithTcpKeepAlive(TimeSpan time, TimeSpan interval, int retryCount = 3)
+    public KafkaClientBuilder WithTcpKeepAlive(
+        TimeSpan time,
+        TimeSpan interval,
+        int retryCount = ConnectionOptions.DefaultTcpKeepAliveRetryCount)
     {
         ConnectionOptionValidation.ValidateTcpKeepAlive(time, interval, retryCount);
         _enableTcpKeepAlive = true;
@@ -484,11 +487,11 @@ internal sealed class KafkaClientOptions
     public bool UseTls { get; init; }
     public TlsConfig? TlsConfig { get; init; }
     public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; init; }
-    public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
-    public bool EnableTcpKeepAlive { get; init; } = true;
-    public TimeSpan TcpKeepAliveTime { get; init; } = TimeSpan.FromMinutes(2);
-    public TimeSpan TcpKeepAliveInterval { get; init; } = TimeSpan.FromSeconds(30);
-    public int TcpKeepAliveRetryCount { get; init; } = 3;
+    public TimeSpan ConnectionTimeout { get; init; } = ConnectionOptions.DefaultConnectionTimeout;
+    public bool EnableTcpKeepAlive { get; init; } = ConnectionOptions.DefaultEnableTcpKeepAlive;
+    public TimeSpan TcpKeepAliveTime { get; init; } = ConnectionOptions.DefaultTcpKeepAliveTime;
+    public TimeSpan TcpKeepAliveInterval { get; init; } = ConnectionOptions.DefaultTcpKeepAliveInterval;
+    public int TcpKeepAliveRetryCount { get; init; } = ConnectionOptions.DefaultTcpKeepAliveRetryCount;
     public SaslMechanism SaslMechanism { get; init; }
     public string? SaslUsername { get; init; }
     public string? SaslPassword { get; init; }

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -1,5 +1,6 @@
 namespace Dekaf;
 
+using System.Net.Security;
 using Admin;
 using Consumer;
 using Dekaf.Internal;
@@ -98,6 +99,12 @@ public sealed class KafkaClientBuilder
     private int _maxInFlightRequestsPerConnection = 5;
     private int _maxConnectionsPerBroker = 10;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
+    private TimeSpan _connectionTimeout = TimeSpan.FromSeconds(30);
+    private bool _enableTcpKeepAlive = true;
+    private TimeSpan _tcpKeepAliveTime = TimeSpan.FromMinutes(2);
+    private TimeSpan _tcpKeepAliveInterval = TimeSpan.FromSeconds(30);
+    private int _tcpKeepAliveRetryCount = 3;
+    private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private TimeSpan? _metadataMaxAge;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
@@ -171,6 +178,54 @@ public sealed class KafkaClientBuilder
     {
         _useTls = true;
         _tlsConfig = config;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum time allowed for socket connection setup, including TLS/SASL handshakes.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.ms</c>.
+    /// </summary>
+    /// <param name="timeout">The connection setup timeout. Must be positive.</param>
+    public KafkaClientBuilder WithConnectionTimeout(TimeSpan timeout)
+    {
+        _connectionTimeout = ConnectionOptionValidation.ValidatePositiveTimeout(
+            timeout,
+            nameof(timeout),
+            "Connection timeout must be positive");
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables TCP keepalive on broker sockets.
+    /// Equivalent to Kafka's <c>socket.keepalive.enable</c>.
+    /// </summary>
+    public KafkaClientBuilder WithTcpKeepAlive(bool enabled = true)
+    {
+        _enableTcpKeepAlive = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures TCP keepalive probe timing on broker sockets and enables TCP keepalive.
+    /// Unsupported platforms ignore individual probe options.
+    /// </summary>
+    public KafkaClientBuilder WithTcpKeepAlive(TimeSpan time, TimeSpan interval, int retryCount = 3)
+    {
+        ConnectionOptionValidation.ValidateTcpKeepAlive(time, interval, retryCount);
+        _enableTcpKeepAlive = true;
+        _tcpKeepAliveTime = time;
+        _tcpKeepAliveInterval = interval;
+        _tcpKeepAliveRetryCount = retryCount;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a custom TLS certificate validation callback and enables TLS.
+    /// </summary>
+    public KafkaClientBuilder WithRemoteCertificateValidationCallback(RemoteCertificateValidationCallback callback)
+    {
+        _useTls = true;
+        _remoteCertificateValidationCallback = callback ?? throw new ArgumentNullException(nameof(callback));
         return this;
     }
 
@@ -388,6 +443,12 @@ public sealed class KafkaClientBuilder
             ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
+            RemoteCertificateValidationCallback = _remoteCertificateValidationCallback,
+            ConnectionTimeout = _connectionTimeout,
+            EnableTcpKeepAlive = _enableTcpKeepAlive,
+            TcpKeepAliveTime = _tcpKeepAliveTime,
+            TcpKeepAliveInterval = _tcpKeepAliveInterval,
+            TcpKeepAliveRetryCount = _tcpKeepAliveRetryCount,
             SaslMechanism = _saslMechanism,
             SaslUsername = _saslUsername,
             SaslPassword = _saslPassword,
@@ -422,6 +483,12 @@ internal sealed class KafkaClientOptions
     public int ReconnectBackoffMaxMs { get; init; }
     public bool UseTls { get; init; }
     public TlsConfig? TlsConfig { get; init; }
+    public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; init; }
+    public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    public bool EnableTcpKeepAlive { get; init; } = true;
+    public TimeSpan TcpKeepAliveTime { get; init; } = TimeSpan.FromMinutes(2);
+    public TimeSpan TcpKeepAliveInterval { get; init; } = TimeSpan.FromSeconds(30);
+    public int TcpKeepAliveRetryCount { get; init; } = 3;
     public SaslMechanism SaslMechanism { get; init; }
     public string? SaslUsername { get; init; }
     public string? SaslPassword { get; init; }
@@ -491,6 +558,12 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             {
                 UseTls = options.UseTls,
                 TlsConfig = options.TlsConfig,
+                RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
+                ConnectionTimeout = options.ConnectionTimeout,
+                EnableTcpKeepAlive = options.EnableTcpKeepAlive,
+                TcpKeepAliveTime = options.TcpKeepAliveTime,
+                TcpKeepAliveInterval = options.TcpKeepAliveInterval,
+                TcpKeepAliveRetryCount = options.TcpKeepAliveRetryCount,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
                 ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -2854,23 +2854,23 @@ public sealed class ConnectionOptions
     /// <summary>
     /// Whether to enable TCP keepalive on broker sockets.
     /// </summary>
-    public bool EnableTcpKeepAlive { get; init; } = true;
+    public bool EnableTcpKeepAlive { get; init; } = DefaultEnableTcpKeepAlive;
 
     /// <summary>
     /// Idle time before TCP keepalive probes start. Unsupported platforms ignore this.
     /// </summary>
-    public TimeSpan TcpKeepAliveTime { get; init; } = TimeSpan.FromMinutes(2);
+    public TimeSpan TcpKeepAliveTime { get; init; } = DefaultTcpKeepAliveTime;
 
     /// <summary>
     /// Interval between TCP keepalive probes. Unsupported platforms ignore this.
     /// </summary>
-    public TimeSpan TcpKeepAliveInterval { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan TcpKeepAliveInterval { get; init; } = DefaultTcpKeepAliveInterval;
 
     /// <summary>
     /// Number of TCP keepalive probes before the connection is considered dead.
     /// Unsupported platforms ignore this.
     /// </summary>
-    public int TcpKeepAliveRetryCount { get; init; } = 3;
+    public int TcpKeepAliveRetryCount { get; init; } = DefaultTcpKeepAliveRetryCount;
 
     /// <summary>
     /// Minimum segment size for pipe.
@@ -2885,7 +2885,7 @@ public sealed class ConnectionOptions
     /// <summary>
     /// Connection timeout.
     /// </summary>
-    public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan ConnectionTimeout { get; init; } = DefaultConnectionTimeout;
 
     /// <summary>
     /// Request timeout.
@@ -2929,6 +2929,11 @@ public sealed class ConnectionOptions
     internal ClientDnsEndpointResolver DnsResolver { get; init; } = ClientDnsEndpointResolver.Default;
 
     internal const int DefaultConnectionsMaxIdleMs = 540000;
+    internal static readonly TimeSpan DefaultConnectionTimeout = TimeSpan.FromSeconds(30);
+    internal const bool DefaultEnableTcpKeepAlive = true;
+    internal static readonly TimeSpan DefaultTcpKeepAliveTime = TimeSpan.FromMinutes(2);
+    internal static readonly TimeSpan DefaultTcpKeepAliveInterval = TimeSpan.FromSeconds(30);
+    internal const int DefaultTcpKeepAliveRetryCount = 3;
 
     internal static int ValidateConnectionsMaxIdleMs(int value, string paramName)
     {

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -220,6 +220,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 UseTls = options.UseTls,
                 TlsConfig = options.TlsConfig,
+                RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
+                ConnectionTimeout = options.ConnectionTimeout,
+                EnableTcpKeepAlive = options.EnableTcpKeepAlive,
+                TcpKeepAliveTime = options.TcpKeepAliveTime,
+                TcpKeepAliveInterval = options.TcpKeepAliveInterval,
+                TcpKeepAliveRetryCount = options.TcpKeepAliveRetryCount,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
                 ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net.Security;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol.Records;
@@ -52,6 +53,32 @@ public sealed class ProducerOptions
     /// Set to -1 to disable client-side idle connection reaping.
     /// </summary>
     public int ConnectionsMaxIdleMs { get; init; } = ConnectionOptions.DefaultConnectionsMaxIdleMs;
+
+    /// <summary>
+    /// Maximum time allowed for socket connection setup, including TLS/SASL handshakes.
+    /// </summary>
+    public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Whether to enable TCP keepalive on broker sockets.
+    /// </summary>
+    public bool EnableTcpKeepAlive { get; init; } = true;
+
+    /// <summary>
+    /// Idle time before TCP keepalive probes start. Unsupported platforms ignore this.
+    /// </summary>
+    public TimeSpan TcpKeepAliveTime { get; init; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Interval between TCP keepalive probes. Unsupported platforms ignore this.
+    /// </summary>
+    public TimeSpan TcpKeepAliveInterval { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Number of TCP keepalive probes before the connection is considered dead.
+    /// Unsupported platforms ignore this.
+    /// </summary>
+    public int TcpKeepAliveRetryCount { get; init; } = 3;
 
     /// <summary>
     /// Linger time in milliseconds before sending a batch.
@@ -284,6 +311,11 @@ public sealed class ProducerOptions
     /// When set, <see cref="UseTls"/> is automatically enabled.
     /// </summary>
     public TlsConfig? TlsConfig { get; init; }
+
+    /// <summary>
+    /// Custom TLS certificate validation callback.
+    /// </summary>
+    public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; init; }
 
     /// <summary>
     /// SASL authentication mechanism.

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -57,28 +57,28 @@ public sealed class ProducerOptions
     /// <summary>
     /// Maximum time allowed for socket connection setup, including TLS/SASL handshakes.
     /// </summary>
-    public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan ConnectionTimeout { get; init; } = ConnectionOptions.DefaultConnectionTimeout;
 
     /// <summary>
     /// Whether to enable TCP keepalive on broker sockets.
     /// </summary>
-    public bool EnableTcpKeepAlive { get; init; } = true;
+    public bool EnableTcpKeepAlive { get; init; } = ConnectionOptions.DefaultEnableTcpKeepAlive;
 
     /// <summary>
     /// Idle time before TCP keepalive probes start. Unsupported platforms ignore this.
     /// </summary>
-    public TimeSpan TcpKeepAliveTime { get; init; } = TimeSpan.FromMinutes(2);
+    public TimeSpan TcpKeepAliveTime { get; init; } = ConnectionOptions.DefaultTcpKeepAliveTime;
 
     /// <summary>
     /// Interval between TCP keepalive probes. Unsupported platforms ignore this.
     /// </summary>
-    public TimeSpan TcpKeepAliveInterval { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan TcpKeepAliveInterval { get; init; } = ConnectionOptions.DefaultTcpKeepAliveInterval;
 
     /// <summary>
     /// Number of TCP keepalive probes before the connection is considered dead.
     /// Unsupported platforms ignore this.
     /// </summary>
-    public int TcpKeepAliveRetryCount { get; init; } = 3;
+    public int TcpKeepAliveRetryCount { get; init; } = ConnectionOptions.DefaultTcpKeepAliveRetryCount;
 
     /// <summary>
     /// Linger time in milliseconds before sending a batch.

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -74,6 +74,12 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             {
                 UseTls = options.UseTls,
                 TlsConfig = options.TlsConfig,
+                RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
+                ConnectionTimeout = options.ConnectionTimeout,
+                EnableTcpKeepAlive = options.EnableTcpKeepAlive,
+                TcpKeepAliveTime = options.TcpKeepAliveTime,
+                TcpKeepAliveInterval = options.TcpKeepAliveInterval,
+                TcpKeepAliveRetryCount = options.TcpKeepAliveRetryCount,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
                 ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -95,28 +95,28 @@ public sealed class ShareConsumerOptions
     /// <summary>
     /// Maximum time allowed for socket connection setup, including TLS/SASL handshakes.
     /// </summary>
-    public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan ConnectionTimeout { get; init; } = ConnectionOptions.DefaultConnectionTimeout;
 
     /// <summary>
     /// Whether to enable TCP keepalive on broker sockets.
     /// </summary>
-    public bool EnableTcpKeepAlive { get; init; } = true;
+    public bool EnableTcpKeepAlive { get; init; } = ConnectionOptions.DefaultEnableTcpKeepAlive;
 
     /// <summary>
     /// Idle time before TCP keepalive probes start. Unsupported platforms ignore this.
     /// </summary>
-    public TimeSpan TcpKeepAliveTime { get; init; } = TimeSpan.FromMinutes(2);
+    public TimeSpan TcpKeepAliveTime { get; init; } = ConnectionOptions.DefaultTcpKeepAliveTime;
 
     /// <summary>
     /// Interval between TCP keepalive probes. Unsupported platforms ignore this.
     /// </summary>
-    public TimeSpan TcpKeepAliveInterval { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan TcpKeepAliveInterval { get; init; } = ConnectionOptions.DefaultTcpKeepAliveInterval;
 
     /// <summary>
     /// Number of TCP keepalive probes before the connection is considered dead.
     /// Unsupported platforms ignore this.
     /// </summary>
-    public int TcpKeepAliveRetryCount { get; init; } = 3;
+    public int TcpKeepAliveRetryCount { get; init; } = ConnectionOptions.DefaultTcpKeepAliveRetryCount;
 
     /// <summary>
     /// Whether to use TLS for broker connections.

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -1,3 +1,4 @@
+using System.Net.Security;
 using Dekaf.Networking;
 using Dekaf.Retry;
 using Dekaf.Security;
@@ -92,6 +93,32 @@ public sealed class ShareConsumerOptions
     public int ConnectionsMaxIdleMs { get; init; } = ConnectionOptions.DefaultConnectionsMaxIdleMs;
 
     /// <summary>
+    /// Maximum time allowed for socket connection setup, including TLS/SASL handshakes.
+    /// </summary>
+    public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Whether to enable TCP keepalive on broker sockets.
+    /// </summary>
+    public bool EnableTcpKeepAlive { get; init; } = true;
+
+    /// <summary>
+    /// Idle time before TCP keepalive probes start. Unsupported platforms ignore this.
+    /// </summary>
+    public TimeSpan TcpKeepAliveTime { get; init; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Interval between TCP keepalive probes. Unsupported platforms ignore this.
+    /// </summary>
+    public TimeSpan TcpKeepAliveInterval { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Number of TCP keepalive probes before the connection is considered dead.
+    /// Unsupported platforms ignore this.
+    /// </summary>
+    public int TcpKeepAliveRetryCount { get; init; } = 3;
+
+    /// <summary>
     /// Whether to use TLS for broker connections.
     /// </summary>
     public bool UseTls { get; init; }
@@ -100,6 +127,11 @@ public sealed class ShareConsumerOptions
     /// Custom TLS configuration.
     /// </summary>
     public TlsConfig? TlsConfig { get; init; }
+
+    /// <summary>
+    /// Custom TLS certificate validation callback.
+    /// </summary>
+    public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; init; }
 
     /// <summary>
     /// SASL authentication mechanism.

--- a/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
@@ -1,0 +1,129 @@
+using System.Net.Security;
+using System.Reflection;
+using Dekaf.Admin;
+using Dekaf.Networking;
+
+namespace Dekaf.Tests.Unit.Builder;
+
+public sealed class ConnectionBuilderOptionsTests
+{
+    [Test]
+    public async Task ProducerBuilder_WithConnectionOptions_ConfiguresConnectionPool()
+    {
+        RemoteCertificateValidationCallback callback = (_, _, _, errors) => errors == SslPolicyErrors.None;
+
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithConnectionTimeout(TimeSpan.FromSeconds(7))
+            .WithTcpKeepAlive(TimeSpan.FromSeconds(11), TimeSpan.FromSeconds(3), retryCount: 4)
+            .WithRemoteCertificateValidationCallback(callback)
+            .Build();
+
+        var options = GetConnectionOptions(producer);
+
+        await AssertConnectionOptions(options, callback, keepAliveEnabled: true);
+    }
+
+    [Test]
+    public async Task ConsumerBuilder_WithConnectionOptions_ConfiguresConnectionPool()
+    {
+        RemoteCertificateValidationCallback callback = (_, _, _, errors) => errors == SslPolicyErrors.None;
+
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("group")
+            .WithConnectionTimeout(TimeSpan.FromSeconds(7))
+            .WithTcpKeepAlive(TimeSpan.FromSeconds(11), TimeSpan.FromSeconds(3), retryCount: 4)
+            .WithRemoteCertificateValidationCallback(callback)
+            .Build();
+
+        var options = GetConnectionOptions(consumer);
+
+        await AssertConnectionOptions(options, callback, keepAliveEnabled: true);
+    }
+
+    [Test]
+    public async Task AdminClientBuilder_WithConnectionOptions_ConfiguresConnectionPool()
+    {
+        RemoteCertificateValidationCallback callback = (_, _, _, errors) => errors == SslPolicyErrors.None;
+
+        await using var admin = new AdminClientBuilder()
+            .WithBootstrapServers("localhost:9092")
+            .WithConnectionTimeout(TimeSpan.FromSeconds(7))
+            .WithTcpKeepAlive(TimeSpan.FromSeconds(11), TimeSpan.FromSeconds(3), retryCount: 4)
+            .WithRemoteCertificateValidationCallback(callback)
+            .Build();
+
+        var options = GetConnectionOptions(admin);
+
+        await AssertConnectionOptions(options, callback, keepAliveEnabled: true);
+    }
+
+    [Test]
+    public async Task KafkaClientBuilder_WithConnectionOptions_ConfiguresSharedConnectionPool()
+    {
+        RemoteCertificateValidationCallback callback = (_, _, _, errors) => errors == SslPolicyErrors.None;
+
+        await using var client = Kafka.Connect("localhost:9092", builder => builder
+            .WithConnectionTimeout(TimeSpan.FromSeconds(7))
+            .WithTcpKeepAlive(TimeSpan.FromSeconds(11), TimeSpan.FromSeconds(3), retryCount: 4)
+            .WithRemoteCertificateValidationCallback(callback));
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var options = GetConnectionOptions(producer);
+
+        await AssertConnectionOptions(options, callback, keepAliveEnabled: true);
+    }
+
+    [Test]
+    public async Task BuilderConnectionOptions_CanDisableTcpKeepAlive()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTcpKeepAlive(false)
+            .Build();
+
+        var options = GetConnectionOptions(producer);
+
+        await Assert.That(options.EnableTcpKeepAlive).IsFalse();
+    }
+
+    [Test]
+    public async Task BuilderConnectionOptions_ValidateInputs()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        await Assert.That(() => builder.WithConnectionTimeout(TimeSpan.Zero))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => builder.WithTcpKeepAlive(TimeSpan.Zero, TimeSpan.FromSeconds(1)))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => builder.WithTcpKeepAlive(TimeSpan.FromSeconds(1), TimeSpan.Zero))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => builder.WithTcpKeepAlive(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), retryCount: 0))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => builder.WithRemoteCertificateValidationCallback(null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    private static async Task AssertConnectionOptions(
+        ConnectionOptions options,
+        RemoteCertificateValidationCallback callback,
+        bool keepAliveEnabled)
+    {
+        await Assert.That(options.UseTls).IsTrue();
+        await Assert.That((object?)options.RemoteCertificateValidationCallback).IsSameReferenceAs(callback);
+        await Assert.That(options.ConnectionTimeout).IsEqualTo(TimeSpan.FromSeconds(7));
+        await Assert.That(options.EnableTcpKeepAlive).IsEqualTo(keepAliveEnabled);
+        await Assert.That(options.TcpKeepAliveTime).IsEqualTo(TimeSpan.FromSeconds(11));
+        await Assert.That(options.TcpKeepAliveInterval).IsEqualTo(TimeSpan.FromSeconds(3));
+        await Assert.That(options.TcpKeepAliveRetryCount).IsEqualTo(4);
+    }
+
+    private static ConnectionOptions GetConnectionOptions(object client)
+    {
+        var poolField = client.GetType().GetField("_connectionPool", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"Could not find _connectionPool on {client.GetType()}");
+
+        return ((ConnectionPool)poolField.GetValue(client)!).EffectiveConnectionOptions;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Net.Security;
 using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Metadata;
@@ -86,6 +87,12 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithConnectionTimeout(TimeSpan.FromSeconds(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithTcpKeepAlive(false))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithRemoteCertificateValidationCallback(AcceptCertificate))
+            .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithClientDnsLookup(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly))
             .Throws<InvalidOperationException>();
 
@@ -105,6 +112,12 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithConnectionTimeout(TimeSpan.FromSeconds(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithTcpKeepAlive(false))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithRemoteCertificateValidationCallback(AcceptCertificate))
+            .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithClientDnsLookup(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly))
             .Throws<InvalidOperationException>();
 
@@ -119,6 +132,12 @@ public sealed class KafkaClientBuilderTests
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithConnectionTimeout(TimeSpan.FromSeconds(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithTcpKeepAlive(false))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithRemoteCertificateValidationCallback(AcceptCertificate))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithClientDnsLookup(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly))
             .Throws<InvalidOperationException>();
@@ -136,6 +155,12 @@ public sealed class KafkaClientBuilderTests
         await Assert.That(() => client.CreateAdminClient().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateAdminClient().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithConnectionTimeout(TimeSpan.FromSeconds(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithTcpKeepAlive(false))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithRemoteCertificateValidationCallback(AcceptCertificate))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateAdminClient().WithClientDnsLookup(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly))
             .Throws<InvalidOperationException>();
@@ -247,4 +272,10 @@ public sealed class KafkaClientBuilderTests
             ?? throw new InvalidOperationException($"Could not find {name} on {instance.GetType()}");
         return (T)field.GetValue(instance)!;
     }
+
+    private static bool AcceptCertificate(
+        object sender,
+        System.Security.Cryptography.X509Certificates.X509Certificate? certificate,
+        System.Security.Cryptography.X509Certificates.X509Chain? chain,
+        SslPolicyErrors sslPolicyErrors) => sslPolicyErrors == SslPolicyErrors.None;
 }


### PR DESCRIPTION
Closes #1392

## Summary
- Expose connection setup timeout, TCP keepalive, and TLS cert validation callback on producer, consumer, admin, share-consumer, and root Kafka client builders.
- Carry the new settings through public options, DI binding, and connection pool creation.
- Document producer/consumer connection settings and add focused builder coverage.

## Tests
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -v:minimal`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ProducerBuilderValidationTests/*|/*/*/ConsumerBuilderValidationTests/*|/*/*/AdminClientBuilderTests/*|/*/*/KafkaClientBuilderTests/*|/*/*/ConnectionBuilderOptionsTests/*"`
- `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/DependencyInjectionTests/*"`