### PR TITLE
feat(serialization): async serializer preparation to remove sync-over-async schema fetch

### DIFF
--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -35,7 +35,7 @@ namespace Dekaf.SchemaRegistry.Avro;
 /// <typeparam name="T">The type to serialize. Must be either an Avro ISpecificRecord or GenericRecord.</typeparam>
 public sealed class AvroSchemaRegistrySerializer<
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>
-    : ISerializer<T>, IAsyncDisposable
+    : ISerializer<T>, IAsyncSerializerPreparer<T>, IAsyncDisposable
 {
     private const byte MagicByte = 0x00;
     private const int WireHeaderSize = 5;
@@ -97,6 +97,25 @@ public sealed class AvroSchemaRegistrySerializer<
         var schemaId = await GetOrFetchSchemaIdAsync(subject, schema, cancellationToken).ConfigureAwait(false);
         CacheSubjectSchemaId(topic, isKey, subject, schemaId, schema);
         return schemaId;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Delegates to <see cref="WarmupAsync"/>. Returns a synchronously completed <see cref="ValueTask"/>
+    /// with no allocation once the subject's schema ID is cached, so the producer's steady-state hot path
+    /// stays fully synchronous and only the first value per subject pays the async schema fetch.
+    /// </remarks>
+    public ValueTask PrepareAsync(T value, SerializationContext context, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        var isKey = context.Component == SerializationComponent.Key;
+        if (_subjectSchemaIdCache.Contains(context.Topic, isKey))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return new ValueTask(WarmupAsync(context.Topic, value, isKey, cancellationToken));
     }
 
     /// <summary>

--- a/src/Dekaf.SchemaRegistry/SubjectSchemaIdCache.cs
+++ b/src/Dekaf.SchemaRegistry/SubjectSchemaIdCache.cs
@@ -22,19 +22,38 @@ internal sealed class SubjectSchemaIdCache
         Func<TState, string, SubjectSchemaIdCacheValue> getSchema)
     {
         var key = new SubjectSchemaIdCacheKey(topic, isKey);
-        var last = Volatile.Read(ref _last);
-        if (last is not null && last.Key.Equals(key))
-            return last;
-
-        if (_cache.TryGetValue(key, out var cached))
-        {
-            Volatile.Write(ref _last, cached);
+        if (TryGetCached(key, out var cached))
             return cached;
-        }
 
         var subject = getSubjectName(state, topic, isKey);
         var schema = getSchema(state, subject);
         return Cache(key, subject, schema.SchemaId, schema.Schema);
+    }
+
+    // Cheap membership check for async preparation: true once (topic, isKey) has a resolved schema ID,
+    // meaning a subsequent synchronous GetOrAdd for it will hit the cache instead of fetching/blocking.
+    internal bool Contains(string topic, bool isKey) =>
+        TryGetCached(new SubjectSchemaIdCacheKey(topic, isKey), out _);
+
+    // Shared lookup: the single-entry MRU (_last) fast-check followed by the concurrent dictionary.
+    private bool TryGetCached(in SubjectSchemaIdCacheKey key, out SubjectSchemaIdCacheEntry entry)
+    {
+        var last = Volatile.Read(ref _last);
+        if (last is not null && last.Key.Equals(key))
+        {
+            entry = last;
+            return true;
+        }
+
+        if (_cache.TryGetValue(key, out var cached))
+        {
+            Volatile.Write(ref _last, cached);
+            entry = cached;
+            return true;
+        }
+
+        entry = null!;
+        return false;
     }
 
     internal int Cache(string topic, bool isKey, string subject, int schemaId, Schema? schema) =>

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -39,6 +39,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly ProducerOptions _options;
     private readonly ISerializer<TKey> _keySerializer;
     private readonly ISerializer<TValue> _valueSerializer;
+    // Non-null when a serializer needs a one-time async setup (e.g. a Schema Registry fetch) before the
+    // synchronous Serialize can run without blocking. Null for the common case (built-in serializers).
+    private readonly IAsyncSerializerPreparer<TKey>? _keyPreparer;
+    private readonly IAsyncSerializerPreparer<TValue>? _valuePreparer;
     private readonly IPartitioner _partitioner;
     private readonly bool _usesCustomPartitioner;
     private readonly IUniformStickyPartitioner? _uniformStickyPartitioner;
@@ -271,6 +275,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         _options = options;
         _keySerializer = keySerializer;
         _valueSerializer = valueSerializer;
+        _keyPreparer = keySerializer as IAsyncSerializerPreparer<TKey>;
+        _valuePreparer = valueSerializer as IAsyncSerializerPreparer<TValue>;
         _memoryBudget = memoryBudget;
         _ownsInfrastructure = ownsInfrastructure;
         _logger = loggerFactory?.CreateLogger<KafkaProducer<TKey, TValue>>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaProducer<TKey, TValue>>.Instance;
@@ -493,6 +499,26 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         var activity = StartPublishActivity(ref message);
 
+        // If a serializer needs async setup (e.g. a one-time Schema Registry fetch), do it here on the
+        // async path so the synchronous serialize never blocks on it. After the first message for a
+        // subject this completes synchronously and falls straight through to the fast path below.
+        if (_keyPreparer is not null || _valuePreparer is not null)
+        {
+            var prepare = PrepareSerializersAsync(message.Topic, message.Key, message.Value, message.Headers, cancellationToken);
+            if (!prepare.IsCompletedSuccessfully)
+            {
+                return AwaitPrepareThenProduce(prepare, message, activity, cancellationToken);
+            }
+        }
+
+        return ProduceAfterPrepare(message, activity, cancellationToken);
+    }
+
+    private ValueTask<RecordMetadata> ProduceAfterPrepare(
+        ProducerMessage<TKey, TValue> message,
+        Activity? activity,
+        CancellationToken cancellationToken)
+    {
         // Fast path: Try synchronous produce if metadata is initialized and cached.
         // This bypasses channel overhead for 99%+ of calls after warmup.
         if (TryProduceSyncForAsync(message, out var completion))
@@ -517,6 +543,58 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // Slow path: Fall back to channel-based async processing.
         // This handles first-time metadata initialization or cache misses.
         return ProduceAsyncSlow(message, activity, cancellationToken);
+    }
+
+    private async ValueTask<RecordMetadata> AwaitPrepareThenProduce(
+        ValueTask prepare,
+        ProducerMessage<TKey, TValue> message,
+        Activity? activity,
+        CancellationToken cancellationToken)
+    {
+        await prepare.ConfigureAwait(false);
+        return await ProduceAfterPrepare(message, activity, cancellationToken).ConfigureAwait(false);
+    }
+
+    // Ensures any serializer that implements IAsyncSerializerPreparer<T> has fetched its schema (or
+    // other async prerequisite) for this topic before the synchronous serialize runs. Returns a
+    // synchronously-completed ValueTask in the steady state (already prepared), keeping the fast path sync.
+    private ValueTask PrepareSerializersAsync(
+        string topic,
+        TKey? key,
+        TValue? value,
+        Headers? headers,
+        CancellationToken cancellationToken)
+    {
+        var keyPrepare = default(ValueTask);
+        if (_keyPreparer is not null && key is not null)
+        {
+            keyPrepare = _keyPreparer.PrepareAsync(
+                key,
+                new SerializationContext { Topic = topic, Component = SerializationComponent.Key, Headers = headers },
+                cancellationToken);
+        }
+
+        var valuePrepare = default(ValueTask);
+        if (_valuePreparer is not null && value is not null)
+        {
+            valuePrepare = _valuePreparer.PrepareAsync(
+                value,
+                new SerializationContext { Topic = topic, Component = SerializationComponent.Value, Headers = headers },
+                cancellationToken);
+        }
+
+        if (keyPrepare.IsCompletedSuccessfully && valuePrepare.IsCompletedSuccessfully)
+        {
+            return default;
+        }
+
+        return AwaitBothAsync(keyPrepare, valuePrepare);
+
+        static async ValueTask AwaitBothAsync(ValueTask keyPrepare, ValueTask valuePrepare)
+        {
+            await keyPrepare.ConfigureAwait(false);
+            await valuePrepare.ConfigureAwait(false);
+        }
     }
 
     private ValueTask<RecordMetadata> ProduceAsync(
@@ -558,6 +636,29 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // Check cancellation upfront before any work
         cancellationToken.ThrowIfCancellationRequested();
 
+        // See ProduceAsyncCore(ProducerMessage): resolve any async serializer prerequisite before the
+        // synchronous serialize so it never blocks. Steady state completes synchronously and falls through.
+        if (_keyPreparer is not null || _valuePreparer is not null)
+        {
+            var prepare = PrepareSerializersAsync(topic, key, value, headers, cancellationToken);
+            if (!prepare.IsCompletedSuccessfully)
+            {
+                return AwaitPrepareThenProduce(prepare, topic, key, value, headers, partition, timestamp, cancellationToken);
+            }
+        }
+
+        return ProduceAfterPrepare(topic, key, value, headers, partition, timestamp, cancellationToken);
+    }
+
+    private ValueTask<RecordMetadata> ProduceAfterPrepare(
+        string topic,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        int? partition,
+        DateTimeOffset? timestamp,
+        CancellationToken cancellationToken)
+    {
         if (TryProduceSyncForAsync(topic, key, value, headers, partition, timestamp, out var completion))
         {
             // POST-QUEUE: Message appended to batch, committed to being sent
@@ -583,6 +684,20 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             Partition = partition,
             Timestamp = timestamp
         }, activity: null, cancellationToken);
+    }
+
+    private async ValueTask<RecordMetadata> AwaitPrepareThenProduce(
+        ValueTask prepare,
+        string topic,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        int? partition,
+        DateTimeOffset? timestamp,
+        CancellationToken cancellationToken)
+    {
+        await prepare.ConfigureAwait(false);
+        return await ProduceAfterPrepare(topic, key, value, headers, partition, timestamp, cancellationToken).ConfigureAwait(false);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -504,7 +504,19 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // subject this completes synchronously and falls straight through to the fast path below.
         if (_keyPreparer is not null || _valuePreparer is not null)
         {
-            var prepare = PrepareSerializersAsync(message.Topic, message.Key, message.Value, message.Headers, cancellationToken);
+            ValueTask prepare;
+            try
+            {
+                prepare = PrepareSerializersAsync(message.Topic, message.Key, message.Value, message.Headers, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                // A preparer that throws synchronously must still stop and tag the started span,
+                // matching the invariant AwaitWithActivity enforces on every other completion path.
+                RecordActivityFault(activity, ex);
+                throw;
+            }
+
             if (!prepare.IsCompletedSuccessfully)
             {
                 return AwaitPrepareThenProduce(prepare, message, activity, cancellationToken);
@@ -512,6 +524,20 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         return ProduceAfterPrepare(message, activity, cancellationToken);
+    }
+
+    // Stops and error-tags a started span when async serializer preparation fails before the
+    // message is appended. ProduceAfterPrepare owns the activity on all post-preparation paths,
+    // so this only runs when preparation itself throws or faults. No-op when tracing is disabled.
+    private static void RecordActivityFault(Activity? activity, Exception ex)
+    {
+        if (activity is null)
+        {
+            return;
+        }
+
+        Diagnostics.DekafDiagnostics.RecordException(activity, ex);
+        activity.Dispose();
     }
 
     private ValueTask<RecordMetadata> ProduceAfterPrepare(
@@ -551,7 +577,18 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         Activity? activity,
         CancellationToken cancellationToken)
     {
-        await prepare.ConfigureAwait(false);
+        try
+        {
+            await prepare.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Preparation faulted (e.g. Schema Registry unreachable or cancelled mid-fetch) before the
+            // message was appended. Stop and error-tag the span here; ProduceAfterPrepare never runs.
+            RecordActivityFault(activity, ex);
+            throw;
+        }
+
         return await ProduceAfterPrepare(message, activity, cancellationToken).ConfigureAwait(false);
     }
 
@@ -592,8 +629,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         static async ValueTask AwaitBothAsync(ValueTask keyPrepare, ValueTask valuePrepare)
         {
-            await keyPrepare.ConfigureAwait(false);
-            await valuePrepare.ConfigureAwait(false);
+            // Await both even when one faults first, so a later fault on the other side is always
+            // observed rather than left as an unobserved task exception. This is the cold path
+            // (first message per subject); the steady state returns synchronously above.
+            await Task.WhenAll(keyPrepare.AsTask(), valuePrepare.AsTask()).ConfigureAwait(false);
         }
     }
 

--- a/src/Dekaf/Serialization/IAsyncSerializerPreparer.cs
+++ b/src/Dekaf/Serialization/IAsyncSerializerPreparer.cs
@@ -1,0 +1,45 @@
+namespace Dekaf.Serialization;
+
+/// <summary>
+/// Optional companion to <see cref="ISerializer{T}"/> for serializers whose one-time setup is
+/// asynchronous — most notably Schema Registry serializers, which must fetch (or register) a schema
+/// ID over the network before the first value for a subject can be encoded.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ISerializer{T}.Serialize"/> is intentionally synchronous and zero-allocation (it writes
+/// into a pooled <c>ref struct</c> buffer, which cannot cross an <c>await</c>), so it has no way to do
+/// async work itself. Without this hook a serializer's only options are to block a thread on the async
+/// fetch (sync-over-async) or to require the caller to remember to warm up first.
+/// </para>
+/// <para>
+/// When a serializer implements this interface, the producer awaits <see cref="PrepareAsync"/> on its
+/// asynchronous produce path <em>before</em> invoking the synchronous <see cref="ISerializer{T}.Serialize"/>.
+/// That moves the one-time async fetch onto the async path where it belongs, so the encode never blocks
+/// a thread. Once prepared, the result is expected to be cached: implementations should return an already
+/// completed <see cref="ValueTask"/> with no allocation, keeping the steady-state hot path fully synchronous.
+/// </para>
+/// <para>
+/// This is an optimization, not a correctness requirement: <see cref="ISerializer{T}.Serialize"/> must still
+/// succeed if it is reached without a prior <see cref="PrepareAsync"/> (it will resolve the prerequisite
+/// itself, blocking on the first call for a subject). Fire-and-forget produce paths are synchronous and
+/// cannot await preparation, so callers that use them should pre-warm the serializer explicitly.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">The type the serializer handles.</typeparam>
+public interface IAsyncSerializerPreparer<in T>
+{
+    /// <summary>
+    /// Ensures any asynchronous prerequisites for serializing <paramref name="value"/> in the given
+    /// <paramref name="context"/> are satisfied and cached, so a subsequent synchronous
+    /// <see cref="ISerializer{T}.Serialize"/> for the same subject does not block.
+    /// </summary>
+    /// <param name="value">The value about to be serialized (needed to resolve its schema).</param>
+    /// <param name="context">The serialization context (topic and key/value component).</param>
+    /// <param name="cancellationToken">A token to cancel the preparation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that completes when preparation is done. Implementations should return
+    /// an already completed task (no allocation) when the subject is already prepared.
+    /// </returns>
+    ValueTask PrepareAsync(T value, SerializationContext context, CancellationToken cancellationToken = default);
+}

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerAsyncPreparerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerAsyncPreparerTests.cs
@@ -1,0 +1,193 @@
+using System.Buffers;
+using System.Diagnostics;
+using System.Reflection;
+using Dekaf.Diagnostics;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+// Drives the real KafkaProducer async produce path with a serializer that implements
+// IAsyncSerializerPreparer<T>, exercising the preparer gate in ProduceAsyncCore. Uses a
+// process-wide ActivityListener, so it must not run alongside other producing tests.
+[NotInParallel("ActivityListener")]
+public class ProducerAsyncPreparerTests
+{
+    private const string Topic = "prepare-topic";
+
+    // --- Activity lifecycle when preparation faults (regression: a faulting preparer must still
+    //     stop and error-tag the started span, matching every other completion path). ---
+
+    [Test]
+    public async Task ProduceAsync_PreparerFaultsAsynchronously_StopsAndErrorTagsActivity()
+    {
+        var (started, stopped, listener) = ListenForActivities();
+        using (listener)
+        {
+            var valueSerializer = new PreparingSerializer(_ => new ValueTask(Task.FromException(
+                new InvalidOperationException("schema registry unreachable"))));
+
+            await using var producer = CreateProducer(Serializers.String, valueSerializer);
+            await ReadyProducerAsync(producer);
+
+            await Assert.That(async () => await producer.ProduceAsync(NewMessage()))
+                .Throws<InvalidOperationException>();
+
+            await Assert.That(started.Count).IsGreaterThan(0);
+            // No leaked span: every started activity was also stopped.
+            await Assert.That(stopped.Count).IsEqualTo(started.Count);
+            await Assert.That(started[0].Status).IsEqualTo(ActivityStatusCode.Error);
+        }
+    }
+
+    [Test]
+    public async Task ProduceAsync_PreparerThrowsSynchronously_StopsAndErrorTagsActivity()
+    {
+        var (started, stopped, listener) = ListenForActivities();
+        using (listener)
+        {
+            var valueSerializer = new PreparingSerializer(
+                _ => throw new InvalidOperationException("schema resolution failed"));
+
+            await using var producer = CreateProducer(Serializers.String, valueSerializer);
+            await ReadyProducerAsync(producer);
+
+            await Assert.That(async () => await producer.ProduceAsync(NewMessage()))
+                .Throws<InvalidOperationException>();
+
+            await Assert.That(started.Count).IsGreaterThan(0);
+            await Assert.That(stopped.Count).IsEqualTo(started.Count);
+            await Assert.That(started[0].Status).IsEqualTo(ActivityStatusCode.Error);
+        }
+    }
+
+    // --- Both preparers observed even when one faults first (regression: the value preparer must
+    //     not be left unawaited/unobserved when the key preparer faults). ---
+
+    [Test]
+    public async Task ProduceAsync_KeyPreparerFaultsFirst_StillAwaitsValuePreparer()
+    {
+        var keyGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var valueGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var keySerializer = new PreparingSerializer(_ => new ValueTask(keyGate.Task));
+        var valueSerializer = new PreparingSerializer(_ => new ValueTask(valueGate.Task));
+
+        await using var producer = CreateProducer(keySerializer, valueSerializer);
+        await ReadyProducerAsync(producer);
+
+        var produce = producer.ProduceAsync(NewMessage()).AsTask();
+
+        // Key preparation fails first while value preparation is still in flight.
+        keyGate.SetException(new InvalidOperationException("key schema failed"));
+
+        // A sequential "await key; await value" would surface the key fault and complete the produce
+        // right here, leaving the value preparer unobserved. Give that path ample time to appear;
+        // awaiting both keeps the produce pending until the value preparer also completes.
+        for (var i = 0; i < 100 && !produce.IsCompleted; i++)
+            await Task.Delay(10);
+
+        await Assert.That(produce.IsCompleted).IsFalse();
+
+        valueGate.SetException(new InvalidOperationException("value schema failed"));
+
+        await Assert.That(async () => await produce).Throws<Exception>();
+    }
+
+    // --- Cancellation during preparation is "pre-append": it throws and nothing is buffered. ---
+
+    [Test]
+    public async Task ProduceAsync_CancelledDuringPreparation_ThrowsAndDoesNotAppend()
+    {
+        using var cts = new CancellationTokenSource();
+        var valueSerializer = new PreparingSerializer(ct => new ValueTask(Task.Delay(Timeout.Infinite, ct)));
+
+        await using var producer = CreateProducer(Serializers.String, valueSerializer);
+        await ReadyProducerAsync(producer);
+
+        var produce = producer.ProduceAsync(NewMessage(), cts.Token).AsTask();
+        await Task.Yield();
+        await Assert.That(produce.IsCompleted).IsFalse();
+
+        cts.Cancel();
+
+        await Assert.That(async () => await produce).Throws<OperationCanceledException>();
+        // Pre-append semantics: the message never reached the accumulator.
+        await Assert.That(producer.RecordAccumulator.BufferedBytes).IsEqualTo(0L);
+    }
+
+    private static ProducerMessage<string, string> NewMessage() =>
+        new() { Topic = Topic, Key = "k", Value = "v" };
+
+    private static (List<Activity> Started, List<Activity> Stopped, ActivityListener Listener) ListenForActivities()
+    {
+        var started = new List<Activity>();
+        var stopped = new List<Activity>();
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == DekafDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = started.Add,
+            ActivityStopped = stopped.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+        return (started, stopped, listener);
+    }
+
+    private static KafkaProducer<string, string> CreateProducer(
+        ISerializer<string> keySerializer,
+        ISerializer<string> valueSerializer)
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "prepare-test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 4096,
+            LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000
+        };
+
+        return new KafkaProducer<string, string>(options, keySerializer, valueSerializer);
+    }
+
+    // Stops the background loops (so nothing tries to reach a broker) and marks the producer
+    // initialized, so ProduceAsync reaches the preparer gate instead of the not-initialized guard.
+    private static async Task ReadyProducerAsync(KafkaProducer<string, string> producer)
+    {
+        var cts = GetField<CancellationTokenSource>(producer, "_senderCts");
+        var senderTask = GetField<Task>(producer, "_senderTask");
+        var lingerTask = GetField<Task>(producer, "_lingerTask");
+
+        await cts.CancelAsync();
+        await Task.WhenAll(senderTask, lingerTask).WaitAsync(TimeSpan.FromSeconds(5));
+
+        SetField(producer, "_initialized", true);
+    }
+
+    private static T GetField<T>(object target, string name)
+    {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        return (T)target.GetType().GetField(name, flags)!.GetValue(target)!;
+    }
+
+    private static void SetField<T>(object target, string name, T value)
+    {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        target.GetType().GetField(name, flags)!.SetValue(target, value);
+    }
+
+    // A serializer with a configurable async prerequisite, so a test can make preparation complete,
+    // fault, or block on cancellation. Serialization itself defers to the real string serializer.
+    private sealed class PreparingSerializer(Func<CancellationToken, ValueTask> prepare)
+        : ISerializer<string>, IAsyncSerializerPreparer<string>
+    {
+        public ValueTask PrepareAsync(string value, SerializationContext context, CancellationToken cancellationToken = default)
+            => prepare(cancellationToken);
+
+        public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
+            where TWriter : IBufferWriter<byte>, allows ref struct
+            => Serializers.String.Serialize(value, ref destination, context);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSerializerTests.cs
@@ -589,6 +589,61 @@ public sealed class AvroSerializerTests
     }
 
     [Test]
+    public async Task Serializer_PrepareAsync_IsAsynchronous_WhenSchemaNotYetCached()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        schemaRegistry.BlockNextGetOrRegisterSchema();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+
+        var schema = AvroSchema.Parse(SimpleRecordSchema) as Avro.RecordSchema;
+        var record = new GenericRecord(schema!);
+        record.Add("id", 1);
+        record.Add("name", "prepare");
+
+        // Cold path: the schema fetch is in flight, so preparation must be genuinely asynchronous
+        // (not blocking a thread) - that is the whole point of the hook.
+        var prepare = serializer.PrepareAsync(record, CreateContext("prepare-topic"));
+        await schemaRegistry.WaitForBlockedGetOrRegisterSchemaAsync(TimeSpan.FromSeconds(2));
+        await Assert.That(prepare.IsCompleted).IsFalse();
+
+        schemaRegistry.ReleaseBlockedGetOrRegisterSchema();
+        await prepare;
+
+        await Assert.That(schemaRegistry.GetOrRegisterSchemaCallCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Serializer_PrepareAsync_WhenAlreadyPrepared_CompletesSynchronouslyAndSerializeDoesNotRefetch()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+
+        var schema = AvroSchema.Parse(SimpleRecordSchema) as Avro.RecordSchema;
+        var record = new GenericRecord(schema!);
+        record.Add("id", 1);
+        record.Add("name", "prepare");
+
+        var context = CreateContext("prepare-topic");
+
+        // First prepare warms the subject cache with a single registry call.
+        await serializer.PrepareAsync(record, context);
+        await Assert.That(schemaRegistry.GetOrRegisterSchemaCallCount).IsEqualTo(1);
+
+        // Once warmed, prepare completes synchronously (no allocation, no registry call) so the
+        // producer's fast path stays synchronous.
+        var warm = serializer.PrepareAsync(record, context);
+        await Assert.That(warm.IsCompletedSuccessfully).IsTrue();
+        await warm;
+
+        // And the synchronous serialize now runs against the cached schema id without re-fetching.
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize(record, ref buffer, context);
+
+        await Assert.That(schemaRegistry.GetOrRegisterSchemaCallCount).IsEqualTo(1);
+        await Assert.That(buffer.WrittenCount).IsGreaterThan(5); // magic byte + 4-byte schema id + payload
+    }
+
+    [Test]
     public async Task Deserializer_WarmupAsync_RetriesAfterTransientSchemaFetchFailure()
     {
         using var schemaRegistry = new MockSchemaRegistryClient


### PR DESCRIPTION
## Problem

`ISerializer<T>.Serialize` is **synchronous and zero-allocation by design** — it writes into a `ref struct` `IBufferWriter<byte>`, which cannot cross an `await`, so it structurally cannot be async. The only async dependency in the Schema Registry serializers is a **one-time schema-ID fetch** per subject. Today that's resolved with a **sync-over-async block** on the first message for each subject (`GetSchemaIdCached` → `task.WaitAsync(...).GetAwaiter().GetResult()`), unless the caller remembers to `WarmupAsync` first. Under load that blocks a pool thread on a network round-trip.

Follow-up to a design discussion: *is this bad design, and can it be truly async?* Making `Serialize` async is out (kills zero-alloc). The clean fix is to **resolve the schema asynchronously on the async produce path, before the sync encode**.

## Approach

New opt-in companion interface:

```csharp
public interface IAsyncSerializerPreparer<in T>
{
    ValueTask PrepareAsync(T value, SerializationContext context, CancellationToken ct = default);
}
```

- The producer awaits `PrepareAsync` on its async `ProduceAsync` path **before** the synchronous `Serialize`. The one-time fetch runs where async belongs; the encode never blocks.
- **Zero added hot-path cost:** preparers are captured once in the ctor via `as`-cast. When no serializer needs preparation (built-in serializers), the gate is two null checks. After the first message per subject, `PrepareAsync` returns a synchronously-completed `ValueTask` (via a cheap `SubjectSchemaIdCache.Contains` check → `ValueTask.CompletedTask`, no `Task` allocation), so the produce path stays fully synchronous on the fast path.
- **Opt-in and non-breaking:** `Serialize` still works if reached without preparation (falls back to the existing behavior).

## Changes

- `IAsyncSerializerPreparer<T>` — new interface.
- `AvroSchemaRegistrySerializer<T>` — implements `PrepareAsync` (delegates to existing `WarmupAsync`, short-circuits when warm).
- `SubjectSchemaIdCache` — `Contains` warm-check (via a shared `TryGetCached` lookup primitive).
- `KafkaProducer` — captures `_keyPreparer`/`_valuePreparer`; gates both async `ProduceAsync` cores (message and topic/key/value). Fast path extracted, unchanged.

## Testing

- New unit tests prove the contract: cold `PrepareAsync` is **genuinely async** (doesn't block while the fetch is in flight); warm `PrepareAsync` completes **synchronously** with no extra registry call, and the subsequent `Serialize` doesn't re-fetch.
- Full `AvroSerializerTests` class passes; core + Avro + unit build clean.

## Prototype scope / follow-ups

- Covers **Avro** + the **two async `ProduceAsync` overloads**.
- **Fire-and-forget** produce is synchronous and cannot await — still needs a manual `WarmupAsync` (documented on the interface).
- **Protobuf** SR serializer has the same sync-over-async block; wiring is mechanical (mirror Avro) — follow-up.
- **Benchmark** validation of the produce hot path recommended before merge (design preserves zero-alloc by construction; a `[MemoryDiagnoser]` run should confirm).

> Note: this branch is off `main` and does not include the thread-pool pre-sizing fix from #1531; several unrelated timing tests (`SendLoop_*`, `ReceiveLoop_*`) flake under full-suite load until that lands. They pass in isolation. Rebase after #1531 merges for stable CI.