### PR TITLE
perf(protocol): encode strings in one pass

### DIFF
--- a/src/Dekaf/Protocol/KafkaProtocolWriter.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolWriter.cs
@@ -11,6 +11,10 @@ namespace Dekaf.Protocol;
 /// </summary>
 public ref struct KafkaProtocolWriter
 {
+    private const int StackallocCharThreshold = 128;
+    private const int StackallocUtf8ByteCount = StackallocCharThreshold * 4;
+    private const int MaxUnsignedVarIntByteCount = 5;
+
     private readonly IBufferWriter<byte> _output;
     private int _bytesWritten;
 
@@ -137,6 +141,20 @@ public ref struct KafkaProtocolWriter
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int WriteVarUIntToSpan(uint value, Span<byte> span)
+    {
+        var pos = 0;
+        while (value >= 0x80)
+        {
+            span[pos++] = (byte)(value | 0x80);
+            value >>= 7;
+        }
+
+        span[pos++] = (byte)value;
+        return pos;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void WriteVarUInt(uint value)
     {
         // Fast path: single byte (0-127) - most common case
@@ -249,40 +267,7 @@ public ref struct KafkaProtocolWriter
             return;
         }
 
-        // Fast path for short strings (topic names, client IDs, etc.)
-        // Avoids double-pass of GetByteCount + GetBytes by using stackalloc buffer
-        if (value.Length <= 128)
-        {
-            // Max UTF-8 expansion is 4 bytes per char (surrogate pairs)
-            // For 128 chars, 512 bytes covers all cases including emojis
-            Span<byte> buffer = stackalloc byte[512];
-            var actualBytes = Encoding.UTF8.GetBytes(value, buffer);
-            WriteInt16((short)actualBytes);
-            if (actualBytes > 0)
-            {
-                var outputSpan = _output.GetSpan(actualBytes);
-                buffer[..actualBytes].CopyTo(outputSpan);
-                _output.Advance(actualBytes);
-                _bytesWritten += actualBytes;
-            }
-            return;
-        }
-
-        // Slow path for long strings
-        var byteCount = Encoding.UTF8.GetByteCount(value);
-
-        if (byteCount > short.MaxValue)
-            throw new ArgumentException($"String exceeds maximum Kafka short-prefixed string length ({byteCount} bytes > {short.MaxValue}).", nameof(value));
-
-        WriteInt16((short)byteCount);
-
-        if (byteCount > 0)
-        {
-            var span = _output.GetSpan(byteCount);
-            Encoding.UTF8.GetBytes(value, span);
-            _output.Advance(byteCount);
-            _bytesWritten += byteCount;
-        }
+        WriteStringValue(value);
     }
 
     /// <summary>
@@ -292,53 +277,17 @@ public ref struct KafkaProtocolWriter
     [SkipLocalsInit]
     public void WriteStringContent(string value)
     {
-        // Fast path for short strings
-        // Avoids double-pass of GetByteCount + GetBytes by using stackalloc buffer
-        if (value.Length <= 128)
-        {
-            // Max UTF-8 expansion is 4 bytes per char (surrogate pairs)
-            Span<byte> buffer = stackalloc byte[512];
-            var actualBytes = Encoding.UTF8.GetBytes(value, buffer);
-            if (actualBytes > 0)
-            {
-                var outputSpan = _output.GetSpan(actualBytes);
-                buffer[..actualBytes].CopyTo(outputSpan);
-                _output.Advance(actualBytes);
-                _bytesWritten += actualBytes;
-            }
-            return;
-        }
-
-        // Slow path for long strings
-        var byteCount = Encoding.UTF8.GetByteCount(value);
-        if (byteCount > 0)
-        {
-            var span = _output.GetSpan(byteCount);
-            Encoding.UTF8.GetBytes(value, span);
-            _output.Advance(byteCount);
-            _bytesWritten += byteCount;
-        }
+        ArgumentNullException.ThrowIfNull(value);
+        WriteStringContent(value.AsSpan());
     }
 
     /// <summary>
     /// Writes a string with 2-byte length prefix (legacy format) from a span.
     /// </summary>
+    [SkipLocalsInit]
     public void WriteString(ReadOnlySpan<char> value)
     {
-        var byteCount = Encoding.UTF8.GetByteCount(value);
-
-        if (byteCount > short.MaxValue)
-            throw new ArgumentException($"String exceeds maximum Kafka short-prefixed string length ({byteCount} bytes > {short.MaxValue}).", nameof(value));
-
-        WriteInt16((short)byteCount);
-
-        if (byteCount > 0)
-        {
-            var span = _output.GetSpan(byteCount);
-            Encoding.UTF8.GetBytes(value, span);
-            _output.Advance(byteCount);
-            _bytesWritten += byteCount;
-        }
+        WriteStringValue(value);
     }
 
     /// <summary>
@@ -354,53 +303,100 @@ public ref struct KafkaProtocolWriter
             return;
         }
 
-        // Fast path for short strings (topic names, header keys, etc.)
-        // Avoids double-pass of GetByteCount + GetBytes by using stackalloc buffer
-        if (value.Length <= 128)
-        {
-            // Max UTF-8 expansion is 4 bytes per char (surrogate pairs)
-            // For 128 chars, 512 bytes covers all cases including emojis
-            Span<byte> buffer = stackalloc byte[512];
-            var actualBytes = Encoding.UTF8.GetBytes(value, buffer);
-            WriteUnsignedVarInt(actualBytes + 1);
-            if (actualBytes > 0)
-            {
-                var outputSpan = _output.GetSpan(actualBytes);
-                buffer[..actualBytes].CopyTo(outputSpan);
-                _output.Advance(actualBytes);
-                _bytesWritten += actualBytes;
-            }
-            return;
-        }
-
-        // Slow path for long strings
-        var byteCount = Encoding.UTF8.GetByteCount(value);
-        WriteUnsignedVarInt(byteCount + 1);
-
-        if (byteCount > 0)
-        {
-            var span = _output.GetSpan(byteCount);
-            Encoding.UTF8.GetBytes(value, span);
-            _output.Advance(byteCount);
-            _bytesWritten += byteCount;
-        }
+        WriteCompactStringValue(value);
     }
 
     /// <summary>
     /// Writes a compact string with unsigned varint length prefix (flexible format) from a span.
     /// </summary>
+    [SkipLocalsInit]
     public void WriteCompactString(ReadOnlySpan<char> value)
     {
-        var byteCount = Encoding.UTF8.GetByteCount(value);
-        WriteUnsignedVarInt(byteCount + 1);
+        WriteCompactStringValue(value);
+    }
 
-        if (byteCount > 0)
+    [SkipLocalsInit]
+    private void WriteStringValue(ReadOnlySpan<char> value)
+    {
+        if (value.Length <= StackallocCharThreshold)
         {
-            var span = _output.GetSpan(byteCount);
-            Encoding.UTF8.GetBytes(value, span);
-            _output.Advance(byteCount);
-            _bytesWritten += byteCount;
+            Span<byte> buffer = stackalloc byte[StackallocUtf8ByteCount];
+            var byteCount = Encoding.UTF8.GetBytes(value, buffer);
+            WriteInt16((short)byteCount);
+            WriteUtf8Bytes(buffer[..byteCount]);
+            return;
         }
+
+        if (value.Length > short.MaxValue)
+        {
+            var byteCount = Encoding.UTF8.GetByteCount(value);
+            throw new ArgumentException($"String exceeds maximum Kafka short-prefixed string length ({byteCount} bytes > {short.MaxValue}).", nameof(value));
+        }
+
+        var maxByteCount = Encoding.UTF8.GetMaxByteCount(value.Length);
+        var span = _output.GetSpan(sizeof(short) + maxByteCount);
+        var actualBytes = Encoding.UTF8.GetBytes(value, span[sizeof(short)..]);
+
+        if (actualBytes > short.MaxValue)
+            throw new ArgumentException($"String exceeds maximum Kafka short-prefixed string length ({actualBytes} bytes > {short.MaxValue}).", nameof(value));
+
+        BinaryPrimitives.WriteInt16BigEndian(span, (short)actualBytes);
+        _output.Advance(sizeof(short) + actualBytes);
+        _bytesWritten += sizeof(short) + actualBytes;
+    }
+
+    [SkipLocalsInit]
+    private void WriteStringContent(ReadOnlySpan<char> value)
+    {
+        if (value.Length <= StackallocCharThreshold)
+        {
+            Span<byte> buffer = stackalloc byte[StackallocUtf8ByteCount];
+            var byteCount = Encoding.UTF8.GetBytes(value, buffer);
+            WriteUtf8Bytes(buffer[..byteCount]);
+            return;
+        }
+
+        var maxByteCount = Encoding.UTF8.GetMaxByteCount(value.Length);
+        var span = _output.GetSpan(maxByteCount);
+        var actualBytes = Encoding.UTF8.GetBytes(value, span);
+        _output.Advance(actualBytes);
+        _bytesWritten += actualBytes;
+    }
+
+    [SkipLocalsInit]
+    private void WriteCompactStringValue(ReadOnlySpan<char> value)
+    {
+        if (value.Length <= StackallocCharThreshold)
+        {
+            Span<byte> buffer = stackalloc byte[StackallocUtf8ByteCount];
+            var byteCount = Encoding.UTF8.GetBytes(value, buffer);
+            WriteUnsignedVarInt(byteCount + 1);
+            WriteUtf8Bytes(buffer[..byteCount]);
+            return;
+        }
+
+        var maxByteCount = Encoding.UTF8.GetMaxByteCount(value.Length);
+        var span = _output.GetSpan(MaxUnsignedVarIntByteCount + maxByteCount);
+        var actualBytes = Encoding.UTF8.GetBytes(value, span[MaxUnsignedVarIntByteCount..]);
+        var lengthBytes = WriteVarUIntToSpan((uint)(actualBytes + 1), span);
+
+        if (actualBytes > 0 && lengthBytes != MaxUnsignedVarIntByteCount)
+            span.Slice(MaxUnsignedVarIntByteCount, actualBytes).CopyTo(span[lengthBytes..]);
+
+        _output.Advance(lengthBytes + actualBytes);
+        _bytesWritten += lengthBytes + actualBytes;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void WriteUtf8Bytes(scoped ReadOnlySpan<byte> value)
+    {
+        if (value.Length == 0)
+            return;
+
+        var span = _output.GetSpan(value.Length);
+        value.CopyTo(span);
+        _output.Advance(value.Length);
+        _bytesWritten += value.Length;
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolWriterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolWriterTests.cs
@@ -144,7 +144,15 @@ public class KafkaProtocolWriterTests
             typeof(KafkaProtocolWriter).GetMethod(
                 nameof(KafkaProtocolWriter.WriteCompactString),
                 BindingFlags.Instance | BindingFlags.Public,
-                [typeof(string)])
+                [typeof(string)]),
+            typeof(KafkaProtocolWriter).GetMethod(
+                nameof(KafkaProtocolWriter.WriteString),
+                BindingFlags.Instance | BindingFlags.Public,
+                [typeof(ReadOnlySpan<char>)]),
+            typeof(KafkaProtocolWriter).GetMethod(
+                nameof(KafkaProtocolWriter.WriteCompactString),
+                BindingFlags.Instance | BindingFlags.Public,
+                [typeof(ReadOnlySpan<char>)])
         };
 
         foreach (var method in methods)

--- a/tests/Dekaf.Tests.Unit/Protocol/StringBytesEncodingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/StringBytesEncodingTests.cs
@@ -56,6 +56,25 @@ public class StringBytesEncodingTests
     }
 
     [Test]
+    public async Task String_SpanOverload_Utf8_EncodedCorrectly()
+    {
+        var bytes = WriteStringSpan("日本語");
+
+        var reader = new KafkaProtocolReader(bytes);
+        await Assert.That(reader.ReadString()).IsEqualTo("日本語");
+    }
+
+    [Test]
+    public async Task String_SpanOverload_LongUtf8_RoundTrips()
+    {
+        var value = string.Concat(Enumerable.Repeat("日本語", 50));
+        var bytes = WriteStringSpan(value);
+
+        var reader = new KafkaProtocolReader(bytes);
+        await Assert.That(reader.ReadString()).IsEqualTo(value);
+    }
+
+    [Test]
     public async Task NullableString_Null_EncodedAsMinusOne()
     {
         var buffer = new ArrayBufferWriter<byte>();
@@ -102,6 +121,25 @@ public class StringBytesEncodingTests
         // length + 1 = 5 (0x05), then "test"
         await Assert.That(buffer.WrittenSpan.ToArray())
             .IsEquivalentTo(new byte[] { 0x05, (byte)'t', (byte)'e', (byte)'s', (byte)'t' });
+    }
+
+    [Test]
+    public async Task CompactString_SpanOverload_Utf8_EncodedCorrectly()
+    {
+        var bytes = WriteCompactStringSpan("日本語");
+
+        var reader = new KafkaProtocolReader(bytes);
+        await Assert.That(reader.ReadCompactString()).IsEqualTo("日本語");
+    }
+
+    [Test]
+    public async Task CompactString_SpanOverload_LongUtf8_RoundTrips()
+    {
+        var value = string.Concat(Enumerable.Repeat("日本語", 50));
+        var bytes = WriteCompactStringSpan(value);
+
+        var reader = new KafkaProtocolReader(bytes);
+        await Assert.That(reader.ReadCompactString()).IsEqualTo(value);
     }
 
     [Test]
@@ -281,4 +319,20 @@ public class StringBytesEncodingTests
     }
 
     #endregion
+
+    private static byte[] WriteStringSpan(string value)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteString(value.AsSpan());
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static byte[] WriteCompactStringSpan(string value)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactString(value.AsSpan());
+        return buffer.WrittenSpan.ToArray();
+    }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtocolBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtocolBenchmarks.cs
@@ -19,12 +19,14 @@ public class ProtocolBenchmarks
     private byte[] _varIntData = null!;
     private byte[] _recordBatchBytes = null!;
     private string _testString = null!;
+    private string _longString = null!;
 
     [GlobalSetup]
     public void Setup()
     {
         _buffer = new ArrayBufferWriter<byte>(65536);
         _testString = new string('a', 100);
+        _longString = new string('a', 300);
 
         // Pre-create int32 data for reading
         var tempBuffer = new ArrayBufferWriter<byte>(4096);
@@ -75,6 +77,7 @@ public class ProtocolBenchmarks
     [Benchmark(Description = "Write 1000 Int32s")]
     public void WriteInt32_Thousand()
     {
+        _buffer.Clear();
         var writer = new KafkaProtocolWriter(_buffer);
         for (var i = 0; i < 1000; i++)
         {
@@ -85,6 +88,7 @@ public class ProtocolBenchmarks
     [Benchmark(Description = "Write 100 Strings (100 chars)")]
     public void WriteString_Hundred()
     {
+        _buffer.Clear();
         var writer = new KafkaProtocolWriter(_buffer);
         for (var i = 0; i < 100; i++)
         {
@@ -92,9 +96,33 @@ public class ProtocolBenchmarks
         }
     }
 
+    [Benchmark(Description = "Write 100 Strings (300 chars)")]
+    public void WriteString_Long()
+    {
+        _buffer.Clear();
+        var writer = new KafkaProtocolWriter(_buffer);
+        for (var i = 0; i < 100; i++)
+        {
+            writer.WriteString(_longString);
+        }
+    }
+
+    [Benchmark(Description = "Write 100 String spans (300 chars)")]
+    public void WriteStringSpan_Long()
+    {
+        _buffer.Clear();
+        var writer = new KafkaProtocolWriter(_buffer);
+        var value = _longString.AsSpan();
+        for (var i = 0; i < 100; i++)
+        {
+            writer.WriteString(value);
+        }
+    }
+
     [Benchmark(Description = "Write 100 CompactStrings")]
     public void WriteCompactString_Hundred()
     {
+        _buffer.Clear();
         var writer = new KafkaProtocolWriter(_buffer);
         for (var i = 0; i < 100; i++)
         {
@@ -102,9 +130,33 @@ public class ProtocolBenchmarks
         }
     }
 
+    [Benchmark(Description = "Write 100 CompactStrings (300 chars)")]
+    public void WriteCompactString_Long()
+    {
+        _buffer.Clear();
+        var writer = new KafkaProtocolWriter(_buffer);
+        for (var i = 0; i < 100; i++)
+        {
+            writer.WriteCompactString(_longString);
+        }
+    }
+
+    [Benchmark(Description = "Write 100 CompactString spans (300 chars)")]
+    public void WriteCompactStringSpan_Long()
+    {
+        _buffer.Clear();
+        var writer = new KafkaProtocolWriter(_buffer);
+        var value = _longString.AsSpan();
+        for (var i = 0; i < 100; i++)
+        {
+            writer.WriteCompactString(value);
+        }
+    }
+
     [Benchmark(Description = "Write 1000 VarInts")]
     public void WriteVarInt_Thousand()
     {
+        _buffer.Clear();
         var writer = new KafkaProtocolWriter(_buffer);
         for (var i = -500; i < 500; i++)
         {
@@ -143,6 +195,7 @@ public class ProtocolBenchmarks
     [Benchmark(Description = "Write RecordBatch (10 records)")]
     public void WriteRecordBatch()
     {
+        _buffer.Clear();
         var batch = CreateTenRecordBatch();
 
         batch.Write(_buffer);
@@ -151,6 +204,7 @@ public class ProtocolBenchmarks
     [Benchmark(Description = "Write RecordBatch pre-serialized (10 records)")]
     public void WriteRecordBatchPreSerialized()
     {
+        _buffer.Clear();
         var batch = CreateTenRecordBatch();
 
         batch.PreCompress(CompressionType.None, null);


### PR DESCRIPTION
## Summary
- Share one-pass UTF-8 encoding helpers across string and `ReadOnlySpan<char>` protocol writer overloads
- Encode long legacy/content strings directly into reserved output spans, and backfill compact string varint lengths after one encode
- Add span-overload round-trip coverage for short and long UTF-8 strings

Closes #1373.

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/(KafkaProtocolWriterTests|StringBytesEncodingTests)/*"`
- `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --framework netstandard2.0 -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet format Dekaf.sln --verify-no-changes --verbosity minimal`