### PR TITLE
fix(networking): pool large serialize buffers

### DIFF
--- a/src/Dekaf/DekafPools.cs
+++ b/src/Dekaf/DekafPools.cs
@@ -10,8 +10,10 @@ namespace Dekaf;
 /// </summary>
 internal static class DekafPools
 {
+    internal const int SerializationBufferMaxArrayLength = 32 * 1024 * 1024;
+
     private static readonly RatchetableArrayPool<byte> s_serializationPool = new(
-        maxArrayLength: 4 * 1024 * 1024,
+        maxArrayLength: SerializationBufferMaxArrayLength,
         initialArraysPerBucket: 16);
 
     /// <summary>
@@ -19,9 +21,10 @@ internal static class DekafPools
     /// (<see cref="Networking.RentedBufferWriter"/>) and record batch building
     /// (<c>PooledReusableBufferWriter</c> in <c>RecordBatch.cs</c>).
     /// <para/>
-    /// <c>maxArrayLength: 4MB</c> covers ProduceRequests with default 1MB batch size plus
-    /// header overhead and multi-batch coalescing. Bucket depth is scaled via
-    /// <see cref="RatchetSerializationBucketCapacity"/> when concurrent connection counts increase.
+    /// <c>maxArrayLength: 32MB</c> covers coalesced ProduceRequests with default 1MB
+    /// batches (up to ~20MB plus protocol overhead) without falling through to exact-size
+    /// LOH allocations. Bucket depth is scaled via <see cref="RatchetSerializationBucketCapacity"/>
+    /// when concurrent connection counts increase.
     /// </summary>
     internal static ArrayPool<byte> SerializationBuffers => s_serializationPool.Pool;
 

--- a/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
@@ -378,6 +378,26 @@ public class PoolSizingTests
 
     [Test]
     [NotInParallel("DekafPools")]
+    public async Task SerializationBuffers_AboveLegacyFourMbCap_ReusesReturnedArray()
+    {
+        const int sizeAboveLegacyCap = 5 * 1024 * 1024;
+
+        var first = DekafPools.SerializationBuffers.Rent(sizeAboveLegacyCap);
+        DekafPools.SerializationBuffers.Return(first, clearArray: false);
+
+        var second = DekafPools.SerializationBuffers.Rent(sizeAboveLegacyCap);
+        try
+        {
+            await Assert.That(second).IsSameReferenceAs(first);
+        }
+        finally
+        {
+            DekafPools.SerializationBuffers.Return(second, clearArray: false);
+        }
+    }
+
+    [Test]
+    [NotInParallel("DekafPools")]
     public async Task SerializationBuffers_RatchetUp_ReplacesPool()
     {
         // This test must use the HIGHEST values across all DekafPools tests


### PR DESCRIPTION
## Summary
- raise `DekafPools.SerializationBuffers` max array length from 4MB to 32MB
- document that the cap covers coalesced produce requests around 20MB plus protocol overhead
- add a regression proving a 5MB serialization buffer is retained/reused instead of dropped

Fixes #1517

## Validation
- dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj -c Release
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PoolSizingTests/*"
- dotnet format Dekaf.sln --include src\Dekaf\DekafPools.cs tests\Dekaf.Tests.Unit\Internal\PoolSizingTests.cs --verify-no-changes
- tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/KafkaConnectionTests/*"

Full unit suite note: one full run hit the known transient `KafkaConnectionTests` timeout pair (`ReceiveLoop_IdleLongerThanRequestTimeout_RemainsConnected`, `SendAsync_CallerCanceledRequest_DoesNotFailIdleConnectionAfterRequestTimeout`) on this branch, then the focused `KafkaConnectionTests` rerun passed 28/28.
