### PR TITLE
fix(networking): wake receive loop on dispose

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -2517,6 +2517,9 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         }
 
         _receiveCts?.Cancel();
+        // Wake an idle PipeReader.ReadAsync immediately; cancellation alone can leave
+        // disposal waiting for the fallback receive-loop timeout.
+        _reader?.CancelPendingRead();
 
         if (_receiveTask is not null)
         {

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -291,6 +291,7 @@ public sealed class KafkaConnectionTests
             await Task.Delay(TimeSpan.FromMilliseconds(1500), cancellationToken);
 
             await Assert.That(connection.IsConnected).IsTrue();
+            await connection.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2), cancellationToken);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Cancel pending pipe reads during connection disposal so an idle receive loop wakes immediately.
- Extend the caller-canceled request regression test to assert disposal completes promptly.

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal /p:UseAppHost=true`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-ansi --timeout 30s --treenode-filter "/*/*/KafkaConnectionTests/SendAsync_CallerCanceledRequest_DoesNotFailIdleConnectionAfterRequestTimeout"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-ansi --timeout 120s --treenode-filter "/*/*/KafkaConnectionTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --no-ansi --timeout 6m`

Closes #1484
