### PR TITLE
perf(consumer): reduce lane resume churn

### DIFF
--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -1451,13 +1451,12 @@ internal sealed class PartitionLane<TKey, TValue>
         if (Volatile.Read(ref _completed) != 0)
             return false;
 
+        if (!_channel.Writer.TryWrite(result))
+            return false;
+
         TrackPending(result);
         Interlocked.Increment(ref _bufferedCount);
-        if (_channel.Writer.TryWrite(result))
-            return true;
-
-        Interlocked.Decrement(ref _bufferedCount);
-        return false;
+        return true;
     }
 
     public ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken)

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -916,7 +916,6 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
 
         if (_pausedByRuntime.Add(lane.TopicPartition))
         {
-            lane.MarkRuntimeBackpressurePaused();
             _consumer.Partitions.Pause(lane.TopicPartition);
         }
     }
@@ -928,14 +927,13 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
 
         if (_pausedByRuntime.Remove(lane.TopicPartition))
         {
-            lane.ClearRuntimeBackpressurePaused();
             _consumer.Partitions.Resume(lane.TopicPartition);
         }
     }
 
     private void OnLaneCapacityAvailable(PartitionLane<TKey, TValue> lane)
     {
-        if (_options.BackpressureMode != PartitionBackpressureMode.PauseResume || !lane.IsRuntimeBackpressurePaused)
+        if (_options.BackpressureMode != PartitionBackpressureMode.PauseResume)
             return;
 
         _commands.Writer.TryWrite(RuntimeCommand<TKey, TValue>.Resume(lane));
@@ -1037,7 +1035,6 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         }
         else if (_pausedByRuntime.Remove(lane.TopicPartition))
         {
-            lane.ClearRuntimeBackpressurePaused();
             _consumer.Partitions.Resume(lane.TopicPartition);
         }
 
@@ -1176,7 +1173,6 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
 
         _lanes.Remove(partition);
         _pausedByRuntime.Remove(partition);
-        lane.ClearRuntimeBackpressurePaused();
         _pendingIgnoreRestarts.Remove(partition);
         _ignoreRestartFailures.Remove(partition);
 
@@ -1375,7 +1371,6 @@ internal sealed class PartitionLane<TKey, TValue>
     private readonly int _capacity;
     private Task? _processorTask;
     private int _bufferedCount;
-    private int _runtimeBackpressurePaused;
     private int _completed;
     private readonly SortedSet<long> _completedOffsets = [];
     private readonly Dictionary<long, int> _leaderEpochs = [];
@@ -1424,18 +1419,6 @@ internal sealed class PartitionLane<TKey, TValue>
     public bool IsFull => Volatile.Read(ref _bufferedCount) >= _capacity;
 
     public bool HasCapacity => Volatile.Read(ref _bufferedCount) < _capacity;
-
-    public bool IsRuntimeBackpressurePaused => Volatile.Read(ref _runtimeBackpressurePaused) != 0;
-
-    public void MarkRuntimeBackpressurePaused()
-    {
-        Volatile.Write(ref _runtimeBackpressurePaused, 1);
-    }
-
-    public void ClearRuntimeBackpressurePaused()
-    {
-        Volatile.Write(ref _runtimeBackpressurePaused, 0);
-    }
 
     public void Start(PartitionProcessor<TKey, TValue> processor)
     {

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -915,7 +915,10 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             return;
 
         if (_pausedByRuntime.Add(lane.TopicPartition))
+        {
+            lane.MarkRuntimeBackpressurePaused();
             _consumer.Partitions.Pause(lane.TopicPartition);
+        }
     }
 
     private void ResumeIfNeeded(PartitionLane<TKey, TValue> lane)
@@ -924,11 +927,17 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             return;
 
         if (_pausedByRuntime.Remove(lane.TopicPartition))
+        {
+            lane.ClearRuntimeBackpressurePaused();
             _consumer.Partitions.Resume(lane.TopicPartition);
+        }
     }
 
     private void OnLaneCapacityAvailable(PartitionLane<TKey, TValue> lane)
     {
+        if (_options.BackpressureMode != PartitionBackpressureMode.PauseResume || !lane.IsRuntimeBackpressurePaused)
+            return;
+
         _commands.Writer.TryWrite(RuntimeCommand<TKey, TValue>.Resume(lane));
     }
 
@@ -1028,6 +1037,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
         }
         else if (_pausedByRuntime.Remove(lane.TopicPartition))
         {
+            lane.ClearRuntimeBackpressurePaused();
             _consumer.Partitions.Resume(lane.TopicPartition);
         }
 
@@ -1166,6 +1176,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
 
         _lanes.Remove(partition);
         _pausedByRuntime.Remove(partition);
+        lane.ClearRuntimeBackpressurePaused();
         _pendingIgnoreRestarts.Remove(partition);
         _ignoreRestartFailures.Remove(partition);
 
@@ -1364,6 +1375,7 @@ internal sealed class PartitionLane<TKey, TValue>
     private readonly int _capacity;
     private Task? _processorTask;
     private int _bufferedCount;
+    private int _runtimeBackpressurePaused;
     private int _completed;
     private readonly SortedSet<long> _completedOffsets = [];
     private readonly Dictionary<long, int> _leaderEpochs = [];
@@ -1412,6 +1424,18 @@ internal sealed class PartitionLane<TKey, TValue>
     public bool IsFull => Volatile.Read(ref _bufferedCount) >= _capacity;
 
     public bool HasCapacity => Volatile.Read(ref _bufferedCount) < _capacity;
+
+    public bool IsRuntimeBackpressurePaused => Volatile.Read(ref _runtimeBackpressurePaused) != 0;
+
+    public void MarkRuntimeBackpressurePaused()
+    {
+        Volatile.Write(ref _runtimeBackpressurePaused, 1);
+    }
+
+    public void ClearRuntimeBackpressurePaused()
+    {
+        Volatile.Write(ref _runtimeBackpressurePaused, 0);
+    }
 
     public void Start(PartitionProcessor<TKey, TValue> processor)
     {
@@ -1468,8 +1492,10 @@ internal sealed class PartitionLane<TKey, TValue>
         if (!_channel.Reader.TryRead(out message))
             return false;
 
-        Interlocked.Decrement(ref _bufferedCount);
-        _capacityAvailable(this);
+        var bufferedCount = Interlocked.Decrement(ref _bufferedCount);
+        if (bufferedCount == _capacity - 1)
+            _capacityAvailable(this);
+
         return true;
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -145,6 +145,44 @@ public sealed class PartitionedConsumerRuntimeTests
     }
 
     [Test]
+    public async Task PartitionLane_DoesNotSignalCapacityWhenNotPreviouslyFull()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var callbacks = 0;
+        var lane = CreateLane(
+            partition,
+            capacity: 4,
+            _ => Interlocked.Increment(ref callbacks));
+
+        for (var offset = 0; offset < 3; offset++)
+            await Assert.That(lane.TryEnqueue(CreateResult(partition, offset))).IsTrue();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await ReadLaneMessagesAsync(lane, count: 3, cts.Token).ConfigureAwait(false);
+
+        await Assert.That(Volatile.Read(ref callbacks)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task PartitionLane_SignalsCapacityOnceWhenFullLaneHasRoom()
+    {
+        var partition = new TopicPartition("topic-a", 0);
+        var callbacks = 0;
+        var lane = CreateLane(
+            partition,
+            capacity: 4,
+            _ => Interlocked.Increment(ref callbacks));
+
+        for (var offset = 0; offset < 4; offset++)
+            await Assert.That(lane.TryEnqueue(CreateResult(partition, offset))).IsTrue();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await ReadLaneMessagesAsync(lane, count: 4, cts.Token).ConfigureAwait(false);
+
+        await Assert.That(Volatile.Read(ref callbacks)).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task RunPartitionedAsync_RevokedPartitionStopsRoutingAndCommitsProcessedOnly()
     {
         var partition = new TopicPartition("topic-a", 0);
@@ -994,6 +1032,32 @@ public sealed class PartitionedConsumerRuntimeTests
 
         lock (offsets)
             return offsets.ToArray();
+    }
+
+    private static PartitionLane<string, string> CreateLane(
+        TopicPartition partition,
+        int capacity,
+        Action<PartitionLane<string, string>> capacityAvailable)
+    {
+        return new PartitionLane<string, string>(
+            partition,
+            capacity,
+            static (_, _) => ValueTask.CompletedTask,
+            capacityAvailable,
+            static (_, exception) => throw new InvalidOperationException("Lane failed.", exception));
+    }
+
+    private static async Task ReadLaneMessagesAsync(
+        PartitionLane<string, string> lane,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        await using var enumerator = lane.Messages.GetAsyncEnumerator(cancellationToken);
+        for (var i = 0; i < count; i++)
+        {
+            var hasMessage = await enumerator.MoveNextAsync().ConfigureAwait(false);
+            await Assert.That(hasMessage).IsTrue();
+        }
     }
 
     private static ConsumeResult<string, string> CreateResult(


### PR DESCRIPTION
## Summary
- Signal lane capacity only on the full-to-has-room transition.
- Track backpressure pause state on the lane so processor threads only enqueue Resume commands when the runtime actually paused that lane.
- Add focused lane tests for capacity callback churn.

## Test plan
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter /*/*/PartitionedConsumerRuntimeTests/*`
- `dotnet format Dekaf.sln --verify-no-changes --verbosity minimal`

Closes #1354.