### PR TITLE
perf(producer): pre-serialize sealed batches

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1275,10 +1275,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 continue;
             }
 
-            // Batches are pre-serialized when sealed. Keep a defensive fallback so a
-            // manually-created or legacy batch cannot be orphaned in the ready queue.
+            // Pre-serialization runs on a worker after seal. If the notification arrives
+            // before that worker finishes, leave the batch queued; completion re-notifies.
             if (!head.IsPreSerialized)
-                PreSerializeBatch(head);
+                continue;
 
             // Sealed batches in the deque are always sendable. The linger/micro-linger
             // timer already determined readiness when it sealed the batch, so re-checking
@@ -1785,6 +1785,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (Interlocked.Exchange(ref batch._returnedToPool, 1) != 0)
             return;
 
+        batch.WaitForPreSerializationIfStarted();
         batch.WaitForCleanupIfStarted();
         _readyBatchPool.Return(batch);
     }
@@ -2248,7 +2249,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 }
 
                 if (batchToPublish is not null)
-                    PublishSealedBatch(batchToPublish);
+                    StartPreSerialization(batchToPublish);
 
                 if (batchToReturn is not null)
                     _batchPool.Return(batchToReturn);
@@ -2593,7 +2594,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 }
 
                 if (batchToPublish is not null)
-                    PublishSealedBatch(batchToPublish);
+                    StartPreSerialization(batchToPublish);
 
                 if (batchToReturn is not null)
                     _batchPool.Return(batchToReturn);
@@ -2847,7 +2848,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             if (currentBatch.PartitionCount > 1)
                 _onBatchComplete?.Invoke(readyBatch.TopicPartition.Topic, currentBatch.PartitionCount);
             if (preSerialize)
-                PreSerializeBatch(readyBatch);
+            {
+                if (_options.CompressionType == CompressionType.None)
+                    PrepareBatchForPublish(readyBatch);
+                else
+                    readyBatch.SetPreSerializationTask(CreatePreSerializationTask(readyBatch));
+            }
         }
 
         _batchPool.Return(currentBatch);
@@ -2890,18 +2896,62 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Prepares a sealed batch's records for send, compressing when configured. Called when
-    /// completing a detached batch, outside the partition SpinLock, before it is enqueued as
-    /// ready. Record bytes are already encoded at append time, so this step either leaves
-    /// the arena-backed records in place or compresses those encoded bytes.
+    /// Starts pre-serialization after the batch is visible in its partition deque, so the
+    /// worker cannot publish a notification before the sender can observe the batch.
+    /// </summary>
+    private void StartPreSerialization(ReadyBatch readyBatch)
+    {
+        if (readyBatch.IsPreSerialized)
+        {
+            PublishSealedBatch(readyBatch);
+            return;
+        }
+
+        readyBatch.StartPreSerializationTask();
+    }
+
+    private Task CreatePreSerializationTask(ReadyBatch readyBatch)
+    {
+        return new Task(
+            static state =>
+            {
+                var workItem = (PreSerializationWorkItem)state!;
+                workItem.Accumulator.PreSerializeAndPublishBatch(workItem.Batch);
+            },
+            new PreSerializationWorkItem(this, readyBatch),
+            CancellationToken.None,
+            TaskCreationOptions.DenyChildAttach);
+    }
+
+    private void PreSerializeAndPublishBatch(ReadyBatch readyBatch)
+    {
+        if (PrepareBatchForPublish(readyBatch) && !readyBatch.IsReturnedToPool)
+            PublishSealedBatch(readyBatch);
+    }
+
+    private sealed class PreSerializationWorkItem(
+        RecordAccumulator accumulator,
+        ReadyBatch batch)
+    {
+        public RecordAccumulator Accumulator { get; } = accumulator;
+
+        public ReadyBatch Batch { get; } = batch;
+    }
+
+    /// <summary>
+    /// Prepares a sealed batch's records for send, compressing when configured. Runs on a
+    /// worker after the batch is enqueued, outside producer caller threads and outside the
+    /// partition rotation gate. Record bytes are already encoded at append time, so this step
+    /// either leaves the arena-backed records in place or compresses those encoded bytes.
     ///
     /// Thread safety: the batch is already sealed and detached from its mutable
     /// <see cref="PartitionBatch"/>, so no append thread can modify it. The drain loop skips
     /// batches where <see cref="ReadyBatch.IsPreSerialized"/> is false, so the sender only
     /// picks up wire-ready batches.
     /// </summary>
-    private void PreSerializeBatch(ReadyBatch readyBatch)
+    private bool PrepareBatchForPublish(ReadyBatch readyBatch)
     {
+        Exception? failure = null;
         try
         {
             readyBatch.RecordBatch.PreCompress(_options.CompressionType, _compressionCodecs);
@@ -2909,13 +2959,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            // Fail delivery tasks so callers aren't stuck waiting, then mark ready
-            // so subsequent batches in this partition aren't permanently blocked.
-            readyBatch.Fail(ex);
+            failure = ex;
         }
 
         // Mark pre-serialization complete so the drain loop can pick up this batch.
         readyBatch.MarkPreSerialized();
+        if (failure is null)
+            return !readyBatch.IsSendCompleted;
+
+        return readyBatch.FailFromPreSerialization(failure);
     }
 
     /// <summary>
@@ -3476,7 +3528,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (sealedBatch is null)
             return false;
 
-        PublishSealedBatch(sealedBatch, signalWakeup: false);
+        StartPreSerialization(sealedBatch);
         return true;
     }
 
@@ -5083,7 +5135,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
 
     /// <summary>
     /// Whether the batch's records have been pre-serialized (and compressed, when
-    /// configured). Set after <see cref="RecordAccumulator.PreSerializeBatch"/> finishes.
+    /// configured). Set after <see cref="RecordAccumulator.PrepareBatchForPublish"/> finishes.
     /// The drain loop skips batches where this is false so the per-broker send loop
     /// only ever handles wire-ready payloads.
     /// Uses Volatile reads for lock-free checking from the sender thread.
@@ -5097,11 +5149,33 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
 
     /// <summary>
     /// Marks pre-serialization as complete. Called by
-    /// <see cref="RecordAccumulator.PreSerializeBatch"/> after the records are encoded
+    /// <see cref="RecordAccumulator.PrepareBatchForPublish"/> after the records are encoded
     /// (and compressed, when configured).
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void MarkPreSerialized() => Volatile.Write(ref _preSerialized, 1);
+
+    internal void SetPreSerializationTask(Task task)
+    {
+        Volatile.Write(ref _preSerializationTask, task);
+    }
+
+    internal void StartPreSerializationTask()
+    {
+        var task = Volatile.Read(ref _preSerializationTask)
+            ?? throw new InvalidOperationException("Pre-serialization task was not created.");
+
+        task.Start(TaskScheduler.Default);
+    }
+
+    internal void WaitForPreSerializationIfStarted()
+    {
+        var task = Volatile.Read(ref _preSerializationTask);
+        if (task is null || task.IsCompleted)
+            return;
+
+        task.GetAwaiter().GetResult();
+    }
 
     /// <summary>
     /// Whether BufferMemory has already been released for this batch.
@@ -5172,12 +5246,15 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     private int _sendCompleted; // 0 = not done, 1 = done (prevents concurrent CompleteSend/Fail)
     internal int _returnedToPool; // 0 = not returned, 1 = returned (prevents double pool return)
     private int _generation; // Incremented on each Initialize() — detects batch object recycling
+    private Task? _preSerializationTask;
 
     /// <summary>
     /// True when this batch has been returned to the pool. The authoritative signal for
     /// "batch is no longer live" — set atomically by ReturnReadyBatch before Reset() runs.
     /// </summary>
     internal bool IsReturnedToPool => Volatile.Read(ref _returnedToPool) != 0;
+
+    internal bool IsSendCompleted => Volatile.Read(ref _sendCompleted) != 0;
 
     /// <summary>
     /// Monotonically increasing counter, incremented on each Initialize(). Used to detect
@@ -5220,6 +5297,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         Interlocked.Exchange(ref _returnedToPool, 0);
         Interlocked.Exchange(ref _memoryReleased, 0);
         Volatile.Write(ref _preSerialized, 0);
+        Volatile.Write(ref _preSerializationTask, null);
         Interlocked.Increment(ref _generation);
 
         _topicPartition = topicPartition;
@@ -5417,11 +5495,20 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     /// DoneTask completes with false (no exception) to avoid UnobservedTaskException.
     /// </summary>
     public void Fail(Exception exception)
+        => FailCore(exception, waitForPreSerialization: true);
+
+    internal bool FailFromPreSerialization(Exception exception)
+        => FailCore(exception, waitForPreSerialization: false);
+
+    private bool FailCore(Exception exception, bool waitForPreSerialization)
     {
         // Atomic entry guard: only one thread can execute Fail/CompleteSend.
         // Separate from _cleanedUp so Cleanup() in the finally block still runs.
         if (Interlocked.Exchange(ref _sendCompleted, 1) != 0)
-            return;
+            return false;
+
+        if (waitForPreSerialization)
+            WaitForPreSerializationIfStarted();
 
         try
         {
@@ -5479,6 +5566,8 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         {
             Cleanup();
         }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1275,9 +1275,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 continue;
             }
 
-            // Pre-serialize only batches that will actually drain this cycle — batches
-            // deferred above (backoff, unknown leader) would waste the encode and hold
-            // the pooled buffer for the whole deferral window.
+            // Batches are pre-serialized when sealed. Keep a defensive fallback so a
+            // manually-created or legacy batch cannot be orphaned in the ready queue.
             if (!head.IsPreSerialized)
                 PreSerializeBatch(head);
 
@@ -2837,7 +2836,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// <summary>
     /// Completes and returns a detached batch outside the partition SpinLock.
     /// </summary>
-    private ReadyBatch? CompleteDetachedBatch(PartitionBatch currentBatch)
+    private ReadyBatch? CompleteDetachedBatch(PartitionBatch currentBatch, bool preSerialize = true)
     {
         var readyBatch = currentBatch.Complete();
         if (readyBatch is not null)
@@ -2847,6 +2846,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             ProducerDebugCounters.RecordBatchCompleted(readyBatch.CompletionSourcesCount);
             if (currentBatch.PartitionCount > 1)
                 _onBatchComplete?.Invoke(readyBatch.TopicPartition.Topic, currentBatch.PartitionCount);
+            if (preSerialize)
+                PreSerializeBatch(readyBatch);
         }
 
         _batchPool.Return(currentBatch);
@@ -2879,9 +2880,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Publishes a sealed batch to the sender loop. Record serialization (and compression,
-    /// when enabled) is deferred to <see cref="Ready"/> so the append caller only pays the
-    /// queue notification cost.
+    /// Publishes a sealed, wire-ready batch to the sender loop.
     /// </summary>
     private void PublishSealedBatch(ReadyBatch readyBatch, bool signalWakeup = true)
     {
@@ -2891,14 +2890,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Prepares a sealed batch's records for send, compressing when configured. Called by the
-    /// sender thread from <see cref="Ready"/>, outside the partition SpinLock, before the
-    /// batch can drain. Record bytes are already encoded at append time, so this step either
-    /// leaves the arena-backed records in place or compresses those encoded bytes.
+    /// Prepares a sealed batch's records for send, compressing when configured. Called when
+    /// completing a detached batch, outside the partition SpinLock, before it is enqueued as
+    /// ready. Record bytes are already encoded at append time, so this step either leaves
+    /// the arena-backed records in place or compresses those encoded bytes.
     ///
-    /// Thread safety: the batch is already sealed and in the deque; no other thread can
-    /// modify it. The drain loop skips batches where <see cref="ReadyBatch.IsPreSerialized"/>
-    /// is false, so the sender won't pick it up until we finish and set the flag.
+    /// Thread safety: the batch is already sealed and detached from its mutable
+    /// <see cref="PartitionBatch"/>, so no append thread can modify it. The drain loop skips
+    /// batches where <see cref="ReadyBatch.IsPreSerialized"/> is false, so the sender only
+    /// picks up wire-ready batches.
     /// </summary>
     private void PreSerializeBatch(ReadyBatch readyBatch)
     {
@@ -3796,7 +3796,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             foreach (var currentBatch in currentBatches)
             {
-                var readyBatch = CompleteDetachedBatch(currentBatch);
+                var readyBatch = CompleteDetachedBatch(currentBatch, preSerialize: false);
                 if (readyBatch is not null)
                 {
                     readyBatches ??= new List<ReadyBatch>();

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -8,6 +8,7 @@ using Dekaf.Producer;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
+using Dekaf.Tests.Unit;
 
 namespace Dekaf.Tests.Unit.Producer;
 
@@ -137,8 +138,10 @@ public class RecordAccumulatorReadyTests
                     pooledKey, pooledValue, null, 0, completion);
             }
 
+            await TestWait.UntilAsync(
+                () => codec.CompressCount > 0,
+                TimeSpan.FromSeconds(5));
             var compressCountBeforeReady = codec.CompressCount;
-            await Assert.That(compressCountBeforeReady).IsGreaterThan(0);
 
             var readyNodes = new HashSet<int>();
             var (_, unknownLeadersExist) = accumulator.Ready(metadataManager, readyNodes);
@@ -149,6 +152,77 @@ public class RecordAccumulatorReadyTests
         }
         finally
         {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Append_SealedCompressedBatch_DoesNotWaitForCompressionWorker()
+    {
+        var options = CreateTestOptions(batchSize: 50, compressionType: CompressionType.Gzip);
+        var codec = new BlockingCompressionCodec(CompressionType.Gzip);
+        var compressionCodecs = new CompressionCodecRegistry();
+        compressionCodecs.Register(codec);
+
+        var accumulator = new RecordAccumulator(options, compressionCodecs);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var metadataManager = CreateMetadataManager("test-topic", 1, nodeId: 1);
+
+        try
+        {
+            var pooledKey = new PooledMemory(null, 0, isNull: true);
+            var pooledValue = new PooledMemory(null, 0, isNull: true);
+
+            var fillTask = Task.Run(async () =>
+            {
+                for (var i = 0; i < 10; i++)
+                {
+                    var completion = pool.Rent();
+                    accumulator.TryAppendWithCompletion("test-topic", 0,
+                        DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        pooledKey, pooledValue, null, 0, completion);
+                    await Task.Yield();
+                }
+            });
+
+            await codec.CompressStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await fillTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var appendWhileCompressionBlocked = accumulator.AppendFromSpansAsync(
+                "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                ReadOnlySpan<byte>.Empty,
+                valueIsNull: true,
+                headers: null,
+                headerCount: 0,
+                callback: null,
+                CancellationToken.None).AsTask();
+
+            await appendWhileCompressionBlocked.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var readyNodesWhileBlocked = new HashSet<int>();
+            accumulator.Ready(metadataManager, readyNodesWhileBlocked);
+            await Assert.That(readyNodesWhileBlocked).IsEmpty();
+
+            codec.AllowCompression.SetResult();
+
+            await TestWait.UntilAsync(
+                () =>
+                {
+                    var readyNodes = new HashSet<int>();
+                    accumulator.Ready(metadataManager, readyNodes);
+                    return readyNodes.Contains(1);
+                },
+                TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            codec.AllowCompression.TrySetResult();
             await accumulator.DisposeAsync();
             await pool.DisposeAsync();
             await metadataManager.DisposeAsync();
@@ -1016,6 +1090,31 @@ public class RecordAccumulatorReadyTests
         public void Compress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
         {
             Interlocked.Increment(ref _compressCount);
+            foreach (var segment in source)
+                destination.Write(segment.Span);
+        }
+
+        public void Decompress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+        {
+            foreach (var segment in source)
+                destination.Write(segment.Span);
+        }
+    }
+
+    private sealed class BlockingCompressionCodec(CompressionType type) : ICompressionCodec
+    {
+        public CompressionType Type { get; } = type;
+
+        public TaskCompletionSource CompressStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowCompression { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Compress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+        {
+            CompressStarted.TrySetResult();
+            AllowCompression.Task.GetAwaiter().GetResult();
             foreach (var segment in source)
                 destination.Write(segment.Span);
         }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -112,7 +112,7 @@ public class RecordAccumulatorReadyTests
     }
 
     [Test]
-    public async Task Ready_CompressesSealedBatch_OutsideAppendPath()
+    public async Task Ready_SealedCompressedBatch_DoesNotCompressOnSenderCoordinator()
     {
         var options = CreateTestOptions(batchSize: 50, compressionType: CompressionType.Gzip);
 
@@ -137,12 +137,13 @@ public class RecordAccumulatorReadyTests
                     pooledKey, pooledValue, null, 0, completion);
             }
 
-            await Assert.That(codec.CompressCount).IsEqualTo(0);
+            var compressCountBeforeReady = codec.CompressCount;
+            await Assert.That(compressCountBeforeReady).IsGreaterThan(0);
 
             var readyNodes = new HashSet<int>();
             var (_, unknownLeadersExist) = accumulator.Ready(metadataManager, readyNodes);
 
-            await Assert.That(codec.CompressCount).IsEqualTo(1);
+            await Assert.That(codec.CompressCount).IsEqualTo(compressCountBeforeReady);
             await Assert.That(readyNodes).Contains(1);
             await Assert.That(unknownLeadersExist).IsFalse();
         }


### PR DESCRIPTION
## Summary
- Pre-serialize/compress sealed producer batches during detached completion instead of on the sender `Ready()` coordinator path.
- Keep a defensive `Ready()` fallback for any un-pre-serialized batch so ready partitions cannot be stranded.
- Skip pre-serialization for batches being purged and update ready-path coverage to assert no compression happens during `Ready()`.

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal /p:UseAppHost=true`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-ansi --timeout 90s --treenode-filter "/*/*/RecordAccumulatorReadyTests/*"`

Closes #1365
