### PR TITLE
fix(consumer): serialize loop starts

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -681,6 +681,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     // Background prefetch support
     private readonly MpscFetchBuffer _prefetchBuffer;
+    private readonly object _prefetchStartLock = new();
     private CancellationTokenSource? _prefetchCts;
     private Task? _prefetchTask;
     private long _prefetchedBytes;
@@ -702,7 +703,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // Lock ordering (always acquire in this order to prevent deadlocks):
     //   1. _initLock          — guards one-time initialization; never held while acquiring other locks
     //   2. _assignmentLock    — serializes assignment changes between the consume loop and prefetch loop
-    //   3. _partitionCacheLock / _fetchCacheLock — guard per-broker partition cache and fetch request
+    //   3. _autoCommitStartLock / _prefetchStartLock — guard background loop start/stop snapshots;
+    //      never held while awaiting. When both are needed, acquire auto-commit before prefetch.
+    //   4. _partitionCacheLock / _fetchCacheLock — guard per-broker partition cache and fetch request
     //      cache respectively; acquired under _assignmentLock (via InvalidatePartitionCache /
     //      InvalidateFetchRequestCache) and independently; never nested with each other
     private readonly SemaphoreSlim _initLock = new(1, 1);
@@ -710,6 +713,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private readonly ConcurrentDictionary<CancellationTokenSource, byte> _activeConsumeCancellationSources = new();
     private readonly CancellationTokenSource _leaderRefreshCts = new();
+    private readonly object _autoCommitStartLock = new();
     private CancellationTokenSource? _autoCommitCts;
     private Task? _autoCommitTask;
     private int _fetchApiVersion = -1;
@@ -1853,11 +1857,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void StartPrefetch()
     {
-        if (_prefetchTask is not null)
+        if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
             return;
 
-        _prefetchCts = new CancellationTokenSource();
-        _prefetchTask = PrefetchLoopAsync(_prefetchCts.Token);
+        lock (_prefetchStartLock)
+        {
+            if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
+                return;
+
+            if (_prefetchTask is not null)
+                return;
+
+            _prefetchCts = new CancellationTokenSource();
+            _prefetchTask = PrefetchLoopAsync(_prefetchCts.Token);
+        }
     }
 
     private Task PrefetchLoopAsync(CancellationToken cancellationToken)
@@ -5118,25 +5131,40 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private async Task StartAutoCommitAsync(CancellationToken cancellationToken)
     {
-        var currentTask = _autoCommitTask;
-        if (currentTask is { IsCompleted: false })
+        if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
             return;
 
-        if (currentTask is not null)
+        Task? oldTask;
+        CancellationTokenSource? oldCts;
+        lock (_autoCommitStartLock)
+        {
+            if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
+                return;
+
+            var currentTask = _autoCommitTask;
+            if (currentTask is { IsCompleted: false })
+                return;
+
+            oldTask = currentTask;
+            oldCts = _autoCommitCts;
+
+            _autoCommitCts = new CancellationTokenSource();
+            _autoCommitTask = AutoCommitLoopAsync(_autoCommitCts.Token);
+        }
+
+        if (oldTask is not null)
         {
             try
             {
-                await currentTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+                await oldTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
             }
             catch
             {
                 // Swallow — old task may have completed from cancellation or fault.
             }
-            _autoCommitCts?.Dispose();
         }
 
-        _autoCommitCts = new CancellationTokenSource();
-        _autoCommitTask = AutoCommitLoopAsync(_autoCommitCts.Token);
+        oldCts?.Dispose();
     }
 
     private async Task AutoCommitLoopAsync(CancellationToken cancellationToken)
@@ -5204,12 +5232,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // CommitAsync (which waits up to RequestTimeoutMs=30s for network I/O) would cause
         // CloseAsync to hang for the full network timeout, chaining across multiple consumers
         // during sequential `await using` disposal and exceeding test timeouts.
-        _autoCommitCts?.Cancel();
-        if (_autoCommitTask is not null)
+        Task? autoCommitTask;
+        CancellationTokenSource? autoCommitCts;
+        lock (_autoCommitStartLock)
+        {
+            autoCommitCts = _autoCommitCts;
+            autoCommitTask = _autoCommitTask;
+        }
+
+        autoCommitCts?.Cancel();
+        if (autoCommitTask is not null)
         {
             try
             {
-                await _autoCommitTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+                await autoCommitTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
             }
             catch
             {
@@ -5220,12 +5256,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Step 4: Stop prefetch task
         // Same rationale as Step 3: a mid-flight FetchAsync network operation could hang for
         // up to RequestTimeoutMs without the WaitAsync timeout bounding it.
-        _prefetchCts?.Cancel();
-        if (_prefetchTask is not null)
+        Task? prefetchTask;
+        CancellationTokenSource? prefetchCts;
+        lock (_prefetchStartLock)
+        {
+            prefetchCts = _prefetchCts;
+            prefetchTask = _prefetchTask;
+        }
+
+        prefetchCts?.Cancel();
+        if (prefetchTask is not null)
         {
             try
             {
-                await _prefetchTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+                await prefetchTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
             }
             catch
             {
@@ -5506,16 +5550,31 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         CancelActiveConsumeOperations();
         _leaderRefreshCts.Cancel();
-        _autoCommitCts?.Cancel();
-        _prefetchCts?.Cancel();
+        Task? autoCommitTask;
+        Task? prefetchTask;
+        CancellationTokenSource? autoCommitCts;
+        CancellationTokenSource? prefetchCts;
+        lock (_autoCommitStartLock)
+        {
+            autoCommitCts = _autoCommitCts;
+            autoCommitTask = _autoCommitTask;
+        }
+        lock (_prefetchStartLock)
+        {
+            prefetchCts = _prefetchCts;
+            prefetchTask = _prefetchTask;
+        }
+
+        autoCommitCts?.Cancel();
+        prefetchCts?.Cancel();
 
         await WaitForLeaderRefreshTasksAsync().ConfigureAwait(false);
 
-        if (_autoCommitTask is not null)
+        if (autoCommitTask is not null)
         {
             try
             {
-                await _autoCommitTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                await autoCommitTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
             }
             catch
             {
@@ -5523,11 +5582,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
         }
 
-        if (_prefetchTask is not null)
+        if (prefetchTask is not null)
         {
             try
             {
-                await _prefetchTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                await prefetchTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
             }
             catch
             {
@@ -5535,8 +5594,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
         }
 
-        _autoCommitCts?.Dispose();
-        _prefetchCts?.Dispose();
+        autoCommitCts?.Dispose();
+        prefetchCts?.Dispose();
         _leaderRefreshCts.Dispose();
 
         // Clear and dispose CancellationTokenSource pool

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerBackgroundLoopStartTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerBackgroundLoopStartTests.cs
@@ -1,0 +1,100 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerBackgroundLoopStartTests
+{
+    [Test]
+    public async Task StartAutoCommitAsync_ConcurrentCalls_InstallSingleLoop()
+    {
+        await using var consumer = CreateConsumer();
+        var consumerType = typeof(KafkaConsumer<string, string>);
+        var startAutoCommit = consumerType.GetMethod(
+            "StartAutoCommitAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var taskField = consumerType.GetField(
+            "_autoCommitTask",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var ctsField = consumerType.GetField(
+            "_autoCommitCts",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        var seenTasks = new ConcurrentDictionary<Task, byte>();
+        var seenCts = new ConcurrentDictionary<CancellationTokenSource, byte>();
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callers = Enumerable.Range(0, 128)
+            .Select(_ => Task.Run(async () =>
+            {
+                await start.Task.ConfigureAwait(false);
+                await ((Task)startAutoCommit.Invoke(consumer, [CancellationToken.None])!).ConfigureAwait(false);
+
+                if (taskField.GetValue(consumer) is Task task)
+                    seenTasks.TryAdd(task, 0);
+                if (ctsField.GetValue(consumer) is CancellationTokenSource cts)
+                    seenCts.TryAdd(cts, 0);
+            }))
+            .ToArray();
+
+        start.SetResult();
+        await Task.WhenAll(callers).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(seenTasks.Count).IsEqualTo(1);
+        await Assert.That(seenCts.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task StartPrefetch_ConcurrentCalls_InstallSingleLoop()
+    {
+        await using var consumer = CreateConsumer();
+        var consumerType = typeof(KafkaConsumer<string, string>);
+        var startPrefetch = consumerType.GetMethod(
+            "StartPrefetch",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var taskField = consumerType.GetField(
+            "_prefetchTask",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var ctsField = consumerType.GetField(
+            "_prefetchCts",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        var seenTasks = new ConcurrentDictionary<Task, byte>();
+        var seenCts = new ConcurrentDictionary<CancellationTokenSource, byte>();
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callers = Enumerable.Range(0, 128)
+            .Select(_ => Task.Run(async () =>
+            {
+                await start.Task.ConfigureAwait(false);
+                startPrefetch.Invoke(consumer, []);
+
+                if (taskField.GetValue(consumer) is Task task)
+                    seenTasks.TryAdd(task, 0);
+                if (ctsField.GetValue(consumer) is CancellationTokenSource cts)
+                    seenCts.TryAdd(cts, 0);
+            }))
+            .ToArray();
+
+        start.SetResult();
+        await Task.WhenAll(callers).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(seenTasks.Count).IsEqualTo(1);
+        await Assert.That(seenCts.Count).IsEqualTo(1);
+    }
+
+    private static KafkaConsumer<string, string> CreateConsumer()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "background-loop-start-test",
+            AutoCommitIntervalMs = 60_000
+        };
+
+        return new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerBackgroundLoopStartTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerBackgroundLoopStartTests.cs
@@ -83,6 +83,121 @@ public sealed class ConsumerBackgroundLoopStartTests
         await Assert.That(seenCts.Count).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task CloseAsync_SnapshotsLoopStartedAfterCloseFlag()
+    {
+        await using var consumer = CreateConsumer();
+
+        await VerifyTeardownSnapshotsLoopStartedAfterFlagAsync(
+            consumer,
+            static c => c.CloseAsync().AsTask(),
+            "_closed");
+    }
+
+    [Test]
+    public async Task DisposeAsync_SnapshotsLoopStartedAfterDisposeFlag()
+    {
+        var consumer = CreateConsumer();
+
+        try
+        {
+            await VerifyTeardownSnapshotsLoopStartedAfterFlagAsync(
+                consumer,
+                static c => c.DisposeAsync().AsTask(),
+                "_consumerDisposed");
+        }
+        finally
+        {
+            await consumer.DisposeAsync();
+        }
+    }
+
+    private static async Task VerifyTeardownSnapshotsLoopStartedAfterFlagAsync(
+        KafkaConsumer<string, string> consumer,
+        Func<KafkaConsumer<string, string>, Task> teardown,
+        string flagFieldName)
+    {
+        var consumerType = typeof(KafkaConsumer<string, string>);
+        var flagField = consumerType.GetField(flagFieldName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var autoCommitLock = consumerType.GetField(
+            "_autoCommitStartLock",
+            BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(consumer)!;
+        var prefetchLock = consumerType.GetField(
+            "_prefetchStartLock",
+            BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(consumer)!;
+        var autoCommitLoop = new InstalledLoop(
+            consumerType.GetField("_autoCommitTask", BindingFlags.NonPublic | BindingFlags.Instance)!,
+            consumerType.GetField("_autoCommitCts", BindingFlags.NonPublic | BindingFlags.Instance)!);
+        var prefetchLoop = new InstalledLoop(
+            consumerType.GetField("_prefetchTask", BindingFlags.NonPublic | BindingFlags.Instance)!,
+            consumerType.GetField("_prefetchCts", BindingFlags.NonPublic | BindingFlags.Instance)!);
+
+        Task teardownTask;
+        lock (autoCommitLock)
+        {
+            lock (prefetchLock)
+            {
+                teardownTask = Task.Run(() => teardown(consumer));
+
+                if (!SpinWait.SpinUntil(
+                    () => (int)flagField.GetValue(consumer)! != 0,
+                    TimeSpan.FromSeconds(5)))
+                {
+                    Assert.Fail($"{flagFieldName} was not set before teardown tried to snapshot background loops.");
+                }
+
+                autoCommitLoop.Install(consumer);
+                prefetchLoop.Install(consumer);
+            }
+        }
+
+        await teardownTask.WaitAsync(TimeSpan.FromSeconds(10));
+        await autoCommitLoop.CancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await prefetchLoop.CancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(autoCommitLoop.Task.IsCompleted).IsTrue();
+        await Assert.That(prefetchLoop.Task.IsCompleted).IsTrue();
+    }
+
+    private sealed class InstalledLoop
+    {
+        private readonly FieldInfo _taskField;
+        private readonly FieldInfo _ctsField;
+        private readonly CancellationTokenSource _cts = new();
+
+        internal InstalledLoop(FieldInfo taskField, FieldInfo ctsField)
+        {
+            _taskField = taskField;
+            _ctsField = ctsField;
+            Task = RunUntilCancelledAsync(CancellationObserved, _cts.Token);
+        }
+
+        internal Task Task { get; }
+
+        internal TaskCompletionSource CancellationObserved { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal void Install(KafkaConsumer<string, string> consumer)
+        {
+            _ctsField.SetValue(consumer, _cts);
+            _taskField.SetValue(consumer, Task);
+        }
+
+        private static async Task RunUntilCancelledAsync(
+            TaskCompletionSource cancellationObserved,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                cancellationObserved.SetResult();
+            }
+        }
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer()
     {
         var options = new ConsumerOptions


### PR DESCRIPTION
## Summary
- serialize auto-commit and prefetch loop starts so concurrent consume entries cannot orphan overwritten CTS/task pairs
- snapshot background-loop CTS/task under the same locks during close/dispose so shutdown cannot miss a just-started loop
- add concurrent-start regressions for auto-commit and prefetch loops

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -v:minimal
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --minimum-expected-tests 1 --treenode-filter "/*/*/ConsumerBackgroundLoopStartTests/*" --timeout 1m --no-progress
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --minimum-expected-tests 1 --treenode-filter "/*/*/ConsumerAutoCommitTests/*" --timeout 1m --no-progress
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --minimum-expected-tests 1 --treenode-filter "/*/*/ConsumeOneFastPathTests/*" --timeout 1m --no-progress
- [x] dotnet format tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --verify-no-changes -v minimal --include src\Dekaf\Consumer\KafkaConsumer.cs tests\Dekaf.Tests.Unit\Consumer\ConsumerBackgroundLoopStartTests.cs
- [x] git diff --check

Closes #1344
