### PR TITLE
feat(admin): add streams group APIs

### DIFF
--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -776,6 +776,46 @@ public sealed class InMemoryAdminClient : IAdminClient
         return ValueTask.FromResult<IReadOnlyDictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>>(result);
     }
 
+    public ValueTask<IReadOnlyDictionary<string, StreamsGroupDescription>> DescribeStreamsGroupsAsync(
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(groupIds);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        var result = groupIds.ToDictionary(
+            groupId => groupId,
+            groupId => new StreamsGroupDescription
+            {
+                GroupId = groupId,
+                GroupState = "Stable",
+                Members = []
+            },
+            StringComparer.Ordinal);
+
+        return ValueTask.FromResult<IReadOnlyDictionary<string, StreamsGroupDescription>>(result);
+    }
+
+    public ValueTask<IReadOnlyList<GroupListing>> ListStreamsGroupsAsync(
+        ListStreamsGroupsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        IReadOnlyList<GroupListing> result = _cluster.ListGroups()
+            .Select(groupId => new GroupListing
+            {
+                GroupId = groupId,
+                ProtocolType = "streams",
+                State = "Stable"
+            })
+            .ToArray();
+
+        return ValueTask.FromResult(result);
+    }
+
     public ValueTask<IReadOnlyDictionary<string, ShareGroupDescription>> DescribeShareGroupsAsync(
         IEnumerable<string> groupIds,
         CancellationToken cancellationToken = default)

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -3255,6 +3255,269 @@ public sealed class AdminClient : IAdminClient
 
     private readonly record struct ReplicaLogDirAssignment(TopicPartitionReplica Replica, string LogDir);
 
+    public async ValueTask<IReadOnlyDictionary<string, StreamsGroupDescription>> DescribeStreamsGroupsAsync(
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var groupIdList = groupIds.ToList();
+
+        return await WithRetryAsync<IReadOnlyDictionary<string, StreamsGroupDescription>>(async () =>
+        {
+            var coordinatorTasks = groupIdList
+                .Select(async g => (GroupId: g, CoordinatorId: await FindGroupCoordinatorAsync(g, cancellationToken).ConfigureAwait(false)));
+            var coordinatorResults = await Task.WhenAll(coordinatorTasks).ConfigureAwait(false);
+
+            var groupsByCoordinator = new Dictionary<int, List<string>>();
+            foreach (var (groupId, coordinatorId) in coordinatorResults)
+            {
+                if (!groupsByCoordinator.TryGetValue(coordinatorId, out var groups))
+                {
+                    groups = [];
+                    groupsByCoordinator[coordinatorId] = groups;
+                }
+                groups.Add(groupId);
+            }
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.StreamsGroupDescribe,
+                StreamsGroupDescribeRequest.LowestSupportedVersion,
+                StreamsGroupDescribeRequest.HighestSupportedVersion);
+
+            var describeResponses = await Task.WhenAll(groupsByCoordinator.Select(async kvp =>
+            {
+                var connection = await _connectionPool.GetConnectionAsync(kvp.Key, cancellationToken).ConfigureAwait(false);
+
+                var request = new StreamsGroupDescribeRequest
+                {
+                    GroupIds = kvp.Value,
+                    IncludeAuthorizedOperations = true
+                };
+
+                return await connection.SendAsync<StreamsGroupDescribeRequest, StreamsGroupDescribeResponse>(
+                    request,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+            })).ConfigureAwait(false);
+
+            var result = new Dictionary<string, StreamsGroupDescription>();
+
+            foreach (var response in describeResponses)
+            {
+                foreach (var group in response.Groups)
+                {
+                    if (group.ErrorCode != Protocol.ErrorCode.None)
+                    {
+                        throw new Errors.GroupException(group.ErrorCode,
+                            $"DescribeStreamsGroups failed for group '{group.GroupId}': {group.ErrorCode}")
+                        {
+                            GroupId = group.GroupId
+                        };
+                    }
+
+                    result[group.GroupId] = MapStreamsGroupDescription(group);
+                }
+            }
+
+            return result;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<IReadOnlyList<GroupListing>> ListStreamsGroupsAsync(
+        ListStreamsGroupsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        var opts = options ?? new ListStreamsGroupsOptions();
+
+        return await WithRetryAsync<IReadOnlyList<GroupListing>>(async () =>
+        {
+            var brokers = _metadataManager.Metadata.GetBrokers();
+            if (brokers.Count == 0)
+            {
+                throw new InvalidOperationException("No brokers available");
+            }
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.ListGroups,
+                ListGroupsRequest.LowestSupportedVersion,
+                ListGroupsRequest.HighestSupportedVersion);
+
+            var request = new ListGroupsRequest
+            {
+                StatesFilter = apiVersion >= 4 ? opts.States : null,
+                TypesFilter = apiVersion >= 5 ? ["streams"] : null
+            };
+
+            var responses = await Task.WhenAll(brokers.Select(async broker =>
+            {
+                var connection = await _connectionPool.GetConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
+
+                var response = await connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(
+                    request,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (response.ErrorCode != Protocol.ErrorCode.None)
+                {
+                    throw new KafkaException(response.ErrorCode,
+                        $"ListStreamsGroups failed on broker {broker.NodeId}: {response.ErrorCode}");
+                }
+
+                return response;
+            })).ConfigureAwait(false);
+
+            var seenGroupIds = new HashSet<string>();
+            var result = new List<GroupListing>();
+
+            foreach (var response in responses)
+            {
+                foreach (var group in response.Groups)
+                {
+                    if (apiVersion < 5 || !string.Equals(group.GroupType, "streams", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    if (!seenGroupIds.Add(group.GroupId))
+                        continue;
+
+                    if (apiVersion < 4 && opts.States is { Count: > 0 } && group.GroupState is not null)
+                    {
+                        if (!opts.States.Contains(group.GroupState, StringComparer.OrdinalIgnoreCase))
+                            continue;
+                    }
+
+                    result.Add(new GroupListing
+                    {
+                        GroupId = group.GroupId,
+                        ProtocolType = group.ProtocolType,
+                        State = group.GroupState
+                    });
+                }
+            }
+
+            return result;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static StreamsGroupDescription MapStreamsGroupDescription(StreamsGroupDescribeGroup group)
+    {
+        return new StreamsGroupDescription
+        {
+            GroupId = group.GroupId,
+            GroupState = group.GroupState,
+            GroupEpoch = group.GroupEpoch,
+            AssignmentEpoch = group.AssignmentEpoch,
+            Topology = MapStreamsGroupTopology(group.Topology),
+            Members = group.Members.Select(MapStreamsGroupMember).ToList(),
+            AuthorizedOperations = group.AuthorizedOperations
+        };
+    }
+
+    private static StreamsGroupTopology? MapStreamsGroupTopology(StreamsGroupDescribeTopology? topology)
+    {
+        if (topology is null)
+        {
+            return null;
+        }
+
+        return new StreamsGroupTopology
+        {
+            Epoch = topology.Epoch,
+            Subtopologies = topology.Subtopologies?.Select(MapStreamsGroupSubtopology).ToList()
+        };
+    }
+
+    private static StreamsGroupSubtopology MapStreamsGroupSubtopology(StreamsGroupDescribeSubtopology subtopology)
+    {
+        return new StreamsGroupSubtopology
+        {
+            SubtopologyId = subtopology.SubtopologyId,
+            SourceTopics = subtopology.SourceTopics,
+            RepartitionSinkTopics = subtopology.RepartitionSinkTopics,
+            StateChangelogTopics = subtopology.StateChangelogTopics.Select(MapStreamsGroupTopicInfo).ToList(),
+            RepartitionSourceTopics = subtopology.RepartitionSourceTopics.Select(MapStreamsGroupTopicInfo).ToList()
+        };
+    }
+
+    private static StreamsGroupTopicInfo MapStreamsGroupTopicInfo(StreamsGroupDescribeTopicInfo topic)
+    {
+        return new StreamsGroupTopicInfo
+        {
+            Name = topic.Name,
+            Partitions = topic.Partitions,
+            ReplicationFactor = topic.ReplicationFactor,
+            TopicConfigs = topic.TopicConfigs.Select(MapStreamsGroupKeyValue).ToList()
+        };
+    }
+
+    private static StreamsGroupMemberDescription MapStreamsGroupMember(StreamsGroupDescribeMember member)
+    {
+        return new StreamsGroupMemberDescription
+        {
+            MemberId = member.MemberId,
+            MemberEpoch = member.MemberEpoch,
+            InstanceId = member.InstanceId,
+            RackId = member.RackId,
+            ClientId = member.ClientId,
+            ClientHost = member.ClientHost,
+            TopologyEpoch = member.TopologyEpoch,
+            ProcessId = member.ProcessId,
+            UserEndpoint = member.UserEndpoint is null
+                ? null
+                : new StreamsGroupEndpoint
+                {
+                    Host = member.UserEndpoint.Host,
+                    Port = member.UserEndpoint.Port
+                },
+            ClientTags = member.ClientTags.Select(MapStreamsGroupKeyValue).ToList(),
+            TaskOffsets = member.TaskOffsets.Select(MapStreamsGroupTaskOffset).ToList(),
+            TaskEndOffsets = member.TaskEndOffsets.Select(MapStreamsGroupTaskOffset).ToList(),
+            Assignment = MapStreamsGroupAssignment(member.Assignment),
+            TargetAssignment = MapStreamsGroupAssignment(member.TargetAssignment),
+            IsClassic = member.IsClassic
+        };
+    }
+
+    private static StreamsGroupKeyValue MapStreamsGroupKeyValue(StreamsGroupDescribeKeyValue keyValue)
+    {
+        return new StreamsGroupKeyValue
+        {
+            Key = keyValue.Key,
+            Value = keyValue.Value
+        };
+    }
+
+    private static StreamsGroupTaskOffset MapStreamsGroupTaskOffset(StreamsGroupDescribeTaskOffset taskOffset)
+    {
+        return new StreamsGroupTaskOffset
+        {
+            SubtopologyId = taskOffset.SubtopologyId,
+            Partition = taskOffset.Partition,
+            Offset = taskOffset.Offset
+        };
+    }
+
+    private static StreamsGroupMemberAssignment MapStreamsGroupAssignment(StreamsGroupDescribeAssignment assignment)
+    {
+        return new StreamsGroupMemberAssignment
+        {
+            ActiveTasks = assignment.ActiveTasks.Select(MapStreamsGroupTaskIds).ToList(),
+            StandbyTasks = assignment.StandbyTasks.Select(MapStreamsGroupTaskIds).ToList(),
+            WarmupTasks = assignment.WarmupTasks.Select(MapStreamsGroupTaskIds).ToList()
+        };
+    }
+
+    private static StreamsGroupTaskIds MapStreamsGroupTaskIds(StreamsGroupDescribeTaskIds taskIds)
+    {
+        return new StreamsGroupTaskIds
+        {
+            SubtopologyId = taskIds.SubtopologyId,
+            Partitions = taskIds.Partitions
+        };
+    }
+
     public async ValueTask<IReadOnlyDictionary<string, ShareGroupDescription>> DescribeShareGroupsAsync(
         IEnumerable<string> groupIds,
         CancellationToken cancellationToken = default)

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -390,6 +390,20 @@ public interface IAdminClient : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Describes streams groups.
+    /// </summary>
+    ValueTask<IReadOnlyDictionary<string, StreamsGroupDescription>> DescribeStreamsGroupsAsync(
+        IEnumerable<string> groupIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists streams groups across the cluster.
+    /// </summary>
+    ValueTask<IReadOnlyList<GroupListing>> ListStreamsGroupsAsync(
+        ListStreamsGroupsOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Describes share groups.
     /// </summary>
     ValueTask<IReadOnlyDictionary<string, ShareGroupDescription>> DescribeShareGroupsAsync(

--- a/src/Dekaf/Admin/StreamsGroupTypes.cs
+++ b/src/Dekaf/Admin/StreamsGroupTypes.cs
@@ -1,0 +1,124 @@
+namespace Dekaf.Admin;
+
+/// <summary>
+/// Streams group description.
+/// </summary>
+public sealed class StreamsGroupDescription
+{
+    public required string GroupId { get; init; }
+    public required string GroupState { get; init; }
+    public int GroupEpoch { get; init; }
+    public int AssignmentEpoch { get; init; }
+    public StreamsGroupTopology? Topology { get; init; }
+    public required IReadOnlyList<StreamsGroupMemberDescription> Members { get; init; }
+    public int AuthorizedOperations { get; init; } = int.MinValue;
+}
+
+/// <summary>
+/// Streams topology metadata initialized for a group.
+/// </summary>
+public sealed class StreamsGroupTopology
+{
+    public int Epoch { get; init; }
+    public IReadOnlyList<StreamsGroupSubtopology>? Subtopologies { get; init; }
+}
+
+/// <summary>
+/// Streams subtopology metadata.
+/// </summary>
+public sealed class StreamsGroupSubtopology
+{
+    public required string SubtopologyId { get; init; }
+    public required IReadOnlyList<string> SourceTopics { get; init; }
+    public required IReadOnlyList<string> RepartitionSinkTopics { get; init; }
+    public required IReadOnlyList<StreamsGroupTopicInfo> StateChangelogTopics { get; init; }
+    public required IReadOnlyList<StreamsGroupTopicInfo> RepartitionSourceTopics { get; init; }
+}
+
+/// <summary>
+/// Streams-internal topic metadata.
+/// </summary>
+public sealed class StreamsGroupTopicInfo
+{
+    public required string Name { get; init; }
+    public int Partitions { get; init; }
+    public short ReplicationFactor { get; init; }
+    public required IReadOnlyList<StreamsGroupKeyValue> TopicConfigs { get; init; }
+}
+
+/// <summary>
+/// Streams group key/value metadata.
+/// </summary>
+public sealed class StreamsGroupKeyValue
+{
+    public required string Key { get; init; }
+    public required string Value { get; init; }
+}
+
+/// <summary>
+/// Streams group member description.
+/// </summary>
+public sealed class StreamsGroupMemberDescription
+{
+    public required string MemberId { get; init; }
+    public int MemberEpoch { get; init; }
+    public string? InstanceId { get; init; }
+    public string? RackId { get; init; }
+    public required string ClientId { get; init; }
+    public required string ClientHost { get; init; }
+    public int TopologyEpoch { get; init; }
+    public required string ProcessId { get; init; }
+    public StreamsGroupEndpoint? UserEndpoint { get; init; }
+    public required IReadOnlyList<StreamsGroupKeyValue> ClientTags { get; init; }
+    public required IReadOnlyList<StreamsGroupTaskOffset> TaskOffsets { get; init; }
+    public required IReadOnlyList<StreamsGroupTaskOffset> TaskEndOffsets { get; init; }
+    public required StreamsGroupMemberAssignment Assignment { get; init; }
+    public required StreamsGroupMemberAssignment TargetAssignment { get; init; }
+    public bool IsClassic { get; init; }
+}
+
+/// <summary>
+/// Interactive Query endpoint for a streams group member.
+/// </summary>
+public sealed class StreamsGroupEndpoint
+{
+    public required string Host { get; init; }
+    public int Port { get; init; }
+}
+
+/// <summary>
+/// Cumulative task changelog offset.
+/// </summary>
+public sealed class StreamsGroupTaskOffset
+{
+    public required string SubtopologyId { get; init; }
+    public int Partition { get; init; }
+    public long Offset { get; init; }
+}
+
+/// <summary>
+/// Streams member assignment.
+/// </summary>
+public sealed class StreamsGroupMemberAssignment
+{
+    public required IReadOnlyList<StreamsGroupTaskIds> ActiveTasks { get; init; }
+    public required IReadOnlyList<StreamsGroupTaskIds> StandbyTasks { get; init; }
+    public required IReadOnlyList<StreamsGroupTaskIds> WarmupTasks { get; init; }
+}
+
+/// <summary>
+/// Streams task IDs grouped by subtopology.
+/// </summary>
+public sealed class StreamsGroupTaskIds
+{
+    public required string SubtopologyId { get; init; }
+    public required IReadOnlyList<int> Partitions { get; init; }
+}
+
+/// <summary>
+/// Options for ListStreamsGroups.
+/// </summary>
+public sealed class ListStreamsGroupsOptions
+{
+    public IReadOnlyList<string>? States { get; init; }
+}

--- a/src/Dekaf/Protocol/ErrorCode.cs
+++ b/src/Dekaf/Protocol/ErrorCode.cs
@@ -135,7 +135,13 @@ public enum ErrorCode : short
     DuplicateVoter = 126,
     VoterNotFound = 127,
     InvalidRegularExpression = 128,
-    RebootstrapRequired = 129
+    RebootstrapRequired = 129,
+    StreamsInvalidTopology = 130,
+    StreamsInvalidTopologyEpoch = 131,
+    StreamsTopologyFenced = 132,
+    ShareSessionLimitReached = 133,
+    GroupDeletionFailed = 134,
+    StreamsTopologyDescriptionUpdateFailed = 135
 }
 
 /// <summary>

--- a/src/Dekaf/Protocol/Messages/StreamsGroupDescribeRequest.cs
+++ b/src/Dekaf/Protocol/Messages/StreamsGroupDescribeRequest.cs
@@ -1,0 +1,33 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// StreamsGroupDescribe request (API key 89).
+/// Describes streams groups (KIP-1071).
+/// </summary>
+public sealed class StreamsGroupDescribeRequest : IKafkaRequest<StreamsGroupDescribeResponse>
+{
+    public static ApiKey ApiKey => ApiKey.StreamsGroupDescribe;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// The group IDs to describe.
+    /// </summary>
+    public required IReadOnlyList<string> GroupIds { get; init; }
+
+    /// <summary>
+    /// Whether to include authorized operations.
+    /// </summary>
+    public bool IncludeAuthorizedOperations { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactArray(
+            GroupIds,
+            static (ref KafkaProtocolWriter w, string groupId) => w.WriteCompactString(groupId));
+
+        writer.WriteBoolean(IncludeAuthorizedOperations);
+
+        writer.WriteEmptyTaggedFields();
+    }
+}

--- a/src/Dekaf/Protocol/Messages/StreamsGroupDescribeResponse.cs
+++ b/src/Dekaf/Protocol/Messages/StreamsGroupDescribeResponse.cs
@@ -1,0 +1,533 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// StreamsGroupDescribe response (API key 89).
+/// Contains the descriptions of streams groups (KIP-1071).
+/// </summary>
+public sealed class StreamsGroupDescribeResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.StreamsGroupDescribe;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    /// <summary>
+    /// The duration in milliseconds for which the request was throttled due to quota violation
+    /// (zero if not throttled).
+    /// </summary>
+    public int ThrottleTimeMs { get; init; }
+
+    /// <summary>
+    /// The described groups.
+    /// </summary>
+    public required IReadOnlyList<StreamsGroupDescribeGroup> Groups { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteInt32(ThrottleTimeMs);
+        writer.WriteCompactArray(
+            Groups,
+            static (ref KafkaProtocolWriter w, StreamsGroupDescribeGroup group) => group.Write(ref w));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+
+        var groups = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeGroup.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new StreamsGroupDescribeResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            Groups = groups
+        };
+    }
+}
+
+/// <summary>
+/// Described group in a StreamsGroupDescribe response.
+/// </summary>
+public sealed class StreamsGroupDescribeGroup
+{
+    public ErrorCode ErrorCode { get; init; }
+    public string? ErrorMessage { get; init; }
+    public required string GroupId { get; init; }
+    public required string GroupState { get; init; }
+    public int GroupEpoch { get; init; }
+    public int AssignmentEpoch { get; init; }
+    public StreamsGroupDescribeTopology? Topology { get; init; }
+    public required IReadOnlyList<StreamsGroupDescribeMember> Members { get; init; }
+    public int AuthorizedOperations { get; init; } = int.MinValue;
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt16((short)ErrorCode);
+        writer.WriteCompactNullableString(ErrorMessage);
+        writer.WriteCompactString(GroupId);
+        writer.WriteCompactString(GroupState);
+        writer.WriteInt32(GroupEpoch);
+        writer.WriteInt32(AssignmentEpoch);
+        StreamsGroupDescribeTopology.WriteNullable(ref writer, Topology);
+        writer.WriteCompactArray(
+            Members,
+            static (ref KafkaProtocolWriter w, StreamsGroupDescribeMember member) => member.Write(ref w));
+        writer.WriteInt32(AuthorizedOperations);
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static StreamsGroupDescribeGroup Read(ref KafkaProtocolReader reader)
+    {
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+        var groupId = reader.ReadCompactString() ?? string.Empty;
+        var groupState = reader.ReadCompactString() ?? string.Empty;
+        var groupEpoch = reader.ReadInt32();
+        var assignmentEpoch = reader.ReadInt32();
+        var topology = StreamsGroupDescribeTopology.ReadNullable(ref reader);
+        var members = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeMember.Read(ref r));
+        var authorizedOperations = reader.ReadInt32();
+
+        reader.SkipTaggedFields();
+
+        return new StreamsGroupDescribeGroup
+        {
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            GroupId = groupId,
+            GroupState = groupState,
+            GroupEpoch = groupEpoch,
+            AssignmentEpoch = assignmentEpoch,
+            Topology = topology,
+            Members = members,
+            AuthorizedOperations = authorizedOperations
+        };
+    }
+}
+
+/// <summary>
+/// Topology metadata in a StreamsGroupDescribe response.
+/// </summary>
+public sealed class StreamsGroupDescribeTopology
+{
+    public int Epoch { get; init; }
+    public IReadOnlyList<StreamsGroupDescribeSubtopology>? Subtopologies { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt32(Epoch);
+        writer.WriteCompactNullableArray(
+            Subtopologies,
+            static (ref KafkaProtocolWriter w, StreamsGroupDescribeSubtopology subtopology) => subtopology.Write(ref w));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static void WriteNullable(ref KafkaProtocolWriter writer, StreamsGroupDescribeTopology? topology)
+    {
+        if (topology is null)
+        {
+            writer.WriteInt8(-1);
+            return;
+        }
+
+        writer.WriteInt8(1);
+        topology.Write(ref writer);
+    }
+
+    public static StreamsGroupDescribeTopology? ReadNullable(ref KafkaProtocolReader reader)
+    {
+        var marker = reader.ReadInt8();
+        if (marker < 0)
+        {
+            return null;
+        }
+
+        var epoch = reader.ReadInt32();
+        var subtopologies = reader.ReadCompactNullableArray(
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeSubtopology.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new StreamsGroupDescribeTopology
+        {
+            Epoch = epoch,
+            Subtopologies = subtopologies
+        };
+    }
+}
+
+/// <summary>
+/// Subtopology metadata in a StreamsGroupDescribe response.
+/// </summary>
+public sealed class StreamsGroupDescribeSubtopology
+{
+    public required string SubtopologyId { get; init; }
+    public required IReadOnlyList<string> SourceTopics { get; init; }
+    public required IReadOnlyList<string> RepartitionSinkTopics { get; init; }
+    public required IReadOnlyList<StreamsGroupDescribeTopicInfo> StateChangelogTopics { get; init; }
+    public required IReadOnlyList<StreamsGroupDescribeTopicInfo> RepartitionSourceTopics { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(SubtopologyId);
+        writer.WriteCompactArray(
+            SourceTopics,
+            static (ref KafkaProtocolWriter w, string topic) => w.WriteCompactString(topic));
+        writer.WriteCompactArray(
+            RepartitionSinkTopics,
+            static (ref KafkaProtocolWriter w, string topic) => w.WriteCompactString(topic));
+        writer.WriteCompactArray(
+            StateChangelogTopics,
+            static (ref KafkaProtocolWriter w, StreamsGroupDescribeTopicInfo topic) => topic.Write(ref w));
+        writer.WriteCompactArray(
+            RepartitionSourceTopics,
+            static (ref KafkaProtocolWriter w, StreamsGroupDescribeTopicInfo topic) => topic.Write(ref w));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static StreamsGroupDescribeSubtopology Read(ref KafkaProtocolReader reader)
+    {
+        var subtopologyId = reader.ReadCompactString() ?? string.Empty;
+        var sourceTopics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty);
+        var repartitionSinkTopics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty);
+        var stateChangelogTopics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTopicInfo.Read(ref r));
+        var repartitionSourceTopics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTopicInfo.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new StreamsGroupDescribeSubtopology
+        {
+            SubtopologyId = subtopologyId,
+            SourceTopics = sourceTopics,
+            RepartitionSinkTopics = repartitionSinkTopics,
+            StateChangelogTopics = stateChangelogTopics,
+            RepartitionSourceTopics = repartitionSourceTopics
+        };
+    }
+}
+
+/// <summary>
+/// Topic information in a StreamsGroupDescribe response.
+/// </summary>
+public sealed class StreamsGroupDescribeTopicInfo
+{
+    public required string Name { get; init; }
+    public int Partitions { get; init; }
+    public short ReplicationFactor { get; init; }
+    public required IReadOnlyList<StreamsGroupDescribeKeyValue> TopicConfigs { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(Name);
+        writer.WriteInt32(Partitions);
+        writer.WriteInt16(ReplicationFactor);
+        writer.WriteCompactArray(
+            TopicConfigs,
+            static (ref KafkaProtocolWriter w, StreamsGroupDescribeKeyValue config) => config.Write(ref w));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static StreamsGroupDescribeTopicInfo Read(ref KafkaProtocolReader reader)
+    {
+        var name = reader.ReadCompactString() ?? string.Empty;
+        var partitions = reader.ReadInt32();
+        var replicationFactor = reader.ReadInt16();
+        var topicConfigs = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeKeyValue.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new StreamsGroupDescribeTopicInfo
+        {
+            Name = name,
+            Partitions = partitions,
+            ReplicationFactor = replicationFactor,
+            TopicConfigs = topicConfigs
+        };
+    }
+}
+
+/// <summary>
+/// Key/value pair in a StreamsGroupDescribe response.
+/// </summary>
+public sealed class StreamsGroupDescribeKeyValue
+{
+    public required string Key { get; init; }
+    public required string Value { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(Key);
+        writer.WriteCompactString(Value);
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static StreamsGroupDescribeKeyValue Read(ref KafkaProtocolReader reader)
+    {
+        var key = reader.ReadCompactString() ?? string.Empty;
+        var value = reader.ReadCompactString() ?? string.Empty;
+
+        reader.SkipTaggedFields();
+
+        return new StreamsGroupDescribeKeyValue
+        {
+            Key = key,
+            Value = value
+        };
+    }
+}
+
+/// <summary>
+/// Member in a StreamsGroupDescribe response.
+/// </summary>
+public sealed class StreamsGroupDescribeMember
+{
+    public required string MemberId { get; init; }
+    public int MemberEpoch { get; init; }
+    public string? InstanceId { get; init; }
+    public string? RackId { get; init; }
+    public required string ClientId { get; init; }
+    public required string ClientHost { get; init; }
+    public int TopologyEpoch { get; init; }
+    public required string ProcessId { get; init; }
+    public StreamsGroupDescribeEndpoint? UserEndpoint { get; init; }
+    public required IReadOnlyList<StreamsGroupDescribeKeyValue> ClientTags { get; init; }
+    public required IReadOnlyList<StreamsGroupDescribeTaskOffset> TaskOffsets { get; init; }
+    public required IReadOnlyList<StreamsGroupDescribeTaskOffset> TaskEndOffsets { get; init; }
+    public required StreamsGroupDescribeAssignment Assignment { get; init; }
+    public required StreamsGroupDescribeAssignment TargetAssignment { get; init; }
+    public bool IsClassic { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(MemberId);
+        writer.WriteInt32(MemberEpoch);
+        writer.WriteCompactNullableString(InstanceId);
+        writer.WriteCompactNullableString(RackId);
+        writer.WriteCompactString(ClientId);
+        writer.WriteCompactString(ClientHost);
+        writer.WriteInt32(TopologyEpoch);
+        writer.WriteCompactString(ProcessId);
+        StreamsGroupDescribeEndpoint.WriteNullable(ref writer, UserEndpoint);
+        writer.WriteCompactArray(
+            ClientTags,
+            static (ref KafkaProtocolWriter w, StreamsGroupDescribeKeyValue tag) => tag.Write(ref w));
+        writer.WriteCompactArray(
+            TaskOffsets,
+            static (ref KafkaProtocolWriter w, StreamsGroupDescribeTaskOffset offset) => offset.Write(ref w));
+        writer.WriteCompactArray(
+            TaskEndOffsets,
+            static (ref KafkaProtocolWriter w, StreamsGroupDescribeTaskOffset offset) => offset.Write(ref w));
+        Assignment.Write(ref writer);
+        TargetAssignment.Write(ref writer);
+        writer.WriteBoolean(IsClassic);
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static StreamsGroupDescribeMember Read(ref KafkaProtocolReader reader)
+    {
+        var memberId = reader.ReadCompactString() ?? string.Empty;
+        var memberEpoch = reader.ReadInt32();
+        var instanceId = reader.ReadCompactString();
+        var rackId = reader.ReadCompactString();
+        var clientId = reader.ReadCompactString() ?? string.Empty;
+        var clientHost = reader.ReadCompactString() ?? string.Empty;
+        var topologyEpoch = reader.ReadInt32();
+        var processId = reader.ReadCompactString() ?? string.Empty;
+        var userEndpoint = StreamsGroupDescribeEndpoint.ReadNullable(ref reader);
+        var clientTags = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeKeyValue.Read(ref r));
+        var taskOffsets = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskOffset.Read(ref r));
+        var taskEndOffsets = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskOffset.Read(ref r));
+        var assignment = StreamsGroupDescribeAssignment.Read(ref reader);
+        var targetAssignment = StreamsGroupDescribeAssignment.Read(ref reader);
+        var isClassic = reader.ReadBoolean();
+
+        reader.SkipTaggedFields();
+
+        return new StreamsGroupDescribeMember
+        {
+            MemberId = memberId,
+            MemberEpoch = memberEpoch,
+            InstanceId = instanceId,
+            RackId = rackId,
+            ClientId = clientId,
+            ClientHost = clientHost,
+            TopologyEpoch = topologyEpoch,
+            ProcessId = processId,
+            UserEndpoint = userEndpoint,
+            ClientTags = clientTags,
+            TaskOffsets = taskOffsets,
+            TaskEndOffsets = taskEndOffsets,
+            Assignment = assignment,
+            TargetAssignment = targetAssignment,
+            IsClassic = isClassic
+        };
+    }
+}
+
+/// <summary>
+/// Interactive Query endpoint in a StreamsGroupDescribe response.
+/// </summary>
+public sealed class StreamsGroupDescribeEndpoint
+{
+    public required string Host { get; init; }
+    public ushort Port { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(Host);
+        writer.WriteUInt16(Port);
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static void WriteNullable(ref KafkaProtocolWriter writer, StreamsGroupDescribeEndpoint? endpoint)
+    {
+        if (endpoint is null)
+        {
+            writer.WriteInt8(-1);
+            return;
+        }
+
+        writer.WriteInt8(1);
+        endpoint.Write(ref writer);
+    }
+
+    public static StreamsGroupDescribeEndpoint? ReadNullable(ref KafkaProtocolReader reader)
+    {
+        var marker = reader.ReadInt8();
+        if (marker < 0)
+        {
+            return null;
+        }
+
+        var host = reader.ReadCompactString() ?? string.Empty;
+        var port = reader.ReadUInt16();
+
+        reader.SkipTaggedFields();
+
+        return new StreamsGroupDescribeEndpoint
+        {
+            Host = host,
+            Port = port
+        };
+    }
+}
+
+/// <summary>
+/// Cumulative task changelog offset in a StreamsGroupDescribe response.
+/// </summary>
+public sealed class StreamsGroupDescribeTaskOffset
+{
+    public required string SubtopologyId { get; init; }
+    public int Partition { get; init; }
+    public long Offset { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(SubtopologyId);
+        writer.WriteInt32(Partition);
+        writer.WriteInt64(Offset);
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static StreamsGroupDescribeTaskOffset Read(ref KafkaProtocolReader reader)
+    {
+        var subtopologyId = reader.ReadCompactString() ?? string.Empty;
+        var partition = reader.ReadInt32();
+        var offset = reader.ReadInt64();
+
+        reader.SkipTaggedFields();
+
+        return new StreamsGroupDescribeTaskOffset
+        {
+            SubtopologyId = subtopologyId,
+            Partition = partition,
+            Offset = offset
+        };
+    }
+}
+
+/// <summary>
+/// Task assignment in a StreamsGroupDescribe response.
+/// </summary>
+public sealed class StreamsGroupDescribeAssignment
+{
+    public required IReadOnlyList<StreamsGroupDescribeTaskIds> ActiveTasks { get; init; }
+    public required IReadOnlyList<StreamsGroupDescribeTaskIds> StandbyTasks { get; init; }
+    public required IReadOnlyList<StreamsGroupDescribeTaskIds> WarmupTasks { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactArray(
+            ActiveTasks,
+            static (ref KafkaProtocolWriter w, StreamsGroupDescribeTaskIds tasks) => tasks.Write(ref w));
+        writer.WriteCompactArray(
+            StandbyTasks,
+            static (ref KafkaProtocolWriter w, StreamsGroupDescribeTaskIds tasks) => tasks.Write(ref w));
+        writer.WriteCompactArray(
+            WarmupTasks,
+            static (ref KafkaProtocolWriter w, StreamsGroupDescribeTaskIds tasks) => tasks.Write(ref w));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static StreamsGroupDescribeAssignment Read(ref KafkaProtocolReader reader)
+    {
+        var activeTasks = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskIds.Read(ref r));
+        var standbyTasks = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskIds.Read(ref r));
+        var warmupTasks = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskIds.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new StreamsGroupDescribeAssignment
+        {
+            ActiveTasks = activeTasks,
+            StandbyTasks = standbyTasks,
+            WarmupTasks = warmupTasks
+        };
+    }
+}
+
+/// <summary>
+/// Task IDs by subtopology in a StreamsGroupDescribe response.
+/// </summary>
+public sealed class StreamsGroupDescribeTaskIds
+{
+    public required string SubtopologyId { get; init; }
+    public required IReadOnlyList<int> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(SubtopologyId);
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, int partition) => w.WriteInt32(partition));
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static StreamsGroupDescribeTaskIds Read(ref KafkaProtocolReader reader)
+    {
+        var subtopologyId = reader.ReadCompactString() ?? string.Empty;
+        var partitions = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
+
+        reader.SkipTaggedFields();
+
+        return new StreamsGroupDescribeTaskIds
+        {
+            SubtopologyId = subtopologyId,
+            Partitions = partitions
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientStreamsGroupTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientStreamsGroupTests.cs
@@ -1,0 +1,288 @@
+using Dekaf.Admin;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public sealed class AdminClientStreamsGroupTests
+{
+    [Test]
+    public async Task ListStreamsGroupsAsync_FiltersByStreamsTypeAndDeduplicates()
+    {
+        var (admin, connections) = CreateAdminWithMockConnections();
+
+        connections[1].SendAsync<ListGroupsRequest, ListGroupsResponse>(
+                Arg.Any<ListGroupsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ListGroupsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Groups =
+                [
+                    Group("streams-a", "Streams", "Stable"),
+                    Group("share-a", "Share", "Stable")
+                ]
+            }));
+
+        connections[2].SendAsync<ListGroupsRequest, ListGroupsResponse>(
+                Arg.Any<ListGroupsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ListGroupsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Groups =
+                [
+                    Group("streams-a", "Streams", "Stable"),
+                    Group("streams-b", "Streams", "Empty")
+                ]
+            }));
+
+        var result = await admin.ListStreamsGroupsAsync(new ListStreamsGroupsOptions
+        {
+            States = ["Stable"]
+        });
+
+        await Assert.That(result.Select(g => g.GroupId)).IsEquivalentTo(["streams-a", "streams-b"]);
+        await connections[1].Received(1).SendAsync<ListGroupsRequest, ListGroupsResponse>(
+            Arg.Is<ListGroupsRequest>(r =>
+                r.StatesFilter!.Count == 1 &&
+                r.StatesFilter[0] == "Stable" &&
+                r.TypesFilter!.Count == 1 &&
+                r.TypesFilter[0] == "streams"),
+            5,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DescribeStreamsGroupsAsync_UsesStreamsDescribeAndMapsResults()
+    {
+        var (admin, connections) = CreateAdminWithMockConnections();
+        var connection = connections[1];
+
+        connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<FindCoordinatorRequest>();
+                return ValueTask.FromResult(new FindCoordinatorResponse
+                {
+                    Coordinators =
+                    [
+                        new Coordinator
+                        {
+                            Key = request.Key,
+                            NodeId = 1,
+                            Host = "localhost",
+                            Port = 9092,
+                            ErrorCode = ErrorCode.None
+                        }
+                    ]
+                });
+            });
+
+        connection.SendAsync<StreamsGroupDescribeRequest, StreamsGroupDescribeResponse>(
+                Arg.Any<StreamsGroupDescribeRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<StreamsGroupDescribeRequest>();
+                return ValueTask.FromResult(new StreamsGroupDescribeResponse
+                {
+                    Groups = request.GroupIds.Select(static groupId => new StreamsGroupDescribeGroup
+                    {
+                        ErrorCode = ErrorCode.None,
+                        GroupId = groupId,
+                        GroupState = "Stable",
+                        GroupEpoch = 7,
+                        AssignmentEpoch = 6,
+                        AuthorizedOperations = 123,
+                        Topology = new StreamsGroupDescribeTopology
+                        {
+                            Epoch = 5,
+                            Subtopologies =
+                            [
+                                new StreamsGroupDescribeSubtopology
+                                {
+                                    SubtopologyId = "0",
+                                    SourceTopics = ["input-a"],
+                                    RepartitionSinkTopics = ["app-repartition"],
+                                    StateChangelogTopics =
+                                    [
+                                        TopicInfo("app-store-changelog")
+                                    ],
+                                    RepartitionSourceTopics =
+                                    [
+                                        TopicInfo("app-repartition")
+                                    ]
+                                }
+                            ]
+                        },
+                        Members =
+                        [
+                            new StreamsGroupDescribeMember
+                            {
+                                MemberId = "member-a",
+                                MemberEpoch = 4,
+                                InstanceId = "instance-a",
+                                RackId = "rack-a",
+                                ClientId = "client-a",
+                                ClientHost = "/10.0.0.1",
+                                TopologyEpoch = 5,
+                                ProcessId = "process-a",
+                                UserEndpoint = new StreamsGroupDescribeEndpoint
+                                {
+                                    Host = "host-a",
+                                    Port = 7070
+                                },
+                                ClientTags =
+                                [
+                                    new StreamsGroupDescribeKeyValue { Key = "zone", Value = "a" }
+                                ],
+                                TaskOffsets =
+                                [
+                                    new StreamsGroupDescribeTaskOffset
+                                    {
+                                        SubtopologyId = "0",
+                                        Partition = 1,
+                                        Offset = 42
+                                    }
+                                ],
+                                TaskEndOffsets =
+                                [
+                                    new StreamsGroupDescribeTaskOffset
+                                    {
+                                        SubtopologyId = "0",
+                                        Partition = 1,
+                                        Offset = 50
+                                    }
+                                ],
+                                Assignment = Assignment("0", [1, 2]),
+                                TargetAssignment = Assignment("0", [1, 2, 3]),
+                                IsClassic = false
+                            }
+                        ]
+                    }).ToList()
+                });
+            });
+
+        var descriptions = await admin.DescribeStreamsGroupsAsync(["streams-a"]);
+        var description = descriptions["streams-a"];
+        var member = description.Members[0];
+
+        await Assert.That(description.GroupEpoch).IsEqualTo(7);
+        await Assert.That(description.Topology!.Subtopologies![0].StateChangelogTopics[0].TopicConfigs[0].Value).IsEqualTo("compact");
+        await Assert.That(member.ProcessId).IsEqualTo("process-a");
+        await Assert.That(member.UserEndpoint!.Port).IsEqualTo(7070);
+        await Assert.That(member.TargetAssignment.ActiveTasks[0].Partitions).IsEquivalentTo([1, 2, 3]);
+        await connection.Received(1).SendAsync<StreamsGroupDescribeRequest, StreamsGroupDescribeResponse>(
+            Arg.Is<StreamsGroupDescribeRequest>(r =>
+                r.IncludeAuthorizedOperations &&
+                r.GroupIds.Count == 1 &&
+                r.GroupIds[0] == "streams-a"),
+            0,
+            Arg.Any<CancellationToken>());
+    }
+
+    private static ListGroupsResponseGroup Group(string groupId, string groupType, string state) => new()
+    {
+        GroupId = groupId,
+        GroupType = groupType,
+        GroupState = state,
+        ProtocolType = "streams"
+    };
+
+    private static StreamsGroupDescribeTopicInfo TopicInfo(string name) => new()
+    {
+        Name = name,
+        Partitions = 2,
+        ReplicationFactor = 3,
+        TopicConfigs =
+        [
+            new StreamsGroupDescribeKeyValue
+            {
+                Key = "cleanup.policy",
+                Value = "compact"
+            }
+        ]
+    };
+
+    private static StreamsGroupDescribeAssignment Assignment(string subtopologyId, IReadOnlyList<int> partitions) => new()
+    {
+        ActiveTasks =
+        [
+            new StreamsGroupDescribeTaskIds
+            {
+                SubtopologyId = subtopologyId,
+                Partitions = partitions
+            }
+        ],
+        StandbyTasks = [],
+        WarmupTasks = []
+    };
+
+    private static (AdminClient Admin, IReadOnlyDictionary<int, IKafkaConnection> Connections) CreateAdminWithMockConnections()
+    {
+        var connections = new Dictionary<int, IKafkaConnection>
+        {
+            [1] = CreateConnection(1),
+            [2] = CreateConnection(2)
+        };
+
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => ValueTask.FromResult(connections[callInfo.ArgAt<int>(0)]));
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connections[1]));
+
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata
+                {
+                    NodeId = 1,
+                    Host = "localhost",
+                    Port = 9092
+                },
+                new BrokerMetadata
+                {
+                    NodeId = 2,
+                    Host = "localhost",
+                    Port = 9093
+                }
+            ],
+            ClusterId = "test-cluster",
+            ControllerId = 1,
+            Topics = []
+        });
+        metadataManager.SetApiVersion(ApiKey.FindCoordinator, 4, 5);
+        metadataManager.SetApiVersion(ApiKey.ListGroups, 5, 5);
+        metadataManager.SetApiVersion(ApiKey.StreamsGroupDescribe, 0, 0);
+
+        var admin = new AdminClient(
+            new AdminClientOptions { BootstrapServers = ["localhost:9092"] },
+            pool,
+            metadataManager);
+
+        return (admin, connections);
+    }
+
+    private static IKafkaConnection CreateConnection(int brokerId)
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.BrokerId.Returns(brokerId);
+        connection.Host.Returns("localhost");
+        connection.Port.Returns(9091 + brokerId);
+        connection.IsConnected.Returns(true);
+        return connection;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/StreamsGroupDescribeMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/StreamsGroupDescribeMessageTests.cs
@@ -1,0 +1,247 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class StreamsGroupDescribeMessageTests
+{
+    [Test]
+    public async Task Request_Metadata_UsesStreamsGroupDescribeV0()
+    {
+        await Assert.That(StreamsGroupDescribeRequest.ApiKey).IsEqualTo(ApiKey.StreamsGroupDescribe);
+        await Assert.That(StreamsGroupDescribeRequest.LowestSupportedVersion).IsEqualTo((short)0);
+        await Assert.That(StreamsGroupDescribeRequest.HighestSupportedVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task Request_Write_EncodesGroupsAndAuthorizedOperations()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new StreamsGroupDescribeRequest
+        {
+            GroupIds = ["streams-a", "streams-b"],
+            IncludeAuthorizedOperations = true
+        };
+
+        request.Write(ref writer, version: 0);
+
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(0);
+        await Assert.That(buffer.WrittenSpan[^2]).IsEqualTo((byte)1);
+        await Assert.That(buffer.WrittenSpan[^1]).IsEqualTo((byte)0);
+    }
+
+    [Test]
+    public async Task Response_WriteAndRead_WithTopologyAndMember_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new StreamsGroupDescribeResponse
+        {
+            ThrottleTimeMs = 10,
+            Groups =
+            [
+                new StreamsGroupDescribeGroup
+                {
+                    ErrorCode = ErrorCode.None,
+                    GroupId = "streams-a",
+                    GroupState = "Stable",
+                    GroupEpoch = 7,
+                    AssignmentEpoch = 6,
+                    AuthorizedOperations = 123,
+                    Topology = new StreamsGroupDescribeTopology
+                    {
+                        Epoch = 5,
+                        Subtopologies =
+                        [
+                            new StreamsGroupDescribeSubtopology
+                            {
+                                SubtopologyId = "0",
+                                SourceTopics = ["input-a"],
+                                RepartitionSinkTopics = ["streams-a-repartition"],
+                                StateChangelogTopics =
+                                [
+                                    TopicInfo("streams-a-store-changelog")
+                                ],
+                                RepartitionSourceTopics =
+                                [
+                                    TopicInfo("streams-a-repartition")
+                                ]
+                            }
+                        ]
+                    },
+                    Members =
+                    [
+                        new StreamsGroupDescribeMember
+                        {
+                            MemberId = "member-a",
+                            MemberEpoch = 4,
+                            InstanceId = "instance-a",
+                            RackId = "rack-a",
+                            ClientId = "client-a",
+                            ClientHost = "/10.0.0.1",
+                            TopologyEpoch = 5,
+                            ProcessId = "process-a",
+                            UserEndpoint = new StreamsGroupDescribeEndpoint
+                            {
+                                Host = "host-a",
+                                Port = 7070
+                            },
+                            ClientTags =
+                            [
+                                new StreamsGroupDescribeKeyValue { Key = "zone", Value = "a" }
+                            ],
+                            TaskOffsets =
+                            [
+                                new StreamsGroupDescribeTaskOffset
+                                {
+                                    SubtopologyId = "0",
+                                    Partition = 1,
+                                    Offset = 42
+                                }
+                            ],
+                            TaskEndOffsets =
+                            [
+                                new StreamsGroupDescribeTaskOffset
+                                {
+                                    SubtopologyId = "0",
+                                    Partition = 1,
+                                    Offset = 50
+                                }
+                            ],
+                            Assignment = Assignment("0", [1, 2]),
+                            TargetAssignment = Assignment("0", [1, 2, 3]),
+                            IsClassic = false
+                        }
+                    ]
+                }
+            ]
+        };
+
+        original.Write(ref writer, version: 0);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (StreamsGroupDescribeResponse)StreamsGroupDescribeResponse.Read(ref reader, version: 0);
+        var group = response.Groups[0];
+        var topology = group.Topology!;
+        var member = group.Members[0];
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(10);
+        await Assert.That(group.GroupId).IsEqualTo("streams-a");
+        await Assert.That(group.GroupEpoch).IsEqualTo(7);
+        await Assert.That(group.AuthorizedOperations).IsEqualTo(123);
+        await Assert.That(topology.Epoch).IsEqualTo(5);
+        await Assert.That(topology.Subtopologies![0].StateChangelogTopics[0].TopicConfigs[0].Key).IsEqualTo("cleanup.policy");
+        await Assert.That(member.MemberId).IsEqualTo("member-a");
+        await Assert.That(member.UserEndpoint!.Host).IsEqualTo("host-a");
+        await Assert.That(member.TaskOffsets[0].Offset).IsEqualTo(42);
+        await Assert.That(member.TargetAssignment.ActiveTasks[0].Partitions).IsEquivalentTo([1, 2, 3]);
+    }
+
+    [Test]
+    public async Task Response_WriteAndRead_NullTopologyAndEndpoint_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var original = new StreamsGroupDescribeGroup
+        {
+            ErrorCode = ErrorCode.GroupIdNotFound,
+            ErrorMessage = "missing",
+            GroupId = "streams-missing",
+            GroupState = "",
+            GroupEpoch = -1,
+            AssignmentEpoch = -1,
+            Topology = null,
+            Members =
+            [
+                new StreamsGroupDescribeMember
+                {
+                    MemberId = "member-a",
+                    MemberEpoch = 1,
+                    ClientId = "client-a",
+                    ClientHost = "/10.0.0.1",
+                    TopologyEpoch = 1,
+                    ProcessId = "process-a",
+                    UserEndpoint = null,
+                    ClientTags = [],
+                    TaskOffsets = [],
+                    TaskEndOffsets = [],
+                    Assignment = EmptyAssignment(),
+                    TargetAssignment = EmptyAssignment(),
+                    IsClassic = true
+                }
+            ]
+        };
+
+        original.Write(ref writer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var deserialized = StreamsGroupDescribeGroup.Read(ref reader);
+
+        await Assert.That(deserialized.ErrorCode).IsEqualTo(ErrorCode.GroupIdNotFound);
+        await Assert.That(deserialized.ErrorMessage).IsEqualTo("missing");
+        await Assert.That(deserialized.Topology).IsNull();
+        await Assert.That(deserialized.Members[0].UserEndpoint).IsNull();
+        await Assert.That(deserialized.Members[0].IsClassic).IsTrue();
+    }
+
+    [Test]
+    public async Task Topology_WriteAndRead_NullSubtopologies_RoundTrips()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        StreamsGroupDescribeTopology.WriteNullable(ref writer, new StreamsGroupDescribeTopology
+        {
+            Epoch = 3,
+            Subtopologies = null
+        });
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var topology = StreamsGroupDescribeTopology.ReadNullable(ref reader);
+
+        await Assert.That(topology).IsNotNull();
+        await Assert.That(topology!.Epoch).IsEqualTo(3);
+        await Assert.That(topology.Subtopologies).IsNull();
+    }
+
+    private static StreamsGroupDescribeTopicInfo TopicInfo(string name) => new()
+    {
+        Name = name,
+        Partitions = 2,
+        ReplicationFactor = 3,
+        TopicConfigs =
+        [
+            new StreamsGroupDescribeKeyValue
+            {
+                Key = "cleanup.policy",
+                Value = "compact"
+            }
+        ]
+    };
+
+    private static StreamsGroupDescribeAssignment Assignment(string subtopologyId, IReadOnlyList<int> partitions) => new()
+    {
+        ActiveTasks =
+        [
+            new StreamsGroupDescribeTaskIds
+            {
+                SubtopologyId = subtopologyId,
+                Partitions = partitions
+            }
+        ],
+        StandbyTasks = [],
+        WarmupTasks = []
+    };
+
+    private static StreamsGroupDescribeAssignment EmptyAssignment() => new()
+    {
+        ActiveTasks = [],
+        StandbyTasks = [],
+        WarmupTasks = []
+    };
+}


### PR DESCRIPTION
## Summary
- add `DescribeStreamsGroupsAsync` and `ListStreamsGroupsAsync` admin APIs
- add StreamsGroupDescribe v0 request/response protocol models with topology, member, endpoint, task offset, and assignment structures
- expose streams group admin result types and in-memory admin stubs

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- [x] focused TUnit runs for new streams group admin/protocol tests
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build --` (4227/4227)

Closes #1390
