### PR TITLE
perf(consumer): cache owned heartbeat data

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -926,7 +926,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             ? []
             : BuildOwnedTopicPartitions(_assignedPartitions);
 
-        if (ownedTopicPartitions is not null || _assignedPartitions.Count == 0)
+        if (ownedTopicPartitions is not null)
         {
             _cachedOwnedTopicPartitions = ownedTopicPartitions;
             Volatile.Write(ref _cachedOwnedTopicPartitionsVersion, assignmentVersion);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -59,6 +59,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
     private volatile StringSet? _subscribedTopics;
     private volatile string? _subscribedTopicRegex;
+    private IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? _cachedOwnedTopicPartitions;
+    private int _cachedOwnedTopicPartitionsVersion = -1;
+    private int _sentOwnedTopicPartitionsVersion = -1;
 
     internal static int GetCoordinationConnectionIndex(int connectionsPerBroker)
         => connectionsPerBroker - 1;
@@ -774,8 +777,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         // On initial join, send empty array (owns nothing). null means "unchanged" in KIP-848
         // which is invalid when there's no previous state.
+        var assignmentVersion = Volatile.Read(ref _assignmentVersion);
         IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? ownedTopicPartitions =
-            isInitial ? [] : BuildOwnedTopicPartitions(_assignedPartitions);
+            isInitial ? [] : GetOwnedTopicPartitionsForHeartbeat(assignmentVersion);
 
         // Atomically snapshot and clear the subscription-changed flag to prevent a race where
         // a concurrent EnsureActiveGroupConsumerProtocolAsync sets new topics + flag=true,
@@ -811,6 +815,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         {
             HandleConsumerGroupHeartbeatError(response, subscribedTopicRegex);
         }
+
+        if (!isInitial && ownedTopicPartitions is not null)
+            Volatile.Write(ref _sentOwnedTopicPartitionsVersion, assignmentVersion);
 
         if (response.MemberId is not null)
             _memberId = response.MemberId;
@@ -904,6 +911,28 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         }
 
         return result.Count > 0 ? result : null;
+    }
+
+    private IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? GetOwnedTopicPartitionsForHeartbeat(
+        int assignmentVersion)
+    {
+        if (Volatile.Read(ref _sentOwnedTopicPartitionsVersion) == assignmentVersion)
+            return null;
+
+        if (Volatile.Read(ref _cachedOwnedTopicPartitionsVersion) == assignmentVersion)
+            return _cachedOwnedTopicPartitions;
+
+        var ownedTopicPartitions = _assignedPartitions.Count == 0
+            ? []
+            : BuildOwnedTopicPartitions(_assignedPartitions);
+
+        if (ownedTopicPartitions is not null || _assignedPartitions.Count == 0)
+        {
+            _cachedOwnedTopicPartitions = ownedTopicPartitions;
+            Volatile.Write(ref _cachedOwnedTopicPartitionsVersion, assignmentVersion);
+        }
+
+        return ownedTopicPartitions;
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -430,6 +430,53 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_SteadyHeartbeat_SendsOwnedPartitionsOnlyWhenAssignmentChanged()
+    {
+        SetupFindCoordinator();
+
+        var requests = new List<ConsumerGroupHeartbeatRequest>();
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var request = ci.Arg<ConsumerGroupHeartbeatRequest>();
+                requests.Add(request);
+                var call = requests.Count;
+
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = request.MemberId.Length == 0 ? "member-1" : request.MemberId,
+                    MemberEpoch = request.MemberEpoch == 0 ? 1 : request.MemberEpoch,
+                    HeartbeatIntervalMs = 60000,
+                    Assignment = call == 1 ? CreateAssignment(TestTopicId, 0, 1) : null
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        await InvokeSteadyConsumerGroupHeartbeatAsync(coordinator);
+        await InvokeSteadyConsumerGroupHeartbeatAsync(coordinator);
+
+        await Assert.That(requests).Count().IsEqualTo(3);
+        await Assert.That(requests[0].TopicPartitions).IsNotNull();
+        await Assert.That(requests[0].TopicPartitions!).IsEmpty();
+
+        await Assert.That(requests[1].TopicPartitions).IsNotNull();
+        await Assert.That(requests[1].TopicPartitions!).Count().IsEqualTo(1);
+        await Assert.That(requests[1].TopicPartitions![0].TopicId).IsEqualTo(TestTopicId);
+        await Assert.That(requests[1].TopicPartitions![0].Partitions).Count().IsEqualTo(2);
+        await Assert.That(requests[1].TopicPartitions![0].Partitions[0]).IsEqualTo(0);
+        await Assert.That(requests[1].TopicPartitions![0].Partitions[1]).IsEqualTo(1);
+
+        await Assert.That(requests[2].TopicPartitions).IsNull();
+    }
+
+    [Test]
     public async Task ConsumerProtocol_InitialJoin_SendsMemberEpochZero()
     {
         SetupSuccessfulConsumerProtocolJoin();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -182,6 +182,20 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         };
     }
 
+    private static async Task AssertOwnedTopicPartitionsAsync(
+        IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? topicPartitions,
+        Guid topicId,
+        params int[] partitions)
+    {
+        await Assert.That(topicPartitions).IsNotNull();
+        await Assert.That(topicPartitions!).Count().IsEqualTo(1);
+        await Assert.That(topicPartitions![0].TopicId).IsEqualTo(topicId);
+        await Assert.That(topicPartitions![0].Partitions).Count().IsEqualTo(partitions.Length);
+
+        for (var i = 0; i < partitions.Length; i++)
+            await Assert.That(topicPartitions![0].Partitions[i]).IsEqualTo(partitions[i]);
+    }
+
     #region Broker Version Guard
 
     [Test]
@@ -466,14 +480,60 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await Assert.That(requests[0].TopicPartitions).IsNotNull();
         await Assert.That(requests[0].TopicPartitions!).IsEmpty();
 
-        await Assert.That(requests[1].TopicPartitions).IsNotNull();
-        await Assert.That(requests[1].TopicPartitions!).Count().IsEqualTo(1);
-        await Assert.That(requests[1].TopicPartitions![0].TopicId).IsEqualTo(TestTopicId);
-        await Assert.That(requests[1].TopicPartitions![0].Partitions).Count().IsEqualTo(2);
-        await Assert.That(requests[1].TopicPartitions![0].Partitions[0]).IsEqualTo(0);
-        await Assert.That(requests[1].TopicPartitions![0].Partitions[1]).IsEqualTo(1);
+        await AssertOwnedTopicPartitionsAsync(requests[1].TopicPartitions, TestTopicId, 0, 1);
 
         await Assert.That(requests[2].TopicPartitions).IsNull();
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_SteadyHeartbeat_RetriesOwnedPartitionsAfterFailedHeartbeat()
+    {
+        SetupFindCoordinator();
+
+        var requests = new List<ConsumerGroupHeartbeatRequest>();
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var request = ci.Arg<ConsumerGroupHeartbeatRequest>();
+                requests.Add(request);
+                var call = requests.Count;
+
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = call == 2 ? ErrorCode.NotCoordinator : ErrorCode.None,
+                    ErrorMessage = call == 2 ? "Coordinator moved" : null,
+                    MemberId = request.MemberId.Length == 0 ? "member-1" : request.MemberId,
+                    MemberEpoch = request.MemberEpoch == 0 ? 1 : request.MemberEpoch,
+                    HeartbeatIntervalMs = 60000,
+                    Assignment = call == 1 ? CreateAssignment(TestTopicId, 0, 1) : null
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        GroupException? caught = null;
+        try
+        {
+            await InvokeSteadyConsumerGroupHeartbeatAsync(coordinator);
+        }
+        catch (GroupException ex)
+        {
+            caught = ex;
+        }
+
+        await InvokeSteadyConsumerGroupHeartbeatAsync(coordinator);
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.ErrorCode).IsEqualTo(ErrorCode.NotCoordinator);
+        await Assert.That(requests).Count().IsEqualTo(3);
+        await AssertOwnedTopicPartitionsAsync(requests[1].TopicPartitions, TestTopicId, 0, 1);
+        await AssertOwnedTopicPartitionsAsync(requests[2].TopicPartitions, TestTopicId, 0, 1);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Cache owned `ConsumerGroupHeartbeat` topic-partition payloads by assignment version
- Send owned partitions only after assignment changes; steady unchanged heartbeats now send `TopicPartitions = null`
- Mark an assignment version as sent only after a successful heartbeat response so failures retry the payload
- Add KIP-848 coordinator coverage for initial, changed, and unchanged owned-partition requests

Closes #1377.

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/Dekaf.Tests.Unit/Dekaf.Tests.Unit.Consumer/ConsumerCoordinatorKip848Tests/**" --disable-logo --no-progress`
- `dotnet build src\Dekaf\Dekaf.csproj --configuration Release --framework netstandard2.0 -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet format Dekaf.sln --verify-no-changes --verbosity minimal`