### PR TITLE
perf(avro): avoid payload copies

### DIFF
--- a/src/Dekaf.SchemaRegistry.Avro/AvroCodecCache.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroCodecCache.cs
@@ -37,12 +37,17 @@ internal sealed class AvroSerializationThreadState
 {
     internal AvroSerializationThreadState()
     {
-        Stream = new PooledMemoryStream([]);
-        Encoder = new BinaryEncoder(Stream);
+        BufferedStream = new PooledMemoryStream([]);
+        BufferedEncoder = new BinaryEncoder(BufferedStream);
+        DirectStream = new FixedMemoryStream();
+        DirectEncoder = new BinaryEncoder(DirectStream);
     }
 
-    internal PooledMemoryStream Stream { get; }
-    internal BinaryEncoder Encoder { get; }
+    internal PooledMemoryStream BufferedStream { get; }
+    internal BinaryEncoder BufferedEncoder { get; }
+    internal FixedMemoryStream DirectStream { get; }
+    internal BinaryEncoder DirectEncoder { get; }
+    internal int PayloadSizeHint { get; set; } = 1024;
 }
 
 internal sealed class AvroDeserializationThreadState

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistryDeserializer.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using Avro.Generic;
 using Avro.IO;
 using Avro.Specific;
@@ -114,7 +115,7 @@ public sealed class AvroSchemaRegistryDeserializer<
         // Get writer schema from registry (cached with lazy initialization)
         var writerSchema = GetWriterSchemaCached(schemaId);
 
-        // Extract Avro payload using pooled buffer to avoid allocation
+        // Extract Avro payload. Array-backed payloads decode in place; other memory falls back to a pooled copy.
         var payloadMemory = data.Slice(5);
         if (_config.RuleExecutor is not null)
         {
@@ -131,15 +132,35 @@ public sealed class AvroSchemaRegistryDeserializer<
                 });
         }
 
-        var payload = payloadMemory.Span;
         var codecState = AvroCodecThreadStateCache.Deserialization ??= new AvroDeserializationThreadState();
-        var memoryStream = codecState.Stream;
-        var rentedBuffer = ArrayPool<byte>.Shared.Rent(payload.Length);
+        return ReadAvroPayload(payloadMemory, writerSchema, codecState);
+    }
 
+    private T ReadAvroPayload(
+        ReadOnlyMemory<byte> payloadMemory,
+        AvroSchema writerSchema,
+        AvroDeserializationThreadState codecState)
+    {
+        var memoryStream = codecState.Stream;
+
+        if (MemoryMarshal.TryGetArray(payloadMemory, out var segment) && segment.Array is not null)
+        {
+            memoryStream.Reset(segment.Array, segment.Offset, segment.Count);
+            try
+            {
+                return ReadAvroValue(writerSchema, codecState.Decoder);
+            }
+            finally
+            {
+                memoryStream.DetachBuffer();
+            }
+        }
+
+        var payload = payloadMemory.Span;
+        var rentedBuffer = ArrayPool<byte>.Shared.Rent(payload.Length);
         try
         {
             payload.CopyTo(rentedBuffer);
-
             memoryStream.Reset(rentedBuffer, payload.Length);
 
             return ReadAvroValue(writerSchema, codecState.Decoder);

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -38,6 +38,9 @@ public sealed class AvroSchemaRegistrySerializer<
     : ISerializer<T>, IAsyncDisposable
 {
     private const byte MagicByte = 0x00;
+    private const int WireHeaderSize = 5;
+    private const int InitialAvroPayloadBufferSize = 1024;
+    private const int MaxRetainedAvroPayloadBufferSize = 1024 * 1024;
     private static readonly TimeSpan SchemaRegistryTimeout = TimeSpan.FromSeconds(30);
 
     private readonly ISchemaRegistryClient _schemaRegistry;
@@ -115,37 +118,95 @@ public sealed class AvroSchemaRegistrySerializer<
         var schemaId = schemaEntry.SchemaId;
 
         var codecState = AvroCodecThreadStateCache.Serialization ??= new AvroSerializationThreadState();
-        var memoryStream = codecState.Stream;
-        var rentedBuffer = ArrayPool<byte>.Shared.Rent(1024);
+        if (_config.RuleExecutor is null)
+        {
+            SerializeDirect(value, ref destination, schemaId, codecState);
+            return;
+        }
+
+        SerializeWithRuleExecutor(value, ref destination, context, schemaEntry, schemaId, codecState);
+    }
+
+    private void SerializeDirect<TWriter>(
+        T value,
+        ref TWriter destination,
+        int schemaId,
+        AvroSerializationThreadState codecState)
+        where TWriter : IBufferWriter<byte>, allows ref struct
+    {
+        var payloadSizeHint = codecState.PayloadSizeHint;
+
+        while (true)
+        {
+            var memory = destination.GetMemory(WireHeaderSize + payloadSizeHint);
+            var stream = codecState.DirectStream;
+            stream.Reset(memory.Slice(WireHeaderSize));
+
+            try
+            {
+                WriteAvroValue(value, codecState.DirectEncoder);
+                codecState.DirectEncoder.Flush();
+
+                var payloadLength = stream.WrittenCount;
+                var span = memory.Span;
+                span[0] = MagicByte;
+                BinaryPrimitives.WriteInt32BigEndian(span.Slice(1, 4), schemaId);
+
+                destination.Advance(WireHeaderSize + payloadLength);
+                codecState.PayloadSizeHint = payloadLength > MaxRetainedAvroPayloadBufferSize
+                    ? InitialAvroPayloadBufferSize
+                    : Math.Max(InitialAvroPayloadBufferSize, payloadLength);
+                stream.Reset(default);
+                return;
+            }
+            catch (FixedMemoryStreamOverflowException ex)
+            {
+                stream.Reset(default);
+                payloadSizeHint = GrowPayloadSizeHint(payloadSizeHint, ex.RequiredCapacity);
+            }
+            catch
+            {
+                stream.Reset(default);
+                throw;
+            }
+        }
+    }
+
+    private void SerializeWithRuleExecutor<TWriter>(
+        T value,
+        ref TWriter destination,
+        SerializationContext context,
+        SubjectSchemaIdCache.SubjectSchemaIdCacheEntry schemaEntry,
+        int schemaId,
+        AvroSerializationThreadState codecState)
+        where TWriter : IBufferWriter<byte>, allows ref struct
+    {
+        var memoryStream = codecState.BufferedStream;
+        memoryStream.ResetForWriting(InitialAvroPayloadBufferSize);
 
         try
         {
-            // Initial estimate: 1KB should handle most messages; the stream grows if needed.
-            memoryStream.Reset(rentedBuffer);
-            var encoder = codecState.Encoder;
+            var encoder = codecState.BufferedEncoder;
 
             WriteAvroValue(value, encoder);
             encoder.Flush();
 
             var avroPayloadLength = (int)memoryStream.Position;
             var payload = new ReadOnlyMemory<byte>(memoryStream.GetBuffer(), 0, avroPayloadLength);
-            if (_config.RuleExecutor is not null)
-            {
-                payload = _config.RuleExecutor.TransformSerializedPayload(
-                    payload,
-                    new SchemaRegistryRuleContext
-                    {
-                        Topic = context.Topic,
-                        Component = context.Component,
-                        SchemaId = schemaId,
-                        Subject = schemaEntry.Subject,
-                        Schema = schemaEntry.Schema,
-                        PayloadFormat = SchemaRegistryPayloadFormat.Avro
-                    });
-            }
+            payload = _config.RuleExecutor!.TransformSerializedPayload(
+                payload,
+                new SchemaRegistryRuleContext
+                {
+                    Topic = context.Topic,
+                    Component = context.Component,
+                    SchemaId = schemaId,
+                    Subject = schemaEntry.Subject,
+                    Schema = schemaEntry.Schema,
+                    PayloadFormat = SchemaRegistryPayloadFormat.Avro
+                });
 
             // Write wire format: [0x00] [schema ID] [Avro payload]
-            var totalSize = 1 + 4 + payload.Length;
+            var totalSize = WireHeaderSize + payload.Length;
             var span = destination.GetSpan(totalSize);
 
             span[0] = MagicByte;
@@ -156,9 +217,19 @@ public sealed class AvroSchemaRegistrySerializer<
         }
         finally
         {
-            memoryStream.DetachBuffer();
-            ArrayPool<byte>.Shared.Return(rentedBuffer);
+            if (memoryStream.Capacity > MaxRetainedAvroPayloadBufferSize)
+                memoryStream.DetachBuffer();
         }
+    }
+
+    private static int GrowPayloadSizeHint(int currentHint, int requiredCapacity)
+    {
+        var maxPayloadSize = Array.MaxLength - WireHeaderSize;
+        if (requiredCapacity > maxPayloadSize)
+            throw new NotSupportedException($"Avro payloads larger than {maxPayloadSize} bytes are not supported.");
+
+        var nextHint = Math.Max((long)currentHint * 2, requiredCapacity);
+        return (int)Math.Min(nextHint, maxPayloadSize);
     }
 
     private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry GetSchemaForContext(string topic, bool isKey, T value)

--- a/src/Dekaf.SchemaRegistry.Avro/FixedMemoryStream.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/FixedMemoryStream.cs
@@ -1,0 +1,62 @@
+namespace Dekaf.SchemaRegistry.Avro;
+
+internal sealed class FixedMemoryStream : Stream
+{
+    private Memory<byte> _memory;
+    private int _position;
+
+    public int WrittenCount => _position;
+
+    public void Reset(Memory<byte> memory)
+    {
+        _memory = memory;
+        _position = 0;
+    }
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Length => _position;
+
+    public override long Position
+    {
+        get => _position;
+        set => throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        var newPosition = _position + count;
+        if (newPosition > _memory.Length)
+            throw new FixedMemoryStreamOverflowException(newPosition);
+
+        buffer.AsSpan(offset, count).CopyTo(_memory.Span.Slice(_position));
+        _position = newPosition;
+    }
+
+    public override void WriteByte(byte value)
+    {
+        var newPosition = _position + 1;
+        if (newPosition > _memory.Length)
+            throw new FixedMemoryStreamOverflowException(newPosition);
+
+        _memory.Span[_position] = value;
+        _position = newPosition;
+    }
+
+    public override void Flush() { }
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException();
+
+    public override long Seek(long offset, SeekOrigin origin) =>
+        throw new NotSupportedException();
+
+    public override void SetLength(long value) =>
+        throw new NotSupportedException();
+}
+
+internal sealed class FixedMemoryStreamOverflowException(int requiredCapacity) : Exception
+{
+    public int RequiredCapacity { get; } = requiredCapacity;
+}

--- a/src/Dekaf.SchemaRegistry.Avro/PooledMemoryStream.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/PooledMemoryStream.cs
@@ -11,6 +11,7 @@ internal sealed class PooledMemoryStream : Stream
     private static readonly byte[] EmptyBuffer = [];
 
     private byte[] _buffer;
+    private int _origin;
     private int _position;
     private int _length;
     private bool _disposed;
@@ -39,17 +40,41 @@ internal sealed class PooledMemoryStream : Stream
 
     public void Reset(byte[] buffer, int length = 0)
     {
+        Reset(buffer, offset: 0, length);
+    }
+
+    public void Reset(byte[] buffer, int offset, int length)
+    {
         ArgumentNullException.ThrowIfNull(buffer);
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
         ArgumentOutOfRangeException.ThrowIfNegative(length);
-        if (length > buffer.Length)
-            throw new ArgumentOutOfRangeException(nameof(length), "Length cannot exceed buffer length.");
+        if (offset > buffer.Length || length > buffer.Length - offset)
+            throw new ArgumentOutOfRangeException(nameof(length), "Offset and length must describe a valid range in the buffer.");
 
         ReleaseOwnedBuffer();
 
         _buffer = buffer;
+        _origin = offset;
         _position = 0;
         _length = length;
         _ownsBuffer = false; // Caller owns the supplied buffer
+        _disposed = false;
+    }
+
+    public void ResetForWriting(int minimumCapacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(minimumCapacity);
+
+        if (!_ownsBuffer || _buffer.Length < minimumCapacity)
+        {
+            ReleaseOwnedBuffer();
+            _buffer = ArrayPool<byte>.Shared.Rent(minimumCapacity);
+            _ownsBuffer = true;
+        }
+
+        _origin = 0;
+        _position = 0;
+        _length = 0;
         _disposed = false;
     }
 
@@ -58,6 +83,7 @@ internal sealed class PooledMemoryStream : Stream
         ReleaseOwnedBuffer();
 
         _buffer = EmptyBuffer;
+        _origin = 0;
         _position = 0;
         _length = 0;
         _ownsBuffer = false;
@@ -79,9 +105,11 @@ internal sealed class PooledMemoryStream : Stream
     }
 
     /// <summary>
-    /// Gets the underlying buffer. Only valid bytes are from 0 to Position.
+    /// Gets the underlying buffer. For write-mode streams, valid bytes are from 0 to Position.
     /// </summary>
     public byte[] GetBuffer() => _buffer;
+
+    public int Capacity => _buffer.Length - _origin;
 
     public override void Write(byte[] buffer, int offset, int count)
     {
@@ -92,7 +120,7 @@ internal sealed class PooledMemoryStream : Stream
             throw new NotSupportedException($"PooledMemoryStream does not support streams larger than {Array.MaxLength} bytes.");
 
         EnsureCapacity((int)newPosition);
-        Buffer.BlockCopy(buffer, offset, _buffer, _position, count);
+        Buffer.BlockCopy(buffer, offset, _buffer, _origin + _position, count);
         _position += count;
         if (_position > _length)
             _length = _position;
@@ -106,7 +134,7 @@ internal sealed class PooledMemoryStream : Stream
             throw new NotSupportedException($"PooledMemoryStream does not support streams larger than {Array.MaxLength} bytes.");
 
         EnsureCapacity(_position + 1);
-        _buffer[_position++] = value;
+        _buffer[_origin + _position++] = value;
         if (_position > _length)
             _length = _position;
     }
@@ -122,7 +150,7 @@ internal sealed class PooledMemoryStream : Stream
         if (count > available)
             count = available;
 
-        Buffer.BlockCopy(_buffer, _position, buffer, offset, count);
+        Buffer.BlockCopy(_buffer, _origin + _position, buffer, offset, count);
         _position += count;
         return count;
     }
@@ -136,7 +164,7 @@ internal sealed class PooledMemoryStream : Stream
             return 0;
 
         var count = Math.Min(buffer.Length, available);
-        _buffer.AsSpan(_position, count).CopyTo(buffer);
+        _buffer.AsSpan(_origin + _position, count).CopyTo(buffer);
         _position += count;
         return count;
     }
@@ -148,7 +176,7 @@ internal sealed class PooledMemoryStream : Stream
         if (_position >= _length)
             return -1;
 
-        return _buffer[_position++];
+        return _buffer[_origin + _position++];
     }
 
     public override long Seek(long offset, SeekOrigin origin)
@@ -187,20 +215,20 @@ internal sealed class PooledMemoryStream : Stream
 
     private void EnsureCapacity(int requiredCapacity)
     {
-        if (requiredCapacity <= _buffer.Length)
+        if (_origin + requiredCapacity <= _buffer.Length)
             return;
 
         // Grow the buffer by at least doubling, but at least to the required capacity.
         // Widen to long to detect overflow and cap at Array.MaxLength.
-        var doubled = Math.Min((long)_buffer.Length * 2, Array.MaxLength);
+        var doubled = Math.Min((long)Capacity * 2, Array.MaxLength);
         var newCapacity = (int)Math.Max(doubled, requiredCapacity);
 
-        if (newCapacity <= _buffer.Length)
+        if (newCapacity <= Capacity)
             throw new InvalidOperationException("Cannot grow buffer: maximum size reached.");
 
         var newBuffer = ArrayPool<byte>.Shared.Rent(newCapacity);
 
-        Buffer.BlockCopy(_buffer, 0, newBuffer, 0, _length);
+        Buffer.BlockCopy(_buffer, _origin, newBuffer, 0, _length);
 
         // Return the old buffer if we own it (we grew it)
         if (_ownsBuffer)
@@ -210,6 +238,7 @@ internal sealed class PooledMemoryStream : Stream
         }
 
         _buffer = newBuffer;
+        _origin = 0;
         _ownsBuffer = true; // We now own this buffer
     }
 
@@ -234,6 +263,7 @@ internal sealed class PooledMemoryStream : Stream
         }
 
         _buffer = EmptyBuffer;
+        _origin = 0;
         _disposed = true;
         base.Dispose(disposing);
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -171,6 +171,36 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Deserializer_DeserializesGenericRecord_FromSlicedWireMemory()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        var schemaObj = new RegistrySchema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = SimpleRecordSchema
+        };
+        var schemaId = await schemaRegistry.RegisterSchemaAsync("test-topic-value", schemaObj);
+
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(schemaRegistry);
+        await deserializer.WarmupAsync(schemaId);
+
+        var avroSchema = AvroSchema.Parse(SimpleRecordSchema) as Avro.RecordSchema;
+        var record = new GenericRecord(avroSchema!);
+        record.Add("id", 64);
+        record.Add("name", "offset");
+
+        var wireFormat = CreateWireFormat(schemaId, SerializeAvroRecord(record, avroSchema!));
+        var offset = 7;
+        var backing = new byte[offset + wireFormat.Length + 3];
+        wireFormat.CopyTo(backing.AsSpan(offset));
+
+        var result = deserializer.Deserialize(backing.AsMemory(offset, wireFormat.Length), CreateContext());
+
+        await Assert.That((int)result["id"]!).IsEqualTo(64);
+        await Assert.That((string)result["name"]!).IsEqualTo("offset");
+    }
+
+    [Test]
     public async Task Deserializer_RuleExecutor_TransformsAvroPayload()
     {
         using var schemaRegistry = new MockSchemaRegistryClient();
@@ -224,6 +254,28 @@ public sealed class AvroSerializerTests
         // Assert
         await Assert.That((int)result["id"]!).IsEqualTo(123);
         await Assert.That((string)result["name"]!).IsEqualTo("round trip test");
+    }
+
+    [Test]
+    public async Task Serializer_RoundTrips_GenericRecord_LargerThanInitialBuffer()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        await using var deserializer = new AvroSchemaRegistryDeserializer<GenericRecord>(schemaRegistry);
+
+        var schema = AvroSchema.Parse(SimpleRecordSchema) as Avro.RecordSchema;
+        var record = new GenericRecord(schema!);
+        var name = new string('x', 5000);
+        record.Add("id", 321);
+        record.Add("name", name);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize(record, ref buffer, CreateContext());
+
+        var result = deserializer.Deserialize(buffer.WrittenMemory, CreateContext());
+
+        await Assert.That((int)result["id"]!).IsEqualTo(321);
+        await Assert.That((string)result["name"]!).IsEqualTo(name);
     }
 
     [Test]
@@ -484,6 +536,20 @@ public sealed class AvroSerializerTests
 
         await Assert.That(deserializer.CachedGenericReaderCount).IsEqualTo(1);
         await Assert.That(deserializer.CachedSpecificReaderCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task PooledMemoryStream_ResetWithOffset_ReadsOnlyRequestedRange()
+    {
+        var stream = new PooledMemoryStream([]);
+        var source = new byte[] { 9, 1, 2, 3, 8 };
+        var buffer = new byte[5];
+
+        stream.Reset(source, offset: 1, length: 3);
+        var count = stream.Read(buffer, 0, buffer.Length);
+
+        await Assert.That(count).IsEqualTo(3);
+        await Assert.That(buffer.AsSpan(0, count).ToArray()).IsEquivalentTo(new byte[] { 1, 2, 3 });
     }
 
     private static byte[] CreateWireFormat(int schemaId, byte[] avroPayload)


### PR DESCRIPTION
## Summary
- Write normal Avro serialization directly into destination memory with retry-on-grow sizing.
- Keep rule-executor serialization buffered because transform APIs need payload memory, but reuse the pooled stream buffer instead of renting every message.
- Decode array-backed Avro payload slices in place and fall back to a pooled copy only for non-array memory.

## Tests
- dotnet build src/Dekaf.SchemaRegistry.Avro/Dekaf.SchemaRegistry.Avro.csproj --configuration Release
- dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release
- dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress

Closes #1376