### PR TITLE
feat(security): add Azure IMDS OAuth source

### DIFF
--- a/docs/docs/security/oauth.md
+++ b/docs/docs/security/oauth.md
@@ -113,6 +113,31 @@ var producer = await Kafka.CreateProducer<string, string>()
     .BuildAsync();
 ```
 
+## Azure IMDS Managed Identity
+
+On Azure VMs and AKS nodes with managed identity, Dekaf can fetch OAUTHBEARER
+tokens directly from the Azure Instance Metadata Service:
+
+```csharp
+using Dekaf;
+
+await using var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("kafka.example.com:9092")
+    .UseTls()
+    .WithOAuthBearerAzureImds(options =>
+    {
+        options.Resource = "api://kafka";
+        // Optional: set for user-assigned managed identity.
+        options.ClientId = "managed-identity-client-id";
+    })
+    .BuildAsync();
+```
+
+The built-in provider calls
+`http://169.254.169.254/metadata/identity/oauth2/token` with
+`Metadata: true`, `api-version=2018-02-01`, and the configured `resource`.
+Omit `ClientId` for a system-assigned managed identity.
+
 ## AWS MSK IAM
 
 For Amazon MSK IAM access control, prefer the native AWS_MSK_IAM mechanism:

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -4860,6 +4860,33 @@ public sealed class AdminClientBuilder
     }
 
     /// <summary>
+    /// Configures SASL/OAUTHBEARER authentication using Azure IMDS managed identity.
+    /// </summary>
+    /// <param name="options">The Azure IMDS OAuth options.</param>
+    public AdminClientBuilder WithOAuthBearerAzureImds(OAuthBearerAzureImdsOptions options)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ArgumentNullException.ThrowIfNull(options);
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = options.ToOAuthBearerConfig();
+        _oauthTokenProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures SASL/OAUTHBEARER authentication using Azure IMDS managed identity.
+    /// </summary>
+    /// <param name="configure">Callback that configures the Azure IMDS OAuth options.</param>
+    public AdminClientBuilder WithOAuthBearerAzureImds(Action<OAuthBearerAzureImdsOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerAzureImdsOptions { Resource = string.Empty };
+        configure(options);
+        return WithOAuthBearerAzureImds(options);
+    }
+
+    /// <summary>
     /// Configures SASL/OAUTHBEARER authentication using a custom token provider.
     /// </summary>
     /// <param name="tokenProvider">A callback that returns an OAuth bearer token on demand.</param>

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -623,6 +623,33 @@ public sealed class ProducerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Configures OAUTHBEARER authentication using Azure IMDS managed identity.
+    /// </summary>
+    /// <param name="options">The Azure IMDS OAuth options.</param>
+    public ProducerBuilder<TKey, TValue> WithOAuthBearerAzureImds(OAuthBearerAzureImdsOptions options)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ArgumentNullException.ThrowIfNull(options);
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = options.ToOAuthBearerConfig();
+        _oauthTokenProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures OAUTHBEARER authentication using Azure IMDS managed identity.
+    /// </summary>
+    /// <param name="configure">Callback that configures the Azure IMDS OAuth options.</param>
+    public ProducerBuilder<TKey, TValue> WithOAuthBearerAzureImds(Action<OAuthBearerAzureImdsOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerAzureImdsOptions { Resource = string.Empty };
+        configure(options);
+        return WithOAuthBearerAzureImds(options);
+    }
+
+    /// <summary>
     /// Configures OAUTHBEARER authentication using a custom token provider.
     /// </summary>
     /// <param name="tokenProvider">A function that provides OAuth tokens on demand.</param>
@@ -1810,6 +1837,33 @@ public sealed class ConsumerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Configures OAUTHBEARER authentication using Azure IMDS managed identity.
+    /// </summary>
+    /// <param name="options">The Azure IMDS OAuth options.</param>
+    public ConsumerBuilder<TKey, TValue> WithOAuthBearerAzureImds(OAuthBearerAzureImdsOptions options)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ArgumentNullException.ThrowIfNull(options);
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = options.ToOAuthBearerConfig();
+        _oauthTokenProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures OAUTHBEARER authentication using Azure IMDS managed identity.
+    /// </summary>
+    /// <param name="configure">Callback that configures the Azure IMDS OAuth options.</param>
+    public ConsumerBuilder<TKey, TValue> WithOAuthBearerAzureImds(Action<OAuthBearerAzureImdsOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerAzureImdsOptions { Resource = string.Empty };
+        configure(options);
+        return WithOAuthBearerAzureImds(options);
+    }
+
+    /// <summary>
     /// Configures OAUTHBEARER authentication using a custom token provider.
     /// </summary>
     /// <param name="tokenProvider">A function that provides OAuth tokens on demand.</param>
@@ -2885,6 +2939,25 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         var options = new OAuthBearerJwtBearerOptions();
         configure(options);
         return WithOAuthBearerJwtBearer(options);
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerAzureImds(OAuthBearerAzureImdsOptions options)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ArgumentNullException.ThrowIfNull(options);
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = options.ToOAuthBearerConfig();
+        _oauthTokenProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerAzureImds(Action<OAuthBearerAzureImdsOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerAzureImdsOptions { Resource = string.Empty };
+        configure(options);
+        return WithOAuthBearerAzureImds(options);
     }
 
     public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerTokenProvider(Func<CancellationToken, ValueTask<OAuthBearerToken>> provider)

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -313,6 +313,24 @@ public sealed class KafkaClientBuilder
         return WithOAuthBearerJwtBearer(options);
     }
 
+    public KafkaClientBuilder WithOAuthBearerAzureImds(OAuthBearerAzureImdsOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = options.ToOAuthBearerConfig();
+        _oauthTokenProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public KafkaClientBuilder WithOAuthBearerAzureImds(Action<OAuthBearerAzureImdsOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerAzureImdsOptions { Resource = string.Empty };
+        configure(options);
+        return WithOAuthBearerAzureImds(options);
+    }
+
     public KafkaClientBuilder WithOAuthBearer(Func<CancellationToken, ValueTask<OAuthBearerToken>> tokenProvider)
     {
         _saslMechanism = SaslMechanism.OAuthBearer;

--- a/src/Dekaf/Security/Sasl/OAuthBearerAzureImdsOptions.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerAzureImdsOptions.cs
@@ -1,0 +1,81 @@
+namespace Dekaf.Security.Sasl;
+
+/// <summary>
+/// Azure Instance Metadata Service managed identity options for OAUTHBEARER token acquisition.
+/// </summary>
+public sealed class OAuthBearerAzureImdsOptions
+{
+    /// <summary>
+    /// Default Azure IMDS managed identity token endpoint.
+    /// </summary>
+    public const string DefaultTokenEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";
+
+    /// <summary>
+    /// Default Azure IMDS API version for managed identity tokens.
+    /// </summary>
+    public const string DefaultApiVersion = "2018-02-01";
+
+    /// <summary>
+    /// Azure IMDS token endpoint. Defaults to the link-local metadata endpoint.
+    /// </summary>
+    public string TokenEndpoint { get; set; } = DefaultTokenEndpoint;
+
+    /// <summary>
+    /// Azure IMDS API version. Defaults to 2018-02-01.
+    /// </summary>
+    public string ApiVersion { get; set; } = DefaultApiVersion;
+
+    /// <summary>
+    /// App ID URI of the target resource, for example https://management.azure.com/.
+    /// </summary>
+    public required string Resource { get; set; }
+
+    /// <summary>
+    /// Optional client ID for a user-assigned managed identity. Omit for system-assigned identity.
+    /// </summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>
+    /// The number of seconds before token expiration to trigger a refresh.
+    /// </summary>
+    public int TokenRefreshBufferSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Converts this options object to the shared OAuth bearer configuration model.
+    /// </summary>
+    internal OAuthBearerConfig ToOAuthBearerConfig()
+    {
+        Validate();
+        return new OAuthBearerConfig
+        {
+            GrantType = OAuthBearerGrantType.AzureImds,
+            TokenEndpointUrl = TokenEndpoint,
+            ClientId = ClientId ?? string.Empty,
+            AzureImds = Clone(),
+            TokenRefreshBufferSeconds = TokenRefreshBufferSeconds
+        };
+    }
+
+    private void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(TokenEndpoint))
+            throw new InvalidOperationException("Azure IMDS token endpoint is required.");
+        if (!Uri.TryCreate(TokenEndpoint, UriKind.Absolute, out _))
+            throw new InvalidOperationException("Azure IMDS token endpoint must be an absolute URI.");
+        if (string.IsNullOrWhiteSpace(ApiVersion))
+            throw new InvalidOperationException("Azure IMDS API version is required.");
+        if (string.IsNullOrWhiteSpace(Resource))
+            throw new InvalidOperationException("Azure IMDS resource is required.");
+        if (TokenRefreshBufferSeconds < 0)
+            throw new InvalidOperationException("Token refresh buffer must be non-negative.");
+    }
+
+    private OAuthBearerAzureImdsOptions Clone() => new()
+    {
+        TokenEndpoint = TokenEndpoint,
+        ApiVersion = ApiVersion,
+        Resource = Resource,
+        ClientId = ClientId,
+        TokenRefreshBufferSeconds = TokenRefreshBufferSeconds
+    };
+}

--- a/src/Dekaf/Security/Sasl/OAuthBearerConfig.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerConfig.cs
@@ -42,6 +42,12 @@ public sealed class OAuthBearerConfig
     public OAuthBearerJwtBearerOptions? JwtBearer { get; init; }
 
     /// <summary>
+    /// Azure IMDS managed identity settings. Required when <see cref="GrantType"/> is
+    /// <see cref="OAuthBearerGrantType.AzureImds"/>.
+    /// </summary>
+    public OAuthBearerAzureImdsOptions? AzureImds { get; init; }
+
+    /// <summary>
     /// The number of seconds before token expiration to trigger a refresh.
     /// Default is 60 seconds.
     /// </summary>
@@ -61,5 +67,10 @@ public enum OAuthBearerGrantType
     /// <summary>
     /// OAuth 2.0 JWT bearer assertion grant.
     /// </summary>
-    JwtBearer
+    JwtBearer,
+
+    /// <summary>
+    /// Azure Instance Metadata Service managed identity token source.
+    /// </summary>
+    AzureImds
 }

--- a/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
@@ -254,7 +254,8 @@ public sealed class OAuthBearerTokenProvider : IDisposable
 
         // Calculate expiration
         DateTimeOffset expiration;
-        if (root.TryGetProperty("expires_in", out var expiresInElement) && expiresInElement.TryGetInt32(out var expiresIn))
+        if (root.TryGetProperty("expires_in", out var expiresInElement)
+            && TryGetExpiresInSeconds(expiresInElement, out var expiresIn))
         {
             expiration = DateTimeOffset.UtcNow.AddSeconds(expiresIn);
         }
@@ -273,6 +274,22 @@ public sealed class OAuthBearerTokenProvider : IDisposable
             Expiration = expiration,
             PrincipalName = principalName
         };
+    }
+
+    private static bool TryGetExpiresInSeconds(JsonElement expiresInElement, out int expiresIn)
+    {
+        if (expiresInElement.ValueKind == JsonValueKind.Number)
+        {
+            return expiresInElement.TryGetInt32(out expiresIn);
+        }
+
+        if (expiresInElement.ValueKind == JsonValueKind.String)
+        {
+            return int.TryParse(expiresInElement.GetString(), out expiresIn);
+        }
+
+        expiresIn = 0;
+        return false;
     }
 
     private static string ExtractPrincipalName(string accessToken, JsonElement tokenResponse)

--- a/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
@@ -11,6 +11,8 @@ namespace Dekaf.Security.Sasl;
 public sealed class OAuthBearerTokenProvider : IDisposable
 {
     private static readonly TimeSpan PooledConnectionLifetime = TimeSpan.FromMinutes(2);
+    private static readonly string[] TokenResponsePrincipalClaims = ["sub", "client_id", "object_id", "oid"];
+    private static readonly string[] JwtPrincipalClaims = ["sub", "azp", "client_id", "appid", "oid"];
 
     private readonly OAuthBearerConfig _config;
     private readonly HttpClient _httpClient;
@@ -23,7 +25,7 @@ public sealed class OAuthBearerTokenProvider : IDisposable
     /// </summary>
     /// <param name="config">The OAuth configuration.</param>
     public OAuthBearerTokenProvider(OAuthBearerConfig config)
-        : this(config, new HttpClient(CreateHttpHandler(), disposeHandler: true), ownsHttpClient: true)
+        : this(config, CreateDefaultHttpClient(config), ownsHttpClient: true)
     {
     }
 
@@ -37,7 +39,7 @@ public sealed class OAuthBearerTokenProvider : IDisposable
     {
     }
 
-    internal static HttpMessageHandler CreateHttpHandler()
+    internal static HttpMessageHandler CreateHttpHandler(bool useProxy = true)
     {
 #if NETSTANDARD2_0
         var handlerType = Type.GetType("System.Net.Http.SocketsHttpHandler, System.Net.Http");
@@ -47,17 +49,22 @@ public sealed class OAuthBearerTokenProvider : IDisposable
             if (lifetimeProperty is not null && lifetimeProperty.CanWrite)
             {
                 lifetimeProperty.SetValue(handler, PooledConnectionLifetime);
+                var useProxyProperty = handlerType.GetProperty("UseProxy");
+                if (useProxyProperty is not null && useProxyProperty.CanWrite)
+                    useProxyProperty.SetValue(handler, useProxy);
+
                 return handler;
             }
 
             handler.Dispose();
         }
 
-        return new HttpClientHandler();
+        return new HttpClientHandler { UseProxy = useProxy };
 #else
         return new SocketsHttpHandler
         {
-            PooledConnectionLifetime = PooledConnectionLifetime
+            PooledConnectionLifetime = PooledConnectionLifetime,
+            UseProxy = useProxy
         };
 #endif
     }
@@ -67,6 +74,14 @@ public sealed class OAuthBearerTokenProvider : IDisposable
         _config = config ?? throw new ArgumentNullException(nameof(config));
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _ownsHttpClient = ownsHttpClient;
+    }
+
+    private static HttpClient CreateDefaultHttpClient(OAuthBearerConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var useProxy = config.GrantType != OAuthBearerGrantType.AzureImds;
+        return new HttpClient(CreateHttpHandler(useProxy), disposeHandler: true);
     }
 
     /// <summary>
@@ -101,6 +116,13 @@ public sealed class OAuthBearerTokenProvider : IDisposable
 
     private async Task<OAuthBearerToken> FetchTokenAsync(CancellationToken cancellationToken)
     {
+        return _config.GrantType == OAuthBearerGrantType.AzureImds
+            ? await FetchAzureImdsTokenAsync(cancellationToken).ConfigureAwait(false)
+            : await FetchOAuthTokenEndpointAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<OAuthBearerToken> FetchOAuthTokenEndpointAsync(CancellationToken cancellationToken)
+    {
         var requestBody = BuildTokenRequestBody();
 
         using var request = new HttpRequestMessage(HttpMethod.Post, _config.TokenEndpointUrl)
@@ -129,6 +151,42 @@ public sealed class OAuthBearerTokenProvider : IDisposable
         }
 
         return ParseTokenResponse(responseContent);
+    }
+
+    private async Task<OAuthBearerToken> FetchAzureImdsTokenAsync(CancellationToken cancellationToken)
+    {
+        var options = _config.AzureImds
+            ?? throw new InvalidOperationException("Azure IMDS OAuth grant requires AzureImds options");
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, BuildAzureImdsTokenUri(options));
+        request.Headers.TryAddWithoutValidation("Metadata", "true");
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        var responseContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new AuthenticationException(
+                $"Azure IMDS token request failed with status {response.StatusCode}: {responseContent}");
+        }
+
+        return ParseTokenResponse(responseContent);
+    }
+
+    private static Uri BuildAzureImdsTokenUri(OAuthBearerAzureImdsOptions options)
+    {
+        var endpoint = options.TokenEndpoint;
+        var separator = endpoint.Contains('?', StringComparison.Ordinal) ? "&" : "?";
+        var uri = new StringBuilder(endpoint)
+            .Append(separator)
+            .Append("api-version=").Append(Uri.EscapeDataString(options.ApiVersion))
+            .Append("&resource=").Append(Uri.EscapeDataString(options.Resource));
+
+        if (!string.IsNullOrWhiteSpace(options.ClientId))
+            uri.Append("&client_id=").Append(Uri.EscapeDataString(options.ClientId!));
+
+        return new Uri(uri.ToString(), UriKind.Absolute);
     }
 
     private Dictionary<string, string> BuildTokenRequestBody()
@@ -220,11 +278,14 @@ public sealed class OAuthBearerTokenProvider : IDisposable
     private static string ExtractPrincipalName(string accessToken, JsonElement tokenResponse)
     {
         // First, try to get from token response (some providers include it)
-        if (tokenResponse.TryGetProperty("sub", out var subElement))
+        foreach (var responseClaim in TokenResponsePrincipalClaims)
         {
-            var sub = subElement.GetString();
-            if (!string.IsNullOrEmpty(sub))
-                return sub!;
+            if (tokenResponse.TryGetProperty(responseClaim, out var responseClaimElement))
+            {
+                var value = responseClaimElement.GetString();
+                if (!string.IsNullOrEmpty(value))
+                    return value!;
+            }
         }
 
         // Try to decode JWT and extract subject claim
@@ -251,7 +312,7 @@ public sealed class OAuthBearerTokenProvider : IDisposable
                 var payloadRoot = payloadDoc.RootElement;
 
                 // Try 'sub' claim first, then 'azp' (authorized party), then 'client_id'
-                foreach (var claim in new[] { "sub", "azp", "client_id" })
+                foreach (var claim in JwtPrincipalClaims)
                 {
                     if (payloadRoot.TryGetProperty(claim, out var claimElement))
                     {

--- a/tests/Dekaf.Tests.Unit/Builder/OAuthBearerJwtBearerBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/OAuthBearerJwtBearerBuilderTests.cs
@@ -80,6 +80,81 @@ public sealed class OAuthBearerJwtBearerBuilderTests
     }
 
     [Test]
+    public async Task Producer_WithOAuthBearerAzureImds_ReturnsSameBuilderAndConfiguresGrant()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var result = builder.WithOAuthBearerAzureImds(CreateAzureImdsOptions());
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(GetSaslMechanism(builder)).IsEqualTo(SaslMechanism.OAuthBearer);
+        await Assert.That(GetOAuthConfig(builder)!.GrantType).IsEqualTo(OAuthBearerGrantType.AzureImds);
+    }
+
+    [Test]
+    public async Task Producer_WithOAuthBearerAzureImdsAction_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var result = builder.WithOAuthBearerAzureImds(options =>
+        {
+            options.Resource = "api://kafka";
+            options.ClientId = "managed-identity-client";
+        });
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task Consumer_WithOAuthBearerAzureImds_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var result = builder.WithOAuthBearerAzureImds(CreateAzureImdsOptions());
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task ShareConsumer_WithOAuthBearerAzureImds_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateShareConsumer<string, string>();
+
+        var result = builder.WithOAuthBearerAzureImds(CreateAzureImdsOptions());
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task AdminClient_WithOAuthBearerAzureImds_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateAdminClient();
+
+        var result = builder.WithOAuthBearerAzureImds(CreateAzureImdsOptions());
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task KafkaClient_WithOAuthBearerAzureImds_ReturnsSameBuilder()
+    {
+        var builder = Kafka.Connect();
+
+        var result = builder.WithOAuthBearerAzureImds(CreateAzureImdsOptions());
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task Producer_WithOAuthBearerAzureImds_MissingResource_ThrowsInvalidOperationException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        await Assert.That(() => builder.WithOAuthBearerAzureImds(new OAuthBearerAzureImdsOptions { Resource = string.Empty }))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task Producer_WithOAuthBearerJwtBearer_NullOptions_ThrowsArgumentNullException()
     {
         var builder = Kafka.CreateProducer<string, string>();
@@ -136,6 +211,12 @@ public sealed class OAuthBearerJwtBearerBuilderTests
         Audience = "kafka"
     };
 
+    private static OAuthBearerAzureImdsOptions CreateAzureImdsOptions() => new()
+    {
+        Resource = "api://kafka",
+        ClientId = "managed-identity-client"
+    };
+
     private static async Task AssertInvalidJwtBearerDoesNotChangeSaslMechanism<TBuilder>(
         TBuilder builder,
         Action<TBuilder> configure)
@@ -152,5 +233,14 @@ public sealed class OAuthBearerJwtBearerBuilderTests
             ?? throw new InvalidOperationException("_saslMechanism field not found");
 
         return (SaslMechanism)field.GetValue(builder)!;
+    }
+
+    private static OAuthBearerConfig? GetOAuthConfig(object builder)
+    {
+        var field = builder.GetType()
+            .GetField("_oauthConfig", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_oauthConfig field not found");
+
+        return (OAuthBearerConfig?)field.GetValue(builder);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
@@ -278,6 +278,56 @@ public sealed class OAuthBearerTokenProviderTests
     }
 
     [Test]
+    public async Task GetTokenAsync_WithAzureImds_SendsMetadataGetRequest()
+    {
+        var handler = new CapturingAzureImdsHandler();
+        var options = new OAuthBearerAzureImdsOptions
+        {
+            TokenEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token",
+            Resource = "api://kafka",
+            ClientId = "managed-identity-client"
+        };
+        using var provider = new OAuthBearerTokenProvider(options.ToOAuthBearerConfig(), new HttpClient(handler));
+
+        var token = await provider.GetTokenAsync();
+
+        await Assert.That(token.TokenValue).IsEqualTo("azure-access-token");
+        await Assert.That(token.PrincipalName).IsEqualTo("managed-identity-client");
+        await Assert.That(handler.Requests.Count).IsEqualTo(1);
+
+        var request = handler.Requests[0];
+        await Assert.That(request.Method).IsEqualTo(HttpMethod.Get);
+        await Assert.That(request.HasContent).IsFalse();
+        await Assert.That(request.MetadataHeader).IsEqualTo("true");
+        await Assert.That(request.Query["api-version"]).IsEqualTo("2018-02-01");
+        await Assert.That(request.Query["resource"]).IsEqualTo("api://kafka");
+        await Assert.That(request.Query["client_id"]).IsEqualTo("managed-identity-client");
+    }
+
+    [Test]
+    public async Task GetTokenAsync_WithAzureImdsSystemAssignedIdentity_OmitsClientId()
+    {
+        var handler = new CapturingAzureImdsHandler();
+        var options = new OAuthBearerAzureImdsOptions
+        {
+            Resource = "https://eventhubs.azure.net/"
+        };
+        using var provider = new OAuthBearerTokenProvider(options.ToOAuthBearerConfig(), new HttpClient(handler));
+
+        _ = await provider.GetTokenAsync();
+
+        await Assert.That(handler.Requests[0].Query.ContainsKey("client_id")).IsFalse();
+    }
+
+    [Test]
+    public async Task ToOAuthBearerConfig_WithAzureImdsMissingResource_ThrowsInvalidOperationException()
+    {
+        var options = new OAuthBearerAzureImdsOptions { Resource = string.Empty };
+
+        await Assert.That(() => options.ToOAuthBearerConfig()).Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task GetTokenAsync_WithValidCachedToken_ReusesToken()
     {
         using var rsa = RSA.Create(2048);
@@ -411,4 +461,48 @@ public sealed class OAuthBearerTokenProviderTests
         private static string DecodeFormValue(string value) =>
             Uri.UnescapeDataString(value.Replace('+', ' '));
     }
+
+    private sealed class CapturingAzureImdsHandler : HttpMessageHandler
+    {
+        public List<AzureImdsRequest> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(new AzureImdsRequest(
+                request.Method,
+                request.Content is not null,
+                request.Headers.TryGetValues("Metadata", out var metadataValues)
+                    ? metadataValues.Single()
+                    : null,
+                ParseQuery(request.RequestUri!.Query)));
+
+            const string json = """{"access_token":"azure-access-token","expires_in":3600,"client_id":"managed-identity-client"}""";
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+        }
+
+        private static IReadOnlyDictionary<string, string> ParseQuery(string query)
+        {
+            var result = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var pair in query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var parts = pair.Split('=', 2);
+                var key = Uri.UnescapeDataString(parts[0]);
+                var value = parts.Length == 2 ? Uri.UnescapeDataString(parts[1]) : string.Empty;
+                result[key] = value;
+            }
+
+            return result;
+        }
+    }
+
+    private sealed record AzureImdsRequest(
+        HttpMethod Method,
+        bool HasContent,
+        string? MetadataHeader,
+        IReadOnlyDictionary<string, string> Query);
 }

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
@@ -478,7 +478,7 @@ public sealed class OAuthBearerTokenProviderTests
                     : null,
                 ParseQuery(request.RequestUri!.Query)));
 
-            const string json = """{"access_token":"azure-access-token","expires_in":3600,"client_id":"managed-identity-client"}""";
+            const string json = """{"access_token":"azure-access-token","expires_in":"3600","client_id":"managed-identity-client"}""";
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(json, Encoding.UTF8, "application/json")


### PR DESCRIPTION
## Summary
- add Azure IMDS managed identity OAuth options and token fetch path
- add fluent builder APIs for producer, consumer, share consumer, admin, and shared client
- document Azure IMDS OAUTHBEARER usage and cover request/query behavior in unit tests

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal
- [x] dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/*/(OAuthBearerJwtBearerBuilderTests|OAuthBearerTokenProviderTests)/*"
- [x] dotnet build src\Dekaf\Dekaf.csproj --configuration Release --framework netstandard2.0 -p:TreatWarningsAsErrors=true -v:minimal
- [x] dotnet format Dekaf.sln --verify-no-changes --verbosity minimal

Closes #1397