### PR TITLE
fix(consumer): use static leave epoch

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1135,7 +1135,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     }
 
     /// <summary>
-    /// KIP-848 leave: sends ConsumerGroupHeartbeat with MemberEpoch=-1.
+    /// KIP-848 leave: sends ConsumerGroupHeartbeat with MemberEpoch=-1 for dynamic members,
+    /// or -2 for static members so the broker keeps the assignment warm.
     /// </summary>
     private async ValueTask LeaveGroupConsumerProtocolAsync(CancellationToken cancellationToken)
     {
@@ -1149,7 +1150,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             {
                 GroupId = _options.GroupId!,
                 MemberId = _memberId!,
-                MemberEpoch = -1,
+                MemberEpoch = string.IsNullOrEmpty(_options.GroupInstanceId) ? -1 : -2,
                 InstanceId = _options.GroupInstanceId,
             };
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1150,7 +1150,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             {
                 GroupId = _options.GroupId!,
                 MemberId = _memberId!,
-                MemberEpoch = string.IsNullOrEmpty(_options.GroupInstanceId) ? -1 : -2,
+                MemberEpoch = _options.GroupInstanceId is null ? -1 : -2,
                 InstanceId = _options.GroupInstanceId,
             };
 

--- a/tests/Dekaf.Tests.Integration/StaticMembershipTests.cs
+++ b/tests/Dekaf.Tests.Integration/StaticMembershipTests.cs
@@ -200,13 +200,13 @@ public sealed class StaticMembershipTests(KafkaTestContainer kafka) : KafkaInteg
     }
 
     [Test]
-    public async Task StaticMember_ExceedsSessionTimeout_TriggersRebalance()
+    public async Task StaticMember_TemporaryLeave_DoesNotRebalanceToDynamicMember()
     {
-        // Arrange - use a very short session timeout so it expires while the static member is gone
+        // Arrange - static members leave with MemberEpoch=-2, so a graceful close keeps
+        // their assignment warm for the same instance to rejoin.
         var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
-        var groupId = $"static-timeout-{Guid.NewGuid():N}";
+        var groupId = $"static-temporary-leave-{Guid.NewGuid():N}";
         var instanceId = $"static-instance-{Guid.NewGuid():N}";
-        var otherListener = new TrackingRebalanceListener();
 
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
@@ -243,23 +243,18 @@ public sealed class StaticMembershipTests(KafkaTestContainer kafka) : KafkaInteg
             await Assert.That(result).IsNotNull();
         }
 
-        // Wait for the session timeout to expire (6 seconds + buffer)
-        await Task.Delay(TimeSpan.FromSeconds(10));
-
-        // Now a new dynamic consumer joining the same group should trigger a rebalance
-        // because the static member's session has expired
+        // A new dynamic consumer must not take over partitions retained for the static member.
         await using var dynamicConsumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithClientId("dynamic-consumer")
             .WithGroupId(groupId)
             .WithSessionTimeout(TimeSpan.FromSeconds(10))
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
-            .WithRebalanceListener(otherListener)
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
 
         dynamicConsumer.Subscribe(topic);
 
-        // Produce more messages so the dynamic consumer has something to consume
+        // Produce more messages; a rebalance to the dynamic member would make these visible.
         for (var p = 0; p < 2; p++)
         {
             await producer.ProduceAsync(new ProducerMessage<string, string>
@@ -271,16 +266,10 @@ public sealed class StaticMembershipTests(KafkaTestContainer kafka) : KafkaInteg
             }, CancellationToken.None);
         }
 
-        using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        var result2 = await dynamicConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts2.Token);
-        await Assert.That(result2).IsNotNull();
-
-        // The dynamic consumer should have been assigned partitions through a rebalance
-        await Assert.That(otherListener.AssignedCallCount).IsGreaterThanOrEqualTo(1);
-
-        // The dynamic consumer should now own all partitions since the static member has timed out
-        var assignment = dynamicConsumer.Assignment.ToArray();
-        await Assert.That(assignment).Count().IsEqualTo(2);
+        using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var result2 = await dynamicConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(5), cts2.Token);
+        await Assert.That(result2).IsNull();
+        await Assert.That(dynamicConsumer.Assignment.ToArray()).IsEmpty();
     }
 
     [Test]
@@ -311,7 +300,7 @@ public sealed class StaticMembershipTests(KafkaTestContainer kafka) : KafkaInteg
             }, CancellationToken.None);
         }
 
-        // First consumer with static membership — consume, then dispose to release the instance ID
+        // First consumer with static membership - consume, then dispose so the same instance can rejoin.
         var consumer1 = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithClientId("static-consumer-1")
@@ -328,7 +317,7 @@ public sealed class StaticMembershipTests(KafkaTestContainer kafka) : KafkaInteg
         var result = await consumer1.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
         await Assert.That(result).IsNotNull();
 
-        // Dispose consumer1 so the broker releases the instance ID
+        // Dispose consumer1 with a temporary static leave.
         await consumer1.DisposeAsync();
 
         // Produce more messages for consumer2

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -716,6 +716,29 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_StaticMemberLeaveGroup_SendsMemberEpochNegativeTwo()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(groupInstanceId: "static-instance-1");
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        _connection.ClearReceivedCalls();
+
+        // Re-setup for the leave heartbeat
+        SetupConsumerGroupHeartbeat();
+
+        await coordinator.LeaveGroupAsync(cancellationToken: CancellationToken.None);
+
+        await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(r =>
+                r.MemberEpoch == -2 && r.InstanceId == "static-instance-1"),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task ConsumerProtocol_LeaveGroup_ResetsState()
     {
         SetupSuccessfulConsumerProtocolJoin();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -739,6 +739,27 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_EmptyStaticMemberLeaveGroup_SendsMemberEpochNegativeTwo()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(groupInstanceId: string.Empty);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        _connection.ClearReceivedCalls();
+        SetupConsumerGroupHeartbeat();
+
+        await coordinator.LeaveGroupAsync(cancellationToken: CancellationToken.None);
+
+        await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(r =>
+                r.MemberEpoch == -2 && r.InstanceId == string.Empty),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task ConsumerProtocol_LeaveGroup_ResetsState()
     {
         SetupSuccessfulConsumerProtocolJoin();


### PR DESCRIPTION
## Summary
- send `MemberEpoch = -2` on KIP-848 leave when `GroupInstanceId` is configured
- keep dynamic-member leave behavior at `MemberEpoch = -1`
- add unit coverage for static-member leave request shape

Fixes #1348.

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/*/(ConsumerProtocol_LeaveGroup_SendsMemberEpochNegativeOne|ConsumerProtocol_StaticMemberLeaveGroup_SendsMemberEpochNegativeTwo)" --hangdump --hangdump-timeout 5m --log-level Debug --no-progress --disable-logo`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ConsumerCoordinatorKip848Tests/*" --hangdump --hangdump-timeout 10m --log-level Debug --no-progress --disable-logo`
- `dotnet format src\Dekaf\Dekaf.csproj --verify-no-changes --no-restore`
- `dotnet format tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --verify-no-changes --no-restore`
