### PR TITLE
feat(schemaregistry): add data contract models

### DIFF
--- a/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
@@ -110,6 +110,16 @@ public sealed class Schema
     /// Schema references for schemas that depend on other schemas.
     /// </summary>
     public IReadOnlyList<SchemaReference>? References { get; init; }
+
+    /// <summary>
+    /// Optional Schema Registry data-contract metadata, including field tags used by CSFLE policies.
+    /// </summary>
+    public SchemaMetadata? Metadata { get; init; }
+
+    /// <summary>
+    /// Optional Schema Registry rule set for data-contract validation, migration, and encryption rules.
+    /// </summary>
+    public SchemaRuleSet? RuleSet { get; init; }
 }
 
 /// <summary>
@@ -136,6 +146,166 @@ public sealed class RegisteredSchema
     /// The schema.
     /// </summary>
     public required Schema Schema { get; init; }
+}
+
+/// <summary>
+/// Schema Registry data-contract metadata.
+/// </summary>
+public sealed class SchemaMetadata
+{
+    /// <summary>
+    /// Field or schema paths mapped to tag names, for example PII or encrypted.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlySet<string>>? Tags { get; init; }
+
+    /// <summary>
+    /// Arbitrary schema metadata properties.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Properties { get; init; }
+
+    /// <summary>
+    /// Names of metadata properties that should be treated as sensitive.
+    /// </summary>
+    public IReadOnlySet<string>? Sensitive { get; init; }
+}
+
+/// <summary>
+/// Schema Registry data-contract rule set.
+/// </summary>
+public sealed class SchemaRuleSet
+{
+    /// <summary>
+    /// Rules used when migrating between schema versions.
+    /// </summary>
+    public IReadOnlyList<SchemaRule>? MigrationRules { get; init; }
+
+    /// <summary>
+    /// Rules used for validation or transforms on the current schema.
+    /// </summary>
+    public IReadOnlyList<SchemaRule>? DomainRules { get; init; }
+
+    /// <summary>
+    /// Rules used for encoding transforms such as field-level encryption.
+    /// </summary>
+    public IReadOnlyList<SchemaRule>? EncodingRules { get; init; }
+
+    /// <summary>
+    /// Optional Schema Registry activation marker.
+    /// </summary>
+    public string? EnableAt { get; init; }
+}
+
+/// <summary>
+/// Schema Registry data-contract rule.
+/// </summary>
+public sealed class SchemaRule
+{
+    /// <summary>
+    /// Rule name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Optional rule documentation.
+    /// </summary>
+    public string? Doc { get; init; }
+
+    /// <summary>
+    /// Rule kind.
+    /// </summary>
+    public SchemaRuleKind Kind { get; init; }
+
+    /// <summary>
+    /// Rule mode.
+    /// </summary>
+    public SchemaRuleMode Mode { get; init; }
+
+    /// <summary>
+    /// Rule executor type, for example ENCRYPT or CEL.
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Tags this rule applies to.
+    /// </summary>
+    public IReadOnlySet<string>? Tags { get; init; }
+
+    /// <summary>
+    /// Rule parameters.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Parameters { get; init; }
+
+    /// <summary>
+    /// Optional rule expression.
+    /// </summary>
+    public string? Expr { get; init; }
+
+    /// <summary>
+    /// Optional action on rule success.
+    /// </summary>
+    public string? OnSuccess { get; init; }
+
+    /// <summary>
+    /// Optional action on rule failure.
+    /// </summary>
+    public string? OnFailure { get; init; }
+
+    /// <summary>
+    /// Whether this rule is disabled.
+    /// </summary>
+    public bool Disabled { get; init; }
+}
+
+/// <summary>
+/// Schema Registry rule kind.
+/// </summary>
+public enum SchemaRuleKind
+{
+    /// <summary>
+    /// A transform rule.
+    /// </summary>
+    Transform,
+
+    /// <summary>
+    /// A validation or condition rule.
+    /// </summary>
+    Condition
+}
+
+/// <summary>
+/// Schema Registry rule mode.
+/// </summary>
+public enum SchemaRuleMode
+{
+    /// <summary>
+    /// Upgrade migration rule.
+    /// </summary>
+    Upgrade,
+
+    /// <summary>
+    /// Downgrade migration rule.
+    /// </summary>
+    Downgrade,
+
+    /// <summary>
+    /// Upgrade and downgrade migration rule.
+    /// </summary>
+    UpDown,
+
+    /// <summary>
+    /// Read-side rule.
+    /// </summary>
+    Read,
+
+    /// <summary>
+    /// Write-side rule.
+    /// </summary>
+    Write,
+
+    /// <summary>
+    /// Write and read rule.
+    /// </summary>
+    WriteRead
 }
 
 /// <summary>

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -83,17 +83,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         if (_idBySchemaCache.TryGetValue(cacheKey, out var cachedId))
             return cachedId;
 
-        var request = new RegisterSchemaRequest
-        {
-            Schema = schema.SchemaString,
-            SchemaType = schema.SchemaType == SchemaType.Avro ? null : schema.SchemaType.ToString().ToUpperInvariant(),
-            References = schema.References?.Select(r => new SchemaReferenceDto
-            {
-                Name = r.Name,
-                Subject = r.Subject,
-                Version = r.Version
-            }).ToList()
-        };
+        var request = CreateRegisterSchemaRequest(schema);
 
         using var response = await _httpClient.PostAsJsonAsync(
             $"subjects/{Uri.EscapeDataString(subject)}/versions",
@@ -126,18 +116,10 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 
         var result = await response.Content.ReadFromJsonAsync<GetSchemaResponse>(
             SchemaRegistryJsonContext.Default.GetSchemaResponse, cancellationToken).ConfigureAwait(false);
+        if (result is null)
+            throw new SchemaRegistryException((int)response.StatusCode, "Schema Registry returned an empty schema response");
 
-        var schema = new Schema
-        {
-            SchemaString = result!.Schema,
-            SchemaType = ParseSchemaType(result.SchemaType),
-            References = result.References?.Select(r => new SchemaReference
-            {
-                Name = r.Name,
-                Subject = r.Subject,
-                Version = r.Version
-            }).ToList()
-        };
+        var schema = CreateSchema(result);
 
         CacheSchema(id, subject: null, schema);
         return schema;
@@ -156,18 +138,10 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 
         var result = await response.Content.ReadFromJsonAsync<GetSubjectVersionResponse>(
             SchemaRegistryJsonContext.Default.GetSubjectVersionResponse, cancellationToken).ConfigureAwait(false);
+        if (result is null)
+            throw new SchemaRegistryException((int)response.StatusCode, "Schema Registry returned an empty schema response");
 
-        var schema = new Schema
-        {
-            SchemaString = result!.Schema,
-            SchemaType = ParseSchemaType(result.SchemaType),
-            References = result.References?.Select(r => new SchemaReference
-            {
-                Name = r.Name,
-                Subject = r.Subject,
-                Version = r.Version
-            }).ToList()
-        };
+        var schema = CreateSchema(result);
 
         CacheSchema(result.Id, subject: null, schema);
 
@@ -187,17 +161,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             return cachedId;
 
         // Try to get existing schema first
-        var request = new RegisterSchemaRequest
-        {
-            Schema = schema.SchemaString,
-            SchemaType = schema.SchemaType == SchemaType.Avro ? null : schema.SchemaType.ToString().ToUpperInvariant(),
-            References = schema.References?.Select(r => new SchemaReferenceDto
-            {
-                Name = r.Name,
-                Subject = r.Subject,
-                Version = r.Version
-            }).ToList()
-        };
+        var request = CreateRegisterSchemaRequest(schema);
 
         using var response = await _httpClient.PostAsJsonAsync(
             $"subjects/{Uri.EscapeDataString(subject)}",
@@ -215,8 +179,10 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 
         var result = await response.Content.ReadFromJsonAsync<GetSubjectVersionResponse>(
             SchemaRegistryJsonContext.Default.GetSubjectVersionResponse, cancellationToken).ConfigureAwait(false);
+        if (result is null)
+            throw new SchemaRegistryException((int)response.StatusCode, "Schema Registry returned an empty schema response");
 
-        var id = result!.Id;
+        var id = result.Id;
 
         CacheSchema(id, subject, schema);
 
@@ -267,17 +233,7 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
 
     public async Task<bool> IsCompatibleAsync(string subject, Schema schema, string version = "latest", CancellationToken cancellationToken = default)
     {
-        var request = new RegisterSchemaRequest
-        {
-            Schema = schema.SchemaString,
-            SchemaType = schema.SchemaType == SchemaType.Avro ? null : schema.SchemaType.ToString().ToUpperInvariant(),
-            References = schema.References?.Select(r => new SchemaReferenceDto
-            {
-                Name = r.Name,
-                Subject = r.Subject,
-                Version = r.Version
-            }).ToList()
-        };
+        var request = CreateRegisterSchemaRequest(schema);
 
         using var response = await _httpClient.PostAsJsonAsync(
             $"compatibility/subjects/{Uri.EscapeDataString(subject)}/versions/{Uri.EscapeDataString(version)}",
@@ -309,6 +265,143 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             SchemaRegistryJsonContext.Default.ListInt32, cancellationToken).ConfigureAwait(false) ?? [];
     }
 
+    private static RegisterSchemaRequest CreateRegisterSchemaRequest(Schema schema) => new()
+    {
+        Schema = schema.SchemaString,
+        SchemaType = schema.SchemaType == SchemaType.Avro ? null : schema.SchemaType.ToString().ToUpperInvariant(),
+        References = schema.References?.Select(ToReferenceDto).ToList(),
+        Metadata = ToMetadataDto(schema.Metadata),
+        RuleSet = ToRuleSetDto(schema.RuleSet)
+    };
+
+    private static Schema CreateSchema(GetSchemaResponse response) => new()
+    {
+        SchemaString = response.Schema,
+        SchemaType = ParseSchemaType(response.SchemaType),
+        References = response.References?.Select(ToReference).ToList(),
+        Metadata = ToMetadata(response.Metadata),
+        RuleSet = ToRuleSet(response.RuleSet)
+    };
+
+    private static Schema CreateSchema(GetSubjectVersionResponse response) => new()
+    {
+        SchemaString = response.Schema,
+        SchemaType = ParseSchemaType(response.SchemaType),
+        References = response.References?.Select(ToReference).ToList(),
+        Metadata = ToMetadata(response.Metadata),
+        RuleSet = ToRuleSet(response.RuleSet)
+    };
+
+    private static SchemaReferenceDto ToReferenceDto(SchemaReference reference) => new()
+    {
+        Name = reference.Name,
+        Subject = reference.Subject,
+        Version = reference.Version
+    };
+
+    private static SchemaReference ToReference(SchemaReferenceDto reference) => new()
+    {
+        Name = reference.Name,
+        Subject = reference.Subject,
+        Version = reference.Version
+    };
+
+    private static SchemaMetadataDto? ToMetadataDto(SchemaMetadata? metadata)
+    {
+        if (metadata is null)
+            return null;
+
+        return new SchemaMetadataDto
+        {
+            Tags = metadata.Tags?.ToDictionary(
+                static kvp => kvp.Key,
+                static kvp => kvp.Value.ToHashSet(StringComparer.Ordinal),
+                StringComparer.Ordinal),
+            Properties = metadata.Properties?.ToDictionary(
+                static kvp => kvp.Key,
+                static kvp => kvp.Value,
+                StringComparer.Ordinal),
+            Sensitive = metadata.Sensitive?.ToHashSet(StringComparer.Ordinal)
+        };
+    }
+
+    private static SchemaMetadata? ToMetadata(SchemaMetadataDto? metadata)
+    {
+        if (metadata is null)
+            return null;
+
+        return new SchemaMetadata
+        {
+            Tags = metadata.Tags?.ToDictionary(
+                static kvp => kvp.Key,
+                static kvp => (IReadOnlySet<string>)kvp.Value,
+                StringComparer.Ordinal),
+            Properties = metadata.Properties,
+            Sensitive = metadata.Sensitive
+        };
+    }
+
+    private static SchemaRuleSetDto? ToRuleSetDto(SchemaRuleSet? ruleSet)
+    {
+        if (ruleSet is null)
+            return null;
+
+        return new SchemaRuleSetDto
+        {
+            MigrationRules = ruleSet.MigrationRules?.Select(ToRuleDto).ToList(),
+            DomainRules = ruleSet.DomainRules?.Select(ToRuleDto).ToList(),
+            EncodingRules = ruleSet.EncodingRules?.Select(ToRuleDto).ToList(),
+            EnableAt = ruleSet.EnableAt
+        };
+    }
+
+    private static SchemaRuleSet? ToRuleSet(SchemaRuleSetDto? ruleSet)
+    {
+        if (ruleSet is null)
+            return null;
+
+        return new SchemaRuleSet
+        {
+            MigrationRules = ruleSet.MigrationRules?.Select(ToRule).ToList(),
+            DomainRules = ruleSet.DomainRules?.Select(ToRule).ToList(),
+            EncodingRules = ruleSet.EncodingRules?.Select(ToRule).ToList(),
+            EnableAt = ruleSet.EnableAt
+        };
+    }
+
+    private static SchemaRuleDto ToRuleDto(SchemaRule rule) => new()
+    {
+        Name = rule.Name,
+        Doc = rule.Doc,
+        Kind = FormatRuleKind(rule.Kind),
+        Mode = FormatRuleMode(rule.Mode),
+        Type = rule.Type,
+        Tags = rule.Tags?.ToHashSet(StringComparer.Ordinal),
+        Params = rule.Parameters?.ToDictionary(
+            static kvp => kvp.Key,
+            static kvp => kvp.Value,
+            StringComparer.Ordinal),
+        Expr = rule.Expr,
+        OnSuccess = rule.OnSuccess,
+        OnFailure = rule.OnFailure,
+        Disabled = rule.Disabled
+    };
+
+    private static SchemaRule ToRule(SchemaRuleDto rule) => new()
+    {
+        Name = rule.Name ?? string.Empty,
+        Doc = rule.Doc,
+        Kind = ParseRuleKind(rule.Kind),
+        Mode = ParseRuleMode(rule.Mode),
+        Type = rule.Type ?? string.Empty,
+        Tags = rule.Tags,
+        Parameters = rule.Params,
+        Expr = rule.Expr,
+        OnSuccess = rule.OnSuccess,
+        OnFailure = rule.OnFailure,
+        Disabled = rule.Disabled
+    };
+
     private static SchemaType ParseSchemaType(string? schemaType)
     {
         return schemaType?.ToUpperInvariant() switch
@@ -318,6 +411,41 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             _ => SchemaType.Avro
         };
     }
+
+    private static string FormatRuleKind(SchemaRuleKind kind)
+        => kind switch
+        {
+            SchemaRuleKind.Condition => "CONDITION",
+            _ => "TRANSFORM"
+        };
+
+    private static SchemaRuleKind ParseRuleKind(string? kind)
+        => string.Equals(kind, "CONDITION", StringComparison.OrdinalIgnoreCase)
+            ? SchemaRuleKind.Condition
+            : SchemaRuleKind.Transform;
+
+    private static string FormatRuleMode(SchemaRuleMode mode)
+        => mode switch
+        {
+            SchemaRuleMode.Upgrade => "UPGRADE",
+            SchemaRuleMode.Downgrade => "DOWNGRADE",
+            SchemaRuleMode.UpDown => "UPDOWN",
+            SchemaRuleMode.Read => "READ",
+            SchemaRuleMode.Write => "WRITE",
+            SchemaRuleMode.WriteRead => "WRITEREAD",
+            _ => "WRITE"
+        };
+
+    private static SchemaRuleMode ParseRuleMode(string? mode)
+        => mode?.ToUpperInvariant() switch
+        {
+            "UPGRADE" => SchemaRuleMode.Upgrade,
+            "DOWNGRADE" => SchemaRuleMode.Downgrade,
+            "UPDOWN" => SchemaRuleMode.UpDown,
+            "READ" => SchemaRuleMode.Read,
+            "WRITEREAD" => SchemaRuleMode.WriteRead,
+            _ => SchemaRuleMode.Write
+        };
 
     private static async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
     {

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryJsonContext.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryJsonContext.cs
@@ -10,6 +10,9 @@ namespace Dekaf.SchemaRegistry;
 [JsonSerializable(typeof(GetSchemaResponse))]
 [JsonSerializable(typeof(GetSubjectVersionResponse))]
 [JsonSerializable(typeof(SchemaReferenceDto))]
+[JsonSerializable(typeof(SchemaMetadataDto))]
+[JsonSerializable(typeof(SchemaRuleSetDto))]
+[JsonSerializable(typeof(SchemaRuleDto))]
 [JsonSerializable(typeof(CompatibilityResponse))]
 [JsonSerializable(typeof(ErrorResponse))]
 [JsonSerializable(typeof(List<string>))]
@@ -21,6 +24,8 @@ internal sealed class RegisterSchemaRequest
     public required string Schema { get; init; }
     public string? SchemaType { get; init; }
     public List<SchemaReferenceDto>? References { get; init; }
+    public SchemaMetadataDto? Metadata { get; init; }
+    public SchemaRuleSetDto? RuleSet { get; init; }
 }
 
 internal sealed class RegisterSchemaResponse
@@ -33,6 +38,8 @@ internal sealed class GetSchemaResponse
     public required string Schema { get; init; }
     public string? SchemaType { get; init; }
     public List<SchemaReferenceDto>? References { get; init; }
+    public SchemaMetadataDto? Metadata { get; init; }
+    public SchemaRuleSetDto? RuleSet { get; init; }
 }
 
 internal sealed class GetSubjectVersionResponse
@@ -43,6 +50,8 @@ internal sealed class GetSubjectVersionResponse
     public required string Schema { get; init; }
     public string? SchemaType { get; init; }
     public List<SchemaReferenceDto>? References { get; init; }
+    public SchemaMetadataDto? Metadata { get; init; }
+    public SchemaRuleSetDto? RuleSet { get; init; }
 }
 
 internal sealed class SchemaReferenceDto
@@ -50,6 +59,37 @@ internal sealed class SchemaReferenceDto
     public required string Name { get; init; }
     public required string Subject { get; init; }
     public int Version { get; init; }
+}
+
+internal sealed class SchemaMetadataDto
+{
+    public Dictionary<string, HashSet<string>>? Tags { get; init; }
+    public Dictionary<string, string>? Properties { get; init; }
+    public HashSet<string>? Sensitive { get; init; }
+}
+
+internal sealed class SchemaRuleSetDto
+{
+    public List<SchemaRuleDto>? MigrationRules { get; init; }
+    public List<SchemaRuleDto>? DomainRules { get; init; }
+    public List<SchemaRuleDto>? EncodingRules { get; init; }
+    public string? EnableAt { get; init; }
+}
+
+internal sealed class SchemaRuleDto
+{
+    public string? Name { get; init; }
+    public string? Doc { get; init; }
+    public string? Kind { get; init; }
+    public string? Mode { get; init; }
+    public string? Type { get; init; }
+    public HashSet<string>? Tags { get; init; }
+    [JsonPropertyName("params")]
+    public Dictionary<string, string>? Params { get; init; }
+    public string? Expr { get; init; }
+    public string? OnSuccess { get; init; }
+    public string? OnFailure { get; init; }
+    public bool Disabled { get; init; }
 }
 
 internal sealed class CompatibilityResponse

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryDataContractTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryDataContractTests.cs
@@ -1,0 +1,148 @@
+using System.Net;
+using System.Text.Json;
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class SchemaRegistryDataContractTests
+{
+    [Test]
+    public async Task RegisterSchemaAsync_SendsMetadataAndRuleSet()
+    {
+        var handler = new CapturingSchemaRegistryHandler("""{ "id": 7 }""");
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local"
+        }, handler);
+
+        var schema = CreateDataContractSchema();
+
+        var id = await client.RegisterSchemaAsync("orders-value", schema);
+
+        await Assert.That(id).IsEqualTo(7);
+        using var document = JsonDocument.Parse(handler.LastRequestBody!);
+        var root = document.RootElement;
+        var metadata = root.GetProperty("metadata");
+        var rule = root.GetProperty("ruleSet").GetProperty("encodingRules")[0];
+
+        await Assert.That(metadata.GetProperty("tags").GetProperty("$.name")[0].GetString()).IsEqualTo("PII");
+        await Assert.That(metadata.GetProperty("properties").GetProperty("owner").GetString()).IsEqualTo("payments");
+        await Assert.That(rule.GetProperty("kind").GetString()).IsEqualTo("TRANSFORM");
+        await Assert.That(rule.GetProperty("mode").GetString()).IsEqualTo("WRITEREAD");
+        await Assert.That(rule.GetProperty("params").GetProperty("encrypt.kek.name").GetString())
+            .IsEqualTo("payments-kek");
+    }
+
+    [Test]
+    public async Task GetSchemaBySubjectAsync_MapsMetadataAndRuleSet()
+    {
+        var handler = new CapturingSchemaRegistryHandler("""
+            {
+              "subject": "orders-value",
+              "version": 3,
+              "id": 42,
+              "schema": "{\"type\":\"object\"}",
+              "schemaType": "JSON",
+              "metadata": {
+                "tags": { "$.name": [ "PII" ] },
+                "properties": { "owner": "payments" },
+                "sensitive": [ "owner" ]
+              },
+              "ruleSet": {
+                "encodingRules": [
+                  {
+                    "name": "encryptPii",
+                    "doc": "Encrypt PII fields",
+                    "kind": "TRANSFORM",
+                    "mode": "WRITEREAD",
+                    "type": "ENCRYPT",
+                    "tags": [ "PII" ],
+                    "params": { "encrypt.kek.name": "payments-kek" },
+                    "expr": "message.name",
+                    "onSuccess": "NONE",
+                    "onFailure": "ERROR",
+                    "disabled": false
+                  }
+                ]
+              }
+            }
+            """);
+        using var client = new SchemaRegistryClient(new SchemaRegistryConfig
+        {
+            Url = "http://schema-registry.local"
+        }, handler);
+
+        var registered = await client.GetSchemaBySubjectAsync("orders-value");
+        var metadata = registered.Schema.Metadata!;
+        var ruleSet = registered.Schema.RuleSet!;
+        var rule = ruleSet.EncodingRules![0];
+
+        await Assert.That(registered.Id).IsEqualTo(42);
+        await Assert.That(metadata.Tags!["$.name"]).Contains("PII");
+        await Assert.That(metadata.Properties!["owner"]).IsEqualTo("payments");
+        await Assert.That(metadata.Sensitive!).Contains("owner");
+
+        await Assert.That(rule.Name).IsEqualTo("encryptPii");
+        await Assert.That(rule.Kind).IsEqualTo(SchemaRuleKind.Transform);
+        await Assert.That(rule.Mode).IsEqualTo(SchemaRuleMode.WriteRead);
+        await Assert.That(rule.Type).IsEqualTo("ENCRYPT");
+        await Assert.That(rule.Tags!).Contains("PII");
+        await Assert.That(rule.Parameters!["encrypt.kek.name"]).IsEqualTo("payments-kek");
+        await Assert.That(rule.Expr).IsEqualTo("message.name");
+    }
+
+    private static Schema CreateDataContractSchema() => new()
+    {
+        SchemaType = SchemaType.Json,
+        SchemaString = """{ "type": "object" }""",
+        Metadata = new SchemaMetadata
+        {
+            Tags = new Dictionary<string, IReadOnlySet<string>>
+            {
+                ["$.name"] = new HashSet<string>(StringComparer.Ordinal) { "PII" }
+            },
+            Properties = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["owner"] = "payments"
+            },
+            Sensitive = new HashSet<string>(StringComparer.Ordinal) { "owner" }
+        },
+        RuleSet = new SchemaRuleSet
+        {
+            EncodingRules =
+            [
+                new SchemaRule
+                {
+                    Name = "encryptPii",
+                    Doc = "Encrypt PII fields",
+                    Kind = SchemaRuleKind.Transform,
+                    Mode = SchemaRuleMode.WriteRead,
+                    Type = "ENCRYPT",
+                    Tags = new HashSet<string>(StringComparer.Ordinal) { "PII" },
+                    Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["encrypt.kek.name"] = "payments-kek"
+                    }
+                }
+            ]
+        }
+    };
+
+    private sealed class CapturingSchemaRegistryHandler(string responseContent) : HttpMessageHandler
+    {
+        public string? LastRequestBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+                LastRequestBody = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseContent)
+            };
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryJsonAotTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryJsonAotTests.cs
@@ -34,7 +34,37 @@ public sealed class SchemaRegistryJsonAotTests
                     Subject = "shared-value",
                     Version = 2
                 }
-            ]
+            ],
+            Metadata = new SchemaMetadataDto
+            {
+                Tags = new Dictionary<string, HashSet<string>>
+                {
+                    ["$.name"] = ["PII"]
+                },
+                Properties = new Dictionary<string, string>
+                {
+                    ["owner"] = "payments"
+                },
+                Sensitive = ["owner"]
+            },
+            RuleSet = new SchemaRuleSetDto
+            {
+                EncodingRules =
+                [
+                    new SchemaRuleDto
+                    {
+                        Name = "encryptPii",
+                        Kind = "TRANSFORM",
+                        Mode = "WRITEREAD",
+                        Type = "ENCRYPT",
+                        Tags = ["PII"],
+                        Params = new Dictionary<string, string>
+                        {
+                            ["encrypt.kek.name"] = "payments-kek"
+                        }
+                    }
+                ]
+            }
         };
 
         var requestJson = JsonSerializer.SerializeToUtf8Bytes(
@@ -57,7 +87,24 @@ public sealed class SchemaRegistryJsonAotTests
                   "subject": "shared-value",
                   "version": 2
                 }
-              ]
+              ],
+              "metadata": {
+                "tags": { "$.name": [ "PII" ] },
+                "properties": { "owner": "payments" },
+                "sensitive": [ "owner" ]
+              },
+              "ruleSet": {
+                "encodingRules": [
+                  {
+                    "name": "encryptPii",
+                    "kind": "TRANSFORM",
+                    "mode": "WRITEREAD",
+                    "type": "ENCRYPT",
+                    "tags": [ "PII" ],
+                    "params": { "encrypt.kek.name": "payments-kek" }
+                  }
+                ]
+              }
             }
             """u8;
         var subjectResponse = JsonSerializer.Deserialize(
@@ -75,8 +122,12 @@ public sealed class SchemaRegistryJsonAotTests
 
         await Assert.That(roundTrippedRequest!.SchemaType).IsEqualTo("JSON");
         await Assert.That(roundTrippedRequest.References!.Count).IsEqualTo(1);
+        await Assert.That(roundTrippedRequest.Metadata!.Tags!["$.name"]).Contains("PII");
+        await Assert.That(roundTrippedRequest.RuleSet!.EncodingRules![0].Params!["encrypt.kek.name"]).IsEqualTo("payments-kek");
         await Assert.That(subjectResponse!.Subject).IsEqualTo("orders-value");
         await Assert.That(subjectResponse.References!.Count).IsEqualTo(1);
+        await Assert.That(subjectResponse.Metadata!.Properties!["owner"]).IsEqualTo("payments");
+        await Assert.That(subjectResponse.RuleSet!.EncodingRules![0].Mode).IsEqualTo("WRITEREAD");
         await Assert.That(compatibilityDocument.RootElement.TryGetProperty("is_compatible", out _)).IsTrue();
         await Assert.That(errorDocument.RootElement.TryGetProperty("error_code", out _)).IsTrue();
     }


### PR DESCRIPTION
## Summary
- add public Schema Registry metadata/rule-set models for data-contract schemas
- serialize/deserialize metadata and ruleSet through AOT JSON DTOs
- preserve CSFLE ENCRYPT rule parameters and field tags through register/get flows

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release
- [x] dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress --treenode-filter "/*/*/SchemaRegistryDataContractTests/*"
- [x] dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress --treenode-filter "/*/*/SchemaRegistryJsonAotTests/*"
- [x] dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress --treenode-filter "/*/*/SchemaRegistryCacheTests/*"
- [x] dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress (4282/4283 passed; KafkaConnection_ConnectAsync_TriesAllResolvedAddresses timed out once, then passed on focused rerun)

Note: this PR adds Schema Registry transport/model support for metadata and ruleSet. CSFLE crypto/KMS execution remains future work.

Refs #1382
