### PR TITLE
fix(telemetry): serialize stop with start

### DIFF
--- a/src/Dekaf/Telemetry/ClientTelemetryManager.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryManager.cs
@@ -105,6 +105,13 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
                 return;
             }
 
+            if (Volatile.Read(ref _disposed) != 0 ||
+                Volatile.Read(ref _stopped) != 0 ||
+                Volatile.Read(ref _disabled) != 0)
+            {
+                return;
+            }
+
             _subscription = subscription;
             var loopCts = new CancellationTokenSource();
             _loopCts = loopCts;
@@ -129,50 +136,58 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
             timeout = DefaultStopTimeout;
         }
 
-        using var timeoutCts = new CancellationTokenSource(timeout);
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
-        var stopToken = linkedCts.Token;
-
-        _loopCts?.Cancel();
-
-        var loopTask = _loopTask;
-        if (loopTask is not null)
+        await _startLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            try
-            {
-                await loopTask.WaitAsync(stopToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Shutdown is bounded by stopToken.
-            }
-            catch (Exception ex)
-            {
-                LogTelemetryLoopFailed(ex);
-            }
-        }
+            using var timeoutCts = new CancellationTokenSource(timeout);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
+            var stopToken = linkedCts.Token;
 
-        if (!stopToken.IsCancellationRequested &&
-            Volatile.Read(ref _disabled) == 0 &&
-            _subscription is { } subscription)
+            _loopCts?.Cancel();
+
+            var loopTask = _loopTask;
+            if (loopTask is not null)
+            {
+                try
+                {
+                    await loopTask.WaitAsync(stopToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Shutdown is bounded by stopToken.
+                }
+                catch (Exception ex)
+                {
+                    LogTelemetryLoopFailed(ex);
+                }
+            }
+
+            if (!stopToken.IsCancellationRequested &&
+                Volatile.Read(ref _disabled) == 0 &&
+                _subscription is { } subscription)
+            {
+                try
+                {
+                    _ = await PushTelemetryAsync(subscription, terminating: true, stopToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Shutdown is bounded by stopToken.
+                }
+                catch (Exception ex)
+                {
+                    LogTerminatingPushFailed(ex);
+                }
+            }
+
+            _loopCts?.Dispose();
+            _loopCts = null;
+            _loopTask = null;
+        }
+        finally
         {
-            try
-            {
-                _ = await PushTelemetryAsync(subscription, terminating: true, stopToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Shutdown is bounded by stopToken.
-            }
-            catch (Exception ex)
-            {
-                LogTerminatingPushFailed(ex);
-            }
+            _startLock.Release();
         }
-
-        _loopCts?.Dispose();
-        _loopCts = null;
-        _loopTask = null;
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
@@ -90,6 +90,51 @@ public sealed class ClientTelemetryManagerTests
     }
 
     [Test]
+    public async Task StopAsync_DuringSubscriptionFetch_PreventsLoopStart()
+    {
+        await using var context = new TelemetryTestContext();
+        context.Connection.Enqueue(Subscription(
+            Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            subscriptionId: 16,
+            pushIntervalMs: 60000));
+        context.Connection.BlockNextRequest<GetTelemetrySubscriptionsRequest>();
+
+        var startTask = context.Manager.StartAsync().AsTask();
+        await context.Connection.WaitForBlockedRequestAsync(TimeSpan.FromSeconds(2));
+
+        var stopTask = context.Manager.StopAsync(TimeSpan.FromSeconds(2)).AsTask();
+
+        context.Connection.ReleaseBlockedRequest();
+        await startTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await stopTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        await Assert.That(context.Manager.IsStarted).IsFalse();
+        await Assert.That(context.Connection.RequestsOfType<PushTelemetryRequest>().Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DisposeAsync_DuringSubscriptionFetch_DoesNotDisposeStartLockUnderStart()
+    {
+        await using var context = new TelemetryTestContext();
+        context.Connection.Enqueue(Subscription(
+            Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+            subscriptionId: 17,
+            pushIntervalMs: 60000));
+        context.Connection.BlockNextRequest<GetTelemetrySubscriptionsRequest>();
+
+        var startTask = context.Manager.StartAsync().AsTask();
+        await context.Connection.WaitForBlockedRequestAsync(TimeSpan.FromSeconds(2));
+
+        var disposeTask = context.Manager.DisposeAsync().AsTask();
+
+        context.Connection.ReleaseBlockedRequest();
+        await startTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        await Assert.That(context.Manager.IsStarted).IsFalse();
+    }
+
+    [Test]
     public async Task StopAsync_TerminatingPushIncludesApplicationMetrics()
     {
         var collector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);
@@ -397,6 +442,10 @@ public sealed class ClientTelemetryManagerTests
         private readonly ConcurrentQueue<object> _responses = new();
         private readonly ConcurrentQueue<object> _requests = new();
         private readonly SemaphoreSlim _requestSignal = new(0);
+        private readonly object _blockLock = new();
+        private Type? _blockedRequestType;
+        private TaskCompletionSource? _blockedRequestSeen;
+        private TaskCompletionSource? _blockedRequestRelease;
 
         public int BrokerId => 0;
         public string Host => "localhost";
@@ -409,6 +458,39 @@ public sealed class ClientTelemetryManagerTests
 
         public IReadOnlyList<T> RequestsOfType<T>() =>
             _requests.ToArray().OfType<T>().ToArray();
+
+        public void BlockNextRequest<TRequest>()
+        {
+            lock (_blockLock)
+            {
+                _blockedRequestType = typeof(TRequest);
+                _blockedRequestSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _blockedRequestRelease = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+        }
+
+        public async Task WaitForBlockedRequestAsync(TimeSpan timeout)
+        {
+            Task waitTask;
+            lock (_blockLock)
+            {
+                waitTask = _blockedRequestSeen?.Task
+                    ?? throw new InvalidOperationException("No blocked request was configured.");
+            }
+
+            await waitTask.WaitAsync(timeout).ConfigureAwait(false);
+        }
+
+        public void ReleaseBlockedRequest()
+        {
+            lock (_blockLock)
+            {
+                _blockedRequestRelease?.TrySetResult();
+                _blockedRequestType = null;
+                _blockedRequestSeen = null;
+                _blockedRequestRelease = null;
+            }
+        }
 
         public async Task<IReadOnlyList<T>> WaitForRequestsAsync<T>(int count, TimeSpan timeout)
         {
@@ -432,7 +514,7 @@ public sealed class ClientTelemetryManagerTests
             }
         }
 
-        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+        public async ValueTask<TResponse> SendAsync<TRequest, TResponse>(
             TRequest request,
             short apiVersion,
             CancellationToken cancellationToken = default)
@@ -441,6 +523,24 @@ public sealed class ClientTelemetryManagerTests
         {
             _requests.Enqueue(request);
             _requestSignal.Release();
+
+            TaskCompletionSource? blockedRequestSeen = null;
+            TaskCompletionSource? blockedRequestRelease = null;
+            lock (_blockLock)
+            {
+                if (_blockedRequestType == typeof(TRequest))
+                {
+                    blockedRequestSeen = _blockedRequestSeen;
+                    blockedRequestRelease = _blockedRequestRelease;
+                    _blockedRequestType = null;
+                }
+            }
+
+            if (blockedRequestRelease is not null)
+            {
+                blockedRequestSeen!.TrySetResult();
+                await blockedRequestRelease.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             if (!_responses.TryDequeue(out var response))
             {
@@ -454,7 +554,7 @@ public sealed class ClientTelemetryManagerTests
                 }
             }
 
-            return ValueTask.FromResult((TResponse)response);
+            return (TResponse)response;
         }
 
         public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(


### PR DESCRIPTION
## Summary
- Serialize telemetry stop/dispose with in-flight start so a stopped manager cannot install a push loop after subscription fetch completes.
- Recheck stopped/disposed/disabled state after fetching telemetry subscriptions before starting the loop.
- Add regression coverage for StopAsync and DisposeAsync racing a blocked subscription fetch.

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ClientTelemetryManagerTests/StopAsync_DuringSubscriptionFetch_PreventsLoopStart"
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ClientTelemetryManagerTests/DisposeAsync_DuringSubscriptionFetch_DoesNotDisposeStartLockUnderStart"
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ClientTelemetryManagerTests/*"

Closes #1345
