### PR TITLE
fix(producer): release span seal refund

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2528,6 +2528,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             }
         }
 
+        void ReleaseDetachedBatchBytesIfSafe()
+        {
+            if (!ownsRotation && sealedBatchToEnqueue is null && sealedBatchBytesToRelease > 0)
+            {
+                var bytesToRelease = sealedBatchBytesToRelease;
+                sealedBatchBytesToRelease = 0;
+                ReleaseMemory(bytesToRelease);
+            }
+        }
+
         void ClearAppendAndRotationInProgressUnderLock()
         {
             ClearAppendInProgressUnderLock(pd);
@@ -2657,12 +2667,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         ReleaseMemory(batchToFail.DataSize);
                 }
 
-                if (!ownsRotation && sealedBatchToEnqueue is null && sealedBatchBytesToRelease > 0)
-                {
-                    var bytesToRelease = sealedBatchBytesToRelease;
-                    sealedBatchBytesToRelease = 0;
-                    ReleaseMemory(bytesToRelease);
-                }
+                ReleaseDetachedBatchBytesIfSafe();
 
                 if (appendReserved)
                 {
@@ -2735,8 +2740,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             var readyBatch = CompleteDetachedBatchAndEnqueue(pd, batchToComplete);
                             if (readyBatch is not null)
                                 StartPreSerialization(readyBatch);
+                            ownsRotation = false;
                         }
 
+                        ReleaseDetachedBatchBytesIfSafe();
                         return true;
                     }
                     catch

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1022,6 +1022,9 @@ public class RecordAccumulatorTests
         await Assert.That(firstBatch.DataSize).IsEqualTo(firstRecordSize);
         await Assert.That(firstBatch.RecordBatch.GetEncodedSize()).IsEqualTo(options.BatchSize);
 
+        var currentBatch = GetCurrentPartitionBatch(accumulator, topicPartition);
+        await Assert.That(accumulator.BufferedBytes).IsEqualTo(firstBatch.DataSize + currentBatch.ReservedSize);
+
         var secondBatch = CompleteCurrentBatch(accumulator, topicPartition);
         await Assert.That(secondBatch.RecordBatch.Records.Count).IsEqualTo(1);
         await Assert.That(secondBatch.RecordBatch.GetEncodedSize()).IsLessThanOrEqualTo(options.BatchSize);


### PR DESCRIPTION
## Summary
- release span-path seal overestimate refunds after the rotation gate clears
- add a buffered-bytes regression assertion for span overflow rotation

## Test plan
- [x] `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordAccumulatorTests/AppendFromSpansAsync_BatchSizeBudgetReservesWireBatchHeader"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordAccumulatorTests/*"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaConnectionTests/SendAsync_CallerCanceledRequest_DoesNotFailIdleConnectionAfterRequestTimeout"`
- [x] `tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaConnectionTests/ReceiveLoop_IdleLongerThanRequestTimeout_RemainsConnected"`
- [x] `dotnet format Dekaf.sln --include src\Dekaf\Producer\RecordAccumulator.cs tests\Dekaf.Tests.Unit\Producer\RecordAccumulatorTests.cs --verify-no-changes`
- [ ] full `Dekaf.Tests.Unit.exe` hit unrelated `ReceiveLoop_IdleLongerThanRequestTimeout_RemainsConnected` timeout once; focused rerun passed

Closes #1516
