### PR TITLE
feat(producer): add librdkafka partitioners

### DIFF
--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -192,6 +192,8 @@ Control how messages are assigned to partitions:
 .WithPartitioner(PartitionerType.Default)     // Hash key or sticky null keys
 .WithPartitioner(PartitionerType.Sticky)      // Stick null keys for batching
 .WithPartitioner(PartitionerType.RoundRobin)  // Even distribution
+.WithPartitioner(PartitionerType.ConsistentRandom) // librdkafka default
+.WithPartitioner(PartitionerType.Fnv1ARandom)      // librdkafka/Sarama-compatible
 ```
 
 ## Transactions

--- a/docs/docs/producer/partitioning.md
+++ b/docs/docs/producer/partitioning.md
@@ -79,9 +79,18 @@ var producer = await Kafka.CreateProducer<string, string>()
 
 | Partitioner | Behavior |
 |-------------|----------|
-| `Default` | Hash key for keyed messages, sticks null keys until batch completion |
-| `Sticky` | Sticks to one partition for null keys until batch completion |
-| `RoundRobin` | Distributes all messages evenly |
+| `Default` | Murmur2 positive-hash keyed messages, sticky null or empty keys until batch completion |
+| `Sticky` | Murmur2 positive-hash keyed messages, sticky null or empty keys until batch completion |
+| `RoundRobin` | Cycles through partitions |
+| `Random` | Ignores keys and picks a pseudo-random partition |
+| `Consistent` | librdkafka `consistent`: CRC32 hash; null and empty keys map to one partition |
+| `ConsistentRandom` | librdkafka `consistent_random`: CRC32 hash; null and empty keys are random |
+| `Murmur2` | librdkafka `murmur2`: Java-compatible Murmur2 hash; null keys map to one partition |
+| `Murmur2Random` | librdkafka `murmur2_random`: Java-compatible Murmur2 hash; null keys are random |
+| `Fnv1A` | librdkafka `fnv1a`: Sarama-compatible FNV-1a hash; null keys map to one partition |
+| `Fnv1ARandom` | librdkafka `fnv1a_random`: Sarama-compatible FNV-1a hash; null keys are random |
+
+Use `ConsistentRandom` when matching librdkafka or Confluent.Kafka's default `consistent_random` mapping. Use `Murmur2Random` when matching the Java producer's null-key behavior.
 
 ### Default and Sticky Partitioners
 

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -314,6 +314,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         {
             PartitionerType.Sticky => new StickyPartitioner(),
             PartitionerType.RoundRobin => new RoundRobinPartitioner(),
+            PartitionerType.Random => new RandomPartitioner(),
+            PartitionerType.Consistent => new ConsistentPartitioner(),
+            PartitionerType.ConsistentRandom => new ConsistentRandomPartitioner(),
+            PartitionerType.Murmur2 => new Murmur2Partitioner(),
+            PartitionerType.Murmur2Random => new Murmur2RandomPartitioner(),
+            PartitionerType.Fnv1A => new Fnv1APartitioner(),
+            PartitionerType.Fnv1ARandom => new Fnv1ARandomPartitioner(),
             _ => new DefaultPartitioner()
         };
 

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.IO.Hashing;
 
 namespace Dekaf.Producer;
 
@@ -123,6 +124,160 @@ public sealed class RoundRobinPartitioner : IPartitioner
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
         return (int)(++_counter % (uint)partitionCount);
+    }
+}
+
+/// <summary>
+/// Random partitioner - ignores keys and distributes across partitions.
+/// </summary>
+public sealed class RandomPartitioner : IPartitioner
+{
+    private readonly RandomPartitionSelector _randomPartitionSelector = new();
+
+    public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+    {
+        return _randomPartitionSelector.NextPartition(partitionCount);
+    }
+}
+
+/// <summary>
+/// librdkafka consistent partitioner - CRC32 hash of key.
+/// Null and empty keys map to the same partition.
+/// </summary>
+public sealed class ConsistentPartitioner : IPartitioner
+{
+    public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+    {
+        return LibrdkafkaCrc32.Partition(key, partitionCount);
+    }
+}
+
+/// <summary>
+/// librdkafka consistent_random partitioner - CRC32 for non-empty keys, random for null or empty keys.
+/// </summary>
+public sealed class ConsistentRandomPartitioner : IPartitioner
+{
+    private readonly RandomPartitionSelector _randomPartitionSelector = new();
+
+    public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+    {
+        return key.Length == 0
+            ? _randomPartitionSelector.NextPartition(partitionCount)
+            : LibrdkafkaCrc32.Partition(key, partitionCount);
+    }
+}
+
+/// <summary>
+/// librdkafka murmur2 partitioner - Java-compatible Murmur2 hash of key.
+/// Null keys map to the hash of an empty key.
+/// </summary>
+public sealed class Murmur2Partitioner : IPartitioner
+{
+    public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+    {
+        return Murmur2.Partition(key, partitionCount);
+    }
+}
+
+/// <summary>
+/// librdkafka murmur2_random partitioner - Murmur2 for non-null keys, random for null keys.
+/// </summary>
+public sealed class Murmur2RandomPartitioner : IPartitioner
+{
+    private readonly RandomPartitionSelector _randomPartitionSelector = new();
+
+    public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+    {
+        return keyIsNull
+            ? _randomPartitionSelector.NextPartition(partitionCount)
+            : Murmur2.Partition(key, partitionCount);
+    }
+}
+
+/// <summary>
+/// librdkafka fnv1a partitioner - Sarama-compatible FNV-1a hash of key.
+/// Null and empty keys map to the same partition.
+/// </summary>
+public sealed class Fnv1APartitioner : IPartitioner
+{
+    public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+    {
+        return Fnv1A.Partition(key, partitionCount);
+    }
+}
+
+/// <summary>
+/// librdkafka fnv1a_random partitioner - FNV-1a for non-null keys, random for null keys.
+/// </summary>
+public sealed class Fnv1ARandomPartitioner : IPartitioner
+{
+    private readonly RandomPartitionSelector _randomPartitionSelector = new();
+
+    public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+    {
+        return keyIsNull
+            ? _randomPartitionSelector.NextPartition(partitionCount)
+            : Fnv1A.Partition(key, partitionCount);
+    }
+}
+
+internal sealed class RandomPartitionSelector
+{
+    private const int GoldenRatioIncrement = unchecked((int)0x9e3779b9);
+    private const uint MixMultiplier1 = 0x7feb352d;
+    private const uint MixMultiplier2 = 0x846ca68b;
+
+    private int _state = Environment.TickCount;
+
+    public int NextPartition(int partitionCount)
+    {
+        var value = unchecked((uint)Interlocked.Add(ref _state, GoldenRatioIncrement));
+        value ^= value >> 16;
+        value *= MixMultiplier1;
+        value ^= value >> 15;
+        value *= MixMultiplier2;
+        value ^= value >> 16;
+        return (int)(value % (uint)partitionCount);
+    }
+}
+
+internal static class LibrdkafkaCrc32
+{
+    public static int Partition(ReadOnlySpan<byte> key, int partitionCount)
+    {
+        return (int)(Hash(key) % (uint)partitionCount);
+    }
+
+    public static uint Hash(ReadOnlySpan<byte> key)
+    {
+        return Crc32.HashToUInt32(key);
+    }
+}
+
+internal static class Fnv1A
+{
+    private const uint Offset = 0x811c9dc5;
+    private const uint Prime = 0x01000193;
+
+    public static int Partition(ReadOnlySpan<byte> key, int partitionCount)
+    {
+        return (int)(Hash(key) % (uint)partitionCount);
+    }
+
+    public static uint Hash(ReadOnlySpan<byte> key)
+    {
+        var hash = Offset;
+
+        foreach (var value in key)
+        {
+            hash ^= value;
+            hash *= Prime;
+        }
+
+        var signedHash = unchecked((int)hash);
+        return signedHash < 0
+            ? unchecked((uint)-signedHash)
+            : hash;
     }
 }
 

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -505,5 +505,40 @@ public enum PartitionerType
     /// <summary>
     /// Round-robin partitioner.
     /// </summary>
-    RoundRobin
+    RoundRobin,
+
+    /// <summary>
+    /// Random partitioner.
+    /// </summary>
+    Random,
+
+    /// <summary>
+    /// librdkafka consistent partitioner (CRC32 hash; null and empty keys map to one partition).
+    /// </summary>
+    Consistent,
+
+    /// <summary>
+    /// librdkafka consistent_random partitioner (CRC32 hash; null and empty keys are random).
+    /// </summary>
+    ConsistentRandom,
+
+    /// <summary>
+    /// librdkafka murmur2 partitioner (Java-compatible Murmur2 hash; null keys map to one partition).
+    /// </summary>
+    Murmur2,
+
+    /// <summary>
+    /// librdkafka murmur2_random partitioner (Java-compatible Murmur2 hash; null keys are random).
+    /// </summary>
+    Murmur2Random,
+
+    /// <summary>
+    /// librdkafka fnv1a partitioner (Sarama-compatible FNV-1a hash; null keys map to one partition).
+    /// </summary>
+    Fnv1A,
+
+    /// <summary>
+    /// librdkafka fnv1a_random partitioner (Sarama-compatible FNV-1a hash; null keys are random).
+    /// </summary>
+    Fnv1ARandom
 }

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text;
 using Dekaf.Producer;
 
 namespace Dekaf.Tests.Unit.Producer;
@@ -356,4 +357,125 @@ public class RoundRobinPartitionerTests
         await Task.WhenAll(tasks);
         await Assert.That(allValid).IsTrue();
     }
+}
+
+public class LibrdkafkaPartitionerTests
+{
+    private static readonly LibrdkafkaHashVector[] HashVectors =
+    [
+        new("kafka", 10, Crc32: 0x5bbc7517, Crc32Partition: 9, Fnv1A: 0x0d33c4e1, Fnv1APartition: 5),
+        new("user-123", 10, Crc32: 0xa2686a4e, Crc32Partition: 0, Fnv1A: 0x736c336d, Fnv1APartition: 3),
+        new("order-123", 12, Crc32: 0x0a2544a5, Crc32Partition: 1, Fnv1A: 0x5af730e6, Fnv1APartition: 6),
+        new("giberish123456789", 50, Crc32: 0x7b3a8e3f, Crc32Partition: 21, Fnv1A: 0x77a58295, Fnv1APartition: 23)
+    ];
+
+    [Test]
+    public async Task ConsistentPartitioner_MatchesLibrdkafkaCrc32Vectors()
+    {
+        var partitioner = new ConsistentPartitioner();
+
+        foreach (var vector in HashVectors)
+        {
+            var key = Encoding.UTF8.GetBytes(vector.Key);
+
+            await Assert.That(LibrdkafkaCrc32.Hash(key)).IsEqualTo(vector.Crc32);
+            await Assert.That(partitioner.Partition("topic", key, keyIsNull: false, vector.PartitionCount))
+                .IsEqualTo(vector.Crc32Partition);
+        }
+    }
+
+    [Test]
+    public async Task ConsistentPartitioner_NullAndEmptyKeys_MapToSinglePartition()
+    {
+        var partitioner = new ConsistentPartitioner();
+
+        await Assert.That(partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, keyIsNull: true, 17))
+            .IsEqualTo(0);
+        await Assert.That(partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, keyIsNull: false, 17))
+            .IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Fnv1APartitioner_MatchesLibrdkafkaVectors()
+    {
+        var partitioner = new Fnv1APartitioner();
+
+        foreach (var vector in HashVectors)
+        {
+            var key = Encoding.UTF8.GetBytes(vector.Key);
+
+            await Assert.That(Fnv1A.Hash(key)).IsEqualTo(vector.Fnv1A);
+            await Assert.That(partitioner.Partition("topic", key, keyIsNull: false, vector.PartitionCount))
+                .IsEqualTo(vector.Fnv1APartition);
+        }
+    }
+
+    [Test]
+    public async Task Fnv1APartitioner_NullAndEmptyKeys_MapToSinglePartition()
+    {
+        var partitioner = new Fnv1APartitioner();
+        var expected = (int)(Fnv1A.Hash(ReadOnlySpan<byte>.Empty) % 17u);
+
+        await Assert.That(Fnv1A.Hash(ReadOnlySpan<byte>.Empty)).IsEqualTo(0x7ee3623bu);
+        await Assert.That(expected).IsEqualTo(0);
+        await Assert.That(partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, keyIsNull: true, 17))
+            .IsEqualTo(expected);
+        await Assert.That(partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, keyIsNull: false, 17))
+            .IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task Murmur2RandomPartitioner_EmptyNonNullKey_UsesMurmur2()
+    {
+        var partitioner = new Murmur2RandomPartitioner();
+
+        await Assert.That(partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, keyIsNull: false, 17))
+            .IsEqualTo(Murmur2.Partition(ReadOnlySpan<byte>.Empty, 17));
+    }
+
+    [Test]
+    public async Task Fnv1ARandomPartitioner_EmptyNonNullKey_UsesFnv1A()
+    {
+        var partitioner = new Fnv1ARandomPartitioner();
+        var expected = (int)(Fnv1A.Hash(ReadOnlySpan<byte>.Empty) % 17u);
+
+        await Assert.That(partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, keyIsNull: false, 17))
+            .IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ConsistentRandomPartitioner_EmptyKey_UsesRandomPartition()
+    {
+        var partitioner = new ConsistentRandomPartitioner();
+
+        for (var i = 0; i < 20; i++)
+        {
+            var partition = partitioner.Partition("topic", ReadOnlySpan<byte>.Empty, keyIsNull: false, 17);
+
+            await Assert.That(partition).IsGreaterThanOrEqualTo(0);
+            await Assert.That(partition).IsLessThan(17);
+        }
+    }
+
+    [Test]
+    public async Task RandomPartitioner_IgnoresKeyAndReturnsValidPartitions()
+    {
+        var partitioner = new RandomPartitioner();
+
+        for (var i = 0; i < 20; i++)
+        {
+            var partition = partitioner.Partition("topic", "same-key"u8, keyIsNull: false, 17);
+
+            await Assert.That(partition).IsGreaterThanOrEqualTo(0);
+            await Assert.That(partition).IsLessThan(17);
+        }
+    }
+
+    private sealed record LibrdkafkaHashVector(
+        string Key,
+        int PartitionCount,
+        uint Crc32,
+        int Crc32Partition,
+        uint Fnv1A,
+        int Fnv1APartition);
 }


### PR DESCRIPTION
## Summary
- add built-in librdkafka-compatible partitioners: random, consistent, consistent_random, murmur2, murmur2_random, fnv1a, and fnv1a_random
- add CRC32/FNV-1a vector coverage against librdkafka-compatible values and null/empty-key behavior
- document new `PartitionerType` choices and migration guidance

## Test plan
- [x] `dotnet build src/Dekaf/Dekaf.csproj --configuration Release`
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter /*/*/LibrdkafkaPartitionerTests/*`
- [x] `Dekaf.Tests.Unit.exe` (4222/4222 passed; after isolating an earlier parallel-run DNS test interference)
- [x] `npm run build --prefix docs`

Closes #1386
