### PR TITLE
fix(producer): keep pre-serialization ready notifications

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -897,9 +897,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     //
     // Duplicate entries for the same partition are harmless: Ready() dequeues and checks the
     // partition deque, so extra notifications for an already-drained partition are no-ops.
-    // The queue is bounded: each partition appears at most once per seal event, muted
-    // partitions are dropped (not re-enqueued), and UnmutePartition re-enqueues only if
-    // sealed batches exist. Total size <= number of sealed batches <= BufferMemory / BatchSize.
+    // Muted partitions are dropped (not re-enqueued), and UnmutePartition re-enqueues only if
+    // sealed batches exist.
     private readonly ConcurrentQueue<TopicPartition> _readyPartitions = new();
 
     // Per-node partition tracking: populated by Ready() with the specific partitions it
@@ -1286,10 +1285,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 continue;
             }
 
-            // Pre-serialization runs on a worker after seal. If the notification arrives
-            // before that worker finishes, leave the batch queued; completion re-notifies.
+            // Pre-serialization runs on a worker after seal. If a stale or early
+            // notification arrives first, preserve it so the fallback sender tick can
+            // retry without relying solely on the worker's completion publish.
             if (!head.IsPreSerialized)
+            {
+                _readyPartitions.Enqueue(tp);
                 continue;
+            }
 
             // Sealed batches in the deque are always sendable. The linger/micro-linger
             // timer already determined readiness when it sealed the batch, so re-checking
@@ -1426,9 +1429,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
                 // Safety check: Ready() should have pre-serialized the head batch before
                 // marking this node ready. If another path exposes an unready batch,
-                // leave it in the deque until the next notification.
+                // keep the consumed notification alive for the next sender cycle.
                 if (!batch.IsPreSerialized)
+                {
+                    _readyPartitions.Enqueue(tp);
                     continue;
+                }
 
                 if (batch.IsRetry && batch.RetryNotBefore > 0
                     && now < batch.RetryNotBefore)

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -225,8 +225,18 @@ public class RecordAccumulatorReadyTests
             await appendWhileCompressionBlocked.WaitAsync(TimeSpan.FromSeconds(5));
 
             var readyNodesWhileBlocked = new HashSet<int>();
+            var topicPartition = new TopicPartition("test-topic", 0);
+            var readyQueue = GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_readyPartitions");
+            readyQueue.Enqueue(topicPartition);
+
             accumulator.Ready(metadataManager, readyNodesWhileBlocked);
             await Assert.That(readyNodesWhileBlocked).IsEmpty();
+            await Assert.That(readyQueue.Count).IsEqualTo(1);
+
+            readyNodesWhileBlocked.Clear();
+            accumulator.Ready(metadataManager, readyNodesWhileBlocked);
+            await Assert.That(readyNodesWhileBlocked).IsEmpty();
+            await Assert.That(readyQueue.Count).IsEqualTo(1);
 
             codec.AllowCompression.SetResult();
 
@@ -244,6 +254,59 @@ public class RecordAccumulatorReadyTests
             codec.AllowCompression.TrySetResult();
             await accumulator.DisposeAsync();
             await pool.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Drain_UnpreSerializedTrackedPartition_ReenqueuesNotification()
+    {
+        var options = CreateTestOptions(batchSize: 100_000, lingerMs: 0, compressionType: CompressionType.Gzip);
+        var codec = new BlockingCompressionCodec(CompressionType.Gzip);
+        var compressionCodecs = new CompressionCodecRegistry();
+        compressionCodecs.Register(codec);
+
+        var accumulator = new RecordAccumulator(options, compressionCodecs);
+        var metadataManager = CreateMetadataManager("test-topic", 1, nodeId: 1);
+
+        try
+        {
+            var appended = await accumulator.AppendAsync(
+                "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null,
+                PooledMemory.Null,
+                headers: null,
+                headerCount: 0,
+                completionSource: null,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 1);
+
+            await Assert.That(appended).IsTrue();
+            await codec.CompressStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var topicPartition = new TopicPartition("test-topic", 0);
+            var trackedPartitions = GetPrivateField<Dictionary<int, List<TopicPartition>>>(
+                accumulator,
+                "_readyPartitionsPerNode");
+            trackedPartitions[1] = [topicPartition];
+
+            var readyNodes = new HashSet<int> { 1 };
+            var drainResult = new Dictionary<int, List<ReadyBatch>>();
+            var batchListPool = new Stack<List<ReadyBatch>>();
+            var readyQueue = GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_readyPartitions");
+
+            accumulator.Drain(metadataManager, readyNodes, int.MaxValue, drainResult, batchListPool);
+
+            await Assert.That(drainResult).IsEmpty();
+            await Assert.That(readyQueue.Count).IsEqualTo(1);
+        }
+        finally
+        {
+            codec.AllowCompression.TrySetResult();
+            await accumulator.DisposeAsync();
             await metadataManager.DisposeAsync();
         }
     }


### PR DESCRIPTION
## Summary
- re-enqueue ready partitions when Ready observes a head batch still waiting on pre-serialization
- re-enqueue the tracked partition in Drain's unpre-serialized safety path
- add regressions for blocked compressed pre-serialization so stale notifications are not consumed

Fixes #1519

## Validation
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/RecordAccumulatorReadyTests/*"
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/*RecordAccumulator*/*"
- dotnet format Dekaf.sln --include src\Dekaf\Producer\RecordAccumulator.cs tests\Dekaf.Tests.Unit\Producer\RecordAccumulatorReadyTests.cs --verify-no-changes
