### PR TITLE
perf(consumer): avoid pending fetch boxing

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2715,8 +2715,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         var batches = pending.GetBatches();
         long bytes = PerPartitionResponseOverhead;
-        foreach (var batch in batches)
+        for (var i = 0; i < batches.Count; i++)
         {
+            var batch = batches[i];
             bytes += batch.BatchLength + PerBatchHeaderOverhead;
         }
         return bytes;


### PR DESCRIPTION
## Summary
- Change `EstimatePendingFetchBytes` from interface `foreach` to indexed iteration
- Avoid boxing the `IReadOnlyList<RecordBatch>` enumerator on prefetch memory accounting paths

Closes #1361.

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter /*/*/EstimatePendingFetchBytesTests/*`
- `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --framework netstandard2.0 -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet format Dekaf.sln --verify-no-changes --verbosity minimal`