### PR TITLE
perf(sharegroups): track acknowledgements as ranges

### DIFF
--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -11,23 +11,14 @@ namespace Dekaf.ShareConsumer;
 /// </summary>
 internal sealed class AcknowledgementTracker
 {
-    private Dictionary<TopicPartition, Dictionary<long, AcknowledgeType>> _pendingAcks = new();
+    private Dictionary<TopicPartition, PartitionAcknowledgements> _pendingAcks = new();
 
     /// <summary>
     /// Tracks records delivered by a poll. All records default to Accept.
     /// </summary>
     internal void TrackDeliveredRecords(TopicPartition tp, long firstOffset, long lastOffset)
     {
-        if (!_pendingAcks.TryGetValue(tp, out var offsets))
-        {
-            offsets = new Dictionary<long, AcknowledgeType>();
-            _pendingAcks[tp] = offsets;
-        }
-
-        for (long offset = firstOffset; offset <= lastOffset; offset++)
-        {
-            offsets[offset] = AcknowledgeType.Accept;
-        }
+        GetOrAddPartition(tp).TrackRange(firstOffset, lastOffset, AcknowledgeType.Accept);
     }
 
     /// <summary>
@@ -36,7 +27,7 @@ internal sealed class AcknowledgementTracker
     /// </summary>
     internal void Acknowledge(TopicPartition tp, long offset, AcknowledgeType type, bool requireTracked = true)
     {
-        if (!_pendingAcks.TryGetValue(tp, out var offsets))
+        if (!_pendingAcks.TryGetValue(tp, out var partitionAcks))
         {
             if (requireTracked)
             {
@@ -44,16 +35,16 @@ internal sealed class AcknowledgementTracker
                     $"Cannot acknowledge offset {offset} for {tp} — record was not delivered by the current poll.");
             }
 
-            offsets = new Dictionary<long, AcknowledgeType>();
-            _pendingAcks[tp] = offsets;
+            partitionAcks = new PartitionAcknowledgements();
+            _pendingAcks[tp] = partitionAcks;
         }
-        else if (requireTracked && !offsets.ContainsKey(offset))
+        else if (requireTracked && !partitionAcks.ContainsOffset(offset))
         {
             throw new InvalidOperationException(
                 $"Cannot acknowledge offset {offset} for {tp} — record was not delivered by the current poll.");
         }
 
-        offsets[offset] = type;
+        partitionAcks.SetExplicit(offset, type);
     }
 
     /// <summary>
@@ -71,15 +62,16 @@ internal sealed class AcknowledgementTracker
         // Swap to a fresh dictionary so any new acks after this point go into a fresh
         // bucket — avoids the per-partition TryRemove race of the snapshot-and-remove pattern.
         var old = _pendingAcks;
-        _pendingAcks = new Dictionary<TopicPartition, Dictionary<long, AcknowledgeType>>();
+        _pendingAcks = new Dictionary<TopicPartition, PartitionAcknowledgements>();
 
         Dictionary<TopicPartition, List<AcknowledgementBatchData>> result = new();
 
-        foreach (var (tp, offsets) in old)
+        foreach (var (tp, partitionAcks) in old)
         {
-            if (offsets.Count > 0)
+            var batches = partitionAcks.BuildBatches();
+            if (batches.Count > 0)
             {
-                result[tp] = BuildBatches(offsets);
+                result[tp] = batches;
             }
         }
 
@@ -95,74 +87,216 @@ internal sealed class AcknowledgementTracker
     {
         foreach (var (tp, batches) in acks)
         {
-            if (!_pendingAcks.TryGetValue(tp, out var offsets))
-            {
-                offsets = new Dictionary<long, AcknowledgeType>();
-                _pendingAcks[tp] = offsets;
-            }
+            var partitionAcks = GetOrAddPartition(tp);
 
             foreach (var batch in batches)
             {
-                for (int i = 0; i < batch.AcknowledgeTypes.Length; i++)
+                long? runStart = null;
+                long runEnd = 0;
+                var runType = AcknowledgeType.Accept;
+
+                for (var i = 0; i < batch.AcknowledgeTypes.Length; i++)
                 {
                     var offset = batch.FirstOffset + i;
                     // TryAdd intentionally: preserve any explicit acknowledgement the user set
                     // after the flush. A newer Acknowledge() call takes priority over re-queued
                     // stale acks from a failed CommitAsync.
-                    offsets.TryAdd(offset, (AcknowledgeType)batch.AcknowledgeTypes[i]);
+                    if (partitionAcks.ContainsOffset(offset))
+                    {
+                        if (runStart is not null)
+                        {
+                            partitionAcks.TrackRange(runStart.Value, runEnd, runType);
+                            runStart = null;
+                        }
+
+                        continue;
+                    }
+
+                    var type = (AcknowledgeType)batch.AcknowledgeTypes[i];
+                    if (runStart is not null && type == runType && offset == runEnd + 1)
+                    {
+                        runEnd = offset;
+                        continue;
+                    }
+
+                    if (runStart is not null)
+                        partitionAcks.TrackRange(runStart.Value, runEnd, runType);
+
+                    runStart = offset;
+                    runEnd = offset;
+                    runType = type;
+                }
+
+                if (runStart is not null)
+                    partitionAcks.TrackRange(runStart.Value, runEnd, runType);
+            }
+        }
+    }
+
+    private PartitionAcknowledgements GetOrAddPartition(TopicPartition tp)
+    {
+        if (_pendingAcks.TryGetValue(tp, out var partitionAcks))
+            return partitionAcks;
+
+        partitionAcks = new PartitionAcknowledgements();
+        _pendingAcks[tp] = partitionAcks;
+        return partitionAcks;
+    }
+
+    private sealed class PartitionAcknowledgements
+    {
+        private readonly List<AckRange> _ranges = [];
+        private Dictionary<long, AcknowledgeType>? _explicitAcks;
+
+        internal void TrackRange(long firstOffset, long lastOffset, AcknowledgeType type)
+        {
+            if (lastOffset < firstOffset)
+                return;
+
+            if (_ranges.Count > 0)
+            {
+                var last = _ranges[^1];
+                if (last.AcknowledgeType == type && firstOffset <= last.LastOffset + 1)
+                {
+                    _ranges[^1] = last with { LastOffset = Math.Max(last.LastOffset, lastOffset) };
+                    return;
                 }
             }
+
+            _ranges.Add(new AckRange(firstOffset, lastOffset, type));
+        }
+
+        internal bool ContainsOffset(long offset)
+        {
+            if (_explicitAcks is not null && _explicitAcks.ContainsKey(offset))
+                return true;
+
+            return ContainsOffsetInRanges(offset);
+        }
+
+        internal void SetExplicit(long offset, AcknowledgeType type)
+        {
+            _explicitAcks ??= new Dictionary<long, AcknowledgeType>();
+            _explicitAcks[offset] = type;
+        }
+
+        internal List<AcknowledgementBatchData> BuildBatches()
+        {
+            List<AcknowledgementBatchData> batches = [];
+
+            foreach (var range in _ranges)
+                batches.Add(BuildRangeBatch(range));
+
+            if (_explicitAcks is not null)
+                AddStandaloneExplicitBatches(batches);
+
+            if (batches.Count <= 1)
+                return batches;
+
+            batches.Sort(static (left, right) => left.FirstOffset.CompareTo(right.FirstOffset));
+            return MergeConsecutiveBatches(batches);
+        }
+
+        private AcknowledgementBatchData BuildRangeBatch(AckRange range)
+        {
+            var length = checked((int)(range.LastOffset - range.FirstOffset + 1));
+            var acknowledgeTypes = new byte[length];
+            Array.Fill(acknowledgeTypes, (byte)range.AcknowledgeType);
+
+            if (_explicitAcks is not null)
+            {
+                foreach (var (offset, type) in _explicitAcks)
+                {
+                    if (offset >= range.FirstOffset && offset <= range.LastOffset)
+                        acknowledgeTypes[offset - range.FirstOffset] = (byte)type;
+                }
+            }
+
+            return new AcknowledgementBatchData(range.FirstOffset, range.LastOffset, acknowledgeTypes);
+        }
+
+        private void AddStandaloneExplicitBatches(List<AcknowledgementBatchData> batches)
+        {
+            if (_explicitAcks is null)
+                return;
+
+            List<KeyValuePair<long, AcknowledgeType>>? standaloneAcks = null;
+            foreach (var kvp in _explicitAcks)
+            {
+                if (ContainsOffsetInRanges(kvp.Key))
+                    continue;
+
+                standaloneAcks ??= [];
+                standaloneAcks.Add(kvp);
+            }
+
+            if (standaloneAcks is null)
+                return;
+
+            standaloneAcks.Sort(static (left, right) => left.Key.CompareTo(right.Key));
+
+            var runStart = standaloneAcks[0].Key;
+            var previousOffset = runStart;
+            List<byte> runTypes = [(byte)standaloneAcks[0].Value];
+
+            for (var i = 1; i < standaloneAcks.Count; i++)
+            {
+                var (offset, type) = standaloneAcks[i];
+                if (offset == previousOffset + 1)
+                {
+                    runTypes.Add((byte)type);
+                }
+                else
+                {
+                    batches.Add(new AcknowledgementBatchData(runStart, previousOffset, runTypes.ToArray()));
+                    runStart = offset;
+                    runTypes = [(byte)type];
+                }
+
+                previousOffset = offset;
+            }
+
+            batches.Add(new AcknowledgementBatchData(runStart, previousOffset, runTypes.ToArray()));
+        }
+
+        private bool ContainsOffsetInRanges(long offset)
+        {
+            foreach (var range in _ranges)
+            {
+                if (offset >= range.FirstOffset && offset <= range.LastOffset)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static List<AcknowledgementBatchData> MergeConsecutiveBatches(List<AcknowledgementBatchData> batches)
+        {
+            List<AcknowledgementBatchData> merged = [];
+            var current = batches[0];
+
+            for (var i = 1; i < batches.Count; i++)
+            {
+                var next = batches[i];
+                if (current.LastOffset + 1 != next.FirstOffset)
+                {
+                    merged.Add(current);
+                    current = next;
+                    continue;
+                }
+
+                var combinedTypes = new byte[current.AcknowledgeTypes.Length + next.AcknowledgeTypes.Length];
+                Array.Copy(current.AcknowledgeTypes, combinedTypes, current.AcknowledgeTypes.Length);
+                Array.Copy(next.AcknowledgeTypes, 0, combinedTypes, current.AcknowledgeTypes.Length, next.AcknowledgeTypes.Length);
+                current = new AcknowledgementBatchData(current.FirstOffset, next.LastOffset, combinedTypes);
+            }
+
+            merged.Add(current);
+            return merged;
         }
     }
 
-    /// <summary>
-    /// Builds wire-format acknowledgement batches from an offset dictionary.
-    /// Sorts keys once then groups consecutive offsets into batches with per-record
-    /// AcknowledgeTypes arrays.
-    /// </summary>
-    private static List<AcknowledgementBatchData> BuildBatches(Dictionary<long, AcknowledgeType> offsets)
-    {
-        List<AcknowledgementBatchData> batches = [];
-
-        if (offsets.Count == 0)
-        {
-            return batches;
-        }
-
-        // Sort keys once at flush time — O(n log n) here instead of O(n) insert cost
-        // per TrackDeliveredRecords/Acknowledge call.
-        var sortedOffsets = offsets.Keys.Order().ToArray();
-
-        long batchStart = sortedOffsets[0];
-        long previousOffset = batchStart;
-        List<byte> currentTypes = [(byte)offsets[batchStart]];
-
-        for (int i = 1; i < sortedOffsets.Length; i++)
-        {
-            long offset = sortedOffsets[i];
-            AcknowledgeType type = offsets[offset];
-
-            if (offset == previousOffset + 1)
-            {
-                // Consecutive — extend current batch
-                currentTypes.Add((byte)type);
-            }
-            else
-            {
-                // Gap — close current batch and start new one
-                batches.Add(new AcknowledgementBatchData(batchStart, previousOffset, currentTypes.ToArray()));
-                batchStart = offset;
-                currentTypes = [(byte)type];
-            }
-
-            previousOffset = offset;
-        }
-
-        // Close final batch
-        batches.Add(new AcknowledgementBatchData(batchStart, previousOffset, currentTypes.ToArray()));
-
-        return batches;
-    }
+    private readonly record struct AckRange(long FirstOffset, long LastOffset, AcknowledgeType AcknowledgeType);
 }
 
 /// <summary>

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -187,11 +187,38 @@ internal sealed class AcknowledgementTracker
                     continue;
                 }
 
-                if (incoming.FirstOffset < current.FirstOffset)
+                if (Overlaps(current, incoming))
+                {
+                    _ranges.RemoveAt(index);
+
+                    if (current.FirstOffset < incoming.FirstOffset)
+                    {
+                        _ranges.Insert(
+                            index,
+                            current with { LastOffset = incoming.FirstOffset - 1 });
+                        index++;
+                    }
+
+                    if (current.LastOffset > incoming.LastOffset)
+                    {
+                        _ranges.Insert(
+                            index,
+                            current with { FirstOffset = incoming.LastOffset + 1 });
+                        index++;
+                    }
+
+                    continue;
+                }
+
+                if (incoming.LastOffset < current.FirstOffset)
                     break;
 
                 index++;
             }
+
+            index = 0;
+            while (index < _ranges.Count && _ranges[index].FirstOffset < incoming.FirstOffset)
+                index++;
 
             _ranges.Insert(index, incoming);
         }
@@ -208,6 +235,12 @@ internal sealed class AcknowledgementTracker
         {
             return !EndsBeforeWithGap(left.LastOffset, right.FirstOffset) &&
                    !EndsBeforeWithGap(right.LastOffset, left.FirstOffset);
+        }
+
+        private static bool Overlaps(AckRange left, AckRange right)
+        {
+            return left.FirstOffset <= right.LastOffset &&
+                   right.FirstOffset <= left.LastOffset;
         }
 
         private static bool EndsBeforeWithGap(long lastOffset, long firstOffset)

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -98,9 +98,9 @@ internal sealed class AcknowledgementTracker
                 for (var i = 0; i < batch.AcknowledgeTypes.Length; i++)
                 {
                     var offset = batch.FirstOffset + i;
-                    // TryAdd intentionally: preserve any explicit acknowledgement the user set
-                    // after the flush. A newer Acknowledge() call takes priority over re-queued
-                    // stale acks from a failed CommitAsync.
+                    // Preserve any acknowledgement tracked after the flush. A newer
+                    // Acknowledge() call takes priority over stale re-queued acks
+                    // from a failed CommitAsync.
                     if (partitionAcks.ContainsOffset(offset))
                     {
                         if (runStart is not null)

--- a/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
+++ b/src/Dekaf/ShareConsumer/AcknowledgementTracker.cs
@@ -153,17 +153,66 @@ internal sealed class AcknowledgementTracker
             if (lastOffset < firstOffset)
                 return;
 
+            var incoming = new AckRange(firstOffset, lastOffset, type);
+
             if (_ranges.Count > 0)
             {
                 var last = _ranges[^1];
-                if (last.AcknowledgeType == type && firstOffset <= last.LastOffset + 1)
+                if (last.AcknowledgeType == type && TouchesOrOverlaps(last, incoming))
                 {
-                    _ranges[^1] = last with { LastOffset = Math.Max(last.LastOffset, lastOffset) };
+                    _ranges[^1] = Merge(last, incoming);
+                    return;
+                }
+
+                if (firstOffset > last.LastOffset)
+                {
+                    _ranges.Add(incoming);
                     return;
                 }
             }
 
-            _ranges.Add(new AckRange(firstOffset, lastOffset, type));
+            InsertRange(incoming);
+        }
+
+        private void InsertRange(AckRange incoming)
+        {
+            var index = 0;
+            while (index < _ranges.Count)
+            {
+                var current = _ranges[index];
+                if (current.AcknowledgeType == incoming.AcknowledgeType && TouchesOrOverlaps(current, incoming))
+                {
+                    incoming = Merge(current, incoming);
+                    _ranges.RemoveAt(index);
+                    continue;
+                }
+
+                if (incoming.FirstOffset < current.FirstOffset)
+                    break;
+
+                index++;
+            }
+
+            _ranges.Insert(index, incoming);
+        }
+
+        private static AckRange Merge(AckRange left, AckRange right)
+        {
+            return new AckRange(
+                Math.Min(left.FirstOffset, right.FirstOffset),
+                Math.Max(left.LastOffset, right.LastOffset),
+                left.AcknowledgeType);
+        }
+
+        private static bool TouchesOrOverlaps(AckRange left, AckRange right)
+        {
+            return !EndsBeforeWithGap(left.LastOffset, right.FirstOffset) &&
+                   !EndsBeforeWithGap(right.LastOffset, left.FirstOffset);
+        }
+
+        private static bool EndsBeforeWithGap(long lastOffset, long firstOffset)
+        {
+            return lastOffset < firstOffset && lastOffset + 1 < firstOffset;
         }
 
         internal bool ContainsOffset(long offset)

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -723,6 +723,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         var results = new List<ShareConsumeResult<TKey, TValue>>();
 
         var reader = new KafkaProtocolReader(partition.RecordBytes);
+        var acquiredRecordIndex = 0;
         while (!reader.End && results.Count < maxRecords)
         {
             RecordBatch batch;
@@ -742,7 +743,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
                 var offset = batch.BaseOffset + record.OffsetDelta;
 
-                var deliveryCount = FindDeliveryCount(partition.AcquiredRecords, offset);
+                var deliveryCount = FindDeliveryCount(
+                    partition.AcquiredRecords,
+                    offset,
+                    ref acquiredRecordIndex);
                 if (deliveryCount < 0)
                     continue;
 
@@ -930,14 +934,21 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int FindDeliveryCount(
         IReadOnlyList<ShareFetchAcquiredRecords> acquiredRecords,
-        long offset)
+        long offset,
+        ref int acquiredRecordIndex)
     {
-        for (var i = 0; i < acquiredRecords.Count; i++)
+        while (acquiredRecordIndex < acquiredRecords.Count)
         {
-            var range = acquiredRecords[i];
+            var range = acquiredRecords[acquiredRecordIndex];
             if (offset >= range.FirstOffset && offset <= range.LastOffset)
                 return range.DeliveryCount;
+
+            if (offset < range.FirstOffset)
+                return -1;
+
+            acquiredRecordIndex++;
         }
+
         return -1;
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -144,7 +144,15 @@ public class RecordAccumulatorReadyTests
             var compressCountBeforeReady = codec.CompressCount;
 
             var readyNodes = new HashSet<int>();
-            var (_, unknownLeadersExist) = accumulator.Ready(metadataManager, readyNodes);
+            var unknownLeadersExist = false;
+            await TestWait.UntilAsync(
+                () =>
+                {
+                    readyNodes.Clear();
+                    (_, unknownLeadersExist) = accumulator.Ready(metadataManager, readyNodes);
+                    return readyNodes.Contains(1);
+                },
+                TimeSpan.FromSeconds(5));
 
             await Assert.That(codec.CompressCount).IsEqualTo(compressCountBeforeReady);
             await Assert.That(readyNodes).Contains(1);
@@ -175,7 +183,7 @@ public class RecordAccumulatorReadyTests
             var pooledKey = new PooledMemory(null, 0, isNull: true);
             var pooledValue = new PooledMemory(null, 0, isNull: true);
 
-            var fillTask = Task.Run(async () =>
+            var fillTask = Task.Run(() =>
             {
                 for (var i = 0; i < 10; i++)
                 {
@@ -183,7 +191,6 @@ public class RecordAccumulatorReadyTests
                     accumulator.TryAppendWithCompletion("test-topic", 0,
                         DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                         pooledKey, pooledValue, null, 0, completion);
-                    await Task.Yield();
                 }
             });
 

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
@@ -405,4 +405,62 @@ public class AcknowledgementTrackerTests
         await Assert.That(newerBatch.FirstOffset).IsEqualTo(100);
         await Assert.That(newerBatch.LastOffset).IsEqualTo(110);
     }
+
+    [Test]
+    public async Task TrackDeliveredRecords_OverwritesRequeuedDifferentTypeRange()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 10, 10);
+        tracker.Acknowledge(tp, 10, AcknowledgeType.Reject);
+        var flushed = tracker.Flush();
+
+        tracker.RequeueAcks(flushed);
+        tracker.TrackDeliveredRecords(tp, 10, 10);
+
+        var result = tracker.Flush();
+        await Assert.That(result).ContainsKey(tp);
+        await Assert.That(result[tp].Count).IsEqualTo(1);
+
+        var batch = result[tp][0];
+        await Assert.That(batch.FirstOffset).IsEqualTo(10);
+        await Assert.That(batch.LastOffset).IsEqualTo(10);
+        await Assert.That(batch.AcknowledgeTypes[0]).IsEqualTo((byte)AcknowledgeType.Accept);
+    }
+
+    [Test]
+    public async Task TrackDeliveredRecords_SplitsRequeuedDifferentTypeOverlap()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 10, 14);
+        for (var offset = 10; offset <= 14; offset++)
+        {
+            tracker.Acknowledge(tp, offset, AcknowledgeType.Reject);
+        }
+
+        var flushed = tracker.Flush();
+
+        tracker.RequeueAcks(flushed);
+        tracker.TrackDeliveredRecords(tp, 12, 16);
+
+        var result = tracker.Flush();
+        await Assert.That(result).ContainsKey(tp);
+        await Assert.That(result[tp].Count).IsEqualTo(1);
+
+        var batch = result[tp][0];
+        await Assert.That(batch.FirstOffset).IsEqualTo(10);
+        await Assert.That(batch.LastOffset).IsEqualTo(16);
+        for (var i = 0; i < 2; i++)
+        {
+            await Assert.That(batch.AcknowledgeTypes[i]).IsEqualTo((byte)AcknowledgeType.Reject);
+        }
+
+        for (var i = 2; i < batch.AcknowledgeTypes.Length; i++)
+        {
+            await Assert.That(batch.AcknowledgeTypes[i]).IsEqualTo((byte)AcknowledgeType.Accept);
+        }
+    }
 }

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/AcknowledgementTrackerTests.cs
@@ -342,4 +342,67 @@ public class AcknowledgementTrackerTests
         await Assert.That(batch.AcknowledgeTypes[1]).IsEqualTo((byte)AcknowledgeType.Reject);
         await Assert.That(batch.AcknowledgeTypes[2]).IsEqualTo((byte)AcknowledgeType.Accept);
     }
+
+    [Test]
+    public async Task RequeueAcks_PreservesOlderRangeWhenNewerRangeAlreadyTracked()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 50, 60);
+        var flushed = tracker.Flush();
+
+        tracker.TrackDeliveredRecords(tp, 100, 110);
+        tracker.RequeueAcks(flushed);
+
+        var result = tracker.Flush();
+        await Assert.That(result).ContainsKey(tp);
+        await Assert.That(result[tp].Count).IsEqualTo(2);
+
+        var olderBatch = result[tp][0];
+        await Assert.That(olderBatch.FirstOffset).IsEqualTo(50);
+        await Assert.That(olderBatch.LastOffset).IsEqualTo(60);
+        await Assert.That(olderBatch.AcknowledgeTypes.Length).IsEqualTo(11);
+
+        foreach (var ackType in olderBatch.AcknowledgeTypes)
+        {
+            await Assert.That(ackType).IsEqualTo((byte)AcknowledgeType.Accept);
+        }
+
+        var newerBatch = result[tp][1];
+        await Assert.That(newerBatch.FirstOffset).IsEqualTo(100);
+        await Assert.That(newerBatch.LastOffset).IsEqualTo(110);
+        await Assert.That(newerBatch.AcknowledgeTypes.Length).IsEqualTo(11);
+    }
+
+    [Test]
+    public async Task RequeueAcks_PreservesOlderRangeAndExplicitGapAck()
+    {
+        var tracker = new AcknowledgementTracker();
+        var tp = new TopicPartition("topic1", 0);
+
+        tracker.TrackDeliveredRecords(tp, 50, 60);
+        var flushed = tracker.Flush();
+
+        tracker.TrackDeliveredRecords(tp, 100, 110);
+        tracker.Acknowledge(tp, 75, AcknowledgeType.Release, requireTracked: false);
+        tracker.RequeueAcks(flushed);
+
+        var result = tracker.Flush();
+        await Assert.That(result).ContainsKey(tp);
+        await Assert.That(result[tp].Count).IsEqualTo(3);
+
+        var olderBatch = result[tp][0];
+        await Assert.That(olderBatch.FirstOffset).IsEqualTo(50);
+        await Assert.That(olderBatch.LastOffset).IsEqualTo(60);
+
+        var gapBatch = result[tp][1];
+        await Assert.That(gapBatch.FirstOffset).IsEqualTo(75);
+        await Assert.That(gapBatch.LastOffset).IsEqualTo(75);
+        await Assert.That(gapBatch.AcknowledgeTypes[0]).IsEqualTo((byte)AcknowledgeType.Release);
+
+        var newerBatch = result[tp][2];
+        await Assert.That(newerBatch.FirstOffset).IsEqualTo(100);
+        await Assert.That(newerBatch.LastOffset).IsEqualTo(110);
+    }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AcknowledgementTrackerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AcknowledgementTrackerBenchmarks.cs
@@ -1,0 +1,116 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Compares the share-consumer acknowledgement range tracker against a
+/// per-offset dictionary baseline for a contiguous poll result.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 1, iterationCount: 3)]
+public class AcknowledgementTrackerBenchmarks
+{
+    private TopicPartition _topicPartition;
+
+    [Params(100, 1_000, 10_000)]
+    public int RecordCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _topicPartition = new TopicPartition("bench-topic", 0);
+    }
+
+    [Benchmark]
+    public int RangeTracker_TrackAndFlush()
+    {
+        var tracker = new AcknowledgementTracker();
+
+        tracker.TrackDeliveredRecords(_topicPartition, 0, RecordCount - 1);
+        var result = tracker.Flush();
+
+        return result[_topicPartition][0].AcknowledgeTypes.Length;
+    }
+
+    [Benchmark(Baseline = true)]
+    public int DictionaryPerOffset_TrackAndFlush()
+    {
+        var tracker = new DictionaryAcknowledgementTracker();
+
+        tracker.TrackDeliveredRecords(_topicPartition, 0, RecordCount - 1);
+        var result = tracker.Flush();
+
+        return result[_topicPartition][0].AcknowledgeTypes.Length;
+    }
+
+    private sealed class DictionaryAcknowledgementTracker
+    {
+        private readonly Dictionary<TopicPartition, Dictionary<long, AcknowledgeType>> _pendingAcks = [];
+
+        internal void TrackDeliveredRecords(TopicPartition topicPartition, long firstOffset, long lastOffset)
+        {
+            var capacity = checked((int)(lastOffset - firstOffset + 1));
+            var partitionAcks = GetOrAddPartition(topicPartition, capacity);
+            for (var offset = firstOffset; offset <= lastOffset; offset++)
+                partitionAcks[offset] = AcknowledgeType.Accept;
+        }
+
+        internal Dictionary<TopicPartition, List<AcknowledgementBatchData>> Flush()
+        {
+            var result = new Dictionary<TopicPartition, List<AcknowledgementBatchData>>(_pendingAcks.Count);
+
+            foreach (var (topicPartition, partitionAcks) in _pendingAcks)
+                result[topicPartition] = BuildBatches(partitionAcks);
+
+            _pendingAcks.Clear();
+            return result;
+        }
+
+        private Dictionary<long, AcknowledgeType> GetOrAddPartition(TopicPartition topicPartition, int capacity)
+        {
+            if (_pendingAcks.TryGetValue(topicPartition, out var partitionAcks))
+                return partitionAcks;
+
+            partitionAcks = new Dictionary<long, AcknowledgeType>(capacity);
+            _pendingAcks[topicPartition] = partitionAcks;
+            return partitionAcks;
+        }
+
+        private static List<AcknowledgementBatchData> BuildBatches(
+            Dictionary<long, AcknowledgeType> partitionAcks)
+        {
+            if (partitionAcks.Count == 0)
+                return [];
+
+            var offsets = partitionAcks.Keys.ToArray();
+            Array.Sort(offsets);
+
+            List<AcknowledgementBatchData> batches = [];
+            var runStart = offsets[0];
+            var previousOffset = runStart;
+            List<byte> runTypes = [(byte)partitionAcks[runStart]];
+
+            for (var i = 1; i < offsets.Length; i++)
+            {
+                var offset = offsets[i];
+                if (offset == previousOffset + 1)
+                {
+                    runTypes.Add((byte)partitionAcks[offset]);
+                }
+                else
+                {
+                    batches.Add(new AcknowledgementBatchData(runStart, previousOffset, runTypes.ToArray()));
+                    runStart = offset;
+                    runTypes = [(byte)partitionAcks[offset]];
+                }
+
+                previousOffset = offset;
+            }
+
+            batches.Add(new AcknowledgementBatchData(runStart, previousOffset, runTypes.ToArray()));
+            return batches;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Store share-consumer pending acknowledgements as per-partition ranges plus sparse explicit overrides instead of one dictionary entry per delivered offset.
- Preserve failed-commit requeue semantics by skipping offsets already tracked after the flush.
- Use an acquired-record cursor while parsing ordered share fetch records instead of scanning acquired ranges for every record.

## Test plan
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter /*/*/AcknowledgementTrackerTests/*`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter /*/*/Share*/*`
- `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --framework netstandard2.0 -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release --no-build -- --treenode-filter /*/*/ShareConsumerTests/*` (7 passed, 14 skipped because local Kafka matrix entries were below required 4.2)
- `dotnet format Dekaf.sln --verify-no-changes --verbosity minimal`

Closes #1360