### PR TITLE
feat(producer): add KIP-794 partitioning

### DIFF
--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -89,6 +89,9 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `UseCompression(...)` | `CompressionType` | `None`, `Gzip`, `Snappy`, `Lz4`, `Zstd` |
 | `WithCompressionLevel(...)` | `CompressionLevel` | Codec-specific integer |
 | `WithPartitioner(...)` | `Partitioner` | `Default`, `Sticky`, `RoundRobin` |
+| `WithAdaptivePartitioning(...)` | `EnableAdaptivePartitioning` | Boolean; Kafka `partitioner.adaptive.partitioning.enable` |
+| `WithPartitionerAvailabilityTimeout(...)` | `PartitionerAvailabilityTimeoutMs` | Milliseconds; Kafka `partitioner.availability.timeout.ms` |
+| `WithPartitionerIgnoreKeys(...)` | `IgnorePartitionerKeys` | Boolean; Kafka `partitioner.ignore.keys` |
 | `UseTls(...)` | `UseTls`, `TlsConfig` | `TlsConfig` can bind certificate path fields |
 | `WithRemoteCertificateValidationCallback(...)` | Runtime callback | Custom TLS certificate validation |
 | `WithSaslPlain(...)` / `WithSaslScramSha512(...)` | `SaslMechanism`, `SaslUsername`, `SaslPassword` | `SaslMechanism` values match the enum names |
@@ -198,6 +201,8 @@ Control how messages are assigned to partitions:
 .WithPartitioner(PartitionerType.ConsistentRandom) // librdkafka default
 .WithPartitioner(PartitionerType.Fnv1ARandom)      // librdkafka/Sarama-compatible
 ```
+
+The built-in default and sticky partitioners use KIP-794 behavior for sticky records: they stay on a partition until at least `BatchSize` bytes have been produced to it. Adaptive partitioning is enabled by default and weights new sticky choices away from partitions with queued batches. Set `.WithAdaptivePartitioning(false)` for uniform switching, `.WithPartitionerAvailabilityTimeout(...)` to exclude backed-up partitions after a timeout, or `.WithPartitionerIgnoreKeys()` to use sticky partitioning even when records have keys.
 
 ## Transactions
 
@@ -374,6 +379,9 @@ Enable logging:
 | `UseCompression` | None | Compression codec |
 | `WithCompressionLevel` | null | Codec-specific compression level |
 | `WithPartitioner` | Default | Partition strategy |
+| `WithAdaptivePartitioning` | true | Adapt sticky partition choices to queued broker load |
+| `WithPartitionerAvailabilityTimeout` | 0ms | Exclude backed-up partitions after timeout; 0 disables |
+| `WithPartitionerIgnoreKeys` | false | Ignore keys for built-in sticky partitioning |
 | `WithConnectionsPerBroker` | 1 | TCP connections per broker |
 | `WithConnectionsMaxIdle` | 540000ms | Close unused broker connections; `Timeout.InfiniteTimeSpan` disables |
 | `WithConnectionTimeout` | 30000ms | Socket connection setup timeout |

--- a/docs/docs/producer/partitioning.md
+++ b/docs/docs/producer/partitioning.md
@@ -79,8 +79,8 @@ var producer = await Kafka.CreateProducer<string, string>()
 
 | Partitioner | Behavior |
 |-------------|----------|
-| `Default` | Murmur2 positive-hash keyed messages, sticky null or empty keys until batch completion |
-| `Sticky` | Murmur2 positive-hash keyed messages, sticky null or empty keys until batch completion |
+| `Default` | Murmur2 positive-hash keyed messages, KIP-794 uniform sticky null or empty keys until `BatchSize` bytes |
+| `Sticky` | Murmur2 positive-hash keyed messages, KIP-794 uniform sticky null or empty keys until `BatchSize` bytes |
 | `RoundRobin` | Cycles through partitions |
 | `Random` | Ignores keys and picks a pseudo-random partition |
 | `Consistent` | librdkafka `consistent`: CRC32 hash; null and empty keys map to one partition |
@@ -94,7 +94,7 @@ Use `ConsistentRandom` when matching librdkafka or Confluent.Kafka's default `co
 
 ### Default and Sticky Partitioners
 
-The default partitioner uses sticky null-key partitioning to improve batching efficiency. You can also select `Sticky` explicitly:
+The default partitioner uses KIP-794 uniform sticky partitioning for null or empty keys. It keeps producing to the same partition until at least `BatchSize` bytes have been appended, then switches. By default, adaptive partitioning weights the next sticky partition away from partitions with queued batches. You can also select `Sticky` explicitly:
 
 ```csharp
 using Dekaf;
@@ -109,6 +109,15 @@ var producer = await Kafka.CreateProducer<string, string>()
 producer.Produce("events", null, "event1");
 producer.Produce("events", null, "event2");
 producer.Produce("events", null, "event3");
+```
+
+```csharp
+var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithAdaptivePartitioning(false)
+    .WithPartitionerAvailabilityTimeout(TimeSpan.Zero)
+    .WithPartitionerIgnoreKeys()
+    .BuildAsync();
 ```
 
 ## Partition Count Considerations

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -44,6 +44,9 @@ public sealed class ProducerBuilder<TKey, TValue>
     private int _initialBatchRecordCapacity;
     private PartitionerType _partitionerType = PartitionerType.Default;
     private IPartitioner? _customPartitioner;
+    private bool _enableAdaptivePartitioning = true;
+    private int _partitionerAvailabilityTimeoutMs;
+    private bool _ignorePartitionerKeys;
     private bool _useTls;
     private TlsConfig? _tlsConfig;
     private SaslMechanism _saslMechanism = SaslMechanism.None;
@@ -396,6 +399,41 @@ public sealed class ProducerBuilder<TKey, TValue>
     {
         _partitionerType = partitionerType;
         _customPartitioner = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables KIP-794 adaptive partitioning for built-in sticky partitioners.
+    /// </summary>
+    /// <param name="enable">Whether partition choice should adapt to queued broker load.</param>
+    public ProducerBuilder<TKey, TValue> WithAdaptivePartitioning(bool enable = true)
+    {
+        _enableAdaptivePartitioning = enable;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets how long a backed-up partition may remain unavailable to send before adaptive
+    /// partitioning excludes it from new sticky choices. Set to zero to disable exclusion.
+    /// </summary>
+    /// <param name="timeout">Availability timeout. Cannot be negative.</param>
+    public ProducerBuilder<TKey, TValue> WithPartitionerAvailabilityTimeout(TimeSpan timeout)
+    {
+        if (timeout < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Partitioner availability timeout cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+
+        _partitionerAvailabilityTimeoutMs = (int)timeout.TotalMilliseconds;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the built-in default partitioner to ignore message keys and use uniform
+    /// sticky partitioning for all records.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithPartitionerIgnoreKeys(bool ignoreKeys = true)
+    {
+        _ignorePartitionerKeys = ignoreKeys;
         return this;
     }
 
@@ -1084,6 +1122,9 @@ public sealed class ProducerBuilder<TKey, TValue>
             CompressionLevel = _compressionLevel,
             Partitioner = _partitionerType,
             CustomPartitioner = _customPartitioner,
+            EnableAdaptivePartitioning = _enableAdaptivePartitioning,
+            PartitionerAvailabilityTimeoutMs = _partitionerAvailabilityTimeoutMs,
+            IgnorePartitionerKeys = _ignorePartitionerKeys,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
             RemoteCertificateValidationCallback = _remoteCertificateValidationCallback,

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -42,6 +42,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly ISerializer<TValue> _valueSerializer;
     private readonly IPartitioner _partitioner;
     private readonly bool _usesCustomPartitioner;
+    private readonly IUniformStickyPartitioner? _uniformStickyPartitioner;
     private readonly ConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
     private readonly IDisposable _brokerCountDiscoveredRegistration;
@@ -318,7 +319,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         _usesCustomPartitioner = options.CustomPartitioner is not null;
         _partitioner = options.CustomPartitioner ?? options.Partitioner switch
         {
-            PartitionerType.Sticky => new StickyPartitioner(),
+            PartitionerType.Sticky => new StickyPartitioner(
+                options.BatchSize,
+                options.EnableAdaptivePartitioning,
+                options.PartitionerAvailabilityTimeoutMs,
+                options.IgnorePartitionerKeys),
             PartitionerType.RoundRobin => new RoundRobinPartitioner(),
             PartitionerType.Random => new RandomPartitioner(),
             PartitionerType.Consistent => new ConsistentPartitioner(),
@@ -327,8 +332,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             PartitionerType.Murmur2Random => new Murmur2RandomPartitioner(),
             PartitionerType.Fnv1A => new Fnv1APartitioner(),
             PartitionerType.Fnv1ARandom => new Fnv1ARandomPartitioner(),
-            _ => new DefaultPartitioner()
+            _ => new DefaultPartitioner(
+                options.BatchSize,
+                options.EnableAdaptivePartitioning,
+                options.PartitionerAvailabilityTimeoutMs,
+                options.IgnorePartitionerKeys)
         };
+        _uniformStickyPartitioner = _usesCustomPartitioner ? null : _partitioner as IUniformStickyPartitioner;
 
         _connectionPool = infrastructure.Pool;
         _metadataManager = infrastructure.Metadata;
@@ -360,14 +370,20 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         });
 
         _compressionCodecs = CreateCompressionCodecRegistry(options);
-        Action<string, int>? batchCompletionCallback = _partitioner is IBatchCompletionAwarePartitioner batchCompletionAware
+        Action<string, int>? batchCompletionCallback = _uniformStickyPartitioner is null
+            && _partitioner is IBatchCompletionAwarePartitioner batchCompletionAware
             ? batchCompletionAware.OnBatchComplete
+            : null;
+        Action<string, int, int, int>? recordAppendedCallback = _uniformStickyPartitioner is not null
+            ? _uniformStickyPartitioner.OnRecordAppended
             : null;
         _accumulator = new RecordAccumulator(
             options,
             _compressionCodecs,
             loggerFactory?.CreateLogger<RecordAccumulator>(),
-            batchCompletionCallback);
+            batchCompletionCallback,
+            recordAppendedCallback);
+        _uniformStickyPartitioner?.SetPartitionQueueByteProvider(_accumulator.GetPartitionQueueBytes);
 
         // Inflight tracker enables coordinated retry with multiple in-flight batches per partition.
         // The broker uses sequence numbers to guarantee ordering, so multiple batches can be
@@ -999,6 +1015,23 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             topicInfo,
             completion);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int GetUniformStickyPartitionCount(
+        int? explicitPartition,
+        ReadOnlySpan<byte> key,
+        bool keyIsNull,
+        int partitionCount)
+    {
+        if (explicitPartition is not null)
+            return 0;
+
+        var uniformStickyPartitioner = _uniformStickyPartitioner;
+        if (uniformStickyPartitioner is not null)
+            return uniformStickyPartitioner.UsesStickyPartition(key, keyIsNull) ? partitionCount : 0;
+
+        return keyIsNull && _partitioner is IBatchCompletionAwarePartitioner ? partitionCount : 0;
+    }
+
     private SyncProduceResult TryProduceSyncCore(
         string topic,
         TKey? key,
@@ -1070,9 +1103,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 resolvedPartition = _partitioner.Partition(topic, keySpan, keyIsNull, topicInfo.PartitionCount);
             }
 
-            var batchCompletionPartitionCount = partition is null && keyIsNull
-                ? topicInfo.PartitionCount
-                : 0;
+            var batchCompletionPartitionCount = GetUniformStickyPartitionCount(
+                partition, keySpan, keyIsNull, topicInfo.PartitionCount);
 
             // Get timestamp - use fast cached timestamp when no override provided
             var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs();
@@ -1328,9 +1360,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // Determine partition
         var partition = message.Partition
             ?? _partitioner.Partition(message.Topic, key.Span, keyIsNull, topicInfo.PartitionCount);
-        var batchCompletionPartitionCount = message.Partition is null && keyIsNull
-            ? topicInfo.PartitionCount
-            : 0;
+        var batchCompletionPartitionCount = GetUniformStickyPartitionCount(
+            message.Partition, key.Span, keyIsNull, topicInfo.PartitionCount);
 
         // Get timestamp
         var timestamp = message.Timestamp ?? DateTimeOffset.UtcNow;
@@ -2766,9 +2797,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var keySpan = keyIsNull ? ReadOnlySpan<byte>.Empty : cache.KeySerializationBuffer.AsSpan(0, keyLength);
         var resolvedPartition = partition
             ?? _partitioner.Partition(topic, keySpan, keyIsNull, topicInfo.PartitionCount);
-        var batchCompletionPartitionCount = partition is null && keyIsNull
-            ? topicInfo.PartitionCount
-            : 0;
+        var batchCompletionPartitionCount = GetUniformStickyPartitionCount(
+            partition, keySpan, keyIsNull, topicInfo.PartitionCount);
 
         var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs();
 

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -62,14 +62,17 @@ internal sealed class StickyPartitionTracker
         var state = _partitions.GetOrAdd(topic,
             topicName => new StickyPartitionState(NextPartition(topicName, partitionCount, currentPartition: null)));
 
-        lock (state)
+        while (true)
         {
-            if (state.Partition >= 0 && state.Partition < partitionCount)
-                return state.Partition;
+            var packedState = Volatile.Read(ref state.PackedState);
+            var partition = UnpackPartition(packedState);
+            if (partition >= 0 && partition < partitionCount)
+                return partition;
 
-            state.Partition = NextPartition(topic, partitionCount, currentPartition: null);
-            state.ProducedBytes = 0;
-            return state.Partition;
+            var nextPartition = NextPartition(topic, partitionCount, currentPartition: null);
+            var nextState = PackState(nextPartition, producedBytes: 0);
+            if (Interlocked.CompareExchange(ref state.PackedState, nextState, packedState) == packedState)
+                return nextPartition;
         }
     }
 
@@ -78,10 +81,14 @@ internal sealed class StickyPartitionTracker
         var state = _partitions.GetOrAdd(topic,
             topicName => new StickyPartitionState(NextPartition(topicName, partitionCount, currentPartition: null)));
 
-        lock (state)
+        while (true)
         {
-            state.Partition = NextPartition(topic, partitionCount, state.Partition);
-            state.ProducedBytes = 0;
+            var packedState = Volatile.Read(ref state.PackedState);
+            var partition = UnpackPartition(packedState);
+            var nextPartition = NextPartition(topic, partitionCount, partition);
+            var nextState = PackState(nextPartition, producedBytes: 0);
+            if (Interlocked.CompareExchange(ref state.PackedState, nextState, packedState) == packedState)
+                return;
         }
     }
 
@@ -91,17 +98,26 @@ internal sealed class StickyPartitionTracker
             return;
 
         var state = _partitions.GetOrAdd(topic, _ => new StickyPartitionState(partition));
-        lock (state)
+        while (true)
         {
-            if (state.Partition != partition)
+            var packedState = Volatile.Read(ref state.PackedState);
+            if (UnpackPartition(packedState) != partition)
                 return;
 
-            state.ProducedBytes += bytes;
-            if (state.ProducedBytes < stickyBatchSize)
-                return;
+            var producedBytes = SaturatingAdd(UnpackProducedBytes(packedState), bytes);
+            if (producedBytes < stickyBatchSize)
+            {
+                var updatedState = PackState(partition, producedBytes);
+                if (Interlocked.CompareExchange(ref state.PackedState, updatedState, packedState) == packedState)
+                    return;
 
-            state.Partition = NextPartition(topic, partitionCount, partition);
-            state.ProducedBytes = 0;
+                continue;
+            }
+
+            var nextPartition = NextPartition(topic, partitionCount, partition);
+            var nextState = PackState(nextPartition, producedBytes: 0);
+            if (Interlocked.CompareExchange(ref state.PackedState, nextState, packedState) == packedState)
+                return;
         }
     }
 
@@ -159,6 +175,9 @@ internal sealed class StickyPartitionTracker
 
         if (eligibleCount == 0)
         {
+            // Every other partition has stayed backed up past the timeout. Fall back to
+            // the weighted choice across all partitions; NextPartition still prevents a
+            // no-op rotation if the current partition wins.
             for (var partition = 0; partition < partitionCount; partition++)
             {
                 var queueSize = Math.Max(0, partitionQueueBytes(topic, partition));
@@ -238,6 +257,18 @@ internal sealed class StickyPartitionTracker
         return positiveRandom % upperExclusive;
     }
 
+    private static long PackState(int partition, int producedBytes)
+        => ((long)partition << 32) | (uint)producedBytes;
+
+    private static int UnpackPartition(long packedState)
+        => (int)(packedState >> 32);
+
+    private static int UnpackProducedBytes(long packedState)
+        => (int)(packedState & 0x7fff_ffff);
+
+    private static int SaturatingAdd(int left, int right)
+        => left > int.MaxValue - right ? int.MaxValue : left + right;
+
     private static long SaturatingAdd(long left, long right)
     {
         var result = left + right;
@@ -246,8 +277,7 @@ internal sealed class StickyPartitionTracker
 
     private sealed class StickyPartitionState(int partition)
     {
-        public int Partition = partition;
-        public long ProducedBytes;
+        public long PackedState = PackState(partition, producedBytes: 0);
     }
 
     private sealed class PartitionAvailabilityState(long busySinceTimestamp)

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.IO.Hashing;
 
 namespace Dekaf.Producer;
@@ -21,53 +22,266 @@ internal interface IBatchCompletionAwarePartitioner
     void OnBatchComplete(string topic, int partitionCount);
 }
 
+internal interface IUniformStickyPartitioner
+{
+    bool UsesStickyPartition(ReadOnlySpan<byte> key, bool keyIsNull);
+    void OnRecordAppended(string topic, int partition, int bytes, int partitionCount);
+    void SetPartitionQueueByteProvider(Func<string, int, long> partitionQueueBytes);
+}
+
 internal sealed class StickyPartitionTracker
 {
-    private readonly ConcurrentDictionary<string, int> _partitions = new();
+    private readonly ConcurrentDictionary<string, StickyPartitionState> _partitions = new();
+    private readonly bool _adaptivePartitioning;
+    private readonly int _availabilityTimeoutMs;
+    private readonly RandomPartitionSelector _randomPartitionSelector = new();
+    private readonly ConcurrentDictionary<(string Topic, int Partition), PartitionAvailabilityState> _availability = new();
+    private Func<string, int, long>? _partitionQueueBytes;
 #if NETSTANDARD2_0
     private int _counter;
 #else
     private uint _counter;
 #endif
 
+    public StickyPartitionTracker(bool adaptivePartitioning = false, int availabilityTimeoutMs = 0)
+    {
+        if (availabilityTimeoutMs < 0)
+            throw new ArgumentOutOfRangeException(nameof(availabilityTimeoutMs), "Availability timeout cannot be negative");
+
+        _adaptivePartitioning = adaptivePartitioning;
+        _availabilityTimeoutMs = availabilityTimeoutMs;
+    }
+
+    public void SetPartitionQueueByteProvider(Func<string, int, long> partitionQueueBytes)
+    {
+        _partitionQueueBytes = partitionQueueBytes ?? throw new ArgumentNullException(nameof(partitionQueueBytes));
+    }
+
     public int GetOrAssign(string topic, int partitionCount)
     {
-        if (_partitions.TryGetValue(topic, out var partition))
-        {
-            return partition;
-        }
+        var state = _partitions.GetOrAdd(topic,
+            topicName => new StickyPartitionState(NextPartition(topicName, partitionCount, currentPartition: null)));
 
-        var newPartition = NextPartition(partitionCount);
-        return _partitions.GetOrAdd(topic, newPartition);
+        lock (state)
+        {
+            if (state.Partition >= 0 && state.Partition < partitionCount)
+                return state.Partition;
+
+            state.Partition = NextPartition(topic, partitionCount, currentPartition: null);
+            state.ProducedBytes = 0;
+            return state.Partition;
+        }
     }
 
     public void Rotate(string topic, int partitionCount)
     {
-        _partitions.AddOrUpdate(
-            topic,
-            _ => NextPartition(partitionCount),
-            (_, _) => NextPartition(partitionCount));
+        var state = _partitions.GetOrAdd(topic,
+            topicName => new StickyPartitionState(NextPartition(topicName, partitionCount, currentPartition: null)));
+
+        lock (state)
+        {
+            state.Partition = NextPartition(topic, partitionCount, state.Partition);
+            state.ProducedBytes = 0;
+        }
+    }
+
+    public void OnRecordAppended(string topic, int partition, int bytes, int partitionCount, int stickyBatchSize)
+    {
+        if (bytes <= 0 || partitionCount <= 1)
+            return;
+
+        var state = _partitions.GetOrAdd(topic, _ => new StickyPartitionState(partition));
+        lock (state)
+        {
+            if (state.Partition != partition)
+                return;
+
+            state.ProducedBytes += bytes;
+            if (state.ProducedBytes < stickyBatchSize)
+                return;
+
+            state.Partition = NextPartition(topic, partitionCount, partition);
+            state.ProducedBytes = 0;
+        }
     }
 
 #if NETSTANDARD2_0
-    private int NextPartition(int partitionCount)
+    private int NextSequentialPartition(int partitionCount)
         => (int)((uint)Interlocked.Increment(ref _counter) % (uint)partitionCount);
 #else
-    private int NextPartition(int partitionCount)
+    private int NextSequentialPartition(int partitionCount)
         => (int)(Interlocked.Increment(ref _counter) % (uint)partitionCount);
 #endif
+
+    private int NextPartition(string topic, int partitionCount, int? currentPartition)
+    {
+        var nextPartition = TryNextAdaptivePartition(topic, partitionCount, currentPartition) ?? NextSequentialPartition(partitionCount);
+        if (partitionCount > 1 && currentPartition == nextPartition)
+            nextPartition = (nextPartition + 1) % partitionCount;
+        return nextPartition;
+    }
+
+    private int? TryNextAdaptivePartition(string topic, int partitionCount, int? currentPartition)
+    {
+        var partitionQueueBytes = _partitionQueueBytes;
+        if (!_adaptivePartitioning || partitionQueueBytes is null || partitionCount < 2)
+            return null;
+
+        Span<long> queueSizes = partitionCount <= 64 ? stackalloc long[partitionCount] : new long[partitionCount];
+        var eligibleCount = 0;
+        var allEqual = true;
+        var maxQueueSize = 0L;
+        long? firstQueueSize = null;
+
+        for (var partition = 0; partition < partitionCount; partition++)
+        {
+            if (currentPartition == partition)
+            {
+                queueSizes[partition] = -1;
+                continue;
+            }
+
+            var queueSize = Math.Max(0, partitionQueueBytes(topic, partition));
+            if (IsUnavailable(topic, partition, queueSize))
+            {
+                queueSizes[partition] = -1;
+                continue;
+            }
+
+            queueSizes[partition] = queueSize;
+            eligibleCount++;
+            firstQueueSize ??= queueSize;
+            if (queueSize != firstQueueSize.Value)
+                allEqual = false;
+            if (queueSize > maxQueueSize)
+                maxQueueSize = queueSize;
+        }
+
+        if (eligibleCount == 0)
+        {
+            for (var partition = 0; partition < partitionCount; partition++)
+            {
+                var queueSize = Math.Max(0, partitionQueueBytes(topic, partition));
+                queueSizes[partition] = queueSize;
+                if (partition == 0)
+                {
+                    firstQueueSize = queueSize;
+                    maxQueueSize = queueSize;
+                }
+                else
+                {
+                    if (queueSize != firstQueueSize!.Value)
+                        allEqual = false;
+                    if (queueSize > maxQueueSize)
+                        maxQueueSize = queueSize;
+                }
+            }
+
+            eligibleCount = partitionCount;
+        }
+
+        if (allEqual && eligibleCount == partitionCount)
+            return null;
+
+        var maxWeightSource = maxQueueSize == long.MaxValue ? long.MaxValue : maxQueueSize + 1;
+        var totalWeight = 0L;
+        for (var partition = 0; partition < partitionCount; partition++)
+        {
+            var queueSize = queueSizes[partition];
+            if (queueSize < 0)
+                continue;
+
+            var weight = Math.Max(1L, maxWeightSource - queueSize);
+            totalWeight = SaturatingAdd(totalWeight, weight);
+        }
+
+        if (totalWeight <= 0)
+            return null;
+
+        var target = PositiveRandomLong(totalWeight);
+        var cumulative = 0L;
+        for (var partition = 0; partition < partitionCount; partition++)
+        {
+            var queueSize = queueSizes[partition];
+            if (queueSize < 0)
+                continue;
+
+            var weight = Math.Max(1L, maxWeightSource - queueSize);
+            cumulative = SaturatingAdd(cumulative, weight);
+            if (target < cumulative)
+                return partition;
+        }
+
+        return null;
+    }
+
+    private bool IsUnavailable(string topic, int partition, long queueSize)
+    {
+        if (_availabilityTimeoutMs <= 0)
+            return false;
+
+        var key = (topic, partition);
+        if (queueSize <= 0)
+        {
+            _availability.TryRemove(key, out _);
+            return false;
+        }
+
+        var state = _availability.GetOrAdd(key, static _ => new PartitionAvailabilityState(Stopwatch.GetTimestamp()));
+        var elapsedMs = (Stopwatch.GetTimestamp() - Volatile.Read(ref state.BusySinceTimestamp)) * 1000 / Stopwatch.Frequency;
+        return elapsedMs >= _availabilityTimeoutMs;
+    }
+
+    private long PositiveRandomLong(long upperExclusive)
+    {
+        var positiveRandom = (uint)_randomPartitionSelector.NextPartition(int.MaxValue);
+        return positiveRandom % upperExclusive;
+    }
+
+    private static long SaturatingAdd(long left, long right)
+    {
+        var result = left + right;
+        return result < left ? long.MaxValue : result;
+    }
+
+    private sealed class StickyPartitionState(int partition)
+    {
+        public int Partition = partition;
+        public long ProducedBytes;
+    }
+
+    private sealed class PartitionAvailabilityState(long busySinceTimestamp)
+    {
+        public long BusySinceTimestamp = busySinceTimestamp;
+    }
 }
 
 /// <summary>
 /// Default partitioner - uses murmur2 hash of key, or sticky partitioning for null keys.
 /// </summary>
-public sealed class DefaultPartitioner : IPartitioner, IBatchCompletionAwarePartitioner
+public sealed class DefaultPartitioner : IPartitioner, IBatchCompletionAwarePartitioner, IUniformStickyPartitioner
 {
-    private readonly StickyPartitionTracker _stickyPartitionTracker = new();
+    private readonly StickyPartitionTracker _stickyPartitionTracker;
+    private readonly int _stickyBatchSize;
+    private readonly bool _ignoreKeys;
+
+    public DefaultPartitioner(
+        int stickyBatchSize = int.MaxValue,
+        bool adaptivePartitioning = false,
+        int availabilityTimeoutMs = 0,
+        bool ignoreKeys = false)
+    {
+        if (stickyBatchSize < 1)
+            throw new ArgumentOutOfRangeException(nameof(stickyBatchSize), "Sticky batch size must be at least 1 byte");
+
+        _stickyBatchSize = stickyBatchSize;
+        _ignoreKeys = ignoreKeys;
+        _stickyPartitionTracker = new StickyPartitionTracker(adaptivePartitioning, availabilityTimeoutMs);
+    }
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
-        if (keyIsNull || key.Length == 0)
+        if (UsesStickyPartition(key, keyIsNull))
         {
             return _stickyPartitionTracker.GetOrAssign(topic, partitionCount);
         }
@@ -83,19 +297,50 @@ public sealed class DefaultPartitioner : IPartitioner, IBatchCompletionAwarePart
     {
         _stickyPartitionTracker.Rotate(topic, partitionCount);
     }
+
+    bool IUniformStickyPartitioner.UsesStickyPartition(ReadOnlySpan<byte> key, bool keyIsNull)
+        => UsesStickyPartition(key, keyIsNull);
+
+    void IUniformStickyPartitioner.OnRecordAppended(string topic, int partition, int bytes, int partitionCount)
+    {
+        _stickyPartitionTracker.OnRecordAppended(topic, partition, bytes, partitionCount, _stickyBatchSize);
+    }
+
+    void IUniformStickyPartitioner.SetPartitionQueueByteProvider(Func<string, int, long> partitionQueueBytes)
+    {
+        _stickyPartitionTracker.SetPartitionQueueByteProvider(partitionQueueBytes);
+    }
+
+    private bool UsesStickyPartition(ReadOnlySpan<byte> key, bool keyIsNull)
+        => _ignoreKeys || keyIsNull || key.Length == 0;
 }
 
 /// <summary>
 /// Sticky partitioner - sticks to a partition for null keys until batch is full.
-/// Uses ConcurrentDictionary for lock-free read access in the hot path.
 /// </summary>
-public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwarePartitioner
+public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwarePartitioner, IUniformStickyPartitioner
 {
-    private readonly StickyPartitionTracker _stickyPartitionTracker = new();
+    private readonly StickyPartitionTracker _stickyPartitionTracker;
+    private readonly int _stickyBatchSize;
+    private readonly bool _ignoreKeys;
+
+    public StickyPartitioner(
+        int stickyBatchSize = int.MaxValue,
+        bool adaptivePartitioning = false,
+        int availabilityTimeoutMs = 0,
+        bool ignoreKeys = false)
+    {
+        if (stickyBatchSize < 1)
+            throw new ArgumentOutOfRangeException(nameof(stickyBatchSize), "Sticky batch size must be at least 1 byte");
+
+        _stickyBatchSize = stickyBatchSize;
+        _ignoreKeys = ignoreKeys;
+        _stickyPartitionTracker = new StickyPartitionTracker(adaptivePartitioning, availabilityTimeoutMs);
+    }
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
-        if (keyIsNull || key.Length == 0)
+        if (UsesStickyPartition(key, keyIsNull))
         {
             return _stickyPartitionTracker.GetOrAssign(topic, partitionCount);
         }
@@ -110,6 +355,22 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
     {
         _stickyPartitionTracker.Rotate(topic, partitionCount);
     }
+
+    bool IUniformStickyPartitioner.UsesStickyPartition(ReadOnlySpan<byte> key, bool keyIsNull)
+        => UsesStickyPartition(key, keyIsNull);
+
+    void IUniformStickyPartitioner.OnRecordAppended(string topic, int partition, int bytes, int partitionCount)
+    {
+        _stickyPartitionTracker.OnRecordAppended(topic, partition, bytes, partitionCount, _stickyBatchSize);
+    }
+
+    void IUniformStickyPartitioner.SetPartitionQueueByteProvider(Func<string, int, long> partitionQueueBytes)
+    {
+        _stickyPartitionTracker.SetPartitionQueueByteProvider(partitionQueueBytes);
+    }
+
+    private bool UsesStickyPartition(ReadOnlySpan<byte> key, bool keyIsNull)
+        => _ignoreKeys || keyIsNull || key.Length == 0;
 }
 
 /// <summary>

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -302,6 +302,27 @@ public sealed class ProducerOptions
     public IPartitioner? CustomPartitioner { get; init; }
 
     /// <summary>
+    /// Whether built-in sticky partitioning adapts partition choice to queued broker load.
+    /// Equivalent to Kafka's <c>partitioner.adaptive.partitioning.enable</c>. Default is true.
+    /// Has no effect when <see cref="CustomPartitioner"/> is set.
+    /// </summary>
+    public bool EnableAdaptivePartitioning { get; init; } = true;
+
+    /// <summary>
+    /// Milliseconds a partition may stay backed up before adaptive partitioning treats it as unavailable.
+    /// Set to 0 to disable availability exclusion. Equivalent to Kafka's
+    /// <c>partitioner.availability.timeout.ms</c>. Default is 0.
+    /// </summary>
+    public int PartitionerAvailabilityTimeoutMs { get; init; }
+
+    /// <summary>
+    /// When true, built-in default partitioning ignores message keys and uses uniform sticky partitioning.
+    /// Equivalent to Kafka's <c>partitioner.ignore.keys</c>. Default is false.
+    /// Has no effect when <see cref="CustomPartitioner"/> is set.
+    /// </summary>
+    public bool IgnorePartitionerKeys { get; init; }
+
+    /// <summary>
     /// Use TLS.
     /// </summary>
     public bool UseTls { get; init; }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -920,6 +920,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     private readonly ILogger _logger;
     private readonly Action<string, int>? _onBatchComplete;
+    private readonly Action<string, int, int, int>? _onRecordAppended;
+    private readonly ConcurrentDictionary<TopicPartition, long> _partitionQueueBytes = new();
 
     private int _disposed;
     private int _closed;
@@ -1678,16 +1680,25 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         _wakeupSignal.RegisterShutdownToken(cancellationToken);
     }
 
+    internal long GetPartitionQueueBytes(string topic, int partition)
+    {
+        return _partitionQueueBytes.TryGetValue(new TopicPartition(topic, partition), out var bytes)
+            ? Math.Max(0, bytes)
+            : 0;
+    }
+
     public RecordAccumulator(
         ProducerOptions options,
         CompressionCodecRegistry? compressionCodecs = null,
         ILogger? logger = null,
-        Action<string, int>? onBatchComplete = null)
+        Action<string, int>? onBatchComplete = null,
+        Action<string, int, int, int>? onRecordAppended = null)
     {
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
         _options = options;
         _compressionCodecs = compressionCodecs;
         _onBatchComplete = onBatchComplete;
+        _onRecordAppended = onRecordAppended;
 
         ProducerOptions.ValidateArenaCapacity(options.BatchSize, options.ArenaCapacity);
 
@@ -2159,6 +2170,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 var disposed = false;
                 var messageTooLarge = false;
                 var memoryToReleaseAfterLock = 0;
+                var actualBytesAdded = 0;
 
                 {
                     using var guard = new SpinLockGuard(ref pd.Lock);
@@ -2192,9 +2204,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         if (pd.CurrentBatch is { } currentBatch)
                         {
                             if (TryAppendToBatch(currentBatch, timestamp, key, value, headers, headerCount,
-                                completionSource, callback, recordSize, out var overestimatedBytesToRelease))
+                                completionSource, callback, recordSize, out var overestimatedBytesToRelease,
+                                out var appendedBytes))
                             {
                                 memoryToReleaseAfterLock = overestimatedBytesToRelease;
+                                actualBytesAdded = appendedBytes;
                                 ownsReservation = false;
                                 ownsRecordResources = false;
                                 ownsPendingCount = false;
@@ -2224,9 +2238,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
 
                             if (TryAppendToBatch(newBatch, timestamp, key, value, headers, headerCount,
-                                completionSource, callback, recordSize, out var overestimatedBytesToRelease))
+                                completionSource, callback, recordSize, out var overestimatedBytesToRelease,
+                                out var appendedBytes))
                             {
                                 memoryToReleaseAfterLock = overestimatedBytesToRelease;
+                                actualBytesAdded = appendedBytes;
                                 ownsReservation = false;
                                 ownsRecordResources = false;
                                 ownsPendingCount = false;
@@ -2279,7 +2295,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 }
 
                 if (appendSucceeded)
+                {
+                    NotifyRecordAppended(topic, partition, actualBytesAdded, partitionCount);
                     return true;
+                }
 
                 if (waitForRotation)
                 {
@@ -2504,6 +2523,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 var disposed = false;
                 var messageTooLarge = false;
                 var memoryToReleaseAfterLock = 0;
+                var actualBytesAdded = 0;
 
                 {
                     using var guard = new SpinLockGuard(ref pd.Lock);
@@ -2537,9 +2557,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         if (pd.CurrentBatch is { } currentBatch)
                         {
                             if (TryAppendFromSpansToBatch(currentBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                                headers, headerCount, completionSource, callback, recordSize, out var overestimatedBytesToRelease))
+                                headers, headerCount, completionSource, callback, recordSize, out var overestimatedBytesToRelease,
+                                out var appendedBytes))
                             {
                                 memoryToReleaseAfterLock = overestimatedBytesToRelease;
+                                actualBytesAdded = appendedBytes;
                                 ownsReservation = false;
                                 ownsHeaderResources = false;
                                 ownsPendingCount = false;
@@ -2569,9 +2591,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
 
                             if (TryAppendFromSpansToBatch(newBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                                headers, headerCount, completionSource, callback, recordSize, out var overestimatedBytesToRelease))
+                                headers, headerCount, completionSource, callback, recordSize, out var overestimatedBytesToRelease,
+                                out var appendedBytes))
                             {
                                 memoryToReleaseAfterLock = overestimatedBytesToRelease;
+                                actualBytesAdded = appendedBytes;
                                 ownsReservation = false;
                                 ownsHeaderResources = false;
                                 ownsPendingCount = false;
@@ -2624,7 +2648,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 }
 
                 if (appendSucceeded)
+                {
+                    NotifyRecordAppended(topic, partition, actualBytesAdded, partitionCount);
                     return true;
+                }
 
                 if (waitForRotation)
                 {
@@ -2670,15 +2697,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
         int estimatedSize,
-        out int overestimatedBytesToRelease)
+        out int overestimatedBytesToRelease,
+        out int actualBytesAdded)
     {
         overestimatedBytesToRelease = 0;
+        actualBytesAdded = 0;
         var result = batch.TryAppend(timestamp, key, value, headers, headerCount, completionSource, callback);
 
         if (result.Success)
         {
             ProducerDebugCounters.RecordMessageAppended(hasCompletionSource: completionSource is not null);
             overestimatedBytesToRelease = Math.Max(0, estimatedSize - result.ActualSizeAdded);
+            actualBytesAdded = result.ActualSizeAdded;
             return true;
         }
 
@@ -2805,9 +2835,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
         int estimatedSize,
-        out int overestimatedBytesToRelease)
+        out int overestimatedBytesToRelease,
+        out int actualBytesAdded)
     {
         overestimatedBytesToRelease = 0;
+        actualBytesAdded = 0;
         var result = batch.TryAppendFromSpans(timestamp, keyData, keyIsNull, valueData, valueIsNull,
             headers, headerCount, completionSource, callback);
 
@@ -2815,6 +2847,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             ProducerDebugCounters.RecordMessageAppended(hasCompletionSource: completionSource is not null);
             overestimatedBytesToRelease = Math.Max(0, estimatedSize - result.ActualSizeAdded);
+            actualBytesAdded = result.ActualSizeAdded;
             return true;
         }
 
@@ -2851,6 +2884,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         _batchPool.Return(currentBatch);
         return readyBatch;
+    }
+
+    private void NotifyRecordAppended(string topic, int partition, int actualBytesAdded, int partitionCount)
+    {
+        if (partitionCount > 1 && actualBytesAdded > 0)
+            _onRecordAppended?.Invoke(topic, partition, actualBytesAdded, partitionCount);
+    }
+
+    private static long SaturatingAdd(long current, int value)
+    {
+        var result = current + value;
+        return result < current ? long.MaxValue : result;
     }
 
     /// <summary>
@@ -3486,6 +3531,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     private void OnBatchEntersPipeline(ReadyBatch batch)
     {
+        _partitionQueueBytes.AddOrUpdate(
+            batch.TopicPartition,
+            batch.DataSize,
+            (_, current) => SaturatingAdd(current, batch.DataSize));
+
         // Counter first, list second. If a batch races between the counter increment
         // and the list add, the sweep will miss it in the snapshot — but that's acceptable
         // because the sweep is defense-in-depth at 3× delivery timeout and the batch will
@@ -3508,6 +3558,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // concurrent cleanup paths (e.g., DisposeAsync racing with SendLoopAsync's finally block).
         if (!InFlightBatchListRemove(batch))
             return false;
+
+        _partitionQueueBytes.AddOrUpdate(
+            batch.TopicPartition,
+            0,
+            (_, current) => Math.Max(0, current - batch.DataSize));
 
         batch.AppendDiag('X');
         var count = Interlocked.Decrement(ref _inFlightBatchCount);

--- a/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
@@ -79,6 +79,16 @@ public class ProducerBuilderValidationTests
     }
 
     [Test]
+    public async Task WithPartitionerAvailabilityTimeout_WhenNegative_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var act = () => builder.WithPartitionerAvailabilityTimeout(TimeSpan.FromMilliseconds(-1));
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     public async Task BuildForTopic_WithNullTopic_ThrowsArgumentNullException()
     {
         var builder = Kafka.CreateProducer<string, string>()
@@ -178,6 +188,30 @@ public class ProducerBuilderValidationTests
     {
         var builder = Kafka.CreateProducer<string, string>();
         var result = builder.WithPartitioner(Dekaf.Producer.PartitionerType.RoundRobin);
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithAdaptivePartitioning_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+        var result = builder.WithAdaptivePartitioning(false);
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithPartitionerAvailabilityTimeout_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+        var result = builder.WithPartitionerAvailabilityTimeout(TimeSpan.FromMilliseconds(5));
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithPartitionerIgnoreKeys_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+        var result = builder.WithPartitionerIgnoreKeys();
         await Assert.That(result).IsSameReferenceAs(builder);
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -112,22 +112,69 @@ public class KafkaProducerFastPathTests
         await Assert.That(metadata.Offset).IsEqualTo(7);
     }
 
-    private static TopicInfo CreateTopicInfo() => new()
+    [Test]
+    public async Task FireAsync_KeyedMessageOnStickyPartition_DoesNotAdvanceUniformStickyCounter()
+    {
+        const int partitionCount = 3;
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 1024,
+            LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000,
+            EnableAdaptivePartitioning = false
+        };
+
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        await StopProducerBackgroundLoopsAsync(producer);
+        SeedProducerMetadata(producer, partitionCount);
+        SetInstanceField(producer, "_initialized", true);
+
+        var partitioner = GetInstanceField<IPartitioner>(producer, "_partitioner");
+        var stickyPartition = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount);
+        var keyOnStickyPartition = FindKeyForPartition(partitioner, stickyPartition, partitionCount);
+
+        await producer.FireAsync(Topic, key: null, value: "sticky");
+        var bufferedAfterStickyAppend = producer.RecordAccumulator.BufferedBytes;
+        for (var i = 0; i < 6; i++)
+        {
+            await producer.FireAsync(Topic, keyOnStickyPartition, new string('v', 512));
+        }
+
+        await Assert.That(producer.RecordAccumulator.BufferedBytes)
+            .IsGreaterThan(bufferedAfterStickyAppend + 1024);
+
+        var partitionAfterKeyedAppends = partitioner.Partition(
+            Topic,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            partitionCount);
+
+        await Assert.That(partitionAfterKeyedAppends).IsEqualTo(stickyPartition);
+    }
+
+    private static TopicInfo CreateTopicInfo(int partitionCount = 1) => new()
     {
         Name = Topic,
-        Partitions =
-        [
-            new PartitionInfo
+        Partitions = Enumerable.Range(0, partitionCount)
+            .Select(partition => new PartitionInfo
             {
-                PartitionIndex = 0,
+                PartitionIndex = partition,
                 LeaderId = 0,
                 ReplicaNodes = [0],
                 IsrNodes = [0]
-            }
-        ]
+            })
+            .ToArray()
     };
 
-    private static void SeedProducerMetadata(KafkaProducer<string, string> producer)
+    private static void SeedProducerMetadata(KafkaProducer<string, string> producer, int partitionCount = 1)
     {
         var metadataManager = GetInstanceField<MetadataManager>(producer, "_metadataManager");
         metadataManager.Metadata.Update(new MetadataResponse
@@ -149,20 +196,32 @@ public class KafkaProducerFastPathTests
                 {
                     ErrorCode = ErrorCode.None,
                     Name = Topic,
-                    Partitions =
-                    [
-                        new PartitionMetadata
+                    Partitions = Enumerable.Range(0, partitionCount)
+                        .Select(partition => new PartitionMetadata
                         {
                             ErrorCode = ErrorCode.None,
-                            PartitionIndex = 0,
+                            PartitionIndex = partition,
                             LeaderId = 0,
                             ReplicaNodes = [0],
                             IsrNodes = [0]
-                        }
-                    ]
+                        })
+                        .ToArray()
                 }
             ]
         });
+    }
+
+    private static string FindKeyForPartition(IPartitioner partitioner, int targetPartition, int partitionCount)
+    {
+        for (var i = 0; i < 10_000; i++)
+        {
+            var key = $"key-{i}";
+            var keyBytes = Encoding.UTF8.GetBytes(key);
+            if (partitioner.Partition(Topic, keyBytes, keyIsNull: false, partitionCount) == targetPartition)
+                return key;
+        }
+
+        throw new InvalidOperationException($"Could not find a key for partition {targetPartition}.");
     }
 
     private static object InvokeTryProduceSyncCore(

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using Dekaf.Producer;
 
 namespace Dekaf.Tests.Unit.Producer;
@@ -80,6 +81,57 @@ public class DefaultPartitionerTests
         await Assert.That(partition1).IsEqualTo(partition2);
         await Assert.That(partition1).IsGreaterThanOrEqualTo(0);
         await Assert.That(partition1).IsLessThan(5);
+    }
+
+    [Test]
+    public async Task OnRecordAppended_WhenBatchSizeReached_SwitchesPartition()
+    {
+        var partitioner = new DefaultPartitioner(stickyBatchSize: 10);
+        var uniformStickyPartitioner = (IUniformStickyPartitioner)partitioner;
+        const int partitionCount = 5;
+
+        var partition1 = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, partitionCount);
+        uniformStickyPartitioner.OnRecordAppended("test-topic", partition1, bytes: 4, partitionCount);
+        var stillSticky = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, partitionCount);
+
+        uniformStickyPartitioner.OnRecordAppended("test-topic", partition1, bytes: 6, partitionCount);
+        var partition2 = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, partitionCount);
+
+        await Assert.That(stillSticky).IsEqualTo(partition1);
+        await Assert.That(partition2).IsNotEqualTo(partition1);
+    }
+
+    [Test]
+    public async Task Partition_WhenIgnoreKeysTrue_UsesStickyPartitionForKeyedMessages()
+    {
+        var partitioner = new DefaultPartitioner(stickyBatchSize: 1024, ignoreKeys: true);
+
+        var partition1 = partitioner.Partition("test-topic", "key-1"u8, false, 5);
+        var partition2 = partitioner.Partition("test-topic", "key-2"u8, false, 5);
+
+        await Assert.That(partition2).IsEqualTo(partition1);
+    }
+
+    [Test]
+    public async Task AdaptivePartitioning_WithAvailabilityTimeout_SkipsBackedUpPartition()
+    {
+        var partitioner = new DefaultPartitioner(
+            stickyBatchSize: 1,
+            adaptivePartitioning: true,
+            availabilityTimeoutMs: 1);
+        var uniformStickyPartitioner = (IUniformStickyPartitioner)partitioner;
+        const int partitionCount = 3;
+
+        StickyPartitionerTestHelpers.SetCounter(partitioner, uint.MaxValue);
+        var partition1 = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, partitionCount);
+        uniformStickyPartitioner.SetPartitionQueueByteProvider(
+            (_, partition) => partition == partition1 ? 1024 : 0);
+
+        Thread.Sleep(5);
+        uniformStickyPartitioner.OnRecordAppended("test-topic", partition1, bytes: 1, partitionCount);
+        var partition2 = partitioner.Partition("test-topic", ReadOnlySpan<byte>.Empty, true, partitionCount);
+
+        await Assert.That(partition2).IsNotEqualTo(partition1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
@@ -153,6 +153,27 @@ public class ProducerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task EnableAdaptivePartitioning_DefaultsTo_True()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.EnableAdaptivePartitioning).IsTrue();
+    }
+
+    [Test]
+    public async Task PartitionerAvailabilityTimeoutMs_DefaultsTo_0()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.PartitionerAvailabilityTimeoutMs).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task IgnorePartitionerKeys_DefaultsTo_False()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.IgnorePartitionerKeys).IsFalse();
+    }
+
+    [Test]
     public async Task UseTls_DefaultsTo_False()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -76,6 +76,48 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task AppendAsync_WhenStickyPartitionTracked_NotifiesRecordAppendCallback()
+    {
+        var options = CreateTestOptions();
+        var callbackCount = 0;
+        string? callbackTopic = null;
+        var callbackPartition = -1;
+        var callbackBytes = 0;
+        var callbackPartitionCount = 0;
+
+        await using var accumulator = new RecordAccumulator(
+            options,
+            onRecordAppended: (topic, partition, bytes, partitionCount) =>
+            {
+                callbackCount++;
+                callbackTopic = topic;
+                callbackPartition = partition;
+                callbackBytes = bytes;
+                callbackPartitionCount = partitionCount;
+            });
+
+        var appended = await accumulator.AppendAsync(
+            "test-topic",
+            partition: 2,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            PooledMemory.Null,
+            PooledMemory.Null,
+            headers: null,
+            headerCount: 0,
+            completionSource: null,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 3);
+
+        await Assert.That(appended).IsTrue();
+        await Assert.That(callbackCount).IsEqualTo(1);
+        await Assert.That(callbackTopic).IsEqualTo("test-topic");
+        await Assert.That(callbackPartition).IsEqualTo(2);
+        await Assert.That(callbackBytes).IsGreaterThan(0);
+        await Assert.That(callbackPartitionCount).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task BatchRotation_EnqueuesReadyBatchesInOrderAndClearsRotationGate()
     {
         var options = new ProducerOptions


### PR DESCRIPTION
Closes #1385

## Summary
- add KIP-794 uniform sticky partitioning for built-in default/sticky producers, switching after BatchSize bytes
- add adaptive partition selection from accumulator queue bytes plus availability timeout and ignore-keys options
- expose fluent builder/options docs and cover partitioner/accumulator/builder defaults in unit tests

## Validation
- dotnet build src\\Dekaf\\Dekaf.csproj --configuration Release --framework netstandard2.0 -p:TreatWarningsAsErrors=true -v:minimal
- dotnet build tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal
- dotnet run --project tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --maximum-parallel-tests 1
- focused producer partitioner/options/builder filters after final rebase