### PR TITLE
perf(sharegroups): honor heartbeat join wait

### DIFF
--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -51,6 +51,9 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     internal static int GetCoordinationConnectionIndex(int connectionsPerBroker)
         => connectionsPerBroker - 1;
 
+    internal static int GetWaitForAssignmentDelayMs(int retryDelayMs, int heartbeatIntervalMs)
+        => Math.Max(retryDelayMs, heartbeatIntervalMs);
+
     public ShareConsumerCoordinator(
         ShareConsumerOptions options,
         IConnectionPool connectionPool,
@@ -426,7 +429,9 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                         // Broker accepted us but hasn't assigned partitions yet.
                         // Wait before re-sending heartbeat.
                         LogWaitingForAssignment();
-                        await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                        await Task.Delay(
+                            GetWaitForAssignmentDelayMs(retryDelayMs, _heartbeatIntervalMs),
+                            cancellationToken).ConfigureAwait(false);
                     }
                 }
                 catch (GroupException ex) when (ex.ErrorCode == ErrorCode.FencedMemberEpoch)

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerCoordinatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerCoordinatorTests.cs
@@ -1,0 +1,26 @@
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed class ShareConsumerCoordinatorTests
+{
+    [Test]
+    public async Task WaitForAssignmentDelay_UsesHeartbeatIntervalWhenLonger()
+    {
+        var delayMs = ShareConsumerCoordinator.GetWaitForAssignmentDelayMs(
+            retryDelayMs: 200,
+            heartbeatIntervalMs: 3000);
+
+        await Assert.That(delayMs).IsEqualTo(3000);
+    }
+
+    [Test]
+    public async Task WaitForAssignmentDelay_UsesRetryDelayWhenLonger()
+    {
+        var delayMs = ShareConsumerCoordinator.GetWaitForAssignmentDelayMs(
+            retryDelayMs: 1000,
+            heartbeatIntervalMs: 500);
+
+        await Assert.That(delayMs).IsEqualTo(1000);
+    }
+}


### PR DESCRIPTION
## Summary
- Wait for `Math.Max(retryDelayMs, _heartbeatIntervalMs)` while share-group join is accepted but unassigned
- Add focused coverage for assignment-wait delay selection

Closes #1378.

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter /*/*/ShareConsumerCoordinatorTests/*`
- `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --framework netstandard2.0 -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet format Dekaf.sln --verify-no-changes --verbosity minimal`