### PR TITLE
perf(networking): size produce serialization buffers

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -170,6 +170,9 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
     private const int MinimumResponseFrameSize = 4; // Correlation ID is always first in the response header.
     // SASL handshake/auth responses are small; this pre-auth path must not honor untrusted large frame claims.
     private const int MaxSaslResponseFrameSize = 1024 * 1024;
+    internal const int DefaultPreSerializeInitialCapacity = 4096;
+    private const int MessageSizePrefixLength = 4;
+    private const int RequestHeaderSizeSlack = 128;
     private static int s_globalCorrelationId;
     private readonly PendingRequestShard[] _pendingRequestShards;
     private readonly SemaphoreSlim _pendingRequestSlots;
@@ -910,7 +913,9 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
     {
         // Serialize directly into a rented array at offset 4 (reserving space for the size
         // prefix). The only copy is rented array -> PipeWriter under the write lock.
-        using var writer = new RentedBufferWriter(initialCapacity: 4096, offset: 4);
+        using var writer = new RentedBufferWriter(
+            GetPreSerializeInitialCapacity<TResponse>(request),
+            MessageSizePrefixLength);
 
         var bodyWriter = new KafkaProtocolWriter(writer);
         var header = new RequestHeader
@@ -931,6 +936,19 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         BinaryPrimitives.WriteInt32BigEndian(rentedArray, bodyWriter.BytesWritten);
 
         return (rentedArray, totalLength);
+    }
+
+    internal static int GetPreSerializeInitialCapacity<TResponse>(IKafkaRequest<TResponse> request)
+        where TResponse : IKafkaResponse
+    {
+        if (request is not IKafkaRequestBodySizeHint { RequestBodySizeHint: > 0 } sizeHint)
+            return DefaultPreSerializeInitialCapacity;
+
+        var hintedCapacity = Math.Min(
+            (long)Array.MaxLength - MessageSizePrefixLength,
+            (long)sizeHint.RequestBodySizeHint + RequestHeaderSizeSlack);
+
+        return Math.Max(DefaultPreSerializeInitialCapacity, (int)hintedCapacity);
     }
 
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Channels;
 using Dekaf.Compression;
 using Dekaf.Errors;
@@ -2366,6 +2367,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var topicIdx = 0;
             var partIdx = 0;
             var runStart = 0;
+            var requestBodySizeHint = checked(
+                CompactStringSize(_request.TransactionalId) +
+                2 + // Acks
+                4 + // TimeoutMs
+                CompactArrayLengthSize(topicCount) +
+                1); // Request tagged fields
 
             // Single pass: populate scratch topic and partition data from contiguous runs
             while (runStart < count)
@@ -2379,6 +2386,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                 var partCount = runEnd - runStart;
                 var partitionDataStart = partIdx;
+                requestBodySizeHint = checked(
+                    requestBodySizeHint +
+                    CompactStringSize(topicName) +
+                    CompactArrayLengthSize(partCount) +
+                    1); // Topic tagged fields
+
                 for (var p = 0; p < partCount; p++)
                 {
                     var batch = batchesSpan[runStart + p];
@@ -2386,6 +2399,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     var partData = _partitionData[partIdx];
                     partData.Index = batch.TopicPartition.Partition;
                     partData.Records = _recordBatches[partIdx];
+                    requestBodySizeHint = checked(
+                        requestBodySizeHint +
+                        4 + // Partition index
+                        CompactBytesLengthSize(batch.EncodedSize) +
+                        batch.EncodedSize +
+                        1); // Partition tagged fields
                     partIdx++;
                 }
 
@@ -2400,6 +2419,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             _request.TopicData = new ArraySegment<ProduceRequestTopicData>(
                 _topicData, 0, topicCount);
+            _request.RequestBodySizeHint = requestBodySizeHint;
             _lastTopicCount = topicCount;
             _lastPartitionCount = partIdx;
             return _request;
@@ -2412,6 +2432,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         public void ClearReferences()
         {
             _request.TopicData = [];
+            _request.RequestBodySizeHint = 0;
             for (var i = 0; i < _lastTopicCount; i++)
             {
                 _topicData[i].Name = string.Empty;
@@ -2425,6 +2446,21 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _lastTopicCount = 0;
             _lastPartitionCount = 0;
         }
+
+        private static int CompactStringSize(string? value)
+        {
+            if (value is null)
+                return 1;
+
+            var byteCount = Encoding.UTF8.GetByteCount(value);
+            return checked(CompactBytesLengthSize(byteCount) + byteCount);
+        }
+
+        private static int CompactArrayLengthSize(int count)
+            => Record.VarUIntSize((uint)checked(count + 1));
+
+        private static int CompactBytesLengthSize(int byteCount)
+            => Record.VarUIntSize((uint)checked(byteCount + 1));
     }
 
     /// <summary>

--- a/src/Dekaf/Protocol/IKafkaMessage.cs
+++ b/src/Dekaf/Protocol/IKafkaMessage.cs
@@ -56,6 +56,14 @@ public interface IKafkaRequest<TResponse> : IKafkaMessage
 }
 
 /// <summary>
+/// Optional request-side hint for sizing the pre-serialization buffer.
+/// </summary>
+internal interface IKafkaRequestBodySizeHint
+{
+    int RequestBodySizeHint { get; }
+}
+
+/// <summary>
 /// Interface for Kafka response messages.
 /// </summary>
 public interface IKafkaResponse : IKafkaMessage

--- a/src/Dekaf/Protocol/Messages/ProduceRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceRequest.cs
@@ -8,7 +8,7 @@ namespace Dekaf.Protocol.Messages;
 /// Produce request (API key 0).
 /// Sends records to topic partitions.
 /// </summary>
-public sealed class ProduceRequest : IKafkaRequest<ProduceResponse>
+public sealed class ProduceRequest : IKafkaRequest<ProduceResponse>, IKafkaRequestBodySizeHint
 {
     public static ApiKey ApiKey => ApiKey.Produce;
     public static short LowestSupportedVersion => 9;
@@ -36,6 +36,10 @@ public sealed class ProduceRequest : IKafkaRequest<ProduceResponse>
     /// Topic data to produce.
     /// </summary>
     public IReadOnlyList<ProduceRequestTopicData> TopicData { get; internal set; } = [];
+
+    internal int RequestBodySizeHint { get; set; }
+
+    int IKafkaRequestBodySizeHint.RequestBodySizeHint => RequestBodySizeHint;
 
     public void Write(ref KafkaProtocolWriter writer, short version)
     {

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -82,6 +82,29 @@ public sealed class KafkaConnectionTests
     }
 
     [Test]
+    public async Task GetPreSerializeInitialCapacity_WithoutHint_ReturnsDefault()
+    {
+        var request = new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" };
+
+        var capacity = KafkaConnection.GetPreSerializeInitialCapacity<ApiVersionsResponse>(request);
+
+        await Assert.That(capacity).IsEqualTo(KafkaConnection.DefaultPreSerializeInitialCapacity);
+    }
+
+    [Test]
+    public async Task GetPreSerializeInitialCapacity_WithProduceHint_AddsHeaderSlack()
+    {
+        var request = new ProduceRequest
+        {
+            RequestBodySizeHint = 1_048_576
+        };
+
+        var capacity = KafkaConnection.GetPreSerializeInitialCapacity<ProduceResponse>(request);
+
+        await Assert.That(capacity).IsEqualTo(1_048_704);
+    }
+
+    [Test]
     public async Task Host_ReturnsConstructorValue()
     {
         var connection = new KafkaConnection("my-broker.example.com", 9092);


### PR DESCRIPTION
Fixes #1370.\n\n## Summary\n- add an internal request body size-hint hook for pre-serialization buffers\n- set ProduceRequest body hints from BrokerSender scratch using existing ReadyBatch.EncodedSize values and compact protocol overhead\n- size KafkaConnection's rented serialization buffer from the hint plus header slack, falling back to 4KB for ordinary requests\n\n## Tests\n- dotnet build tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --configuration Release\n- dotnet format src\\Dekaf\\Dekaf.csproj --verify-no-changes --include src\\Dekaf\\Protocol\\IKafkaMessage.cs src\\Dekaf\\Networking\\KafkaConnection.cs src\\Dekaf\\Protocol\\Messages\\ProduceRequest.cs src\\Dekaf\\Producer\\BrokerSender.cs\n- dotnet format tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --verify-no-changes --include tests\\Dekaf.Tests.Unit\\Networking\\KafkaConnectionTests.cs\n- dotnet run --project tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --disable-logo --no-ansi --maximum-parallel-tests 10\n\nNote: an earlier full unit run at --maximum-parallel-tests 20 hit a pre-existing networking test timeout; the same test passed in isolation and the full suite passed at parallelism 10.