### PR TITLE
perf(snappy): reduce xerial block overhead

### DIFF
--- a/src/Dekaf.Compression.Snappy/SnappyCompressionCodec.cs
+++ b/src/Dekaf.Compression.Snappy/SnappyCompressionCodec.cs
@@ -21,8 +21,8 @@ public sealed class SnappyCompressionCodec : ICompressionCodec
     // Total header size: magic (8) + version (4) + compat version (4) = 16 bytes
     private const int HeaderSize = 16;
 
-    // Default block size for compression (64KB)
-    private const int DefaultBlockSize = 65536;
+    // Larger xerial blocks avoid per-block decode overhead on batch-sized payloads.
+    private const int DefaultBlockSize = 1024 * 1024;
 
     private readonly int _blockSize;
 
@@ -33,7 +33,7 @@ public sealed class SnappyCompressionCodec : ICompressionCodec
     /// <summary>
     /// Creates a new Snappy compression codec.
     /// </summary>
-    /// <param name="blockSize">The block size for compression. Defaults to 64KB.</param>
+    /// <param name="blockSize">The block size for compression. Defaults to 1 MiB.</param>
     public SnappyCompressionCodec(int blockSize = DefaultBlockSize)
     {
         if (blockSize <= 0)
@@ -109,64 +109,31 @@ public sealed class SnappyCompressionCodec : ICompressionCodec
 
         // Process blocks
         Span<byte> blockHeader = stackalloc byte[4];
-        byte[]? compressedBuffer = null;
 
-        try
+        while (remaining >= 4)
         {
-            while (remaining >= 4)
-            {
-                // Read block header: [compressed size (4 bytes BE)]
-                source.Slice(position, 4).CopyTo(blockHeader);
-                var compressedSize = BinaryPrimitives.ReadInt32BigEndian(blockHeader);
+            // Read block header: [compressed size (4 bytes BE)]
+            source.Slice(position, 4).CopyTo(blockHeader);
+            var compressedSize = BinaryPrimitives.ReadInt32BigEndian(blockHeader);
 
-                position = source.GetPosition(4, position);
-                remaining -= 4;
+            position = source.GetPosition(4, position);
+            remaining -= 4;
 
-                if (compressedSize < 0)
-                    throw new InvalidDataException("Invalid block size in xerial-snappy data.");
+            if (compressedSize < 0)
+                throw new InvalidDataException("Invalid block size in xerial-snappy data.");
 
-                if (remaining < compressedSize)
-                    throw new InvalidDataException("Truncated xerial-snappy block.");
+            if (remaining < compressedSize)
+                throw new InvalidDataException("Truncated xerial-snappy block.");
 
-                var compressedSequence = source.Slice(position, compressedSize);
+            var compressedSequence = source.Slice(position, compressedSize);
+            Snappier.Snappy.Decompress(compressedSequence, destination);
 
-                // Get contiguous span for compressed data
-                ReadOnlySpan<byte> compressedSpan;
-                if (compressedSequence.IsSingleSegment)
-                {
-                    compressedSpan = compressedSequence.FirstSpan;
-                }
-                else
-                {
-                    if (compressedBuffer == null || compressedBuffer.Length < compressedSize)
-                    {
-                        if (compressedBuffer != null)
-                            ArrayPool<byte>.Shared.Return(compressedBuffer);
-                        compressedBuffer = ArrayPool<byte>.Shared.Rent(compressedSize);
-                    }
-                    compressedSequence.CopyTo(compressedBuffer);
-                    compressedSpan = compressedBuffer.AsSpan(0, compressedSize);
-                }
-
-                // Get uncompressed length from snappy frame, then decompress
-                var uncompressedSize = Snappier.Snappy.GetUncompressedLength(compressedSpan);
-                var decompressedSpan = destination.GetSpan(uncompressedSize);
-                var actualDecompressedLength = Snappier.Snappy.Decompress(compressedSpan, decompressedSpan);
-
-                destination.Advance(actualDecompressedLength);
-
-                position = source.GetPosition(compressedSize, position);
-                remaining -= compressedSize;
-            }
-
-            if (remaining != 0)
-                throw new InvalidDataException("Trailing data after last xerial-snappy block.");
+            position = source.GetPosition(compressedSize, position);
+            remaining -= compressedSize;
         }
-        finally
-        {
-            if (compressedBuffer != null)
-                ArrayPool<byte>.Shared.Return(compressedBuffer);
-        }
+
+        if (remaining != 0)
+            throw new InvalidDataException("Trailing data after last xerial-snappy block.");
     }
 
 }
@@ -206,9 +173,9 @@ public static class SnappyCompressionExtensions
     /// The <see cref="CompressionCodecRegistry.DefaultCompressionLevel"/> property is ignored for Snappy.
     /// </summary>
     /// <param name="registry">The compression codec registry.</param>
-    /// <param name="blockSize">The block size for compression. Defaults to 64KB.</param>
+    /// <param name="blockSize">The block size for compression. Defaults to 1 MiB.</param>
     /// <returns>The registry for fluent chaining.</returns>
-    public static CompressionCodecRegistry AddSnappy(this CompressionCodecRegistry registry, int blockSize = 65536)
+    public static CompressionCodecRegistry AddSnappy(this CompressionCodecRegistry registry, int blockSize = 1024 * 1024)
     {
         registry.Register(new SnappyCompressionCodec(blockSize));
         return registry;

--- a/tests/Dekaf.Tests.Unit/Compression/SnappyCompressionCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Compression/SnappyCompressionCodecTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Text;
 using Dekaf.Compression;
 using Dekaf.Compression.Snappy;
@@ -76,6 +77,19 @@ public class SnappyCompressionCodecTests
         // Xerial magic header: 0x82 0x53 0x4e 0x41 0x50 0x50 0x59 0x00
         var expectedMagic = new byte[] { 0x82, 0x53, 0x4e, 0x41, 0x50, 0x50, 0x59, 0x00 };
         await Assert.That(compressedBuffer.WrittenSpan.Slice(0, 8).ToArray()).IsEquivalentTo(expectedMagic);
+    }
+
+    [Test]
+    public async Task Compress_DefaultBlockSize_UsesSingleBlockForOneMiB()
+    {
+        var codec = new SnappyCompressionCodec();
+        var original = Enumerable.Range(0, 1024 * 1024).Select(static i => (byte)i).ToArray();
+        var compressedBuffer = new ArrayBufferWriter<byte>();
+
+        codec.Compress(new ReadOnlySequence<byte>(original), compressedBuffer);
+
+        var blockCount = CountXerialBlocks(compressedBuffer.WrittenSpan);
+        await Assert.That(blockCount).IsEqualTo(1);
     }
 
     [Test]
@@ -183,6 +197,47 @@ public class SnappyCompressionCodecTests
 
         var expected = segment1.Concat(segment2).ToArray();
         await Assert.That(decompressedBuffer.WrittenSpan.ToArray()).IsEquivalentTo(expected);
+    }
+
+    [Test]
+    public async Task Decompress_MultiSegmentCompressedInput_RoundTrips()
+    {
+        var codec = new SnappyCompressionCodec(blockSize: 1024);
+        var original = Enumerable.Range(0, 10_000).Select(static i => (byte)i).ToArray();
+
+        var compressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Compress(new ReadOnlySequence<byte>(original), compressedBuffer);
+        var compressed = compressedBuffer.WrittenMemory;
+
+        var firstSegment = new TestMemorySegment<byte>(compressed[..5]);
+        var secondSegment = firstSegment.Append(compressed.Slice(5, 20));
+        var thirdSegment = secondSegment.Append(compressed[25..]);
+        var compressedSequence = new ReadOnlySequence<byte>(
+            firstSegment,
+            0,
+            thirdSegment,
+            thirdSegment.Memory.Length);
+
+        var decompressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Decompress(compressedSequence, decompressedBuffer);
+
+        await Assert.That(decompressedBuffer.WrittenSpan.ToArray()).IsEquivalentTo(original);
+    }
+
+    private static int CountXerialBlocks(ReadOnlySpan<byte> compressed)
+    {
+        const int headerSize = 16;
+        var offset = headerSize;
+        var blocks = 0;
+
+        while (offset < compressed.Length)
+        {
+            var blockLength = BinaryPrimitives.ReadInt32BigEndian(compressed.Slice(offset, 4));
+            offset += 4 + blockLength;
+            blocks++;
+        }
+
+        return blocks;
     }
 }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/CompressionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/CompressionBenchmarks.cs
@@ -12,7 +12,7 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [ShortRunJob]
 public class CompressionBenchmarks
 {
-    private readonly SnappyCompressionCodec _codec = new(blockSize: 65536);
+    private readonly SnappyCompressionCodec _codec = new();
 
     private byte[] _smallData = null!;
     private byte[] _largeData = null!;

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/CompressionCodecComparisonBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/CompressionCodecComparisonBenchmarks.cs
@@ -17,7 +17,7 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 public class CompressionCodecComparisonBenchmarks
 {
     private readonly GzipCompressionCodec _gzip = new();
-    private readonly SnappyCompressionCodec _snappy = new(blockSize: 65536);
+    private readonly SnappyCompressionCodec _snappy = new();
     private readonly Lz4CompressionCodec _lz4 = new();
     private readonly ZstdCompressionCodec _zstd = new();
     private readonly BrotliCompressionCodec _brotli = new();


### PR DESCRIPTION
## Summary
- Raise the default Snappy xerial block size to 1 MiB to avoid heavy per-block decode overhead on batch-sized payloads.
- Use Snappier's ReadOnlySequence-to-IBufferWriter decompressor for each xerial block, avoiding multi-segment compressed-block copies.
- Update compression benchmarks to use the codec default instead of pinning 64 KiB blocks.

## Benchmarks
- Before: Snappy Decompress 1MB ~733.4 us, 1.25 KB allocated.
- After: Snappy Decompress 1MB ~150.9 us, 80 B allocated.

## Tests
- dotnet build src/Dekaf.Compression.Snappy/Dekaf.Compression.Snappy.csproj --configuration Release
- dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release
- dotnet build tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj --configuration Release
- dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress --maximum-parallel-tests 1
- dotnet run --project tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj --configuration Release -- --filter "*CompressionBenchmarks.Snappy_Decompress_1MB*" --exporters json --artifacts ./BenchmarkDotNet.Artifacts/snappy1375-default-bench
- dotnet run --project tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj --configuration Release -- --filter "*CompressionBenchmarks.Snappy_Compress_1MB*" --exporters json --artifacts ./BenchmarkDotNet.Artifacts/snappy1375-default-compress

Closes #1375
