### PR TITLE
fix(security): refresh oauth endpoint DNS

### DIFF
--- a/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
@@ -10,6 +10,8 @@ namespace Dekaf.Security.Sasl;
 /// </summary>
 public sealed class OAuthBearerTokenProvider : IDisposable
 {
+    private static readonly TimeSpan PooledConnectionLifetime = TimeSpan.FromMinutes(2);
+
     private readonly OAuthBearerConfig _config;
     private readonly HttpClient _httpClient;
     private readonly bool _ownsHttpClient;
@@ -21,7 +23,7 @@ public sealed class OAuthBearerTokenProvider : IDisposable
     /// </summary>
     /// <param name="config">The OAuth configuration.</param>
     public OAuthBearerTokenProvider(OAuthBearerConfig config)
-        : this(config, new HttpClient(), ownsHttpClient: true)
+        : this(config, new HttpClient(CreateHttpHandler(), disposeHandler: true), ownsHttpClient: true)
     {
     }
 
@@ -33,6 +35,31 @@ public sealed class OAuthBearerTokenProvider : IDisposable
     public OAuthBearerTokenProvider(OAuthBearerConfig config, HttpClient httpClient)
         : this(config, httpClient, ownsHttpClient: false)
     {
+    }
+
+    internal static HttpMessageHandler CreateHttpHandler()
+    {
+#if NETSTANDARD2_0
+        var handlerType = Type.GetType("System.Net.Http.SocketsHttpHandler, System.Net.Http");
+        if (handlerType is not null && Activator.CreateInstance(handlerType) is HttpMessageHandler handler)
+        {
+            var lifetimeProperty = handlerType.GetProperty("PooledConnectionLifetime");
+            if (lifetimeProperty is not null && lifetimeProperty.CanWrite)
+            {
+                lifetimeProperty.SetValue(handler, PooledConnectionLifetime);
+                return handler;
+            }
+
+            handler.Dispose();
+        }
+
+        return new HttpClientHandler();
+#else
+        return new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = PooledConnectionLifetime
+        };
+#endif
     }
 
     private OAuthBearerTokenProvider(OAuthBearerConfig config, HttpClient httpClient, bool ownsHttpClient)

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
@@ -248,6 +248,15 @@ public sealed class OAuthBearerTokenProviderTests
     }
 
     [Test]
+    public async Task CreateHttpHandler_SetsPooledConnectionLifetime()
+    {
+        using var handler = OAuthBearerTokenProvider.CreateHttpHandler();
+
+        await Assert.That(handler).IsTypeOf<SocketsHttpHandler>();
+        await Assert.That(((SocketsHttpHandler)handler).PooledConnectionLifetime).IsEqualTo(TimeSpan.FromMinutes(2));
+    }
+
+    [Test]
     public async Task GetTokenAsync_WithJwtBearer_SendsAssertionGrant()
     {
         using var rsa = RSA.Create(2048);


### PR DESCRIPTION
## Summary
- Create the default OAuth bearer token `HttpClient` with a pooled handler
- Set `PooledConnectionLifetime` to 2 minutes so token-endpoint DNS can refresh
- Add focused coverage for the OAuth handler lifetime

Closes #1380.

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter /*/*/OAuthBearerTokenProviderTests/*`
- `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --framework netstandard2.0 -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet format Dekaf.sln --verify-no-changes --verbosity minimal`