### PR TITLE
perf(protocol): cache record payload CRC

### DIFF
--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -450,6 +450,7 @@ public sealed class RecordBatch : IDisposable
 
     /// <summary>
     /// CRC32C of the bytes in <see cref="PreCompressedRecords"/>.
+    /// Valid only while the pooled buffer remains retained for this batch and unmodified through Write().
     /// </summary>
     internal uint PreCompressedRecordsCrc { get; private set; }
 
@@ -457,6 +458,7 @@ public sealed class RecordBatch : IDisposable
 
     private ReadOnlyMemory<byte> _preEncodedRecords;
     private bool _hasPreEncodedRecords;
+    // Valid only while _preEncodedRecords remains retained for this batch and unmodified through Write().
     private uint _preEncodedRecordsCrc;
 
     internal bool HasPreEncodedRecords => _hasPreEncodedRecords;

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -199,6 +199,8 @@ internal sealed class DetachableBufferWriter : IBufferWriter<byte>, IDisposable
         _buffer = pool.Rent(Math.Max(MinimumInitialCapacity, initialCapacity));
     }
 
+    public ReadOnlySpan<byte> WrittenSpan => _buffer.AsSpan(0, _written);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Advance(int count)
     {
@@ -446,10 +448,16 @@ public sealed class RecordBatch : IDisposable
     /// </summary>
     internal CompressionType PreCompressedType { get; private set; }
 
+    /// <summary>
+    /// CRC32C of the bytes in <see cref="PreCompressedRecords"/>.
+    /// </summary>
+    internal uint PreCompressedRecordsCrc { get; private set; }
+
     internal bool HasPreCompressedRecords => PreCompressedRecords is not null;
 
     private ReadOnlyMemory<byte> _preEncodedRecords;
     private bool _hasPreEncodedRecords;
+    private uint _preEncodedRecordsCrc;
 
     internal bool HasPreEncodedRecords => _hasPreEncodedRecords;
 
@@ -457,6 +465,7 @@ public sealed class RecordBatch : IDisposable
     {
         _preEncodedRecords = records;
         _hasPreEncodedRecords = true;
+        _preEncodedRecordsCrc = Crc32C.Compute(records.Span);
     }
 
     /// <summary>
@@ -483,6 +492,7 @@ public sealed class RecordBatch : IDisposable
             var writer = new KafkaProtocolWriter(encodedBuffer);
             WriteRecords(uncompressedRecords, ref writer);
 
+            PreCompressedRecordsCrc = Crc32C.Compute(encodedBuffer.WrittenSpan);
             PreCompressedRecords = encodedBuffer.DetachBuffer(out var encodedLength);
             PreCompressedLength = encodedLength;
             PreCompressedType = CompressionType.None;
@@ -495,6 +505,7 @@ public sealed class RecordBatch : IDisposable
         {
             using var compressedBuffer = new DetachableBufferWriter(ProducerDataPool.BytePool, _preEncodedRecords.Length);
             codec.Compress(new ReadOnlySequence<byte>(_preEncodedRecords), compressedBuffer);
+            PreCompressedRecordsCrc = Crc32C.Compute(compressedBuffer.WrittenSpan);
             PreCompressedRecords = compressedBuffer.DetachBuffer(out var compressedLength);
             PreCompressedLength = compressedLength;
             PreCompressedType = compression;
@@ -512,6 +523,7 @@ public sealed class RecordBatch : IDisposable
             WriteRecords(records, ref recordsWriter);
             using var serializedCompressedBuffer = new DetachableBufferWriter(ProducerDataPool.BytePool, recordsBuffer.WrittenCount);
             codec.Compress(new ReadOnlySequence<byte>(recordsBuffer.WrittenMemory), serializedCompressedBuffer);
+            PreCompressedRecordsCrc = Crc32C.Compute(serializedCompressedBuffer.WrittenSpan);
             PreCompressedRecords = serializedCompressedBuffer.DetachBuffer(out var serializedCompressedLength);
             PreCompressedLength = serializedCompressedLength;
             PreCompressedType = compression;
@@ -534,6 +546,7 @@ public sealed class RecordBatch : IDisposable
             PreCompressedRecords = null;
             PreCompressedLength = 0;
             PreCompressedType = CompressionType.None;
+            PreCompressedRecordsCrc = 0;
             Producer.ProducerDataPool.BytePool.Return(array, clearArray: false);
         }
     }
@@ -582,8 +595,10 @@ public sealed class RecordBatch : IDisposable
             item.PreCompressedRecords = null;
             item.PreCompressedLength = 0;
             item.PreCompressedType = CompressionType.None;
+            item.PreCompressedRecordsCrc = 0;
             item._preEncodedRecords = default;
             item._hasPreEncodedRecords = false;
+            item._preEncodedRecordsCrc = 0;
 
             // Reset mutable state to defaults
             item.BaseOffset = 0;
@@ -658,6 +673,7 @@ public sealed class RecordBatch : IDisposable
         batch.Records = Records;
         batch._preEncodedRecords = _preEncodedRecords;
         batch._hasPreEncodedRecords = _hasPreEncodedRecords;
+        batch._preEncodedRecordsCrc = _preEncodedRecordsCrc;
 
         // Transfer pre-compressed data — records content is unchanged,
         // only header fields differ (CRC is recomputed in Write()).
@@ -666,11 +682,13 @@ public sealed class RecordBatch : IDisposable
             batch.PreCompressedRecords = PreCompressedRecords;
             batch.PreCompressedLength = PreCompressedLength;
             batch.PreCompressedType = PreCompressedType;
+            batch.PreCompressedRecordsCrc = PreCompressedRecordsCrc;
 
             // Clear from old batch to prevent double-return to ArrayPool
             PreCompressedRecords = null;
             PreCompressedLength = 0;
             PreCompressedType = CompressionType.None;
+            PreCompressedRecordsCrc = 0;
         }
 
         return batch;
@@ -695,6 +713,7 @@ public sealed class RecordBatch : IDisposable
         // If pre-compressed at seal time, use that data directly (skip CPU-bound compression
         // on the send loop thread). Otherwise, serialize and compress inline.
         ReadOnlySpan<byte> compressedRecords;
+        uint compressedRecordsCrc;
         CompressionType effectiveCompression;
 
         // Rent a scratch cache only when needed (no pre-compressed data available).
@@ -706,11 +725,13 @@ public sealed class RecordBatch : IDisposable
             {
                 // Pre-compressed at seal time — use the stored data directly
                 compressedRecords = PreCompressedRecords.AsSpan(0, PreCompressedLength);
+                compressedRecordsCrc = PreCompressedRecordsCrc;
                 effectiveCompression = PreCompressedType;
             }
             else if (_hasPreEncodedRecords)
             {
                 compressedRecords = _preEncodedRecords.Span;
+                compressedRecordsCrc = _preEncodedRecordsCrc;
                 effectiveCompression = CompressionType.None;
             }
             else
@@ -731,11 +752,13 @@ public sealed class RecordBatch : IDisposable
                     var compressedBuffer = GetCompressedBuffer(cache);
                     codec.Compress(new ReadOnlySequence<byte>(recordsBuffer.WrittenMemory), compressedBuffer);
                     compressedRecords = compressedBuffer.WrittenSpan;
+                    compressedRecordsCrc = Crc32C.Compute(compressedRecords);
                     effectiveCompression = compression;
                 }
                 else
                 {
                     compressedRecords = recordsBuffer.WrittenSpan;
+                    compressedRecordsCrc = Crc32C.Compute(compressedRecords);
                     effectiveCompression = CompressionType.None;
                 }
             }
@@ -786,9 +809,10 @@ public sealed class RecordBatch : IDisposable
             offset += 4;
             BinaryPrimitives.WriteInt32BigEndian(contentSpan[offset..], records.Count);
             offset += 4;
+            var headerCrc = Crc32C.Compute(contentSpan[..crcContentFixedSize]);
             compressedRecords.CopyTo(contentSpan[offset..]);
 
-            var crc = Crc32C.Compute(contentSpan[..crcContentSize]);
+            var crc = Crc32C.Combine(headerCrc, compressedRecordsCrc, compressedRecords.Length);
 
             // Backpatch CRC at the beginning
             BinaryPrimitives.WriteInt32BigEndian(crcAndContentSpan, (int)crc);
@@ -1416,6 +1440,10 @@ internal static class Crc32C
 
         return ComputeSoftware(data);
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static uint Combine(uint prefixCrc, uint suffixCrc, int suffixByteCount)
+        => ShiftCrc32C(prefixCrc, suffixByteCount) ^ suffixCrc;
 
 #if !NETSTANDARD2_0
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/Dekaf.Tests.Unit/Protocol/Crc32CTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/Crc32CTests.cs
@@ -153,7 +153,7 @@ public class Crc32CTests
 
     private static int[] CombineLengths() =>
     [
-        0, 1, 2, 3, 7, 8, 31, 32, 63, 64, 255, 512, 513, 1024, 4096, 65536
+        0, 1, 2, 3, 7, 8, 31, 32, 63, 64, 255, 512, 513, 1024, 4096, 65536, 1048576
     ];
 
     private static uint ComputeBitwise(ReadOnlySpan<byte> data)

--- a/tests/Dekaf.Tests.Unit/Protocol/Crc32CTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/Crc32CTests.cs
@@ -31,6 +31,30 @@ public class Crc32CTests
     }
 
     [Test]
+    public async Task Combine_MixedLengths_MatchesConcatenatedCompute()
+    {
+        foreach (var prefixLength in CombineLengths())
+        {
+            foreach (var suffixLength in CombineLengths())
+            {
+                var prefix = CreateDeterministicBytes(prefixLength);
+                var suffix = CreateDeterministicBytes(suffixLength);
+                var combined = new byte[prefix.Length + suffix.Length];
+                prefix.CopyTo(combined, 0);
+                suffix.CopyTo(combined, prefix.Length);
+
+                var expected = Crc32C.Compute(combined);
+                var actual = Crc32C.Combine(
+                    Crc32C.Compute(prefix),
+                    Crc32C.Compute(suffix),
+                    suffix.Length);
+
+                await Assert.That(actual).IsEqualTo(expected);
+            }
+        }
+    }
+
+    [Test]
     public async Task ComputeSoftware_MixedLengths_MatchesBitwiseReference()
     {
         foreach (var length in MixedLengths())
@@ -126,6 +150,11 @@ public class Crc32CTests
             yield return length;
         }
     }
+
+    private static int[] CombineLengths() =>
+    [
+        0, 1, 2, 3, 7, 8, 31, 32, 63, 64, 255, 512, 513, 1024, 4096, 65536
+    ];
 
     private static uint ComputeBitwise(ReadOnlySpan<byte> data)
     {

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using Dekaf.Compression;
 using Dekaf.Protocol;
@@ -568,6 +569,32 @@ public class RecordBatchTests
     }
 
     [Test]
+    public async Task Write_WithPreCompressedRecords_WritesMatchingCrc()
+    {
+        using var batch = CreateTwoRecordBatch();
+        batch.PreCompress(CompressionType.Gzip, null);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        batch.Write(buffer);
+
+        var (storedCrc, computedCrc) = ReadRecordBatchCrcs(buffer.WrittenSpan);
+        await Assert.That(storedCrc).IsEqualTo(computedCrc);
+    }
+
+    [Test]
+    public async Task Write_WithPreEncodedRecords_WritesMatchingCrc()
+    {
+        using var batch = CreateTwoRecordBatch();
+        batch.SetPreEncodedRecords(EncodeRecords(batch.Records));
+
+        var buffer = new ArrayBufferWriter<byte>();
+        batch.Write(buffer);
+
+        var (storedCrc, computedCrc) = ReadRecordBatchCrcs(buffer.WrittenSpan);
+        await Assert.That(storedCrc).IsEqualTo(computedCrc);
+    }
+
+    [Test]
     public async Task PreCompress_None_RoundTripsThroughRead()
     {
         using var batch = CreateTwoRecordBatch();
@@ -610,6 +637,27 @@ public class RecordBatchTests
             }
         ]
     };
+
+    private static byte[] EncodeRecords(IReadOnlyList<Record> records)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        foreach (var record in records)
+            record.Write(ref writer);
+
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static (uint Stored, uint Computed) ReadRecordBatchCrcs(ReadOnlySpan<byte> batch)
+    {
+        const int crcOffset = 8 + 4 + 4 + 1;
+        const int crcContentOffset = crcOffset + 4;
+
+        var stored = BinaryPrimitives.ReadUInt32BigEndian(batch.Slice(crcOffset, 4));
+        var computed = Crc32C.Compute(batch[crcContentOffset..]);
+        return (stored, computed);
+    }
 
     [Test]
     public async Task ReturnPreCompressedBuffer_CalledTwice_IsIdempotent()

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -512,6 +512,9 @@ public class RecordBatchTests
         await Assert.That(batch.PreCompressedRecords).IsNotNull();
         await Assert.That(batch.PreCompressedLength).IsGreaterThan(0);
         await Assert.That(batch.PreCompressedType).IsEqualTo(CompressionType.Gzip);
+        var batchCrc = batch.PreCompressedRecordsCrc;
+        await Assert.That(batchCrc)
+            .IsEqualTo(Crc32C.Compute(batch.PreCompressedRecords!.AsSpan(0, batch.PreCompressedLength)));
 
         // Transfer to new batch via WithProducerState
         var newBatch = batch.WithProducerState(42, 1, 10);
@@ -520,6 +523,7 @@ public class RecordBatchTests
         await Assert.That(newBatch.PreCompressedRecords).IsNotNull();
         await Assert.That(newBatch.PreCompressedLength).IsGreaterThan(0);
         await Assert.That(newBatch.PreCompressedType).IsEqualTo(CompressionType.Gzip);
+        await Assert.That(newBatch.PreCompressedRecordsCrc).IsEqualTo(batchCrc);
         await Assert.That(newBatch.ProducerId).IsEqualTo(42L);
         await Assert.That(newBatch.ProducerEpoch).IsEqualTo((short)1);
         await Assert.That(newBatch.BaseSequence).IsEqualTo(10);
@@ -528,6 +532,7 @@ public class RecordBatchTests
         await Assert.That(batch.PreCompressedRecords).IsNull();
         await Assert.That(batch.PreCompressedLength).IsEqualTo(0);
         await Assert.That(batch.PreCompressedType).IsEqualTo(CompressionType.None);
+        await Assert.That(batch.PreCompressedRecordsCrc).IsEqualTo(0u);
 
         // Clean up
         newBatch.Dispose();
@@ -543,6 +548,8 @@ public class RecordBatchTests
         await Assert.That(batch.PreCompressedRecords).IsNotNull();
         await Assert.That(batch.PreCompressedLength).IsGreaterThan(0);
         await Assert.That(batch.PreCompressedType).IsEqualTo(CompressionType.None);
+        await Assert.That(batch.PreCompressedRecordsCrc)
+            .IsEqualTo(Crc32C.Compute(batch.PreCompressedRecords!.AsSpan(0, batch.PreCompressedLength)));
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- cache CRC32C for pre-serialized/pre-compressed record payload bytes
- compute record-batch CRC from the 40-byte mutable header plus cached payload CRC via `Crc32C.Combine`
- cover CRC combine math and cached payload CRC transfer/reset paths

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- [x] `dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress --treenode-filter "/*/*/Crc32CTests/*"`
- [x] `dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress --treenode-filter "/*/*/RecordBatchTests/*"`
- [x] `dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress --maximum-parallel-tests 1`
- [x] `dotnet build tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj --configuration Release`
- [x] `git diff --check` (line-ending warnings only)

Closes #1371
