### PR TITLE
feat(schemaregistry): add rule dispatcher

### DIFF
--- a/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
@@ -236,9 +236,21 @@ public sealed class SchemaRegistryRuleExecutor : ISchemaRegistryRuleExecutor
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        var rules = GetActiveEncodingRules(context.Schema, direction);
-        foreach (var rule in rules)
+        var rules = context.Schema?.RuleSet?.EncodingRules;
+        if (rules is null || rules.Count == 0)
+            return payload;
+
+        var isWrite = direction == SchemaRegistryRuleDirection.Write;
+        var index = isWrite ? 0 : rules.Count - 1;
+        var end = isWrite ? rules.Count : -1;
+        var step = isWrite ? 1 : -1;
+
+        for (; index != end; index += step)
         {
+            var rule = rules[index];
+            if (!IsActiveTransformRule(rule, direction))
+                continue;
+
             if (!_handlers.TryGetValue(rule.Type, out var handler))
                 throw new SchemaRegistryRuleException(
                     $"No Schema Registry rule handler is registered for rule type '{rule.Type}' (rule '{rule.Name}').");
@@ -276,42 +288,6 @@ public sealed class SchemaRegistryRuleExecutor : ISchemaRegistryRuleExecutor
                 ex);
         }
     }
-
-    private static IEnumerable<SchemaRule> GetActiveEncodingRules(
-        Schema? schema,
-        SchemaRegistryRuleDirection direction)
-    {
-        var rules = schema?.RuleSet?.EncodingRules;
-        if (rules is null || rules.Count == 0)
-            return [];
-
-        return direction == SchemaRegistryRuleDirection.Write
-            ? EnumerateRules(rules, direction)
-            : EnumerateRulesReverse(rules, direction);
-    }
-
-    private static IEnumerable<SchemaRule> EnumerateRules(
-        IReadOnlyList<SchemaRule> rules,
-        SchemaRegistryRuleDirection direction)
-    {
-        for (var i = 0; i < rules.Count; i++)
-        {
-            if (IsActiveTransformRule(rules[i], direction))
-                yield return rules[i];
-        }
-    }
-
-    private static IEnumerable<SchemaRule> EnumerateRulesReverse(
-        IReadOnlyList<SchemaRule> rules,
-        SchemaRegistryRuleDirection direction)
-    {
-        for (var i = rules.Count - 1; i >= 0; i--)
-        {
-            if (IsActiveTransformRule(rules[i], direction))
-                yield return rules[i];
-        }
-    }
-
     private static bool IsActiveTransformRule(SchemaRule rule, SchemaRegistryRuleDirection direction)
     {
         if (rule.Disabled || rule.Kind != SchemaRuleKind.Transform || string.IsNullOrWhiteSpace(rule.Type))

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryRules.cs
@@ -98,3 +98,227 @@ public interface ISchemaRegistryRuleExecutor
         ReadOnlyMemory<byte> payload,
         SchemaRegistryRuleContext context);
 }
+
+/// <summary>
+/// Direction for a Schema Registry payload rule transform.
+/// </summary>
+public enum SchemaRegistryRuleDirection
+{
+    /// <summary>
+    /// Rule is running before bytes are written to Kafka.
+    /// </summary>
+    Write,
+
+    /// <summary>
+    /// Rule is running after bytes are read from Kafka.
+    /// </summary>
+    Read
+}
+
+/// <summary>
+/// Context passed to a typed Schema Registry rule handler.
+/// </summary>
+public sealed class SchemaRegistryRuleHandlerContext
+{
+    /// <summary>
+    /// Gets the payload context shared by all rule executors.
+    /// </summary>
+    public required SchemaRegistryRuleContext PayloadContext { get; init; }
+
+    /// <summary>
+    /// Gets the Schema Registry rule being executed.
+    /// </summary>
+    public required SchemaRule Rule { get; init; }
+
+    /// <summary>
+    /// Gets the transform direction.
+    /// </summary>
+    public required SchemaRegistryRuleDirection Direction { get; init; }
+}
+
+/// <summary>
+/// Handles one Schema Registry rule type, such as ENCRYPT or CEL.
+/// </summary>
+public interface ISchemaRegistryRuleHandler
+{
+    /// <summary>
+    /// Gets the Schema Registry rule type this handler supports.
+    /// </summary>
+    string Type { get; }
+
+    /// <summary>
+    /// Applies a write-side transform for the rule.
+    /// </summary>
+    ReadOnlyMemory<byte> TransformSerializedPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleHandlerContext context);
+
+    /// <summary>
+    /// Applies a read-side transform for the rule.
+    /// </summary>
+    ReadOnlyMemory<byte> TransformDeserializedPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleHandlerContext context);
+}
+
+/// <summary>
+/// Exception thrown when Schema Registry rule execution fails.
+/// </summary>
+public sealed class SchemaRegistryRuleException : Exception
+{
+    /// <summary>
+    /// Creates a rule exception.
+    /// </summary>
+    public SchemaRegistryRuleException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Creates a rule exception with an inner exception.
+    /// </summary>
+    public SchemaRegistryRuleException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Executes Schema Registry encoding rules by dispatching each active rule to a typed handler.
+/// </summary>
+/// <remarks>
+/// This executor operates on codec payload bytes. It intentionally fails closed when a schema
+/// contains an active encoding rule with no registered handler, so protected data is not
+/// accidentally produced or consumed without the configured transform.
+/// </remarks>
+public sealed class SchemaRegistryRuleExecutor : ISchemaRegistryRuleExecutor
+{
+    private readonly IReadOnlyDictionary<string, ISchemaRegistryRuleHandler> _handlers;
+
+    /// <summary>
+    /// Creates a Schema Registry rule executor.
+    /// </summary>
+    /// <param name="handlers">Rule handlers keyed by <see cref="ISchemaRegistryRuleHandler.Type" />.</param>
+    public SchemaRegistryRuleExecutor(IEnumerable<ISchemaRegistryRuleHandler> handlers)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+
+        var dictionary = new Dictionary<string, ISchemaRegistryRuleHandler>(StringComparer.OrdinalIgnoreCase);
+        foreach (var handler in handlers)
+        {
+            ArgumentNullException.ThrowIfNull(handler);
+            if (string.IsNullOrWhiteSpace(handler.Type))
+                throw new ArgumentException("Rule handler type cannot be null or whitespace.", nameof(handlers));
+
+            if (!dictionary.TryAdd(handler.Type, handler))
+                throw new ArgumentException($"A rule handler for type '{handler.Type}' is already registered.", nameof(handlers));
+        }
+
+        _handlers = dictionary;
+    }
+
+    /// <inheritdoc />
+    public ReadOnlyMemory<byte> TransformSerializedPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext context)
+        => ApplyRules(payload, context, SchemaRegistryRuleDirection.Write);
+
+    /// <inheritdoc />
+    public ReadOnlyMemory<byte> TransformDeserializedPayload(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext context)
+        => ApplyRules(payload, context, SchemaRegistryRuleDirection.Read);
+
+    private ReadOnlyMemory<byte> ApplyRules(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext context,
+        SchemaRegistryRuleDirection direction)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var rules = GetActiveEncodingRules(context.Schema, direction);
+        foreach (var rule in rules)
+        {
+            if (!_handlers.TryGetValue(rule.Type, out var handler))
+                throw new SchemaRegistryRuleException(
+                    $"No Schema Registry rule handler is registered for rule type '{rule.Type}' (rule '{rule.Name}').");
+
+            payload = ApplyRule(payload, context, rule, handler, direction);
+        }
+
+        return payload;
+    }
+
+    private static ReadOnlyMemory<byte> ApplyRule(
+        ReadOnlyMemory<byte> payload,
+        SchemaRegistryRuleContext payloadContext,
+        SchemaRule rule,
+        ISchemaRegistryRuleHandler handler,
+        SchemaRegistryRuleDirection direction)
+    {
+        var handlerContext = new SchemaRegistryRuleHandlerContext
+        {
+            PayloadContext = payloadContext,
+            Rule = rule,
+            Direction = direction
+        };
+
+        try
+        {
+            return direction == SchemaRegistryRuleDirection.Write
+                ? handler.TransformSerializedPayload(payload, handlerContext)
+                : handler.TransformDeserializedPayload(payload, handlerContext);
+        }
+        catch (Exception ex) when (ex is not SchemaRegistryRuleException)
+        {
+            throw new SchemaRegistryRuleException(
+                $"Schema Registry rule '{rule.Name}' of type '{rule.Type}' failed during {direction.ToString().ToLowerInvariant()} transform.",
+                ex);
+        }
+    }
+
+    private static IEnumerable<SchemaRule> GetActiveEncodingRules(
+        Schema? schema,
+        SchemaRegistryRuleDirection direction)
+    {
+        var rules = schema?.RuleSet?.EncodingRules;
+        if (rules is null || rules.Count == 0)
+            return [];
+
+        return direction == SchemaRegistryRuleDirection.Write
+            ? EnumerateRules(rules, direction)
+            : EnumerateRulesReverse(rules, direction);
+    }
+
+    private static IEnumerable<SchemaRule> EnumerateRules(
+        IReadOnlyList<SchemaRule> rules,
+        SchemaRegistryRuleDirection direction)
+    {
+        for (var i = 0; i < rules.Count; i++)
+        {
+            if (IsActiveTransformRule(rules[i], direction))
+                yield return rules[i];
+        }
+    }
+
+    private static IEnumerable<SchemaRule> EnumerateRulesReverse(
+        IReadOnlyList<SchemaRule> rules,
+        SchemaRegistryRuleDirection direction)
+    {
+        for (var i = rules.Count - 1; i >= 0; i--)
+        {
+            if (IsActiveTransformRule(rules[i], direction))
+                yield return rules[i];
+        }
+    }
+
+    private static bool IsActiveTransformRule(SchemaRule rule, SchemaRegistryRuleDirection direction)
+    {
+        if (rule.Disabled || rule.Kind != SchemaRuleKind.Transform || string.IsNullOrWhiteSpace(rule.Type))
+            return false;
+
+        return direction == SchemaRegistryRuleDirection.Write
+            ? rule.Mode is SchemaRuleMode.Write or SchemaRuleMode.WriteRead
+            : rule.Mode is SchemaRuleMode.Read or SchemaRuleMode.WriteRead;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryRuleExecutorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryRuleExecutorTests.cs
@@ -1,0 +1,168 @@
+using System.Text;
+using Dekaf.SchemaRegistry;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class SchemaRegistryRuleExecutorTests
+{
+    [Test]
+    public async Task TransformSerializedPayload_AppliesActiveEncodingRulesInOrder()
+    {
+        var calls = new List<string>();
+        var executor = new SchemaRegistryRuleExecutor(
+        [
+            new AppendingRuleHandler("A", calls),
+            new AppendingRuleHandler("B", calls)
+        ]);
+
+        var schema = CreateSchema(
+            CreateRule("encrypt-a", "A", SchemaRuleMode.WriteRead),
+            CreateRule("write-b", "B", SchemaRuleMode.Write),
+            CreateRule("disabled", "missing", SchemaRuleMode.WriteRead, disabled: true),
+            CreateRule("read-only", "missing", SchemaRuleMode.Read));
+
+        var result = executor.TransformSerializedPayload(
+            "payload"u8.ToArray(),
+            CreateContext(schema));
+
+        await Assert.That(Encoding.UTF8.GetString(result.Span)).IsEqualTo("payload|AW|BW");
+        await Assert.That(calls).IsEquivalentTo([
+            "Write:encrypt-a:Json",
+            "Write:write-b:Json"
+        ]);
+    }
+
+    [Test]
+    public async Task TransformDeserializedPayload_AppliesActiveEncodingRulesInReverseOrder()
+    {
+        var calls = new List<string>();
+        var executor = new SchemaRegistryRuleExecutor(
+        [
+            new AppendingRuleHandler("A", calls),
+            new AppendingRuleHandler("B", calls)
+        ]);
+
+        var schema = CreateSchema(
+            CreateRule("encrypt-a", "A", SchemaRuleMode.WriteRead),
+            CreateRule("read-b", "B", SchemaRuleMode.Read),
+            CreateRule("write-only", "missing", SchemaRuleMode.Write));
+
+        var result = executor.TransformDeserializedPayload(
+            "payload"u8.ToArray(),
+            CreateContext(schema));
+
+        await Assert.That(Encoding.UTF8.GetString(result.Span)).IsEqualTo("payload|BR|AR");
+        await Assert.That(calls).IsEquivalentTo([
+            "Read:read-b:Json",
+            "Read:encrypt-a:Json"
+        ]);
+    }
+
+    [Test]
+    public async Task TransformSerializedPayload_MissingHandlerForActiveRule_Throws()
+    {
+        var executor = new SchemaRegistryRuleExecutor([]);
+        var schema = CreateSchema(CreateRule("encrypt", "ENCRYPT", SchemaRuleMode.Write));
+
+        await Assert.That(() => executor.TransformSerializedPayload("payload"u8.ToArray(), CreateContext(schema)))
+            .Throws<SchemaRegistryRuleException>()
+            .WithMessageContaining("ENCRYPT")
+            .And
+            .WithMessageContaining("encrypt");
+    }
+
+    [Test]
+    public async Task TransformSerializedPayload_NullSchema_ReturnsOriginalPayload()
+    {
+        var executor = new SchemaRegistryRuleExecutor([]);
+        var payload = "payload"u8.ToArray();
+
+        var result = executor.TransformSerializedPayload(payload, CreateContext(schema: null));
+
+        await Assert.That(result.ToArray()).IsEquivalentTo(payload);
+    }
+
+    [Test]
+    public async Task Constructor_DuplicateHandlerType_Throws()
+    {
+        var calls = new List<string>();
+
+        await Assert.That(() =>
+            _ = new SchemaRegistryRuleExecutor(
+            [
+                new AppendingRuleHandler("ENCRYPT", calls),
+                new AppendingRuleHandler("encrypt", calls)
+            ]))
+            .Throws<ArgumentException>()
+            .WithMessageContaining("encrypt");
+    }
+
+    private static SchemaRegistryRuleContext CreateContext(Schema? schema) =>
+        new()
+        {
+            Topic = "test-topic",
+            Component = SerializationComponent.Value,
+            SchemaId = 42,
+            Subject = "test-topic-value",
+            Schema = schema,
+            PayloadFormat = SchemaRegistryPayloadFormat.Json
+        };
+
+    private static Schema CreateSchema(params SchemaRule[] rules) =>
+        new()
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = "{}",
+            RuleSet = new SchemaRuleSet
+            {
+                EncodingRules = rules
+            }
+        };
+
+    private static SchemaRule CreateRule(
+        string name,
+        string type,
+        SchemaRuleMode mode,
+        bool disabled = false) =>
+        new()
+        {
+            Name = name,
+            Kind = SchemaRuleKind.Transform,
+            Mode = mode,
+            Type = type,
+            Disabled = disabled
+        };
+
+    private sealed class AppendingRuleHandler(
+        string type,
+        List<string> calls) : ISchemaRegistryRuleHandler
+    {
+        public string Type => type;
+
+        public ReadOnlyMemory<byte> TransformSerializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context)
+        {
+            calls.Add($"{context.Direction}:{context.Rule.Name}:{context.PayloadContext.PayloadFormat}");
+            return Append(payload, $"|{Type}W");
+        }
+
+        public ReadOnlyMemory<byte> TransformDeserializedPayload(
+            ReadOnlyMemory<byte> payload,
+            SchemaRegistryRuleHandlerContext context)
+        {
+            calls.Add($"{context.Direction}:{context.Rule.Name}:{context.PayloadContext.PayloadFormat}");
+            return Append(payload, $"|{Type}R");
+        }
+
+        private static ReadOnlyMemory<byte> Append(ReadOnlyMemory<byte> payload, string suffix)
+        {
+            var suffixBytes = Encoding.UTF8.GetBytes(suffix);
+            var result = new byte[payload.Length + suffixBytes.Length];
+            payload.Span.CopyTo(result);
+            suffixBytes.CopyTo(result.AsSpan(payload.Length));
+            return result;
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryRuleExecutorTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryRuleExecutorTests.cs
@@ -84,6 +84,19 @@ public sealed class SchemaRegistryRuleExecutorTests
     }
 
     [Test]
+    public async Task TransformSerializedPayload_ConditionKindEncodingRule_SkipsRule()
+    {
+        var executor = new SchemaRegistryRuleExecutor([]);
+        var payload = "payload"u8.ToArray();
+        var schema = CreateSchema(
+            CreateRule("condition", "missing", SchemaRuleMode.WriteRead, kind: SchemaRuleKind.Condition));
+
+        var result = executor.TransformSerializedPayload(payload, CreateContext(schema));
+
+        await Assert.That(result.ToArray()).IsEquivalentTo(payload);
+    }
+
+    [Test]
     public async Task Constructor_DuplicateHandlerType_Throws()
     {
         var calls = new List<string>();
@@ -124,11 +137,12 @@ public sealed class SchemaRegistryRuleExecutorTests
         string name,
         string type,
         SchemaRuleMode mode,
-        bool disabled = false) =>
+        bool disabled = false,
+        SchemaRuleKind kind = SchemaRuleKind.Transform) =>
         new()
         {
             Name = name,
-            Kind = SchemaRuleKind.Transform,
+            Kind = kind,
             Mode = mode,
             Type = type,
             Disabled = disabled


### PR DESCRIPTION
## Summary
- Add a typed Schema Registry rule dispatcher over `Schema.RuleSet.EncodingRules`.
- Apply write transforms in schema order and read transforms in reverse order for reversible stacks.
- Fail closed when an active rule has no registered handler.

Refs #1382

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal /p:UseAppHost=true`
- `Dekaf.Tests.Unit.exe --filter-uid ...SchemaRegistryRuleExecutorTests...` (5 tests)