### PR TITLE
feat(producer): add 2PC prepare API

### DIFF
--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -211,6 +211,17 @@ Enable transactional producer:
 
 Must be unique per producer instance.
 
+### WithTwoPhaseCommit
+
+Enable KIP-939 two-phase commit participation for transactional producers:
+
+```csharp
+.WithTransactionalId("my-service-tx-1")
+.WithTwoPhaseCommit()
+```
+
+Requires broker support for `transaction.version` 3 and `InitProducerId` v6.
+
 ## Security
 
 ### UseTls

--- a/docs/docs/producer/transactions.md
+++ b/docs/docs/producer/transactions.md
@@ -82,16 +82,16 @@ await transaction.ProduceAsync(new ProducerMessage<string, string>
 var prepared = await transaction.PrepareAsync();
 
 // Store prepared.ToString() with the external transaction decision.
-await producer.CompletePreparedTransactionAsync(prepared);
+await producer.CompletePreparedTransactionAsync(prepared, committed: true);
 ```
 
 If the process restarts after prepare, initialize with `keepPreparedTransaction: true`
-and complete using the stored state:
+and complete using the stored state plus the external coordinator's decision:
 
 ```csharp
 await producer.InitTransactionsAsync(keepPreparedTransaction: true);
 var prepared = PreparedTransactionState.Parse(storedPreparedState);
-await producer.CompletePreparedTransactionAsync(prepared);
+await producer.CompletePreparedTransactionAsync(prepared, committed: shouldCommit);
 ```
 
 This requires broker support for `transaction.version` 3 and `InitProducerId` v6.

--- a/docs/docs/producer/transactions.md
+++ b/docs/docs/producer/transactions.md
@@ -58,6 +58,46 @@ catch (Exception ex)
 }
 ```
 
+## Two-Phase Commit Participation
+
+For external transaction coordinators, enable KIP-939 two-phase commit participation:
+
+```csharp
+await using var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithTransactionalId("orders-2pc")
+    .WithTwoPhaseCommit()
+    .BuildAsync();
+
+await producer.InitTransactionsAsync();
+
+await using var transaction = producer.BeginTransaction();
+await transaction.ProduceAsync(new ProducerMessage<string, string>
+{
+    Topic = "orders",
+    Key = orderId,
+    Value = orderJson
+});
+
+var prepared = await transaction.PrepareAsync();
+
+// Store prepared.ToString() with the external transaction decision.
+await producer.CompletePreparedTransactionAsync(prepared);
+```
+
+If the process restarts after prepare, initialize with `keepPreparedTransaction: true`
+and complete using the stored state:
+
+```csharp
+await producer.InitTransactionsAsync(keepPreparedTransaction: true);
+var prepared = PreparedTransactionState.Parse(storedPreparedState);
+await producer.CompletePreparedTransactionAsync(prepared);
+```
+
+This requires broker support for `transaction.version` 3 and `InitProducerId` v6.
+After `PrepareAsync`, only commit, abort, dispose, or `CompletePreparedTransactionAsync`
+are valid until the prepared transaction is finished.
+
 ## Exactly-Once Processing (Consume-Transform-Produce)
 
 The most common use case for transactions is exactly-once stream processing:

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -180,8 +180,10 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
 
     public ValueTask CompletePreparedTransactionAsync(
         PreparedTransactionState preparedState,
+        bool committed,
         CancellationToken cancellationToken = default)
     {
+        _ = committed;
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
         throw new NotSupportedException("In-memory producer transactions are not supported.");

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -171,6 +171,22 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         return ValueTask.CompletedTask;
     }
 
+    public ValueTask InitTransactionsAsync(bool keepPreparedTransaction, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask CompletePreparedTransactionAsync(
+        PreparedTransactionState preparedState,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        throw new NotSupportedException("In-memory producer transactions are not supported.");
+    }
+
     public ITopicProducer<TKey, TValue> ForTopic(string topic)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(topic);

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -31,6 +31,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private int _batchSize = 1048576;
     private string? _transactionalId;
     private int? _transactionTimeoutMs;
+    private bool _enableTwoPhaseCommit;
     private Protocol.Records.CompressionType _compressionType = Protocol.Records.CompressionType.None;
     private int? _compressionLevel;
     private int _maxInFlightRequestsPerConnection = 5;
@@ -179,6 +180,17 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithTransactionalId(string transactionalId)
     {
         _transactionalId = transactionalId;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables KIP-939 two-phase commit participation.
+    /// Requires a transactional producer and broker support for <c>transaction.version</c> 3.
+    /// </summary>
+    /// <param name="enable">Whether to enable two-phase commit participation.</param>
+    public ProducerBuilder<TKey, TValue> WithTwoPhaseCommit(bool enable = true)
+    {
+        _enableTwoPhaseCommit = enable;
         return this;
     }
 
@@ -1019,6 +1031,9 @@ public sealed class ProducerBuilder<TKey, TValue>
                 "Transaction coordination requests require a single connection per broker. " +
                 "Either remove WithTransactionalId() or use ConnectionsPerBroker = 1.");
 
+        if (_enableTwoPhaseCommit && string.IsNullOrEmpty(_transactionalId))
+            throw new InvalidOperationException("Two-phase commit requires TransactionalId to be set.");
+
         if (_enableIdempotence && _acks == Acks.None)
             throw new InvalidOperationException("Acks.None is incompatible with idempotence because the broker cannot acknowledge sequence numbers without sending a response.");
 
@@ -1077,6 +1092,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             EnableIdempotence = _enableIdempotence,
             ConnectionsPerBroker = _connectionsPerBroker,
             TransactionalId = _transactionalId,
+            EnableTwoPhaseCommit = _enableTwoPhaseCommit,
             TransactionTimeoutMs = _transactionTimeoutMs ?? 60000,
             CloseTimeoutMs = _closeTimeoutMs,
             MaxRequestSize = _maxRequestSize,

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -197,6 +197,21 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     ValueTask InitTransactionsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Initializes transactions and optionally keeps an existing prepared transaction for completion.
+    /// </summary>
+    ValueTask InitTransactionsAsync(
+        bool keepPreparedTransaction,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Completes a prepared transaction. The transaction is committed when the provided state
+    /// matches the prepared state returned by the broker; otherwise it is aborted.
+    /// </summary>
+    ValueTask CompletePreparedTransactionAsync(
+        PreparedTransactionState preparedState,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Creates a topic-specific producer bound to the specified topic.
     /// </summary>
     /// <remarks>
@@ -333,6 +348,12 @@ public interface ITransaction<TKey, TValue> : IAsyncDisposable
     ValueTask CommitAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Flushes all pending records and prepares the transaction for a two-phase commit.
+    /// After prepare, only commit, abort, dispose, or producer-level completion are valid.
+    /// </summary>
+    ValueTask<PreparedTransactionState> PrepareAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Aborts the transaction.
     /// </summary>
     ValueTask AbortAsync(CancellationToken cancellationToken = default);
@@ -344,4 +365,58 @@ public interface ITransaction<TKey, TValue> : IAsyncDisposable
         IEnumerable<TopicPartitionOffset> offsets,
         string consumerGroupId,
         CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Identifies a transaction that has been prepared for two-phase commit.
+/// </summary>
+public readonly record struct PreparedTransactionState(long ProducerId, short ProducerEpoch)
+{
+    /// <summary>
+    /// Empty state used when there is no prepared transaction.
+    /// </summary>
+    public static PreparedTransactionState Empty { get; } = new(-1, -1);
+
+    /// <summary>
+    /// True when this state identifies a prepared transaction.
+    /// </summary>
+    public bool HasTransaction => ProducerId >= 0 && ProducerEpoch >= 0;
+
+    /// <summary>
+    /// Parses the stable string form emitted by <see cref="ToString"/>.
+    /// </summary>
+    public static PreparedTransactionState Parse(string value)
+    {
+        if (TryParse(value, out var state))
+            return state;
+
+        throw new FormatException("Prepared transaction state must be empty or in 'producerId:producerEpoch' form.");
+    }
+
+    /// <summary>
+    /// Attempts to parse the stable string form emitted by <see cref="ToString"/>.
+    /// </summary>
+    public static bool TryParse(string? value, out PreparedTransactionState state)
+    {
+        state = Empty;
+
+        if (string.IsNullOrEmpty(value))
+            return true;
+
+        var parts = value!.Split(':');
+        if (parts.Length != 2 || parts[0].Length == 0 || parts[1].Length == 0)
+            return false;
+
+        if (!long.TryParse(parts[0], out var producerId))
+            return false;
+
+        if (!short.TryParse(parts[1], out var producerEpoch))
+            return false;
+
+        state = new PreparedTransactionState(producerId, producerEpoch);
+        return state.HasTransaction;
+    }
+
+    public override string ToString()
+        => HasTransaction ? $"{ProducerId}:{ProducerEpoch}" : string.Empty;
 }

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -204,11 +204,14 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Completes a prepared transaction. The transaction is committed when the provided state
-    /// matches the prepared state returned by the broker; otherwise it is aborted.
+    /// Completes a prepared transaction using the external coordinator decision.
     /// </summary>
+    /// <param name="preparedState">The prepared transaction identity returned by <see cref="ITransaction{TKey, TValue}.PrepareAsync"/>.</param>
+    /// <param name="committed">True to commit the prepared transaction; false to abort it.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     ValueTask CompletePreparedTransactionAsync(
         PreparedTransactionState preparedState,
+        bool committed,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -85,6 +85,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private volatile bool _idempotentInitialized;
     private int _transactionCoordinatorId = -1;
     internal volatile TransactionState _transactionState = TransactionState.Uninitialized;
+    internal PreparedTransactionState _preparedTransactionState = PreparedTransactionState.Empty;
     // The error code that drove the transaction into AbortableError/FatalError, surfaced by
     // the fail-fast produce guard for context. ErrorCode is short-backed, so volatile is valid.
     internal volatile ErrorCode _lastTransactionError = ErrorCode.None;
@@ -1472,6 +1473,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         var transactionState = _transactionState;
         if (transactionState is TransactionState.InTransaction
+            or TransactionState.PreparedTransaction
             or TransactionState.CommittingTransaction
             or TransactionState.AbortingTransaction
             or TransactionState.AbortableError)
@@ -1530,6 +1532,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 "A transaction is already in progress. Commit or abort it before starting a new one.");
         }
 
+        if (_transactionState == TransactionState.PreparedTransaction)
+        {
+            throw new InvalidOperationException(
+                "A prepared transaction is waiting for completion. Complete, commit, or abort it before starting a new one.");
+        }
+
         if (_transactionState != TransactionState.Ready)
         {
             throw new InvalidOperationException(
@@ -1537,6 +1545,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         _transactionState = TransactionState.InTransaction;
+        _preparedTransactionState = PreparedTransactionState.Empty;
         _lastTransactionError = ErrorCode.None;
         _currentTransactionUsesTV2 = _metadataManager.GetFinalizedFeatureVersion(TransactionVersionFeature) >= 2;
         lock (_partitionsInTransactionLock)
@@ -1547,7 +1556,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         return new Transaction<TKey, TValue>(this);
     }
 
-    public async ValueTask InitTransactionsAsync(CancellationToken cancellationToken = default)
+    public ValueTask InitTransactionsAsync(CancellationToken cancellationToken = default)
+        => InitTransactionsAsync(keepPreparedTransaction: false, cancellationToken);
+
+    public async ValueTask InitTransactionsAsync(
+        bool keepPreparedTransaction,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(_options.TransactionalId))
         {
@@ -1556,6 +1570,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         ThrowIfNotInitialized();
+        ThrowIfTwoPhaseCommitUnsupported(keepPreparedTransaction);
 
         await SemaphoreHelper.AcquireOrThrowDisposedAsync(_transactionLock, nameof(KafkaProducer<TKey, TValue>), cancellationToken).ConfigureAwait(false);
         try
@@ -1565,13 +1580,134 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
 
             // Step 2: Initialize the producer ID via the coordinator
-            await ReinitializeProducerIdAsync(cancellationToken).ConfigureAwait(false);
+            _currentTransactionUsesTV2 = _metadataManager.GetFinalizedFeatureVersion(TransactionVersionFeature) >= 2;
+            await ReinitializeProducerIdAsync(cancellationToken, keepPreparedTransaction).ConfigureAwait(false);
 
-            _transactionState = TransactionState.Ready;
+            _transactionState = _preparedTransactionState.HasTransaction
+                ? TransactionState.PreparedTransaction
+                : TransactionState.Ready;
         }
         finally
         {
             SemaphoreHelper.ReleaseSafely(_transactionLock);
+        }
+    }
+
+    public async ValueTask CompletePreparedTransactionAsync(
+        PreparedTransactionState preparedState,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(_options.TransactionalId))
+        {
+            throw new InvalidOperationException(
+                "Cannot complete a prepared transaction: TransactionalId is not set in producer options.");
+        }
+
+        if (!preparedState.HasTransaction)
+            throw new ArgumentException("Prepared transaction state must identify a transaction.", nameof(preparedState));
+
+        ThrowIfNotInitialized();
+
+        if (_transactionState != TransactionState.PreparedTransaction)
+        {
+            throw new TransactionException(ErrorCode.InvalidTxnState,
+                $"Cannot complete prepared transaction in state: {_transactionState}")
+            {
+                TransactionalId = _options.TransactionalId
+            };
+        }
+
+        var committed = preparedState == _preparedTransactionState;
+        _transactionState = committed
+            ? TransactionState.CommittingTransaction
+            : TransactionState.AbortingTransaction;
+
+        try
+        {
+            await EndTransactionAsync(committed, cancellationToken).ConfigureAwait(false);
+
+            if (!committed && !_currentTransactionUsesTV2)
+            {
+                await ReinitializeProducerIdAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            FinalizeCompletedTransactionState();
+        }
+    }
+
+    private void ThrowIfTwoPhaseCommitUnsupported(bool keepPreparedTransaction)
+    {
+        if (!_options.EnableTwoPhaseCommit && !keepPreparedTransaction)
+            return;
+
+        var transactionVersion = _metadataManager.GetFinalizedFeatureVersion(TransactionVersionFeature);
+        if (transactionVersion < 3)
+        {
+            throw new BrokerVersionException(
+                "Broker does not support KIP-939 two-phase commit (transaction.version >= 3 required).");
+        }
+    }
+
+    internal PreparedTransactionState PrepareCurrentTransaction()
+    {
+        if (!_options.EnableTwoPhaseCommit)
+        {
+            throw new TransactionException(ErrorCode.InvalidTxnState,
+                "Cannot prepare a transaction when two-phase commit is not enabled.")
+            {
+                TransactionalId = _options.TransactionalId
+            };
+        }
+
+        ThrowIfTwoPhaseCommitUnsupported(keepPreparedTransaction: false);
+
+        if (_transactionState != TransactionState.InTransaction)
+        {
+            throw new TransactionException(ErrorCode.InvalidTxnState,
+                $"Cannot prepare transaction in state: {_transactionState}")
+            {
+                TransactionalId = _options.TransactionalId
+            };
+        }
+
+        var preparedState = new PreparedTransactionState(_producerId, _producerEpoch);
+        if (!preparedState.HasTransaction)
+        {
+            throw new TransactionException(ErrorCode.InvalidTxnState,
+                "Cannot prepare transaction before InitTransactionsAsync has assigned a producer ID.")
+            {
+                TransactionalId = _options.TransactionalId
+            };
+        }
+
+        _preparedTransactionState = preparedState;
+        _transactionState = TransactionState.PreparedTransaction;
+        return preparedState;
+    }
+
+    internal void ThrowIfInPreparedTransaction()
+    {
+        if (_transactionState == TransactionState.PreparedTransaction)
+        {
+            throw new InvalidOperationException(
+                "Cannot perform this operation while the transaction is prepared. Only commit, abort, dispose, or complete are permitted.");
+        }
+    }
+
+    internal void FinalizeCompletedTransactionState()
+    {
+        lock (_partitionsInTransactionLock)
+        {
+            _partitionsInTransaction.Clear();
+        }
+
+        _preparedTransactionState = PreparedTransactionState.Empty;
+
+        if (_transactionState is not (TransactionState.AbortableError or TransactionState.FatalError))
+        {
+            _transactionState = TransactionState.Ready;
         }
     }
 
@@ -1619,7 +1755,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         throw CreateTransactionException(errorCode, classification, $"{operation} failed: {errorCode}");
     }
 
-    internal async ValueTask ReinitializeProducerIdAsync(CancellationToken cancellationToken)
+    internal async ValueTask ReinitializeProducerIdAsync(
+        CancellationToken cancellationToken,
+        bool keepPreparedTransaction = false)
     {
         const int maxRetries = 10;
         var retryDelayMs = 100;
@@ -1634,12 +1772,20 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 InitProducerIdRequest.LowestSupportedVersion,
                 InitProducerIdRequest.HighestSupportedVersion);
 
+            if ((_options.EnableTwoPhaseCommit || keepPreparedTransaction) && initProducerIdVersion < 6)
+            {
+                throw new BrokerVersionException(
+                    "Broker does not support InitProducerId v6 required for KIP-939 two-phase commit.");
+            }
+
             var request = new InitProducerIdRequest
             {
                 TransactionalId = _options.TransactionalId,
                 TransactionTimeoutMs = _options.TransactionTimeoutMs,
                 ProducerId = _producerId,
-                ProducerEpoch = _producerEpoch
+                ProducerEpoch = _producerEpoch,
+                EnableTwoPhaseCommit = _options.EnableTwoPhaseCommit,
+                KeepPreparedTransaction = keepPreparedTransaction
             };
 
             var response = (InitProducerIdResponse)await connection
@@ -1689,6 +1835,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             _accumulator.IsTransactional = true;
 
             _accumulator.ResetSequenceNumbers();
+            _preparedTransactionState = response.OngoingTransactionProducerId >= 0
+                && response.OngoingTransactionProducerEpoch >= 0
+                    ? new PreparedTransactionState(
+                        response.OngoingTransactionProducerId,
+                        response.OngoingTransactionProducerEpoch)
+                    : PreparedTransactionState.Empty;
 
             LogTransactionsInitialized(_producerId, _producerEpoch);
             return;
@@ -2595,6 +2747,15 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         {
             throw new FatalTransactionException(_lastTransactionError,
                 "Cannot produce: the producer is in a fatal error state and must be closed.")
+            {
+                TransactionalId = _options.TransactionalId
+            };
+        }
+
+        if (txnState == TransactionState.PreparedTransaction)
+        {
+            throw new TransactionException(ErrorCode.InvalidTxnState,
+                "Cannot produce: the current transaction is prepared. Only commit, abort, or complete are permitted.")
             {
                 TransactionalId = _options.TransactionalId
             };
@@ -3579,6 +3740,8 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
         if (_committed || _aborted)
             throw new InvalidOperationException("Transaction is already completed");
 
+        _producer.ThrowIfInPreparedTransaction();
+
         // Partition registration with AddPartitionsToTxn is handled automatically
         // by BrokerSender before the ProduceRequest is sent to the broker.
         return await _producer.ProduceAsync(message, cancellationToken).ConfigureAwait(false);
@@ -3607,6 +3770,17 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
         }
     }
 
+    public async ValueTask<PreparedTransactionState> PrepareAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfProducerDisposed();
+
+        if (_committed || _aborted)
+            throw new InvalidOperationException("Transaction is already completed");
+
+        await _producer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        return _producer.PrepareCurrentTransaction();
+    }
+
     /// <summary>
     /// Clears the transaction's partition set and returns the producer to
     /// <see cref="TransactionState.Ready"/> for the next transaction — unless ending the transaction
@@ -3614,15 +3788,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
     /// </summary>
     private void FinalizeTransactionState()
     {
-        lock (_producer._partitionsInTransactionLock)
-        {
-            _producer._partitionsInTransaction.Clear();
-        }
-
-        if (_producer._transactionState is not (TransactionState.AbortableError or TransactionState.FatalError))
-        {
-            _producer._transactionState = TransactionState.Ready;
-        }
+        _producer.FinalizeCompletedTransactionState();
     }
 
     public async ValueTask AbortAsync(CancellationToken cancellationToken = default)
@@ -3663,6 +3829,8 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
 
         if (_committed || _aborted)
             throw new InvalidOperationException("Transaction is already completed");
+
+        _producer.ThrowIfInPreparedTransaction();
 
         await _producer.SendOffsetsToTransactionInternalAsync(offsets, consumerGroupId, cancellationToken)
             .ConfigureAwait(false);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1595,6 +1595,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
     public async ValueTask CompletePreparedTransactionAsync(
         PreparedTransactionState preparedState,
+        bool committed,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(_options.TransactionalId))
@@ -1618,7 +1619,15 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         var transactionToComplete = _preparedTransactionState;
-        var committed = preparedState == transactionToComplete;
+        if (preparedState != transactionToComplete)
+        {
+            throw new TransactionException(ErrorCode.InvalidTxnState,
+                "Prepared transaction state does not match the pending prepared transaction.")
+            {
+                TransactionalId = _options.TransactionalId
+            };
+        }
+
         _transactionState = committed
             ? TransactionState.CommittingTransaction
             : TransactionState.AbortingTransaction;

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1617,14 +1617,25 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             };
         }
 
-        var committed = preparedState == _preparedTransactionState;
+        var transactionToComplete = _preparedTransactionState;
+        var committed = preparedState == transactionToComplete;
         _transactionState = committed
             ? TransactionState.CommittingTransaction
             : TransactionState.AbortingTransaction;
 
         try
         {
-            await EndTransactionAsync(committed, cancellationToken).ConfigureAwait(false);
+            var applyResponseProducerState =
+                transactionToComplete.ProducerId == _producerId
+                && transactionToComplete.ProducerEpoch == _producerEpoch;
+
+            await EndTransactionAsync(
+                    committed,
+                    transactionToComplete.ProducerId,
+                    transactionToComplete.ProducerEpoch,
+                    applyResponseProducerState,
+                    cancellationToken)
+                .ConfigureAwait(false);
 
             if (!committed && !_currentTransactionUsesTV2)
             {
@@ -2040,7 +2051,20 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         };
     }
 
-    internal async ValueTask EndTransactionAsync(bool committed, CancellationToken cancellationToken)
+    internal ValueTask EndTransactionAsync(bool committed, CancellationToken cancellationToken)
+        => EndTransactionAsync(
+            committed,
+            _producerId,
+            _producerEpoch,
+            applyResponseProducerState: true,
+            cancellationToken);
+
+    private async ValueTask EndTransactionAsync(
+        bool committed,
+        long producerId,
+        short producerEpoch,
+        bool applyResponseProducerState,
+        CancellationToken cancellationToken)
     {
         const int maxRetries = 5;
         var retryDelayMs = 100;
@@ -2058,8 +2082,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             var request = new EndTxnRequest
             {
                 TransactionalId = _options.TransactionalId!,
-                ProducerId = _producerId,
-                ProducerEpoch = _producerEpoch,
+                ProducerId = producerId,
+                ProducerEpoch = producerEpoch,
                 Committed = committed
             };
 
@@ -2075,7 +2099,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 // a separate InitProducerId round-trip.
                 // Safe without _epochBumpLock: EndTxn is called only after FlushAsync
                 // drains all in-flight batches, so no BrokerSender is active.
-                if (_currentTransactionUsesTV2 && response.ProducerId >= 0)
+                if (applyResponseProducerState && _currentTransactionUsesTV2 && response.ProducerId >= 0)
                 {
                     _producerId = response.ProducerId;
                     _producerEpoch = response.ProducerEpoch;

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -247,6 +247,12 @@ public sealed class ProducerOptions
     public string? TransactionalId { get; init; }
 
     /// <summary>
+    /// Enables KIP-939 two-phase commit participation for transactional producers.
+    /// Requires broker support for <c>transaction.version</c> 3 and InitProducerId v6.
+    /// </summary>
+    public bool EnableTwoPhaseCommit { get; init; }
+
+    /// <summary>
     /// Transaction timeout in milliseconds.
     /// </summary>
     public int TransactionTimeoutMs { get; init; } = 60000;

--- a/src/Dekaf/Producer/TransactionState.cs
+++ b/src/Dekaf/Producer/TransactionState.cs
@@ -21,6 +21,11 @@ internal enum TransactionState
     InTransaction,
 
     /// <summary>
+    /// The current transaction has been prepared for a two-phase commit.
+    /// </summary>
+    PreparedTransaction,
+
+    /// <summary>
     /// The current transaction is being committed.
     /// </summary>
     CommittingTransaction,

--- a/src/Dekaf/Protocol/Messages/InitProducerIdRequest.cs
+++ b/src/Dekaf/Protocol/Messages/InitProducerIdRequest.cs
@@ -8,7 +8,7 @@ public sealed class InitProducerIdRequest : IKafkaRequest<InitProducerIdResponse
 {
     public static ApiKey ApiKey => ApiKey.InitProducerId;
     public static short LowestSupportedVersion => 2;
-    public static short HighestSupportedVersion => 5;
+    public static short HighestSupportedVersion => 6;
 
     /// <summary>
     /// The transactional ID, or null for idempotent-only producers.
@@ -30,6 +30,16 @@ public sealed class InitProducerIdRequest : IKafkaRequest<InitProducerIdResponse
     /// </summary>
     public short ProducerEpoch { get; init; } = -1;
 
+    /// <summary>
+    /// Enables KIP-939 two-phase commit participation (v6+).
+    /// </summary>
+    public bool EnableTwoPhaseCommit { get; init; }
+
+    /// <summary>
+    /// Keeps an existing prepared transaction when re-initializing (v6+).
+    /// </summary>
+    public bool KeepPreparedTransaction { get; init; }
+
     public void Write(ref KafkaProtocolWriter writer, short version)
     {
         writer.WriteCompactNullableString(TransactionalId);
@@ -40,6 +50,12 @@ public sealed class InitProducerIdRequest : IKafkaRequest<InitProducerIdResponse
         {
             writer.WriteInt64(ProducerId);
             writer.WriteInt16(ProducerEpoch);
+        }
+
+        if (version >= 6)
+        {
+            writer.WriteBoolean(EnableTwoPhaseCommit);
+            writer.WriteBoolean(KeepPreparedTransaction);
         }
 
         writer.WriteEmptyTaggedFields();

--- a/src/Dekaf/Protocol/Messages/InitProducerIdResponse.cs
+++ b/src/Dekaf/Protocol/Messages/InitProducerIdResponse.cs
@@ -8,7 +8,7 @@ public sealed class InitProducerIdResponse : IKafkaResponse
 {
     public static ApiKey ApiKey => ApiKey.InitProducerId;
     public static short LowestSupportedVersion => 2;
-    public static short HighestSupportedVersion => 5;
+    public static short HighestSupportedVersion => 6;
 
     /// <summary>
     /// Throttle time in milliseconds.
@@ -30,12 +30,30 @@ public sealed class InitProducerIdResponse : IKafkaResponse
     /// </summary>
     public short ProducerEpoch { get; init; } = -1;
 
+    /// <summary>
+    /// Producer ID for an ongoing prepared transaction returned by InitProducerId v6.
+    /// </summary>
+    public long OngoingTransactionProducerId { get; init; } = -1;
+
+    /// <summary>
+    /// Producer epoch for an ongoing prepared transaction returned by InitProducerId v6.
+    /// </summary>
+    public short OngoingTransactionProducerEpoch { get; init; } = -1;
+
     public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
     {
         var throttleTimeMs = reader.ReadInt32();
         var errorCode = (ErrorCode)reader.ReadInt16();
         var producerId = reader.ReadInt64();
         var producerEpoch = reader.ReadInt16();
+        var ongoingTransactionProducerId = -1L;
+        short ongoingTransactionProducerEpoch = -1;
+
+        if (version >= 6)
+        {
+            ongoingTransactionProducerId = reader.ReadInt64();
+            ongoingTransactionProducerEpoch = reader.ReadInt16();
+        }
 
         reader.SkipTaggedFields();
 
@@ -44,7 +62,9 @@ public sealed class InitProducerIdResponse : IKafkaResponse
             ThrottleTimeMs = throttleTimeMs,
             ErrorCode = errorCode,
             ProducerId = producerId,
-            ProducerEpoch = producerEpoch
+            ProducerEpoch = producerEpoch,
+            OngoingTransactionProducerId = ongoingTransactionProducerId,
+            OngoingTransactionProducerEpoch = ongoingTransactionProducerEpoch
         };
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
@@ -105,6 +105,14 @@ internal sealed class FastPathProducerSpy<TKey, TValue> : IKafkaProducer<TKey, T
 
     public ValueTask InitTransactionsAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
+    public ValueTask InitTransactionsAsync(bool keepPreparedTransaction, CancellationToken cancellationToken = default)
+        => ValueTask.CompletedTask;
+
+    public ValueTask CompletePreparedTransactionAsync(
+        PreparedTransactionState preparedState,
+        CancellationToken cancellationToken = default)
+        => ValueTask.CompletedTask;
+
     public ITopicProducer<TKey, TValue> ForTopic(string topic) => new TopicProducer<TKey, TValue>(this, topic, ownsProducer: false);
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
@@ -110,6 +110,7 @@ internal sealed class FastPathProducerSpy<TKey, TValue> : IKafkaProducer<TKey, T
 
     public ValueTask CompletePreparedTransactionAsync(
         PreparedTransactionState preparedState,
+        bool committed,
         CancellationToken cancellationToken = default)
         => ValueTask.CompletedTask;
 

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -258,6 +258,10 @@ public sealed class TransactionTests
         await Assert.That(methodNames).Contains("BeginTransaction");
         await Assert.That(methodNames).Contains("InitTransactionsAsync");
         await Assert.That(methodNames).Contains("CompletePreparedTransactionAsync");
+
+        var completePreparedMethod = methods.Single(m => m.Name == "CompletePreparedTransactionAsync");
+        await Assert.That(completePreparedMethod.GetParameters().Any(p =>
+            p.Name == "committed" && p.ParameterType == typeof(bool))).IsTrue();
     }
 
     [Test]
@@ -364,7 +368,7 @@ public sealed class TransactionTests
 
         await Assert.That(async () =>
         {
-            await producer.CompletePreparedTransactionAsync(PreparedTransactionState.Empty);
+            await producer.CompletePreparedTransactionAsync(PreparedTransactionState.Empty, committed: true);
         }).Throws<ArgumentException>();
     }
 
@@ -377,7 +381,7 @@ public sealed class TransactionTests
             currentProducerId: 2002,
             currentProducerEpoch: 9);
 
-        await harness.Producer.CompletePreparedTransactionAsync(preparedState);
+        await harness.Producer.CompletePreparedTransactionAsync(preparedState, committed: true);
 
         var request = harness.CapturedRequest;
         await Assert.That(request.ProducerId).IsEqualTo(preparedState.ProducerId);
@@ -398,7 +402,7 @@ public sealed class TransactionTests
             currentProducerId: 2002,
             currentProducerEpoch: 9);
 
-        await harness.Producer.CompletePreparedTransactionAsync(new PreparedTransactionState(9999, 1));
+        await harness.Producer.CompletePreparedTransactionAsync(preparedState, committed: false);
 
         var request = harness.CapturedRequest;
         await Assert.That(request.ProducerId).IsEqualTo(preparedState.ProducerId);
@@ -408,6 +412,26 @@ public sealed class TransactionTests
         await Assert.That(GetInstanceField<short>(harness.Producer, "_producerEpoch")).IsEqualTo((short)9);
         await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.Ready);
         await Assert.That(harness.Producer._preparedTransactionState).IsEqualTo(PreparedTransactionState.Empty);
+    }
+
+    [Test]
+    public async Task CompletePreparedTransactionAsync_MismatchedState_ThrowsTransactionException()
+    {
+        var preparedState = new PreparedTransactionState(1001, 4);
+        await using var harness = BuildPreparedCompletionHarness(
+            preparedState,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9);
+
+        await Assert.That(async () =>
+        {
+            await harness.Producer.CompletePreparedTransactionAsync(
+                new PreparedTransactionState(9999, 1),
+                committed: false);
+        }).Throws<TransactionException>();
+
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.PreparedTransaction);
+        await Assert.That(harness.Producer._preparedTransactionState).IsEqualTo(preparedState);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -1,7 +1,13 @@
 using System.Reflection;
 using Dekaf.Errors;
+using Dekaf.Internal;
+using Dekaf.Metadata;
+using Dekaf.Networking;
 using Dekaf.Producer;
+using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Producer;
 
@@ -363,6 +369,48 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task CompletePreparedTransactionAsync_Commit_UsesPreparedTransactionProducerIdentity()
+    {
+        var preparedState = new PreparedTransactionState(1001, 4);
+        await using var harness = BuildPreparedCompletionHarness(
+            preparedState,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9);
+
+        await harness.Producer.CompletePreparedTransactionAsync(preparedState);
+
+        var request = harness.CapturedRequest;
+        await Assert.That(request.ProducerId).IsEqualTo(preparedState.ProducerId);
+        await Assert.That(request.ProducerEpoch).IsEqualTo(preparedState.ProducerEpoch);
+        await Assert.That(request.Committed).IsTrue();
+        await Assert.That(GetInstanceField<long>(harness.Producer, "_producerId")).IsEqualTo(2002);
+        await Assert.That(GetInstanceField<short>(harness.Producer, "_producerEpoch")).IsEqualTo((short)9);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.Ready);
+        await Assert.That(harness.Producer._preparedTransactionState).IsEqualTo(PreparedTransactionState.Empty);
+    }
+
+    [Test]
+    public async Task CompletePreparedTransactionAsync_Abort_UsesPreparedTransactionProducerIdentity()
+    {
+        var preparedState = new PreparedTransactionState(1001, 4);
+        await using var harness = BuildPreparedCompletionHarness(
+            preparedState,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9);
+
+        await harness.Producer.CompletePreparedTransactionAsync(new PreparedTransactionState(9999, 1));
+
+        var request = harness.CapturedRequest;
+        await Assert.That(request.ProducerId).IsEqualTo(preparedState.ProducerId);
+        await Assert.That(request.ProducerEpoch).IsEqualTo(preparedState.ProducerEpoch);
+        await Assert.That(request.Committed).IsFalse();
+        await Assert.That(GetInstanceField<long>(harness.Producer, "_producerId")).IsEqualTo(2002);
+        await Assert.That(GetInstanceField<short>(harness.Producer, "_producerEpoch")).IsEqualTo((short)9);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.Ready);
+        await Assert.That(harness.Producer._preparedTransactionState).IsEqualTo(PreparedTransactionState.Empty);
+    }
+
+    [Test]
     public async Task InitTransactionsAsync_WithKeepPreparedAndUnsupportedFeature_ThrowsBrokerVersionException()
     {
         await using var producer = Kafka.CreateProducer<string, string>()
@@ -417,6 +465,68 @@ public sealed class TransactionTests
         return producer;
     }
 
+    private static PreparedCompletionHarness BuildPreparedCompletionHarness(
+        PreparedTransactionState preparedState,
+        long currentProducerId,
+        short currentProducerEpoch)
+    {
+        EndTxnRequest? capturedRequest = null;
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.IsConnected.Returns(true);
+        connection.BrokerId.Returns(1);
+        connection
+            .SendAsync<EndTxnRequest, EndTxnResponse>(
+                Arg.Do<EndTxnRequest>(request => capturedRequest = request),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<EndTxnResponse>(new EndTxnResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ProducerId = preparedState.ProducerId,
+                ProducerEpoch = (short)(preparedState.ProducerEpoch + 1)
+            }));
+
+        var connectionPool = new ConnectionPool(
+            clientId: "test-producer",
+            connectionOptions: null,
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => new ValueTask<IKafkaConnection>(connection));
+        connectionPool.RegisterBroker(1, "localhost", 9092);
+
+        var metadataManager = new MetadataManager(connectionPool, ["localhost:9092"]);
+        metadataManager.SetApiVersion(
+            ApiKey.EndTxn,
+            EndTxnRequest.LowestSupportedVersion,
+            EndTxnRequest.HighestSupportedVersion);
+
+        var producer = new KafkaProducer<string, string>(
+            new ProducerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                TransactionalId = "test-txn-id",
+                EnableTwoPhaseCommit = true,
+                CloseTimeoutMs = 100
+            },
+            Serializers.String,
+            Serializers.String,
+            connectionPool,
+            metadataManager,
+            DekafMemoryBudget.Global);
+
+        SetInstanceField(producer, "_initialized", true);
+        SetInstanceField(producer, "_producerId", currentProducerId);
+        SetInstanceField(producer, "_producerEpoch", currentProducerEpoch);
+        SetInstanceField(producer, "_transactionCoordinatorId", 1);
+        SetInstanceField(producer, "_currentTransactionUsesTV2", true);
+        producer._preparedTransactionState = preparedState;
+        producer._transactionState = TransactionState.PreparedTransaction;
+
+        return new PreparedCompletionHarness(
+            producer,
+            connectionPool,
+            () => capturedRequest ?? throw new InvalidOperationException("EndTxn request was not captured."));
+    }
+
     private static void SetFinalizedTransactionVersion(KafkaProducer<string, string> producer, short version)
     {
         var metadataManager = GetInstanceField<object>(producer, "_metadataManager");
@@ -440,5 +550,21 @@ public sealed class TransactionTests
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
         var field = target.GetType().GetField(name, instanceFieldFlags);
         return (T)field!.GetValue(target)!;
+    }
+
+    private sealed class PreparedCompletionHarness(
+        KafkaProducer<string, string> producer,
+        ConnectionPool connectionPool,
+        Func<EndTxnRequest> capturedRequest) : IAsyncDisposable
+    {
+        public KafkaProducer<string, string> Producer { get; } = producer;
+
+        public EndTxnRequest CapturedRequest => capturedRequest();
+
+        public async ValueTask DisposeAsync()
+        {
+            await Producer.DisposeAsync().ConfigureAwait(false);
+            await connectionPool.DisposeAsync().ConfigureAwait(false);
+        }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
+using Dekaf.Errors;
 using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
 
 namespace Dekaf.Tests.Unit.Producer;
 
@@ -98,10 +100,11 @@ public sealed class TransactionTests
     {
         // Verify enum values exist and are distinct
         var values = Enum.GetValues<TransactionState>();
-        await Assert.That(values).Count().IsEqualTo(7);
+        await Assert.That(values).Count().IsEqualTo(8);
         await Assert.That(values).Contains(TransactionState.Uninitialized);
         await Assert.That(values).Contains(TransactionState.Ready);
         await Assert.That(values).Contains(TransactionState.InTransaction);
+        await Assert.That(values).Contains(TransactionState.PreparedTransaction);
         await Assert.That(values).Contains(TransactionState.CommittingTransaction);
         await Assert.That(values).Contains(TransactionState.AbortingTransaction);
         await Assert.That(values).Contains(TransactionState.AbortableError);
@@ -124,6 +127,13 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task ProducerOptions_EnableTwoPhaseCommit_DefaultsToFalse()
+    {
+        var options = new ProducerOptions { BootstrapServers = ["localhost:9092"] };
+        await Assert.That(options.EnableTwoPhaseCommit).IsFalse();
+    }
+
+    [Test]
     public async Task ProducerOptions_TransactionTimeoutMs_DefaultsTo60000()
     {
         var options = new ProducerOptions { BootstrapServers = ["localhost:9092"] };
@@ -139,6 +149,17 @@ public sealed class TransactionTests
             TransactionalId = "my-txn-id"
         };
         await Assert.That(options.TransactionalId).IsEqualTo("my-txn-id");
+    }
+
+    [Test]
+    public async Task ProducerOptions_EnableTwoPhaseCommit_CanBeSet()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            EnableTwoPhaseCommit = true
+        };
+        await Assert.That(options.EnableTwoPhaseCommit).IsTrue();
     }
 
     [Test]
@@ -175,6 +196,28 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task WithTwoPhaseCommit_ReturnsBuilderForChaining()
+    {
+        var originalBuilder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTransactionalId("test-txn-id");
+
+        var returnedBuilder = originalBuilder.WithTwoPhaseCommit();
+
+        await Assert.That(returnedBuilder).IsSameReferenceAs(originalBuilder);
+    }
+
+    [Test]
+    public async Task Build_WithTwoPhaseCommitWithoutTransactionalId_ThrowsInvalidOperationException()
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTwoPhaseCommit();
+
+        await Assert.That(() => builder.Build()).Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task WithTransactionalId_CanChainWithAcks()
     {
         await using var producer = Kafka.CreateProducer<string, string>()
@@ -195,8 +238,144 @@ public sealed class TransactionTests
 
         await Assert.That(methodNames).Contains("ProduceAsync");
         await Assert.That(methodNames).Contains("CommitAsync");
+        await Assert.That(methodNames).Contains("PrepareAsync");
         await Assert.That(methodNames).Contains("AbortAsync");
         await Assert.That(methodNames).Contains("SendOffsetsToTransactionAsync");
+    }
+
+    [Test]
+    public async Task IKafkaProducer_Interface_HasExpectedTransactionMethods()
+    {
+        var methods = typeof(IKafkaProducer<string, string>).GetMethods();
+        var methodNames = methods.Select(m => m.Name).ToArray();
+
+        await Assert.That(methodNames).Contains("BeginTransaction");
+        await Assert.That(methodNames).Contains("InitTransactionsAsync");
+        await Assert.That(methodNames).Contains("CompletePreparedTransactionAsync");
+    }
+
+    [Test]
+    public async Task PreparedTransactionState_ToStringAndParse_RoundTrips()
+    {
+        var state = new PreparedTransactionState(42, 7);
+        var text = state.ToString();
+        var parsed = PreparedTransactionState.Parse(text);
+
+        await Assert.That(text).IsEqualTo("42:7");
+        await Assert.That(parsed).IsEqualTo(state);
+        await Assert.That(parsed.HasTransaction).IsTrue();
+    }
+
+    [Test]
+    public async Task PreparedTransactionState_Empty_HasNoTransaction()
+    {
+        var state = PreparedTransactionState.Empty;
+
+        await Assert.That(state.HasTransaction).IsFalse();
+        await Assert.That(state.ToString()).IsEqualTo(string.Empty);
+        await Assert.That(PreparedTransactionState.Parse(string.Empty)).IsEqualTo(state);
+    }
+
+    [Test]
+    public async Task PrepareAsync_WithTwoPhaseCommit_SetsPreparedState()
+    {
+        await using var producer = BuildInitializedTransactionalProducer(enableTwoPhaseCommit: true);
+        await using var transaction = producer.BeginTransaction();
+
+        var state = await transaction.PrepareAsync();
+
+        await Assert.That(state).IsEqualTo(new PreparedTransactionState(42, 5));
+        await Assert.That(producer._transactionState).IsEqualTo(TransactionState.PreparedTransaction);
+        await Assert.That(producer._preparedTransactionState).IsEqualTo(state);
+    }
+
+    [Test]
+    public async Task PrepareAsync_WithoutTwoPhaseCommit_ThrowsTransactionException()
+    {
+        await using var producer = BuildInitializedTransactionalProducer(enableTwoPhaseCommit: false);
+        var transaction = producer.BeginTransaction();
+
+        try
+        {
+            await Assert.That(async () =>
+            {
+                await transaction.PrepareAsync();
+            }).Throws<TransactionException>();
+        }
+        finally
+        {
+            producer._transactionState = TransactionState.Ready;
+            await transaction.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task BeginTransaction_WithPreparedTransaction_ThrowsInvalidOperationException()
+    {
+        await using var producer = BuildInitializedTransactionalProducer(enableTwoPhaseCommit: true);
+        await using var transaction = producer.BeginTransaction();
+        await transaction.PrepareAsync();
+
+        await Assert.That(() => producer.BeginTransaction()).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ProduceAsync_AfterPrepare_ThrowsInvalidOperationException()
+    {
+        await using var producer = BuildInitializedTransactionalProducer(enableTwoPhaseCommit: true);
+        await using var transaction = producer.BeginTransaction();
+        await transaction.PrepareAsync();
+
+        await Assert.That(async () =>
+        {
+            await transaction.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = "orders",
+                Value = "value"
+            });
+        }).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task SendOffsetsToTransactionAsync_AfterPrepare_ThrowsInvalidOperationException()
+    {
+        await using var producer = BuildInitializedTransactionalProducer(enableTwoPhaseCommit: true);
+        await using var transaction = producer.BeginTransaction();
+        await transaction.PrepareAsync();
+
+        await Assert.That(async () =>
+        {
+            await transaction.SendOffsetsToTransactionAsync(
+                [new TopicPartitionOffset("orders", 0, 10)],
+                "group-1");
+        }).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task CompletePreparedTransactionAsync_WithEmptyState_ThrowsArgumentException()
+    {
+        await using var producer = BuildInitializedTransactionalProducer(enableTwoPhaseCommit: true);
+
+        await Assert.That(async () =>
+        {
+            await producer.CompletePreparedTransactionAsync(PreparedTransactionState.Empty);
+        }).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task InitTransactionsAsync_WithKeepPreparedAndUnsupportedFeature_ThrowsBrokerVersionException()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTransactionalId("test-txn-id")
+            .Build();
+
+        SetInstanceField(producer, "_initialized", true);
+
+        await Assert.That(async () =>
+        {
+            await producer.InitTransactionsAsync(keepPreparedTransaction: true);
+        }).Throws<BrokerVersionException>();
     }
 
     [Test]
@@ -220,11 +399,46 @@ public sealed class TransactionTests
         await Assert.That(tpo1).IsNotEqualTo(tpo3);
     }
 
+    private static KafkaProducer<string, string> BuildInitializedTransactionalProducer(bool enableTwoPhaseCommit)
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTransactionalId("test-txn-id");
+
+        if (enableTwoPhaseCommit)
+            builder.WithTwoPhaseCommit();
+
+        var producer = (KafkaProducer<string, string>)builder.Build();
+        SetInstanceField(producer, "_initialized", true);
+        SetInstanceField(producer, "_producerId", 42L);
+        SetInstanceField(producer, "_producerEpoch", (short)5);
+        SetFinalizedTransactionVersion(producer, 3);
+        producer._transactionState = TransactionState.Ready;
+        return producer;
+    }
+
+    private static void SetFinalizedTransactionVersion(KafkaProducer<string, string> producer, short version)
+    {
+        var metadataManager = GetInstanceField<object>(producer, "_metadataManager");
+        SetInstanceField<IReadOnlyList<FinalizedFeature>>(
+            metadataManager,
+            "_finalizedFeatures",
+            [new FinalizedFeature("transaction.version", version, version)]);
+    }
+
     private static void SetInstanceField<T>(object target, string name, T value)
     {
         const BindingFlags instanceFieldFlags =
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
         var field = target.GetType().GetField(name, instanceFieldFlags);
         field!.SetValue(target, value);
+    }
+
+    private static T GetInstanceField<T>(object target, string name)
+    {
+        const BindingFlags instanceFieldFlags =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        var field = target.GetType().GetField(name, instanceFieldFlags);
+        return (T)field!.GetValue(target)!;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Protocol/TransactionProtocolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/TransactionProtocolTests.cs
@@ -69,6 +69,43 @@ public sealed class TransactionProtocolTests
     }
 
     [Test]
+    public async Task InitProducerIdRequest_V6_IncludesTwoPhaseCommitFlags()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        var request = new InitProducerIdRequest
+        {
+            TransactionalId = "txn-2pc",
+            TransactionTimeoutMs = 60000,
+            ProducerId = 42,
+            ProducerEpoch = 5,
+            EnableTwoPhaseCommit = true,
+            KeepPreparedTransaction = true
+        };
+        request.Write(ref writer, version: 6);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+
+        var txnId = reader.ReadCompactString();
+        var timeoutMs = reader.ReadInt32();
+        var producerId = reader.ReadInt64();
+        var producerEpoch = reader.ReadInt16();
+        var enableTwoPhaseCommit = reader.ReadBoolean();
+        var keepPreparedTransaction = reader.ReadBoolean();
+        reader.SkipTaggedFields();
+        var end = reader.End;
+
+        await Assert.That(txnId).IsEqualTo("txn-2pc");
+        await Assert.That(timeoutMs).IsEqualTo(60000);
+        await Assert.That(producerId).IsEqualTo(42L);
+        await Assert.That(producerEpoch).IsEqualTo((short)5);
+        await Assert.That(enableTwoPhaseCommit).IsTrue();
+        await Assert.That(keepPreparedTransaction).IsTrue();
+        await Assert.That(end).IsTrue();
+    }
+
+    [Test]
     public async Task InitProducerIdResponse_V2_Flexible_ReadsCorrectly()
     {
         var buffer = new ArrayBufferWriter<byte>();
@@ -87,6 +124,31 @@ public sealed class TransactionProtocolTests
         await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
         await Assert.That(response.ProducerId).IsEqualTo(2000L);
         await Assert.That(response.ProducerEpoch).IsEqualTo((short)7);
+    }
+
+    [Test]
+    public async Task InitProducerIdResponse_V6_ReadsOngoingPreparedTransaction()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(50);
+        writer.WriteInt16(0);
+        writer.WriteInt64(2000);
+        writer.WriteInt16(7);
+        writer.WriteInt64(3000);
+        writer.WriteInt16(9);
+        writer.WriteEmptyTaggedFields();
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (InitProducerIdResponse)InitProducerIdResponse.Read(ref reader, version: 6);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(50);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ProducerId).IsEqualTo(2000L);
+        await Assert.That(response.ProducerEpoch).IsEqualTo((short)7);
+        await Assert.That(response.OngoingTransactionProducerId).IsEqualTo(3000L);
+        await Assert.That(response.OngoingTransactionProducerEpoch).IsEqualTo((short)9);
     }
 
     [Test]
@@ -508,7 +570,7 @@ public sealed class TransactionProtocolTests
     {
         await Assert.That(InitProducerIdRequest.ApiKey).IsEqualTo(ApiKey.InitProducerId);
         await Assert.That(InitProducerIdRequest.LowestSupportedVersion).IsEqualTo((short)2);
-        await Assert.That(InitProducerIdRequest.HighestSupportedVersion).IsEqualTo((short)5);
+        await Assert.That(InitProducerIdRequest.HighestSupportedVersion).IsEqualTo((short)6);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add InitProducerId v6 request/response fields for KIP-939 Enable2Pc, KeepPreparedTxn, and ongoing prepared transaction state
- add producer two-phase commit API: WithTwoPhaseCommit, PrepareAsync, PreparedTransactionState, keep-prepared init, and CompletePreparedTransactionAsync
- enforce prepared-transaction state so only commit, abort, dispose, or complete can run, plus docs/tests

## References
- KIP-939: https://cwiki.apache.org/confluence/display/KAFKA/KIP-939%3A%2BSupport%2BParticipation%2Bin%2B2PC
- Kafka InitProducerId v6 schemas: Apache Kafka 4.3.1 request/response JSON

## Tests
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal
- dotnet build src\Dekaf\Dekaf.csproj --configuration Release --framework netstandard2.0 -p:TreatWarningsAsErrors=true -v:minimal
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/TransactionTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/TransactionProtocolTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build --

Closes #1387.