### PR TITLE
feat(admin): add KRaft quorum APIs

### DIFF
--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -533,6 +533,91 @@ public sealed class InMemoryAdminClient : IAdminClient
         return ValueTask.FromResult<IReadOnlyDictionary<TopicPartition, ElectLeadersResultInfo>>(result);
     }
 
+    public ValueTask<MetadataQuorumDescription> DescribeMetadataQuorumAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        return ValueTask.FromResult(new MetadataQuorumDescription
+        {
+            LeaderId = 0,
+            LeaderEpoch = 0,
+            HighWatermark = 0,
+            CurrentVoters =
+            [
+                new QuorumReplicaState
+                {
+                    ReplicaId = 0,
+                    LogEndOffset = 0
+                }
+            ],
+            Observers = [],
+            Nodes =
+            [
+                new QuorumNode
+                {
+                    NodeId = 0,
+                    Listeners =
+                    [
+                        new RaftVoterEndpoint
+                        {
+                            Name = "PLAINTEXT",
+                            Host = "in-memory",
+                            Port = 0
+                        }
+                    ]
+                }
+            ]
+        });
+    }
+
+    public ValueTask AddRaftVoterAsync(
+        int voterId,
+        Guid voterDirectoryId,
+        IEnumerable<RaftVoterEndpoint> endpoints,
+        AddRaftVoterOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(voterId);
+        if (voterDirectoryId == Guid.Empty)
+        {
+            throw new ArgumentException("Voter directory ID must not be empty.", nameof(voterDirectoryId));
+        }
+
+        ValidateRaftVoterEndpoints(endpoints);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask RemoveRaftVoterAsync(
+        int voterId,
+        Guid voterDirectoryId,
+        RemoveRaftVoterOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(voterId);
+        if (voterDirectoryId == Guid.Empty)
+        {
+            throw new ArgumentException("Voter directory ID must not be empty.", nameof(voterDirectoryId));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask UnregisterBrokerAsync(int brokerId, CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(brokerId);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        return ValueTask.CompletedTask;
+    }
+
     public ValueTask<IReadOnlyDictionary<ClientQuotaEntity, IReadOnlyDictionary<string, double>>> DescribeClientQuotasAsync(
         ClientQuotaFilter filter,
         DescribeClientQuotasOptions? options = null,
@@ -946,6 +1031,29 @@ public sealed class InMemoryAdminClient : IAdminClient
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(topicPartition.Topic);
         ArgumentOutOfRangeException.ThrowIfNegative(topicPartition.Partition);
+    }
+
+    private static void ValidateRaftVoterEndpoints(IEnumerable<RaftVoterEndpoint> endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var count = 0;
+        foreach (var endpoint in endpoints)
+        {
+            count++;
+            ArgumentNullException.ThrowIfNull(endpoint);
+            ArgumentException.ThrowIfNullOrWhiteSpace(endpoint.Name);
+            ArgumentException.ThrowIfNullOrWhiteSpace(endpoint.Host);
+            if (endpoint.Port is < 0 or > ushort.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(endpoints), endpoint.Port, "Port must be between 0 and 65535.");
+            }
+        }
+
+        if (count == 0)
+        {
+            throw new ArgumentException("At least one listener endpoint is required.", nameof(endpoints));
+        }
     }
 
     private static TimeSpan ValidateDelegationTokenDuration(

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -22,6 +22,9 @@ namespace Dekaf.Admin;
 /// </summary>
 public sealed class AdminClient : IAdminClient
 {
+    private const string MetadataQuorumTopic = "__cluster_metadata";
+    private const int MetadataQuorumPartition = 0;
+
     private readonly AdminClientOptions _options;
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
@@ -2997,6 +3000,223 @@ public sealed class AdminClient : IAdminClient
         }, cancellationToken).ConfigureAwait(false);
     }
 
+    public async ValueTask<MetadataQuorumDescription> DescribeMetadataQuorumAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!_metadataManager.HasApiKey(Protocol.ApiKey.DescribeQuorum))
+        {
+            throw new Errors.BrokerVersionException("Broker does not support DescribeQuorum (API key 55).");
+        }
+
+        return await WithRetryAsync(async () =>
+        {
+            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.DescribeQuorum,
+                DescribeQuorumRequest.LowestSupportedVersion,
+                DescribeQuorumRequest.HighestSupportedVersion);
+
+            var response = await controller.SendAsync<DescribeQuorumRequest, DescribeQuorumResponse>(
+                new DescribeQuorumRequest
+                {
+                    Topics =
+                    [
+                        new DescribeQuorumRequestTopic
+                        {
+                            TopicName = MetadataQuorumTopic,
+                            Partitions =
+                            [
+                                new DescribeQuorumRequestPartition
+                                {
+                                    PartitionIndex = MetadataQuorumPartition
+                                }
+                            ]
+                        }
+                    ]
+                },
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            if (response.ErrorCode != Protocol.ErrorCode.None)
+            {
+                throw KafkaException.FromErrorCode(
+                    response.ErrorCode,
+                    response.ErrorMessage ?? $"DescribeQuorum failed: {response.ErrorCode}");
+            }
+
+            var topic = response.Topics.FirstOrDefault(static t => string.Equals(t.TopicName, MetadataQuorumTopic, StringComparison.Ordinal));
+            var partition = topic?.Partitions.FirstOrDefault(static p => p.PartitionIndex == MetadataQuorumPartition);
+            if (partition is null)
+            {
+                throw new KafkaException(
+                    Protocol.ErrorCode.UnknownServerError,
+                    "DescribeQuorum response did not include the metadata quorum partition.");
+            }
+
+            if (partition.ErrorCode != Protocol.ErrorCode.None)
+            {
+                throw KafkaException.FromErrorCode(
+                    partition.ErrorCode,
+                    partition.ErrorMessage ?? $"DescribeQuorum partition failed: {partition.ErrorCode}");
+            }
+
+            return new MetadataQuorumDescription
+            {
+                LeaderId = partition.LeaderId,
+                LeaderEpoch = partition.LeaderEpoch,
+                HighWatermark = partition.HighWatermark,
+                CurrentVoters = partition.CurrentVoters.Select(MapQuorumReplicaState).ToArray(),
+                Observers = partition.Observers.Select(MapQuorumReplicaState).ToArray(),
+                Nodes = response.Nodes.Select(MapQuorumNode).ToArray()
+            };
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask AddRaftVoterAsync(
+        int voterId,
+        Guid voterDirectoryId,
+        IEnumerable<RaftVoterEndpoint> endpoints,
+        AddRaftVoterOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(voterId);
+        if (voterDirectoryId == Guid.Empty)
+        {
+            throw new ArgumentException("Voter directory ID must not be empty.", nameof(voterDirectoryId));
+        }
+
+        var listenerData = BuildRaftVoterEndpoints(endpoints);
+        var opts = options ?? new AddRaftVoterOptions();
+        ArgumentOutOfRangeException.ThrowIfNegative(opts.TimeoutMs);
+
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!_metadataManager.HasApiKey(Protocol.ApiKey.AddRaftVoter))
+        {
+            throw new Errors.BrokerVersionException("Broker does not support AddRaftVoter (API key 80).");
+        }
+
+        await WithRetryAsync(async () =>
+        {
+            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.AddRaftVoter,
+                AddRaftVoterRequest.LowestSupportedVersion,
+                AddRaftVoterRequest.HighestSupportedVersion);
+
+            if (!opts.AckWhenCommitted && apiVersion < 1)
+            {
+                throw new Errors.BrokerVersionException(
+                    "Broker does not support AddRaftVoter AckWhenCommitted=false (API key 80 v1).");
+            }
+
+            var response = await controller.SendAsync<AddRaftVoterRequest, AddRaftVoterResponse>(
+                new AddRaftVoterRequest
+                {
+                    ClusterId = opts.ClusterId,
+                    TimeoutMs = opts.TimeoutMs,
+                    VoterId = voterId,
+                    VoterDirectoryId = voterDirectoryId,
+                    Listeners = listenerData,
+                    AckWhenCommitted = opts.AckWhenCommitted
+                },
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            if (response.ErrorCode != Protocol.ErrorCode.None)
+            {
+                throw KafkaException.FromErrorCode(
+                    response.ErrorCode,
+                    response.ErrorMessage ?? $"AddRaftVoter failed: {response.ErrorCode}");
+            }
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask RemoveRaftVoterAsync(
+        int voterId,
+        Guid voterDirectoryId,
+        RemoveRaftVoterOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(voterId);
+        if (voterDirectoryId == Guid.Empty)
+        {
+            throw new ArgumentException("Voter directory ID must not be empty.", nameof(voterDirectoryId));
+        }
+
+        var opts = options ?? new RemoveRaftVoterOptions();
+
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!_metadataManager.HasApiKey(Protocol.ApiKey.RemoveRaftVoter))
+        {
+            throw new Errors.BrokerVersionException("Broker does not support RemoveRaftVoter (API key 81).");
+        }
+
+        await WithRetryAsync(async () =>
+        {
+            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.RemoveRaftVoter,
+                RemoveRaftVoterRequest.LowestSupportedVersion,
+                RemoveRaftVoterRequest.HighestSupportedVersion);
+
+            var response = await controller.SendAsync<RemoveRaftVoterRequest, RemoveRaftVoterResponse>(
+                new RemoveRaftVoterRequest
+                {
+                    ClusterId = opts.ClusterId,
+                    VoterId = voterId,
+                    VoterDirectoryId = voterDirectoryId
+                },
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            if (response.ErrorCode != Protocol.ErrorCode.None)
+            {
+                throw KafkaException.FromErrorCode(
+                    response.ErrorCode,
+                    response.ErrorMessage ?? $"RemoveRaftVoter failed: {response.ErrorCode}");
+            }
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask UnregisterBrokerAsync(
+        int brokerId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(brokerId);
+
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!_metadataManager.HasApiKey(Protocol.ApiKey.UnregisterBroker))
+        {
+            throw new Errors.BrokerVersionException("Broker does not support UnregisterBroker (API key 64).");
+        }
+
+        await WithRetryAsync(async () =>
+        {
+            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.UnregisterBroker,
+                UnregisterBrokerRequest.LowestSupportedVersion,
+                UnregisterBrokerRequest.HighestSupportedVersion);
+
+            var response = await controller.SendAsync<UnregisterBrokerRequest, UnregisterBrokerResponse>(
+                new UnregisterBrokerRequest { BrokerId = brokerId },
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            if (response.ErrorCode != Protocol.ErrorCode.None)
+            {
+                throw KafkaException.FromErrorCode(
+                    response.ErrorCode,
+                    response.ErrorMessage ?? $"UnregisterBroker failed: {response.ErrorCode}");
+            }
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
     public async ValueTask<IReadOnlyDictionary<int, IReadOnlyDictionary<string, LogDirDescription>>> DescribeLogDirsAsync(
         IEnumerable<int> brokerIds,
         IEnumerable<TopicPartition>? partitions = null,
@@ -3725,6 +3945,61 @@ public sealed class AdminClient : IAdminClient
         }
 
         return await _connectionPool.GetConnectionAsync(controllerId, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static QuorumReplicaState MapQuorumReplicaState(DescribeQuorumReplicaState state) =>
+        new()
+        {
+            ReplicaId = state.ReplicaId,
+            ReplicaDirectoryId = state.ReplicaDirectoryId,
+            LogEndOffset = state.LogEndOffset,
+            LastFetchTimestamp = state.LastFetchTimestamp,
+            LastCaughtUpTimestamp = state.LastCaughtUpTimestamp
+        };
+
+    private static QuorumNode MapQuorumNode(DescribeQuorumResponseNode node) =>
+        new()
+        {
+            NodeId = node.NodeId,
+            Listeners = node.Listeners.Select(MapRaftVoterEndpoint).ToArray()
+        };
+
+    private static RaftVoterEndpoint MapRaftVoterEndpoint(RaftVoterEndpointData endpoint) =>
+        new()
+        {
+            Name = endpoint.Name,
+            Host = endpoint.Host,
+            Port = endpoint.Port
+        };
+
+    private static IReadOnlyList<RaftVoterEndpointData> BuildRaftVoterEndpoints(IEnumerable<RaftVoterEndpoint> endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var result = endpoints.Select(endpoint =>
+        {
+            ArgumentNullException.ThrowIfNull(endpoint);
+            ArgumentException.ThrowIfNullOrWhiteSpace(endpoint.Name);
+            ArgumentException.ThrowIfNullOrWhiteSpace(endpoint.Host);
+            if (endpoint.Port is < 0 or > ushort.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(endpoints), endpoint.Port, "Port must be between 0 and 65535.");
+            }
+
+            return new RaftVoterEndpointData
+            {
+                Name = endpoint.Name,
+                Host = endpoint.Host,
+                Port = (ushort)endpoint.Port
+            };
+        }).ToArray();
+
+        if (result.Length == 0)
+        {
+            throw new ArgumentException("At least one listener endpoint is required.", nameof(endpoints));
+        }
+
+        return result;
     }
 
     private async ValueTask<int> FindGroupCoordinatorAsync(string groupId, CancellationToken cancellationToken)

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -368,6 +368,38 @@ public interface IAdminClient : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Describes the KRaft metadata quorum.
+    /// </summary>
+    ValueTask<MetadataQuorumDescription> DescribeMetadataQuorumAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a voter to the KRaft metadata quorum.
+    /// </summary>
+    ValueTask AddRaftVoterAsync(
+        int voterId,
+        Guid voterDirectoryId,
+        IEnumerable<RaftVoterEndpoint> endpoints,
+        AddRaftVoterOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a voter from the KRaft metadata quorum.
+    /// </summary>
+    ValueTask RemoveRaftVoterAsync(
+        int voterId,
+        Guid voterDirectoryId,
+        RemoveRaftVoterOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Unregisters a broker from KRaft metadata.
+    /// </summary>
+    ValueTask UnregisterBrokerAsync(
+        int brokerId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Describes log directories on the specified brokers.
     /// </summary>
     /// <param name="brokerIds">The broker IDs to query.</param>

--- a/src/Dekaf/Admin/KRaftQuorumTypes.cs
+++ b/src/Dekaf/Admin/KRaftQuorumTypes.cs
@@ -1,0 +1,63 @@
+namespace Dekaf.Admin;
+
+/// <summary>
+/// KRaft metadata quorum description.
+/// </summary>
+public sealed class MetadataQuorumDescription
+{
+    public int LeaderId { get; init; }
+    public int LeaderEpoch { get; init; }
+    public long HighWatermark { get; init; }
+    public required IReadOnlyList<QuorumReplicaState> CurrentVoters { get; init; }
+    public required IReadOnlyList<QuorumReplicaState> Observers { get; init; }
+    public IReadOnlyList<QuorumNode> Nodes { get; init; } = [];
+}
+
+/// <summary>
+/// State of a KRaft quorum voter or observer.
+/// </summary>
+public sealed class QuorumReplicaState
+{
+    public int ReplicaId { get; init; }
+    public Guid? ReplicaDirectoryId { get; init; }
+    public long LogEndOffset { get; init; }
+    public long LastFetchTimestamp { get; init; } = -1;
+    public long LastCaughtUpTimestamp { get; init; } = -1;
+}
+
+/// <summary>
+/// KRaft quorum node and its controller listeners.
+/// </summary>
+public sealed class QuorumNode
+{
+    public int NodeId { get; init; }
+    public required IReadOnlyList<RaftVoterEndpoint> Listeners { get; init; }
+}
+
+/// <summary>
+/// Endpoint used to communicate with a KRaft voter.
+/// </summary>
+public sealed class RaftVoterEndpoint
+{
+    public required string Name { get; init; }
+    public required string Host { get; init; }
+    public int Port { get; init; }
+}
+
+/// <summary>
+/// Options for adding a KRaft voter.
+/// </summary>
+public sealed class AddRaftVoterOptions
+{
+    public string? ClusterId { get; init; }
+    public int TimeoutMs { get; init; } = 30000;
+    public bool AckWhenCommitted { get; init; } = true;
+}
+
+/// <summary>
+/// Options for removing a KRaft voter.
+/// </summary>
+public sealed class RemoveRaftVoterOptions
+{
+    public string? ClusterId { get; init; }
+}

--- a/src/Dekaf/Protocol/ApiKey.cs
+++ b/src/Dekaf/Protocol/ApiKey.cs
@@ -85,6 +85,8 @@ public enum ApiKey : short
     ShareGroupDescribe = 77,
     ShareFetch = 78,
     ShareAcknowledge = 79,
+    AddRaftVoter = 80,
+    RemoveRaftVoter = 81,
     StreamsGroupHeartbeat = 88,
     StreamsGroupDescribe = 89,
     DescribeShareGroupOffsets = 90,

--- a/src/Dekaf/Protocol/Messages/DescribeQuorumRequest.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeQuorumRequest.cs
@@ -1,0 +1,48 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DescribeQuorum request (API key 55).
+/// Describes KRaft quorum state for topic partitions.
+/// </summary>
+public sealed class DescribeQuorumRequest : IKafkaRequest<DescribeQuorumResponse>
+{
+    public static ApiKey ApiKey => ApiKey.DescribeQuorum;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 2;
+
+    public required IReadOnlyList<DescribeQuorumRequestTopic> Topics { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactArray(
+            Topics,
+            static (ref KafkaProtocolWriter w, DescribeQuorumRequestTopic topic) => topic.Write(ref w));
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+public sealed class DescribeQuorumRequestTopic
+{
+    public required string TopicName { get; init; }
+    public required IReadOnlyList<DescribeQuorumRequestPartition> Partitions { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(TopicName);
+        writer.WriteCompactArray(
+            Partitions,
+            static (ref KafkaProtocolWriter w, DescribeQuorumRequestPartition partition) => partition.Write(ref w));
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+public sealed class DescribeQuorumRequestPartition
+{
+    public int PartitionIndex { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt32(PartitionIndex);
+        writer.WriteEmptyTaggedFields();
+    }
+}

--- a/src/Dekaf/Protocol/Messages/DescribeQuorumResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeQuorumResponse.cs
@@ -1,0 +1,152 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// DescribeQuorum response (API key 55).
+/// Contains KRaft quorum state.
+/// </summary>
+public sealed class DescribeQuorumResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.DescribeQuorum;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 2;
+
+    public ErrorCode ErrorCode { get; init; }
+    public string? ErrorMessage { get; init; }
+    public required IReadOnlyList<DescribeQuorumResponseTopic> Topics { get; init; }
+    public IReadOnlyList<DescribeQuorumResponseNode> Nodes { get; init; } = [];
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = version >= 2 ? reader.ReadCompactString() : null;
+        var topics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => DescribeQuorumResponseTopic.Read(ref r, v),
+            version);
+        var nodes = version >= 2
+            ? reader.ReadCompactArray(static (ref KafkaProtocolReader r) => DescribeQuorumResponseNode.Read(ref r))
+            : [];
+
+        reader.SkipTaggedFields();
+
+        return new DescribeQuorumResponse
+        {
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            Topics = topics,
+            Nodes = nodes
+        };
+    }
+}
+
+public sealed class DescribeQuorumResponseTopic
+{
+    public required string TopicName { get; init; }
+    public required IReadOnlyList<DescribeQuorumResponsePartition> Partitions { get; init; }
+
+    public static DescribeQuorumResponseTopic Read(ref KafkaProtocolReader reader, short version)
+    {
+        var topicName = reader.ReadCompactString() ?? string.Empty;
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => DescribeQuorumResponsePartition.Read(ref r, v),
+            version);
+
+        reader.SkipTaggedFields();
+
+        return new DescribeQuorumResponseTopic
+        {
+            TopicName = topicName,
+            Partitions = partitions
+        };
+    }
+}
+
+public sealed class DescribeQuorumResponsePartition
+{
+    public int PartitionIndex { get; init; }
+    public ErrorCode ErrorCode { get; init; }
+    public string? ErrorMessage { get; init; }
+    public int LeaderId { get; init; }
+    public int LeaderEpoch { get; init; }
+    public long HighWatermark { get; init; }
+    public required IReadOnlyList<DescribeQuorumReplicaState> CurrentVoters { get; init; }
+    public required IReadOnlyList<DescribeQuorumReplicaState> Observers { get; init; }
+
+    public static DescribeQuorumResponsePartition Read(ref KafkaProtocolReader reader, short version)
+    {
+        var partitionIndex = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = version >= 2 ? reader.ReadCompactString() : null;
+        var leaderId = reader.ReadInt32();
+        var leaderEpoch = reader.ReadInt32();
+        var highWatermark = reader.ReadInt64();
+        var currentVoters = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => DescribeQuorumReplicaState.Read(ref r, v),
+            version);
+        var observers = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => DescribeQuorumReplicaState.Read(ref r, v),
+            version);
+
+        reader.SkipTaggedFields();
+
+        return new DescribeQuorumResponsePartition
+        {
+            PartitionIndex = partitionIndex,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            LeaderId = leaderId,
+            LeaderEpoch = leaderEpoch,
+            HighWatermark = highWatermark,
+            CurrentVoters = currentVoters,
+            Observers = observers
+        };
+    }
+}
+
+public sealed class DescribeQuorumReplicaState
+{
+    public int ReplicaId { get; init; }
+    public Guid? ReplicaDirectoryId { get; init; }
+    public long LogEndOffset { get; init; }
+    public long LastFetchTimestamp { get; init; } = -1;
+    public long LastCaughtUpTimestamp { get; init; } = -1;
+
+    public static DescribeQuorumReplicaState Read(ref KafkaProtocolReader reader, short version)
+    {
+        var replicaId = reader.ReadInt32();
+        Guid? replicaDirectoryId = version >= 2 ? reader.ReadUuid() : null;
+        var logEndOffset = reader.ReadInt64();
+        var lastFetchTimestamp = version >= 1 ? reader.ReadInt64() : -1;
+        var lastCaughtUpTimestamp = version >= 1 ? reader.ReadInt64() : -1;
+
+        reader.SkipTaggedFields();
+
+        return new DescribeQuorumReplicaState
+        {
+            ReplicaId = replicaId,
+            ReplicaDirectoryId = replicaDirectoryId,
+            LogEndOffset = logEndOffset,
+            LastFetchTimestamp = lastFetchTimestamp,
+            LastCaughtUpTimestamp = lastCaughtUpTimestamp
+        };
+    }
+}
+
+public sealed class DescribeQuorumResponseNode
+{
+    public int NodeId { get; init; }
+    public required IReadOnlyList<RaftVoterEndpointData> Listeners { get; init; }
+
+    public static DescribeQuorumResponseNode Read(ref KafkaProtocolReader reader)
+    {
+        var nodeId = reader.ReadInt32();
+        var listeners = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => RaftVoterEndpointData.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new DescribeQuorumResponseNode
+        {
+            NodeId = nodeId,
+            Listeners = listeners
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/RaftVoterMessages.cs
+++ b/src/Dekaf/Protocol/Messages/RaftVoterMessages.cs
@@ -1,0 +1,151 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// AddRaftVoter request (API key 80).
+/// Adds a voter to the KRaft metadata quorum.
+/// </summary>
+public sealed class AddRaftVoterRequest : IKafkaRequest<AddRaftVoterResponse>
+{
+    public static ApiKey ApiKey => ApiKey.AddRaftVoter;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 1;
+
+    public string? ClusterId { get; init; }
+    public int TimeoutMs { get; init; } = 30000;
+    public int VoterId { get; init; }
+    public Guid VoterDirectoryId { get; init; }
+    public required IReadOnlyList<RaftVoterEndpointData> Listeners { get; init; }
+    public bool AckWhenCommitted { get; init; } = true;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactNullableString(ClusterId);
+        writer.WriteInt32(TimeoutMs);
+        writer.WriteInt32(VoterId);
+        writer.WriteUuid(VoterDirectoryId);
+        writer.WriteCompactArray(
+            Listeners,
+            static (ref KafkaProtocolWriter w, RaftVoterEndpointData listener) => listener.Write(ref w));
+
+        if (version >= 1)
+        {
+            writer.WriteBoolean(AckWhenCommitted);
+        }
+
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// AddRaftVoter response (API key 80).
+/// </summary>
+public sealed class AddRaftVoterResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.AddRaftVoter;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 1;
+
+    public int ThrottleTimeMs { get; init; }
+    public ErrorCode ErrorCode { get; init; }
+    public string? ErrorMessage { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+
+        reader.SkipTaggedFields();
+
+        return new AddRaftVoterResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+    }
+}
+
+/// <summary>
+/// RemoveRaftVoter request (API key 81).
+/// Removes a voter from the KRaft metadata quorum.
+/// </summary>
+public sealed class RemoveRaftVoterRequest : IKafkaRequest<RemoveRaftVoterResponse>
+{
+    public static ApiKey ApiKey => ApiKey.RemoveRaftVoter;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    public string? ClusterId { get; init; }
+    public int VoterId { get; init; }
+    public Guid VoterDirectoryId { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteCompactNullableString(ClusterId);
+        writer.WriteInt32(VoterId);
+        writer.WriteUuid(VoterDirectoryId);
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// RemoveRaftVoter response (API key 81).
+/// </summary>
+public sealed class RemoveRaftVoterResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.RemoveRaftVoter;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    public int ThrottleTimeMs { get; init; }
+    public ErrorCode ErrorCode { get; init; }
+    public string? ErrorMessage { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+
+        reader.SkipTaggedFields();
+
+        return new RemoveRaftVoterResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+    }
+}
+
+public sealed class RaftVoterEndpointData
+{
+    public required string Name { get; init; }
+    public required string Host { get; init; }
+    public ushort Port { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(Name);
+        writer.WriteCompactString(Host);
+        writer.WriteUInt16(Port);
+        writer.WriteEmptyTaggedFields();
+    }
+
+    public static RaftVoterEndpointData Read(ref KafkaProtocolReader reader)
+    {
+        var name = reader.ReadCompactString() ?? string.Empty;
+        var host = reader.ReadCompactString() ?? string.Empty;
+        var port = reader.ReadUInt16();
+
+        reader.SkipTaggedFields();
+
+        return new RaftVoterEndpointData
+        {
+            Name = name,
+            Host = host,
+            Port = port
+        };
+    }
+}

--- a/src/Dekaf/Protocol/Messages/UnregisterBrokerMessages.cs
+++ b/src/Dekaf/Protocol/Messages/UnregisterBrokerMessages.cs
@@ -1,0 +1,50 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// UnregisterBroker request (API key 64).
+/// Unregisters a broker from KRaft metadata.
+/// </summary>
+public sealed class UnregisterBrokerRequest : IKafkaRequest<UnregisterBrokerResponse>
+{
+    public static ApiKey ApiKey => ApiKey.UnregisterBroker;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    public int BrokerId { get; init; }
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteInt32(BrokerId);
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// UnregisterBroker response (API key 64).
+/// </summary>
+public sealed class UnregisterBrokerResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.UnregisterBroker;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    public int ThrottleTimeMs { get; init; }
+    public ErrorCode ErrorCode { get; init; }
+    public string? ErrorMessage { get; init; }
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var errorMessage = reader.ReadCompactString();
+
+        reader.SkipTaggedFields();
+
+        return new UnregisterBrokerResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientKRaftQuorumTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientKRaftQuorumTests.cs
@@ -1,0 +1,301 @@
+using Dekaf.Admin;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public sealed class AdminClientKRaftQuorumTests
+{
+    [Test]
+    public async Task DescribeMetadataQuorumAsync_SendsMetadataPartitionAndMapsResult()
+    {
+        await using var context = new AdminTestContext();
+        var directoryId = Guid.NewGuid();
+        context.EnqueueDescribe(new DescribeQuorumResponse
+        {
+            ErrorCode = ErrorCode.None,
+            Topics =
+            [
+                new DescribeQuorumResponseTopic
+                {
+                    TopicName = "__cluster_metadata",
+                    Partitions =
+                    [
+                        new DescribeQuorumResponsePartition
+                        {
+                            PartitionIndex = 0,
+                            ErrorCode = ErrorCode.None,
+                            LeaderId = 1,
+                            LeaderEpoch = 7,
+                            HighWatermark = 42,
+                            CurrentVoters =
+                            [
+                                new DescribeQuorumReplicaState
+                                {
+                                    ReplicaId = 1,
+                                    ReplicaDirectoryId = directoryId,
+                                    LogEndOffset = 41,
+                                    LastFetchTimestamp = 100,
+                                    LastCaughtUpTimestamp = 99
+                                }
+                            ],
+                            Observers = []
+                        }
+                    ]
+                }
+            ],
+            Nodes =
+            [
+                new DescribeQuorumResponseNode
+                {
+                    NodeId = 1,
+                    Listeners =
+                    [
+                        new RaftVoterEndpointData
+                        {
+                            Name = "CONTROLLER",
+                            Host = "localhost",
+                            Port = 9093
+                        }
+                    ]
+                }
+            ]
+        });
+
+        var result = await context.Client.DescribeMetadataQuorumAsync();
+
+        var request = context.SingleRequest<DescribeQuorumRequest>();
+        var requestTopic = request.Topics.Single();
+        await Assert.That(context.SingleVersion<DescribeQuorumRequest>()).IsEqualTo((short)2);
+        await Assert.That(requestTopic.TopicName).IsEqualTo("__cluster_metadata");
+        await Assert.That(requestTopic.Partitions.Single().PartitionIndex).IsEqualTo(0);
+        await Assert.That(result.LeaderId).IsEqualTo(1);
+        await Assert.That(result.LeaderEpoch).IsEqualTo(7);
+        await Assert.That(result.HighWatermark).IsEqualTo(42);
+        var voter = result.CurrentVoters.Single();
+        await Assert.That(voter.ReplicaDirectoryId).IsEqualTo(directoryId);
+        var listener = result.Nodes.Single().Listeners.Single();
+        await Assert.That(listener.Port).IsEqualTo(9093);
+    }
+
+    [Test]
+    public async Task AddRaftVoterAsync_SendsControllerRequest()
+    {
+        await using var context = new AdminTestContext();
+        var directoryId = Guid.NewGuid();
+        context.EnqueueAdd(new AddRaftVoterResponse
+        {
+            ErrorCode = ErrorCode.None
+        });
+
+        await context.Client.AddRaftVoterAsync(
+            voterId: 2,
+            voterDirectoryId: directoryId,
+            endpoints:
+            [
+                new RaftVoterEndpoint
+                {
+                    Name = "CONTROLLER",
+                    Host = "localhost",
+                    Port = 9093
+                }
+            ],
+            options: new AddRaftVoterOptions
+            {
+                ClusterId = "cluster-a",
+                TimeoutMs = 1234,
+                AckWhenCommitted = false
+            });
+
+        var request = context.SingleRequest<AddRaftVoterRequest>();
+        await Assert.That(context.SingleVersion<AddRaftVoterRequest>()).IsEqualTo((short)1);
+        await Assert.That(request.ClusterId).IsEqualTo("cluster-a");
+        await Assert.That(request.TimeoutMs).IsEqualTo(1234);
+        await Assert.That(request.VoterId).IsEqualTo(2);
+        await Assert.That(request.VoterDirectoryId).IsEqualTo(directoryId);
+        await Assert.That(request.AckWhenCommitted).IsFalse();
+        await Assert.That(request.Listeners.Single().Port).IsEqualTo((ushort)9093);
+    }
+
+    [Test]
+    public async Task AddRaftVoterAsync_AckWhenCommittedFalseOnV0Broker_ThrowsBrokerVersionException()
+    {
+        await using var context = new AdminTestContext(addRaftVoterMaxVersion: 0);
+
+        await Assert.That(async () => await context.Client.AddRaftVoterAsync(
+                voterId: 2,
+                voterDirectoryId: Guid.NewGuid(),
+                endpoints:
+                [
+                    new RaftVoterEndpoint
+                    {
+                        Name = "CONTROLLER",
+                        Host = "localhost",
+                        Port = 9093
+                    }
+                ],
+                options: new AddRaftVoterOptions { AckWhenCommitted = false }))
+            .Throws<BrokerVersionException>();
+
+        await Assert.That(context.RequestCount<AddRaftVoterRequest>()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RemoveRaftVoterAsync_SendsControllerRequest()
+    {
+        await using var context = new AdminTestContext();
+        var directoryId = Guid.NewGuid();
+        context.EnqueueRemove(new RemoveRaftVoterResponse
+        {
+            ErrorCode = ErrorCode.None
+        });
+
+        await context.Client.RemoveRaftVoterAsync(
+            voterId: 2,
+            voterDirectoryId: directoryId,
+            options: new RemoveRaftVoterOptions { ClusterId = "cluster-a" });
+
+        var request = context.SingleRequest<RemoveRaftVoterRequest>();
+        await Assert.That(context.SingleVersion<RemoveRaftVoterRequest>()).IsEqualTo((short)0);
+        await Assert.That(request.ClusterId).IsEqualTo("cluster-a");
+        await Assert.That(request.VoterId).IsEqualTo(2);
+        await Assert.That(request.VoterDirectoryId).IsEqualTo(directoryId);
+    }
+
+    [Test]
+    public async Task UnregisterBrokerAsync_SendsControllerRequest()
+    {
+        await using var context = new AdminTestContext();
+        context.EnqueueUnregister(new UnregisterBrokerResponse
+        {
+            ErrorCode = ErrorCode.None
+        });
+
+        await context.Client.UnregisterBrokerAsync(brokerId: 3);
+
+        var request = context.SingleRequest<UnregisterBrokerRequest>();
+        await Assert.That(context.SingleVersion<UnregisterBrokerRequest>()).IsEqualTo((short)0);
+        await Assert.That(request.BrokerId).IsEqualTo(3);
+    }
+
+    private sealed class AdminTestContext : IAsyncDisposable
+    {
+        private readonly IConnectionPool _pool;
+        private readonly MetadataManager _metadataManager;
+        private readonly Queue<DescribeQuorumResponse> _describeResponses = new();
+        private readonly Queue<AddRaftVoterResponse> _addResponses = new();
+        private readonly Queue<RemoveRaftVoterResponse> _removeResponses = new();
+        private readonly Queue<UnregisterBrokerResponse> _unregisterResponses = new();
+        private readonly List<(object Request, short Version)> _requests = [];
+
+        public AdminTestContext(short addRaftVoterMaxVersion = 1)
+        {
+            Connection = Substitute.For<IKafkaConnection>();
+            Connection.BrokerId.Returns(1);
+            Connection.Host.Returns("localhost");
+            Connection.Port.Returns(9092);
+            Connection.IsConnected.Returns(true);
+
+            Connection.SendAsync<DescribeQuorumRequest, DescribeQuorumResponse>(
+                    Arg.Any<DescribeQuorumRequest>(),
+                    Arg.Any<short>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    Capture(callInfo.ArgAt<DescribeQuorumRequest>(0), callInfo.ArgAt<short>(1));
+                    return new ValueTask<DescribeQuorumResponse>(_describeResponses.Dequeue());
+                });
+
+            Connection.SendAsync<AddRaftVoterRequest, AddRaftVoterResponse>(
+                    Arg.Any<AddRaftVoterRequest>(),
+                    Arg.Any<short>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    Capture(callInfo.ArgAt<AddRaftVoterRequest>(0), callInfo.ArgAt<short>(1));
+                    return new ValueTask<AddRaftVoterResponse>(_addResponses.Dequeue());
+                });
+
+            Connection.SendAsync<RemoveRaftVoterRequest, RemoveRaftVoterResponse>(
+                    Arg.Any<RemoveRaftVoterRequest>(),
+                    Arg.Any<short>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    Capture(callInfo.ArgAt<RemoveRaftVoterRequest>(0), callInfo.ArgAt<short>(1));
+                    return new ValueTask<RemoveRaftVoterResponse>(_removeResponses.Dequeue());
+                });
+
+            Connection.SendAsync<UnregisterBrokerRequest, UnregisterBrokerResponse>(
+                    Arg.Any<UnregisterBrokerRequest>(),
+                    Arg.Any<short>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    Capture(callInfo.ArgAt<UnregisterBrokerRequest>(0), callInfo.ArgAt<short>(1));
+                    return new ValueTask<UnregisterBrokerResponse>(_unregisterResponses.Dequeue());
+                });
+
+            _pool = Substitute.For<IConnectionPool>();
+            _pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<IKafkaConnection>(Connection));
+            _pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<IKafkaConnection>(Connection));
+
+            _metadataManager = new MetadataManager(_pool, ["localhost:9092"]);
+            _metadataManager.Metadata.Update(CreateMetadataResponse());
+            _metadataManager.SetApiVersion(ApiKey.DescribeQuorum, 0, 2);
+            _metadataManager.SetApiVersion(ApiKey.AddRaftVoter, 0, addRaftVoterMaxVersion);
+            _metadataManager.SetApiVersion(ApiKey.RemoveRaftVoter, 0, 0);
+            _metadataManager.SetApiVersion(ApiKey.UnregisterBroker, 0, 0);
+
+            Client = new AdminClient(
+                new AdminClientOptions { BootstrapServers = ["localhost:9092"] },
+                _pool,
+                _metadataManager);
+        }
+
+        public AdminClient Client { get; }
+        public IKafkaConnection Connection { get; }
+
+        public void EnqueueDescribe(DescribeQuorumResponse response) => _describeResponses.Enqueue(response);
+        public void EnqueueAdd(AddRaftVoterResponse response) => _addResponses.Enqueue(response);
+        public void EnqueueRemove(RemoveRaftVoterResponse response) => _removeResponses.Enqueue(response);
+        public void EnqueueUnregister(UnregisterBrokerResponse response) => _unregisterResponses.Enqueue(response);
+
+        public T SingleRequest<T>() where T : class => _requests.Select(static request => request.Request).OfType<T>().Single();
+
+        public short SingleVersion<T>() where T : class => _requests.Single(request => request.Request is T).Version;
+
+        public int RequestCount<T>() where T : class => _requests.Count(request => request.Request is T);
+
+        public async ValueTask DisposeAsync()
+        {
+            await Client.DisposeAsync().ConfigureAwait(false);
+            await _metadataManager.DisposeAsync().ConfigureAwait(false);
+            await _pool.DisposeAsync().ConfigureAwait(false);
+        }
+
+        private void Capture(object request, short version) => _requests.Add((request, version));
+
+        private static MetadataResponse CreateMetadataResponse() => new()
+        {
+            Brokers =
+            [
+                new BrokerMetadata
+                {
+                    NodeId = 1,
+                    Host = "localhost",
+                    Port = 9092
+                }
+            ],
+            ClusterId = "test-cluster",
+            ControllerId = 1,
+            Topics = []
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ApiKeyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ApiKeyTests.cs
@@ -13,4 +13,14 @@ public sealed class ApiKeyTests
         await Assert.That((short)heartbeat).IsEqualTo((short)88);
         await Assert.That((short)describe).IsEqualTo((short)89);
     }
+
+    [Test]
+    public async Task KRaftAdminApiKeys_HaveKafkaAssignedValues()
+    {
+        var addRaftVoter = Enum.Parse<ApiKey>(nameof(ApiKey.AddRaftVoter));
+        var removeRaftVoter = Enum.Parse<ApiKey>(nameof(ApiKey.RemoveRaftVoter));
+
+        await Assert.That((short)addRaftVoter).IsEqualTo((short)80);
+        await Assert.That((short)removeRaftVoter).IsEqualTo((short)81);
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Protocol/KRaftAdminMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/KRaftAdminMessageTests.cs
@@ -1,0 +1,238 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class KRaftAdminMessageTests
+{
+    [Test]
+    public async Task MessageMetadata_MatchesKafkaAssignedApiKeys()
+    {
+        await Assert.That(DescribeQuorumRequest.ApiKey).IsEqualTo(ApiKey.DescribeQuorum);
+        await Assert.That(DescribeQuorumRequest.LowestSupportedVersion).IsEqualTo((short)0);
+        await Assert.That(DescribeQuorumRequest.HighestSupportedVersion).IsEqualTo((short)2);
+
+        await Assert.That(AddRaftVoterRequest.ApiKey).IsEqualTo(ApiKey.AddRaftVoter);
+        await Assert.That(AddRaftVoterRequest.LowestSupportedVersion).IsEqualTo((short)0);
+        await Assert.That(AddRaftVoterRequest.HighestSupportedVersion).IsEqualTo((short)1);
+
+        await Assert.That(RemoveRaftVoterRequest.ApiKey).IsEqualTo(ApiKey.RemoveRaftVoter);
+        await Assert.That(UnregisterBrokerRequest.ApiKey).IsEqualTo(ApiKey.UnregisterBroker);
+    }
+
+    [Test]
+    public async Task DescribeQuorumRequest_Write_V2_EncodesMetadataPartition()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        var request = new DescribeQuorumRequest
+        {
+            Topics =
+            [
+                new DescribeQuorumRequestTopic
+                {
+                    TopicName = "__cluster_metadata",
+                    Partitions =
+                    [
+                        new DescribeQuorumRequestPartition
+                        {
+                            PartitionIndex = 0
+                        }
+                    ]
+                }
+            ]
+        };
+
+        request.Write(ref writer, version: 2);
+
+        string topicName;
+        IReadOnlyList<int> partitions;
+        long remaining;
+        {
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            var topics = reader.ReadCompactArray(static (ref KafkaProtocolReader r) =>
+            {
+                var name = r.ReadCompactString() ?? string.Empty;
+                var partitionIds = r.ReadCompactArray(static (ref KafkaProtocolReader pr) =>
+                {
+                    var partitionId = pr.ReadInt32();
+                    pr.SkipTaggedFields();
+                    return partitionId;
+                });
+
+                r.SkipTaggedFields();
+                return (name, partitionIds);
+            });
+            reader.SkipTaggedFields();
+            topicName = topics[0].name;
+            partitions = topics[0].partitionIds;
+            remaining = reader.Remaining;
+        }
+
+        await Assert.That(topicName).IsEqualTo("__cluster_metadata");
+        await Assert.That(partitions).IsEquivalentTo([0]);
+        await Assert.That(remaining).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task AddRaftVoterRequest_Write_V1_EncodesAckAndListeners()
+    {
+        var directoryId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        var request = new AddRaftVoterRequest
+        {
+            ClusterId = "cluster-a",
+            TimeoutMs = 1234,
+            VoterId = 2,
+            VoterDirectoryId = directoryId,
+            Listeners =
+            [
+                new RaftVoterEndpointData
+                {
+                    Name = "CONTROLLER",
+                    Host = "localhost",
+                    Port = 9093
+                }
+            ],
+            AckWhenCommitted = false
+        };
+
+        request.Write(ref writer, version: 1);
+
+        string? clusterId;
+        int timeoutMs;
+        int voterId;
+        Guid parsedDirectoryId;
+        IReadOnlyList<ListenerData> listeners;
+        bool ackWhenCommitted;
+        long remaining;
+        {
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            clusterId = reader.ReadCompactString();
+            timeoutMs = reader.ReadInt32();
+            voterId = reader.ReadInt32();
+            parsedDirectoryId = reader.ReadUuid();
+            listeners = reader.ReadCompactArray(static (ref KafkaProtocolReader r) =>
+            {
+                var name = r.ReadCompactString() ?? string.Empty;
+                var host = r.ReadCompactString() ?? string.Empty;
+                var port = r.ReadUInt16();
+                r.SkipTaggedFields();
+                return new ListenerData(name, host, port);
+            });
+            ackWhenCommitted = reader.ReadBoolean();
+            reader.SkipTaggedFields();
+            remaining = reader.Remaining;
+        }
+
+        await Assert.That(clusterId).IsEqualTo("cluster-a");
+        await Assert.That(timeoutMs).IsEqualTo(1234);
+        await Assert.That(voterId).IsEqualTo(2);
+        await Assert.That(parsedDirectoryId).IsEqualTo(directoryId);
+        var listener = listeners.Single();
+        await Assert.That(listener.Name).IsEqualTo("CONTROLLER");
+        await Assert.That(listener.Host).IsEqualTo("localhost");
+        await Assert.That(listener.Port).IsEqualTo((ushort)9093);
+        await Assert.That(ackWhenCommitted).IsFalse();
+        await Assert.That(remaining).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DescribeQuorumResponse_Read_V2_ParsesQuorumNodesAndReplicaState()
+    {
+        var directoryId = Guid.NewGuid();
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactNullableString(null);
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteCompactString("__cluster_metadata");
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactNullableString(null);
+        writer.WriteInt32(3);
+        writer.WriteInt32(7);
+        writer.WriteInt64(42);
+        writer.WriteUnsignedVarInt(1 + 1);
+        WriteReplicaState(ref writer, 3, directoryId, logEndOffset: 41, lastFetchTimestamp: 100, lastCaughtUpTimestamp: 99);
+        writer.WriteUnsignedVarInt(0 + 1);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteInt32(3);
+        writer.WriteUnsignedVarInt(1 + 1);
+        writer.WriteCompactString("CONTROLLER");
+        writer.WriteCompactString("localhost");
+        writer.WriteUInt16(9093);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+
+        DescribeQuorumResponse response;
+        long remaining;
+        {
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            response = (DescribeQuorumResponse)DescribeQuorumResponse.Read(ref reader, version: 2);
+            remaining = reader.Remaining;
+        }
+
+        var partition = response.Topics.Single().Partitions.Single();
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(partition.LeaderId).IsEqualTo(3);
+        await Assert.That(partition.LeaderEpoch).IsEqualTo(7);
+        await Assert.That(partition.HighWatermark).IsEqualTo(42);
+        var voter = partition.CurrentVoters.Single();
+        await Assert.That(voter.ReplicaDirectoryId).IsEqualTo(directoryId);
+        await Assert.That(voter.LastFetchTimestamp).IsEqualTo(100);
+        var nodeListener = response.Nodes.Single().Listeners.Single();
+        await Assert.That(nodeListener.Port).IsEqualTo((ushort)9093);
+        await Assert.That(remaining).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task UnregisterBrokerResponse_Read_V0_ParsesErrorFields()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(5);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactNullableString("ok");
+        writer.WriteEmptyTaggedFields();
+
+        UnregisterBrokerResponse response;
+        long remaining;
+        {
+            var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+            response = (UnregisterBrokerResponse)UnregisterBrokerResponse.Read(ref reader, version: 0);
+            remaining = reader.Remaining;
+        }
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(5);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ErrorMessage).IsEqualTo("ok");
+        await Assert.That(remaining).IsEqualTo(0);
+    }
+
+    private static void WriteReplicaState(
+        ref KafkaProtocolWriter writer,
+        int replicaId,
+        Guid directoryId,
+        long logEndOffset,
+        long lastFetchTimestamp,
+        long lastCaughtUpTimestamp)
+    {
+        writer.WriteInt32(replicaId);
+        writer.WriteUuid(directoryId);
+        writer.WriteInt64(logEndOffset);
+        writer.WriteInt64(lastFetchTimestamp);
+        writer.WriteInt64(lastCaughtUpTimestamp);
+        writer.WriteEmptyTaggedFields();
+    }
+
+    private readonly record struct ListenerData(string Name, string Host, ushort Port);
+}


### PR DESCRIPTION
## Summary
- add KRaft metadata quorum admin APIs for DescribeMetadataQuorum, AddRaftVoter, RemoveRaftVoter, and UnregisterBroker
- add protocol messages for API keys 55, 64, 80, and 81
- add in-memory admin stubs plus protocol/admin unit coverage

## Test plan
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/KRaftAdminMessageTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/AdminClientKRaftQuorumTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/ApiKeyTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/KafkaConnectionTests/*"

Full default unit run was attempted after a fresh rebuild and hit unrelated KafkaConnectionTests timeout failures from origin/main; the KafkaConnectionTests class passed in isolation.

Closes #1388.