### PR TITLE
fix(consumer): honor max poll records

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1524,6 +1524,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
 
     public ConsumerBuilder<TKey, TValue> WithMaxPollRecords(int maxPollRecords)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxPollRecords, 1);
         _maxPollRecords = maxPollRecords;
         return this;
     }
@@ -2638,6 +2639,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
 
     public ShareConsumerBuilder<TKey, TValue> WithMaxPollRecords(int maxPollRecords)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxPollRecords, 1);
         _maxPollRecords = maxPollRecords;
         return this;
     }

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -17,16 +17,21 @@ namespace Dekaf.Consumer
         private readonly IDeserializer<TKey>? _keyDeserializer;
         private readonly IDeserializer<TValue>? _valueDeserializer;
         private readonly Func<TopicPartition, bool>? _isPartitionStillAssigned;
+        private readonly int _maxRecords;
+        private long _count;
 
         internal ConsumeBatch(PendingFetchData pendingFetchData,
             IDeserializer<TKey>? keyDeserializer,
             IDeserializer<TValue>? valueDeserializer,
-            Func<TopicPartition, bool>? isPartitionStillAssigned = null)
+            Func<TopicPartition, bool>? isPartitionStillAssigned = null,
+            int maxRecords = int.MaxValue)
         {
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxRecords, 1);
             _pendingFetchData = pendingFetchData;
             _keyDeserializer = keyDeserializer;
             _valueDeserializer = valueDeserializer;
             _isPartitionStillAssigned = isPartitionStillAssigned;
+            _maxRecords = maxRecords;
         }
 
         /// <summary>
@@ -48,7 +53,7 @@ namespace Dekaf.Consumer
         /// Gets the number of messages yielded from this batch after enumeration.
         /// This value is only accurate after the batch has been fully enumerated.
         /// </summary>
-        public long Count => _pendingFetchData.MessageCount;
+        public long Count => _count;
 
         /// <summary>
         /// Returns a struct enumerator that avoids boxing allocation.
@@ -76,10 +81,12 @@ namespace Dekaf.Consumer
         public struct Enumerator : IEnumerator<ConsumeResult<TKey, TValue>>
         {
             private readonly ConsumeBatch<TKey, TValue> _batch;
+            private int _recordsYielded;
 
             internal Enumerator(ConsumeBatch<TKey, TValue> batch)
             {
                 _batch = batch;
+                _recordsYielded = 0;
                 Current = default!;
             }
 
@@ -103,6 +110,12 @@ namespace Dekaf.Consumer
                 if (_batch._isPartitionStillAssigned is not null
                     && !_batch._isPartitionStillAssigned(pending.TopicPartition))
                 {
+                    return false;
+                }
+
+                if (_recordsYielded >= _batch._maxRecords)
+                {
+                    pending.TryBufferNext();
                     return false;
                 }
 
@@ -139,6 +152,8 @@ namespace Dekaf.Consumer
                     valueDeserializer: _batch._valueDeserializer);
 
                 pending.TrackConsumed(offset, messageBytes);
+                _recordsYielded++;
+                _batch._count++;
 
                 return true;
             }

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -42,13 +42,18 @@ namespace Dekaf.Consumer
     {
         private readonly PendingFetchData _pendingFetchData;
         private readonly Func<TopicPartition, bool>? _isPartitionStillAssigned;
+        private readonly int _maxRecords;
+        private long _count;
 
         internal ConsumeRawBatch(
             PendingFetchData pendingFetchData,
-            Func<TopicPartition, bool>? isPartitionStillAssigned = null)
+            Func<TopicPartition, bool>? isPartitionStillAssigned = null,
+            int maxRecords = int.MaxValue)
         {
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxRecords, 1);
             _pendingFetchData = pendingFetchData;
             _isPartitionStillAssigned = isPartitionStillAssigned;
+            _maxRecords = maxRecords;
         }
 
         /// <summary>
@@ -70,7 +75,7 @@ namespace Dekaf.Consumer
         /// Gets the number of messages yielded from this batch after enumeration.
         /// This value is only accurate after the batch has been fully enumerated.
         /// </summary>
-        public long Count => _pendingFetchData.MessageCount;
+        public long Count => _count;
 
         /// <summary>
         /// Returns a struct enumerator that avoids boxing allocation.
@@ -98,10 +103,12 @@ namespace Dekaf.Consumer
         public struct Enumerator : IEnumerator<ConsumeRawRecord>
         {
             private readonly ConsumeRawBatch _batch;
+            private int _recordsYielded;
 
             internal Enumerator(ConsumeRawBatch batch)
             {
                 _batch = batch;
+                _recordsYielded = 0;
                 Current = default;
             }
 
@@ -124,6 +131,12 @@ namespace Dekaf.Consumer
                 if (_batch._isPartitionStillAssigned is not null
                     && !_batch._isPartitionStillAssigned(pending.TopicPartition))
                 {
+                    return false;
+                }
+
+                if (_recordsYielded >= _batch._maxRecords)
+                {
+                    pending.TryBufferNext();
                     return false;
                 }
 
@@ -150,6 +163,8 @@ namespace Dekaf.Consumer
                     isValueNull: record.IsValueNull);
 
                 pending.TrackConsumed(offset, messageBytes);
+                _recordsYielded++;
+                _batch._count++;
 
                 return true;
             }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -82,6 +82,7 @@ internal sealed class PendingFetchData : IDisposable
     private int _disposed;
     private int _headerGeneration;
     private bool _eagerParsed;
+    private bool _hasBufferedCurrent;
 
     public string Topic { get; private set; } = null!;
     public int PartitionIndex { get; private set; }
@@ -129,6 +130,7 @@ internal sealed class PendingFetchData : IDisposable
     /// Using long to prevent overflow in long-running scenarios with large fetches.
     /// </summary>
     public long MessageCount { get; private set; }
+    internal bool IsExhausted { get; private set; }
 
     private long _emittedMessageCount;
     private long _emittedBytesConsumed;
@@ -326,12 +328,21 @@ internal sealed class PendingFetchData : IDisposable
     {
         Debug.Assert(Volatile.Read(ref _disposed) == 0, "MoveNext() called after Dispose()");
 
+        if (IsExhausted)
+            return false;
+
+        if (_hasBufferedCurrent)
+        {
+            _hasBufferedCurrent = false;
+            return true;
+        }
+
         // First call - start at first batch, first record
         if (_batchIndex < 0)
         {
             _batchIndex = 0;
             _recordIndex = 0;
-            return HasCurrentRecord();
+            return HasCurrentRecordOrMarkExhausted();
         }
 
         // Try next record in current batch (uses cached count to avoid Records property access)
@@ -342,7 +353,36 @@ internal sealed class PendingFetchData : IDisposable
         // Move to next batch
         _batchIndex++;
         _recordIndex = 0;
-        return HasCurrentRecord();
+        return HasCurrentRecordOrMarkExhausted();
+    }
+
+    /// <summary>
+    /// Advances to the next record and makes the following <see cref="MoveNext"/> return it.
+    /// Used when a bounded batch reaches its record limit and must distinguish
+    /// "more records remain" from "fetch exhausted" without dropping the next record.
+    /// </summary>
+    internal bool TryBufferNext()
+    {
+        if (IsExhausted)
+            return false;
+
+        if (_hasBufferedCurrent)
+            return true;
+
+        if (!MoveNext())
+            return false;
+
+        _hasBufferedCurrent = true;
+        return true;
+    }
+
+    private bool HasCurrentRecordOrMarkExhausted()
+    {
+        if (HasCurrentRecord())
+            return true;
+
+        IsExhausted = true;
+        return false;
     }
 
     private bool HasCurrentRecord()
@@ -449,6 +489,7 @@ internal sealed class PendingFetchData : IDisposable
         _currentRecords = null;
         _currentRecordsCount = 0;
         _eagerParsed = false;
+        _hasBufferedCurrent = false;
         unchecked
         {
             _headerGeneration++;
@@ -463,6 +504,7 @@ internal sealed class PendingFetchData : IDisposable
         LastYieldedLeaderEpoch = -1;
         TotalBytesConsumed = 0;
         MessageCount = 0;
+        IsExhausted = false;
         _emittedMessageCount = 0;
         _emittedBytesConsumed = 0;
         PartitionIndex = 0;
@@ -896,6 +938,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(options.ConnectionsPerBroker, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(options.ConnectionsPerBroker, options.MaxConnectionsPerBroker);
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxPollRecords, 1);
         AutoOffsetResetStrategy.ValidateOptions(options);
 
         _options = options;
@@ -1675,7 +1718,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 if (ClearFetchBufferForPendingCoordinatorRevocations())
                     continue;
 
-                PendingFetchData pending = _pendingFetches.Dequeue();
+                PendingFetchData pending = _pendingFetches.Peek();
+                int pendingFetchesVersion = Volatile.Read(ref _pendingFetchesVersion);
+                var batchYielded = false;
                 long? batchProcessingStarted = _adaptiveFetchSizer is not null
                     ? Stopwatch.GetTimestamp() : null;
 
@@ -1689,28 +1734,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         pending,
                         _keyDeserializer,
                         _valueDeserializer,
-                        IsCurrentlyAssigned);
+                        IsCurrentlyAssigned,
+                        _options.MaxPollRecords);
+                    batchYielded = true;
                     yield return batch;
-
-                    // After caller finishes iterating: update positions once per batch
-                    FlushConsumedPositions(pending);
-
-                    // Record consumer metrics per-fetch
-                    if (metricsEnabled && pending.MessageCount > 0)
-                    {
-                        EmitFetchMetrics(pending);
-                    }
-
-                    // Report batch processing time to the adaptive fetch sizer
-                    if (batchProcessingStarted.HasValue)
-                    {
-                        TimeSpan processingDuration = Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
-                        _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
-                    }
                 }
                 finally
                 {
-                    pending.Dispose();
+                    CompleteBatchPoll(
+                        pending,
+                        pendingFetchesVersion,
+                        metricsEnabled,
+                        batchProcessingStarted,
+                        disposePending: !batchYielded);
                 }
             }
 
@@ -1822,7 +1858,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 if (ClearFetchBufferForPendingCoordinatorRevocations())
                     continue;
 
-                PendingFetchData pending = _pendingFetches.Dequeue();
+                PendingFetchData pending = _pendingFetches.Peek();
+                int pendingFetchesVersion = Volatile.Read(ref _pendingFetchesVersion);
+                var batchYielded = false;
                 long? batchProcessingStarted = _adaptiveFetchSizer is not null
                     ? Stopwatch.GetTimestamp() : null;
 
@@ -1832,28 +1870,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     pending.EagerParseAll();
 
                     // Yield the raw batch to the caller for synchronous iteration
-                    ConsumeRawBatch batch = new(pending, IsCurrentlyAssigned);
+                    ConsumeRawBatch batch = new(pending, IsCurrentlyAssigned, _options.MaxPollRecords);
+                    batchYielded = true;
                     yield return batch;
-
-                    // After caller finishes iterating: update positions once per batch
-                    FlushConsumedPositions(pending);
-
-                    // Record consumer metrics per-fetch
-                    if (metricsEnabled && pending.MessageCount > 0)
-                    {
-                        EmitFetchMetrics(pending);
-                    }
-
-                    // Report batch processing time to the adaptive fetch sizer
-                    if (batchProcessingStarted.HasValue)
-                    {
-                        TimeSpan processingDuration = Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
-                        _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
-                    }
                 }
                 finally
                 {
-                    pending.Dispose();
+                    CompleteBatchPoll(
+                        pending,
+                        pendingFetchesVersion,
+                        metricsEnabled,
+                        batchProcessingStarted,
+                        disposePending: !batchYielded);
                 }
             }
 
@@ -1863,6 +1891,36 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 // Discarded — EOF is informational and not relevant for raw batch throughput
             }
+        }
+    }
+
+    private void CompleteBatchPoll(
+        PendingFetchData pending,
+        int pendingFetchesVersion,
+        bool metricsEnabled,
+        long? batchProcessingStarted,
+        bool disposePending)
+    {
+        if (Volatile.Read(ref _pendingFetchesVersion) != pendingFetchesVersion)
+            return;
+
+        if (_pendingFetches.Count == 0 || !ReferenceEquals(_pendingFetches.Peek(), pending))
+            return;
+
+        FlushConsumedPositions(pending);
+
+        if (metricsEnabled && pending.MessageCount > 0)
+            EmitFetchMetrics(pending);
+
+        if (batchProcessingStarted.HasValue)
+        {
+            TimeSpan processingDuration = Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
+            _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
+        }
+
+        if (disposePending || pending.IsExhausted || !IsCurrentlyAssigned(pending.TopicPartition))
+        {
+            _pendingFetches.Dequeue().Dispose();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -230,6 +230,30 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task WithMaxPollRecords_LessThan1_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+        await Assert.That(() => builder.WithMaxPollRecords(0))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task ShareConsumer_WithMaxPollRecords_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateShareConsumer<string, string>();
+        var result = builder.WithMaxPollRecords(100);
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task ShareConsumer_WithMaxPollRecords_LessThan1_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateShareConsumer<string, string>();
+        await Assert.That(() => builder.WithMaxPollRecords(0))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     public async Task WithFetchSessions_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateConsumer<string, string>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerMaxPollRecordsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerMaxPollRecordsTests.cs
@@ -1,0 +1,167 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerMaxPollRecordsTests
+{
+    private const string Topic = "test-topic";
+    private const int Partition = 0;
+
+    [Test]
+    public async Task ConsumeBatchAsync_LimitsEachBatchToMaxPollRecords()
+    {
+        await using var consumer = CreateConsumerWithPendingFetches(
+            maxPollRecords: 2,
+            CreatePendingFetchData(messageCount: 5));
+
+        var batchCounts = new List<int>();
+        var offsets = new List<long>();
+
+        await foreach (var batch in consumer.ConsumeBatchAsync(CancellationToken.None))
+        {
+            var currentOffsets = batch.Select(result => result.Offset).ToArray();
+            batchCounts.Add(currentOffsets.Length);
+            offsets.AddRange(currentOffsets);
+
+            if (offsets.Count >= 5)
+                break;
+        }
+
+        await Assert.That(batchCounts).IsEquivalentTo([2, 2, 1]);
+        await Assert.That(offsets).IsEquivalentTo([0L, 1L, 2L, 3L, 4L]);
+    }
+
+    [Test]
+    public async Task ConsumeRawBatchAsync_LimitsEachBatchToMaxPollRecords()
+    {
+        await using var consumer = CreateConsumerWithPendingFetches(
+            maxPollRecords: 2,
+            CreatePendingFetchData(messageCount: 5));
+
+        var batchCounts = new List<int>();
+        var offsets = new List<long>();
+
+        await foreach (var batch in consumer.ConsumeRawBatchAsync(CancellationToken.None))
+        {
+            var currentOffsets = batch.Select(result => result.Offset).ToArray();
+            batchCounts.Add(currentOffsets.Length);
+            offsets.AddRange(currentOffsets);
+
+            if (offsets.Count >= 5)
+                break;
+        }
+
+        await Assert.That(batchCounts).IsEquivalentTo([2, 2, 1]);
+        await Assert.That(offsets).IsEquivalentTo([0L, 1L, 2L, 3L, 4L]);
+    }
+
+    [Test]
+    public async Task ConsumeBatchAsync_ExactMaxPollRecordsMultiple_RemovesExhaustedFetch()
+    {
+        await using var consumer = CreateConsumerWithPendingFetches(
+            maxPollRecords: 2,
+            CreatePendingFetchData(messageCount: 4));
+
+        await using var enumerator = consumer.ConsumeBatchAsync(CancellationToken.None).GetAsyncEnumerator();
+
+        await Assert.That(await enumerator.MoveNextAsync()).IsTrue();
+        await Assert.That(enumerator.Current.Select(result => result.Offset).ToArray())
+            .IsEquivalentTo([0L, 1L]);
+
+        await Assert.That(await enumerator.MoveNextAsync()).IsTrue();
+        await Assert.That(enumerator.Current.Select(result => result.Offset).ToArray())
+            .IsEquivalentTo([2L, 3L]);
+
+        await enumerator.DisposeAsync();
+
+        await Assert.That(GetPendingFetches(consumer).Count).IsEqualTo(0);
+    }
+
+    private static KafkaConsumer<string, string> CreateConsumerWithPendingFetches(
+        int maxPollRecords,
+        params PendingFetchData[] fetches)
+    {
+        var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1,
+                MaxPollRecords = maxPollRecords
+            },
+            Serializers.String,
+            Serializers.String);
+
+        var tp = new TopicPartition(Topic, Partition);
+        consumer.Assign(tp);
+        SetInitialized(consumer);
+        GetFetchPositions(consumer)[tp] = 0;
+
+        var pendingFetches = GetPendingFetches(consumer);
+        foreach (var fetch in fetches)
+            pendingFetches.Enqueue(fetch);
+
+        return consumer;
+    }
+
+    private static void SetInitialized(KafkaConsumer<string, string> consumer)
+    {
+        var initializedField = typeof(KafkaConsumer<string, string>)
+            .GetField("_initialized", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_initialized field not found.");
+
+        initializedField.SetValue(consumer, true);
+    }
+
+    private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions(
+        KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_fetchPositions", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_fetchPositions field not found.");
+
+        return (ConcurrentDictionary<TopicPartition, long>)field.GetValue(consumer)!;
+    }
+
+    private static Queue<PendingFetchData> GetPendingFetches(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_pendingFetches", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_pendingFetches field not found.");
+
+        return (Queue<PendingFetchData>)field.GetValue(consumer)!;
+    }
+
+    private static PendingFetchData CreatePendingFetchData(int messageCount)
+    {
+        var records = new Record[messageCount];
+        for (var i = 0; i < messageCount; i++)
+        {
+            records[i] = new Record
+            {
+                OffsetDelta = i,
+                TimestampDelta = 0,
+                Key = Encoding.UTF8.GetBytes($"key-{i}"),
+                Value = Encoding.UTF8.GetBytes($"value-{i}"),
+                IsKeyNull = false,
+                IsValueNull = false,
+                Headers = null,
+                HeaderCount = 0
+            };
+        }
+
+        var recordBatch = new RecordBatch
+        {
+            BaseOffset = 0,
+            BaseTimestamp = 1700000000000L,
+            Records = records
+        };
+
+        return PendingFetchData.Create(Topic, Partition, [recordBatch]);
+    }
+}


### PR DESCRIPTION
## Summary
- honor `ConsumerOptions.MaxPollRecords` in `ConsumeBatchAsync` and `ConsumeRawBatchAsync`
- keep partially consumed fetches queued between capped batches without dropping the next record
- validate positive `MaxPollRecords` on consumer and share-consumer builders, with typed/raw batch coverage

Closes #1350

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/*/(ConsumerBuilderValidationTests|ConsumerMaxPollRecordsTests)/*"`
- `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --framework netstandard2.0 -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet format Dekaf.sln --verify-no-changes --verbosity minimal`