### PR TITLE
fix(producer): reserve batch header in budget

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4644,8 +4644,10 @@ internal sealed class PartitionBatch
             headerCount);
         var encodedRecordSize = checked(Record.VarIntSize(bodySize) + bodySize);
 
-        // Check size limit
-        if ((long)_estimatedSize + encodedRecordSize > _options.BatchSize && recordIndex > 0)
+        // Check size limit. BatchSize is the full wire batch budget, so records must
+        // leave room for the fixed RecordBatch header.
+        var maxRecordsSize = Math.Max(0, _options.BatchSize - RecordBatch.TotalBatchHeaderSize);
+        if ((long)_estimatedSize + encodedRecordSize > maxRecordsSize && recordIndex > 0)
         {
             return new RecordAppendResult(false);
         }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -514,6 +514,71 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task AppendFromSpansAsync_BatchSizeBudgetReservesWireBatchHeader()
+    {
+        const int firstValueLength = 32;
+        var firstRecordSize = EncodedRecordSize(
+            timestampDelta: 0,
+            offsetDelta: 0,
+            valueLength: firstValueLength);
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = RecordBatch.TotalBatchHeaderSize + firstRecordSize,
+            LingerMs = 10_000
+        };
+
+        await using var accumulator = new RecordAccumulator(options);
+        var topicPartition = new TopicPartition("test-topic", 0);
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        var appended = await accumulator.AppendFromSpansAsync(
+            topicPartition.Topic,
+            topicPartition.Partition,
+            timestamp,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            new byte[firstValueLength],
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(appended).IsTrue();
+
+        appended = await accumulator.AppendFromSpansAsync(
+            topicPartition.Topic,
+            topicPartition.Partition,
+            timestamp + 1,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            new byte[] { 2 },
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(appended).IsTrue();
+        await Assert.That(accumulator.TryDrainBatch(out var firstBatch)).IsTrue();
+        await Assert.That(firstBatch!.RecordBatch.Records.Count).IsEqualTo(1);
+        await Assert.That(firstBatch.DataSize).IsEqualTo(firstRecordSize);
+        await Assert.That(firstBatch.RecordBatch.GetEncodedSize()).IsEqualTo(options.BatchSize);
+
+        var secondBatch = CompleteCurrentBatch(accumulator, topicPartition);
+        await Assert.That(secondBatch.RecordBatch.Records.Count).IsEqualTo(1);
+        await Assert.That(secondBatch.RecordBatch.GetEncodedSize()).IsLessThanOrEqualTo(options.BatchSize);
+
+        firstBatch.CompleteSend(baseOffset: 0, DateTimeOffset.FromUnixTimeMilliseconds(timestamp));
+        secondBatch.CompleteSend(baseOffset: 1, DateTimeOffset.FromUnixTimeMilliseconds(timestamp + 1));
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_ArenaFullBeforeBatchSize_RotatesAndPreservesRecords()
     {
         var options = new ProducerOptions
@@ -2552,6 +2617,20 @@ public class RecordAccumulatorTests
         var partitionBatch = GetCurrentPartitionBatch(accumulator, topicPartition);
         var completeMethod = partitionBatch.GetType().GetMethod("Complete");
         return (ReadyBatch)completeMethod!.Invoke(partitionBatch, null)!;
+    }
+
+    private static int EncodedRecordSize(long timestampDelta, int offsetDelta, int valueLength)
+    {
+        var bodySize = Record.ComputeBodySize(
+            timestampDelta,
+            offsetDelta,
+            isKeyNull: true,
+            keyLength: 0,
+            isValueNull: false,
+            valueLength,
+            headers: null,
+            headerCount: 0);
+        return Record.VarIntSize(bodySize) + bodySize;
     }
 
     private static ProduceException CreatePurgedException()


### PR DESCRIPTION
## Summary
- reserve `RecordBatch.TotalBatchHeaderSize` from the producer record payload budget
- keep first-record oversized behavior intact
- add unit coverage for a size-crafted batch that exactly reaches the wire `BatchSize` limit

Fixes #1349.

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/*/AppendFromSpansAsync_BatchSizeBudgetReservesWireBatchHeader" --hangdump --hangdump-timeout 5m --log-level Debug --no-progress --disable-logo`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/*/(AppendFromSpansAsync_FirstRecordLargerThanBatchSize_UsesExpandedArena|AppendFromSpansAsync_BatchSizeBudgetReservesWireBatchHeader|AppendFromSpansAsync_ArenaFullBeforeBatchSize_RotatesAndPreservesRecords)" --hangdump --hangdump-timeout 5m --log-level Debug --no-progress --disable-logo`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordAccumulatorTests/*" --hangdump --hangdump-timeout 10m --log-level Debug --no-progress --disable-logo`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordBatchTests/*" --hangdump --hangdump-timeout 10m --log-level Debug --no-progress --disable-logo`
- `dotnet format src\Dekaf\Dekaf.csproj --verify-no-changes --no-restore`
- `dotnet format tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --verify-no-changes --no-restore`
- `Dekaf.Tests.Unit.exe --maximum-parallel-tests 20 --hangdump --hangdump-timeout 15m --log-level Debug --no-progress --disable-logo`

Note: default full-unit run at 80-way parallelism timed out six unrelated networking/broker-sender tests; those six passed when rerun alone, and the full suite passed at 20-way parallelism.
