### PR TITLE
feat(consumer): add retry topic tiers

### DIFF
--- a/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
+++ b/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
@@ -24,8 +24,11 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
     private readonly IRetryPolicy? _retryPolicy;
     private readonly RetryTopicOptions? _retryTopicOptions;
     private readonly KafkaConsumerServiceOptions _serviceOptions;
+    private readonly object _retryTopicPostponementsLock = new();
+    private readonly Dictionary<TopicPartition, RetryTopicPostponement> _retryTopicPostponements = [];
     private IKafkaProducer<byte[]?, byte[]?>? _dlqProducer;
     private int _disposeStarted;
+    private static readonly TimeSpan MaxRetryTopicDelayChunk = TimeSpan.FromMilliseconds(int.MaxValue - 1);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="KafkaConsumerService{TKey, TValue}"/> class.
@@ -408,9 +411,13 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
         if (delay <= TimeSpan.Zero)
             return false;
 
+        var partition = new TopicPartition(result.Topic, result.Partition);
+        var postponement = new RetryTopicPostponement(result.Offset, dueAt, delay);
+        if (!TryBeginRetryTopicPostponement(partition, postponement))
+            return true;
+
         LogRetryTopicDelay(result.Topic, result.Partition, result.Offset, delay);
 
-        var partition = new TopicPartition(result.Topic, result.Partition);
         _consumer.Partitions.Pause(partition);
         _consumer.Positions.Seek(new TopicPartitionOffset(
             result.Topic,
@@ -418,20 +425,68 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
             result.Offset,
             result.LeaderEpoch ?? -1));
 
-        _ = ResumeRetryTopicPartitionAfterDelayAsync(partition, delay, cancellationToken);
+        _ = ResumeRetryTopicPartitionAfterDelayAsync(partition, postponement, cancellationToken);
         return true;
+    }
+
+    private bool TryBeginRetryTopicPostponement(
+        TopicPartition partition,
+        RetryTopicPostponement postponement)
+    {
+        lock (_retryTopicPostponementsLock)
+        {
+            if (_retryTopicPostponements.TryGetValue(partition, out var pending) &&
+                !IsEarlierRetryTopicPostponement(postponement, pending))
+            {
+                return false;
+            }
+
+            _retryTopicPostponements[partition] = postponement;
+            return true;
+        }
+    }
+
+    private bool TryCompleteRetryTopicPostponement(
+        TopicPartition partition,
+        RetryTopicPostponement postponement)
+    {
+        lock (_retryTopicPostponementsLock)
+        {
+            if (!_retryTopicPostponements.TryGetValue(partition, out var pending) ||
+                pending != postponement)
+            {
+                return false;
+            }
+
+            _retryTopicPostponements.Remove(partition);
+            return true;
+        }
+    }
+
+    private static bool IsEarlierRetryTopicPostponement(
+        RetryTopicPostponement candidate,
+        RetryTopicPostponement pending)
+    {
+        // Partition order wins over due time; seeking to a later offset can skip an earlier postponed record.
+        if (candidate.Offset != pending.Offset)
+            return candidate.Offset < pending.Offset;
+
+        return candidate.DueAt < pending.DueAt;
     }
 
     private async Task ResumeRetryTopicPartitionAfterDelayAsync(
         TopicPartition partition,
-        TimeSpan delay,
+        RetryTopicPostponement postponement,
         CancellationToken cancellationToken)
     {
         try
         {
-            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            await DelayUntilRetryTopicDueAsync(postponement.DueAt, cancellationToken).ConfigureAwait(false);
+            if (!TryCompleteRetryTopicPostponement(partition, postponement))
+                return;
+
             _consumer.Partitions.Resume(partition);
-            LogRetryTopicPartitionResumed(partition.Topic, partition.Partition, delay);
+            LogRetryTopicPartitionResumed(partition.Topic, partition.Partition, postponement.Delay);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -441,6 +496,29 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
             LogRetryTopicPartitionResumeFailed(ex, partition.Topic, partition.Partition);
         }
     }
+
+    private static async Task DelayUntilRetryTopicDueAsync(
+        DateTimeOffset dueAt,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var remaining = dueAt - DateTimeOffset.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+                return;
+
+            var delay = remaining <= MaxRetryTopicDelayChunk
+                ? remaining
+                : MaxRetryTopicDelayChunk;
+
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private readonly record struct RetryTopicPostponement(
+        long Offset,
+        DateTimeOffset DueAt,
+        TimeSpan Delay);
 
     private void CaptureRawBytesOnFirstFailure(int attempt, ref byte[]? rawKey, ref byte[]? rawValue)
     {

--- a/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
+++ b/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
@@ -294,58 +294,11 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
         byte[]? rawValue = null;
         var previousFailureCount = RetryTopicHeaders.GetFailureCount(result.Headers);
 
-        if (_retryPolicy is not null)
+        var maxAttemptsWithoutPolicy = _retryTopicOptions?.IsEnabled == true ? 1 : _deadLetterOptions?.MaxFailures ?? 1;
+        var attempt = 0;
+        while (true)
         {
-            // Retry policy drives retry count and delays
-            var attempt = 0;
-            while (true)
-            {
-                attempt++;
-                try
-                {
-                    await ProcessAsync(result, stoppingToken).ConfigureAwait(false);
-                    return;
-                }
-                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    CaptureRawBytesOnFirstFailure(attempt, ref rawKey, ref rawValue);
-
-                    await OnErrorAsync(ex, result, stoppingToken).ConfigureAwait(false);
-
-                    var failureCount = previousFailureCount + attempt;
-                    var delay = _retryPolicy.GetNextDelay(attempt, ex);
-                    if (delay is not null)
-                    {
-                        await Task.Delay(delay.Value, stoppingToken).ConfigureAwait(false);
-                        continue;
-                    }
-
-                    // Policy says stop retrying - check DLQ
-                    if (await TryRouteToRetryTopicAsync(result, rawKey, rawValue, failureCount, stoppingToken)
-                            .ConfigureAwait(false))
-                    {
-                        return;
-                    }
-
-                    if (_deadLetterPolicy is not null &&
-                        _deadLetterPolicy.ShouldDeadLetter(result, ex, failureCount))
-                    {
-                        await RouteToDeadLetterAsync(result, ex, rawKey, rawValue, failureCount, stoppingToken)
-                            .ConfigureAwait(false);
-                    }
-                    return;
-                }
-            }
-        }
-
-        // No retry policy: existing behavior (immediate retry up to MaxFailures)
-        var maxAttempts = _retryTopicOptions?.IsEnabled == true ? 1 : _deadLetterOptions?.MaxFailures ?? 1;
-        for (var attempt = 1; attempt <= maxAttempts; attempt++)
-        {
+            attempt++;
             try
             {
                 await ProcessAsync(result, stoppingToken).ConfigureAwait(false);
@@ -361,22 +314,55 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
 
                 await OnErrorAsync(ex, result, stoppingToken).ConfigureAwait(false);
 
-                var failureCount = previousFailureCount + attempt;
-                if (await TryRouteToRetryTopicAsync(result, rawKey, rawValue, failureCount, stoppingToken)
-                        .ConfigureAwait(false))
+                var delay = _retryPolicy?.GetNextDelay(attempt, ex);
+                if (delay is not null)
+                {
+                    await Task.Delay(delay.Value, stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                var deadLetterFailureCount = previousFailureCount + attempt;
+                var retryTopicFailureCount = GetNextRetryTopicFailureCount(previousFailureCount);
+                var retryTopicResult = await TryRouteToRetryTopicAsync(
+                        result,
+                        rawKey,
+                        rawValue,
+                        retryTopicFailureCount,
+                        stoppingToken)
+                    .ConfigureAwait(false);
+                if (retryTopicResult == RetryTopicRouteResult.Routed)
                 {
                     return;
                 }
 
-                if (_deadLetterPolicy is not null &&
-                    _deadLetterPolicy.ShouldDeadLetter(result, ex, failureCount))
+                if (ShouldRouteToDeadLetter(result, ex, deadLetterFailureCount, retryTopicResult))
                 {
-                    await RouteToDeadLetterAsync(result, ex, rawKey, rawValue, failureCount, stoppingToken)
+                    await RouteToDeadLetterAsync(result, ex, rawKey, rawValue, deadLetterFailureCount, stoppingToken)
                         .ConfigureAwait(false);
                     return;
                 }
+
+                if (_retryPolicy is null && attempt < maxAttemptsWithoutPolicy)
+                    continue;
+
+                return;
             }
         }
+    }
+
+    private static int GetNextRetryTopicFailureCount(int previousFailureCount) => previousFailureCount + 1;
+
+    private bool ShouldRouteToDeadLetter(
+        ConsumeResult<TKey, TValue> result,
+        Exception exception,
+        int failureCount,
+        RetryTopicRouteResult retryTopicResult)
+    {
+        if (_deadLetterPolicy is null)
+            return false;
+
+        return retryTopicResult == RetryTopicRouteResult.Exhausted ||
+            _deadLetterPolicy.ShouldDeadLetter(result, exception, failureCount);
     }
 
     private string[] BuildSubscriptionTopics()
@@ -574,7 +560,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
         }
     }
 
-    private async ValueTask<bool> TryRouteToRetryTopicAsync(
+    private async ValueTask<RetryTopicRouteResult> TryRouteToRetryTopicAsync(
         ConsumeResult<TKey, TValue> result,
         byte[]? rawKey, byte[]? rawValue, int failureCount,
         CancellationToken cancellationToken)
@@ -582,12 +568,12 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
         if (_dlqProducer is null ||
             _retryTopicOptions?.IsEnabled != true)
         {
-            return false;
+            return RetryTopicRouteResult.Disabled;
         }
 
         var sourceTopic = RetryTopicHeaders.GetSourceTopic(result.Headers) ?? result.Topic;
         if (!_retryTopicOptions.TryGetRetryTopic(sourceTopic, failureCount, out var retryTopic, out var delay))
-            return false;
+            return RetryTopicRouteResult.Exhausted;
 
         try
         {
@@ -611,13 +597,21 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
             }
 
             LogMessageRoutedToRetryTopic(result.Topic, result.Partition, result.Offset, retryTopic, delay, failureCount);
-            return true;
+            return RetryTopicRouteResult.Routed;
         }
         catch (Exception retryEx)
         {
             await OnRetryTopicRoutingFailedAsync(retryEx, result, cancellationToken).ConfigureAwait(false);
-            return false;
+            return RetryTopicRouteResult.Failed;
         }
+    }
+
+    private enum RetryTopicRouteResult
+    {
+        Disabled,
+        Routed,
+        Exhausted,
+        Failed
     }
 
     private IKafkaProducer<byte[]?, byte[]?> BuildDlqProducer()

--- a/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
+++ b/src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs
@@ -22,6 +22,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
     private readonly DeadLetterOptions? _deadLetterOptions;
     private readonly IDeadLetterPolicy<TKey, TValue>? _deadLetterPolicy;
     private readonly IRetryPolicy? _retryPolicy;
+    private readonly RetryTopicOptions? _retryTopicOptions;
     private readonly KafkaConsumerServiceOptions _serviceOptions;
     private IKafkaProducer<byte[]?, byte[]?>? _dlqProducer;
     private int _disposeStarted;
@@ -45,6 +46,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
         _logger = logger;
         _deadLetterOptions = deadLetterOptions;
         _retryPolicy = retryPolicy;
+        _retryTopicOptions = deadLetterOptions?.RetryTopics;
         _serviceOptions = serviceOptions ?? new KafkaConsumerServiceOptions();
         if (deadLetterOptions is not null)
         {
@@ -83,6 +85,18 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
         return ValueTask.CompletedTask;
     }
 
+    /// <summary>
+    /// Called when routing a message to a retry topic fails.
+    /// Override to implement custom failure handling (e.g., metrics, alerts).
+    /// Default implementation logs the error.
+    /// </summary>
+    protected virtual ValueTask OnRetryTopicRoutingFailedAsync(
+        Exception exception, ConsumeResult<TKey, TValue> result, CancellationToken cancellationToken)
+    {
+        LogRetryTopicRoutingFailed(exception, result.Topic, result.Partition, result.Offset);
+        return ValueTask.CompletedTask;
+    }
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         // Enable raw byte capture and create DLQ producer if configured
@@ -95,11 +109,12 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
 
         await _consumer.InitializeAsync(stoppingToken).ConfigureAwait(false);
 
-        _consumer.Subscribe(Topics.ToArray());
+        var subscriptionTopics = BuildSubscriptionTopics();
+        _consumer.Subscribe(subscriptionTopics);
 
         if (_logger.IsEnabled(LogLevel.Information))
         {
-            var topics = string.Join(", ", Topics);
+            var topics = string.Join(", ", subscriptionTopics);
             LogStartedConsuming(topics);
         }
 
@@ -269,8 +284,12 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
     private async ValueTask ProcessWithRetriesAsync(
         ConsumeResult<TKey, TValue> result, CancellationToken stoppingToken)
     {
+        if (PostponeRetryTopicMessageIfNeeded(result, stoppingToken))
+            return;
+
         byte[]? rawKey = null;
         byte[]? rawValue = null;
+        var previousFailureCount = RetryTopicHeaders.GetFailureCount(result.Headers);
 
         if (_retryPolicy is not null)
         {
@@ -294,6 +313,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
 
                     await OnErrorAsync(ex, result, stoppingToken).ConfigureAwait(false);
 
+                    var failureCount = previousFailureCount + attempt;
                     var delay = _retryPolicy.GetNextDelay(attempt, ex);
                     if (delay is not null)
                     {
@@ -302,10 +322,16 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
                     }
 
                     // Policy says stop retrying - check DLQ
-                    if (_deadLetterPolicy is not null &&
-                        _deadLetterPolicy.ShouldDeadLetter(result, ex, attempt))
+                    if (await TryRouteToRetryTopicAsync(result, rawKey, rawValue, failureCount, stoppingToken)
+                            .ConfigureAwait(false))
                     {
-                        await RouteToDeadLetterAsync(result, ex, rawKey, rawValue, attempt, stoppingToken)
+                        return;
+                    }
+
+                    if (_deadLetterPolicy is not null &&
+                        _deadLetterPolicy.ShouldDeadLetter(result, ex, failureCount))
+                    {
+                        await RouteToDeadLetterAsync(result, ex, rawKey, rawValue, failureCount, stoppingToken)
                             .ConfigureAwait(false);
                     }
                     return;
@@ -314,7 +340,7 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
         }
 
         // No retry policy: existing behavior (immediate retry up to MaxFailures)
-        var maxAttempts = _deadLetterOptions?.MaxFailures ?? 1;
+        var maxAttempts = _retryTopicOptions?.IsEnabled == true ? 1 : _deadLetterOptions?.MaxFailures ?? 1;
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
             try
@@ -332,14 +358,87 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
 
                 await OnErrorAsync(ex, result, stoppingToken).ConfigureAwait(false);
 
-                if (_deadLetterPolicy is not null &&
-                    _deadLetterPolicy.ShouldDeadLetter(result, ex, attempt))
+                var failureCount = previousFailureCount + attempt;
+                if (await TryRouteToRetryTopicAsync(result, rawKey, rawValue, failureCount, stoppingToken)
+                        .ConfigureAwait(false))
                 {
-                    await RouteToDeadLetterAsync(result, ex, rawKey, rawValue, attempt, stoppingToken)
+                    return;
+                }
+
+                if (_deadLetterPolicy is not null &&
+                    _deadLetterPolicy.ShouldDeadLetter(result, ex, failureCount))
+                {
+                    await RouteToDeadLetterAsync(result, ex, rawKey, rawValue, failureCount, stoppingToken)
                         .ConfigureAwait(false);
                     return;
                 }
             }
+        }
+    }
+
+    private string[] BuildSubscriptionTopics()
+    {
+        var sourceTopics = Topics.ToArray();
+        if (_retryTopicOptions?.IsEnabled != true)
+            return sourceTopics;
+
+        var topics = new HashSet<string>(sourceTopics, StringComparer.Ordinal);
+        foreach (var sourceTopic in sourceTopics)
+        {
+            foreach (var retryTopic in _retryTopicOptions.GetRetryTopics(sourceTopic))
+            {
+                topics.Add(retryTopic);
+            }
+        }
+
+        return topics.ToArray();
+    }
+
+    private bool PostponeRetryTopicMessageIfNeeded(
+        ConsumeResult<TKey, TValue> result,
+        CancellationToken cancellationToken)
+    {
+        if (_retryTopicOptions?.IsEnabled != true ||
+            !RetryTopicHeaders.TryGetDueAt(result.Headers, out var dueAt))
+        {
+            return false;
+        }
+
+        var delay = dueAt - DateTimeOffset.UtcNow;
+        if (delay <= TimeSpan.Zero)
+            return false;
+
+        LogRetryTopicDelay(result.Topic, result.Partition, result.Offset, delay);
+
+        var partition = new TopicPartition(result.Topic, result.Partition);
+        _consumer.Partitions.Pause(partition);
+        _consumer.Positions.Seek(new TopicPartitionOffset(
+            result.Topic,
+            result.Partition,
+            result.Offset,
+            result.LeaderEpoch ?? -1));
+
+        _ = ResumeRetryTopicPartitionAfterDelayAsync(partition, delay, cancellationToken);
+        return true;
+    }
+
+    private async Task ResumeRetryTopicPartitionAfterDelayAsync(
+        TopicPartition partition,
+        TimeSpan delay,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            _consumer.Partitions.Resume(partition);
+            LogRetryTopicPartitionResumed(partition.Topic, partition.Partition, delay);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            LogRetryTopicPartitionResumeFailed(ex, partition.Topic, partition.Partition);
         }
     }
 
@@ -365,7 +464,8 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
 
         try
         {
-            var dlqTopic = _deadLetterPolicy.GetDeadLetterTopic(result.Topic);
+            var sourceTopic = RetryTopicHeaders.GetSourceTopic(result.Headers) ?? result.Topic;
+            var dlqTopic = _deadLetterPolicy.GetDeadLetterTopic(sourceTopic);
 
             var headers = DeadLetterHeaders.Build(
                 result, exception, failureCount,
@@ -396,12 +496,58 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
         }
     }
 
+    private async ValueTask<bool> TryRouteToRetryTopicAsync(
+        ConsumeResult<TKey, TValue> result,
+        byte[]? rawKey, byte[]? rawValue, int failureCount,
+        CancellationToken cancellationToken)
+    {
+        if (_dlqProducer is null ||
+            _retryTopicOptions?.IsEnabled != true)
+        {
+            return false;
+        }
+
+        var sourceTopic = RetryTopicHeaders.GetSourceTopic(result.Headers) ?? result.Topic;
+        if (!_retryTopicOptions.TryGetRetryTopic(sourceTopic, failureCount, out var retryTopic, out var delay))
+            return false;
+
+        try
+        {
+            var dueAt = DateTimeOffset.UtcNow + delay;
+            var headers = RetryTopicHeaders.Build(result, failureCount, delay, dueAt);
+            var message = new ProducerMessage<byte[]?, byte[]?>
+            {
+                Topic = retryTopic,
+                Key = rawKey,
+                Value = rawValue ?? [],
+                Headers = headers
+            };
+
+            if (_deadLetterOptions?.AwaitDelivery == true)
+            {
+                await _dlqProducer.ProduceAsync(message, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await _dlqProducer.FireAsync(message).ConfigureAwait(false);
+            }
+
+            LogMessageRoutedToRetryTopic(result.Topic, result.Partition, result.Offset, retryTopic, delay, failureCount);
+            return true;
+        }
+        catch (Exception retryEx)
+        {
+            await OnRetryTopicRoutingFailedAsync(retryEx, result, cancellationToken).ConfigureAwait(false);
+            return false;
+        }
+    }
+
     private IKafkaProducer<byte[]?, byte[]?> BuildDlqProducer()
     {
         if (_deadLetterOptions?.BootstrapServers is null && _deadLetterOptions?.ConfigureProducer is null)
         {
             throw new InvalidOperationException(
-                "Dead letter queue bootstrap servers must be configured. " +
+                "Dead letter or retry topic producer bootstrap servers must be configured. " +
                 "Call WithBootstrapServers() on the dead letter queue builder, " +
                 "or provide a ConfigureProducer action that sets bootstrap servers.");
         }
@@ -467,8 +613,23 @@ public abstract partial class KafkaConsumerService<TKey, TValue> : BackgroundSer
     [LoggerMessage(Level = LogLevel.Information, Message = "Message from {Topic}[{Partition}]@{Offset} routed to dead letter topic {DlqTopic}")]
     private partial void LogMessageRoutedToDeadLetter(string topic, int partition, long offset, string dlqTopic);
 
+    [LoggerMessage(Level = LogLevel.Information, Message = "Message from {Topic}[{Partition}]@{Offset} routed to retry topic {RetryTopic} for {Delay} after failure {FailureCount}")]
+    private partial void LogMessageRoutedToRetryTopic(string topic, int partition, long offset, string retryTopic, TimeSpan delay, int failureCount);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Delaying retry topic message {Topic}[{Partition}]@{Offset} for {Delay}")]
+    private partial void LogRetryTopicDelay(string topic, int partition, long offset, TimeSpan delay);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Resumed retry topic partition {Topic}[{Partition}] after {Delay}")]
+    private partial void LogRetryTopicPartitionResumed(string topic, int partition, TimeSpan delay);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to resume retry topic partition {Topic}[{Partition}]")]
+    private partial void LogRetryTopicPartitionResumeFailed(Exception ex, string topic, int partition);
+
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to route message from {Topic}[{Partition}]@{Offset} to dead letter queue")]
     private partial void LogDeadLetterRoutingFailed(Exception ex, string topic, int partition, long offset);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to route message from {Topic}[{Partition}]@{Offset} to retry topic")]
+    private partial void LogRetryTopicRoutingFailed(Exception ex, string topic, int partition, long offset);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to flush DLQ producer during shutdown")]
     private partial void LogDlqProducerFlushError(Exception ex);

--- a/src/Dekaf/Consumer/DeadLetter/DeadLetterHeaderFormatting.cs
+++ b/src/Dekaf/Consumer/DeadLetter/DeadLetterHeaderFormatting.cs
@@ -1,0 +1,26 @@
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
+
+namespace Dekaf.Consumer.DeadLetter;
+
+internal static class DeadLetterHeaderFormatting
+{
+    public static string FormatInt(int value)
+    {
+        Span<byte> buffer = stackalloc byte[11];
+        if (Utf8Formatter.TryFormat(value, buffer, out var bytesWritten))
+            return Encoding.UTF8.GetString(buffer[..bytesWritten]);
+
+        return value.ToString(CultureInfo.InvariantCulture);
+    }
+
+    public static string FormatLong(long value)
+    {
+        Span<byte> buffer = stackalloc byte[20];
+        if (Utf8Formatter.TryFormat(value, buffer, out var bytesWritten))
+            return Encoding.UTF8.GetString(buffer[..bytesWritten]);
+
+        return value.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/src/Dekaf/Consumer/DeadLetter/DeadLetterHeaders.cs
+++ b/src/Dekaf/Consumer/DeadLetter/DeadLetterHeaders.cs
@@ -1,5 +1,3 @@
-using System.Buffers.Text;
-using System.Text;
 using Dekaf.Serialization;
 
 namespace Dekaf.Consumer.DeadLetter;
@@ -58,9 +56,9 @@ public static class DeadLetterHeaders
         var sourcePartition = RetryTopicHeaders.GetSourcePartition(result.Headers) ?? result.Partition;
         var sourceOffset = RetryTopicHeaders.GetSourceOffset(result.Headers) ?? result.Offset;
         headers.Add(SourceTopicKey, sourceTopic);
-        headers.Add(SourcePartitionKey, FormatInt(sourcePartition));
-        headers.Add(SourceOffsetKey, FormatLong(sourceOffset));
-        headers.Add(FailureCountKey, FormatInt(failureCount));
+        headers.Add(SourcePartitionKey, DeadLetterHeaderFormatting.FormatInt(sourcePartition));
+        headers.Add(SourceOffsetKey, DeadLetterHeaderFormatting.FormatLong(sourceOffset));
+        headers.Add(FailureCountKey, DeadLetterHeaderFormatting.FormatInt(failureCount));
         headers.Add(TimestampKey, DateTimeOffset.UtcNow.ToString("O"));
 
         // Error details (optional)
@@ -71,25 +69,5 @@ public static class DeadLetterHeaders
         }
 
         return headers;
-    }
-
-    private static string FormatInt(int value)
-    {
-        Span<byte> buffer = stackalloc byte[11];
-        if (Utf8Formatter.TryFormat(value, buffer, out var bytesWritten))
-        {
-            return Encoding.UTF8.GetString(buffer[..bytesWritten]);
-        }
-        return value.ToString();
-    }
-
-    private static string FormatLong(long value)
-    {
-        Span<byte> buffer = stackalloc byte[20];
-        if (Utf8Formatter.TryFormat(value, buffer, out var bytesWritten))
-        {
-            return Encoding.UTF8.GetString(buffer[..bytesWritten]);
-        }
-        return value.ToString();
     }
 }

--- a/src/Dekaf/Consumer/DeadLetter/DeadLetterHeaders.cs
+++ b/src/Dekaf/Consumer/DeadLetter/DeadLetterHeaders.cs
@@ -54,9 +54,12 @@ public static class DeadLetterHeaders
         }
 
         // Source metadata
-        headers.Add(SourceTopicKey, result.Topic);
-        headers.Add(SourcePartitionKey, FormatInt(result.Partition));
-        headers.Add(SourceOffsetKey, FormatLong(result.Offset));
+        var sourceTopic = RetryTopicHeaders.GetSourceTopic(result.Headers) ?? result.Topic;
+        var sourcePartition = RetryTopicHeaders.GetSourcePartition(result.Headers) ?? result.Partition;
+        var sourceOffset = RetryTopicHeaders.GetSourceOffset(result.Headers) ?? result.Offset;
+        headers.Add(SourceTopicKey, sourceTopic);
+        headers.Add(SourcePartitionKey, FormatInt(sourcePartition));
+        headers.Add(SourceOffsetKey, FormatLong(sourceOffset));
         headers.Add(FailureCountKey, FormatInt(failureCount));
         headers.Add(TimestampKey, DateTimeOffset.UtcNow.ToString("O"));
 

--- a/src/Dekaf/Consumer/DeadLetter/DeadLetterOptions.cs
+++ b/src/Dekaf/Consumer/DeadLetter/DeadLetterOptions.cs
@@ -41,4 +41,10 @@ public sealed class DeadLetterOptions
     /// The producer uses byte[] serializers by default.
     /// </summary>
     public Action<ProducerBuilder<byte[]?, byte[]?>>? ConfigureProducer { get; init; }
+
+    /// <summary>
+    /// Optional tiered retry-topic configuration. When configured, failed messages are produced
+    /// to retry topics before the dead letter queue.
+    /// </summary>
+    public RetryTopicOptions? RetryTopics { get; init; }
 }

--- a/src/Dekaf/Consumer/DeadLetter/DeadLetterQueueBuilder.cs
+++ b/src/Dekaf/Consumer/DeadLetter/DeadLetterQueueBuilder.cs
@@ -11,6 +11,8 @@ public sealed class DeadLetterQueueBuilder
     private bool _awaitDelivery;
     private string? _bootstrapServers;
     private Action<ProducerBuilder<byte[]?, byte[]?>>? _configureProducer;
+    private readonly List<TimeSpan> _retryTopicDelays = [];
+    private string _retryTopicSuffixFormat = "-retry-{0}";
 
     /// <summary>
     /// Sets the topic suffix for DLQ topic names. Default: ".DLQ".
@@ -80,6 +82,42 @@ public sealed class DeadLetterQueueBuilder
     }
 
     /// <summary>
+    /// Enables tiered retry topics with the supplied retry delays.
+    /// For example, delays of 5s and 30s produce topics such as <c>orders-retry-5s</c>
+    /// and <c>orders-retry-30s</c> before routing to the DLQ.
+    /// </summary>
+    /// <param name="delays">Ordered retry delays.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    public DeadLetterQueueBuilder WithRetryTopics(params TimeSpan[] delays)
+    {
+        ArgumentNullException.ThrowIfNull(delays);
+        if (delays.Length == 0)
+            throw new ArgumentException("At least one retry topic delay is required.", nameof(delays));
+
+        _retryTopicDelays.Clear();
+        foreach (var delay in delays)
+        {
+            RetryTopicOptions.ValidateDelay(delay);
+            _retryTopicDelays.Add(delay);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the suffix format used for retry topic names. The <c>{0}</c> placeholder receives
+    /// a compact delay label such as <c>5s</c>, <c>30s</c>, or <c>1m</c>.
+    /// </summary>
+    /// <param name="suffixFormat">Suffix format appended to the source topic.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    public DeadLetterQueueBuilder WithRetryTopicSuffixFormat(string suffixFormat)
+    {
+        RetryTopicOptions.ValidateTopicSuffixFormat(suffixFormat);
+        _retryTopicSuffixFormat = suffixFormat;
+        return this;
+    }
+
+    /// <summary>
     /// Sets default bootstrap servers only if not already explicitly configured.
     /// Used by DI to inherit from the consumer's bootstrap servers.
     /// </summary>
@@ -100,6 +138,13 @@ public sealed class DeadLetterQueueBuilder
         IncludeExceptionInHeaders = _includeExceptionInHeaders,
         AwaitDelivery = _awaitDelivery,
         BootstrapServers = _bootstrapServers,
-        ConfigureProducer = _configureProducer
+        ConfigureProducer = _configureProducer,
+        RetryTopics = _retryTopicDelays.Count == 0
+            ? null
+            : new RetryTopicOptions
+            {
+                Delays = _retryTopicDelays.ToArray(),
+                TopicSuffixFormat = _retryTopicSuffixFormat
+            }
     };
 }

--- a/src/Dekaf/Consumer/DeadLetter/RetryTopicHeaders.cs
+++ b/src/Dekaf/Consumer/DeadLetter/RetryTopicHeaders.cs
@@ -1,0 +1,126 @@
+using System.Globalization;
+using Dekaf.Serialization;
+
+namespace Dekaf.Consumer.DeadLetter;
+
+/// <summary>
+/// Builds and reads retry-topic metadata headers.
+/// </summary>
+public static class RetryTopicHeaders
+{
+    /// <summary>Header key for the original source topic.</summary>
+    public const string SourceTopicKey = "retry.source.topic";
+    /// <summary>Header key for the original source partition.</summary>
+    public const string SourcePartitionKey = "retry.source.partition";
+    /// <summary>Header key for the original source offset.</summary>
+    public const string SourceOffsetKey = "retry.source.offset";
+    /// <summary>Header key for the cumulative processing failure count.</summary>
+    public const string FailureCountKey = "retry.failure.count";
+    /// <summary>Header key for the retry delay in milliseconds.</summary>
+    public const string DelayMsKey = "retry.delay.ms";
+    /// <summary>Header key for the UTC due timestamp as Unix milliseconds.</summary>
+    public const string DueTimestampMsKey = "retry.due.timestamp.ms";
+
+    /// <summary>
+    /// Builds retry-topic headers while preserving non-retry headers from the consumed record.
+    /// </summary>
+    public static Headers Build<TKey, TValue>(
+        ConsumeResult<TKey, TValue> result,
+        int failureCount,
+        TimeSpan delay,
+        DateTimeOffset dueAt)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(failureCount);
+        RetryTopicOptions.ValidateDelay(delay);
+
+        var sourceTopic = GetSourceTopic(result.Headers) ?? result.Topic;
+        var sourcePartition = GetSourcePartition(result.Headers) ?? result.Partition;
+        var sourceOffset = GetSourceOffset(result.Headers) ?? result.Offset;
+        var originalCount = result.Headers?.Count ?? 0;
+        var headers = new Headers(originalCount + 6);
+
+        if (result.Headers is not null)
+        {
+            foreach (var header in result.Headers)
+            {
+                if (!IsRetryHeader(header.Key))
+                    headers.Add(header);
+            }
+        }
+
+        headers.Add(SourceTopicKey, sourceTopic);
+        headers.Add(SourcePartitionKey, FormatInt(sourcePartition));
+        headers.Add(SourceOffsetKey, FormatLong(sourceOffset));
+        headers.Add(FailureCountKey, FormatInt(failureCount));
+        headers.Add(DelayMsKey, FormatLong(delay.Ticks / TimeSpan.TicksPerMillisecond));
+        headers.Add(DueTimestampMsKey, FormatLong(dueAt.ToUnixTimeMilliseconds()));
+        return headers;
+    }
+
+    /// <summary>
+    /// Gets the cumulative processing failure count from retry headers, or zero when absent.
+    /// </summary>
+    public static int GetFailureCount(IReadOnlyList<Header>? headers)
+        => TryGetInt(headers, FailureCountKey, out var value) && value > 0 ? value : 0;
+
+    /// <summary>
+    /// Gets the retry due timestamp from retry headers.
+    /// </summary>
+    public static bool TryGetDueAt(IReadOnlyList<Header>? headers, out DateTimeOffset dueAt)
+    {
+        if (TryGetLong(headers, DueTimestampMsKey, out var timestampMs))
+        {
+            dueAt = DateTimeOffset.FromUnixTimeMilliseconds(timestampMs);
+            return true;
+        }
+
+        dueAt = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the original source topic from retry headers.
+    /// </summary>
+    public static string? GetSourceTopic(IReadOnlyList<Header>? headers)
+        => GetHeaderValue(headers, SourceTopicKey);
+
+    /// <summary>
+    /// Gets the original source partition from retry headers.
+    /// </summary>
+    public static int? GetSourcePartition(IReadOnlyList<Header>? headers)
+        => TryGetInt(headers, SourcePartitionKey, out var value) ? value : null;
+
+    /// <summary>
+    /// Gets the original source offset from retry headers.
+    /// </summary>
+    public static long? GetSourceOffset(IReadOnlyList<Header>? headers)
+        => TryGetLong(headers, SourceOffsetKey, out var value) ? value : null;
+
+    private static bool IsRetryHeader(string key)
+        => key is SourceTopicKey or SourcePartitionKey or SourceOffsetKey or FailureCountKey or DelayMsKey or DueTimestampMsKey;
+
+    private static string? GetHeaderValue(IReadOnlyList<Header>? headers, string key)
+    {
+        if (headers is null)
+            return null;
+
+        for (var i = 0; i < headers.Count; i++)
+        {
+            var header = headers[i];
+            if (header.Key == key)
+                return header.GetValueAsString();
+        }
+
+        return null;
+    }
+
+    private static bool TryGetInt(IReadOnlyList<Header>? headers, string key, out int value)
+        => int.TryParse(GetHeaderValue(headers, key), NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+
+    private static bool TryGetLong(IReadOnlyList<Header>? headers, string key, out long value)
+        => long.TryParse(GetHeaderValue(headers, key), NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+
+    private static string FormatInt(int value) => value.ToString(CultureInfo.InvariantCulture);
+
+    private static string FormatLong(long value) => value.ToString(CultureInfo.InvariantCulture);
+}

--- a/src/Dekaf/Consumer/DeadLetter/RetryTopicHeaders.cs
+++ b/src/Dekaf/Consumer/DeadLetter/RetryTopicHeaders.cs
@@ -49,11 +49,11 @@ public static class RetryTopicHeaders
         }
 
         headers.Add(SourceTopicKey, sourceTopic);
-        headers.Add(SourcePartitionKey, FormatInt(sourcePartition));
-        headers.Add(SourceOffsetKey, FormatLong(sourceOffset));
-        headers.Add(FailureCountKey, FormatInt(failureCount));
-        headers.Add(DelayMsKey, FormatLong(delay.Ticks / TimeSpan.TicksPerMillisecond));
-        headers.Add(DueTimestampMsKey, FormatLong(dueAt.ToUnixTimeMilliseconds()));
+        headers.Add(SourcePartitionKey, DeadLetterHeaderFormatting.FormatInt(sourcePartition));
+        headers.Add(SourceOffsetKey, DeadLetterHeaderFormatting.FormatLong(sourceOffset));
+        headers.Add(FailureCountKey, DeadLetterHeaderFormatting.FormatInt(failureCount));
+        headers.Add(DelayMsKey, DeadLetterHeaderFormatting.FormatLong(delay.Ticks / TimeSpan.TicksPerMillisecond));
+        headers.Add(DueTimestampMsKey, DeadLetterHeaderFormatting.FormatLong(dueAt.ToUnixTimeMilliseconds()));
         return headers;
     }
 
@@ -120,7 +120,4 @@ public static class RetryTopicHeaders
     private static bool TryGetLong(IReadOnlyList<Header>? headers, string key, out long value)
         => long.TryParse(GetHeaderValue(headers, key), NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
 
-    private static string FormatInt(int value) => value.ToString(CultureInfo.InvariantCulture);
-
-    private static string FormatLong(long value) => value.ToString(CultureInfo.InvariantCulture);
 }

--- a/src/Dekaf/Consumer/DeadLetter/RetryTopicOptions.cs
+++ b/src/Dekaf/Consumer/DeadLetter/RetryTopicOptions.cs
@@ -1,0 +1,96 @@
+using System.Globalization;
+
+namespace Dekaf.Consumer.DeadLetter;
+
+/// <summary>
+/// Configuration for tiered retry topics used before dead-lettering.
+/// </summary>
+public sealed class RetryTopicOptions
+{
+    /// <summary>
+    /// Ordered retry delays. Attempt 1 uses the first delay, attempt 2 uses the second delay, and so on.
+    /// </summary>
+    public IReadOnlyList<TimeSpan> Delays { get; init; } = [];
+
+    /// <summary>
+    /// Suffix format appended to the source topic. The <c>{0}</c> placeholder receives a compact delay label.
+    /// Default: <c>-retry-{0}</c>, e.g. <c>orders-retry-5s</c>.
+    /// </summary>
+    public string TopicSuffixFormat { get; init; } = "-retry-{0}";
+
+    /// <summary>
+    /// Whether at least one retry tier is configured.
+    /// </summary>
+    public bool IsEnabled => Delays.Count > 0;
+
+    /// <summary>
+    /// Gets the retry topic for a specific delay tier.
+    /// </summary>
+    public string GetRetryTopic(string sourceTopic, TimeSpan delay)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceTopic);
+        ValidateDelay(delay);
+        ValidateTopicSuffixFormat(TopicSuffixFormat);
+        return sourceTopic + string.Format(
+            CultureInfo.InvariantCulture,
+            TopicSuffixFormat,
+            FormatDelayLabel(delay));
+    }
+
+    /// <summary>
+    /// Gets all retry topic names for the supplied source topic.
+    /// </summary>
+    public IEnumerable<string> GetRetryTopics(string sourceTopic)
+    {
+        foreach (var delay in Delays)
+        {
+            yield return GetRetryTopic(sourceTopic, delay);
+        }
+    }
+
+    /// <summary>
+    /// Gets the retry topic and delay for a 1-based failure count.
+    /// </summary>
+    internal bool TryGetRetryTopic(string sourceTopic, int failureCount, out string retryTopic, out TimeSpan delay)
+    {
+        if (failureCount <= 0 || failureCount > Delays.Count)
+        {
+            retryTopic = string.Empty;
+            delay = default;
+            return false;
+        }
+
+        delay = Delays[failureCount - 1];
+        retryTopic = GetRetryTopic(sourceTopic, delay);
+        return true;
+    }
+
+    internal static void ValidateDelay(TimeSpan delay)
+    {
+        if (delay <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(delay), delay, "Retry topic delays must be greater than zero.");
+        if (delay.Ticks < TimeSpan.TicksPerMillisecond)
+            throw new ArgumentOutOfRangeException(nameof(delay), delay, "Retry topic delays must be at least one millisecond.");
+    }
+
+    internal static void ValidateTopicSuffixFormat(string suffixFormat)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(suffixFormat);
+        if (!suffixFormat.Contains("{0}", StringComparison.Ordinal))
+            throw new ArgumentException("Retry topic suffix format must contain the {0} delay placeholder.", nameof(suffixFormat));
+    }
+
+    private static string FormatDelayLabel(TimeSpan delay)
+    {
+        if (delay.Ticks % TimeSpan.TicksPerDay == 0)
+            return $"{delay.Ticks / TimeSpan.TicksPerDay}d";
+        if (delay.Ticks % TimeSpan.TicksPerHour == 0)
+            return $"{delay.Ticks / TimeSpan.TicksPerHour}h";
+        if (delay.Ticks % TimeSpan.TicksPerMinute == 0)
+            return $"{delay.Ticks / TimeSpan.TicksPerMinute}m";
+        if (delay.Ticks % TimeSpan.TicksPerSecond == 0)
+            return $"{delay.Ticks / TimeSpan.TicksPerSecond}s";
+
+        return $"{delay.Ticks / TimeSpan.TicksPerMillisecond}ms";
+    }
+}

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3299,14 +3299,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void ClearPendingEofEventsForPartitions(HashSet<TopicPartition> partitionsToRemove)
     {
-        var count = _pendingEofEvents.Count;
-        for (var i = 0; i < count; i++)
+        List<(TopicPartition Partition, long Offset)>? retained = null;
+        while (_pendingEofEvents.TryDequeue(out var eofEvent))
         {
-            if (!_pendingEofEvents.TryDequeue(out var eofEvent))
-                return;
-
             if (!partitionsToRemove.Contains(eofEvent.Partition))
-                _pendingEofEvents.Enqueue(eofEvent);
+                (retained ??= []).Add(eofEvent);
+        }
+
+        if (retained is null)
+            return;
+
+        foreach (var eofEvent in retained)
+        {
+            _pendingEofEvents.Enqueue(eofEvent);
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3164,7 +3164,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         // Reset EOF state for this partition so it can fire again
         _eofEmitted.TryRemove(tp, out _);
-        ClearFetchBuffer();
+        ClearFetchBufferForPartitions([tp]);
     }
 
     public void SeekToBeginning(params TopicPartition[] partitions)
@@ -3182,7 +3182,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             _eofEmitted.TryRemove(partition, out _);
         }
-        ClearFetchBuffer();
+        ClearFetchBufferForPartitions(partitions);
     }
 
     public void SeekToEnd(params TopicPartition[] partitions)
@@ -3200,7 +3200,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             _eofEmitted.TryRemove(partition, out _);
         }
-        ClearFetchBuffer();
+        ClearFetchBufferForPartitions(partitions);
     }
 
     /// <summary>
@@ -3293,6 +3293,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // buffer would be consumed after an incremental unassign (cooperative rebalance),
         // causing data for partitions no longer owned by this consumer to be yielded.
         DrainPrefetchBufferForPartitions(removeSet);
+
+        ClearPendingEofEventsForPartitions(removeSet);
+    }
+
+    private void ClearPendingEofEventsForPartitions(HashSet<TopicPartition> partitionsToRemove)
+    {
+        var count = _pendingEofEvents.Count;
+        for (var i = 0; i < count; i++)
+        {
+            if (!_pendingEofEvents.TryDequeue(out var eofEvent))
+                return;
+
+            if (!partitionsToRemove.Contains(eofEvent.Partition))
+                _pendingEofEvents.Enqueue(eofEvent);
+        }
     }
 
     private void QueueCoordinatorRevokedPartitionsForFetchClear(IReadOnlyList<TopicPartition> partitions)

--- a/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
+++ b/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
@@ -1,8 +1,10 @@
 using System.Collections.Concurrent;
 using Dekaf.Consumer;
+using Dekaf.Consumer.DeadLetter;
 using Dekaf.Extensions.DependencyInjection;
 using Dekaf.Extensions.Hosting;
 using Dekaf.Producer;
+using Dekaf.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -103,6 +105,104 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
     }
 
     [Test]
+    public async Task RetryTopicMessages_NotDue_ResumeAndProcessAcrossPartitions()
+    {
+        var sourceTopic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
+        var retryDelay = TimeSpan.FromMilliseconds(250);
+        var retryOptions = new RetryTopicOptions { Delays = [retryDelay] };
+        var retryTopic = retryOptions.GetRetryTopic(sourceTopic, retryDelay);
+        await KafkaContainer.CreateTopicAsync(retryTopic, partitions: 2);
+
+        var groupId = $"hosted-retry-{Guid.NewGuid():N}";
+        var receivedMessages = new ConcurrentBag<RetryTopicProcessedMessage>();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var dueAt = DateTimeOffset.UtcNow.AddSeconds(5);
+        var inputs = new[]
+        {
+            new RetryTopicInput("retry-p0-a", 0, 0, dueAt),
+            new RetryTopicInput("retry-p0-b", 0, 1, dueAt),
+            new RetryTopicInput("retry-p1-a", 1, 0, dueAt),
+            new RetryTopicInput("retry-p1-b", 1, 1, dueAt)
+        };
+
+        foreach (var input in inputs)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = retryTopic,
+                Key = input.Value,
+                Value = input.Value,
+                Partition = input.Partition,
+                Headers = BuildRetryHeaders(sourceTopic, input.Partition, input.SourceOffset, retryDelay, input.DueAt)
+            }, CancellationToken.None);
+        }
+
+        await producer.FlushWithTimeoutAsync();
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.Services.AddDekaf(dekaf =>
+        {
+            dekaf.AddConsumer<string, string>(
+                c => c.WithBootstrapServers(KafkaContainer.BootstrapServers)
+                    .WithGroupId(groupId)
+                    .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+                    .WithFetchMaxWait(TimeSpan.FromMilliseconds(50)),
+                dlq => dlq.WithRetryTopics(retryDelay));
+        });
+
+        builder.Services.AddSingleton(receivedMessages);
+        builder.Services.AddSingleton<TestTopicHolder>(new TestTopicHolder(sourceTopic));
+        builder.Services.AddHostedService<RetryTopicConsumerService>();
+
+        var host = builder.Build();
+        using var cts = new CancellationTokenSource();
+        var hostTask = host.RunAsync(cts.Token);
+
+        try
+        {
+            await WaitForConditionAsync(
+                () => receivedMessages.Count >= inputs.Length,
+                TimeSpan.FromSeconds(45));
+
+            await Assert.That(receivedMessages.Select(m => m.Value))
+                .IsEquivalentTo(inputs.Select(i => i.Value));
+            await Assert.That(receivedMessages.Select(m => m.Partition).Distinct().Count())
+                .IsEqualTo(2);
+
+            foreach (var message in receivedMessages)
+            {
+                await Assert.That(message.ProcessedAt).IsGreaterThanOrEqualTo(message.DueAt);
+            }
+        }
+        finally
+        {
+            cts.Cancel();
+
+            try
+            {
+                await hostTask.WaitAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected
+            }
+            catch (TimeoutException)
+            {
+                // Host shutdown can be slow on resource-constrained CI runners
+            }
+            finally
+            {
+                host.Dispose();
+            }
+        }
+    }
+
+    [Test]
     public async Task StopsGracefully_NoExceptions()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();
@@ -165,6 +265,18 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
         public string Topic { get; } = topic;
     }
 
+    private sealed record RetryTopicInput(
+        string Value,
+        int Partition,
+        long SourceOffset,
+        DateTimeOffset DueAt);
+
+    private sealed record RetryTopicProcessedMessage(
+        string Value,
+        int Partition,
+        DateTimeOffset DueAt,
+        DateTimeOffset ProcessedAt);
+
     private sealed class TestConsumerService : KafkaConsumerService<string, string>
     {
         private readonly ConcurrentBag<string> _receivedMessages;
@@ -188,5 +300,67 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
             _receivedMessages.Add(result.Value);
             return ValueTask.CompletedTask;
         }
+    }
+
+    private sealed class RetryTopicConsumerService : KafkaConsumerService<string, string>
+    {
+        private readonly ConcurrentBag<RetryTopicProcessedMessage> _receivedMessages;
+        private readonly TestTopicHolder _topicHolder;
+
+        public RetryTopicConsumerService(
+            IKafkaConsumer<string, string> consumer,
+            ILogger<RetryTopicConsumerService> logger,
+            ConcurrentBag<RetryTopicProcessedMessage> receivedMessages,
+            TestTopicHolder topicHolder,
+            DeadLetterOptions deadLetterOptions)
+            : base(
+                consumer,
+                logger,
+                deadLetterOptions,
+                serviceOptions: new KafkaConsumerServiceOptions { DrainOnShutdown = false })
+        {
+            _receivedMessages = receivedMessages;
+            _topicHolder = topicHolder;
+        }
+
+        protected override IEnumerable<string> Topics => [_topicHolder.Topic];
+
+        protected override ValueTask ProcessAsync(ConsumeResult<string, string> result, CancellationToken cancellationToken)
+        {
+            if (!RetryTopicHeaders.TryGetDueAt(result.Headers, out var dueAt))
+                throw new InvalidOperationException("Retry due-at header missing.");
+
+            _receivedMessages.Add(new RetryTopicProcessedMessage(
+                result.Value,
+                result.Partition,
+                dueAt,
+                DateTimeOffset.UtcNow));
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static Headers BuildRetryHeaders(
+        string sourceTopic,
+        int sourcePartition,
+        long sourceOffset,
+        TimeSpan delay,
+        DateTimeOffset dueAt)
+    {
+        var sourceResult = new ConsumeResult<string, string>(
+            topic: sourceTopic,
+            partition: sourcePartition,
+            offset: sourceOffset,
+            keyData: default,
+            isKeyNull: true,
+            valueData: default,
+            isValueNull: true,
+            headers: null,
+            timestampMs: 0,
+            timestampType: TimestampType.NotAvailable,
+            leaderEpoch: null,
+            keyDeserializer: null,
+            valueDeserializer: null);
+
+        return RetryTopicHeaders.Build(sourceResult, failureCount: 1, delay, dueAt);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -144,6 +144,47 @@ public sealed class ConsumeOneFastPathTests
     }
 
     [Test]
+    public async Task Seek_WithPendingFetches_RemovesOnlySeekedPartition()
+    {
+        var seekedPartition = new TopicPartition(Topic, Partition);
+        var retainedPartition = new TopicPartition(Topic, 1);
+        var seekedFetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20, CreateRecord(0, "a", "seeked"))
+        ]);
+        var retainedFetch = PendingFetchData.Create(Topic, retainedPartition.Partition,
+        [
+            CreateBatch(30, CreateRecord(0, "b", "retained"))
+        ]);
+
+        await using var consumer = CreateInitializedConsumer();
+        consumer.Assign(seekedPartition, retainedPartition);
+        var fetchPositions = GetFetchPositions(consumer);
+        fetchPositions[seekedPartition] = 0;
+        fetchPositions[retainedPartition] = 0;
+
+        var pendingFetches = GetPendingFetches(consumer);
+        pendingFetches.Enqueue(seekedFetch);
+        pendingFetches.Enqueue(retainedFetch);
+        var pendingEofEvents = GetPendingEofEvents(consumer);
+        pendingEofEvents.Enqueue((seekedPartition, 20L));
+        pendingEofEvents.Enqueue((retainedPartition, 30L));
+
+        consumer.Seek(new TopicPartitionOffset(Topic, Partition, 20));
+
+        await Assert.That(pendingFetches.Count).IsEqualTo(1);
+        await Assert.That(pendingFetches.Peek().TopicPartition).IsEqualTo(retainedPartition);
+        await Assert.That(pendingEofEvents.ToArray())
+            .IsEquivalentTo([(retainedPartition, 30L)]);
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Partition).IsEqualTo(retainedPartition.Partition);
+        await Assert.That(result.Value.Value).IsEqualTo("retained");
+    }
+
+    [Test]
     public async Task ConsumeOneAsync_EmitsFetchMetricsAsDeltas()
     {
         var messagesReceived = new List<long>();

--- a/tests/Dekaf.Tests.Unit/Consumer/DeadLetter/DeadLetterHeadersTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/DeadLetter/DeadLetterHeadersTests.cs
@@ -94,6 +94,22 @@ public class DeadLetterHeadersTests
         await Assert.That(headers.GetFirstAsString("correlation-id")).IsEqualTo("xyz");
     }
 
+    [Test]
+    public async Task BuildHeaders_FromRetryTopic_UsesOriginalSourceMetadata()
+    {
+        var retryHeaders = new Headers()
+            .Add(RetryTopicHeaders.SourceTopicKey, "orders")
+            .Add(RetryTopicHeaders.SourcePartitionKey, "3")
+            .Add(RetryTopicHeaders.SourceOffsetKey, "99");
+        var result = CreateTestConsumeResult("orders-retry-5s", 0, 7, retryHeaders.ToList());
+
+        var headers = DeadLetterHeaders.Build(result, new InvalidOperationException("bad"), 2, includeException: true);
+
+        await Assert.That(headers.GetFirstAsString(DeadLetterHeaders.SourceTopicKey)).IsEqualTo("orders");
+        await Assert.That(headers.GetFirstAsString(DeadLetterHeaders.SourcePartitionKey)).IsEqualTo("3");
+        await Assert.That(headers.GetFirstAsString(DeadLetterHeaders.SourceOffsetKey)).IsEqualTo("99");
+    }
+
     private static ConsumeResult<string, string> CreateTestConsumeResult(
         string topic = "test", int partition = 0, long offset = 0,
         IReadOnlyList<Header>? headers = null)

--- a/tests/Dekaf.Tests.Unit/Consumer/DeadLetter/DeadLetterQueueBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/DeadLetter/DeadLetterQueueBuilderTests.cs
@@ -47,6 +47,36 @@ public class DeadLetterQueueBuilderTests
     }
 
     [Test]
+    public async Task Build_WithRetryTopics_ReturnsRetryTopicOptions()
+    {
+        var options = new DeadLetterQueueBuilder()
+            .WithRetryTopics(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(30))
+            .Build();
+
+        await Assert.That(options.RetryTopics).IsNotNull();
+        await Assert.That(options.RetryTopics!.IsEnabled).IsTrue();
+        await Assert.That(options.RetryTopics.Delays).IsEquivalentTo(
+            [TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(30)]);
+        await Assert.That(options.RetryTopics.GetRetryTopic("orders", TimeSpan.FromSeconds(5)))
+            .IsEqualTo("orders-retry-5s");
+        await Assert.That(options.RetryTopics.GetRetryTopic("orders", TimeSpan.FromSeconds(30)))
+            .IsEqualTo("orders-retry-30s");
+    }
+
+    [Test]
+    public async Task Build_WithRetryTopicSuffixFormat_UsesCustomFormat()
+    {
+        var options = new DeadLetterQueueBuilder()
+            .WithRetryTopics(TimeSpan.FromMinutes(1))
+            .WithRetryTopicSuffixFormat(".retry.{0}")
+            .Build();
+
+        await Assert.That(options.RetryTopics).IsNotNull();
+        await Assert.That(options.RetryTopics!.GetRetryTopic("orders", TimeSpan.FromMinutes(1)))
+            .IsEqualTo("orders.retry.1m");
+    }
+
+    [Test]
     public async Task Build_ExcludeExceptionInHeaders_ClearsFlag()
     {
         var options = new DeadLetterQueueBuilder()
@@ -68,6 +98,32 @@ public class DeadLetterQueueBuilderTests
             .ExcludeExceptionFromHeaders();
 
         await Assert.That(result).IsEqualTo(builder);
+    }
+
+    [Test]
+    public async Task WithRetryTopics_WithoutDelays_ThrowsArgumentException()
+    {
+        var builder = new DeadLetterQueueBuilder();
+
+        await Assert.That(() => builder.WithRetryTopics()).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task WithRetryTopics_WithNonPositiveDelay_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = new DeadLetterQueueBuilder();
+
+        await Assert.That(() => builder.WithRetryTopics(TimeSpan.Zero))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task WithRetryTopicSuffixFormat_WithoutDelayPlaceholder_ThrowsArgumentException()
+    {
+        var builder = new DeadLetterQueueBuilder();
+
+        await Assert.That(() => builder.WithRetryTopicSuffixFormat("-retry"))
+            .Throws<ArgumentException>();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/DeadLetter/RetryTopicHeadersTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/DeadLetter/RetryTopicHeadersTests.cs
@@ -1,0 +1,114 @@
+using Dekaf.Consumer;
+using Dekaf.Consumer.DeadLetter;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer.DeadLetter;
+
+public sealed class RetryTopicHeadersTests
+{
+    [Test]
+    public async Task Build_IncludesRetryMetadata()
+    {
+        var dueAt = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000);
+        var result = CreateTestConsumeResult("orders", partition: 2, offset: 100);
+
+        var headers = RetryTopicHeaders.Build(result, 3, TimeSpan.FromSeconds(30), dueAt);
+
+        await Assert.That(headers.GetFirstAsString(RetryTopicHeaders.SourceTopicKey)).IsEqualTo("orders");
+        await Assert.That(headers.GetFirstAsString(RetryTopicHeaders.SourcePartitionKey)).IsEqualTo("2");
+        await Assert.That(headers.GetFirstAsString(RetryTopicHeaders.SourceOffsetKey)).IsEqualTo("100");
+        await Assert.That(headers.GetFirstAsString(RetryTopicHeaders.FailureCountKey)).IsEqualTo("3");
+        await Assert.That(headers.GetFirstAsString(RetryTopicHeaders.DelayMsKey)).IsEqualTo("30000");
+        await Assert.That(headers.GetFirstAsString(RetryTopicHeaders.DueTimestampMsKey))
+            .IsEqualTo("1700000000000");
+    }
+
+    [Test]
+    public async Task Build_PreservesOriginalHeadersAndReplacesRetryHeaders()
+    {
+        var originalHeaders = new Headers()
+            .Add("trace-id", "abc123")
+            .Add(RetryTopicHeaders.FailureCountKey, "1");
+        var result = CreateTestConsumeResult("orders-retry-5s", headers: originalHeaders.ToList());
+
+        var headers = RetryTopicHeaders.Build(
+            result,
+            failureCount: 2,
+            delay: TimeSpan.FromSeconds(30),
+            dueAt: DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000));
+
+        await Assert.That(headers.Count).IsEqualTo(7);
+        await Assert.That(headers.GetFirstAsString("trace-id")).IsEqualTo("abc123");
+        await Assert.That(headers.GetFirstAsString(RetryTopicHeaders.FailureCountKey)).IsEqualTo("2");
+    }
+
+    [Test]
+    public async Task Build_WhenSourceRetryHeadersExist_KeepsOriginalSource()
+    {
+        var sourceHeaders = RetryTopicHeaders.Build(
+            CreateTestConsumeResult("orders", partition: 1, offset: 42),
+            failureCount: 1,
+            delay: TimeSpan.FromSeconds(5),
+            dueAt: DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000));
+        var result = CreateTestConsumeResult(
+            "orders-retry-5s",
+            partition: 3,
+            offset: 99,
+            headers: sourceHeaders.ToList());
+
+        var headers = RetryTopicHeaders.Build(
+            result,
+            failureCount: 2,
+            delay: TimeSpan.FromSeconds(30),
+            dueAt: DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_030_000));
+
+        await Assert.That(headers.GetFirstAsString(RetryTopicHeaders.SourceTopicKey)).IsEqualTo("orders");
+        await Assert.That(headers.GetFirstAsString(RetryTopicHeaders.SourcePartitionKey)).IsEqualTo("1");
+        await Assert.That(headers.GetFirstAsString(RetryTopicHeaders.SourceOffsetKey)).IsEqualTo("42");
+        await Assert.That(headers.GetFirstAsString(RetryTopicHeaders.FailureCountKey)).IsEqualTo("2");
+    }
+
+    [Test]
+    public async Task GetFailureCount_WhenHeaderMissing_ReturnsZero()
+    {
+        await Assert.That(RetryTopicHeaders.GetFailureCount(null)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task TryGetDueAt_WhenHeaderPresent_ReturnsTimestamp()
+    {
+        var dueAt = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000);
+        var headers = RetryTopicHeaders.Build(
+            CreateTestConsumeResult("orders"),
+            failureCount: 1,
+            delay: TimeSpan.FromSeconds(5),
+            dueAt: dueAt);
+
+        var found = RetryTopicHeaders.TryGetDueAt(headers.ToList(), out var actual);
+
+        await Assert.That(found).IsTrue();
+        await Assert.That(actual).IsEqualTo(dueAt);
+    }
+
+    private static ConsumeResult<string, string> CreateTestConsumeResult(
+        string topic = "test",
+        int partition = 0,
+        long offset = 0,
+        IReadOnlyList<Header>? headers = null)
+    {
+        return new ConsumeResult<string, string>(
+            topic: topic,
+            partition: partition,
+            offset: offset,
+            keyData: default,
+            isKeyNull: true,
+            valueData: default,
+            isValueNull: true,
+            headers: headers,
+            timestampMs: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            timestampType: TimestampType.CreateTime,
+            leaderEpoch: null,
+            keyDeserializer: null,
+            valueDeserializer: null);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -470,6 +470,31 @@ public class DependencyInjectionTests
         await Assert.That(options.BootstrapServers).IsEqualTo("localhost:9092");
     }
 
+    [Test]
+    public async Task AddConsumer_WithRetryTopics_RegistersRetryTopicOptions()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddConsumer<string, string>(
+                c => c
+                    .WithBootstrapServers("localhost:9092")
+                    .WithGroupId("test-group"),
+                dlq => dlq
+                    .WithRetryTopics(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(30)));
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<DeadLetterOptions>();
+
+        await Assert.That(options.RetryTopics).IsNotNull();
+        await Assert.That(options.RetryTopics!.GetRetryTopic("orders", TimeSpan.FromSeconds(5)))
+            .IsEqualTo("orders-retry-5s");
+        await Assert.That(options.RetryTopics.GetRetryTopic("orders", TimeSpan.FromSeconds(30)))
+            .IsEqualTo("orders-retry-30s");
+    }
+
     #endregion
 
     #region Configuration Binding Tests

--- a/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
@@ -4,6 +4,8 @@ using Dekaf;
 using Dekaf.Consumer;
 using Dekaf.Consumer.DeadLetter;
 using Dekaf.Extensions.Hosting;
+using Dekaf.Producer;
+using Dekaf.Retry;
 using Dekaf.Serialization;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -243,6 +245,78 @@ public sealed class KafkaConsumerServiceTests
             cts.Token);
 
         await Assert.That(async () => await waitTask).Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task ProcessWithRetriesAsync_RetryTopicsExhausted_RoutesToDeadLetterEvenBelowMaxFailures()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var producer = Substitute.For<IKafkaProducer<byte[]?, byte[]?>>();
+        producer.FireAsync(Arg.Any<ProducerMessage<byte[]?, byte[]?>>())
+            .Returns(ValueTask.CompletedTask);
+
+        var source = CreateResult("orders", partition: 1, offset: 42);
+        var retryHeaders = RetryTopicHeaders.Build(
+            source,
+            failureCount: 1,
+            delay: TimeSpan.FromSeconds(5),
+            dueAt: DateTimeOffset.UtcNow.AddSeconds(-1));
+        var retryResult = CreateResult(
+            "orders-retry-5s",
+            partition: 3,
+            offset: 99,
+            headers: retryHeaders.ToList());
+
+        var deadLetterOptions = new DeadLetterOptions
+        {
+            MaxFailures = 3,
+            RetryTopics = new RetryTopicOptions
+            {
+                Delays = [TimeSpan.FromSeconds(5)]
+            }
+        };
+        var service = new FailingConsumerService(consumer, ["orders"], deadLetterOptions);
+        SetDlqProducer(service, producer);
+
+        await ProcessWithRetriesAsync(service, retryResult, CancellationToken.None);
+
+        await producer.Received(1).FireAsync(Arg.Is<ProducerMessage<byte[]?, byte[]?>>(message =>
+            message.Topic == "orders.DLQ" &&
+            message.Headers!.GetFirstAsString(DeadLetterHeaders.FailureCountKey) == "2"));
+    }
+
+    [Test]
+    public async Task ProcessWithRetriesAsync_RetryPolicy_UsesNextRetryTopicTierAfterLocalRetries()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var producer = Substitute.For<IKafkaProducer<byte[]?, byte[]?>>();
+        producer.FireAsync(Arg.Any<ProducerMessage<byte[]?, byte[]?>>())
+            .Returns(ValueTask.CompletedTask);
+
+        var deadLetterOptions = new DeadLetterOptions
+        {
+            MaxFailures = 10,
+            RetryTopics = new RetryTopicOptions
+            {
+                Delays = [TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(30)]
+            }
+        };
+        var retryPolicy = new FixedDelayRetryPolicy
+        {
+            Delay = TimeSpan.Zero,
+            MaxAttempts = 1
+        };
+        var service = new FailingConsumerService(consumer, ["orders"], deadLetterOptions, retryPolicy);
+        SetDlqProducer(service, producer);
+
+        await ProcessWithRetriesAsync(service, CreateResult("orders", partition: 1, offset: 42), CancellationToken.None);
+
+        await producer.Received(1).FireAsync(Arg.Is<ProducerMessage<byte[]?, byte[]?>>(message =>
+            message.Topic == "orders-retry-5s" &&
+            message.Headers!.GetFirstAsString(RetryTopicHeaders.FailureCountKey) == "1"));
+        await producer.DidNotReceive().FireAsync(Arg.Is<ProducerMessage<byte[]?, byte[]?>>(message =>
+            message.Topic == "orders-retry-30s"));
+        await Assert.That(service.Errors).Count().IsEqualTo(2);
     }
 
     #endregion
@@ -611,6 +685,31 @@ public sealed class KafkaConsumerServiceTests
         return (Task)method.Invoke(null, [dueAt, cancellationToken])!;
     }
 
+    private static ValueTask ProcessWithRetriesAsync(
+        TestableKafkaConsumerService service,
+        ConsumeResult<string, string> result,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(Dekaf.Extensions.Hosting.KafkaConsumerService<string, string>).GetMethod(
+            "ProcessWithRetriesAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ProcessWithRetriesAsync method not found.");
+
+        return (ValueTask)method.Invoke(service, [result, cancellationToken])!;
+    }
+
+    private static void SetDlqProducer(
+        TestableKafkaConsumerService service,
+        IKafkaProducer<byte[]?, byte[]?> producer)
+    {
+        var field = typeof(Dekaf.Extensions.Hosting.KafkaConsumerService<string, string>).GetField(
+            "_dlqProducer",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_dlqProducer field not found.");
+
+        field.SetValue(service, producer);
+    }
+
     private static ConsumeResult<string, string> CreateResult(
         string topic,
         int partition = 0,
@@ -657,8 +756,12 @@ public sealed class KafkaConsumerServiceTests
     {
         public List<Exception> Errors { get; } = [];
 
-        public FailingConsumerService(IKafkaConsumer<string, string> consumer, string[] topics)
-            : base(consumer, topics)
+        public FailingConsumerService(
+            IKafkaConsumer<string, string> consumer,
+            string[] topics,
+            DeadLetterOptions? deadLetterOptions = null,
+            IRetryPolicy? retryPolicy = null)
+            : base(consumer, topics, deadLetterOptions: deadLetterOptions, retryPolicy: retryPolicy)
         {
         }
 
@@ -682,8 +785,9 @@ public sealed class KafkaConsumerServiceTests
             IKafkaConsumer<string, string> consumer,
             string[] topics,
             KafkaConsumerServiceOptions? options = null,
-            DeadLetterOptions? deadLetterOptions = null)
-            : base(consumer, NullLogger.Instance, deadLetterOptions, serviceOptions: options)
+            DeadLetterOptions? deadLetterOptions = null,
+            IRetryPolicy? retryPolicy = null)
+            : base(consumer, NullLogger.Instance, deadLetterOptions, retryPolicy, options)
         {
             _topics = topics;
         }

--- a/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Dekaf;
 using Dekaf.Consumer;
@@ -168,6 +169,80 @@ public sealed class KafkaConsumerServiceTests
             items.Length == 1 &&
             items[0].Topic == "orders-retry-5s" &&
             items[0].Partition == 3));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_RetryTopicMessageWithLaterOffset_DoesNotOverwritePendingSeek()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var positions = Substitute.For<IConsumerPositions>();
+        var partitions = Substitute.For<IConsumerPartitions>();
+        consumer.Positions.Returns(positions);
+        consumer.Partitions.Returns(partitions);
+
+        var source = CreateResult("orders", partition: 1, offset: 42);
+        var retryHeaders = RetryTopicHeaders.Build(
+            source,
+            failureCount: 1,
+            delay: TimeSpan.FromSeconds(5),
+            dueAt: DateTimeOffset.UtcNow.AddMinutes(5));
+        var firstRetryResult = CreateResult(
+            "orders-retry-5s",
+            partition: 3,
+            offset: 99,
+            headers: retryHeaders.ToList());
+        var secondRetryResult = CreateResult(
+            "orders-retry-5s",
+            partition: 3,
+            offset: 100,
+            headers: retryHeaders.ToList());
+        var consumed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        consumer.ConsumeAsync(Arg.Any<CancellationToken>())
+            .Returns(CreateResultsAndSignal(consumed, firstRetryResult, secondRetryResult));
+
+        var deadLetterOptions = new DeadLetterOptions
+        {
+            RetryTopics = new RetryTopicOptions
+            {
+                Delays = [TimeSpan.FromSeconds(5)]
+            }
+        };
+        var service = new TestConsumerService(
+            consumer,
+            ["orders"],
+            options: new KafkaConsumerServiceOptions { DrainOnShutdown = false },
+            deadLetterOptions: deadLetterOptions);
+
+        await service.StartAsync(CancellationToken.None);
+        await consumed.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        await service.StopAsync(CancellationToken.None);
+
+        await Assert.That(service.ProcessedMessages).IsEmpty();
+        positions.Received(1).Seek(Arg.Is<TopicPartitionOffset>(offset =>
+            offset.Topic == "orders-retry-5s" &&
+            offset.Partition == 3 &&
+            offset.Offset == 99));
+        positions.DidNotReceive().Seek(Arg.Is<TopicPartitionOffset>(offset =>
+            offset.Topic == "orders-retry-5s" &&
+            offset.Partition == 3 &&
+            offset.Offset == 100));
+        partitions.Received(1).Pause(Arg.Is<TopicPartition[]>(items =>
+            items.Length == 1 &&
+            items[0].Topic == "orders-retry-5s" &&
+            items[0].Partition == 3));
+    }
+
+    [Test]
+    public async Task RetryTopicDelay_WithLongDelay_WaitsInCancelableChunks()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var waitTask = DelayUntilRetryTopicDueAsync(
+            DateTimeOffset.UtcNow.AddDays(30),
+            cts.Token);
+
+        await Assert.That(async () => await waitTask).Throws<OperationCanceledException>();
     }
 
     #endregion
@@ -509,6 +584,31 @@ public sealed class KafkaConsumerServiceTests
         }
 
         await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ConsumeResult<string, string>> CreateResultsAndSignal(
+        TaskCompletionSource completion,
+        params ConsumeResult<string, string>[] items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+
+        completion.TrySetResult();
+        await Task.CompletedTask;
+    }
+
+    private static Task DelayUntilRetryTopicDueAsync(
+        DateTimeOffset dueAt,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(Dekaf.Extensions.Hosting.KafkaConsumerService<string, string>).GetMethod(
+            "DelayUntilRetryTopicDueAsync",
+            BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("DelayUntilRetryTopicDueAsync method not found.");
+
+        return (Task)method.Invoke(null, [dueAt, cancellationToken])!;
     }
 
     private static ConsumeResult<string, string> CreateResult(

--- a/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs
@@ -1,6 +1,9 @@
 using System.Runtime.CompilerServices;
+using Dekaf;
 using Dekaf.Consumer;
+using Dekaf.Consumer.DeadLetter;
 using Dekaf.Extensions.Hosting;
+using Dekaf.Serialization;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
@@ -37,6 +40,37 @@ public sealed class KafkaConsumerServiceTests
         }
 
         await service.StopAsync(CancellationToken.None);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WithRetryTopics_SubscribesToSourceAndRetryTopics()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        consumer.ConsumeAsync(Arg.Any<CancellationToken>())
+            .Returns(callInfo => WaitForCancellation(callInfo.ArgAt<CancellationToken>(0)));
+
+        var deadLetterOptions = new DeadLetterOptions
+        {
+            RetryTopics = new RetryTopicOptions
+            {
+                Delays = [TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(30)]
+            }
+        };
+        var service = new TestConsumerService(
+            consumer,
+            ["orders"],
+            options: new KafkaConsumerServiceOptions { DrainOnShutdown = false },
+            deadLetterOptions: deadLetterOptions);
+
+        await service.StartAsync(CancellationToken.None);
+        await WaitForSubscribeAsync(consumer);
+        await service.StopAsync(CancellationToken.None);
+
+        consumer.Received(1).Subscribe(Arg.Is<string[]>(topics =>
+            topics.Contains("orders") &&
+            topics.Contains("orders-retry-5s") &&
+            topics.Contains("orders-retry-30s") &&
+            topics.Length == 3));
     }
 
     [Test]
@@ -83,6 +117,57 @@ public sealed class KafkaConsumerServiceTests
         await service.StopAsync(CancellationToken.None);
 
         await Assert.That(service.Errors).Count().IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_RetryTopicMessageNotDue_PausesAndSeeksWithoutProcessing()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var positions = Substitute.For<IConsumerPositions>();
+        var partitions = Substitute.For<IConsumerPartitions>();
+        consumer.Positions.Returns(positions);
+        consumer.Partitions.Returns(partitions);
+
+        var source = CreateResult("orders", partition: 1, offset: 42);
+        var retryHeaders = RetryTopicHeaders.Build(
+            source,
+            failureCount: 1,
+            delay: TimeSpan.FromSeconds(5),
+            dueAt: DateTimeOffset.UtcNow.AddMinutes(5));
+        var retryResult = CreateResult(
+            "orders-retry-5s",
+            partition: 3,
+            offset: 99,
+            headers: retryHeaders.ToList());
+        consumer.ConsumeAsync(Arg.Any<CancellationToken>())
+            .Returns(CreateResults(retryResult));
+
+        var deadLetterOptions = new DeadLetterOptions
+        {
+            RetryTopics = new RetryTopicOptions
+            {
+                Delays = [TimeSpan.FromSeconds(5)]
+            }
+        };
+        var service = new TestConsumerService(
+            consumer,
+            ["orders"],
+            options: new KafkaConsumerServiceOptions { DrainOnShutdown = false },
+            deadLetterOptions: deadLetterOptions);
+
+        await service.StartAsync(CancellationToken.None);
+        await WaitForPauseAsync(partitions);
+        await service.StopAsync(CancellationToken.None);
+
+        await Assert.That(service.ProcessedMessages).IsEmpty();
+        positions.Received(1).Seek(Arg.Is<TopicPartitionOffset>(offset =>
+            offset.Topic == "orders-retry-5s" &&
+            offset.Partition == 3 &&
+            offset.Offset == 99));
+        partitions.Received(1).Pause(Arg.Is<TopicPartition[]>(items =>
+            items.Length == 1 &&
+            items[0].Topic == "orders-retry-5s" &&
+            items[0].Partition == 3));
     }
 
     #endregion
@@ -370,6 +455,25 @@ public sealed class KafkaConsumerServiceTests
         throw new TimeoutException("ExecuteAsync did not call Subscribe() within timeout");
     }
 
+    private static async Task WaitForPauseAsync(IConsumerPartitions partitions)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        while (!timeout.IsCancellationRequested)
+        {
+            try
+            {
+                partitions.Received(1).Pause(Arg.Any<TopicPartition[]>());
+                return;
+            }
+            catch (NSubstitute.Exceptions.ReceivedCallsException)
+            {
+                await Task.Delay(10, timeout.Token);
+            }
+        }
+
+        throw new TimeoutException("Retry topic partition was not paused within timeout");
+    }
+
     private static async IAsyncEnumerable<ConsumeResult<string, string>> WaitForCancellation(
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
@@ -390,32 +494,55 @@ public sealed class KafkaConsumerServiceTests
     {
         foreach (var (topic, partition, offset) in items)
         {
-            yield return new ConsumeResult<string, string>(
-                topic: topic,
-                partition: partition,
-                offset: offset,
-                keyData: default,
-                isKeyNull: true,
-                valueData: default,
-                isValueNull: true,
-                headers: null,
-                timestampMs: 0,
-                timestampType: TimestampType.NotAvailable,
-                leaderEpoch: null,
-                keyDeserializer: null,
-                valueDeserializer: null);
+            yield return CreateResult(topic, partition, offset);
         }
 
         await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ConsumeResult<string, string>> CreateResults(
+        params ConsumeResult<string, string>[] items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    private static ConsumeResult<string, string> CreateResult(
+        string topic,
+        int partition = 0,
+        long offset = 0,
+        IReadOnlyList<Header>? headers = null)
+    {
+        return new ConsumeResult<string, string>(
+            topic: topic,
+            partition: partition,
+            offset: offset,
+            keyData: default,
+            isKeyNull: true,
+            valueData: default,
+            isValueNull: true,
+            headers: headers,
+            timestampMs: 0,
+            timestampType: TimestampType.NotAvailable,
+            leaderEpoch: null,
+            keyDeserializer: null,
+            valueDeserializer: null);
     }
 
     private sealed class TestConsumerService : TestableKafkaConsumerService
     {
         public List<ConsumeResult<string, string>> ProcessedMessages { get; } = [];
 
-        public TestConsumerService(IKafkaConsumer<string, string> consumer, string[] topics,
-            KafkaConsumerServiceOptions? options = null)
-            : base(consumer, topics, options)
+        public TestConsumerService(
+            IKafkaConsumer<string, string> consumer,
+            string[] topics,
+            KafkaConsumerServiceOptions? options = null,
+            DeadLetterOptions? deadLetterOptions = null)
+            : base(consumer, topics, options, deadLetterOptions)
         {
         }
 
@@ -451,9 +578,12 @@ public sealed class KafkaConsumerServiceTests
     {
         private readonly string[] _topics;
 
-        protected TestableKafkaConsumerService(IKafkaConsumer<string, string> consumer, string[] topics,
-            KafkaConsumerServiceOptions? options = null)
-            : base(consumer, NullLogger.Instance, serviceOptions: options)
+        protected TestableKafkaConsumerService(
+            IKafkaConsumer<string, string> consumer,
+            string[] topics,
+            KafkaConsumerServiceOptions? options = null,
+            DeadLetterOptions? deadLetterOptions = null)
+            : base(consumer, NullLogger.Instance, deadLetterOptions, serviceOptions: options)
         {
             _topics = topics;
         }

--- a/tools/Dekaf.Pipeline/Modules/RunCompressionIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunCompressionIntegrationTestsModule.cs
@@ -3,4 +3,10 @@ namespace Dekaf.Pipeline.Modules;
 public class RunCompressionIntegrationTestsModule : RunIntegrationTestsModule
 {
     protected override string Category => "Compression";
+
+    protected override TimeSpan ModuleTimeout => TimeSpan.FromMinutes(45);
+
+    protected override TimeSpan ProcessTimeout => TimeSpan.FromMinutes(35);
+
+    protected override int? MaximumParallelTests => 4;
 }

--- a/tools/Dekaf.Pipeline/Modules/RunIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunIntegrationTestsModule.cs
@@ -19,10 +19,16 @@ public abstract class RunIntegrationTestsModule : Module<IReadOnlyList<CommandRe
     /// </summary>
     protected new abstract string Category { get; }
 
+    protected virtual TimeSpan ModuleTimeout => TimeSpan.FromMinutes(30);
+
+    protected virtual TimeSpan ProcessTimeout => TimeSpan.FromMinutes(20);
+
+    protected virtual int? MaximumParallelTests => null;
+
     protected override ModuleConfiguration Configure()
     {
         return new ModuleConfigurationBuilder()
-            .WithTimeout(TimeSpan.FromMinutes(30))
+            .WithTimeout(ModuleTimeout)
             .Build();
     }
 
@@ -56,10 +62,16 @@ public abstract class RunIntegrationTestsModule : Module<IReadOnlyList<CommandRe
             "--treenode-filter", $"/**[Category={Category}]"
         };
 
+        if (MaximumParallelTests is { } maximumParallelTests)
+        {
+            arguments.Add("--maximum-parallel-tests");
+            arguments.Add(maximumParallelTests.ToString());
+        }
+
         context.Logger.LogInformation("Running integration tests for category: {Category}", Category);
 
         // Process-level timeout as safety fallback (matches TestBaseModule pattern)
-        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(20));
+        using var timeoutCts = new CancellationTokenSource(ProcessTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 
         try
@@ -88,7 +100,7 @@ public abstract class RunIntegrationTestsModule : Module<IReadOnlyList<CommandRe
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
             throw new TimeoutException(
-                $"Integration tests for category '{Category}' exceeded 20 minute process timeout");
+                $"Integration tests for category '{Category}' exceeded {ProcessTimeout.TotalMinutes:0} minute process timeout");
         }
 
         return results;


### PR DESCRIPTION
## Summary
- add tiered retry-topic options to the existing DLQ builder
- subscribe hosted consumers to derived retry topics and postpone not-yet-due retry records by seek/pause/scheduled resume instead of blocking the consume loop
- route failed records through retry tiers before dead-lettering, preserving original source metadata in retry and DLQ headers

## Review fixes
- scope `Seek`, `SeekToBeginning`, and `SeekToEnd` buffer clears to affected partitions
- preserve the earliest pending retry-topic offset per partition so later buffered records cannot overwrite the seek target
- wait long retry-topic delays in cancellable chunks under the `Task.Delay` limit
- add unit and Testcontainers coverage for retry-topic postponement across partitions

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/*/KafkaConsumerServiceTests/*RetryTopic*"`
- `dotnet run --project tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/*/ConsumeOneFastPathTests/Seek_WithPendingFetches_RemovesOnlySeekedPartition"`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release -p:TreatWarningsAsErrors=true -v:minimal`
- `dotnet run --project tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release --framework net10.0 --no-build -- --treenode-filter "/*/*/HostedServiceTests/RetryTopicMessages_NotDue_ResumeAndProcessAcrossPartitions"`
- `dotnet format Dekaf.sln --verify-no-changes --include src/Dekaf.Extensions.Hosting/KafkaConsumerService.cs src/Dekaf/Consumer/KafkaConsumer.cs tests/Dekaf.Tests.Unit/Hosting/KafkaConsumerServiceTests.cs tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs tests/Dekaf.Tests.Integration/HostedServiceTests.cs --verbosity minimal`

Closes #1395