### PR TITLE
feat(schemaregistry): add KMS providers

### DIFF
--- a/src/Dekaf.SchemaRegistry/SchemaRegistryKms.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryKms.cs
@@ -1,0 +1,300 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+
+namespace Dekaf.SchemaRegistry;
+
+/// <summary>
+/// Identifies a KMS key used to wrap or unwrap Schema Registry data encryption keys.
+/// </summary>
+public sealed class SchemaRegistryKmsKeyReference
+{
+    /// <summary>
+    /// KMS provider type, for example aws-kms, azure-kv, gcp-kms, or local-kms.
+    /// </summary>
+    public required string KmsType { get; init; }
+
+    /// <summary>
+    /// Provider-specific key identifier or URL.
+    /// </summary>
+    public required string KmsKeyId { get; init; }
+
+    /// <summary>
+    /// Provider-specific KMS properties from Schema Registry.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? KmsProps { get; init; }
+}
+
+/// <summary>
+/// Wraps and unwraps Schema Registry data encryption keys with a KMS-managed key encryption key.
+/// </summary>
+public interface ISchemaRegistryKmsProvider
+{
+    /// <summary>
+    /// KMS provider type handled by this provider.
+    /// </summary>
+    string Type { get; }
+
+    /// <summary>
+    /// Wraps raw data encryption key material.
+    /// </summary>
+    /// <param name="keyMaterial">Raw data encryption key material.</param>
+    /// <param name="keyReference">KMS key reference.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Wrapped key material.</returns>
+    ValueTask<byte[]> WrapKeyAsync(
+        ReadOnlyMemory<byte> keyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Unwraps encrypted data encryption key material.
+    /// </summary>
+    /// <param name="encryptedKeyMaterial">Wrapped key material.</param>
+    /// <param name="keyReference">KMS key reference.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Raw data encryption key material.</returns>
+    ValueTask<byte[]> UnwrapKeyAsync(
+        ReadOnlyMemory<byte> encryptedKeyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Options for configuring Schema Registry KMS providers.
+/// </summary>
+public sealed class SchemaRegistryKmsOptions
+{
+    /// <summary>
+    /// Providers available to Schema Registry rule handlers.
+    /// </summary>
+    public IList<ISchemaRegistryKmsProvider> Providers { get; } = [];
+
+    /// <summary>
+    /// Creates a provider registry from the configured providers.
+    /// </summary>
+    public SchemaRegistryKmsProviderRegistry CreateProviderRegistry() => new(Providers);
+}
+
+/// <summary>
+/// Resolves Schema Registry KMS providers by KMS type.
+/// </summary>
+public sealed class SchemaRegistryKmsProviderRegistry
+{
+    private readonly IReadOnlyDictionary<string, ISchemaRegistryKmsProvider> _providers;
+
+    /// <summary>
+    /// Creates a KMS provider registry.
+    /// </summary>
+    /// <param name="providers">KMS providers keyed by <see cref="ISchemaRegistryKmsProvider.Type" />.</param>
+    public SchemaRegistryKmsProviderRegistry(IEnumerable<ISchemaRegistryKmsProvider> providers)
+    {
+        ArgumentNullException.ThrowIfNull(providers);
+
+        var dictionary = new Dictionary<string, ISchemaRegistryKmsProvider>(StringComparer.OrdinalIgnoreCase);
+        foreach (var provider in providers)
+        {
+            ArgumentNullException.ThrowIfNull(provider);
+            if (string.IsNullOrWhiteSpace(provider.Type))
+                throw new ArgumentException("KMS provider type cannot be null or whitespace.", nameof(providers));
+
+            if (!dictionary.TryAdd(provider.Type, provider))
+                throw new ArgumentException($"A KMS provider for type '{provider.Type}' is already registered.", nameof(providers));
+        }
+
+        _providers = dictionary;
+    }
+
+    /// <summary>
+    /// Attempts to resolve a KMS provider by type.
+    /// </summary>
+    public bool TryGetProvider(
+        string kmsType,
+        [NotNullWhen(true)] out ISchemaRegistryKmsProvider? provider)
+    {
+        if (string.IsNullOrWhiteSpace(kmsType))
+        {
+            provider = null;
+            return false;
+        }
+
+        return _providers.TryGetValue(kmsType, out provider);
+    }
+
+    /// <summary>
+    /// Resolves a KMS provider by type.
+    /// </summary>
+    public ISchemaRegistryKmsProvider GetProvider(string kmsType)
+    {
+        if (TryGetProvider(kmsType, out var provider))
+            return provider;
+
+        throw new SchemaRegistryKmsException(
+            $"No Schema Registry KMS provider is registered for KMS type '{kmsType}'.");
+    }
+
+    /// <summary>
+    /// Wraps raw data encryption key material with the provider selected by <paramref name="keyReference" />.
+    /// </summary>
+    public ValueTask<byte[]> WrapKeyAsync(
+        ReadOnlyMemory<byte> keyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(keyReference);
+        return GetProvider(keyReference.KmsType).WrapKeyAsync(keyMaterial, keyReference, cancellationToken);
+    }
+
+    /// <summary>
+    /// Unwraps encrypted data encryption key material with the provider selected by <paramref name="keyReference" />.
+    /// </summary>
+    public ValueTask<byte[]> UnwrapKeyAsync(
+        ReadOnlyMemory<byte> encryptedKeyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(keyReference);
+        return GetProvider(keyReference.KmsType).UnwrapKeyAsync(encryptedKeyMaterial, keyReference, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Deterministic local KMS provider for tests and offline deployments.
+/// </summary>
+/// <remarks>
+/// The provider uses AES Key Wrap with Padding (AES-KWP) and never contacts an external KMS.
+/// </remarks>
+public sealed class LocalKmsProvider : ISchemaRegistryKmsProvider
+{
+    /// <summary>
+    /// Default local provider type.
+    /// </summary>
+    public const string DefaultType = "local-kms";
+
+    private readonly IReadOnlyDictionary<string, byte[]> _keysById;
+
+    /// <summary>
+    /// Creates a local KMS provider.
+    /// </summary>
+    /// <param name="keysById">AES KEK material keyed by KMS key identifier.</param>
+    /// <param name="type">KMS provider type.</param>
+    public LocalKmsProvider(
+        IReadOnlyDictionary<string, byte[]> keysById,
+        string type = DefaultType)
+    {
+        ArgumentNullException.ThrowIfNull(keysById);
+        if (string.IsNullOrWhiteSpace(type))
+            throw new ArgumentException("KMS provider type cannot be null or whitespace.", nameof(type));
+
+        var keys = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (var entry in keysById)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Key))
+                throw new ArgumentException("KMS key identifiers cannot be null or whitespace.", nameof(keysById));
+
+            if (entry.Value is null)
+                throw new ArgumentException("KMS key material cannot be null.", nameof(keysById));
+
+            if (!IsValidAesKeyLength(entry.Value.Length))
+                throw new ArgumentException("Local KMS KEK material must be 128, 192, or 256 bits.", nameof(keysById));
+
+            keys.Add(entry.Key, entry.Value.ToArray());
+        }
+
+        Type = type;
+        _keysById = keys;
+    }
+
+    /// <inheritdoc />
+    public string Type { get; }
+
+    /// <inheritdoc />
+    public ValueTask<byte[]> WrapKeyAsync(
+        ReadOnlyMemory<byte> keyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(keyReference);
+        if (keyMaterial.IsEmpty)
+            throw new SchemaRegistryKmsException("Local KMS wrap failed. Key material cannot be empty.");
+
+        var kek = ResolveKey(keyReference);
+
+        try
+        {
+            using var aes = Aes.Create();
+            aes.Key = kek;
+            return ValueTask.FromResult(aes.EncryptKeyWrapPadded(keyMaterial.Span));
+        }
+        catch (CryptographicException ex)
+        {
+            throw new SchemaRegistryKmsException("Local KMS wrap failed for the configured KEK.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask<byte[]> UnwrapKeyAsync(
+        ReadOnlyMemory<byte> encryptedKeyMaterial,
+        SchemaRegistryKmsKeyReference keyReference,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(keyReference);
+        if (encryptedKeyMaterial.IsEmpty)
+            throw new SchemaRegistryKmsException("Local KMS unwrap failed. Encrypted key material cannot be empty.");
+
+        var kek = ResolveKey(keyReference);
+
+        try
+        {
+            using var aes = Aes.Create();
+            aes.Key = kek;
+            return ValueTask.FromResult(aes.DecryptKeyWrapPadded(encryptedKeyMaterial.Span));
+        }
+        catch (CryptographicException ex)
+        {
+            throw new SchemaRegistryKmsException(
+                "Local KMS unwrap failed. The encrypted key material is invalid for the configured KEK.",
+                ex);
+        }
+    }
+
+    private byte[] ResolveKey(SchemaRegistryKmsKeyReference keyReference)
+    {
+        if (!string.Equals(Type, keyReference.KmsType, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new SchemaRegistryKmsException(
+                $"Local KMS provider '{Type}' cannot resolve KMS type '{keyReference.KmsType}'.");
+        }
+
+        if (_keysById.TryGetValue(keyReference.KmsKeyId, out var kek))
+            return kek;
+
+        throw new SchemaRegistryKmsException(
+            $"Local KMS key '{keyReference.KmsKeyId}' is not registered.");
+    }
+
+    private static bool IsValidAesKeyLength(int length) => length is 16 or 24 or 32;
+}
+
+/// <summary>
+/// Exception thrown by Schema Registry KMS operations.
+/// </summary>
+public sealed class SchemaRegistryKmsException : Exception
+{
+    /// <summary>
+    /// Creates a KMS exception.
+    /// </summary>
+    public SchemaRegistryKmsException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Creates a KMS exception with an inner exception.
+    /// </summary>
+    public SchemaRegistryKmsException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryKmsTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryKmsTests.cs
@@ -1,0 +1,148 @@
+using System.Text;
+using Dekaf.SchemaRegistry;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public sealed class SchemaRegistryKmsTests
+{
+    private static readonly byte[] KekMaterial =
+    [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+        0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F
+    ];
+
+    [Test]
+    public async Task LocalKmsProvider_WrapIsDeterministicAndUnwrapRestoresPlaintext()
+    {
+        var provider = CreateLocalProvider();
+        var keyReference = CreateKeyReference();
+        var plaintext = Encoding.UTF8.GetBytes("data-encryption-key-material");
+
+        var wrapped1 = await provider.WrapKeyAsync(plaintext, keyReference);
+        var wrapped2 = await provider.WrapKeyAsync(plaintext, keyReference);
+        var unwrapped = await provider.UnwrapKeyAsync(wrapped1, keyReference);
+
+        await Assert.That(wrapped1).IsEquivalentTo(wrapped2);
+        await Assert.That(wrapped1).IsNotEquivalentTo(plaintext);
+        await Assert.That(unwrapped).IsEquivalentTo(plaintext);
+    }
+
+    [Test]
+    public async Task ProviderRegistry_WrapUnwrap_RoutesByKmsType()
+    {
+        var provider = CreateLocalProvider(type: "test-local");
+        var registry = new SchemaRegistryKmsProviderRegistry([provider]);
+        var keyReference = CreateKeyReference(kmsType: "test-local");
+        var plaintext = "schema-registry-dek"u8.ToArray();
+
+        var wrapped = await registry.WrapKeyAsync(plaintext, keyReference);
+        var unwrapped = await registry.UnwrapKeyAsync(wrapped, keyReference);
+
+        await Assert.That(registry.TryGetProvider("TEST-LOCAL", out var resolved)).IsTrue();
+        await Assert.That(resolved).IsSameReferenceAs(provider);
+        await Assert.That(unwrapped).IsEquivalentTo(plaintext);
+    }
+
+    [Test]
+    public async Task ProviderRegistry_DuplicateProviderType_Throws()
+    {
+        var provider1 = CreateLocalProvider(type: "local-kms");
+        var provider2 = CreateLocalProvider(type: "LOCAL-KMS");
+
+        await Assert.That(() => new SchemaRegistryKmsProviderRegistry([provider1, provider2]))
+            .Throws<ArgumentException>()
+            .WithMessageContaining("LOCAL-KMS");
+    }
+
+    [Test]
+    public async Task Options_CreateProviderRegistry_UsesConfiguredProviders()
+    {
+        var options = new SchemaRegistryKmsOptions();
+        var provider = CreateLocalProvider();
+        options.Providers.Add(provider);
+        var registry = options.CreateProviderRegistry();
+
+        var wrapped = await registry.WrapKeyAsync(
+            "offline-dek"u8.ToArray(),
+            CreateKeyReference());
+
+        await Assert.That(wrapped).IsNotEmpty();
+    }
+
+    [Test]
+    public async Task LocalKmsProvider_CopiesConfiguredKeyMaterial()
+    {
+        var originalKek = KekMaterial.ToArray();
+        var provider = new LocalKmsProvider(new Dictionary<string, byte[]>(StringComparer.Ordinal)
+        {
+            ["local://payments"] = originalKek
+        });
+        originalKek.AsSpan().Clear();
+
+        var plaintext = "copied-key-material"u8.ToArray();
+        var wrapped = await provider.WrapKeyAsync(plaintext, CreateKeyReference());
+        var unwrapped = await provider.UnwrapKeyAsync(wrapped, CreateKeyReference());
+
+        await Assert.That(unwrapped).IsEquivalentTo(plaintext);
+    }
+
+    [Test]
+    public async Task LocalKmsProvider_InvalidKeyMaterialLength_Throws()
+    {
+        await Assert.That(() =>
+            new LocalKmsProvider(new Dictionary<string, byte[]>(StringComparer.Ordinal)
+            {
+                ["local://bad"] = [1, 2, 3]
+            }))
+            .Throws<ArgumentException>()
+            .WithMessageContaining("128, 192, or 256 bits");
+    }
+
+    [Test]
+    public async Task Registry_UnknownProvider_DoesNotLeakKeyMaterial()
+    {
+        var registry = new SchemaRegistryKmsProviderRegistry([]);
+        var secret = Encoding.UTF8.GetBytes("super-secret-dek-material");
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            async () => await registry.WrapKeyAsync(
+                secret,
+                CreateKeyReference(kmsType: "missing-kms")));
+
+        await Assert.That(exception!.Message).DoesNotContain("super-secret");
+        await Assert.That(exception.Message).DoesNotContain(Convert.ToBase64String(secret));
+    }
+
+    [Test]
+    public async Task LocalKmsProvider_UnwrapFailure_DoesNotLeakEncryptedMaterial()
+    {
+        var provider = CreateLocalProvider();
+        var encrypted = Convert.FromHexString("00112233445566778899AABBCCDDEEFF");
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            async () => await provider.UnwrapKeyAsync(encrypted, CreateKeyReference()));
+
+        await Assert.That(exception!.Message).DoesNotContain(Convert.ToHexString(encrypted));
+        await Assert.That(exception.Message).Contains("invalid");
+    }
+
+    private static LocalKmsProvider CreateLocalProvider(string type = LocalKmsProvider.DefaultType) =>
+        new(new Dictionary<string, byte[]>(StringComparer.Ordinal)
+        {
+            ["local://payments"] = KekMaterial
+        }, type);
+
+    private static SchemaRegistryKmsKeyReference CreateKeyReference(
+        string kmsType = LocalKmsProvider.DefaultType) =>
+        new()
+        {
+            KmsType = kmsType,
+            KmsKeyId = "local://payments",
+            KmsProps = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["environment"] = "test"
+            }
+        };
+}


### PR DESCRIPTION
## Summary
- add KMS key reference, provider, registry, and options types for Schema Registry rules
- add deterministic local local-kms provider using AES-KWP for tests/offline deployments
- add unit coverage for routing, duplicate providers, key copying, deterministic wrap/unwrap, and secret-safe errors

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release
- [x] 	ests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/SchemaRegistryKmsTests/*"
- [x] 	ests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/*SchemaRegistry*/*"
- [x] dotnet format Dekaf.sln --include src\Dekaf.SchemaRegistry\SchemaRegistryKms.cs tests\Dekaf.Tests.Unit\SchemaRegistry\SchemaRegistryKmsTests.cs --verify-no-changes

Closes #1507
Refs #1382
