### PR TITLE
perf(producer): seal zero-linger appends inline

### DIFF
--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -34,7 +34,7 @@ namespace Dekaf.Producer;
 internal sealed class PendingAppend : IValueTaskSource<bool>
 {
     private ManualResetValueTaskSourceCore<bool> _core;
-    private int _completed; // 0 = pending, 1 = completed (CAS guard)
+    private int _completed = 1; // 0 = pending, 1 = completed or idle (CAS guard)
 
     // Append parameters — stored on Initialize, consumed by drain
     private string _topic = null!;
@@ -54,6 +54,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     private CancellationTokenRegistration _cancellationRegistration;
     private CancellationToken _cancellationToken;
     private long _startTicks;
+    private long _deadlineTickCount;
     private RecordAccumulator _accumulator = null!;
 
     // Pool return
@@ -127,9 +128,11 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _callback = callback;
         _recordSize = recordSize;
         _startTicks = startTicks;
+        _deadlineTickCount = deadlineTickCount;
         _cancellationToken = cancellationToken;
         _accumulator = accumulator;
         _pool = pool;
+        Volatile.Write(ref _completed, 0);
 
         // Arm timeout timer. Compute remaining ms from deadline.
         var remainingMs = deadlineTickCount - Dekaf.MonotonicClock.GetMilliseconds();
@@ -219,15 +222,31 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
 
     private void OnTimeout()
     {
-        var configured = TimeSpan.FromMilliseconds(_accumulator.MaxBlockMsOption);
-        var elapsed = TimeSpan.FromMilliseconds(Dekaf.MonotonicClock.GetMilliseconds() - _startTicks);
+        // Timer.Change(Infinite) can leave an already-queued callback from a previous rental.
+        if (Volatile.Read(ref _completed) != 0)
+            return;
+
+        var now = Dekaf.MonotonicClock.GetMilliseconds();
+        var deadlineTickCount = Volatile.Read(ref _deadlineTickCount);
+        if (now < deadlineTickCount)
+        {
+            _timer.Change(deadlineTickCount - now, Timeout.Infinite);
+            return;
+        }
+
+        var accumulator = _accumulator;
+        if (accumulator is null)
+            return;
+
+        var configured = TimeSpan.FromMilliseconds(accumulator.MaxBlockMsOption);
+        var elapsed = TimeSpan.FromMilliseconds(now - _startTicks);
 
         var exception = new KafkaTimeoutException(
             TimeoutKind.MaxBlock,
             elapsed,
             configured,
-            $"Failed to allocate buffer within max.block.ms ({_accumulator.MaxBlockMsOption}ms). " +
-            $"Requested {_recordSize} bytes, current usage: {_accumulator.BufferedBytes}/{_accumulator.MaxBufferMemory} bytes. " +
+            $"Failed to allocate buffer within max.block.ms ({accumulator.MaxBlockMsOption}ms). " +
+            $"Requested {_recordSize} bytes, current usage: {accumulator.BufferedBytes}/{accumulator.MaxBufferMemory} bytes. " +
             $"Producer is generating messages faster than the network can send them. " +
             $"Consider: increasing BufferMemory, increasing MaxBlockMs, reducing production rate, or checking network connectivity.");
 
@@ -254,9 +273,8 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _completionSource = null;
         _callback = null;
         _cancellationToken = default;
+        _deadlineTickCount = 0;
         _accumulator = null!;
-
-        Volatile.Write(ref _completed, 0);
         _core.Reset();
         _pool.Return(this);
     }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2212,8 +2212,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 ownsReservation = false;
                                 ownsRecordResources = false;
                                 ownsPendingCount = false;
-                                if (completionSource is not null)
+                                if (ShouldSealAppendedBatch(currentBatch))
+                                {
+                                    batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
+                                    ownsRotation = true;
+                                }
+                                else if (completionSource is not null)
+                                {
                                     QueueLingerPartition(pd, topicPartition);
+                                }
                                 batchToReturn = rentedBatch;
                                 rentedBatch = null;
                                 appendSucceeded = true;
@@ -2246,8 +2253,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 ownsReservation = false;
                                 ownsRecordResources = false;
                                 ownsPendingCount = false;
-                                ClearRotationInProgressUnderLock(pd);
-                                ownsRotation = false;
+                                if (ShouldSealAppendedBatch(newBatch))
+                                {
+                                    batchToComplete = DetachCurrentBatchForSealUnderLock(pd, newBatch);
+                                    ownsRotation = true;
+                                }
+                                else
+                                {
+                                    ClearRotationInProgressUnderLock(pd);
+                                    ownsRotation = false;
+                                }
                                 appendSucceeded = true;
                             }
                             else
@@ -2297,6 +2312,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 if (appendSucceeded)
                 {
                     NotifyRecordAppended(topic, partition, actualBytesAdded, partitionCount);
+                    if (batchToComplete is not null)
+                    {
+                        var readyBatch = CompleteDetachedBatchAndEnqueue(pd, batchToComplete);
+                        if (readyBatch is not null)
+                            PublishSealedBatch(readyBatch);
+                    }
+
                     return true;
                 }
 
@@ -2565,8 +2587,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 ownsReservation = false;
                                 ownsHeaderResources = false;
                                 ownsPendingCount = false;
-                                if (completionSource is not null)
+                                if (ShouldSealAppendedBatch(currentBatch))
+                                {
+                                    batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
+                                    ownsRotation = true;
+                                }
+                                else if (completionSource is not null)
+                                {
                                     QueueLingerPartition(pd, topicPartition);
+                                }
                                 batchToReturn = rentedBatch;
                                 rentedBatch = null;
                                 appendSucceeded = true;
@@ -2599,8 +2628,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 ownsReservation = false;
                                 ownsHeaderResources = false;
                                 ownsPendingCount = false;
-                                ClearRotationInProgressUnderLock(pd);
-                                ownsRotation = false;
+                                if (ShouldSealAppendedBatch(newBatch))
+                                {
+                                    batchToComplete = DetachCurrentBatchForSealUnderLock(pd, newBatch);
+                                    ownsRotation = true;
+                                }
+                                else
+                                {
+                                    ClearRotationInProgressUnderLock(pd);
+                                    ownsRotation = false;
+                                }
                                 appendSucceeded = true;
                             }
                             else
@@ -2650,6 +2687,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 if (appendSucceeded)
                 {
                     NotifyRecordAppended(topic, partition, actualBytesAdded, partitionCount);
+                    if (batchToComplete is not null)
+                    {
+                        var readyBatch = CompleteDetachedBatchAndEnqueue(pd, batchToComplete);
+                        if (readyBatch is not null)
+                            PublishSealedBatch(readyBatch);
+                    }
+
                     return true;
                 }
 
@@ -2896,6 +2940,33 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         var result = current + value;
         return result < current ? long.MaxValue : result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool ShouldSealAppendedBatch(PartitionBatch batch)
+        => batch.ShouldFlush(Stopwatch.GetTimestamp(), _options.LingerMs);
+
+    private ReadyBatch? CompleteDetachedBatchAndEnqueue(PartitionDeque pd, PartitionBatch batchToComplete)
+    {
+        ReadyBatch? readyBatch;
+        try
+        {
+            readyBatch = CompleteDetachedBatch(batchToComplete);
+        }
+        catch
+        {
+            ClearRotationInProgress(pd);
+            throw;
+        }
+
+        {
+            using var guard = new SpinLockGuard(ref pd.Lock);
+            if (readyBatch is not null)
+                EnqueueCompletedBatchUnderLock(pd, readyBatch);
+            ClearRotationInProgressUnderLock(pd);
+        }
+
+        return readyBatch;
     }
 
     /// <summary>
@@ -3501,22 +3572,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (batchToComplete is null)
             return false;
 
-        try
-        {
-            sealedBatch = CompleteDetachedBatch(batchToComplete);
-        }
-        catch
-        {
-            ClearRotationInProgress(pd);
-            throw;
-        }
-
-        {
-            using var guard = new SpinLockGuard(ref pd.Lock);
-            if (sealedBatch is not null)
-                EnqueueCompletedBatchUnderLock(pd, sealedBatch);
-            ClearRotationInProgressUnderLock(pd);
-        }
+        sealedBatch = CompleteDetachedBatchAndEnqueue(pd, batchToComplete);
 
         if (sealedBatch is null)
             return false;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2242,7 +2242,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             rentedBatch = null;
                             pd.CurrentBatch = newBatch;
                             Interlocked.Increment(ref _unsealedBatchCount);
-                            TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
 
                             if (TryAppendToBatch(newBatch, timestamp, key, value, headers, headerCount,
                                 completionSource, callback, recordSize, out var overestimatedBytesToRelease,
@@ -2260,6 +2259,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 }
                                 else
                                 {
+                                    TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
                                     ClearRotationInProgressUnderLock(pd);
                                     ownsRotation = false;
                                 }
@@ -2617,7 +2617,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             rentedBatch = null;
                             pd.CurrentBatch = newBatch;
                             Interlocked.Increment(ref _unsealedBatchCount);
-                            TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
 
                             if (TryAppendFromSpansToBatch(newBatch, timestamp, keyData, keyIsNull, valueData, valueIsNull,
                                 headers, headerCount, completionSource, callback, recordSize, out var overestimatedBytesToRelease,
@@ -2635,6 +2634,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 }
                                 else
                                 {
+                                    TrackCurrentBatchForLinger(pd, topicPartition, newBatch);
                                     ClearRotationInProgressUnderLock(pd);
                                     ownsRotation = false;
                                 }
@@ -2944,7 +2944,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSealAppendedBatch(PartitionBatch batch)
-        => batch.ShouldFlush(Stopwatch.GetTimestamp(), _options.LingerMs);
+        => _options.LingerMs == 0 && batch.ShouldFlush(Stopwatch.GetTimestamp(), _options.LingerMs);
 
     private ReadyBatch? CompleteDetachedBatchAndEnqueue(PartitionDeque pd, PartitionBatch batchToComplete)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
@@ -26,7 +26,7 @@ public class AppendWorkerAffinityTests
 
     /// <summary>
     /// Returns the _partitionDeques dictionary. To check for a batch, callers should
-    /// verify the deque contains the key and CurrentBatch is non-null.
+    /// verify the deque contains the key and either current or sealed work is present.
     /// </summary>
     private static object GetPartitionDeques(RecordAccumulator accumulator)
     {
@@ -43,12 +43,11 @@ public class AppendWorkerAffinityTests
         if (!found) return false;
         var pd = parameters[1]!;
         var currentBatch = pd.GetType().GetField("CurrentBatch")!.GetValue(pd);
-        return currentBatch != null;
-    }
+        if (currentBatch is not null)
+            return true;
 
-    private static int GetDequeCount(object deques)
-    {
-        return (int)deques.GetType().GetProperty("Count")!.GetValue(deques)!;
+        var readyCount = (int)pd.GetType().GetProperty("Count")!.GetValue(pd)!;
+        return readyCount > 0;
     }
 
     [Test]
@@ -84,7 +83,7 @@ public class AppendWorkerAffinityTests
         var deques = GetPartitionDeques(accumulator);
         var tp = new TopicPartition("test-topic", 0);
 
-        // Wait deterministically for the worker to create the batch, bounded by the test's
+        // Wait deterministically for the worker to create or seal a batch, bounded by the test's
         // [Timeout] cancellation rather than an arbitrary fixed deadline that flakes when the
         // append workers are thread-pool-starved on loaded runners.
         await TestWait.UntilAsync(
@@ -135,7 +134,7 @@ public class AppendWorkerAffinityTests
 
         var deques = GetPartitionDeques(accumulator);
 
-        // Wait deterministically until workers have created batches for ALL partitions,
+        // Wait deterministically until workers have created or sealed batches for ALL partitions,
         // bounded by the test's [Timeout] cancellation rather than an arbitrary fixed deadline
         // that flakes when the append workers are thread-pool-starved on loaded runners.
         await TestWait.UntilAsync(() =>

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -114,7 +114,7 @@ public class RecordAccumulatorReadyTests
     [Test]
     public async Task Ready_CompressesSealedBatch_OutsideAppendPath()
     {
-        var options = CreateTestOptions(batchSize: 50, compressionType: CompressionType.Gzip);
+        var options = CreateTestOptions(batchSize: 50, lingerMs: 10_000, compressionType: CompressionType.Gzip);
 
         var codec = new CountingCompressionCodec(CompressionType.Gzip);
         var compressionCodecs = new CompressionCodecRegistry();
@@ -270,7 +270,7 @@ public class RecordAccumulatorReadyTests
     public async Task Ready_MutedPartition_SkipsNotification()
     {
         // Arrange
-        var options = CreateTestOptions(batchSize: 50);
+        var options = CreateTestOptions(batchSize: 50, lingerMs: 10_000);
         var accumulator = new RecordAccumulator(options);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var metadataManager = CreateMetadataManager("test-topic", 1, nodeId: 1);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -594,25 +594,37 @@ public class RecordAccumulatorReadyTests
     public async Task ReadyPartitionsQueue_SealViaLinger_EnqueuesNotification()
     {
         // Tests that sealing via linger/flush also pushes to the notification queue.
-        // Use large batch size so only linger (not size) triggers seal, with LingerMs=0 for immediate seal.
-        var options = CreateTestOptions(batchSize: 100_000, lingerMs: 0);
+        // Use large batch size so only linger (not size) triggers seal.
+        var options = CreateTestOptions(batchSize: 100_000, lingerMs: 10_000);
         var accumulator = new RecordAccumulator(options);
-        var pool = new ValueTaskSourcePool<RecordMetadata>();
         var metadataManager = CreateMetadataManager("test-topic", 1, nodeId: 1);
 
         try
         {
-            var pooledKey = new PooledMemory(null, 0, isNull: true);
-            var pooledValue = new PooledMemory(null, 0, isNull: true);
-
-            // Append one record (batch won't seal from size)
-            var completion = pool.Rent();
-            accumulator.TryAppendWithCompletion("test-topic", 0,
+            var appended = await accumulator.AppendFromSpansAsync(
+                "test-topic",
+                partition: 0,
                 DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                pooledKey, pooledValue, null, 0, completion);
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                "value"u8,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 1);
+
+            await Assert.That(appended).IsTrue();
 
             var lingerQueue = GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_lingerPartitions");
             await Assert.That(lingerQueue.Count).IsEqualTo(1);
+
+            var partitionDeque = GetPartitionDeque(accumulator, "test-topic", 0);
+            var currentBatch = partitionDeque.GetType().GetField("CurrentBatch")!.GetValue(partitionDeque)!;
+            var expiredCreatedTicks = Stopwatch.GetTimestamp() - Stopwatch.Frequency * 20;
+            SetInstanceField(currentBatch, "_createdStopwatchTimestamp", expiredCreatedTicks);
+            SetPrivateField(accumulator, "_oldestBatchCreatedTicks", expiredCreatedTicks);
 
             // Seal via linger expiry (doesn't wait for delivery like FlushAsync does)
             await accumulator.ExpireLingerAsync(CancellationToken.None);
@@ -628,7 +640,6 @@ public class RecordAccumulatorReadyTests
         finally
         {
             await accumulator.DisposeAsync();
-            await pool.DisposeAsync();
             await metadataManager.DisposeAsync();
         }
     }
@@ -672,21 +683,33 @@ public class RecordAccumulatorReadyTests
 
         try
         {
-            var pooledKey = new PooledMemory(null, 0, isNull: true);
-            var pooledValue = new PooledMemory(null, 0, isNull: true);
-
-            var firstCompletion = pool.Rent();
-            accumulator.TryAppendWithCompletion("test-topic", 0,
+            var appended = await accumulator.AppendFromSpansAsync(
+                "test-topic",
+                partition: 0,
                 DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                pooledKey, pooledValue, null, 0, firstCompletion);
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                "value"u8,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 1);
+
+            await Assert.That(appended).IsTrue();
 
             var lingerQueue = GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_lingerPartitions");
             await Assert.That(lingerQueue.TryDequeue(out _)).IsTrue();
 
             var partitionDeque = GetPartitionDeque(accumulator, "test-topic", 0);
             SetInstanceField(partitionDeque, "LingerQueued", 0);
+            var currentBatch = partitionDeque.GetType().GetField("CurrentBatch")!.GetValue(partitionDeque)!;
+            SetInstanceField(currentBatch, "_createdStopwatchTimestamp", Stopwatch.GetTimestamp() + Stopwatch.Frequency * 20);
 
             var secondCompletion = pool.Rent();
+            var pooledKey = new PooledMemory(null, 0, isNull: true);
+            var pooledValue = new PooledMemory(null, 0, isNull: true);
             accumulator.TryAppendWithCompletion("test-topic", 0,
                 DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                 pooledKey, pooledValue, null, 0, secondCompletion);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -157,22 +157,28 @@ public class RecordAccumulatorReadyTests
     [Test]
     public async Task Ready_NoSealedBatches_ReturnsEmpty()
     {
-        // Arrange: Large batch size so appending one record won't seal
-        var options = CreateTestOptions(batchSize: 100_000);
+        // Arrange: Large batch size and long linger so appending one fire-and-forget record won't seal.
+        var options = CreateTestOptions(batchSize: 100_000, lingerMs: 10_000);
         var accumulator = new RecordAccumulator(options);
-        var pool = new ValueTaskSourcePool<RecordMetadata>();
         var metadataManager = CreateMetadataManager("test-topic", 1, nodeId: 1);
 
         try
         {
-            // Append one record - batch should not seal (large batch size)
-            var pooledKey = new PooledMemory(null, 0, isNull: true);
-            var pooledValue = new PooledMemory(null, 0, isNull: true);
-            var completion = pool.Rent();
-
-            accumulator.TryAppendWithCompletion("test-topic", 0,
+            var appended = await accumulator.AppendFromSpansAsync(
+                "test-topic",
+                partition: 0,
                 DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                pooledKey, pooledValue, null, 0, completion);
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                "value"u8,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 1);
+
+            await Assert.That(appended).IsTrue();
 
             // Act: Call Ready()
             var readyNodes = new HashSet<int>();
@@ -184,7 +190,78 @@ public class RecordAccumulatorReadyTests
         finally
         {
             await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Ready_LingerMs0_AwaitedAppend_SealsInline()
+    {
+        var options = CreateTestOptions(batchSize: 100_000, lingerMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var metadataManager = CreateMetadataManager("test-topic", 1, nodeId: 1);
+
+        try
+        {
+            var pooledKey = new PooledMemory(null, 0, isNull: true);
+            var pooledValue = new PooledMemory(null, 0, isNull: true);
+            var completion = pool.Rent();
+
+            var appended = accumulator.TryAppendWithCompletion("test-topic", 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                pooledKey, pooledValue, null, 0, completion);
+
+            await Assert.That(appended).IsTrue();
+
+            var readyNodes = new HashSet<int>();
+            var (_, unknownLeadersExist) = accumulator.Ready(metadataManager, readyNodes);
+
+            await Assert.That(readyNodes).Contains(1);
+            await Assert.That(unknownLeadersExist).IsFalse();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
             await pool.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Ready_LingerMs0_FireAndForgetSpanAppend_SealsInline()
+    {
+        var options = CreateTestOptions(batchSize: 100_000, lingerMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var metadataManager = CreateMetadataManager("test-topic", 1, nodeId: 1);
+
+        try
+        {
+            var appended = await accumulator.AppendFromSpansAsync(
+                "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                "value"u8,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 1);
+
+            await Assert.That(appended).IsTrue();
+
+            var readyNodes = new HashSet<int>();
+            var (_, unknownLeadersExist) = accumulator.Ready(metadataManager, readyNodes);
+
+            await Assert.That(readyNodes).Contains(1);
+            await Assert.That(unknownLeadersExist).IsFalse();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
             await metadataManager.DisposeAsync();
         }
     }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Reflection;
 using System.Text;
+using System.Threading.Tasks.Sources;
 using Dekaf.Errors;
 using Dekaf.Producer;
 using Dekaf.Protocol;
@@ -2595,6 +2596,43 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task PendingAppend_StaleTimeoutCallbackAfterPoolReturn_DoesNotThrow()
+    {
+        await using var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
+        var pool = new PendingAppendPool(1);
+        var op = CreatePendingAppend(accumulator, pool);
+
+        await Assert.That(op.TryClaim()).IsTrue();
+        op.CompleteResult(true);
+        ((IValueTaskSource<bool>)op).GetResult(op.Version);
+
+        Action action = () => InvokePendingAppendTimeout(op);
+
+        await Assert.That(action).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task PendingAppend_TimeoutCallbackBeforeDeadline_DoesNotComplete()
+    {
+        await using var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
+        var pool = new PendingAppendPool(1);
+        var op = CreatePendingAppend(accumulator, pool);
+
+        try
+        {
+            Action action = () => InvokePendingAppendTimeout(op);
+
+            await Assert.That(action).ThrowsNothing();
+            await Assert.That(op.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            if (op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator))))
+                op.ReturnToPoolAfterTryFail();
+        }
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_SlowPath_CompletesWhenMemoryReleased()
     {
         var options = new ProducerOptions
@@ -2775,6 +2813,45 @@ public class RecordAccumulatorTests
         var partitionDeque = GetPartitionDeque(accumulator, topicPartition);
         var lockField = partitionDeque.GetType().GetField("Lock");
         lockField!.SetValue(partitionDeque, new SpinLock(enableThreadOwnerTracking: true));
+    }
+
+    private static PendingAppend CreatePendingAppend(RecordAccumulator accumulator, PendingAppendPool pool)
+    {
+        var now = Dekaf.MonotonicClock.GetMilliseconds();
+        var op = pool.Rent();
+        op.Initialize(
+            "test-topic",
+            partition: 0,
+            partitionCount: 1,
+            timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            key: PooledMemory.Null,
+            value: PooledMemory.Null,
+            headers: null,
+            headerCount: 0,
+            completionSource: null,
+            callback: null,
+            recordSize: PartitionBatch.EstimateRecordSize(0, 0, null, 0),
+            startTicks: now,
+            deadlineTickCount: now + 30000,
+            accumulator: accumulator,
+            pool: pool,
+            cancellationToken: CancellationToken.None);
+        return op;
+    }
+
+    private static ProducerOptions CreatePendingAppendTestOptions() => new()
+    {
+        BootstrapServers = new[] { "localhost:9092" },
+        BufferMemory = 4096,
+        BatchSize = 4096,
+        LingerMs = 10,
+        MaxBlockMs = 30000
+    };
+
+    private static void InvokePendingAppendTimeout(PendingAppend op)
+    {
+        var method = typeof(PendingAppend).GetMethod("OnTimeout", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        method.Invoke(op, null);
     }
 
     private static void SetBufferedBytesForTest(RecordAccumulator accumulator, long value)


### PR DESCRIPTION
## Summary
- seal a just-appended batch inline when its effective linger is already satisfied
- reuse the existing detach/complete/enqueue path outside the partition lock and wake the sender immediately
- add regression coverage for LingerMs=0 awaited and fire-and-forget appends becoming ready without the linger timer

## Tests
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --filter-uid "Dekaf.Tests.Unit.Producer.RecordAccumulatorReadyTests.1.1.Ready_LingerMs0_AwaitedAppend_SealsInline.1.1.0" "Dekaf.Tests.Unit.Producer.RecordAccumulatorReadyTests.1.1.Ready_LingerMs0_FireAndForgetSpanAppend_SealsInline.1.1.0" "Dekaf.Tests.Unit.Producer.RecordAccumulatorReadyTests.1.1.Ready_NoSealedBatches_ReturnsEmpty.1.1.0" "Dekaf.Tests.Unit.Producer.RecordAccumulatorReadyTests.1.1.Ready_AfterSealingBatch_ReturnsReadyNode.1.1.0" --no-ansi --maximum-parallel-tests 1 --timeout 1m

Closes #1366