### PR TITLE
perf(producer): encode spans outside lock

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2740,7 +2740,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         {
                             var readyBatch = CompleteDetachedBatchAndEnqueue(pd, batchToComplete);
                             if (readyBatch is not null)
-                                PublishSealedBatch(readyBatch);
+                                StartPreSerialization(readyBatch);
                         }
 
                         return true;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -798,6 +798,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // ReadyBatch lifecycle (seal→send→response→cleanup) is longer than PartitionBatch
     // (create→fill→seal), so its pool needs proportionally more capacity.
     private const int ReadyBatchPoolSizeRatio = 2;
+    private const int DisposeAppendInProgressWaitMs = 5000;
+    private static readonly long DisposeAppendInProgressWaitTicks =
+        (long)(DisposeAppendInProgressWaitMs * (Stopwatch.Frequency / 1000.0));
 
     private readonly ProducerOptions _options;
     private readonly CompressionCodecRegistry? _compressionCodecs;
@@ -4012,22 +4015,41 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         foreach (var kvp in _partitionDeques)
         {
             var pd = kvp.Value;
-            using var guard = new SpinLockGuard(ref pd.Lock);
-
-            if (pd.CurrentBatch is { } currentBatch)
+            var spinner = new SpinWait();
+            while (true)
             {
-                pd.CurrentBatch = null;
-                MarkLingerPartitionDequeued(pd);
-                Interlocked.Decrement(ref _unsealedBatchCount);
+                var waitForAppend = false;
+                {
+                    using var guard = new SpinLockGuard(ref pd.Lock);
 
-                currentBatches ??= new List<PartitionBatch>();
-                currentBatches.Add(currentBatch);
-            }
+                    if (pd.AppendInProgress)
+                    {
+                        waitForAppend = true;
+                    }
+                    else
+                    {
+                        if (pd.CurrentBatch is { } currentBatch)
+                        {
+                            pd.CurrentBatch = null;
+                            MarkLingerPartitionDequeued(pd);
+                            Interlocked.Decrement(ref _unsealedBatchCount);
 
-            while (pd.Count > 0)
-            {
-                readyBatches ??= new List<ReadyBatch>();
-                readyBatches.Add(pd.PollFirst()!);
+                            currentBatches ??= new List<PartitionBatch>();
+                            currentBatches.Add(currentBatch);
+                        }
+
+                        while (pd.Count > 0)
+                        {
+                            readyBatches ??= new List<ReadyBatch>();
+                            readyBatches.Add(pd.PollFirst()!);
+                        }
+                    }
+                }
+
+                if (!waitForAppend)
+                    break;
+
+                spinner.SpinOnce();
             }
         }
 
@@ -4381,41 +4403,67 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         foreach (var kvp in _partitionDeques)
         {
             var pd = kvp.Value;
+            var appendWaitStartTicks = Stopwatch.GetTimestamp();
+            var spinner = new SpinWait();
+
+            while (true)
             {
-                using var guard = new SpinLockGuard(ref pd.Lock);
+                var waitForAppend = false;
+                var appendWaitTimedOut = false;
 
-                // Fail current unsealed batch
-                if (pd.CurrentBatch is { } current)
                 {
-                    var readyBatch = current.Complete();
-                    if (readyBatch is not null)
-                    {
-                        if (readyBatch.CompletionSourcesCount > 0)
-                            Interlocked.Add(ref _pendingAwaitedProduceCount, -readyBatch.CompletionSourcesCount);
+                    using var guard = new SpinLockGuard(ref pd.Lock);
 
-                        readyBatch.Fail(disposedException);
-                        if (readyBatch.TrySetMemoryReleased())
+                    if (pd.AppendInProgress)
+                    {
+                        appendWaitTimedOut = DisposeAppendInProgressWaitTimedOut(appendWaitStartTicks);
+                        waitForAppend = !appendWaitTimedOut;
+                    }
+
+                    if (!waitForAppend)
+                    {
+                        if (appendWaitTimedOut)
                         {
-                            ReleaseMemory(readyBatch.DataSize);
+                            DrainReadyBatchesForDisposeUnderLock(pd, disposedException);
+                        }
+                        else
+                        {
+                            // Fail current unsealed batch
+                            if (pd.CurrentBatch is { } current)
+                            {
+                                var readyBatch = current.Complete();
+                                if (readyBatch is not null)
+                                {
+                                    if (readyBatch.CompletionSourcesCount > 0)
+                                        Interlocked.Add(ref _pendingAwaitedProduceCount, -readyBatch.CompletionSourcesCount);
+
+                                    readyBatch.Fail(disposedException);
+                                    if (readyBatch.TrySetMemoryReleased())
+                                    {
+                                        ReleaseMemory(readyBatch.DataSize);
+                                    }
+                                }
+                                _batchPool.Return(current);
+                                pd.CurrentBatch = null;
+                                MarkLingerPartitionDequeued(pd);
+                                Interlocked.Decrement(ref _unsealedBatchCount);
+                            }
+
+                            DrainReadyBatchesForDisposeUnderLock(pd, disposedException);
                         }
                     }
-                    _batchPool.Return(current);
-                    pd.CurrentBatch = null;
-                    MarkLingerPartitionDequeued(pd);
-                    Interlocked.Decrement(ref _unsealedBatchCount);
                 }
 
-                // Drain sealed batches
-                while (pd.Count > 0)
+                if (waitForAppend)
                 {
-                    var readyBatch = pd.PollFirst()!;
-                    readyBatch.Fail(disposedException);
-                    if (readyBatch.TrySetMemoryReleased())
-                    {
-                        ReleaseMemory(readyBatch.DataSize);
-                    }
-                    OnBatchExitsPipeline(readyBatch);
+                    spinner.SpinOnce();
+                    continue;
                 }
+
+                if (appendWaitTimedOut)
+                    LogAppendInProgressDisposalTimeout(kvp.Key.Topic, kvp.Key.Partition);
+
+                break;
             }
         }
 
@@ -4445,16 +4493,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             var pd = kvp.Value;
             {
                 using var guard = new SpinLockGuard(ref pd.Lock);
-                while (pd.Count > 0)
-                {
-                    var batch = pd.PollFirst()!;
-                    batch.Fail(disposedException);
-                    if (batch.TrySetMemoryReleased())
-                    {
-                        ReleaseMemory(batch.DataSize);
-                    }
-                    OnBatchExitsPipeline(batch); // Decrement counter
-                }
+                DrainReadyBatchesForDisposeUnderLock(pd, disposedException);
             }
         }
 
@@ -4477,6 +4516,23 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         _bufferSpaceSignal.TrySetResult();
         _flushLingerLock.Dispose();
         // _flushTcs doesn't need disposal - it's a TaskCompletionSource
+    }
+
+    private static bool DisposeAppendInProgressWaitTimedOut(long startTicks)
+        => Stopwatch.GetTimestamp() - startTicks >= DisposeAppendInProgressWaitTicks;
+
+    private void DrainReadyBatchesForDisposeUnderLock(PartitionDeque pd, Exception disposedException)
+    {
+        while (pd.Count > 0)
+        {
+            var batch = pd.PollFirst()!;
+            batch.Fail(disposedException);
+            if (batch.TrySetMemoryReleased())
+            {
+                ReleaseMemory(batch.DataSize);
+            }
+            OnBatchExitsPipeline(batch);
+        }
     }
 
     #region Logging
@@ -4519,6 +4575,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Non-fatal exception during batch cleanup step (suppressed)")]
     private partial void LogBatchCleanupStepFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Timed out waiting for in-progress append during accumulator disposal for {Topic}-{Partition}; skipping current batch cleanup")]
+    private partial void LogAppendInProgressDisposalTimeout(string topic, int partition);
 
     #endregion
 }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1061,6 +1061,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         /// </summary>
         public bool RotationInProgress;
 
+        /// <summary>
+        /// True while a thread has reserved space in CurrentBatch and is encoding record bytes outside Lock.
+        /// Appenders and linger sealing wait until the reserved record metadata is committed.
+        /// </summary>
+        public bool AppendInProgress;
+
         /// <summary>Number of batches in the deque.</summary>
         public int Count => _count;
 
@@ -2188,7 +2194,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         }
                         disposed = true;
                     }
-                    else if (pd.RotationInProgress && !ownsRotation)
+                    else if ((pd.RotationInProgress && !ownsRotation) || pd.AppendInProgress)
                     {
                         waitForRotation = true;
                     }
@@ -2531,6 +2537,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             }
         }
 
+        void ClearAppendAndRotationInProgressUnderLock()
+        {
+            ClearAppendInProgressUnderLock(pd);
+            if (ownsRotation)
+            {
+                ClearRotationInProgressUnderLock(pd);
+                ownsRotation = false;
+            }
+        }
+
         try
         {
             while (true)
@@ -2539,13 +2555,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 PartitionBatch? batchToReturn = null;
                 ReadyBatch? batchToPublish = null;
                 ReadyBatch? batchToFail = null;
+                PartitionBatch? reservedAppendBatch = null;
+                PartitionBatch.ReservedRecordAppend reservedAppend = default;
                 var waitForRotation = false;
                 var needBatch = false;
-                var appendSucceeded = false;
+                var appendReserved = false;
+                var reservedAppendStartedNewBatch = false;
                 var disposed = false;
                 var messageTooLarge = false;
-                var memoryToReleaseAfterLock = 0;
-                var actualBytesAdded = 0;
+                var reservedOverestimatedBytesToRelease = 0;
+                var reservedActualBytesAdded = 0;
 
                 {
                     using var guard = new SpinLockGuard(ref pd.Lock);
@@ -2563,7 +2582,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         }
                         disposed = true;
                     }
-                    else if (pd.RotationInProgress && !ownsRotation)
+                    else if ((pd.RotationInProgress && !ownsRotation) || pd.AppendInProgress)
                     {
                         waitForRotation = true;
                     }
@@ -2578,27 +2597,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
                         if (pd.CurrentBatch is { } currentBatch)
                         {
-                            if (TryAppendFromSpansToBatch(currentBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                                headers, headerCount, completionSource, callback, recordSize, out var overestimatedBytesToRelease,
-                                out var appendedBytes))
+                            if (TryReserveAppendFromSpansToBatch(currentBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
+                                headers, headerCount, completionSource, callback, recordSize, out reservedAppend,
+                                out var overestimatedBytesToRelease, out var actualBytesAdded))
                             {
-                                memoryToReleaseAfterLock = overestimatedBytesToRelease;
-                                actualBytesAdded = appendedBytes;
-                                ownsReservation = false;
-                                ownsHeaderResources = false;
-                                ownsPendingCount = false;
-                                if (ShouldSealAppendedBatch(currentBatch))
-                                {
-                                    batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
-                                    ownsRotation = true;
-                                }
-                                else if (completionSource is not null)
-                                {
-                                    QueueLingerPartition(pd, topicPartition);
-                                }
+                                pd.AppendInProgress = true;
+                                reservedAppendBatch = currentBatch;
+                                reservedOverestimatedBytesToRelease = overestimatedBytesToRelease;
+                                reservedActualBytesAdded = actualBytesAdded;
                                 batchToReturn = rentedBatch;
                                 rentedBatch = null;
-                                appendSucceeded = true;
+                                appendReserved = true;
                             }
                             else
                             {
@@ -2618,27 +2627,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             pd.CurrentBatch = newBatch;
                             Interlocked.Increment(ref _unsealedBatchCount);
 
-                            if (TryAppendFromSpansToBatch(newBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
-                                headers, headerCount, completionSource, callback, recordSize, out var overestimatedBytesToRelease,
-                                out var appendedBytes))
+                            if (TryReserveAppendFromSpansToBatch(newBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
+                                headers, headerCount, completionSource, callback, recordSize, out reservedAppend,
+                                out var overestimatedBytesToRelease, out var actualBytesAdded))
                             {
-                                memoryToReleaseAfterLock = overestimatedBytesToRelease;
-                                actualBytesAdded = appendedBytes;
-                                ownsReservation = false;
-                                ownsHeaderResources = false;
-                                ownsPendingCount = false;
-                                if (ShouldSealAppendedBatch(newBatch))
-                                {
-                                    batchToComplete = DetachCurrentBatchForSealUnderLock(pd, newBatch);
-                                    ownsRotation = true;
-                                }
-                                else
-                                {
-                                    TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
-                                    ClearRotationInProgressUnderLock(pd);
-                                    ownsRotation = false;
-                                }
-                                appendSucceeded = true;
+                                pd.AppendInProgress = true;
+                                reservedAppendBatch = newBatch;
+                                reservedAppendStartedNewBatch = true;
+                                reservedOverestimatedBytesToRelease = overestimatedBytesToRelease;
+                                appendReserved = true;
+                                reservedActualBytesAdded = actualBytesAdded;
                             }
                             else
                             {
@@ -2668,8 +2666,94 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         ReleaseMemory(batchToFail.DataSize);
                 }
 
-                if (memoryToReleaseAfterLock > 0)
-                    ReleaseMemory(memoryToReleaseAfterLock);
+                if (appendReserved)
+                {
+                    var committedReservedAppend = false;
+
+                    try
+                    {
+                        PartitionBatch.EncodeReservedAppendFromSpans(
+                            reservedAppend,
+                            keyData,
+                            keyIsNull,
+                            valueData,
+                            valueIsNull,
+                            headers,
+                            headerCount);
+
+                        var disposedAfterReserve = false;
+                        {
+                            using var guard = new SpinLockGuard(ref pd.Lock);
+
+                            if (Volatile.Read(ref _disposed) != 0)
+                            {
+                                PartitionBatch.CancelReservedAppend(reservedAppend);
+                                ClearAppendAndRotationInProgressUnderLock();
+                                disposedAfterReserve = true;
+                            }
+                            else
+                            {
+                                reservedAppendBatch!.CommitReservedAppendFromSpans(
+                                    reservedAppend,
+                                    completionSource,
+                                    callback,
+                                    headers);
+                                committedReservedAppend = true;
+                                ProducerDebugCounters.RecordMessageAppended(hasCompletionSource: completionSource is not null);
+                                ClearAppendInProgressUnderLock(pd);
+                                ownsReservation = false;
+                                ownsHeaderResources = false;
+                                ownsPendingCount = false;
+
+                                if (ShouldSealAppendedBatch(reservedAppendBatch))
+                                {
+                                    batchToComplete = DetachCurrentBatchForSealUnderLock(pd, reservedAppendBatch);
+                                    ownsRotation = true;
+                                }
+                                else if (reservedAppendStartedNewBatch)
+                                {
+                                    TrackCurrentBatchForLinger(pd, topicPartition, reservedAppendBatch);
+                                    ClearRotationInProgressUnderLock(pd);
+                                    ownsRotation = false;
+                                }
+                                else if (completionSource is not null)
+                                {
+                                    QueueLingerPartition(pd, topicPartition);
+                                }
+                            }
+                        }
+
+                        if (disposedAfterReserve)
+                        {
+                            ReleaseOwnedAppendState();
+                            return false;
+                        }
+
+                        if (reservedOverestimatedBytesToRelease > 0)
+                            ReleaseMemory(reservedOverestimatedBytesToRelease);
+
+                        NotifyRecordAppended(topic, partition, reservedActualBytesAdded, partitionCount);
+                        if (batchToComplete is not null)
+                        {
+                            var readyBatch = CompleteDetachedBatchAndEnqueue(pd, batchToComplete);
+                            if (readyBatch is not null)
+                                PublishSealedBatch(readyBatch);
+                        }
+
+                        return true;
+                    }
+                    catch
+                    {
+                        if (!committedReservedAppend)
+                        {
+                            using var guard = new SpinLockGuard(ref pd.Lock);
+                            PartitionBatch.CancelReservedAppend(reservedAppend);
+                            ClearAppendAndRotationInProgressUnderLock();
+                        }
+
+                        throw;
+                    }
+                }
 
                 if (disposed)
                 {
@@ -2682,19 +2766,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     ReleaseOwnedAppendState();
                     throw new KafkaException(ErrorCode.MessageTooLarge,
                         $"Record of size {recordSize} exceeds maximum batch size of {_options.BatchSize}");
-                }
-
-                if (appendSucceeded)
-                {
-                    NotifyRecordAppended(topic, partition, actualBytesAdded, partitionCount);
-                    if (batchToComplete is not null)
-                    {
-                        var readyBatch = CompleteDetachedBatchAndEnqueue(pd, batchToComplete);
-                        if (readyBatch is not null)
-                            PublishSealedBatch(readyBatch);
-                    }
-
-                    return true;
                 }
 
                 if (waitForRotation)
@@ -2864,10 +2935,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Helper: tries to append a record from span data to the given batch using arena zero-copy.
+    /// Helper: reserves space for a span-backed record using arena zero-copy.
     /// Called under the deque lock.
     /// </summary>
-    private static bool TryAppendFromSpansToBatch(
+    private static bool TryReserveAppendFromSpansToBatch(
         PartitionBatch batch,
         long timestamp,
         ReadOnlySpan<byte> keyData,
@@ -2879,17 +2950,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
         int estimatedSize,
+        out PartitionBatch.ReservedRecordAppend reservedAppend,
         out int overestimatedBytesToRelease,
         out int actualBytesAdded)
     {
         overestimatedBytesToRelease = 0;
         actualBytesAdded = 0;
-        var result = batch.TryAppendFromSpans(timestamp, keyData, keyIsNull, valueData, valueIsNull,
-            headers, headerCount, completionSource, callback);
+        var result = batch.TryReserveAppendFromSpans(timestamp, keyData, keyIsNull, valueData, valueIsNull,
+            headers, headerCount, completionSource, callback, out reservedAppend);
 
         if (result.Success)
         {
-            ProducerDebugCounters.RecordMessageAppended(hasCompletionSource: completionSource is not null);
             overestimatedBytesToRelease = Math.Max(0, estimatedSize - result.ActualSizeAdded);
             actualBytesAdded = result.ActualSizeAdded;
             return true;
@@ -2999,6 +3070,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         using var guard = new SpinLockGuard(ref pd.Lock);
         ClearRotationInProgressUnderLock(pd);
+    }
+
+    private static void ClearAppendInProgressUnderLock(PartitionDeque pd)
+    {
+        pd.AppendInProgress = false;
     }
 
     /// <summary>
@@ -3582,7 +3658,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             {
                 using var guard = new SpinLockGuard(ref pd.Lock);
 
-                if (pd.RotationInProgress)
+                if (pd.RotationInProgress || pd.AppendInProgress)
                 {
                     waitForRotation = true;
                 }
@@ -4698,6 +4774,16 @@ internal sealed class PartitionBatch
     public int RecordCount => _recordCount;
     public int EstimatedSize => _estimatedSize;
 
+    internal readonly record struct ReservedRecordAppend(
+        BatchArena Arena,
+        int RecordIndex,
+        long Timestamp,
+        long BaseTimestamp,
+        long TimestampDelta,
+        int BodySize,
+        int EncodedRecordSize,
+        int EncodedOffset);
+
     /// <summary>
     /// Returns the batch creation timestamp from Stopwatch for efficient age comparisons.
     /// Used by ExpireLingerAsync to track the oldest batch without enumeration.
@@ -4756,28 +4842,69 @@ internal sealed class PartitionBatch
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback)
     {
-        var keyLength = keyIsNull ? 0 : keyData.Length;
-        var valueLength = valueIsNull ? 0 : valueData.Length;
-
-        var result = TryAppendEncoded(
+        var result = TryReserveAppendFromSpans(
             timestamp,
             keyData,
             keyIsNull,
-            keyLength,
             valueData,
+            valueIsNull,
+            headers,
+            headerCount,
+            completionSource,
+            callback,
+            out var reservedAppend);
+
+        if (result.Success)
+        {
+            try
+            {
+                EncodeReservedAppendFromSpans(
+                    reservedAppend,
+                    keyData,
+                    keyIsNull,
+                    valueData,
+                    valueIsNull,
+                    headers,
+                    headerCount);
+            }
+            catch
+            {
+                CancelReservedAppend(reservedAppend);
+                throw;
+            }
+
+            CommitReservedAppendFromSpans(reservedAppend, completionSource, callback, headers);
+        }
+
+        return result;
+    }
+
+    internal RecordAppendResult TryReserveAppendFromSpans(
+        long timestamp,
+        ReadOnlySpan<byte> keyData,
+        bool keyIsNull,
+        ReadOnlySpan<byte> valueData,
+        bool valueIsNull,
+        Header[]? headers,
+        int headerCount,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
+        Action<RecordMetadata, Exception?>? callback,
+        out ReservedRecordAppend reservedAppend)
+    {
+        var keyLength = keyIsNull ? 0 : keyData.Length;
+        var valueLength = valueIsNull ? 0 : valueData.Length;
+
+        return TryReserveAppend(
+            timestamp,
+            keyIsNull,
+            keyLength,
             valueIsNull,
             valueLength,
             headers,
             headerCount,
-            completionSource,
-            callback);
-
-        if (result.Success)
-        {
-            RecordAccumulator.ReturnPooledHeaders(headers);
-        }
-
-        return result;
+            completionSource is not null,
+            callback is not null,
+            out reservedAppend);
     }
 
     private RecordAppendResult TryAppendEncoded(
@@ -4793,15 +4920,65 @@ internal sealed class PartitionBatch
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback)
     {
+        var result = TryReserveAppend(
+            timestamp,
+            keyIsNull,
+            keyLength,
+            valueIsNull,
+            valueLength,
+            headers,
+            headerCount,
+            completionSource is not null,
+            callback is not null,
+            out var reservedAppend);
+
+        if (!result.Success)
+            return result;
+
+        try
+        {
+            EncodeReservedAppend(
+                reservedAppend,
+                keyData,
+                keyIsNull,
+                valueData,
+                valueIsNull,
+                headers,
+                headerCount);
+        }
+        catch
+        {
+            CancelReservedAppend(reservedAppend);
+            throw;
+        }
+
+        CommitReservedAppend(reservedAppend, completionSource, callback);
+        return result;
+    }
+
+    private RecordAppendResult TryReserveAppend(
+        long timestamp,
+        bool keyIsNull,
+        int keyLength,
+        bool valueIsNull,
+        int valueLength,
+        Header[]? headers,
+        int headerCount,
+        bool hasCompletionSource,
+        bool hasCallback,
+        out ReservedRecordAppend reservedAppend)
+    {
         // Check if batch was completed
         if (Volatile.Read(ref _isCompleted) != 0)
         {
+            reservedAppend = default;
             return new RecordAppendResult(false);
         }
 
         // Defensive check: if the array is null, batch is in inconsistent state (being pooled)
         if (_completionSources is null)
         {
+            reservedAppend = default;
             return new RecordAppendResult(false);
         }
 
@@ -4824,6 +5001,7 @@ internal sealed class PartitionBatch
         var maxRecordsSize = Math.Max(0, _options.BatchSize - RecordBatch.TotalBatchHeaderSize);
         if ((long)_estimatedSize + encodedRecordSize > maxRecordsSize && recordIndex > 0)
         {
+            reservedAppend = default;
             return new RecordAppendResult(false);
         }
 
@@ -4833,11 +5011,11 @@ internal sealed class PartitionBatch
         }
 
         // Grow arrays if needed (rare - only happens if batch fills beyond initial capacity)
-        if (completionSource is not null && _completionSourceCount >= _completionSources.Length)
+        if (hasCompletionSource && _completionSourceCount >= _completionSources.Length)
         {
             GrowArray(ref _completionSources, ref _completionSourceCount, ProducerContainerPools.CompletionSources);
         }
-        if (callback is not null)
+        if (hasCallback)
         {
             _callbacks ??= ProducerContainerPools.Callbacks.Rent(_initialRecordCapacity);
             if (_callbackCount >= _callbacks.Length)
@@ -4846,40 +5024,89 @@ internal sealed class PartitionBatch
             }
         }
 
-        if (_arena is null || !_arena.TryAllocate(encodedRecordSize, out var encodedRecord, out var encodedOffset))
+        if (_arena is null || !_arena.TryAllocate(encodedRecordSize, out _, out var encodedOffset))
         {
+            reservedAppend = default;
             return new RecordAppendResult(false);
         }
 
-        try
-        {
-            Record.Encode(
-                encodedRecord,
-                bodySize,
-                timestampDelta,
-                recordIndex,
-                keyData,
-                keyIsNull,
-                valueData,
-                valueIsNull,
-                headers,
-                headerCount);
-        }
-        catch
-        {
-            _arena.TryRewindLastAllocation(encodedOffset, encodedRecordSize);
-            throw;
-        }
+        reservedAppend = new ReservedRecordAppend(
+            _arena,
+            recordIndex,
+            timestamp,
+            baseTimestamp,
+            timestampDelta,
+            bodySize,
+            encodedRecordSize,
+            encodedOffset);
+
+        return new RecordAppendResult(Success: true, ActualSizeAdded: encodedRecordSize);
+    }
+
+    internal static void EncodeReservedAppendFromSpans(
+        in ReservedRecordAppend reservedAppend,
+        ReadOnlySpan<byte> keyData,
+        bool keyIsNull,
+        ReadOnlySpan<byte> valueData,
+        bool valueIsNull,
+        Header[]? headers,
+        int headerCount)
+    {
+        EncodeReservedAppend(reservedAppend, keyData, keyIsNull, valueData, valueIsNull, headers, headerCount);
+    }
+
+    private static void EncodeReservedAppend(
+        in ReservedRecordAppend reservedAppend,
+        ReadOnlySpan<byte> keyData,
+        bool keyIsNull,
+        ReadOnlySpan<byte> valueData,
+        bool valueIsNull,
+        Header[]? headers,
+        int headerCount)
+    {
+        var encodedRecord = reservedAppend.Arena.Buffer.AsSpan(
+            reservedAppend.EncodedOffset,
+            reservedAppend.EncodedRecordSize);
+
+        Record.Encode(
+            encodedRecord,
+            reservedAppend.BodySize,
+            reservedAppend.TimestampDelta,
+            reservedAppend.RecordIndex,
+            keyData,
+            keyIsNull,
+            valueData,
+            valueIsNull,
+            headers,
+            headerCount);
+    }
+
+    internal void CommitReservedAppendFromSpans(
+        in ReservedRecordAppend reservedAppend,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
+        Action<RecordMetadata, Exception?>? callback,
+        Header[]? headers)
+    {
+        CommitReservedAppend(reservedAppend, completionSource, callback);
+        RecordAccumulator.ReturnPooledHeaders(headers);
+    }
+
+    private void CommitReservedAppend(
+        in ReservedRecordAppend reservedAppend,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
+        Action<RecordMetadata, Exception?>? callback)
+    {
+        var recordIndex = reservedAppend.RecordIndex;
 
         if (recordIndex == 0)
         {
-            _baseTimestamp = baseTimestamp;
-            _encodedRecordsStart = encodedOffset;
+            _baseTimestamp = reservedAppend.BaseTimestamp;
+            _encodedRecordsStart = reservedAppend.EncodedOffset;
         }
 
-        Debug.Assert(encodedOffset == _encodedRecordsStart + _encodedRecordsLength);
-        _encodedRecordsLength += encodedRecordSize;
-        _maxTimestamp = recordIndex == 0 ? timestamp : Math.Max(_maxTimestamp, timestamp);
+        Debug.Assert(reservedAppend.EncodedOffset == _encodedRecordsStart + _encodedRecordsLength);
+        _encodedRecordsLength += reservedAppend.EncodedRecordSize;
+        _maxTimestamp = recordIndex == 0 ? reservedAppend.Timestamp : Math.Max(_maxTimestamp, reservedAppend.Timestamp);
 
         if (completionSource is not null)
         {
@@ -4893,9 +5120,12 @@ internal sealed class PartitionBatch
         }
 
         _recordCount = recordIndex + 1;
-        _estimatedSize += encodedRecordSize;
+        _estimatedSize += reservedAppend.EncodedRecordSize;
+    }
 
-        return new RecordAppendResult(Success: true, ActualSizeAdded: encodedRecordSize);
+    internal static void CancelReservedAppend(in ReservedRecordAppend reservedAppend)
+    {
+        reservedAppend.Arena.TryRewindLastAllocation(reservedAppend.EncodedOffset, reservedAppend.EncodedRecordSize);
     }
 
     private void EnsureArenaCanFitFirstRecord(int encodedRecordSize)

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2325,7 +2325,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     {
                         var readyBatch = CompleteDetachedBatchAndEnqueue(pd, batchToComplete);
                         if (readyBatch is not null)
-                            PublishSealedBatch(readyBatch);
+                            StartPreSerialization(readyBatch);
                     }
 
                     return true;

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -304,6 +304,49 @@ public class RecordAccumulatorReadyTests
     }
 
     [Test]
+    public async Task Ready_LingerMs0_CompressedAwaitedAppend_StartsPreSerialization()
+    {
+        var options = CreateTestOptions(batchSize: 100_000, lingerMs: 0, compressionType: CompressionType.Gzip);
+        var codec = new CountingCompressionCodec(CompressionType.Gzip);
+        var compressionCodecs = new CompressionCodecRegistry();
+        compressionCodecs.Register(codec);
+
+        var accumulator = new RecordAccumulator(options, compressionCodecs);
+        var metadataManager = CreateMetadataManager("test-topic", 1, nodeId: 1);
+        ReadyBatch? batch = null;
+
+        try
+        {
+            var appended = await accumulator.AppendAsync(
+                "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null,
+                PooledMemory.Null,
+                headers: null,
+                headerCount: 0,
+                completionSource: null,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 1);
+
+            await Assert.That(appended).IsTrue();
+
+            batch = await DrainSingleReadyBatchAsync(accumulator, metadataManager);
+
+            await Assert.That(batch.IsPreSerialized).IsTrue();
+            await Assert.That(batch.RecordBatch.HasPreCompressedRecords).IsTrue();
+            await Assert.That(codec.CompressCount).IsEqualTo(1);
+        }
+        finally
+        {
+            CompleteAndReturnIfDrained(accumulator, batch);
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task Ready_LingerMs0_FireAndForgetSpanAppend_SealsInline()
     {
         var options = CreateTestOptions(batchSize: 100_000, lingerMs: 0);
@@ -336,6 +379,50 @@ public class RecordAccumulatorReadyTests
         }
         finally
         {
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Ready_LingerMs0_CompressedSpanAppend_StartsPreSerialization()
+    {
+        var options = CreateTestOptions(batchSize: 100_000, lingerMs: 0, compressionType: CompressionType.Gzip);
+        var codec = new CountingCompressionCodec(CompressionType.Gzip);
+        var compressionCodecs = new CompressionCodecRegistry();
+        compressionCodecs.Register(codec);
+
+        var accumulator = new RecordAccumulator(options, compressionCodecs);
+        var metadataManager = CreateMetadataManager("test-topic", 1, nodeId: 1);
+        ReadyBatch? batch = null;
+
+        try
+        {
+            var appended = await accumulator.AppendFromSpansAsync(
+                "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                "value"u8,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 1);
+
+            await Assert.That(appended).IsTrue();
+
+            batch = await DrainSingleReadyBatchAsync(accumulator, metadataManager);
+
+            await Assert.That(batch.IsPreSerialized).IsTrue();
+            await Assert.That(batch.RecordBatch.HasPreCompressedRecords).IsTrue();
+            await Assert.That(codec.CompressCount).IsEqualTo(1);
+        }
+        finally
+        {
+            CompleteAndReturnIfDrained(accumulator, batch);
             await accumulator.DisposeAsync();
             await metadataManager.DisposeAsync();
         }
@@ -1177,6 +1264,36 @@ public class RecordAccumulatorReadyTests
             await pool.DisposeAsync();
             await metadataManager.DisposeAsync();
         }
+    }
+
+    private static async Task<ReadyBatch> DrainSingleReadyBatchAsync(
+        RecordAccumulator accumulator,
+        MetadataManager metadataManager)
+    {
+        var readyNodes = new HashSet<int>();
+        await TestWait.UntilAsync(
+            () =>
+            {
+                readyNodes.Clear();
+                accumulator.Ready(metadataManager, readyNodes);
+                return readyNodes.Contains(1);
+            },
+            TimeSpan.FromSeconds(5));
+
+        var drainResult = new Dictionary<int, List<ReadyBatch>>();
+        var batchListPool = new Stack<List<ReadyBatch>>();
+        accumulator.Drain(metadataManager, readyNodes, int.MaxValue, drainResult, batchListPool);
+
+        return drainResult[1][0];
+    }
+
+    private static void CompleteAndReturnIfDrained(RecordAccumulator accumulator, ReadyBatch? batch)
+    {
+        if (batch is null)
+            return;
+
+        batch.CompleteSend(0, DateTimeOffset.UtcNow);
+        accumulator.ReturnReadyBatch(batch);
     }
 
     private sealed class CountingCompressionCodec(CompressionType type) : ICompressionCodec

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -214,6 +214,99 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task Purge_Queue_WaitsForInProgressSpanAppendBeforeReturningCurrentBatch()
+    {
+        var options = CreateTestOptions();
+        var accumulator = new RecordAccumulator(options);
+        var topicPartition = new TopicPartition("test-topic", 0);
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var headerValue = new BlockingReadOnlyMemoryManager(new byte[] { 1, 2, 3, 4 });
+        var headers = ProducerContainerPools.Headers.Rent(1);
+        headers[0] = new Header("blocked", headerValue.ReadOnlyMemory);
+        var appendTask = Task.Run(async () =>
+            await accumulator.AppendFromSpansAsync(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                timestamp,
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                "value"u8,
+                valueIsNull: false,
+                headers,
+                headerCount: 1,
+                callback: null,
+                CancellationToken.None));
+
+        try
+        {
+            await headerValue.WaitUntilEnteredAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+            var purgeTask = Task.Run(() => accumulator.Purge(PurgeOptions.Queue, CreatePurgedException()));
+            await Task.Delay(100);
+            await Assert.That(purgeTask.IsCompleted).IsFalse();
+
+            headerValue.Release();
+
+            await Assert.That(await appendTask.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(await purgeTask.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(1);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            headerValue.Release();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task DisposeAsync_WaitsForInProgressSpanAppendBeforeReturningCurrentBatch()
+    {
+        var options = CreateTestOptions();
+        var accumulator = new RecordAccumulator(options);
+        var topicPartition = new TopicPartition("test-topic", 0);
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var headerValue = new BlockingReadOnlyMemoryManager(new byte[] { 1, 2, 3, 4 });
+        var headers = ProducerContainerPools.Headers.Rent(1);
+        headers[0] = new Header("blocked", headerValue.ReadOnlyMemory);
+        var disposed = false;
+        var appendTask = Task.Run(async () =>
+            await accumulator.AppendFromSpansAsync(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                timestamp,
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                "value"u8,
+                valueIsNull: false,
+                headers,
+                headerCount: 1,
+                callback: null,
+                CancellationToken.None));
+
+        try
+        {
+            await headerValue.WaitUntilEnteredAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+            var disposeTask = Task.Run(async () => await accumulator.DisposeAsync());
+            await Task.Delay(100);
+            await Assert.That(disposeTask.IsCompleted).IsFalse();
+
+            headerValue.Release();
+
+            await Assert.That(await appendTask.WaitAsync(TimeSpan.FromSeconds(5))).IsFalse();
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+            disposed = true;
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            headerValue.Release();
+            if (!disposed)
+                await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task Purge_Queue_FailsSealedQueuedBatch()
     {
         var options = new ProducerOptions
@@ -2955,6 +3048,38 @@ public class RecordAccumulatorTests
                 throw new InvalidOperationException("Record encode touched header value while holding the partition lock.");
 
             GetSpanCalls++;
+            return buffer;
+        }
+
+        public override MemoryHandle Pin(int elementIndex = 0) =>
+            throw new NotSupportedException();
+
+        public override void Unpin()
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+        }
+    }
+
+    private sealed class BlockingReadOnlyMemoryManager(byte[] buffer) : MemoryManager<byte>
+    {
+        private readonly TaskCompletionSource _entered =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ReadOnlyMemory<byte> ReadOnlyMemory => CreateMemory(buffer.Length);
+
+        public Task WaitUntilEnteredAsync() => _entered.Task;
+
+        public void Release() => _release.TrySetResult();
+
+        public override Span<byte> GetSpan()
+        {
+            _entered.TrySetResult();
+            _release.Task.GetAwaiter().GetResult();
             return buffer;
         }
 

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks.Sources;
@@ -242,7 +243,9 @@ public class RecordAccumulatorTests
             await headerValue.WaitUntilEnteredAsync().WaitAsync(TimeSpan.FromSeconds(5));
 
             var purgeTask = Task.Run(() => accumulator.Purge(PurgeOptions.Queue, CreatePurgedException()));
-            await Task.Delay(100);
+            await WaitUntilAsync(
+                () => purgeTask.Status == TaskStatus.Running || purgeTask.IsCompleted,
+                TimeSpan.FromSeconds(5));
             await Assert.That(purgeTask.IsCompleted).IsFalse();
 
             headerValue.Release();
@@ -288,7 +291,9 @@ public class RecordAccumulatorTests
             await headerValue.WaitUntilEnteredAsync().WaitAsync(TimeSpan.FromSeconds(5));
 
             var disposeTask = Task.Run(async () => await accumulator.DisposeAsync());
-            await Task.Delay(100);
+            await WaitUntilAsync(
+                () => GetPrivateField<int>(accumulator, "_disposed") != 0 || disposeTask.IsCompleted,
+                TimeSpan.FromSeconds(5));
             await Assert.That(disposeTask.IsCompleted).IsFalse();
 
             headerValue.Release();
@@ -3029,6 +3034,18 @@ public class RecordAccumulatorTests
     {
         var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
         return (T)field!.GetValue(instance)!;
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (stopwatch.Elapsed >= timeout)
+                throw new TimeoutException("Condition was not met before timeout.");
+
+            await Task.Yield();
+        }
     }
 
     private sealed class LockAssertingReadOnlyMemoryManager(

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -508,6 +508,77 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task AppendFromSpansAsync_HeaderValueEncode_RunsOutsidePartitionLock()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 1000,
+            LingerMs = 10_000
+        };
+
+        await using var accumulator = new RecordAccumulator(options);
+        var topicPartition = new TopicPartition("test-topic", 0);
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        var seedAppended = await accumulator.AppendFromSpansAsync(
+            topicPartition.Topic,
+            topicPartition.Partition,
+            timestamp,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            "seed"u8,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(seedAppended).IsTrue();
+
+        EnableThreadOwnerTrackingForPartitionLock(accumulator, topicPartition);
+        var headerValue = new LockAssertingReadOnlyMemoryManager(
+            GetPartitionDeque(accumulator, topicPartition),
+            new byte[] { 1, 2, 3, 4 });
+
+        var headers = ProducerContainerPools.Headers.Rent(1);
+        headers[0] = new Header("lock-check", headerValue.ReadOnlyMemory);
+
+        var appended = await accumulator.AppendFromSpansAsync(
+            topicPartition.Topic,
+            topicPartition.Partition,
+            timestamp + 1,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            "value"u8,
+            valueIsNull: false,
+            headers,
+            headerCount: 1,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(appended).IsTrue();
+        await Assert.That(headerValue.GetSpanCalls).IsGreaterThan(0);
+
+        var readyBatch = CompleteCurrentBatch(accumulator, topicPartition);
+        var writer = new ArrayBufferWriter<byte>();
+        readyBatch.RecordBatch.Write(writer);
+        var reader = new KafkaProtocolReader(writer.WrittenMemory);
+        using var parsed = RecordBatch.Read(ref reader);
+
+        var record = parsed.Records[1];
+        var recordHeaders = record.Headers!;
+        await Assert.That(recordHeaders[0].Key).IsEqualTo("lock-check");
+        await Assert.That(recordHeaders[0].Value.ToArray()).IsEquivalentTo(new byte[] { 1, 2, 3, 4 });
+
+        readyBatch.CompleteSend(baseOffset: 0, DateTimeOffset.FromUnixTimeMilliseconds(timestamp));
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_FirstRecordLargerThanBatchSize_UsesExpandedArena()
     {
         const int batchSize = 128;
@@ -2865,6 +2936,38 @@ public class RecordAccumulatorTests
     {
         var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
         return (T)field!.GetValue(instance)!;
+    }
+
+    private sealed class LockAssertingReadOnlyMemoryManager(
+        object partitionDeque,
+        byte[] buffer) : MemoryManager<byte>
+    {
+        private readonly FieldInfo _lockField = partitionDeque.GetType().GetField("Lock")!;
+
+        public int GetSpanCalls { get; private set; }
+
+        public ReadOnlyMemory<byte> ReadOnlyMemory => CreateMemory(buffer.Length);
+
+        public override Span<byte> GetSpan()
+        {
+            var partitionLock = (SpinLock)_lockField.GetValue(partitionDeque)!;
+            if (partitionLock.IsHeldByCurrentThread)
+                throw new InvalidOperationException("Record encode touched header value while holding the partition lock.");
+
+            GetSpanCalls++;
+            return buffer;
+        }
+
+        public override MemoryHandle Pin(int elementIndex = 0) =>
+            throw new NotSupportedException();
+
+        public override void Unpin()
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+        }
     }
 
     private sealed class ThrowingReadOnlyMemoryManager(int length) : MemoryManager<byte>


### PR DESCRIPTION
## Summary
- reserve span-backed record arena space under the partition SpinLock, then encode key/value/header bytes after releasing it
- add an append-in-progress gate so other appenders and linger sealing wait until reserved record metadata is committed
- cover header value encoding with an owner-tracked partition lock regression test

## Tests
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --filter-uid "Dekaf.Tests.Unit.Producer.RecordAccumulatorTests.1.1.AppendFromSpansAsync_HeaderValueEncode_RunsOutsidePartitionLock.1.1.0" "Dekaf.Tests.Unit.Producer.RecordAccumulatorTests.1.1.AppendFromSpansAsync_SealedBatch_UsesPreEncodedArenaRecords.1.1.0" "Dekaf.Tests.Unit.Producer.RecordAccumulatorTests.1.1.PartitionBatch_TryAppendFromSpans_WhenHeaderEncodingThrows_RewindsArenaAllocation.1.1.0" "Dekaf.Tests.Unit.Producer.RecordAccumulatorTests.1.1.AppendFromSpansAsync_HotPathRefund_DrainsPendingAppendAfterPartitionLockReleased.1.1.0" --no-ansi --maximum-parallel-tests 1 --timeout 2m

Closes #1367