### PR TITLE
perf(consumer): avoid blocking ConsumeOne prefetch wait

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2813,7 +2813,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         try
         {
-            if (_prefetchBuffer.WaitToRead(_options.FetchMaxWaitMs, cancellationToken))
+            if (await WaitForPrefetchDataAsync(cancellationToken).ConfigureAwait(false))
             {
                 if (_prefetchBuffer.TryRead(out var fetched))
                 {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Reflection;
 using System.Text;
@@ -206,6 +207,26 @@ public sealed class ConsumeOneFastPathTests
         var prefetchCts = GetPrefetchCts(consumer);
         await Assert.That(prefetchCts).IsNotNull();
         await Assert.That(prefetchCts!.IsCancellationRequested).IsFalse();
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_WithEmptyPrefetchBuffer_DoesNotBlockCaller()
+    {
+        await using var consumer = CreateInitializedConsumer(queuedMinMessages: 2, fetchMaxWaitMs: 1_000);
+        AssignTestPartition(consumer);
+        SetPrefetchStarted(consumer);
+
+        using var cts = new CancellationTokenSource();
+
+        var stopwatch = Stopwatch.StartNew();
+        var consumeTask = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+        stopwatch.Stop();
+
+        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(100));
+        await Assert.That(consumeTask.IsCompleted).IsFalse();
+
+        cts.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await consumeTask);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Use the existing async prefetch-buffer waiter from `ConsumeOneAsync` instead of the synchronous `WaitToRead` path.
- Add a regression test that verifies an empty prefetch buffer returns an incomplete task immediately instead of blocking the caller thread.

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- [x] `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter /*/*/ConsumeOneFastPathTests/*`
- [x] `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj -c Release -f net10.0`
- [x] `dotnet run --project tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release --framework net10.0 --no-build -- --hangdump --hangdump-timeout 15m --log-level Debug --treenode-filter /*/*/CancellationSemanticsTests/ConsumeOneAsync_Timeout_ReturnsNull`
- [x] `dotnet format Dekaf.sln --verify-no-changes --verbosity minimal`

Closes #1355
