### PR TITLE
fix(consumer): surface fatal heartbeat errors

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -50,6 +50,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private readonly SemaphoreSlim _fetchLock = new(1, 1);
 
     private volatile CoordinatorState _state = CoordinatorState.Unjoined;
+    private GroupException? _fatalHeartbeatException;
     private int _disposed;
     private readonly Func<int> _getCoordinationConnectionIndex;
 
@@ -165,6 +166,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (string.IsNullOrEmpty(_options.GroupId))
             return;
 
+        ThrowIfFatalHeartbeatException();
+
         if (_state == CoordinatorState.Stable && SubscriptionMatches(topics, subscribedTopicRegex))
             return;
 
@@ -187,6 +190,19 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         errorCode is ErrorCode.NotCoordinator
             or ErrorCode.CoordinatorNotAvailable
             or ErrorCode.CoordinatorLoadInProgress;
+
+    private void StoreFatalHeartbeatException(GroupException exception)
+    {
+        _state = CoordinatorState.Unjoined;
+        Interlocked.CompareExchange(ref _fatalHeartbeatException, exception, null);
+    }
+
+    private void ThrowIfFatalHeartbeatException()
+    {
+        var exception = Interlocked.Exchange(ref _fatalHeartbeatException, null);
+        if (exception is not null)
+            throw exception;
+    }
 
     private static bool SetEquals(StringSet? current, StringSet next)
     {
@@ -962,6 +978,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
+            ThrowIfFatalHeartbeatException();
+
             if (_state == CoordinatorState.Stable)
                 return;
 
@@ -1123,7 +1141,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                             break;
 
                         default:
-                            continue; // Unrecognized group error — continue heartbeating
+                            StoreFatalHeartbeatException(ge);
+                            break;
                     }
 
                     break;

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -191,10 +191,19 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             or ErrorCode.CoordinatorNotAvailable
             or ErrorCode.CoordinatorLoadInProgress;
 
-    private void StoreFatalHeartbeatException(GroupException exception)
+    private async ValueTask StoreFatalHeartbeatExceptionAsync(GroupException exception)
     {
-        _state = CoordinatorState.Unjoined;
         Interlocked.CompareExchange(ref _fatalHeartbeatException, exception, null);
+
+        await _lock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            _state = CoordinatorState.Unjoined;
+        }
+        finally
+        {
+            _lock.Release();
+        }
     }
 
     private void ThrowIfFatalHeartbeatException()
@@ -1141,7 +1150,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                             break;
 
                         default:
-                            StoreFatalHeartbeatException(ge);
+                            await StoreFatalHeartbeatExceptionAsync(ge).ConfigureAwait(false);
                             break;
                     }
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -195,7 +195,15 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     {
         Interlocked.CompareExchange(ref _fatalHeartbeatException, exception, null);
 
-        await _lock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            await _lock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
+
         try
         {
             _state = CoordinatorState.Unjoined;

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -922,6 +922,73 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    [Arguments(ErrorCode.GroupAuthorizationFailed)]
+    [Arguments(ErrorCode.InvalidGroupId)]
+    public async Task ConsumerProtocol_FatalGroupErrorDuringHeartbeat_PropagatesOnNextEnsureActiveGroup(
+        ErrorCode errorCode)
+    {
+        SetupFindCoordinator();
+
+        var callCount = 0;
+        var fatalHeartbeatReturned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+
+                if (count == 1)
+                {
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-1",
+                        MemberEpoch = 5,
+                        HeartbeatIntervalMs = 100
+                    });
+                }
+
+                fatalHeartbeatReturned.TrySetResult();
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = errorCode,
+                    ErrorMessage = "fatal group error",
+                    HeartbeatIntervalMs = 60000
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 100);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var topics = new HashSet<string> { "test-topic" };
+
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+
+        await fatalHeartbeatReturned.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await TestWait.UntilAsync(
+            () => coordinator.State == CoordinatorState.Unjoined,
+            TimeSpan.FromSeconds(5));
+
+        GroupException? caught = null;
+        try
+        {
+            await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        }
+        catch (GroupException ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.ErrorCode).IsEqualTo(errorCode);
+        await Assert.That(caught.GroupId).IsEqualTo("test-group");
+        await Assert.That(callCount).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task ConsumerProtocol_UnknownMemberId_InJoinPath_ResetsAndRetries()
     {
         SetupFindCoordinator();


### PR DESCRIPTION
Fixes #1347.\n\n## Summary\n- stash non-retriable KIP-848 heartbeat group failures from the background loop\n- rethrow the stored heartbeat failure from the next EnsureActiveGroupAsync call before the stable fast-path can hide it\n- add coverage for GroupAuthorizationFailed and InvalidGroupId mid-session heartbeats\n\n## Tests\n- dotnet build tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --configuration Release\n- dotnet format src\\Dekaf\\Dekaf.csproj --verify-no-changes --include src\\Dekaf\\Consumer\\ConsumerCoordinator.cs\n- dotnet format tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --verify-no-changes --include tests\\Dekaf.Tests.Unit\\Consumer\\ConsumerCoordinatorKip848Tests.cs\n- dotnet run --project tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --disable-logo --no-ansi --maximum-parallel-tests 20