### PR TITLE
Share network partition Kafka fixture per test session

### DIFF
--- a/tests/Dekaf.Tests.Integration/NetworkPartition/ConnectionRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Integration/NetworkPartition/ConnectionRecoveryTests.cs
@@ -8,7 +8,7 @@ namespace Dekaf.Tests.Integration.NetworkPartition;
 /// </summary>
 [Category("NetworkPartition")]
 [NotInParallel("NetworkPartitionKafkaContainer")]
-[ClassDataSource<NetworkPartitionKafkaContainer>(Shared = SharedType.PerClass)]
+[ClassDataSource<NetworkPartitionKafkaContainer>(Shared = SharedType.PerTestSession)]
 public class ConnectionRecoveryTests(NetworkPartitionKafkaContainer kafka)
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/NetworkPartition/ConsumerNetworkPartitionTests.cs
+++ b/tests/Dekaf.Tests.Integration/NetworkPartition/ConsumerNetworkPartitionTests.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Tests.Integration.NetworkPartition;
 /// </summary>
 [Category("NetworkPartition")]
 [NotInParallel("NetworkPartitionKafkaContainer")]
-[ClassDataSource<NetworkPartitionKafkaContainer>(Shared = SharedType.PerClass)]
+[ClassDataSource<NetworkPartitionKafkaContainer>(Shared = SharedType.PerTestSession)]
 public class ConsumerNetworkPartitionTests(NetworkPartitionKafkaContainer kafka)
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/NetworkPartition/NetworkPartitionKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/NetworkPartition/NetworkPartitionKafkaContainer.cs
@@ -6,7 +6,8 @@ namespace Dekaf.Tests.Integration.NetworkPartition;
 /// Kafka container wrapper with pause/unpause capabilities for network partition simulation.
 /// Uses Docker's pause/unpause to freeze container processes, simulating a network partition
 /// where TCP connections go silent (no RST, no FIN).
-/// Not shared across test classes to avoid interference between partition tests.
+/// Shared once per test session for network partition tests. Do not reuse the general
+/// KafkaContainer40 session instance because pause/unpause would affect unrelated tests.
 /// </summary>
 public class NetworkPartitionKafkaContainer : KafkaTestContainer
 {

--- a/tests/Dekaf.Tests.Integration/NetworkPartition/ProducerNetworkPartitionTests.cs
+++ b/tests/Dekaf.Tests.Integration/NetworkPartition/ProducerNetworkPartitionTests.cs
@@ -8,7 +8,7 @@ namespace Dekaf.Tests.Integration.NetworkPartition;
 /// </summary>
 [Category("NetworkPartition")]
 [NotInParallel("NetworkPartitionKafkaContainer")]
-[ClassDataSource<NetworkPartitionKafkaContainer>(Shared = SharedType.PerClass)]
+[ClassDataSource<NetworkPartitionKafkaContainer>(Shared = SharedType.PerTestSession)]
 public class ProducerNetworkPartitionTests(NetworkPartitionKafkaContainer kafka)
 {
     [Test]


### PR DESCRIPTION
## Summary
- Reuse `NetworkPartitionKafkaContainer` with `SharedType.PerTestSession` across network partition test classes.
- Keep a dedicated network partition fixture instead of reusing `KafkaContainer40`, because pause/unpause would affect unrelated tests.
- Update the fixture comment to document the intended sharing boundary.

## Validation
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj`
- `tests\Dekaf.Tests.Integration\bin\Debug\net10.0\Dekaf.Tests.Integration.exe --disable-logo --no-ansi --treenode-filter "/*/Dekaf.Tests.Integration.NetworkPartition/*/*" --timeout 10m --show-stdout Failed --show-stderr Failed`