### PR TITLE
feat(schemaregistry): add DEK registry API

### DIFF
--- a/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/ISchemaRegistryClient.cs
@@ -132,6 +132,178 @@ public interface ISchemaRegistryClient : IDisposable
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of deleted version numbers.</returns>
     Task<IReadOnlyList<int>> DeleteSubjectAsync(string subject, bool permanent = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists Schema Registry Key Encryption Key (KEK) names.
+    /// </summary>
+    /// <param name="deleted">Whether to include soft-deleted KEKs.</param>
+    /// <param name="offset">Pagination offset.</param>
+    /// <param name="limit">Pagination size.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of KEK names.</returns>
+    Task<IReadOnlyList<string>> GetKekNamesAsync(
+        bool deleted = false,
+        int? offset = null,
+        int? limit = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("This Schema Registry client does not support DEK Registry KEK operations.");
+
+    /// <summary>
+    /// Registers a Schema Registry Key Encryption Key (KEK).
+    /// </summary>
+    /// <param name="request">KEK registration request.</param>
+    /// <param name="testSharing">Whether Schema Registry should test KEK sharing.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The registered KEK.</returns>
+    Task<Kek> RegisterKekAsync(
+        RegisterKekRequest request,
+        bool testSharing = false,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("This Schema Registry client does not support DEK Registry KEK operations.");
+
+    /// <summary>
+    /// Gets a Schema Registry Key Encryption Key (KEK) by name.
+    /// </summary>
+    /// <param name="name">KEK name.</param>
+    /// <param name="deleted">Whether to include soft-deleted KEKs.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The KEK.</returns>
+    Task<Kek> GetKekAsync(
+        string name,
+        bool deleted = false,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("This Schema Registry client does not support DEK Registry KEK operations.");
+
+    /// <summary>
+    /// Deletes a Schema Registry Key Encryption Key (KEK).
+    /// </summary>
+    /// <param name="name">KEK name.</param>
+    /// <param name="permanent">Whether to permanently delete the KEK.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeleteKekAsync(
+        string name,
+        bool permanent = false,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("This Schema Registry client does not support DEK Registry KEK operations.");
+
+    /// <summary>
+    /// Lists Data Encryption Key (DEK) subjects for a KEK.
+    /// </summary>
+    /// <param name="kekName">KEK name.</param>
+    /// <param name="deleted">Whether to include soft-deleted DEKs.</param>
+    /// <param name="offset">Pagination offset.</param>
+    /// <param name="limit">Pagination size.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of DEK subjects.</returns>
+    Task<IReadOnlyList<string>> GetDekSubjectsAsync(
+        string kekName,
+        bool deleted = false,
+        int? offset = null,
+        int? limit = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("This Schema Registry client does not support DEK Registry DEK operations.");
+
+    /// <summary>
+    /// Registers a Data Encryption Key (DEK) under a KEK.
+    /// </summary>
+    /// <param name="kekName">KEK name.</param>
+    /// <param name="request">DEK registration request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The registered DEK.</returns>
+    Task<Dek> RegisterDekAsync(
+        string kekName,
+        RegisterDekRequest request,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("This Schema Registry client does not support DEK Registry DEK operations.");
+
+    /// <summary>
+    /// Gets the latest Data Encryption Key (DEK) for a KEK and subject.
+    /// </summary>
+    /// <param name="kekName">KEK name.</param>
+    /// <param name="subject">DEK subject.</param>
+    /// <param name="algorithm">Optional DEK algorithm filter.</param>
+    /// <param name="deleted">Whether to include soft-deleted DEKs.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The DEK.</returns>
+    Task<Dek> GetDekAsync(
+        string kekName,
+        string subject,
+        DekAlgorithm? algorithm = null,
+        bool deleted = false,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("This Schema Registry client does not support DEK Registry DEK operations.");
+
+    /// <summary>
+    /// Gets a Data Encryption Key (DEK) by version.
+    /// </summary>
+    /// <param name="kekName">KEK name.</param>
+    /// <param name="subject">DEK subject.</param>
+    /// <param name="version">DEK version.</param>
+    /// <param name="deleted">Whether to include soft-deleted DEKs.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The DEK.</returns>
+    Task<Dek> GetDekAsync(
+        string kekName,
+        string subject,
+        int version,
+        bool deleted = false,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("This Schema Registry client does not support DEK Registry DEK operations.");
+
+    /// <summary>
+    /// Lists Data Encryption Key (DEK) versions for a KEK and subject.
+    /// </summary>
+    /// <param name="kekName">KEK name.</param>
+    /// <param name="subject">DEK subject.</param>
+    /// <param name="algorithm">Optional DEK algorithm filter.</param>
+    /// <param name="deleted">Whether to include soft-deleted DEKs.</param>
+    /// <param name="offset">Pagination offset.</param>
+    /// <param name="limit">Pagination size.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of DEK versions.</returns>
+    Task<IReadOnlyList<int>> GetDekVersionsAsync(
+        string kekName,
+        string subject,
+        DekAlgorithm? algorithm = null,
+        bool deleted = false,
+        int? offset = null,
+        int? limit = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("This Schema Registry client does not support DEK Registry DEK operations.");
+
+    /// <summary>
+    /// Deletes all versions of a Data Encryption Key (DEK).
+    /// </summary>
+    /// <param name="kekName">KEK name.</param>
+    /// <param name="subject">DEK subject.</param>
+    /// <param name="algorithm">Optional DEK algorithm filter.</param>
+    /// <param name="permanent">Whether to permanently delete the DEK.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeleteDekAsync(
+        string kekName,
+        string subject,
+        DekAlgorithm? algorithm = null,
+        bool permanent = false,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("This Schema Registry client does not support DEK Registry DEK operations.");
+
+    /// <summary>
+    /// Deletes one version of a Data Encryption Key (DEK).
+    /// </summary>
+    /// <param name="kekName">KEK name.</param>
+    /// <param name="subject">DEK subject.</param>
+    /// <param name="version">DEK version.</param>
+    /// <param name="algorithm">Optional DEK algorithm filter.</param>
+    /// <param name="permanent">Whether to permanently delete the DEK.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeleteDekVersionAsync(
+        string kekName,
+        string subject,
+        int version,
+        DekAlgorithm? algorithm = null,
+        bool permanent = false,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("This Schema Registry client does not support DEK Registry DEK operations.");
 }
 
 /// <summary>
@@ -203,6 +375,196 @@ public sealed class RegisteredSchema
     /// The schema.
     /// </summary>
     public required Schema Schema { get; init; }
+}
+
+/// <summary>
+/// Schema Registry Key Encryption Key (KEK).
+/// </summary>
+public sealed class Kek
+{
+    /// <summary>
+    /// KEK name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// KMS provider type, for example aws-kms, azure-kv, or gcp-kms.
+    /// </summary>
+    public required string KmsType { get; init; }
+
+    /// <summary>
+    /// Provider-specific KMS key identifier.
+    /// </summary>
+    public required string KmsKeyId { get; init; }
+
+    /// <summary>
+    /// Provider-specific KMS properties.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? KmsProps { get; init; }
+
+    /// <summary>
+    /// Optional KEK documentation.
+    /// </summary>
+    public string? Doc { get; init; }
+
+    /// <summary>
+    /// Whether this KEK is shared across multiple subjects.
+    /// </summary>
+    public bool Shared { get; init; }
+
+    /// <summary>
+    /// Whether this KEK has been soft-deleted.
+    /// </summary>
+    public bool Deleted { get; init; }
+
+    /// <summary>
+    /// Schema Registry timestamp for this KEK, when returned by the server.
+    /// </summary>
+    public long? Timestamp { get; init; }
+}
+
+/// <summary>
+/// Request used to register a Schema Registry Key Encryption Key (KEK).
+/// </summary>
+public sealed class RegisterKekRequest
+{
+    /// <summary>
+    /// KEK name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// KMS provider type, for example aws-kms, azure-kv, or gcp-kms.
+    /// </summary>
+    public required string KmsType { get; init; }
+
+    /// <summary>
+    /// Provider-specific KMS key identifier.
+    /// </summary>
+    public required string KmsKeyId { get; init; }
+
+    /// <summary>
+    /// Provider-specific KMS properties.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? KmsProps { get; init; }
+
+    /// <summary>
+    /// Optional KEK documentation.
+    /// </summary>
+    public string? Doc { get; init; }
+
+    /// <summary>
+    /// Whether this KEK is shared across multiple subjects.
+    /// </summary>
+    public bool? Shared { get; init; }
+
+    /// <summary>
+    /// Whether this KEK should be registered as deleted.
+    /// </summary>
+    public bool? Deleted { get; init; }
+}
+
+/// <summary>
+/// Schema Registry Data Encryption Key (DEK) algorithm.
+/// </summary>
+public enum DekAlgorithm
+{
+    /// <summary>
+    /// Unknown or server-specific algorithm.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// AES-128 GCM.
+    /// </summary>
+    Aes128Gcm,
+
+    /// <summary>
+    /// AES-256 GCM.
+    /// </summary>
+    Aes256Gcm,
+
+    /// <summary>
+    /// AES-256 SIV.
+    /// </summary>
+    Aes256Siv
+}
+
+/// <summary>
+/// Schema Registry Data Encryption Key (DEK).
+/// </summary>
+public sealed class Dek
+{
+    /// <summary>
+    /// KEK name associated with this DEK.
+    /// </summary>
+    public required string KekName { get; init; }
+
+    /// <summary>
+    /// Subject associated with this DEK.
+    /// </summary>
+    public required string Subject { get; init; }
+
+    /// <summary>
+    /// DEK version.
+    /// </summary>
+    public required int Version { get; init; }
+
+    /// <summary>
+    /// Encryption algorithm used by this DEK.
+    /// </summary>
+    public DekAlgorithm Algorithm { get; init; }
+
+    /// <summary>
+    /// Encrypted DEK material, base64 encoded by Schema Registry.
+    /// </summary>
+    public string? EncryptedKeyMaterial { get; init; }
+
+    /// <summary>
+    /// Raw DEK material when the server returns it.
+    /// </summary>
+    public string? KeyMaterial { get; init; }
+
+    /// <summary>
+    /// Whether this DEK has been soft-deleted.
+    /// </summary>
+    public bool Deleted { get; init; }
+
+    /// <summary>
+    /// Schema Registry timestamp for this DEK, when returned by the server.
+    /// </summary>
+    public long? Timestamp { get; init; }
+}
+
+/// <summary>
+/// Request used to register a Schema Registry Data Encryption Key (DEK).
+/// </summary>
+public sealed class RegisterDekRequest
+{
+    /// <summary>
+    /// Subject associated with this DEK.
+    /// </summary>
+    public required string Subject { get; init; }
+
+    /// <summary>
+    /// Optional explicit DEK version.
+    /// </summary>
+    public int? Version { get; init; }
+
+    /// <summary>
+    /// Optional DEK algorithm. When omitted, Schema Registry chooses its default.
+    /// </summary>
+    public DekAlgorithm? Algorithm { get; init; }
+
+    /// <summary>
+    /// Optional encrypted DEK material.
+    /// </summary>
+    public string? EncryptedKeyMaterial { get; init; }
+
+    /// <summary>
+    /// Whether this DEK should be registered as deleted.
+    /// </summary>
+    public bool? Deleted { get; init; }
 }
 
 /// <summary>

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryClient.cs
@@ -1,8 +1,11 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Dekaf.Security.Sasl;
 
@@ -105,6 +108,29 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             ? path + "&normalize=true"
             : path + "?normalize=true";
     }
+
+    private static string WithQuery(string path, params (string Name, string? Value)[] parameters)
+    {
+        StringBuilder? builder = null;
+        foreach (var (name, value) in parameters)
+        {
+            if (value is null)
+                continue;
+
+            builder ??= new StringBuilder(path);
+            builder.Append(builder.Length == path.Length ? '?' : '&');
+            builder.Append(Uri.EscapeDataString(name));
+            builder.Append('=');
+            builder.Append(Uri.EscapeDataString(value));
+        }
+
+        return builder?.ToString() ?? path;
+    }
+
+    private static string? BoolQuery(bool value) => value ? "true" : null;
+
+    private static string? IntQuery(int? value) =>
+        value.HasValue ? value.Value.ToString(CultureInfo.InvariantCulture) : null;
 
     private Task<HttpResponseMessage> GetWithFailoverAsync(string path, CancellationToken cancellationToken) =>
         SendWithFailoverAsync(baseUri => _httpClient.GetAsync(new Uri(baseUri, path), cancellationToken), cancellationToken);
@@ -393,6 +419,234 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             SchemaRegistryJsonContext.Default.ListInt32, cancellationToken).ConfigureAwait(false) ?? [];
     }
 
+    public async Task<IReadOnlyList<string>> GetKekNamesAsync(
+        bool deleted = false,
+        int? offset = null,
+        int? limit = null,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await GetWithFailoverAsync(
+            WithQuery(
+                "dek-registry/v1/keks",
+                ("deleted", BoolQuery(deleted)),
+                ("offset", IntQuery(offset)),
+                ("limit", IntQuery(limit))),
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        return await response.Content.ReadFromJsonAsync<List<string>>(
+            SchemaRegistryJsonContext.Default.ListString, cancellationToken).ConfigureAwait(false) ?? [];
+    }
+
+    public async Task<Kek> RegisterKekAsync(
+        RegisterKekRequest request,
+        bool testSharing = false,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        using var response = await PostAsJsonWithFailoverAsync(
+            WithQuery("dek-registry/v1/keks", ("testSharing", BoolQuery(testSharing))),
+            ToRegisterKekRequestDto(request),
+            SchemaRegistryJsonContext.Default.RegisterKekRequestDto,
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var result = await response.Content.ReadFromJsonAsync<KekDto>(
+            SchemaRegistryJsonContext.Default.KekDto, cancellationToken).ConfigureAwait(false);
+        if (result is null)
+            throw new SchemaRegistryException((int)response.StatusCode, "Schema Registry returned an empty KEK response");
+
+        return ToKek(result);
+    }
+
+    public async Task<Kek> GetKekAsync(
+        string name,
+        bool deleted = false,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await GetWithFailoverAsync(
+            WithQuery(
+                $"dek-registry/v1/keks/{Uri.EscapeDataString(name)}",
+                ("deleted", BoolQuery(deleted))),
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var result = await response.Content.ReadFromJsonAsync<KekDto>(
+            SchemaRegistryJsonContext.Default.KekDto, cancellationToken).ConfigureAwait(false);
+        if (result is null)
+            throw new SchemaRegistryException((int)response.StatusCode, "Schema Registry returned an empty KEK response");
+
+        return ToKek(result);
+    }
+
+    public async Task DeleteKekAsync(
+        string name,
+        bool permanent = false,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await DeleteWithFailoverAsync(
+            WithQuery(
+                $"dek-registry/v1/keks/{Uri.EscapeDataString(name)}",
+                ("permanent", BoolQuery(permanent))),
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<string>> GetDekSubjectsAsync(
+        string kekName,
+        bool deleted = false,
+        int? offset = null,
+        int? limit = null,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await GetWithFailoverAsync(
+            WithQuery(
+                $"dek-registry/v1/keks/{Uri.EscapeDataString(kekName)}/deks",
+                ("deleted", BoolQuery(deleted)),
+                ("offset", IntQuery(offset)),
+                ("limit", IntQuery(limit))),
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        return await response.Content.ReadFromJsonAsync<List<string>>(
+            SchemaRegistryJsonContext.Default.ListString, cancellationToken).ConfigureAwait(false) ?? [];
+    }
+
+    public async Task<Dek> RegisterDekAsync(
+        string kekName,
+        RegisterDekRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        using var response = await PostAsJsonWithFailoverAsync(
+            $"dek-registry/v1/keks/{Uri.EscapeDataString(kekName)}/deks",
+            ToRegisterDekRequestDto(request),
+            SchemaRegistryJsonContext.Default.RegisterDekRequestDto,
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var result = await response.Content.ReadFromJsonAsync<DekDto>(
+            SchemaRegistryJsonContext.Default.DekDto, cancellationToken).ConfigureAwait(false);
+        if (result is null)
+            throw new SchemaRegistryException((int)response.StatusCode, "Schema Registry returned an empty DEK response");
+
+        return ToDek(result);
+    }
+
+    public async Task<Dek> GetDekAsync(
+        string kekName,
+        string subject,
+        DekAlgorithm? algorithm = null,
+        bool deleted = false,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await GetWithFailoverAsync(
+            WithQuery(
+                $"dek-registry/v1/keks/{Uri.EscapeDataString(kekName)}/deks/{Uri.EscapeDataString(subject)}",
+                ("algorithm", FormatDekAlgorithm(algorithm)),
+                ("deleted", BoolQuery(deleted))),
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var result = await response.Content.ReadFromJsonAsync<DekDto>(
+            SchemaRegistryJsonContext.Default.DekDto, cancellationToken).ConfigureAwait(false);
+        if (result is null)
+            throw new SchemaRegistryException((int)response.StatusCode, "Schema Registry returned an empty DEK response");
+
+        return ToDek(result);
+    }
+
+    public async Task<Dek> GetDekAsync(
+        string kekName,
+        string subject,
+        int version,
+        bool deleted = false,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await GetWithFailoverAsync(
+            WithQuery(
+                $"dek-registry/v1/keks/{Uri.EscapeDataString(kekName)}/deks/{Uri.EscapeDataString(subject)}/versions/{version.ToString(CultureInfo.InvariantCulture)}",
+                ("deleted", BoolQuery(deleted))),
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        var result = await response.Content.ReadFromJsonAsync<DekDto>(
+            SchemaRegistryJsonContext.Default.DekDto, cancellationToken).ConfigureAwait(false);
+        if (result is null)
+            throw new SchemaRegistryException((int)response.StatusCode, "Schema Registry returned an empty DEK response");
+
+        return ToDek(result);
+    }
+
+    public async Task<IReadOnlyList<int>> GetDekVersionsAsync(
+        string kekName,
+        string subject,
+        DekAlgorithm? algorithm = null,
+        bool deleted = false,
+        int? offset = null,
+        int? limit = null,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await GetWithFailoverAsync(
+            WithQuery(
+                $"dek-registry/v1/keks/{Uri.EscapeDataString(kekName)}/deks/{Uri.EscapeDataString(subject)}/versions",
+                ("algorithm", FormatDekAlgorithm(algorithm)),
+                ("deleted", BoolQuery(deleted)),
+                ("offset", IntQuery(offset)),
+                ("limit", IntQuery(limit))),
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        return await response.Content.ReadFromJsonAsync<List<int>>(
+            SchemaRegistryJsonContext.Default.ListInt32, cancellationToken).ConfigureAwait(false) ?? [];
+    }
+
+    public async Task DeleteDekAsync(
+        string kekName,
+        string subject,
+        DekAlgorithm? algorithm = null,
+        bool permanent = false,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await DeleteWithFailoverAsync(
+            WithQuery(
+                $"dek-registry/v1/keks/{Uri.EscapeDataString(kekName)}/deks/{Uri.EscapeDataString(subject)}",
+                ("algorithm", FormatDekAlgorithm(algorithm)),
+                ("permanent", BoolQuery(permanent))),
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task DeleteDekVersionAsync(
+        string kekName,
+        string subject,
+        int version,
+        DekAlgorithm? algorithm = null,
+        bool permanent = false,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await DeleteWithFailoverAsync(
+            WithQuery(
+                $"dek-registry/v1/keks/{Uri.EscapeDataString(kekName)}/deks/{Uri.EscapeDataString(subject)}/versions/{version.ToString(CultureInfo.InvariantCulture)}",
+                ("algorithm", FormatDekAlgorithm(algorithm)),
+                ("permanent", BoolQuery(permanent))),
+            cancellationToken).ConfigureAwait(false);
+
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
     private static RegisterSchemaRequest CreateRegisterSchemaRequest(Schema schema) => new()
     {
         Schema = schema.SchemaString,
@@ -515,6 +769,53 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
         Disabled = rule.Disabled
     };
 
+    private static RegisterKekRequestDto ToRegisterKekRequestDto(RegisterKekRequest request) => new()
+    {
+        Name = request.Name,
+        KmsType = request.KmsType,
+        KmsKeyId = request.KmsKeyId,
+        KmsProps = request.KmsProps?.ToDictionary(
+            static kvp => kvp.Key,
+            static kvp => kvp.Value,
+            StringComparer.Ordinal),
+        Doc = request.Doc,
+        Shared = request.Shared,
+        Deleted = request.Deleted
+    };
+
+    private static Kek ToKek(KekDto dto) => new()
+    {
+        Name = dto.Name ?? string.Empty,
+        KmsType = dto.KmsType ?? string.Empty,
+        KmsKeyId = dto.KmsKeyId ?? string.Empty,
+        KmsProps = dto.KmsProps,
+        Doc = dto.Doc,
+        Shared = dto.Shared,
+        Deleted = dto.Deleted,
+        Timestamp = ReadTimestamp(dto.Ts)
+    };
+
+    private static RegisterDekRequestDto ToRegisterDekRequestDto(RegisterDekRequest request) => new()
+    {
+        Subject = request.Subject,
+        Version = request.Version,
+        Algorithm = FormatDekAlgorithm(request.Algorithm),
+        EncryptedKeyMaterial = request.EncryptedKeyMaterial,
+        Deleted = request.Deleted
+    };
+
+    private static Dek ToDek(DekDto dto) => new()
+    {
+        KekName = dto.KekName ?? string.Empty,
+        Subject = dto.Subject ?? string.Empty,
+        Version = dto.Version,
+        Algorithm = ParseDekAlgorithm(dto.Algorithm),
+        EncryptedKeyMaterial = dto.EncryptedKeyMaterial,
+        KeyMaterial = dto.KeyMaterial,
+        Deleted = dto.Deleted,
+        Timestamp = ReadTimestamp(dto.Ts)
+    };
+
     private static SchemaRule ToRule(SchemaRuleDto rule) => new()
     {
         Name = rule.Name ?? string.Empty,
@@ -574,6 +875,47 @@ public sealed class SchemaRegistryClient : ISchemaRegistryClient, ISchemaRegistr
             "WRITEREAD" => SchemaRuleMode.WriteRead,
             _ => SchemaRuleMode.Write
         };
+
+    private static string? FormatDekAlgorithm(DekAlgorithm? algorithm)
+        => algorithm.HasValue ? FormatDekAlgorithm(algorithm.Value) : null;
+
+    private static string FormatDekAlgorithm(DekAlgorithm algorithm)
+        => algorithm switch
+        {
+            DekAlgorithm.Aes128Gcm => "AES128_GCM",
+            DekAlgorithm.Aes256Gcm => "AES256_GCM",
+            DekAlgorithm.Aes256Siv => "AES256_SIV",
+            _ => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, "Unsupported DEK algorithm.")
+        };
+
+    private static DekAlgorithm ParseDekAlgorithm(string? algorithm)
+        => algorithm?.ToUpperInvariant() switch
+        {
+            "AES128_GCM" => DekAlgorithm.Aes128Gcm,
+            "AES256_GCM" => DekAlgorithm.Aes256Gcm,
+            "AES256_SIV" => DekAlgorithm.Aes256Siv,
+            _ => DekAlgorithm.Unknown
+        };
+
+    private static long? ReadTimestamp(JsonElement? value)
+    {
+        if (!value.HasValue)
+            return null;
+
+        var element = value.Value;
+        if (element.ValueKind == JsonValueKind.Number && element.TryGetInt64(out var timestamp))
+            return timestamp;
+
+        if (element.ValueKind == JsonValueKind.Object &&
+            element.TryGetProperty("timestamp", out var timestampElement) &&
+            timestampElement.ValueKind == JsonValueKind.Number &&
+            timestampElement.TryGetInt64(out timestamp))
+        {
+            return timestamp;
+        }
+
+        return null;
+    }
 
     private static async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
     {

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryJsonContext.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryJsonContext.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Dekaf.SchemaRegistry;
@@ -13,6 +14,10 @@ namespace Dekaf.SchemaRegistry;
 [JsonSerializable(typeof(SchemaMetadataDto))]
 [JsonSerializable(typeof(SchemaRuleSetDto))]
 [JsonSerializable(typeof(SchemaRuleDto))]
+[JsonSerializable(typeof(RegisterKekRequestDto))]
+[JsonSerializable(typeof(KekDto))]
+[JsonSerializable(typeof(RegisterDekRequestDto))]
+[JsonSerializable(typeof(DekDto))]
 [JsonSerializable(typeof(CompatibilityResponse))]
 [JsonSerializable(typeof(ErrorResponse))]
 [JsonSerializable(typeof(List<string>))]
@@ -90,6 +95,50 @@ internal sealed class SchemaRuleDto
     public string? OnSuccess { get; init; }
     public string? OnFailure { get; init; }
     public bool Disabled { get; init; }
+}
+
+internal sealed class RegisterKekRequestDto
+{
+    public required string Name { get; init; }
+    public required string KmsType { get; init; }
+    public required string KmsKeyId { get; init; }
+    public Dictionary<string, string>? KmsProps { get; init; }
+    public string? Doc { get; init; }
+    public bool? Shared { get; init; }
+    public bool? Deleted { get; init; }
+}
+
+internal sealed class KekDto
+{
+    public string? Name { get; init; }
+    public string? KmsType { get; init; }
+    public string? KmsKeyId { get; init; }
+    public Dictionary<string, string>? KmsProps { get; init; }
+    public string? Doc { get; init; }
+    public bool Shared { get; init; }
+    public bool Deleted { get; init; }
+    public JsonElement? Ts { get; init; }
+}
+
+internal sealed class RegisterDekRequestDto
+{
+    public required string Subject { get; init; }
+    public int? Version { get; init; }
+    public string? Algorithm { get; init; }
+    public string? EncryptedKeyMaterial { get; init; }
+    public bool? Deleted { get; init; }
+}
+
+internal sealed class DekDto
+{
+    public string? KekName { get; init; }
+    public string? Subject { get; init; }
+    public int Version { get; init; }
+    public string? Algorithm { get; init; }
+    public string? EncryptedKeyMaterial { get; init; }
+    public string? KeyMaterial { get; init; }
+    public JsonElement? Ts { get; init; }
+    public bool Deleted { get; init; }
 }
 
 internal sealed class CompatibilityResponse

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryDekRegistryTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryDekRegistryTests.cs
@@ -1,0 +1,316 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class SchemaRegistryDekRegistryTests
+{
+    [Test]
+    public async Task RegisterKekAsync_SendsCreateRequestAndMapsResponse()
+    {
+        using var handler = new CapturingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.OK, """
+                {
+                  "name": "payments-kek",
+                  "kmsType": "aws-kms",
+                  "kmsKeyId": "arn:aws:kms:us-west-2:123456789012:key/1234",
+                  "kmsProps": { "region": "us-west-2" },
+                  "doc": "payments",
+                  "shared": true,
+                  "deleted": false,
+                  "ts": { "timestamp": 1631206325000 }
+                }
+                """);
+        using var client = CreateClient(handler);
+
+        var kek = await client.RegisterKekAsync(
+            new RegisterKekRequest
+            {
+                Name = "payments-kek",
+                KmsType = "aws-kms",
+                KmsKeyId = "arn:aws:kms:us-west-2:123456789012:key/1234",
+                KmsProps = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["region"] = "us-west-2"
+                },
+                Doc = "payments",
+                Shared = true
+            },
+            testSharing: true);
+
+        await Assert.That(kek.Name).IsEqualTo("payments-kek");
+        await Assert.That(kek.KmsType).IsEqualTo("aws-kms");
+        await Assert.That(kek.KmsProps!["region"]).IsEqualTo("us-west-2");
+        await Assert.That(kek.Shared).IsTrue();
+        await Assert.That(kek.Timestamp).IsEqualTo(1631206325000);
+
+        var request = handler.Requests[0];
+        await Assert.That(request.Method).IsEqualTo(HttpMethod.Post);
+        await Assert.That(request.Uri.PathAndQuery).IsEqualTo("/dek-registry/v1/keks?testSharing=true");
+
+        using var document = JsonDocument.Parse(request.Body!);
+        var root = document.RootElement;
+        await Assert.That(root.GetProperty("name").GetString()).IsEqualTo("payments-kek");
+        await Assert.That(root.GetProperty("kmsType").GetString()).IsEqualTo("aws-kms");
+        await Assert.That(root.GetProperty("kmsProps").GetProperty("region").GetString()).IsEqualTo("us-west-2");
+        await Assert.That(root.GetProperty("shared").GetBoolean()).IsTrue();
+    }
+
+    [Test]
+    public async Task GetKekNamesAsync_UsesListQuery()
+    {
+        using var handler = new CapturingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.OK, """["payments-kek","orders-kek"]""");
+        using var client = CreateClient(handler);
+
+        var names = await client.GetKekNamesAsync(deleted: true, offset: 5, limit: 10);
+
+        await Assert.That(names).IsEquivalentTo(["payments-kek", "orders-kek"]);
+        await Assert.That(handler.Requests[0].Method).IsEqualTo(HttpMethod.Get);
+        await Assert.That(handler.Requests[0].Uri.PathAndQuery)
+            .IsEqualTo("/dek-registry/v1/keks?deleted=true&offset=5&limit=10");
+    }
+
+    [Test]
+    public async Task GetKekAsync_UsesDeletedQueryAndMapsResponse()
+    {
+        using var handler = new CapturingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.OK, """
+                {
+                  "name": "payments-kek",
+                  "kmsType": "azure-kv",
+                  "kmsKeyId": "https://vault.local/keys/payments",
+                  "deleted": true,
+                  "ts": 42
+                }
+                """);
+        using var client = CreateClient(handler);
+
+        var kek = await client.GetKekAsync("payments-kek", deleted: true);
+
+        await Assert.That(kek.KmsType).IsEqualTo("azure-kv");
+        await Assert.That(kek.Deleted).IsTrue();
+        await Assert.That(kek.Timestamp).IsEqualTo(42);
+        await Assert.That(handler.Requests[0].Uri.PathAndQuery)
+            .IsEqualTo("/dek-registry/v1/keks/payments-kek?deleted=true");
+    }
+
+    [Test]
+    public async Task DeleteKekAsync_UsesPermanentQuery()
+    {
+        using var handler = new CapturingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.NoContent, "");
+        using var client = CreateClient(handler);
+
+        await client.DeleteKekAsync("payments-kek", permanent: true);
+
+        await Assert.That(handler.Requests[0].Method).IsEqualTo(HttpMethod.Delete);
+        await Assert.That(handler.Requests[0].Uri.PathAndQuery)
+            .IsEqualTo("/dek-registry/v1/keks/payments-kek?permanent=true");
+    }
+
+    [Test]
+    public async Task RegisterDekAsync_SendsCreateRequestAndMapsResponse()
+    {
+        using var handler = new CapturingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.OK, """
+                {
+                  "kekName": "payments-kek",
+                  "subject": "orders-value",
+                  "version": 3,
+                  "algorithm": "AES256_SIV",
+                  "encryptedKeyMaterial": "encrypted",
+                  "keyMaterial": "plain",
+                  "deleted": false,
+                  "ts": 123
+                }
+                """);
+        using var client = CreateClient(handler);
+
+        var dek = await client.RegisterDekAsync(
+            "payments-kek",
+            new RegisterDekRequest
+            {
+                Subject = "orders-value",
+                Version = 3,
+                Algorithm = DekAlgorithm.Aes256Siv,
+                EncryptedKeyMaterial = "encrypted"
+            });
+
+        await Assert.That(dek.KekName).IsEqualTo("payments-kek");
+        await Assert.That(dek.Subject).IsEqualTo("orders-value");
+        await Assert.That(dek.Version).IsEqualTo(3);
+        await Assert.That(dek.Algorithm).IsEqualTo(DekAlgorithm.Aes256Siv);
+        await Assert.That(dek.EncryptedKeyMaterial).IsEqualTo("encrypted");
+        await Assert.That(dek.KeyMaterial).IsEqualTo("plain");
+        await Assert.That(dek.Timestamp).IsEqualTo(123);
+
+        var request = handler.Requests[0];
+        await Assert.That(request.Method).IsEqualTo(HttpMethod.Post);
+        await Assert.That(request.Uri.PathAndQuery).IsEqualTo("/dek-registry/v1/keks/payments-kek/deks");
+
+        using var document = JsonDocument.Parse(request.Body!);
+        var root = document.RootElement;
+        await Assert.That(root.GetProperty("subject").GetString()).IsEqualTo("orders-value");
+        await Assert.That(root.GetProperty("version").GetInt32()).IsEqualTo(3);
+        await Assert.That(root.GetProperty("algorithm").GetString()).IsEqualTo("AES256_SIV");
+        await Assert.That(root.GetProperty("encryptedKeyMaterial").GetString()).IsEqualTo("encrypted");
+    }
+
+    [Test]
+    public async Task GetDekSubjectsAsync_UsesListQuery()
+    {
+        using var handler = new CapturingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.OK, """["orders-value","customers-value"]""");
+        using var client = CreateClient(handler);
+
+        var subjects = await client.GetDekSubjectsAsync("payments-kek", deleted: true, offset: 2, limit: 20);
+
+        await Assert.That(subjects).IsEquivalentTo(["orders-value", "customers-value"]);
+        await Assert.That(handler.Requests[0].Uri.PathAndQuery)
+            .IsEqualTo("/dek-registry/v1/keks/payments-kek/deks?deleted=true&offset=2&limit=20");
+    }
+
+    [Test]
+    public async Task GetDekAsync_UsesAlgorithmAndDeletedQuery()
+    {
+        using var handler = new CapturingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.OK, DekJson("payments-kek", "customer/orders-value", 4, "AES256_GCM"));
+        using var client = CreateClient(handler);
+
+        var dek = await client.GetDekAsync(
+            "payments-kek",
+            "customer/orders-value",
+            DekAlgorithm.Aes256Gcm,
+            deleted: true);
+
+        await Assert.That(dek.Algorithm).IsEqualTo(DekAlgorithm.Aes256Gcm);
+        await Assert.That(handler.Requests[0].Uri.PathAndQuery)
+            .IsEqualTo("/dek-registry/v1/keks/payments-kek/deks/customer%2Forders-value?algorithm=AES256_GCM&deleted=true");
+    }
+
+    [Test]
+    public async Task GetDekAsync_ByVersion_UsesVersionPath()
+    {
+        using var handler = new CapturingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.OK, DekJson("payments-kek", "orders-value", 5, "AES128_GCM"));
+        using var client = CreateClient(handler);
+
+        var dek = await client.GetDekAsync("payments-kek", "orders-value", version: 5, deleted: true);
+
+        await Assert.That(dek.Version).IsEqualTo(5);
+        await Assert.That(dek.Algorithm).IsEqualTo(DekAlgorithm.Aes128Gcm);
+        await Assert.That(handler.Requests[0].Uri.PathAndQuery)
+            .IsEqualTo("/dek-registry/v1/keks/payments-kek/deks/orders-value/versions/5?deleted=true");
+    }
+
+    [Test]
+    public async Task GetDekVersionsAsync_UsesVersionListQuery()
+    {
+        using var handler = new CapturingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.OK, "[1,2,3]");
+        using var client = CreateClient(handler);
+
+        var versions = await client.GetDekVersionsAsync(
+            "payments-kek",
+            "orders-value",
+            DekAlgorithm.Aes256Gcm,
+            deleted: true,
+            offset: 1,
+            limit: 2);
+
+        await Assert.That(versions).IsEquivalentTo([1, 2, 3]);
+        await Assert.That(handler.Requests[0].Uri.PathAndQuery)
+            .IsEqualTo("/dek-registry/v1/keks/payments-kek/deks/orders-value/versions?algorithm=AES256_GCM&deleted=true&offset=1&limit=2");
+    }
+
+    [Test]
+    public async Task DeleteDekAsync_UsesSubjectPathWithAlgorithmAndPermanentQuery()
+    {
+        using var handler = new CapturingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.NoContent, "");
+        using var client = CreateClient(handler);
+
+        await client.DeleteDekAsync(
+            "payments-kek",
+            "orders-value",
+            DekAlgorithm.Aes128Gcm,
+            permanent: true);
+
+        await Assert.That(handler.Requests[0].Method).IsEqualTo(HttpMethod.Delete);
+        await Assert.That(handler.Requests[0].Uri.PathAndQuery)
+            .IsEqualTo("/dek-registry/v1/keks/payments-kek/deks/orders-value?algorithm=AES128_GCM&permanent=true");
+    }
+
+    [Test]
+    public async Task DeleteDekVersionAsync_UsesAlgorithmAndPermanentQuery()
+    {
+        using var handler = new CapturingSchemaRegistryHandler()
+            .Enqueue(HttpStatusCode.NoContent, "");
+        using var client = CreateClient(handler);
+
+        await client.DeleteDekVersionAsync(
+            "payments-kek",
+            "orders-value",
+            version: 7,
+            DekAlgorithm.Aes256Siv,
+            permanent: true);
+
+        await Assert.That(handler.Requests[0].Method).IsEqualTo(HttpMethod.Delete);
+        await Assert.That(handler.Requests[0].Uri.PathAndQuery)
+            .IsEqualTo("/dek-registry/v1/keks/payments-kek/deks/orders-value/versions/7?algorithm=AES256_SIV&permanent=true");
+    }
+
+    private static SchemaRegistryClient CreateClient(HttpMessageHandler handler) =>
+        new(new SchemaRegistryConfig { Url = "http://schema-registry.local" }, handler);
+
+    private static string DekJson(string kekName, string subject, int version, string algorithm) =>
+        $$"""
+        {
+          "kekName": "{{kekName}}",
+          "subject": "{{subject}}",
+          "version": {{version}},
+          "algorithm": "{{algorithm}}",
+          "encryptedKeyMaterial": "encrypted",
+          "deleted": false,
+          "ts": 123
+        }
+        """;
+
+    private sealed class CapturingSchemaRegistryHandler : HttpMessageHandler
+    {
+        private readonly Queue<(HttpStatusCode StatusCode, string Content)> _responses = new();
+
+        public List<CapturedRequest> Requests { get; } = [];
+
+        public CapturingSchemaRegistryHandler Enqueue(HttpStatusCode statusCode, string content)
+        {
+            _responses.Enqueue((statusCode, content));
+            return this;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            Requests.Add(new CapturedRequest(request.Method, request.RequestUri!, body));
+
+            var (statusCode, content) = _responses.Count > 0
+                ? _responses.Dequeue()
+                : (HttpStatusCode.OK, "{}");
+
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(content, Encoding.UTF8)
+            };
+        }
+    }
+
+    private sealed record CapturedRequest(HttpMethod Method, Uri Uri, string? Body);
+}


### PR DESCRIPTION
## Summary
- add public KEK/DEK model types and ISchemaRegistryClient DEK Registry methods
- implement Schema Registry /dek-registry/v1 KEK and DEK REST calls with source-generated JSON DTOs
- add focused unit coverage for request paths, query parameters, and response mapping

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release --no-restore
- [x] 	ests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/SchemaRegistryDekRegistryTests/*"
- [x] 	ests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/*SchemaRegistry*/*"
- [x] dotnet format Dekaf.sln --include src\Dekaf.SchemaRegistry\ISchemaRegistryClient.cs src\Dekaf.SchemaRegistry\SchemaRegistryClient.cs src\Dekaf.SchemaRegistry\SchemaRegistryJsonContext.cs tests\Dekaf.Tests.Unit\SchemaRegistry\SchemaRegistryDekRegistryTests.cs --verify-no-changes

Closes #1506
Refs #1382
