### PR TITLE
fix(pipeline): use native GitVersion SemVer instead of commit-height patch

### DIFF
--- a/tools/Dekaf.Pipeline/Modules/CreateReleaseModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/CreateReleaseModule.cs
@@ -15,9 +15,10 @@ namespace Dekaf.Pipeline.Modules;
 /// actually shipped packages in this run.
 /// </summary>
 /// <remarks>
-/// The release is tagged <c>v{version}</c>. Versioning counts commit height from the repository
-/// root (see <see cref="GenerateVersionModule"/>), so these release tags do not feed back into and
-/// corrupt the computed version.
+/// The release is tagged <c>v{version}</c> with the version GitVersion computed (see
+/// <see cref="GenerateVersionModule"/>). These tags are GitVersion's version sources: each one lets
+/// the next commit on main advance the patch, so every publish gets a fresh, unique version. Because
+/// of that, a publish must always create its tag — see the uniqueness note in GenerateVersionModule.
 /// </remarks>
 [RunOnlyOnBranch("main")]
 [DependsOn<UploadToNuGetModule>(Optional = true)]

--- a/tools/Dekaf.Pipeline/Modules/GenerateVersionModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/GenerateVersionModule.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Context;
 using ModularPipelines.Git.Extensions;
@@ -12,49 +11,28 @@ public class GenerateVersionModule : Module<VersionInfo>
 {
     protected override async Task<VersionInfo?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        // Prefer a monotonic, unique-per-commit stable version: {Major}.{Minor}.{commit height}.
-        // Major/Minor come from GitVersion (so +semver bump messages still work); the height is the
-        // commit count, which strictly increases on main so every publish gets a fresh version.
-        // Without this, GitVersion emits a frozen MajorMinorPatch (1.0.0) on every commit, which
-        // made each NuGet push a duplicate that --skip-duplicate silently swallowed (nothing shipped).
-        var major = Environment.GetEnvironmentVariable("GitVersion_Major");
-        var minor = Environment.GetEnvironmentVariable("GitVersion_Minor");
-
-        if (!string.IsNullOrEmpty(major) && !string.IsNullOrEmpty(minor))
-        {
-            // Use commit height from the repository root (git rev-list --count HEAD) rather than
-            // GitVersion's CommitsSinceVersionSource. The latter resets whenever a version-shaped tag
-            // is the nearest version source, so the v{version} release tags CreateReleaseModule pushes
-            // would make the height — and thus the composed version — jump backwards. Commit height is
-            // strictly increasing and tag-independent. Falls back to the GitVersion value if git can't
-            // be queried (identical to the root count while no such tags exist).
-            var commitsOnBranch = context.Git().Information.CommitsOnBranch;
-            var height = commitsOnBranch > 0
-                ? commitsOnBranch.ToString(CultureInfo.InvariantCulture)
-                : Environment.GetEnvironmentVariable("GitVersion_CommitsSinceVersionSource");
-
-            if (!string.IsNullOrEmpty(height))
-            {
-                var version = $"{major}.{minor}.{height}";
-                context.Logger.LogInformation("Using commit-height version: {Version}", version);
-                return new VersionInfo(version, version);
-            }
-        }
-
-        // Fallback for when the Major/Minor/height variables are unavailable (e.g. GitVersion only
-        // partially populated the environment): use the SemVer it computed directly. This still
-        // avoids re-running GitVersion, which can fail on PR branches due to GitVersion 6.x bugs.
+        // Use the version GitVersion computed directly. +semver: bump messages drive Major/Minor/Patch,
+        // and the v{version} release tags CreateReleaseModule pushes act as GitVersion's version
+        // sources, so each publishing commit on main advances the patch and gets a fresh, unique
+        // version. SemVer excludes the +build metadata (which NuGet ignores), so it is the value we
+        // pack and publish.
+        //
+        // NOTE: uniqueness relies on every release pushing a v{version} tag. If a release ships
+        // packages without creating its tag, the next run can recompute the same version, and
+        // UploadToNuGetModule throws once every push is a duplicate (see its guard). Keep the tag and
+        // publish steps together.
         var envSemVer = Environment.GetEnvironmentVariable("GitVersion_SemVer");
         var envFullSemVer = Environment.GetEnvironmentVariable("GitVersion_FullSemVer");
 
         if (!string.IsNullOrEmpty(envSemVer) || !string.IsNullOrEmpty(envFullSemVer))
         {
-            var semVer = envSemVer ?? envFullSemVer ?? "1.0.0";
+            var semVer = envSemVer ?? envFullSemVer!;
             context.Logger.LogInformation("Using GitVersion from environment: {SemVer}", semVer);
             return new VersionInfo(semVer, semVer);
         }
 
-        // Fall back to running GitVersion directly (for local development)
+        // Fall back to running GitVersion directly (local development, where the CI action hasn't
+        // exported the GitVersion_* environment variables).
         try
         {
             var gitVersionInformation = await context.Git().Versioning.GetGitVersioningInformation();


### PR DESCRIPTION
## Problem

`GenerateVersionModule` composed the version as `{Major}.{Minor}.{git rev-list --count HEAD}`, so `+semver:minor` produced `1.1.2501` — the patch was the total commit count, not a real semantic version.

## Why the commit-height hack existed

GitVersion on `main` (ContinuousDeployment, empty label) freezes `MajorMinorPatch` across commits — native `SemVer`/`FullSemVer` don't advance per commit (only `+build` metadata does, which NuGet ignores). Frozen version → every push is a duplicate → `--skip-duplicate` swallows it → nothing ships. So the patch was replaced with the monotonic commit height.

## Why native versioning works now

`CreateReleaseModule` pushes `v{version}` release tags. Those tags act as GitVersion's **version sources**, so each publishing commit on `main` advances the patch on its own — no commit-height crutch needed.

## Change

- `GenerateVersionModule` now uses GitVersion `SemVer` directly (env `GitVersion_SemVer` → `GitVersion_FullSemVer` → live GitVersion → `0.0.1-local`). `+semver:minor` now yields `1.1.0`, then `1.1.1`, and a later bump `1.2.0`.
- Corrected the `CreateReleaseModule` remark, which claimed release tags do **not** feed back into versioning; with native versioning they intentionally do.

## ⚠️ Uniqueness note

Uniqueness now depends on **every release pushing its `v{version}` tag**. If a publish ships packages but skips its tag, the next run recomputes the same version and `UploadToNuGetModule` throws once every push is a duplicate. Publish + tag steps must stay together.

## Follow-up (not in this PR)

Stray tags `v1.1` and `v1.1.2501` sit on HEAD and are the highest reachable version tags, so they'll keep the computed patch at 2501+ until removed:
\`\`\`
git push origin :refs/tags/v1.1 :refs/tags/v1.1.2501
git tag -d v1.1 v1.1.2501
\`\`\`

## Testing

\`dotnet build tools/Dekaf.Pipeline -c Release\` — clean, 0 warnings.