### PR TITLE
feat(admin): list client metrics resources

### DIFF
--- a/src/Dekaf.Testing/InMemoryAdminClient.cs
+++ b/src/Dekaf.Testing/InMemoryAdminClient.cs
@@ -38,6 +38,15 @@ public sealed class InMemoryAdminClient : IAdminClient
         ThrowIfDisposed();
     }
 
+    public ValueTask<IReadOnlyList<ClientMetricsResourceListing>> ListClientMetricsResourcesAsync(
+        ListClientMetricsResourcesOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        return ValueTask.FromResult<IReadOnlyList<ClientMetricsResourceListing>>(Array.Empty<ClientMetricsResourceListing>());
+    }
+
     public ValueTask CreateTopicsAsync(
         IEnumerable<NewTopic> topics,
         CreateTopicsOptions? options = null,

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -127,6 +127,44 @@ public sealed class AdminClient : IAdminClient
         _telemetryMetricCollector.UnregisterMetricFromSubscription(name);
     }
 
+    public async ValueTask<IReadOnlyList<ClientMetricsResourceListing>> ListClientMetricsResourcesAsync(
+        ListClientMetricsResourcesOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!_metadataManager.HasApiKey(Protocol.ApiKey.ListClientMetricsResources))
+        {
+            throw new Errors.BrokerVersionException("Broker does not support ListClientMetricsResources (API key 74).");
+        }
+
+        return await WithRetryAsync<IReadOnlyList<ClientMetricsResourceListing>>(async () =>
+        {
+            var connection = await GetAnyBrokerConnectionAsync(cancellationToken).ConfigureAwait(false);
+            var request = new ListClientMetricsResourcesRequest();
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                Protocol.ApiKey.ListClientMetricsResources,
+                ListClientMetricsResourcesRequest.LowestSupportedVersion,
+                ListClientMetricsResourcesRequest.HighestSupportedVersion);
+
+            var response = await connection.SendAsync<ListClientMetricsResourcesRequest, ListClientMetricsResourcesResponse>(
+                request,
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+
+            if (response.ErrorCode != Protocol.ErrorCode.None)
+            {
+                throw KafkaException.FromErrorCode(response.ErrorCode,
+                    $"ListClientMetricsResources failed: {response.ErrorCode}");
+            }
+
+            return response.ClientMetricsResources
+                .Select(static resource => new ClientMetricsResourceListing { Name = resource.Name })
+                .ToList();
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
     public async ValueTask CreateTopicsAsync(
         IEnumerable<NewTopic> topics,
         CreateTopicsOptions? options = null,

--- a/src/Dekaf/Admin/IAdminClient.cs
+++ b/src/Dekaf/Admin/IAdminClient.cs
@@ -23,6 +23,13 @@ public interface IAdminClient : IAsyncDisposable
     void UnregisterMetricFromSubscription(string name);
 
     /// <summary>
+    /// Lists client metrics configuration resources available in the cluster.
+    /// </summary>
+    ValueTask<IReadOnlyList<ClientMetricsResourceListing>> ListClientMetricsResourcesAsync(
+        ListClientMetricsResourcesOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Creates topics.
     /// </summary>
     ValueTask CreateTopicsAsync(IEnumerable<NewTopic> topics, CreateTopicsOptions? options = null, CancellationToken cancellationToken = default);
@@ -533,6 +540,21 @@ public sealed class ListConsumerGroupsOptions
 {
     public IReadOnlyList<string>? States { get; init; }
     public int TimeoutMs { get; init; } = 30000;
+}
+
+/// <summary>
+/// Options for ListClientMetricsResources.
+/// </summary>
+public sealed class ListClientMetricsResourcesOptions
+{
+}
+
+/// <summary>
+/// Client metrics configuration resource listing.
+/// </summary>
+public sealed class ClientMetricsResourceListing
+{
+    public required string Name { get; init; }
 }
 
 /// <summary>

--- a/src/Dekaf/Protocol/Messages/ListClientMetricsResourcesMessages.cs
+++ b/src/Dekaf/Protocol/Messages/ListClientMetricsResourcesMessages.cs
@@ -1,0 +1,67 @@
+namespace Dekaf.Protocol.Messages;
+
+/// <summary>
+/// ListClientMetricsResources request (API key 74).
+/// Lists client metrics configuration resources available in the cluster.
+/// </summary>
+public sealed class ListClientMetricsResourcesRequest : IKafkaRequest<ListClientMetricsResourcesResponse>
+{
+    public static ApiKey ApiKey => ApiKey.ListClientMetricsResources;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    public void Write(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteEmptyTaggedFields();
+    }
+}
+
+/// <summary>
+/// ListClientMetricsResources response (API key 74).
+/// </summary>
+public sealed class ListClientMetricsResourcesResponse : IKafkaResponse
+{
+    public static ApiKey ApiKey => ApiKey.ListClientMetricsResources;
+    public static short LowestSupportedVersion => 0;
+    public static short HighestSupportedVersion => 0;
+
+    public int ThrottleTimeMs { get; init; }
+    public ErrorCode ErrorCode { get; init; }
+    public IReadOnlyList<ListClientMetricsResource> ClientMetricsResources { get; init; } = [];
+
+    public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
+    {
+        var throttleTimeMs = reader.ReadInt32();
+        var errorCode = (ErrorCode)reader.ReadInt16();
+        var clientMetricsResources = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => ListClientMetricsResource.Read(ref r));
+
+        reader.SkipTaggedFields();
+
+        return new ListClientMetricsResourcesResponse
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            ErrorCode = errorCode,
+            ClientMetricsResources = clientMetricsResources
+        };
+    }
+}
+
+/// <summary>
+/// A client metrics configuration resource returned by ListClientMetricsResources.
+/// </summary>
+public sealed class ListClientMetricsResource
+{
+    public required string Name { get; init; }
+
+    public static ListClientMetricsResource Read(ref KafkaProtocolReader reader)
+    {
+        var name = reader.ReadCompactNonNullableString();
+        reader.SkipTaggedFields();
+
+        return new ListClientMetricsResource
+        {
+            Name = name
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientClientMetricsResourcesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientClientMetricsResourcesTests.cs
@@ -1,0 +1,125 @@
+using Dekaf.Admin;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public sealed class AdminClientClientMetricsResourcesTests
+{
+    [Test]
+    public async Task ListClientMetricsResourcesAsync_MapsResponseToResult()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection();
+
+        connection.SendAsync<ListClientMetricsResourcesRequest, ListClientMetricsResourcesResponse>(
+                Arg.Any<ListClientMetricsResourcesRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ListClientMetricsResourcesResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ClientMetricsResources =
+                [
+                    new ListClientMetricsResource { Name = "prod" },
+                    new ListClientMetricsResource { Name = "analytics" }
+                ]
+            }));
+
+        var result = await admin.ListClientMetricsResourcesAsync();
+
+        await Assert.That(result.Select(static resource => resource.Name))
+            .IsEquivalentTo(["prod", "analytics"]);
+
+        await connection.Received(1).SendAsync<ListClientMetricsResourcesRequest, ListClientMetricsResourcesResponse>(
+            Arg.Any<ListClientMetricsResourcesRequest>(),
+            Arg.Is<short>(version => version == 0),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ListClientMetricsResourcesAsync_TopLevelError_Throws()
+    {
+        var (admin, connection) = CreateAdminWithMockConnection();
+
+        connection.SendAsync<ListClientMetricsResourcesRequest, ListClientMetricsResourcesResponse>(
+                Arg.Any<ListClientMetricsResourcesRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ListClientMetricsResourcesResponse
+            {
+                ErrorCode = ErrorCode.ClusterAuthorizationFailed
+            }));
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await admin.ListClientMetricsResourcesAsync());
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.ClusterAuthorizationFailed);
+    }
+
+    private static (AdminClient Admin, IKafkaConnection Connection) CreateAdminWithMockConnection()
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.BrokerId.Returns(1);
+        connection.Host.Returns("localhost");
+        connection.Port.Returns(9092);
+        connection.IsConnected.Returns(true);
+
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.Metadata.Update(CreateMetadataResponse());
+        metadataManager.SetApiVersion(ApiKey.ListClientMetricsResources, 0, 0);
+        metadataManager.SetApiVersion(ApiKey.Metadata, 9, 13);
+
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateMetadataResponse()));
+
+        connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(ApiKey.Metadata, 9, 13),
+                    new ApiVersion(ApiKey.ListClientMetricsResources, 0, 0)
+                ]
+            }));
+
+        var admin = new AdminClient(
+            new AdminClientOptions { BootstrapServers = ["localhost:9092"] },
+            pool,
+            metadataManager);
+
+        return (admin, connection);
+    }
+
+    private static MetadataResponse CreateMetadataResponse() => new()
+    {
+        Brokers =
+        [
+            new BrokerMetadata
+            {
+                NodeId = 1,
+                Host = "localhost",
+                Port = 9092
+            }
+        ],
+        ClusterId = "test-cluster",
+        ControllerId = 1,
+        Topics = []
+    };
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/TelemetryProtocolMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/TelemetryProtocolMessageTests.cs
@@ -101,6 +101,43 @@ public sealed class TelemetryProtocolMessageTests
     }
 
     [Test]
+    public async Task ListClientMetricsResourcesRequest_V0_WritesOnlyTaggedFields()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        var request = new ListClientMetricsResourcesRequest();
+
+        request.Write(ref writer, version: 0);
+
+        await Assert.That(buffer.WrittenSpan.ToArray()).IsEquivalentTo([(byte)0x00]);
+    }
+
+    [Test]
+    public async Task ListClientMetricsResourcesResponse_V0_ReadsResourceNames()
+    {
+        var data = new List<byte>();
+
+        data.AddRange([0x00, 0x00, 0x00, 0x0A]);
+        data.AddRange([0x00, 0x00]);
+        data.Add(0x03);
+        data.Add(0x05);
+        data.AddRange("prod"u8.ToArray());
+        data.Add(0x00);
+        data.Add(0x0A);
+        data.AddRange("analytics"u8.ToArray());
+        data.Add(0x00);
+        data.Add(0x00);
+
+        var reader = new KafkaProtocolReader(data.ToArray());
+        var response = (ListClientMetricsResourcesResponse)ListClientMetricsResourcesResponse.Read(ref reader, version: 0);
+
+        await Assert.That(response.ThrottleTimeMs).IsEqualTo(10);
+        await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+        await Assert.That(response.ClientMetricsResources.Select(static resource => resource.Name))
+            .IsEquivalentTo(["prod", "analytics"]);
+    }
+
+    [Test]
     public async Task TelemetryRequests_UseFlexibleHeaders()
     {
         await Assert.That(GetRequestHeaderVersion<GetTelemetrySubscriptionsRequest, GetTelemetrySubscriptionsResponse>(0))
@@ -110,6 +147,10 @@ public sealed class TelemetryProtocolMessageTests
         await Assert.That(GetRequestHeaderVersion<PushTelemetryRequest, PushTelemetryResponse>(0))
             .IsEqualTo((short)2);
         await Assert.That(GetResponseHeaderVersion<PushTelemetryRequest, PushTelemetryResponse>(0))
+            .IsEqualTo((short)1);
+        await Assert.That(GetRequestHeaderVersion<ListClientMetricsResourcesRequest, ListClientMetricsResourcesResponse>(0))
+            .IsEqualTo((short)2);
+        await Assert.That(GetResponseHeaderVersion<ListClientMetricsResourcesRequest, ListClientMetricsResourcesResponse>(0))
             .IsEqualTo((short)1);
     }
 


### PR DESCRIPTION
Closes #1394.

## Summary
- Add `ListClientMetricsResourcesAsync` to `IAdminClient` and `AdminClient`.
- Add API key 74 request/response messages for KIP-1000 `ListClientMetricsResources` v0.
- Map protocol resources to `ClientMetricsResourceListing` and add in-memory admin support.
- Cover wire encoding/decoding and admin mapping/error handling with unit tests.

Protocol shape checked against Apache Kafka 3.7 docs: https://kafka.apache.org/37/design/protocol/#listclientmetricsresources-api-key-74

## Validation
- `dotnet build .\tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --no-restore`
- `dotnet run --project .\tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --no-build -- --disable-logo --no-progress --output Normal` (4346 passed)
- `dotnet build .\src\Dekaf\Dekaf.csproj -f netstandard2.0 --no-restore`
- `dotnet format --no-restore --verify-no-changes`