### PR TITLE
perf(consumer): update pause caches incrementally

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4246,9 +4246,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (cached is null)
                 return;
 
-            var updated = new Dictionary<int, List<TopicPartition>>(cached.Count);
+            var cachedPartitions = cached.Value.PartitionsByBroker;
+            var updated = new Dictionary<int, List<TopicPartition>>(cachedPartitions.Count);
             var changed = false;
-            foreach (var kvp in cached)
+            foreach (var kvp in cachedPartitions)
             {
                 var filtered = RemovePartitions(kvp.Value, partitions);
                 if (filtered is null)
@@ -4267,7 +4268,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
 
             if (changed)
-                _cachedPartitionsByBroker = updated;
+                _cachedPartitionsByBroker = new PartitionBrokerCacheEntry(
+                    updated,
+                    cached.Value.PreferredReplicaExpiresAtTimestamp,
+                    cached.Value.MetadataLastRefreshed);
         }
     }
 
@@ -4279,6 +4283,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (cached is null)
                 return;
 
+            var cachedPartitions = cached.Value.PartitionsByBroker;
             if (!_preferredReadReplicas.IsEmpty)
             {
                 _cachedPartitionsByBroker = null;
@@ -4299,7 +4304,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     return;
                 }
 
-                updated ??= new Dictionary<int, List<TopicPartition>>(cached);
+                updated ??= new Dictionary<int, List<TopicPartition>>(cachedPartitions);
                 if (!updated.TryGetValue(leader.NodeId, out var brokerPartitions))
                 {
                     updated[leader.NodeId] = [partition];
@@ -4316,7 +4321,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
 
             if (updated is not null)
-                _cachedPartitionsByBroker = updated;
+                _cachedPartitionsByBroker = new PartitionBrokerCacheEntry(
+                    updated,
+                    cached.Value.PreferredReplicaExpiresAtTimestamp,
+                    cached.Value.MetadataLastRefreshed);
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4242,14 +4242,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_partitionCacheLock)
         {
-            var cached = _cachedPartitionsByBroker;
-            if (cached is null)
+            var cachedEntry = _cachedPartitionsByBroker;
+            if (cachedEntry is null)
                 return;
 
-            var cachedPartitions = cached.Value.PartitionsByBroker;
-            var updated = new Dictionary<int, List<TopicPartition>>(cachedPartitions.Count);
+            var cached = cachedEntry.Value;
+            var partitionsByBroker = cached.PartitionsByBroker;
+            var updated = new Dictionary<int, List<TopicPartition>>(partitionsByBroker.Count);
             var changed = false;
-            foreach (var kvp in cachedPartitions)
+            foreach (var kvp in partitionsByBroker)
             {
                 var filtered = RemovePartitions(kvp.Value, partitions);
                 if (filtered is null)
@@ -4270,8 +4271,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (changed)
                 _cachedPartitionsByBroker = new PartitionBrokerCacheEntry(
                     updated,
-                    cached.Value.PreferredReplicaExpiresAtTimestamp,
-                    cached.Value.MetadataLastRefreshed);
+                    cached.PreferredReplicaExpiresAtTimestamp,
+                    cached.MetadataLastRefreshed);
         }
     }
 
@@ -4279,11 +4280,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_partitionCacheLock)
         {
-            var cached = _cachedPartitionsByBroker;
-            if (cached is null)
+            var cachedEntry = _cachedPartitionsByBroker;
+            if (cachedEntry is null)
                 return;
 
-            var cachedPartitions = cached.Value.PartitionsByBroker;
+            var cached = cachedEntry.Value;
             if (!_preferredReadReplicas.IsEmpty)
             {
                 _cachedPartitionsByBroker = null;
@@ -4304,7 +4305,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     return;
                 }
 
-                updated ??= new Dictionary<int, List<TopicPartition>>(cachedPartitions);
+                updated ??= new Dictionary<int, List<TopicPartition>>(cached.PartitionsByBroker);
                 if (!updated.TryGetValue(leader.NodeId, out var brokerPartitions))
                 {
                     updated[leader.NodeId] = [partition];
@@ -4323,8 +4324,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (updated is not null)
                 _cachedPartitionsByBroker = new PartitionBrokerCacheEntry(
                     updated,
-                    cached.Value.PreferredReplicaExpiresAtTimestamp,
-                    cached.Value.MetadataLastRefreshed);
+                    cached.PreferredReplicaExpiresAtTimestamp,
+                    cached.MetadataLastRefreshed);
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -753,7 +753,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private bool ShouldUseFetchSessions => _options.EnableFetchSessions && !_options.EnablePartitionEof;
 
     // Cached partition grouping by broker to avoid allocations on every fetch.
-    // Invalidated whenever _assignment, _paused, or preferred read replicas change.
+    // Rebuilt when assignment, preferred replicas, or metadata freshness make it stale;
+    // pause/resume updates it incrementally when the cache is already populated.
     // Access to _cachedPartitionsByBroker must be synchronized via _partitionCacheLock
     private PartitionBrokerCacheEntry? _cachedPartitionsByBroker;
     private readonly object _partitionCacheLock = new();
@@ -3430,24 +3431,44 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     public void Pause(params TopicPartition[] partitions)
     {
+        ArgumentNullException.ThrowIfNull(partitions);
+
+        List<TopicPartition>? changedPartitions = null;
         foreach (var partition in partitions)
         {
-            _paused.TryAdd(partition, 0);
+            if (_paused.TryAdd(partition, 0))
+            {
+                changedPartitions ??= [];
+                changedPartitions.Add(partition);
+            }
         }
+
+        if (changedPartitions is null)
+            return;
+
         PublishPausedSnapshot();
-        InvalidatePartitionCache();
-        InvalidateFetchRequestCache();
+        UpdateCachesForPausedPartitions(changedPartitions);
     }
 
     public void Resume(params TopicPartition[] partitions)
     {
+        ArgumentNullException.ThrowIfNull(partitions);
+
+        List<TopicPartition>? changedPartitions = null;
         foreach (var partition in partitions)
         {
-            _paused.TryRemove(partition, out _);
+            if (_paused.TryRemove(partition, out _))
+            {
+                changedPartitions ??= [];
+                changedPartitions.Add(partition);
+            }
         }
+
+        if (changedPartitions is null)
+            return;
+
         PublishPausedSnapshot();
-        InvalidatePartitionCache();
-        InvalidateFetchRequestCache();
+        UpdateCachesForResumedPartitions(changedPartitions);
     }
 
     private void CancelActiveConsumeOperations()
@@ -4200,6 +4221,102 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         lock (_partitionCacheLock)
         {
             _cachedPartitionsByBroker = null;
+        }
+    }
+
+    private void UpdateCachesForPausedPartitions(IReadOnlyList<TopicPartition> partitions)
+    {
+        Interlocked.Increment(ref _assignmentVersion);
+        RemovePausedPartitionsFromPartitionCache(partitions);
+        InvalidateFetchRequestCache();
+    }
+
+    private void UpdateCachesForResumedPartitions(IReadOnlyList<TopicPartition> partitions)
+    {
+        Interlocked.Increment(ref _assignmentVersion);
+        AddResumedPartitionsToPartitionCache(partitions);
+        InvalidateFetchRequestCache();
+    }
+
+    private void RemovePausedPartitionsFromPartitionCache(IReadOnlyList<TopicPartition> partitions)
+    {
+        lock (_partitionCacheLock)
+        {
+            var cached = _cachedPartitionsByBroker;
+            if (cached is null)
+                return;
+
+            var updated = new Dictionary<int, List<TopicPartition>>(cached.Count);
+            var changed = false;
+            foreach (var kvp in cached)
+            {
+                var filtered = RemovePartitions(kvp.Value, partitions);
+                if (filtered is null)
+                {
+                    updated.Add(kvp.Key, kvp.Value);
+                }
+                else if (filtered.Count > 0)
+                {
+                    changed = true;
+                    updated.Add(kvp.Key, filtered);
+                }
+                else
+                {
+                    changed = true;
+                }
+            }
+
+            if (changed)
+                _cachedPartitionsByBroker = updated;
+        }
+    }
+
+    private void AddResumedPartitionsToPartitionCache(IReadOnlyList<TopicPartition> partitions)
+    {
+        lock (_partitionCacheLock)
+        {
+            var cached = _cachedPartitionsByBroker;
+            if (cached is null)
+                return;
+
+            if (!_preferredReadReplicas.IsEmpty)
+            {
+                _cachedPartitionsByBroker = null;
+                return;
+            }
+
+            Dictionary<int, List<TopicPartition>>? updated = null;
+            var assignment = _assignmentSnapshot;
+            foreach (var partition in partitions)
+            {
+                if (_paused.ContainsKey(partition) || !ContainsPartition(assignment, partition))
+                    continue;
+
+                var leader = _metadataManager.TryGetCachedPartitionLeader(partition.Topic, partition.Partition);
+                if (leader is null)
+                {
+                    _cachedPartitionsByBroker = null;
+                    return;
+                }
+
+                updated ??= new Dictionary<int, List<TopicPartition>>(cached);
+                if (!updated.TryGetValue(leader.NodeId, out var brokerPartitions))
+                {
+                    updated[leader.NodeId] = [partition];
+                    continue;
+                }
+
+                if (ContainsPartition(brokerPartitions, partition))
+                    continue;
+
+                var replacement = new List<TopicPartition>(brokerPartitions.Count + 1);
+                replacement.AddRange(brokerPartitions);
+                replacement.Add(partition);
+                updated[leader.NodeId] = replacement;
+            }
+
+            if (updated is not null)
+                _cachedPartitionsByBroker = updated;
         }
     }
 
@@ -5219,6 +5336,43 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             _fetchRequestTemplateCache.Clear();
         }
+    }
+
+    private static List<TopicPartition>? RemovePartitions(
+        List<TopicPartition> source,
+        IReadOnlyList<TopicPartition> partitions)
+    {
+        List<TopicPartition>? updated = null;
+        for (var i = 0; i < source.Count; i++)
+        {
+            var partition = source[i];
+            if (ContainsPartition(partitions, partition))
+            {
+                if (updated is null)
+                {
+                    updated = new List<TopicPartition>(source.Count - 1);
+                    for (var j = 0; j < i; j++)
+                        updated.Add(source[j]);
+                }
+
+                continue;
+            }
+
+            updated?.Add(partition);
+        }
+
+        return updated;
+    }
+
+    private static bool ContainsPartition(IEnumerable<TopicPartition> partitions, TopicPartition partition)
+    {
+        foreach (var candidate in partitions)
+        {
+            if (candidate == partition)
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -35,6 +35,33 @@ public sealed class ConsumerPauseResumeCacheTests
             BindingFlags.Instance | BindingFlags.NonPublic)
         ?? throw new InvalidOperationException("_fetchRequestTemplateCache field not found");
 
+    private static readonly FieldInfo PreferredReadReplicasField =
+        typeof(KafkaConsumer<string, string>).GetField(
+            "_preferredReadReplicas",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("_preferredReadReplicas field not found");
+
+    [Test]
+    public async Task PauseResume_WhenCachesAreEmpty_LeavesCachesEmpty()
+    {
+        var partition0 = new TopicPartition("topic-a", 0);
+        var pool = Substitute.For<IConnectionPool>();
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.Assign(partition0);
+
+        consumer.Pause(partition0);
+
+        await Assert.That(GetCachedPartitionsByBroker(consumer)).IsNull();
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(0);
+
+        consumer.Resume(partition0);
+
+        await Assert.That(GetCachedPartitionsByBroker(consumer)).IsNull();
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(0);
+    }
+
     [Test]
     public async Task PauseResume_UpdatesPartitionBrokerCacheIncrementally()
     {
@@ -67,6 +94,69 @@ public sealed class ConsumerPauseResumeCacheTests
     }
 
     [Test]
+    public async Task Resume_WithPreferredReadReplica_InvalidatesPartitionBrokerCache()
+    {
+        var partition0 = new TopicPartition("topic-a", 0);
+        var partition1 = new TopicPartition("topic-a", 1);
+        var pool = Substitute.For<IConnectionPool>();
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.Assign(partition0, partition1);
+
+        _ = await InvokeGroupPartitionsByBrokerAsync(consumer).ConfigureAwait(false);
+        consumer.Pause(partition0);
+        await Assert.That(GetCachedPartitionsByBroker(consumer)).IsNotNull();
+
+        AddPreferredReadReplica(consumer, partition1, replicaId: 2);
+        consumer.Resume(partition0);
+
+        await Assert.That(GetCachedPartitionsByBroker(consumer)).IsNull();
+    }
+
+    [Test]
+    public async Task Resume_WithUnknownLeader_InvalidatesPartitionBrokerCache()
+    {
+        var knownPartition = new TopicPartition("topic-a", 0);
+        var missingLeaderPartition = new TopicPartition("topic-a", 99);
+        var pool = Substitute.For<IConnectionPool>();
+
+        await using var metadataManager = CreateMetadataManager(
+            pool,
+            new PartitionMetadataSeed("topic-a", 0, 1));
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.Assign(knownPartition, missingLeaderPartition);
+
+        consumer.Pause(missingLeaderPartition);
+        _ = await InvokeGroupPartitionsByBrokerAsync(consumer).ConfigureAwait(false);
+        await Assert.That(GetCachedPartitionsByBroker(consumer)).IsNotNull();
+
+        consumer.Resume(missingLeaderPartition);
+
+        await Assert.That(GetCachedPartitionsByBroker(consumer)).IsNull();
+    }
+
+    [Test]
+    public async Task Pause_AllPartitionsInBrokerBucket_DropsBucketFromPartitionBrokerCache()
+    {
+        var partition0 = new TopicPartition("topic-a", 0);
+        var partition1 = new TopicPartition("topic-a", 1);
+        var pool = Substitute.For<IConnectionPool>();
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.Assign(partition0, partition1);
+
+        _ = await InvokeGroupPartitionsByBrokerAsync(consumer).ConfigureAwait(false);
+
+        consumer.Pause(partition0, partition1);
+
+        var pausedCache = GetCachedPartitionsByBroker(consumer);
+        await Assert.That(pausedCache).IsNotNull();
+        await Assert.That(pausedCache!.Count).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task PauseResume_InvalidatesFetchRequestTemplateCache()
     {
         var partition0 = new TopicPartition("topic-a", 0);
@@ -94,6 +184,65 @@ public sealed class ConsumerPauseResumeCacheTests
         await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task Pause_AllPartitionsInTopicBucket_ClearsFetchRequestTemplateCache()
+    {
+        var partition0 = new TopicPartition("topic-a", 0);
+        var partition1 = new TopicPartition("topic-a", 1);
+        var partitions = new List<TopicPartition> { partition0, partition1 };
+        var pool = Substitute.For<IConnectionPool>();
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.Assign(partition0, partition1);
+
+        var fetchTopics = InvokeBuildFetchRequestTopics(consumer, partitions);
+        ConsumerFetchPools.ReturnFetchRequestTopics(fetchTopics);
+
+        consumer.Pause(partition0, partition1);
+
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task PauseResume_WithMultipleBrokersAndTopics_UpdatesBrokerCacheAndInvalidatesFetchTemplateCache()
+    {
+        var topicA0 = new TopicPartition("topic-a", 0);
+        var topicB0 = new TopicPartition("topic-b", 0);
+        var topicB1 = new TopicPartition("topic-b", 1);
+        var partitions = new List<TopicPartition> { topicA0, topicB0, topicB1 };
+        var pool = Substitute.For<IConnectionPool>();
+
+        await using var metadataManager = CreateMetadataManager(
+            pool,
+            new PartitionMetadataSeed("topic-a", 0, 1),
+            new PartitionMetadataSeed("topic-b", 0, 2),
+            new PartitionMetadataSeed("topic-b", 1, 2));
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.Assign(topicA0, topicB0, topicB1);
+
+        _ = await InvokeGroupPartitionsByBrokerAsync(consumer).ConfigureAwait(false);
+        var fetchTopics = InvokeBuildFetchRequestTopics(consumer, partitions);
+        ConsumerFetchPools.ReturnFetchRequestTopics(fetchTopics);
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(1);
+
+        consumer.Pause(topicB0);
+
+        var pausedBrokerCache = GetCachedPartitionsByBroker(consumer);
+        await Assert.That(pausedBrokerCache).IsNotNull();
+        await Assert.That(pausedBrokerCache![1]).IsEquivalentTo(new[] { topicA0 });
+        await Assert.That(pausedBrokerCache[2]).IsEquivalentTo(new[] { topicB1 });
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(0);
+
+        consumer.Resume(topicB0);
+
+        var resumedBrokerCache = GetCachedPartitionsByBroker(consumer);
+        await Assert.That(resumedBrokerCache).IsNotNull();
+        await Assert.That(resumedBrokerCache![1]).IsEquivalentTo(new[] { topicA0 });
+        await Assert.That(resumedBrokerCache[2]).IsEquivalentTo(new[] { topicB1, topicB0 });
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(0);
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer(
         IConnectionPool pool,
         MetadataManager metadataManager)
@@ -110,6 +259,14 @@ public sealed class ConsumerPauseResumeCacheTests
             metadataManager);
 
     private static MetadataManager CreateMetadataManager(IConnectionPool pool)
+        => CreateMetadataManager(
+            pool,
+            new PartitionMetadataSeed("topic-a", 0, 1),
+            new PartitionMetadataSeed("topic-a", 1, 1));
+
+    private static MetadataManager CreateMetadataManager(
+        IConnectionPool pool,
+        params PartitionMetadataSeed[] partitions)
     {
         var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
         metadataManager.SetApiVersion(ApiKey.Fetch, FetchRequest.LowestSupportedVersion, FetchRequest.HighestSupportedVersion);
@@ -117,42 +274,59 @@ public sealed class ConsumerPauseResumeCacheTests
         {
             ClusterId = "test-cluster",
             ControllerId = 1,
-            Brokers =
-            [
-                new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9092 }
-            ],
-            Topics =
-            [
-                new TopicMetadata
+            Brokers = partitions
+                .Select(static partition => partition.LeaderId)
+                .Distinct()
+                .Order()
+                .Select(static brokerId => new BrokerMetadata
+                {
+                    NodeId = brokerId,
+                    Host = $"broker-{brokerId}",
+                    Port = 9090 + brokerId
+                })
+                .ToArray(),
+            Topics = partitions
+                .GroupBy(static partition => partition.Topic)
+                .Select(static topic => new TopicMetadata
                 {
                     ErrorCode = ErrorCode.None,
-                    Name = "topic-a",
-                    Partitions =
-                    [
-                        new PartitionMetadata
+                    Name = topic.Key,
+                    Partitions = topic
+                        .Select(static partition => new PartitionMetadata
                         {
                             ErrorCode = ErrorCode.None,
-                            PartitionIndex = 0,
-                            LeaderId = 1,
+                            PartitionIndex = partition.Partition,
+                            LeaderId = partition.LeaderId,
                             LeaderEpoch = 5,
-                            ReplicaNodes = [1],
-                            IsrNodes = [1]
-                        },
-                        new PartitionMetadata
-                        {
-                            ErrorCode = ErrorCode.None,
-                            PartitionIndex = 1,
-                            LeaderId = 1,
-                            LeaderEpoch = 5,
-                            ReplicaNodes = [1],
-                            IsrNodes = [1]
-                        }
-                    ]
-                }
-            ]
+                            ReplicaNodes = [partition.LeaderId],
+                            IsrNodes = [partition.LeaderId]
+                        })
+                        .ToArray()
+                })
+                .ToArray()
         });
 
         return metadataManager;
+    }
+
+    private static void AddPreferredReadReplica(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition partition,
+        int replicaId)
+    {
+        var replicas = PreferredReadReplicasField.GetValue(consumer)
+            ?? throw new InvalidOperationException("_preferredReadReplicas was null");
+        var stateType = replicas.GetType().GetGenericArguments()[1];
+        var state = Activator.CreateInstance(
+            stateType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: [replicaId, DateTimeOffset.UtcNow, long.MaxValue],
+            culture: null);
+
+        var tryAdd = replicas.GetType().GetMethod("TryAdd")
+            ?? throw new InvalidOperationException("TryAdd method not found");
+        tryAdd.Invoke(replicas, [partition, state]);
     }
 
     private static async ValueTask<Dictionary<int, List<TopicPartition>>> InvokeGroupPartitionsByBrokerAsync(
@@ -174,11 +348,21 @@ public sealed class ConsumerPauseResumeCacheTests
 
     private static Dictionary<int, List<TopicPartition>>? GetCachedPartitionsByBroker(
         KafkaConsumer<string, string> consumer)
-        => (Dictionary<int, List<TopicPartition>>?)CachedPartitionsByBrokerField.GetValue(consumer);
+    {
+        var entry = CachedPartitionsByBrokerField.GetValue(consumer);
+        if (entry is null)
+            return null;
+
+        var property = entry.GetType().GetProperty("PartitionsByBroker")
+            ?? throw new InvalidOperationException("PartitionsByBroker property not found");
+        return (Dictionary<int, List<TopicPartition>>)property.GetValue(entry)!;
+    }
 
     private static int GetFetchRequestTemplateCacheCount(KafkaConsumer<string, string> consumer)
     {
         var cached = (System.Collections.ICollection)FetchRequestTemplateCacheField.GetValue(consumer)!;
         return cached.Count;
     }
+
+    private readonly record struct PartitionMetadataSeed(string Topic, int Partition, int LeaderId);
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPauseResumeCacheTests.cs
@@ -1,0 +1,184 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerPauseResumeCacheTests
+{
+    private static readonly MethodInfo BuildFetchRequestTopicsMethod =
+        typeof(KafkaConsumer<string, string>).GetMethod(
+            "BuildFetchRequestTopics",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("BuildFetchRequestTopics method not found");
+
+    private static readonly MethodInfo GroupPartitionsByBrokerMethod =
+        typeof(KafkaConsumer<string, string>).GetMethod(
+            "GroupPartitionsByBrokerAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("GroupPartitionsByBrokerAsync method not found");
+
+    private static readonly FieldInfo CachedPartitionsByBrokerField =
+        typeof(KafkaConsumer<string, string>).GetField(
+            "_cachedPartitionsByBroker",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("_cachedPartitionsByBroker field not found");
+
+    private static readonly FieldInfo FetchRequestTemplateCacheField =
+        typeof(KafkaConsumer<string, string>).GetField(
+            "_fetchRequestTemplateCache",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("_fetchRequestTemplateCache field not found");
+
+    [Test]
+    public async Task PauseResume_UpdatesPartitionBrokerCacheIncrementally()
+    {
+        var partition0 = new TopicPartition("topic-a", 0);
+        var partition1 = new TopicPartition("topic-a", 1);
+        var pool = Substitute.For<IConnectionPool>();
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.Assign(partition0, partition1);
+
+        var groups = await InvokeGroupPartitionsByBrokerAsync(consumer).ConfigureAwait(false);
+        await Assert.That(groups[1].Count).IsEqualTo(2);
+
+        consumer.Pause(partition0);
+
+        var pausedCache = GetCachedPartitionsByBroker(consumer);
+        await Assert.That(pausedCache).IsNotNull();
+        await Assert.That(pausedCache![1].Count).IsEqualTo(1);
+        await Assert.That(pausedCache[1].Contains(partition1)).IsTrue();
+        await Assert.That(pausedCache[1].Contains(partition0)).IsFalse();
+
+        consumer.Resume(partition0);
+
+        var resumedCache = GetCachedPartitionsByBroker(consumer);
+        await Assert.That(resumedCache).IsNotNull();
+        await Assert.That(resumedCache![1].Count).IsEqualTo(2);
+        await Assert.That(resumedCache[1].Contains(partition0)).IsTrue();
+        await Assert.That(resumedCache[1].Contains(partition1)).IsTrue();
+    }
+
+    [Test]
+    public async Task PauseResume_InvalidatesFetchRequestTemplateCache()
+    {
+        var partition0 = new TopicPartition("topic-a", 0);
+        var partition1 = new TopicPartition("topic-a", 1);
+        var partitions = new List<TopicPartition> { partition0, partition1 };
+        var pool = Substitute.For<IConnectionPool>();
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.Assign(partition0, partition1);
+
+        var fetchTopics = InvokeBuildFetchRequestTopics(consumer, partitions);
+        ConsumerFetchPools.ReturnFetchRequestTopics(fetchTopics);
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(1);
+
+        consumer.Pause(partition0);
+
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(0);
+        var pausedFetchTopics = InvokeBuildFetchRequestTopics(consumer, [partition1]);
+        ConsumerFetchPools.ReturnFetchRequestTopics(pausedFetchTopics);
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(1);
+
+        consumer.Resume(partition0);
+
+        await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(0);
+    }
+
+    private static KafkaConsumer<string, string> CreateConsumer(
+        IConnectionPool pool,
+        MetadataManager metadataManager)
+        => new(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "test-consumer",
+                EnableFetchSessions = false
+            },
+            Serializers.String,
+            Serializers.String,
+            pool,
+            metadataManager);
+
+    private static MetadataManager CreateMetadataManager(IConnectionPool pool)
+    {
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.SetApiVersion(ApiKey.Fetch, FetchRequest.LowestSupportedVersion, FetchRequest.HighestSupportedVersion);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            ClusterId = "test-cluster",
+            ControllerId = 1,
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9092 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "topic-a",
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 1,
+                            LeaderEpoch = 5,
+                            ReplicaNodes = [1],
+                            IsrNodes = [1]
+                        },
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 1,
+                            LeaderId = 1,
+                            LeaderEpoch = 5,
+                            ReplicaNodes = [1],
+                            IsrNodes = [1]
+                        }
+                    ]
+                }
+            ]
+        });
+
+        return metadataManager;
+    }
+
+    private static async ValueTask<Dictionary<int, List<TopicPartition>>> InvokeGroupPartitionsByBrokerAsync(
+        KafkaConsumer<string, string> consumer)
+    {
+        var result = GroupPartitionsByBrokerMethod.Invoke(consumer, [CancellationToken.None]);
+        if (result is not ValueTask<Dictionary<int, List<TopicPartition>>> valueTask)
+            throw new InvalidOperationException("GroupPartitionsByBrokerAsync returned unexpected type");
+
+        return await valueTask.ConfigureAwait(false);
+    }
+
+    private static List<FetchRequestTopic> InvokeBuildFetchRequestTopics(
+        KafkaConsumer<string, string> consumer,
+        List<TopicPartition> partitions)
+        => (List<FetchRequestTopic>)BuildFetchRequestTopicsMethod.Invoke(
+            consumer,
+            [partitions, 0, partitions.Count, 1])!;
+
+    private static Dictionary<int, List<TopicPartition>>? GetCachedPartitionsByBroker(
+        KafkaConsumer<string, string> consumer)
+        => (Dictionary<int, List<TopicPartition>>?)CachedPartitionsByBrokerField.GetValue(consumer);
+
+    private static int GetFetchRequestTemplateCacheCount(KafkaConsumer<string, string> consumer)
+    {
+        var cached = (System.Collections.ICollection)FetchRequestTemplateCacheField.GetValue(consumer)!;
+        return cached.Count;
+    }
+}


### PR DESCRIPTION
## Summary
- No-op duplicate `Pause`/`Resume` calls that do not change the paused partition set.
- Update cached partition-broker groupings and fetch-request templates copy-on-write for paused/resumed partitions instead of clearing both caches.
- Add unit coverage for incremental pause/resume updates on both cache layers.

## Test plan
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter /*/*/ConsumerPauseResumeCacheTests/*`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter /*/*/PartitionedConsumerRuntimeTests/*`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter /*/*/ConsumerFetchPoolsTests/*`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter /*/*/ConsumerRackAwarenessTests/*`
- `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --framework netstandard2.0 -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet format Dekaf.sln --verify-no-changes --verbosity minimal`

Closes #1359