### PR TITLE
fix(ci): allow positive API surface reviews

### DIFF
--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -168,7 +168,7 @@ function Get-ActionableReviewBodyReason {
     $verifiedCleanHeading =
         '(?=.{1,300}\s*$)merge\s+correctness\b(?=[^\r\n]*\bverified\s+clean\b)[^\r\n]*\s*$'
     $closedCoverageGapHeading =
-        '(?=.{1,300}\s*$)test\s+coverage\b(?=[^\r\n]*\bgap\s+closed\b)[^\r\n]*\s*$'
+        '(?=.{1,300}\s*$)test\s+coverage\b[^\r\n]*\bgap\s+closed\b\s*\.?\s*$'
     $nonActionableHeading =
         '(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking)\b' +
         '|not\s+a\s+regression\b(?:,\s+just\s+noting\s+scope)?\s*$' +

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -155,8 +155,14 @@ function Get-ActionableReviewBodyReason {
         return $null
     }
 
+    $resolvedPriorFindingLineContinuationGuard =
+        '(?![^\r\n]*\b(?:fixed|resolved|addressed|verified)\b[^\r\n]*\b(?:but|however|though|except)\b)'
+    $resolvedPriorFindingContinuationGuard =
+        '(?![\s\S]*\b(?:fixed|resolved|addressed|verified)\b[\s\S]*\b(?:but|however|though|except)\b)'
     $previouslyResolvedHeading =
-        '(?=.{1,300}\s*$)previously[- ]flagged\b(?![^\r\n]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[^\r\n]*\b(?:fixed|resolved|addressed|verified)\b)[^\r\n]*\s*$'
+        '(?=.{1,300}\s*$)previously[- ]flagged\b' +
+        $resolvedPriorFindingLineContinuationGuard +
+        '(?![^\r\n]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[^\r\n]*\b(?:fixed|resolved|addressed|verified)\b)[^\r\n]*\s*$'
     $resolvedFindingHeading =
         '(?=.{1,300}\s*$)(?![^\r\n]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[^\r\n]*\b(?:fix|fix(?:es|ed)?|change|commit|follow[- ]up|resolves?|resolved|addresses?|addressed|verified)\b)(?=[^\r\n]*\b(?:issues?|bugs?|findings?|concerns?|regressions?)\b)[^\r\n]*\s*$'
     $verifiedCleanHeading =
@@ -188,8 +194,8 @@ function Get-ActionableReviewBodyReason {
     $positiveVerdictAlternatives = @(
         "$noCategoryFindings(?:[\s\S]*)?"
         'looks?\s+(?:right|good)(?:[\s\S]*)?'
-        '(?:both\s+)?previously[- ]flagged\b(?![\s\S]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?'
-        '(?:the\s+)?prior\b(?=[\s\S]*\b(?:findings?|issues?|bugs?)\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?'
+        "(?:both\s+)?previously[- ]flagged\b$resolvedPriorFindingContinuationGuard(?![\s\S]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?"
+        "(?:the\s+)?prior\b$resolvedPriorFindingContinuationGuard(?=[\s\S]*\b(?:findings?|issues?|bugs?)\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?"
         'verified(?:\s+against\b[\s\S]*)?'
         'confirmed\b(?:[\s\S]*)?'
         'no\s+concerns\b(?:[\s\S]*)?'
@@ -215,7 +221,7 @@ function Get-ActionableReviewBodyReason {
         } else {
             $heading.Groups['parentheticalVerdict'].Value
         }
-        $headingVerdictResolvesPriorFindings = $headingVerdict -match "(?is)^(?!.*$positiveVerdictBlocker)(?!.*$positiveVerdictContinuationBlocker)\s*(?:both\s+)?previously[- ]flagged\b(?![\s\S]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?$"
+        $headingVerdictResolvesPriorFindings = $headingVerdict -match "(?is)^(?!.*$positiveVerdictBlocker)(?!.*$positiveVerdictContinuationBlocker)\s*(?:both\s+)?previously[- ]flagged\b$resolvedPriorFindingContinuationGuard(?![\s\S]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?$"
         if ($headingVerdict -and $headingVerdict -notmatch $positiveCategoryHeadingVerdict) {
             return "actionable category heading: $($heading.Value.Trim())"
         }

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -105,6 +105,35 @@ function Test-StaleBotReviewCanBeIgnored {
     return Test-StatusCheckCompletedAfterInstant -Checks $Checks -Name 'claude-review' -InstantUtc $HeadCommitCommittedAt
 }
 
+function Test-ReviewCategoryAllowsGlobalNoIssueVerdict {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$CategoryHeading
+    )
+
+    $allowedTerms = @('design', 'architecture', 'api surface')
+    $terms = @(
+        foreach ($term in [regex]::Split($CategoryHeading, '\s*/\s*')) {
+            $normalized = ([regex]::Replace($term.Trim(), '\s+', ' ')).ToLowerInvariant()
+            if ($normalized) {
+                $normalized
+            }
+        }
+    )
+
+    if ($terms.Count -eq 0) {
+        return $false
+    }
+
+    foreach ($term in $terms) {
+        if ($term -notin $allowedTerms) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
 function Get-ActionableReviewBodyReason {
     [CmdletBinding()]
     param(
@@ -160,6 +189,7 @@ function Get-ActionableReviewBodyReason {
         "$noCategoryFindings(?:[\s\S]*)?"
         'looks?\s+(?:right|good)(?:[\s\S]*)?'
         '(?:both\s+)?previously[- ]flagged\b(?![\s\S]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?'
+        '(?:the\s+)?prior\b(?=[\s\S]*\b(?:findings?|issues?|bugs?)\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?'
         'verified(?:\s+against\b[\s\S]*)?'
         'confirmed\b(?:[\s\S]*)?'
         'no\s+concerns\b(?:[\s\S]*)?'
@@ -177,6 +207,7 @@ function Get-ActionableReviewBodyReason {
     $categoryHeadingWithOptionalVerdict = "$categoryOnlyHeading(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*\S[^\r\n#]*)|(?:$horizontalWhitespace*\([^\r\n#)]*\))|(?:$horizontalWhitespace+\S[^\r\n#]*))?:?"
     $categoryHeadingPattern = "(?im)^$horizontalWhitespace*#{2,4}$horizontalWhitespace+($categoryOnlyHeading)(?:(?:$horizontalWhitespace*(?:[-:]|\p{Pd})$horizontalWhitespace*(?<verdict>\S[^\r\n#]*))|(?:$horizontalWhitespace*\((?<parentheticalVerdict>[^)\r\n#]+)\))|(?:$horizontalWhitespace+(?<bareVerdict>\S[^\r\n#]*)))?:?$horizontalWhitespace*\r?$"
     foreach ($heading in [regex]::Matches($Body, $categoryHeadingPattern)) {
+        $allowsGlobalNoIssueVerdict = Test-ReviewCategoryAllowsGlobalNoIssueVerdict -CategoryHeading $heading.Groups[1].Value
         $headingVerdict = if ($heading.Groups['verdict'].Success) {
             $heading.Groups['verdict'].Value
         } elseif ($heading.Groups['bareVerdict'].Success) {
@@ -184,6 +215,7 @@ function Get-ActionableReviewBodyReason {
         } else {
             $heading.Groups['parentheticalVerdict'].Value
         }
+        $headingVerdictResolvesPriorFindings = $headingVerdict -match "(?is)^(?!.*$positiveVerdictBlocker)(?!.*$positiveVerdictContinuationBlocker)\s*(?:both\s+)?previously[- ]flagged\b(?![\s\S]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?$"
         if ($headingVerdict -and $headingVerdict -notmatch $positiveCategoryHeadingVerdict) {
             return "actionable category heading: $($heading.Value.Trim())"
         }
@@ -208,7 +240,8 @@ function Get-ActionableReviewBodyReason {
         }
 
         if ($firstVerdict -notmatch $positiveCategorySection -and
-            -not ($globalNoIssueVerdict -and $sectionBody -notmatch $positiveVerdictContinuationBlocker)) {
+            -not ($headingVerdictResolvesPriorFindings -and $sectionBody -notmatch $positiveVerdictContinuationBlocker) -and
+            -not ($allowsGlobalNoIssueVerdict -and $globalNoIssueVerdict -and $sectionBody -notmatch $positiveVerdictContinuationBlocker)) {
             return "actionable category heading: $($heading.Value.Trim())"
         }
 

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -132,20 +132,25 @@ function Get-ActionableReviewBodyReason {
         '(?=.{1,300}\s*$)(?![^\r\n]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[^\r\n]*\b(?:fix|fix(?:es|ed)?|change|commit|follow[- ]up|resolves?|resolved|addresses?|addressed|verified)\b)(?=[^\r\n]*\b(?:issues?|bugs?|findings?|concerns?|regressions?)\b)[^\r\n]*\s*$'
     $verifiedCleanHeading =
         '(?=.{1,300}\s*$)merge\s+correctness\b(?=[^\r\n]*\bverified\s+clean\b)[^\r\n]*\s*$'
+    $closedCoverageGapHeading =
+        '(?=.{1,300}\s*$)test\s+coverage\b(?=[^\r\n]*\bgap\s+closed\b)[^\r\n]*\s*$'
     $nonActionableHeading =
         '(?:\d+\.\s+)?(?:minor|optional|nit|non[- ]blocking)\b' +
         '|not\s+a\s+regression\b(?:,\s+just\s+noting\s+scope)?\s*$' +
         "|$previouslyResolvedHeading" +
         "|$resolvedFindingHeading" +
-        "|$verifiedCleanHeading"
+        "|$verifiedCleanHeading" +
+        "|$closedCoverageGapHeading"
     $actionableHeadingWord = 'Correctness|Bug|Bugs|Concern|Concerns|Issue|Issues|Regression|Risk|Risks|Design|Leak|Leaks|Gap|Gaps|Silently|(?<!not )(?<!non-)Blocking|(?<!not )(?<!non-)Blocker|Test coverage gap|Required|Must fix'
     $horizontalWhitespace = '[^\S\r\n]'
-    $categoryHeadingTerm = "(?:correctness|security|design|architecture|claude\.md$horizontalWhitespace+(?:compliance|conventions))"
+    $categoryHeadingTerm = "(?:correctness|security|design|architecture|api$horizontalWhitespace+surface|claude\.md$horizontalWhitespace+(?:compliance|conventions))"
     $categoryOnlyHeading = "$categoryHeadingTerm(?:$horizontalWhitespace*/$horizontalWhitespace*$categoryHeadingTerm)*"
     $noCategoryFindings =
         '\bno\s+(?:\w+\s+){0,5}(?:bugs?|issues?|concerns?|blockers?|findings?|problems?)\b(?:\s+(?:found|detected|identified|seen|remain|remaining))?'
+    $globalNoIssueVerdict =
+        $Body -match "(?im)^\s*$noCategoryFindings\s*(?:to\s+flag|found|detected|identified|seen|remain|remaining)?\s*\.?(?:\s+(?!but\b|however\b|though\b|except\b).*)?$"
     $positiveVerdictDefect =
-        '(?<!not\s)incorrect(?:ly)?|(?<!not\s)(?<!nothing\s)wrong|miss(?:es|ing)?|deadlocks?|will\s+throw|throws?\s+(?:an?\s+)?exception|crash(?:es|ing|ed)?|fixme|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|will\s+allocate|allocate\s+per|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|still\s+broken|remains?\s+broken|is\s+broken|leak(?:s|ing|ed)?|never\s+disposed|not\s+disposed|race|corrupt(?:s|ion|ed|ing)?|vulnerabilit(?:y|ies)|vulnerable|insecure|injection|hardcoded|guessable|session\s+token|expos(?:es|ed|ing)?\s+(?:credentials?|secrets?|tokens?)|stack\s+overflow|hang(?:s|ing)?|forever|infinite\s+loop|use[- ]after[- ]free|double[- ]free|double[- ]charges?|not\s+idempotent|(?<!no\s)data\s+loss|silent(?:ly)?\s+drops?(?:\s+\w+){0,2}\s+messages?|skip(?:s|ped|ping)?\s+validation|design\s+risk|risk\s+(?:for|of)|real\s+concerns?|concerns?\s+about|(?:test\s+)?coverage\s+gap|(?<!no\s)(?<!non[- ])block(?:er|ing)|fix\s+is\s+required|required\s+fix|required\s+before|real\s+(?:bug|issue)|edge\s+case|go(?:es|ing)?\s+stale|stale\s+(?:cache|entry)|never\s+refresh|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped)'
+        '(?<!not\s)incorrect(?:ly)?|(?<!not\s)(?<!nothing\s)wrong|miss(?:es|ing)?|deadlocks?|will\s+throw|throws?\s+(?:an?\s+)?exception|crash(?:es|ing|ed)?|fixme|nullreferenceexception|box(?:es|ing|ed)?|allocat(?:es|ing|ed)|will\s+allocate|allocate\s+per|(?:per[- ]message|array)\s+(?:\w+\s+){0,3}allocations?|off[- ]by[- ]one|still\s+broken|remains?\s+broken|is\s+broken|leak(?:s|ing|ed)?|never\s+disposed|not\s+disposed|race\s+condition|(?<!under a )race|(?<!not\s)corrupt(?:s|ion|ed|ing)?|vulnerabilit(?:y|ies)|vulnerable|insecure|injection|hardcoded|guessable|session\s+token|expos(?:es|ed|ing)?\s+(?:credentials?|secrets?|tokens?)|stack\s+overflow|hang(?:s|ing)?|forever|infinite\s+loop|use[- ]after[- ]free|double[- ]free|double[- ]charges?|not\s+idempotent|(?<!no\s)data\s+loss|silent(?:ly)?\s+drops?(?:\s+\w+){0,2}\s+messages?|skip(?:s|ped|ping)?\s+validation|design\s+risk|risk\s+(?:for|of)|real\s+concerns?|concerns?\s+about|(?:test\s+)?coverage\s+gap|(?<!no\s)(?<!non[- ])block(?:er|ing)|fix\s+is\s+required|required\s+fix|required\s+before|real\s+(?:bug|issue)|edge\s+case|go(?:es|ing)?\s+stale|stale\s+(?:cache|entry)|never\s+refresh|not\s+(?:thread[- ]safe|safe|correct|fixed|resolved|addressed|scoped)'
     $positiveVerdictBlocker = '\b(?:' + $positiveVerdictDefect + ')\b'
     $positiveVerdictContinuationDefect =
         "$positiveVerdictDefect|(?<!not\s+a\s)(?<!no\s)regressions?(?!\s+(?:coverage|tests?|risk))|now\s+duplicated|(?<!used\s+to\s+be\s)(?<!previously\s)duplicated\s+across|duplicates?\s+logic|duplication\s+of|swallow(?:s|ed|ing)?"
@@ -154,10 +159,11 @@ function Get-ActionableReviewBodyReason {
     $positiveVerdictAlternatives = @(
         "$noCategoryFindings(?:[\s\S]*)?"
         'looks?\s+(?:right|good)(?:[\s\S]*)?'
+        '(?:both\s+)?previously[- ]flagged\b(?![\s\S]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?'
         'verified(?:\s+against\b[\s\S]*)?'
         'confirmed\b(?:[\s\S]*)?'
         'no\s+concerns\b(?:[\s\S]*)?'
-        '`?configureawait\(false\)`?(?:[\s\S]*\b)?used\s+consistently(?:[\s\S]*)?'
+        '`?configureawait\(false\)`?(?:[\s\S]*\b)?(?:used|applied)\s+consistently(?:[\s\S]*)?'
         '(?:the\s+)?core\s+fix\s+is\s+(?:sound|correct)(?:[\s\S]*)?'
         'genuine\s+improvement,\s+not\s+just\s+churn(?:[\s\S]*)?'
         'fix\s+is\s+scoped(?:\s+to\b[\s\S]*)?'
@@ -201,7 +207,8 @@ function Get-ActionableReviewBodyReason {
             return "actionable category heading: $($heading.Value.Trim())"
         }
 
-        if ($firstVerdict -notmatch $positiveCategorySection) {
+        if ($firstVerdict -notmatch $positiveCategorySection -and
+            -not ($globalNoIssueVerdict -and $sectionBody -notmatch $positiveVerdictContinuationBlocker)) {
             return "actionable category heading: $($heading.Value.Trim())"
         }
 

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -234,6 +234,75 @@ This is still allocation-free and keeps the existing unsafe fast path unchanged.
         Blocks = $false
     },
     @{
+        Name = 'allows positive api surface category with no-issues verdict'
+        Body = @'
+## Review
+
+### Design / API surface
+- Block size default is updated consistently in the codec, extension, and benchmark files.
+- finally/ArrayPool.Return removal is safe because the pooled buffer path is gone.
+
+No issues to flag. This is a clean, well-tested, appropriately-scoped perf change.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'blocks api surface category defect despite no-issues verdict'
+        Body = @'
+## Review
+
+### Design / API surface
+- No issues found.
+- However, this introduces a race condition when two callers close concurrently.
+
+No issues to flag.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'allows category heading with previously flagged bugs verified fixed'
+        Body = @'
+## Review
+
+### Correctness — both previously-flagged bugs verified fixed
+
+The prior cache-key and fallback findings are now resolved on the current diff.
+
+No new or unresolved actionable issues found in the current diff.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'blocks category heading with previously flagged bugs still not fixed'
+        Body = @'
+## Review
+
+### Correctness — both previously-flagged bugs still not fixed
+
+The prior findings remain open.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'allows design conventions with benign race note'
+        Body = @'
+## Review
+
+### Design / CLAUDE.md conventions
+
+- `ConfigureAwait(false)` is applied consistently on every new `await` in `src/`.
+- `_activeBaseUriIndex` uses `Volatile.Read`/`Volatile.Write`; worst case under a race is an extra failover hop, not corrupted state.
+- Non-blocking: minor ergonomics wart, not correctness-affecting.
+
+### Security
+
+No concerns.
+
+No new or unresolved actionable issues found in the current diff.
+'@
+        Blocks = $false
+    },
+    @{
         Name = 'blocks positive phrase followed by incorrect scope'
         Body = @'
 ## Review
@@ -795,6 +864,17 @@ Conflict resolution kept both feature sets.
 ### Self-triggering `UnknownTopicOrPartition` regression (from review #1) - fixed in `bb0f437f`
 
 The regression is covered.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows test coverage gap closed heading'
+        Body = @'
+## Review
+
+### Test coverage — gap closed
+
+The missing tests are now present.
 '@
         Blocks = $false
     },

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -260,6 +260,30 @@ No issues to flag.
         Blocks = $true
     },
     @{
+        Name = 'blocks security category despite global no-issues verdict'
+        Body = @'
+## Review
+
+### Security
+- The new admin endpoint builds the SQL query by concatenating the raw username parameter directly into the WHERE clause before executing it.
+
+No issues to flag.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks correctness category despite global no-issues verdict'
+        Body = @'
+## Review
+
+### Correctness
+- The retry counter is decremented twice per attempt, so this exhausts retries roughly twice as fast as configured.
+
+No issues to flag.
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'allows category heading with previously flagged bugs verified fixed'
         Body = @'
 ## Review
@@ -269,6 +293,21 @@ No issues to flag.
 The prior cache-key and fallback findings are now resolved on the current diff.
 
 No new or unresolved actionable issues found in the current diff.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'allows resolved prior findings heading with itemized verification'
+        Body = @'
+## Review
+
+### Correctness — both previously-flagged bugs verified fixed
+
+**1. Dead `lastException` / unreachable fallback** — the exception filter now catches the final retriable exception, the loop completes, and `lastException` is genuinely thrown afterward. Confirmed correct.
+
+**2. Cache key ignored `normalize`** — `_idBySchemaCache` is now keyed by `(subject, schema, normalize)`, and the effective normalize flag is threaded consistently. Confirmed correct.
+
+Both fixes match what the prior reviews reported and were independently re-verified against the current diff.
 '@
         Blocks = $false
     },

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -323,6 +323,35 @@ The prior findings remain open.
         Blocks = $true
     },
     @{
+        Name = 'blocks prior finding section with continuation defect'
+        Body = @'
+## Review
+
+### Correctness
+
+The prior fallback finding was verified as fixed, but a similar flaw exists in the retry path too.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks prior finding heading with continuation defect'
+        Body = @'
+## Review
+
+### Correctness - prior fallback finding verified, but a similar flaw exists in the retry path
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks previously flagged heading with continuation defect'
+        Body = @'
+## Review
+
+### Correctness - both previously-flagged bugs verified fixed, but a related flaw exists in the retry path
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'allows design conventions with benign race note'
         Body = @'
 ## Review

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -947,6 +947,24 @@ The missing tests are now present.
         Blocks = $false
     },
     @{
+        Name = 'blocks test coverage gap closed heading with trailing vulnerability'
+        Body = @'
+## Review
+
+### Test coverage gap closed. Also this endpoint is vulnerable to SQL injection
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks test coverage gap closed heading with trailing defect'
+        Body = @'
+## Review
+
+### Test coverage gap closed - deadlock still present in flush path
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'blocks previously flagged issue still not fixed'
         Body = @'
 ## Review


### PR DESCRIPTION
## Summary
- Treat `Design / API surface` as a review category heading instead of an automatic finding.
- Allow category sections when the body is descriptive and the review has a clear no-issues verdict.
- Keep defect wording inside the section blocking.

## Test plan
- `pwsh scripts\Test-AssertPrGreenReviewHeuristics.ps1`
- `pwsh scripts\Assert-PrGreen.ps1 -Pr 1453`

Closes #1466.