### PR TITLE
perf(compression): use LZ4 frame writer

### DIFF
--- a/src/Dekaf.Compression.Lz4/Lz4CompressionCodec.cs
+++ b/src/Dekaf.Compression.Lz4/Lz4CompressionCodec.cs
@@ -42,7 +42,8 @@ public sealed class Lz4CompressionCodec : ICompressionCodec
     /// <inheritdoc />
     public void Decompress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
     {
-        LZ4Frame.Decode(source).CopyTo(destination);
+        using var reader = LZ4Frame.Decode(source);
+        reader.CopyTo(destination);
     }
 }
 

--- a/src/Dekaf.Compression.Lz4/Lz4CompressionCodec.cs
+++ b/src/Dekaf.Compression.Lz4/Lz4CompressionCodec.cs
@@ -36,23 +36,13 @@ public sealed class Lz4CompressionCodec : ICompressionCodec
     /// <inheritdoc />
     public void Compress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
     {
-        // Use LZ4 frame format as required by Kafka, with independent blocks (no block chaining)
-        using var outputStream = new BufferWriterStream(destination);
-        using var lz4Stream = LZ4Stream.Encode(outputStream, _encoderSettings, leaveOpen: true);
-
-        foreach (var segment in source)
-        {
-            lz4Stream.Write(segment.Span);
-        }
+        LZ4Frame.Encode(source, destination, _encoderSettings);
     }
 
     /// <inheritdoc />
     public void Decompress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
     {
-        using var inputStream = new ReadOnlySequenceStream(source);
-        using var lz4Stream = LZ4Stream.Decode(inputStream, leaveOpen: true);
-
-        CompressionStreamCopy.CopyToBufferWriter(lz4Stream, destination);
+        LZ4Frame.Decode(source).CopyTo(destination);
     }
 }
 

--- a/tests/Dekaf.Tests.Unit/Compression/Lz4CompressionCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Compression/Lz4CompressionCodecTests.cs
@@ -85,6 +85,20 @@ public class Lz4CompressionCodecTests
         await Assert.That(magic[3]).IsEqualTo((byte)0x18);
     }
 
+    [Test]
+    public async Task Lz4CompressionCodec_Decompress_TruncatedFrame_Throws()
+    {
+        var codec = new Lz4CompressionCodec();
+        var originalData = Enumerable.Range(0, 200).Select(static i => (byte)i).ToArray();
+        var compressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Compress(new ReadOnlySequence<byte>(originalData), compressedBuffer);
+        var truncatedFrame = compressedBuffer.WrittenSpan[..^5].ToArray();
+        var decompressedBuffer = new ArrayBufferWriter<byte>();
+
+        await Assert.That(() => codec.Decompress(new ReadOnlySequence<byte>(truncatedFrame), decompressedBuffer))
+            .Throws<EndOfStreamException>();
+    }
+
     #endregion
 
     #region Compression Level Tests


### PR DESCRIPTION
## Summary
- Use K4os LZ4Frame IBufferWriter APIs for compression and decompression.
- Remove Stream adapter hops from the LZ4 codec path.

## Tests
- dotnet build src/Dekaf.Compression.Lz4/Dekaf.Compression.Lz4.csproj --configuration Release
- dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release
- dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress

Closes #1374