### PR TITLE
perf(producer): remove send-loop allocations

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -233,6 +233,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         private int _count;
 
         public int Count => _count;
+        public Dictionary<TopicPartition, List<ReadyBatch>> Partitions => _partitions;
 
         private List<ReadyBatch> GetOrCreateQueue(TopicPartition tp)
         {
@@ -306,36 +307,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _count = 0;
         }
 
-        /// <summary>Iterates all batches across all partitions (for fail/cleanup/wakeup).</summary>
-        public void ForEach(Action<ReadyBatch> action)
+        public void RemoveAt(List<ReadyBatch> queue, int index)
         {
-            foreach (var kvp in _partitions)
-            {
-                var queue = kvp.Value;
-                for (var i = 0; i < queue.Count; i++)
-                    action(queue[i]);
-            }
-        }
-
-        /// <summary>
-        /// Sweeps expired batches matching the predicate. Calls onRemoved for each,
-        /// then removes it from its partition queue.
-        /// </summary>
-        public void SweepWhere(Func<ReadyBatch, bool> shouldRemove, Action<ReadyBatch> onRemoved)
-        {
-            foreach (var kvp in _partitions)
-            {
-                var queue = kvp.Value;
-                for (var i = queue.Count - 1; i >= 0; i--)
-                {
-                    if (shouldRemove(queue[i]))
-                    {
-                        onRemoved(queue[i]);
-                        queue.RemoveAt(i);
-                        _count--;
-                    }
-                }
-            }
+            queue.RemoveAt(index);
+            _count--;
         }
     }
 
@@ -1807,15 +1782,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
 
         var deliveryTimeoutTicks = _options.DeliveryTimeoutTicks;
-        carryOver.ForEach(batch =>
+        foreach (var kvp in carryOver.Partitions)
         {
-            if (batch.RetryNotBefore > 0 && batch.RetryNotBefore < earliestTicks)
-                earliestTicks = batch.RetryNotBefore;
+            var queue = kvp.Value;
+            for (var i = 0; i < queue.Count; i++)
+            {
+                var batch = queue[i];
+                if (batch.RetryNotBefore > 0 && batch.RetryNotBefore < earliestTicks)
+                    earliestTicks = batch.RetryNotBefore;
 
-            var deadlineTicks = batch.StopwatchCreatedTicks + deliveryTimeoutTicks;
-            if (deadlineTicks < earliestTicks)
-                earliestTicks = deadlineTicks;
-        });
+                var deadlineTicks = batch.StopwatchCreatedTicks + deliveryTimeoutTicks;
+                if (deadlineTicks < earliestTicks)
+                    earliestTicks = deadlineTicks;
+            }
+        }
 
         if (earliestTicks >= long.MaxValue)
             return int.MaxValue;
@@ -2296,7 +2276,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// Pre-allocated scratch space for building ProduceRequest without per-send allocations.
     /// The send loop is single-threaded and awaits each send before reusing, so all
     /// arrays and objects are safe to reuse without synchronization.
-    /// Uses ArraySegment&lt;T&gt; to slice the scratch arrays for IReadOnlyList&lt;T&gt; compatibility.
+    /// Uses internal array slices so ProduceRequest can serialize scratch data without boxing ArraySegment&lt;T&gt;.
     /// </summary>
     private sealed class ProduceRequestScratch
     {
@@ -2443,15 +2423,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                 var topicData = _topicData[topicIdx];
                 topicData.Name = topicName;
-                topicData.PartitionData = new ArraySegment<ProduceRequestPartitionData>(
-                    _partitionData, partitionDataStart, partCount);
+                topicData.SetPartitionDataScratch(_partitionData, partitionDataStart, partCount);
                 topicIdx++;
 
                 runStart = runEnd;
             }
 
-            _request.TopicData = new ArraySegment<ProduceRequestTopicData>(
-                _topicData, 0, topicCount);
+            _request.SetTopicDataScratch(_topicData, topicCount);
             _request.RequestBodySizeHint = requestBodySizeHint;
             _lastTopicCount = topicCount;
             _lastPartitionCount = partIdx;
@@ -2464,12 +2442,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         /// </summary>
         public void ClearReferences()
         {
-            _request.TopicData = [];
+            _request.ClearTopicDataScratch();
             _request.RequestBodySizeHint = 0;
             for (var i = 0; i < _lastTopicCount; i++)
             {
                 _topicData[i].Name = string.Empty;
-                _topicData[i].PartitionData = [];
+                _topicData[i].ClearPartitionDataScratch();
             }
             for (var i = 0; i < _lastPartitionCount; i++)
             {
@@ -2757,13 +2735,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var now = Stopwatch.GetTimestamp();
         var deliveryTimeoutTicks = _options.DeliveryTimeoutTicks;
 
-        carryOver.SweepWhere(
-            batch => now >= batch.StopwatchCreatedTicks + deliveryTimeoutTicks,
-            batch =>
+        foreach (var kvp in carryOver.Partitions)
+        {
+            var queue = kvp.Value;
+            for (var i = queue.Count - 1; i >= 0; i--)
             {
-                // Unmute partition for retry batches (they caused the mute).
-                // Non-retry muted batches: don't unmute — the retry batch for this
-                // partition may still be in play and will unmute on its own expiry.
+                var batch = queue[i];
+                if (now < batch.StopwatchCreatedTicks + deliveryTimeoutTicks)
+                    continue;
+
                 if (batch.IsRetry)
                 {
                     batch.IsRetry = false;
@@ -2780,13 +2760,22 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     elapsed,
                     configured,
                     $"Delivery timeout exceeded for {batch.TopicPartition}"));
-            });
+                carryOver.RemoveAt(queue, i);
+            }
+        }
     }
 
     private void FailCarryOverBatches(PartitionCarryOver carryOver)
     {
         var disposedException = new ObjectDisposedException(nameof(BrokerSender));
-        carryOver.ForEach(batch => FailAndCleanupBatch(batch, disposedException));
+        foreach (var kvp in carryOver.Partitions)
+        {
+            var queue = kvp.Value;
+            for (var i = 0; i < queue.Count; i++)
+            {
+                FailAndCleanupBatch(queue[i], disposedException);
+            }
+        }
     }
 
     private void FailAndCleanupBatch(ReadyBatch batch, Exception ex)

--- a/src/Dekaf/Protocol/KafkaProtocolWriter.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolWriter.cs
@@ -636,6 +636,19 @@ public ref struct KafkaProtocolWriter
     }
 
     /// <summary>
+    /// Writes a compact array with unsigned varint length prefix (flexible format).
+    /// State-passing span overload to avoid list wrappers on hot paths.
+    /// </summary>
+    public void WriteCompactArray<T, TState>(ReadOnlySpan<T> items, WriteAction<T, TState> writeItem, TState state)
+    {
+        WriteUnsignedVarInt(items.Length + 1);
+        foreach (ref readonly var item in items)
+        {
+            writeItem(ref this, item, state);
+        }
+    }
+
+    /// <summary>
     /// Writes a compact nullable array.
     /// State-passing overload to avoid closure allocations.
     /// </summary>

--- a/src/Dekaf/Protocol/Messages/ProduceRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceRequest.cs
@@ -37,9 +37,24 @@ public sealed class ProduceRequest : IKafkaRequest<ProduceResponse>, IKafkaReque
     /// </summary>
     public IReadOnlyList<ProduceRequestTopicData> TopicData { get; internal set; } = [];
 
+    private ProduceRequestTopicData[]? _topicDataScratch;
+    private int _topicDataScratchCount;
+
     internal int RequestBodySizeHint { get; set; }
 
     int IKafkaRequestBodySizeHint.RequestBodySizeHint => RequestBodySizeHint;
+
+    internal void SetTopicDataScratch(ProduceRequestTopicData[] topicData, int count)
+    {
+        _topicDataScratch = topicData;
+        _topicDataScratchCount = count;
+    }
+
+    internal void ClearTopicDataScratch()
+    {
+        _topicDataScratch = null;
+        _topicDataScratchCount = 0;
+    }
 
     public void Write(ref KafkaProtocolWriter writer, short version)
     {
@@ -47,10 +62,20 @@ public sealed class ProduceRequest : IKafkaRequest<ProduceResponse>, IKafkaReque
         writer.WriteInt16(Acks);
         writer.WriteInt32(TimeoutMs);
 
-        writer.WriteCompactArray(
-            TopicData,
-            static (ref KafkaProtocolWriter w, ProduceRequestTopicData t, short v) => t.Write(ref w, v),
-            version);
+        if (_topicDataScratch is { } topicDataScratch)
+        {
+            writer.WriteCompactArray(
+                topicDataScratch.AsSpan(0, _topicDataScratchCount),
+                static (ref KafkaProtocolWriter w, ProduceRequestTopicData t, short v) => t.Write(ref w, v),
+                version);
+        }
+        else
+        {
+            writer.WriteCompactArray(
+                TopicData,
+                static (ref KafkaProtocolWriter w, ProduceRequestTopicData t, short v) => t.Write(ref w, v),
+                version);
+        }
 
         writer.WriteEmptyTaggedFields();
     }
@@ -71,14 +96,42 @@ public sealed class ProduceRequestTopicData
     /// </summary>
     public IReadOnlyList<ProduceRequestPartitionData> PartitionData { get; internal set; } = [];
 
+    private ProduceRequestPartitionData[]? _partitionDataScratch;
+    private int _partitionDataScratchStart;
+    private int _partitionDataScratchCount;
+
+    internal void SetPartitionDataScratch(ProduceRequestPartitionData[] partitionData, int start, int count)
+    {
+        _partitionDataScratch = partitionData;
+        _partitionDataScratchStart = start;
+        _partitionDataScratchCount = count;
+    }
+
+    internal void ClearPartitionDataScratch()
+    {
+        _partitionDataScratch = null;
+        _partitionDataScratchStart = 0;
+        _partitionDataScratchCount = 0;
+    }
+
     public void Write(ref KafkaProtocolWriter writer, short version)
     {
         writer.WriteCompactString(Name);
 
-        writer.WriteCompactArray(
-            PartitionData,
-            static (ref KafkaProtocolWriter w, ProduceRequestPartitionData p, short v) => p.Write(ref w, v),
-            version);
+        if (_partitionDataScratch is { } partitionDataScratch)
+        {
+            writer.WriteCompactArray(
+                partitionDataScratch.AsSpan(_partitionDataScratchStart, _partitionDataScratchCount),
+                static (ref KafkaProtocolWriter w, ProduceRequestPartitionData p, short v) => p.Write(ref w, v),
+                version);
+        }
+        else
+        {
+            writer.WriteCompactArray(
+                PartitionData,
+                static (ref KafkaProtocolWriter w, ProduceRequestPartitionData p, short v) => p.Write(ref w, v),
+                version);
+        }
 
         writer.WriteEmptyTaggedFields();
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1011,10 +1011,12 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
         await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
 
-        await fatalHeartbeatReturned.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var heartbeatTimeout = TimeSpan.FromSeconds(15);
+
+        await fatalHeartbeatReturned.Task.WaitAsync(heartbeatTimeout);
         await TestWait.UntilAsync(
             () => coordinator.State == CoordinatorState.Unjoined,
-            TimeSpan.FromSeconds(5));
+            heartbeatTimeout);
 
         GroupException? caught = null;
         try

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -144,7 +144,15 @@ public class RecordAccumulatorReadyTests
             var compressCountBeforeReady = codec.CompressCount;
 
             var readyNodes = new HashSet<int>();
-            var (_, unknownLeadersExist) = accumulator.Ready(metadataManager, readyNodes);
+            var unknownLeadersExist = false;
+            await TestWait.UntilAsync(
+                () =>
+                {
+                    readyNodes.Clear();
+                    (_, unknownLeadersExist) = accumulator.Ready(metadataManager, readyNodes);
+                    return readyNodes.Contains(1);
+                },
+                TimeSpan.FromSeconds(5));
 
             await Assert.That(codec.CompressCount).IsEqualTo(compressCountBeforeReady);
             await Assert.That(readyNodes).Contains(1);

--- a/tests/Dekaf.Tests.Unit/Protocol/ProduceRequestTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ProduceRequestTests.cs
@@ -217,6 +217,71 @@ public sealed class ProduceRequestTests
         await Assert.That(writerBytesWritten).IsEqualTo(bufferBytesWritten);
     }
 
+    [Test]
+    public async Task Request_Write_WithScratchSlices_MatchesListEncoding()
+    {
+        var partition0 = new ProduceRequestPartitionData
+        {
+            Index = 0,
+            Records = [CreateBatch(baseOffset: 0, offsetDelta: 0, value: "zero"u8.ToArray())]
+        };
+        var partition1 = new ProduceRequestPartitionData
+        {
+            Index = 1,
+            Records = [CreateBatch(baseOffset: 1, offsetDelta: 1, value: "one"u8.ToArray())]
+        };
+        var partition2 = new ProduceRequestPartitionData
+        {
+            Index = 2,
+            Records = [CreateBatch(baseOffset: 2, offsetDelta: 2, value: "two"u8.ToArray())]
+        };
+
+        var listRequest = new ProduceRequest
+        {
+            Acks = 1,
+            TimeoutMs = 30_000,
+            TopicData =
+            [
+                new ProduceRequestTopicData
+                {
+                    Name = "topic-a",
+                    PartitionData = [partition0, partition1]
+                },
+                new ProduceRequestTopicData
+                {
+                    Name = "topic-b",
+                    PartitionData = [partition2]
+                }
+            ]
+        };
+
+        var scratchPartitions = new[] { partition0, partition1, partition2 };
+        var scratchTopics = new[]
+        {
+            new ProduceRequestTopicData { Name = "topic-a" },
+            new ProduceRequestTopicData { Name = "topic-b" }
+        };
+        scratchTopics[0].SetPartitionDataScratch(scratchPartitions, start: 0, count: 2);
+        scratchTopics[1].SetPartitionDataScratch(scratchPartitions, start: 2, count: 1);
+
+        var scratchRequest = new ProduceRequest
+        {
+            Acks = 1,
+            TimeoutMs = 30_000
+        };
+        scratchRequest.SetTopicDataScratch(scratchTopics, count: 2);
+
+        await Assert.That(WriteRequest(scratchRequest)).IsEquivalentTo(WriteRequest(listRequest));
+    }
+
+    private static byte[] WriteRequest(ProduceRequest request)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        request.Write(ref writer, ProduceRequest.HighestSupportedVersion);
+        return buffer.WrittenSpan.ToArray();
+    }
+
     private static RecordBatch CreateBatch(long baseOffset, int offsetDelta, byte[] value)
     {
         return new RecordBatch


### PR DESCRIPTION
## Summary
- serialize ProduceRequest scratch arrays through span-backed internal slices, avoiding ArraySegment boxing
- replace carry-over delegate callbacks with direct loops over send-loop-owned queues
- widen heartbeat failure test wait to cover slower CI timing
- rebase onto current main after producer pre-serialization changes

## Tests
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/*/RecordAccumulatorReadyTests/Ready_SealedCompressedBatch_DoesNotCompressOnSenderCoordinator"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/*/RecordAccumulatorReadyTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/*/ProduceRequestTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/*/BrokerSenderTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/*/BrokerSenderMuteOrderingTests/*"
- dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/*/BrokerSenderSendLoopTests/*"
- dotnet format Dekaf.sln --verify-no-changes --verbosity minimal

Closes #1368