### PR TITLE
feat(sharegroups): add KIP-1206 options

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -2340,6 +2340,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private int _maxPartitionFetchBytes = 1048576;
     private int _fetchMaxWaitMs = 200;
     private int _maxPollRecords = 500;
+    private ShareAcknowledgementMode _acknowledgementMode = ShareAcknowledgementMode.Implicit;
+    private ShareAcquireMode _shareAcquireMode = ShareAcquireMode.BatchOptimized;
     private int _sessionTimeoutMs = 45000;
     private int _heartbeatIntervalMs = 3000;
     private int _requestTimeoutMs = 30000;
@@ -2437,6 +2439,26 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     public ShareConsumerBuilder<TKey, TValue> WithMaxPollRecords(int maxPollRecords)
     {
         _maxPollRecords = maxPollRecords;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets whether records are acknowledged implicitly or only through Acknowledge.
+    /// Equivalent to Kafka's share.acknowledgement.mode.
+    /// </summary>
+    public ShareConsumerBuilder<TKey, TValue> WithAcknowledgementMode(ShareAcknowledgementMode mode)
+    {
+        _acknowledgementMode = mode;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the ShareFetch acquire mode.
+    /// Equivalent to Kafka's share.acquire.mode.
+    /// </summary>
+    public ShareConsumerBuilder<TKey, TValue> WithShareAcquireMode(ShareAcquireMode mode)
+    {
+        _shareAcquireMode = mode;
         return this;
     }
 
@@ -2743,6 +2765,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             MaxPartitionFetchBytes = _maxPartitionFetchBytes,
             FetchMaxWaitMs = _fetchMaxWaitMs,
             MaxPollRecords = _maxPollRecords,
+            AcknowledgementMode = _acknowledgementMode,
+            ShareAcquireMode = _shareAcquireMode,
             SessionTimeoutMs = _sessionTimeoutMs,
             HeartbeatIntervalMs = _heartbeatIntervalMs,
             RequestTimeoutMs = _requestTimeoutMs,

--- a/src/Dekaf/Protocol/Messages/ShareFetchRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ShareFetchRequest.cs
@@ -52,7 +52,7 @@ public sealed class ShareFetchRequest : IKafkaRequest<ShareFetchResponse>
     public int BatchSize { get; init; }
 
     /// <summary>
-    /// The share acquire mode (v2+). 0 = normal acquire.
+    /// The share acquire mode (v2+). 0 = batch_optimized, 1 = record_limit.
     /// </summary>
     public sbyte ShareAcquireMode { get; init; }
 

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -32,11 +32,22 @@ internal sealed class AcknowledgementTracker
 
     /// <summary>
     /// Sets an explicit acknowledgement type for a specific record.
-    /// Throws if the record was not delivered by the current poll.
+    /// Throws if the record was not delivered by the current poll unless requireTracked is false.
     /// </summary>
-    internal void Acknowledge(TopicPartition tp, long offset, AcknowledgeType type)
+    internal void Acknowledge(TopicPartition tp, long offset, AcknowledgeType type, bool requireTracked = true)
     {
-        if (!_pendingAcks.TryGetValue(tp, out var offsets) || !offsets.ContainsKey(offset))
+        if (!_pendingAcks.TryGetValue(tp, out var offsets))
+        {
+            if (requireTracked)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot acknowledge offset {offset} for {tp} — record was not delivered by the current poll.");
+            }
+
+            offsets = new Dictionary<long, AcknowledgeType>();
+            _pendingAcks[tp] = offsets;
+        }
+        else if (requireTracked && !offsets.ContainsKey(offset))
         {
             throw new InvalidOperationException(
                 $"Cannot acknowledge offset {offset} for {tp} — record was not delivered by the current poll.");

--- a/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
@@ -52,21 +52,20 @@ public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, 
     /// <summary>
     /// Polls for records from the share group. Returns an async enumerable of acquired records.
     /// <para>
-    /// <b>Important:</b> Any records from the previous poll that were not explicitly acknowledged
-    /// via <see cref="Acknowledge"/> are implicitly accepted (per the KIP-932 specification).
-    /// If you intend to release or reject records, you must call <see cref="Acknowledge"/> before
-    /// the next <see cref="PollAsync"/> or <see cref="CommitAsync"/> call.
+    /// <b>Important:</b> In <see cref="ShareAcknowledgementMode.Implicit"/> mode, records from
+    /// the previous poll that were not explicitly acknowledged via <see cref="Acknowledge"/> are
+    /// accepted automatically. In <see cref="ShareAcknowledgementMode.Explicit"/> mode, only
+    /// records passed to <see cref="Acknowledge"/> are sent to the broker.
     /// </para>
     /// </summary>
     IAsyncEnumerable<ShareConsumeResult<TKey, TValue>> PollAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Sets the acknowledgement type for a specific record.
-    /// If not called, records default to <see cref="AcknowledgeType.Accept"/>.
+    /// In implicit acknowledgement mode, records default to <see cref="AcknowledgeType.Accept"/>.
     /// <para>
-    /// <b>Warning:</b> You must call this before the next <see cref="PollAsync"/> or
-    /// <see cref="CommitAsync"/>. Any records not explicitly acknowledged are implicitly
-    /// accepted — there is no way to release or reject them after that point.
+    /// <b>Warning:</b> In implicit mode, call this before the next <see cref="PollAsync"/> or
+    /// <see cref="CommitAsync"/> if you need to release or reject a record.
     /// </para>
     /// </summary>
     /// <param name="record">The record to acknowledge.</param>
@@ -75,7 +74,7 @@ public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, 
 
     /// <summary>
     /// Commits all pending acknowledgements to the broker via a standalone ShareAcknowledge request.
-    /// All unacknowledged records are implicitly accepted.
+    /// In implicit mode, pending records default to accepted.
     /// </summary>
     ValueTask CommitAsync(CancellationToken cancellationToken = default);
 

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -244,6 +244,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                     MaxBytes = _options.FetchMaxBytes,
                     MaxRecords = maxRecords,
                     BatchSize = maxRecords,
+                    ShareAcquireMode = (sbyte)_options.ShareAcquireMode,
                     Topics = topics
                 };
 
@@ -339,9 +340,12 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                             if (recordCount >= _options.MaxPollRecords)
                                 break;
 
-                            // Track only records actually yielded to the consumer so we don't
-                            // silently acknowledge offsets truncated by MaxPollRecords.
-                            _ackTracker.TrackDeliveredRecords(tp, result.Offset, result.Offset);
+                            // Track only records actually yielded to the consumer so implicit
+                            // acknowledgements do not include offsets truncated by MaxPollRecords.
+                            if (_options.AcknowledgementMode == ShareAcknowledgementMode.Implicit)
+                            {
+                                _ackTracker.TrackDeliveredRecords(tp, result.Offset, result.Offset);
+                            }
 
                             recordCount++;
                             yield return result;
@@ -361,7 +365,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
         record.AcknowledgeType = type;
         var tp = new TopicPartition(record.Topic, record.Partition);
-        _ackTracker.Acknowledge(tp, record.Offset, type);
+        _ackTracker.Acknowledge(
+            tp,
+            record.Offset,
+            type,
+            requireTracked: _options.AcknowledgementMode == ShareAcknowledgementMode.Implicit);
     }
 
     public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
@@ -610,6 +618,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 MinBytes = 0,
                 MaxBytes = 0,
                 MaxRecords = shareFetchVersion >= 1 ? 1 : 0,
+                ShareAcquireMode = (sbyte)_options.ShareAcquireMode,
                 Topics = topics
             };
 

--- a/src/Dekaf/ShareConsumer/ShareAcknowledgementMode.cs
+++ b/src/Dekaf/ShareConsumer/ShareAcknowledgementMode.cs
@@ -1,0 +1,19 @@
+namespace Dekaf.ShareConsumer;
+
+/// <summary>
+/// Controls whether share consumer records are acknowledged implicitly or only through Acknowledge.
+/// </summary>
+public enum ShareAcknowledgementMode
+{
+    /// <summary>
+    /// Delivered records are accepted automatically unless Acknowledge changes their type before commit.
+    /// Equivalent to Kafka's share.acknowledgement.mode=implicit.
+    /// </summary>
+    Implicit = 0,
+
+    /// <summary>
+    /// Delivered records are not acknowledged until Acknowledge is called.
+    /// Equivalent to Kafka's share.acknowledgement.mode=explicit.
+    /// </summary>
+    Explicit = 1
+}

--- a/src/Dekaf/ShareConsumer/ShareAcquireMode.cs
+++ b/src/Dekaf/ShareConsumer/ShareAcquireMode.cs
@@ -1,0 +1,20 @@
+namespace Dekaf.ShareConsumer;
+
+/// <summary>
+/// Controls how a share consumer acquires records for each ShareFetch request.
+/// Values match the Kafka ShareFetch v2 wire protocol.
+/// </summary>
+public enum ShareAcquireMode : sbyte
+{
+    /// <summary>
+    /// Optimize broker-side acquisition around producer batch boundaries.
+    /// Equivalent to Kafka's share.acquire.mode=batch_optimized.
+    /// </summary>
+    BatchOptimized = 0,
+
+    /// <summary>
+    /// Strictly limit acquired records to MaxPollRecords.
+    /// Equivalent to Kafka's share.acquire.mode=record_limit.
+    /// </summary>
+    RecordLimit = 1
+}

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -57,6 +57,18 @@ public sealed class ShareConsumerOptions
     public int MaxPollRecords { get; init; } = 500;
 
     /// <summary>
+    /// Controls whether records are acknowledged implicitly or only through Acknowledge.
+    /// Equivalent to Kafka's share.acknowledgement.mode.
+    /// </summary>
+    public ShareAcknowledgementMode AcknowledgementMode { get; init; } = ShareAcknowledgementMode.Implicit;
+
+    /// <summary>
+    /// Controls ShareFetch record acquisition behavior.
+    /// Equivalent to Kafka's share.acquire.mode.
+    /// </summary>
+    public ShareAcquireMode ShareAcquireMode { get; init; } = global::Dekaf.ShareConsumer.ShareAcquireMode.BatchOptimized;
+
+    /// <summary>
     /// Session timeout in milliseconds. The coordinator will remove the member if no heartbeat
     /// is received within this interval.
     /// </summary>

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -66,7 +66,7 @@ public sealed class ShareConsumerOptions
     /// Controls ShareFetch record acquisition behavior.
     /// Equivalent to Kafka's share.acquire.mode.
     /// </summary>
-    public ShareAcquireMode ShareAcquireMode { get; init; } = global::Dekaf.ShareConsumer.ShareAcquireMode.BatchOptimized;
+    public ShareAcquireMode ShareAcquireMode { get; init; } = ShareAcquireMode.BatchOptimized;
 
     /// <summary>
     /// Session timeout in milliseconds. The coordinator will remove the member if no heartbeat

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -163,6 +163,55 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
     }
 
     [Test]
+    public async Task ShareConsumer_ExplicitAcknowledgement_DoesNotAutoAcceptPolledRecord()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var groupId = $"share-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await using var firstConsumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit)
+            .WithMaxPollRecords(1)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        firstConsumer.Subscribe(topic);
+
+        var produceTask = ProduceAfterDelayAsync(producer, topic, count: 1);
+        var first = await ConsumeOneAsync(firstConsumer);
+        await produceTask;
+
+        await Assert.That(first.Value).IsEqualTo("value-0");
+
+        await firstConsumer.CommitAsync(CancellationToken.None);
+        firstConsumer.Acknowledge(first, AcknowledgeType.Release);
+        await firstConsumer.CommitAsync(CancellationToken.None);
+        await firstConsumer.CloseAsync(CancellationToken.None);
+
+        await using var secondConsumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit)
+            .WithMaxPollRecords(1)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        secondConsumer.Subscribe(topic);
+
+        var redelivered = await ConsumeOneAsync(secondConsumer);
+
+        await Assert.That(redelivered.Value).IsEqualTo(first.Value);
+        await Assert.That(redelivered.Offset).IsEqualTo(first.Offset);
+        await Assert.That(redelivered.DeliveryCount).IsGreaterThan(first.DeliveryCount);
+    }
+
+    [Test]
     public async Task ShareConsumer_Builder_ConfiguresCorrectly()
     {
         var groupId = $"share-group-{Guid.NewGuid():N}";
@@ -224,6 +273,25 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         IKafkaProducer<string, string> producer, string topic, int count,
         int delayMs = 5000)
         => ShareConsumerTestHelper.ProduceAfterDelayAsync(producer, topic, count, delayMs);
+
+    private static async Task<ShareConsumeResult<string, string>> ConsumeOneAsync(
+        IKafkaShareConsumer<string, string> consumer)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        try
+        {
+            await foreach (var msg in consumer.PollAsync(cts.Token))
+            {
+                return msg;
+            }
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+        }
+
+        throw new InvalidOperationException("Share consumer completed without returning a record.");
+    }
 }
 
 /// <summary>

--- a/tests/Dekaf.Tests.Unit/KafkaFactoryTests.cs
+++ b/tests/Dekaf.Tests.Unit/KafkaFactoryTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
@@ -79,6 +80,22 @@ public sealed class KafkaFactoryTests
     }
 
     [Test]
+    public async Task CreateShareConsumer_BuilderConfiguresKip1206Options()
+    {
+        await using var consumer = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("my-group")
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit)
+            .WithShareAcquireMode(ShareAcquireMode.RecordLimit)
+            .Build();
+
+        var options = GetPrivateField<ShareConsumerOptions>(consumer, "_options");
+
+        await Assert.That(options.AcknowledgementMode).IsEqualTo(ShareAcknowledgementMode.Explicit);
+        await Assert.That(options.ShareAcquireMode).IsEqualTo(ShareAcquireMode.RecordLimit);
+    }
+
+    [Test]
     public async Task CreateAdminClient_ReturnsBuilder()
     {
         var builder = Kafka.CreateAdminClient();
@@ -94,5 +111,11 @@ public sealed class KafkaFactoryTests
             .Build();
 
         await Assert.That(admin).IsAssignableTo<IAdminClient>();
+    }
+
+    private static T GetPrivateField<T>(object target, string name)
+    {
+        var field = target.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+        return (T)field!.GetValue(target)!;
     }
 }

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
@@ -91,6 +91,23 @@ public class AcknowledgementTrackerTests
     }
 
     [Test]
+    public async Task Acknowledge_UntrackedAllowed_AddsExplicitAck()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.Acknowledge(tp, 10, AcknowledgeType.Release, requireTracked: false);
+
+        var result = tracker.Flush();
+        var batch = result[tp][0];
+
+        await Assert.That(batch.FirstOffset).IsEqualTo(10);
+        await Assert.That(batch.LastOffset).IsEqualTo(10);
+        await Assert.That(batch.AcknowledgeTypes.Length).IsEqualTo(1);
+        await Assert.That(batch.AcknowledgeTypes[0]).IsEqualTo((byte)AcknowledgeType.Release);
+    }
+
+    [Test]
     public async Task Flush_ClearsTrackedState()
     {
         var tracker = new AcknowledgementTracker();

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerOptionsDefaultsTests.cs
@@ -38,4 +38,18 @@ public sealed class ShareConsumerOptionsDefaultsTests
         var options = CreateOptions();
         await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.UseAllDnsIps);
     }
+
+    [Test]
+    public async Task AcknowledgementMode_DefaultsTo_Implicit()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.AcknowledgementMode).IsEqualTo(ShareAcknowledgementMode.Implicit);
+    }
+
+    [Test]
+    public async Task ShareAcquireMode_DefaultsTo_BatchOptimized()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.ShareAcquireMode).IsEqualTo(ShareAcquireMode.BatchOptimized);
+    }
 }


### PR DESCRIPTION
Closes #1391.

## Summary
- Add share consumer acknowledgement/acquire mode options with Kafka 4.2-compatible defaults (`implicit`, `batch_optimized`).
- Add builder methods and pass `share.acquire.mode` through to ShareFetch v2 requests.
- Make explicit acknowledgement mode send only records passed to `Acknowledge`, with updated docs and unit coverage.

## Tests
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --no-ansi --disable-logo --minimum-expected-tests 4 --filter-uid ...`
- Full unit suite locally reached 4217/4218 twice with unrelated flaky tests (`RunAsync_MemoryLimitHit_PreservesInFlightPrefetch`, then `KafkaConnection_ConnectAsync_TriesAllResolvedAddresses`); both failed tests passed when rerun by exact UID.