### PR TITLE
perf(consumer): cache fetch subrange templates

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -755,11 +755,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly object _partitionCacheLock = new();
     private int _assignmentVersion;
 
-    // Fetch request cache - reduces allocations when partition assignment is stable
-    // Cache is invalidated when assignment or paused partitions change
+    // Fetch request cache - reduces allocations when partition assignment is stable.
+    // Keyed by partition subrange so adaptive multi-connection fetches can reuse templates.
+    // Cache is invalidated when assignment or paused partitions change.
     private readonly object _fetchCacheLock = new();
-    private Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>>? _cachedTopicPartitions;
-    private List<TopicPartition>? _cachedPartitionsList;
+    private readonly Dictionary<FetchRequestCacheKey, FetchRequestTemplateCacheEntry> _fetchRequestTemplateCache = [];
     private readonly ConcurrentDictionary<TopicPartition, PreferredReadReplicaState> _preferredReadReplicas = new();
     private readonly object _leaderRefreshTasksLock = new();
     private readonly ConcurrentDictionary<string, Task> _pendingLeaderRefreshTasks = new();
@@ -4888,43 +4888,42 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (count == 0)
             return ConsumerFetchPools.RentFetchRequestTopicList(0);
 
-        var isFullList = startIndex == 0 && count == partitions.Count;
+        var cacheKey = new FetchRequestCacheKey(startIndex, count);
 
         // Take snapshots of current state under lock
-        Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>>? cachedDict;
-        List<TopicPartition>? cachedList;
+        FetchRequestTemplateCacheEntry? cachedEntry;
 
         lock (_fetchCacheLock)
         {
-            cachedDict = _cachedTopicPartitions;
-            cachedList = _cachedPartitionsList;
+            _fetchRequestTemplateCache.TryGetValue(cacheKey, out cachedEntry);
         }
 
-        // Check if cache is valid (same partition list as before) — only for full-list case.
-        // When fetchConnectionCount > 1, all calls use subranges so the cache is bypassed.
-        // This is intentional: the cache avoids rebuilding the topic→partition dictionary when
-        // partitions are stable, but subranges change per-connection and aren't worth caching.
-        if (isFullList && cachedDict is not null && cachedList is not null && PartitionListsEqual(partitions, cachedList))
+        // Check if cache is valid for this range. Multi-connection fetches use deterministic
+        // subranges, so stable assignments can reuse one template per connection group.
+        if (cachedEntry is not null
+            && PartitionRangeEquals(partitions, startIndex, count, cachedEntry.Partitions))
         {
             // Cache hit: build a fresh result list with snapshot offsets under lock.
             // Each broker task gets its own FetchRequestPartition objects so that
             // concurrent calls cannot mutate offsets visible to another task.
             // This allocates per fetch cycle (per-batch), not per-message.
             return BuildFetchResult(
-                cachedDict,
+                cachedEntry.TopicPartitions,
                 _fetchPositions,
                 _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
                 _metadataManager.Metadata,
                 _lastConsumedLeaderEpochs);
         }
 
-        // Cache miss (or subrange): build fresh structure with TopicPartition stored alongside
+        // Cache miss: build fresh structure with TopicPartition stored alongside.
         var topicPartitions = new Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>>();
+        var rangePartitions = new List<TopicPartition>(count);
 
         var endIndex = startIndex + count;
         for (var i = startIndex; i < endIndex; i++)
         {
             var p = partitions[i];
+            rangePartitions.Add(p);
             if (!topicPartitions.TryGetValue(p.Topic, out var list))
             {
                 list = [];
@@ -4952,20 +4951,31 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _metadataManager.Metadata,
             _lastConsumedLeaderEpochs);
 
-        // Update cache (first writer wins to avoid overwriting fresher data) — only for full-list case
-        if (isFullList)
+        // Update cache if this range is new or the cached partition range is stale.
+        lock (_fetchCacheLock)
         {
-            lock (_fetchCacheLock)
+            if (!_fetchRequestTemplateCache.TryGetValue(cacheKey, out var currentEntry)
+                || !PartitionRangeEquals(partitions, startIndex, count, currentEntry.Partitions))
             {
-                if (_cachedTopicPartitions is null)
-                {
-                    _cachedTopicPartitions = topicPartitions;
-                    _cachedPartitionsList = new List<TopicPartition>(partitions);
-                }
+                _fetchRequestTemplateCache[cacheKey] = new FetchRequestTemplateCacheEntry(
+                    rangePartitions,
+                    topicPartitions);
             }
         }
 
         return result;
+    }
+
+    private readonly record struct FetchRequestCacheKey(int StartIndex, int Count);
+
+    private sealed class FetchRequestTemplateCacheEntry(
+        List<TopicPartition> partitions,
+        Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>> topicPartitions)
+    {
+        public List<TopicPartition> Partitions { get; } = partitions;
+
+        public Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>> TopicPartitions { get; }
+            = topicPartitions;
     }
 
     /// <summary>
@@ -5058,19 +5068,29 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool PartitionListsEqual(List<TopicPartition> a, List<TopicPartition> b)
+        => PartitionRangeEquals(a, 0, a.Count, b);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool PartitionRangeEquals(
+        List<TopicPartition> partitions,
+        int startIndex,
+        int count,
+        List<TopicPartition> cached)
     {
-        if (a.Count != b.Count)
+        if (count != cached.Count)
             return false;
 
         // For small lists, use O(n²) comparison to avoid HashSet allocation
-        if (a.Count <= 16)
+        if (count <= 16)
         {
-            foreach (var partitionA in a)
+            var endIndex = startIndex + count;
+            for (var i = startIndex; i < endIndex; i++)
             {
+                var partition = partitions[i];
                 var found = false;
-                foreach (var partitionB in b)
+                foreach (var cachedPartition in cached)
                 {
-                    if (partitionA.Topic == partitionB.Topic && partitionA.Partition == partitionB.Partition)
+                    if (partition.Topic == cachedPartition.Topic && partition.Partition == cachedPartition.Partition)
                     {
                         found = true;
                         break;
@@ -5083,10 +5103,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         // For larger lists, use HashSet for O(n) comparison
-        var setB = new HashSet<TopicPartition>(b);
-        foreach (var partitionA in a)
+        var cachedSet = new HashSet<TopicPartition>(cached);
+        var rangeEndIndex = startIndex + count;
+        for (var i = startIndex; i < rangeEndIndex; i++)
         {
-            if (!setB.Contains(partitionA))
+            if (!cachedSet.Contains(partitions[i]))
                 return false;
         }
         return true;
@@ -5100,8 +5121,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_fetchCacheLock)
         {
-            _cachedTopicPartitions = null;
-            _cachedPartitionsList = null;
+            _fetchRequestTemplateCache.Clear();
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2140,7 +2140,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         try
         {
             // Build fetch request — pass index range to avoid GetRange allocation
-            var topicData = BuildFetchRequestTopics(partitions, partitionStartIndex, partitionCount);
+            var topicData = BuildFetchRequestTopics(partitions, partitionStartIndex, partitionCount, brokerId);
             FetchSessionBuildResult? fetchSessionBuild = fetchSessionHandler?.Build(topicData, _metadataManager.Metadata);
 
             var request = FetchRequest.Rent();
@@ -4328,7 +4328,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         await ResolveSpecialOffsetsAsync(partitions, 0, partitions.Count, cancellationToken).ConfigureAwait(false);
 
         // Build fetch request - use imperative code to avoid LINQ allocations
-        var topicData = BuildFetchRequestTopics(partitions, 0, partitions.Count);
+        var topicData = BuildFetchRequestTopics(partitions, 0, partitions.Count, brokerId);
         FetchSessionHandler? fetchSessionHandler = null;
         FetchSessionBuildResult? fetchSessionBuild = null;
         if (ShouldUseFetchSessions && apiVersion >= 7)
@@ -4883,12 +4883,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     private List<FetchRequestTopic> BuildFetchRequestTopics(
-        List<TopicPartition> partitions, int startIndex, int count)
+        List<TopicPartition> partitions, int startIndex, int count, int brokerId)
     {
         if (count == 0)
             return ConsumerFetchPools.RentFetchRequestTopicList(0);
 
-        var cacheKey = new FetchRequestCacheKey(startIndex, count);
+        var cacheKey = new FetchRequestCacheKey(brokerId, startIndex, count);
 
         // Take snapshots of current state under lock
         FetchRequestTemplateCacheEntry? cachedEntry;
@@ -4966,7 +4966,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return result;
     }
 
-    private readonly record struct FetchRequestCacheKey(int StartIndex, int Count);
+    private readonly record struct FetchRequestCacheKey(int BrokerId, int StartIndex, int Count);
 
     private sealed class FetchRequestTemplateCacheEntry(
         List<TopicPartition> partitions,
@@ -5061,14 +5061,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         return result;
     }
-
-    /// <summary>
-    /// Order-independent partition list equality check.
-    /// Uses O(n²) comparison for small lists (allocation-free), O(n) HashSet for larger lists.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool PartitionListsEqual(List<TopicPartition> a, List<TopicPartition> b)
-        => PartitionRangeEquals(a, 0, a.Count, b);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool PartitionRangeEquals(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerFetchPoolsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerFetchPoolsTests.cs
@@ -137,19 +137,57 @@ public sealed class ConsumerFetchPoolsTests
         await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task BuildFetchRequestTopics_DifferentBrokersWithSameShape_CacheSeparateTemplates()
+    {
+        await using var built = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("group-a")
+            .Build();
+        var consumer = (KafkaConsumer<string, string>)built;
+        var brokerOnePartitions = new List<TopicPartition>
+        {
+            new("topic-a", 0),
+            new("topic-a", 1)
+        };
+        var brokerTwoPartitions = new List<TopicPartition>
+        {
+            new("topic-b", 0),
+            new("topic-b", 1)
+        };
+
+        var brokerOneResult = InvokeBuildFetchRequestTopics(consumer, brokerOnePartitions, brokerId: 1);
+        ConsumerFetchPools.ReturnFetchRequestTopics(brokerOneResult);
+
+        var brokerTwoResult = InvokeBuildFetchRequestTopics(consumer, brokerTwoPartitions, brokerId: 2);
+        ConsumerFetchPools.ReturnFetchRequestTopics(brokerTwoResult);
+
+        var brokerOneHit = InvokeBuildFetchRequestTopics(consumer, brokerOnePartitions, brokerId: 1);
+        ConsumerFetchPools.ReturnFetchRequestTopics(brokerOneHit);
+
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(2);
+    }
+
     private static List<FetchRequestTopic> InvokeBuildFetchRequestTopics(
         KafkaConsumer<string, string> consumer,
         List<TopicPartition> partitions)
-        => InvokeBuildFetchRequestTopics(consumer, partitions, 0, partitions.Count);
+        => InvokeBuildFetchRequestTopics(consumer, partitions, 0, partitions.Count, brokerId: 1);
+
+    private static List<FetchRequestTopic> InvokeBuildFetchRequestTopics(
+        KafkaConsumer<string, string> consumer,
+        List<TopicPartition> partitions,
+        int brokerId)
+        => InvokeBuildFetchRequestTopics(consumer, partitions, 0, partitions.Count, brokerId);
 
     private static List<FetchRequestTopic> InvokeBuildFetchRequestTopics(
         KafkaConsumer<string, string> consumer,
         List<TopicPartition> partitions,
         int startIndex,
-        int count)
+        int count,
+        int brokerId = 1)
         => (List<FetchRequestTopic>)BuildFetchRequestTopicsMethod.Invoke(
             consumer,
-            [partitions, startIndex, count])!;
+            [partitions, startIndex, count, brokerId])!;
 
     private static int GetFetchRequestTemplateCacheCount(KafkaConsumer<string, string> consumer)
     {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerFetchPoolsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerFetchPoolsTests.cs
@@ -13,6 +13,11 @@ public sealed class ConsumerFetchPoolsTests
             "BuildFetchRequestTopics",
             BindingFlags.Instance | BindingFlags.NonPublic)
         ?? throw new InvalidOperationException("Could not find BuildFetchRequestTopics");
+    private static readonly FieldInfo FetchRequestTemplateCacheField =
+        typeof(KafkaConsumer<string, string>).GetField(
+            "_fetchRequestTemplateCache",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("Could not find _fetchRequestTemplateCache");
 
     [Test]
     public async Task ReturnedPendingFetchDataLists_AreClearedBeforeRent()
@@ -89,12 +94,77 @@ public sealed class ConsumerFetchPoolsTests
         await AssertFetchPoolsRentClearedLists();
     }
 
+    [Test]
+    public async Task BuildFetchRequestTopics_SubrangeCacheHit_ReturnPooledLists()
+    {
+        await using var built = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("group-a")
+            .Build();
+        var consumer = (KafkaConsumer<string, string>)built;
+        var partitions = CreateTemplateCachePartitions();
+
+        var cacheMissResult = InvokeBuildFetchRequestTopics(consumer, partitions, startIndex: 1, count: 2);
+        await Assert.That(cacheMissResult.Sum(static topic => topic.Partitions.Count)).IsEqualTo(2);
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(1);
+        ConsumerFetchPools.ReturnFetchRequestTopics(cacheMissResult);
+        await AssertFetchPoolsRentClearedLists();
+
+        var cacheHitResult = InvokeBuildFetchRequestTopics(consumer, partitions, startIndex: 1, count: 2);
+        await Assert.That(cacheHitResult.Sum(static topic => topic.Partitions.Count)).IsEqualTo(2);
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(1);
+        await Assert.That(cacheHitResult[0].Partitions).IsTypeOf<List<FetchRequestPartition>>();
+        ConsumerFetchPools.ReturnFetchRequestTopics(cacheHitResult);
+        await AssertFetchPoolsRentClearedLists();
+    }
+
+    [Test]
+    public async Task BuildFetchRequestTopics_DifferentSubranges_CacheSeparateTemplates()
+    {
+        await using var built = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("group-a")
+            .Build();
+        var consumer = (KafkaConsumer<string, string>)built;
+        var partitions = CreateTemplateCachePartitions();
+
+        var firstRange = InvokeBuildFetchRequestTopics(consumer, partitions, startIndex: 0, count: 2);
+        ConsumerFetchPools.ReturnFetchRequestTopics(firstRange);
+
+        var secondRange = InvokeBuildFetchRequestTopics(consumer, partitions, startIndex: 2, count: 2);
+        ConsumerFetchPools.ReturnFetchRequestTopics(secondRange);
+
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(2);
+    }
+
     private static List<FetchRequestTopic> InvokeBuildFetchRequestTopics(
         KafkaConsumer<string, string> consumer,
         List<TopicPartition> partitions)
+        => InvokeBuildFetchRequestTopics(consumer, partitions, 0, partitions.Count);
+
+    private static List<FetchRequestTopic> InvokeBuildFetchRequestTopics(
+        KafkaConsumer<string, string> consumer,
+        List<TopicPartition> partitions,
+        int startIndex,
+        int count)
         => (List<FetchRequestTopic>)BuildFetchRequestTopicsMethod.Invoke(
             consumer,
-            [partitions, 0, partitions.Count])!;
+            [partitions, startIndex, count])!;
+
+    private static int GetFetchRequestTemplateCacheCount(KafkaConsumer<string, string> consumer)
+    {
+        var cache = FetchRequestTemplateCacheField.GetValue(consumer)
+            ?? throw new InvalidOperationException("Fetch request template cache is null");
+        return ((System.Collections.ICollection)cache).Count;
+    }
+
+    private static List<TopicPartition> CreateTemplateCachePartitions() =>
+    [
+        new("topic-a", 0),
+        new("topic-a", 1),
+        new("topic-b", 0),
+        new("topic-b", 1)
+    ];
 
     private static async Task AssertFetchPoolsRentClearedLists()
     {


### PR DESCRIPTION
## Summary
- cache fetch request templates by `(startIndex, count)` instead of only the full broker partition list
- reuse deterministic adaptive-connection subrange templates while still creating fresh request partition objects per fetch
- add tests for subrange cache hits and separate subrange entries

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release
- [x] dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress --treenode-filter "/*/*/ConsumerFetchPoolsTests/*"
- [x] dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress --treenode-filter "/*/*/BuildFetchResultTests/*"
- [x] dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress --treenode-filter "/*/*/ConsumerConnectionScalerTests/*"
- [x] dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release -- --disable-logo --no-progress (4286/4287 passed; KafkaConnection_ConnectAsync_TriesAllResolvedAddresses timed out once, then passed on focused rerun)

Closes #1358
