### PR TITLE
fix: guard empty spans in netstandard2.0 UTF-8 encoding (ns2.0 consumer receives nothing)

### DIFF
--- a/src/Dekaf/Internal/EncodingCompat.cs
+++ b/src/Dekaf/Internal/EncodingCompat.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Dekaf.Internal;
+
+/// <summary>
+/// UTF-8 span helpers that behave identically across all target frameworks.
+/// </summary>
+/// <remarks>
+/// On <c>netstandard2.0</c> the span-based <see cref="Encoding.GetBytes(ReadOnlySpan{char}, Span{byte})"/>
+/// and <c>Encoding.GetByteCount(ReadOnlySpan&lt;char&gt;)</c> overloads are supplied by the Polyfill package,
+/// whose implementation pins the source span with <c>fixed</c>. Pinning an <b>empty</b> span yields a null
+/// pointer, which <see cref="UTF8Encoding"/> rejects with an <see cref="ArgumentNullException"/>
+/// ("Array cannot be null. (Parameter 'chars')"). These helpers short-circuit empty input so the
+/// netstandard2.0 build matches the net10.0 behaviour (zero bytes). On net8.0+/netstandard2.1 the native,
+/// empty-safe overloads are used and the guard is compiled out, so those builds gain no extra branch.
+/// </remarks>
+internal static class EncodingCompat
+{
+    /// <summary>UTF-8 encodes <paramref name="chars"/> into <paramref name="bytes"/>; empty-safe on all TFMs.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetBytes(ReadOnlySpan<char> chars, Span<byte> bytes)
+    {
+#if NETSTANDARD2_0
+        if (chars.IsEmpty)
+            return 0;
+#endif
+        return Encoding.UTF8.GetBytes(chars, bytes);
+    }
+
+    /// <summary>Counts the UTF-8 bytes for <paramref name="chars"/>; empty-safe on all TFMs.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetByteCount(ReadOnlySpan<char> chars)
+    {
+#if NETSTANDARD2_0
+        if (chars.IsEmpty)
+            return 0;
+#endif
+        return Encoding.UTF8.GetByteCount(chars);
+    }
+
+    /// <summary>UTF-8 decodes <paramref name="bytes"/> into a string; empty-safe on all TFMs.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string GetString(ReadOnlySpan<byte> bytes)
+    {
+#if NETSTANDARD2_0
+        if (bytes.IsEmpty)
+            return string.Empty;
+#endif
+        return Encoding.UTF8.GetString(bytes);
+    }
+}

--- a/src/Dekaf/Protocol/KafkaProtocolWriter.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolWriter.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Dekaf.Internal;
 
 namespace Dekaf.Protocol;
 
@@ -321,7 +322,7 @@ public ref struct KafkaProtocolWriter
         if (value.Length <= StackallocCharThreshold)
         {
             Span<byte> buffer = stackalloc byte[StackallocUtf8ByteCount];
-            var byteCount = Encoding.UTF8.GetBytes(value, buffer);
+            var byteCount = EncodingCompat.GetBytes(value, buffer);
             WriteInt16((short)byteCount);
             WriteUtf8Bytes(buffer[..byteCount]);
             return;
@@ -329,13 +330,13 @@ public ref struct KafkaProtocolWriter
 
         if (value.Length > short.MaxValue)
         {
-            var byteCount = Encoding.UTF8.GetByteCount(value);
+            var byteCount = EncodingCompat.GetByteCount(value);
             throw new ArgumentException($"String exceeds maximum Kafka short-prefixed string length ({byteCount} bytes > {short.MaxValue}).", nameof(value));
         }
 
         var maxByteCount = Encoding.UTF8.GetMaxByteCount(value.Length);
         var span = _output.GetSpan(sizeof(short) + maxByteCount);
-        var actualBytes = Encoding.UTF8.GetBytes(value, span[sizeof(short)..]);
+        var actualBytes = EncodingCompat.GetBytes(value, span[sizeof(short)..]);
 
         if (actualBytes > short.MaxValue)
             throw new ArgumentException($"String exceeds maximum Kafka short-prefixed string length ({actualBytes} bytes > {short.MaxValue}).", nameof(value));
@@ -351,14 +352,14 @@ public ref struct KafkaProtocolWriter
         if (value.Length <= StackallocCharThreshold)
         {
             Span<byte> buffer = stackalloc byte[StackallocUtf8ByteCount];
-            var byteCount = Encoding.UTF8.GetBytes(value, buffer);
+            var byteCount = EncodingCompat.GetBytes(value, buffer);
             WriteUtf8Bytes(buffer[..byteCount]);
             return;
         }
 
         var maxByteCount = Encoding.UTF8.GetMaxByteCount(value.Length);
         var span = _output.GetSpan(maxByteCount);
-        var actualBytes = Encoding.UTF8.GetBytes(value, span);
+        var actualBytes = EncodingCompat.GetBytes(value, span);
         _output.Advance(actualBytes);
         _bytesWritten += actualBytes;
     }
@@ -369,7 +370,7 @@ public ref struct KafkaProtocolWriter
         if (value.Length <= StackallocCharThreshold)
         {
             Span<byte> buffer = stackalloc byte[StackallocUtf8ByteCount];
-            var byteCount = Encoding.UTF8.GetBytes(value, buffer);
+            var byteCount = EncodingCompat.GetBytes(value, buffer);
             WriteUnsignedVarInt(byteCount + 1);
             WriteUtf8Bytes(buffer[..byteCount]);
             return;
@@ -377,7 +378,7 @@ public ref struct KafkaProtocolWriter
 
         var maxByteCount = Encoding.UTF8.GetMaxByteCount(value.Length);
         var span = _output.GetSpan(MaxUnsignedVarIntByteCount + maxByteCount);
-        var actualBytes = Encoding.UTF8.GetBytes(value, span[MaxUnsignedVarIntByteCount..]);
+        var actualBytes = EncodingCompat.GetBytes(value, span[MaxUnsignedVarIntByteCount..]);
         var lengthBytes = WriteVarUIntToSpan((uint)(actualBytes + 1), span);
 
         if (actualBytes > 0 && lengthBytes != MaxUnsignedVarIntByteCount)

--- a/src/Dekaf/Security/Sasl/PlainAuthenticator.cs
+++ b/src/Dekaf/Security/Sasl/PlainAuthenticator.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Dekaf.Internal;
 
 namespace Dekaf.Security.Sasl;
 
@@ -41,18 +42,18 @@ public sealed class PlainAuthenticator : ISaslAuthenticator
         // passwd = password
         // Write directly to buffer to avoid string interpolation allocation
         var authzid = _authorizationId ?? string.Empty;
-        var totalBytes = Encoding.UTF8.GetByteCount(authzid) + 1 +
-                         Encoding.UTF8.GetByteCount(_username) + 1 +
-                         Encoding.UTF8.GetByteCount(_password);
+        var totalBytes = EncodingCompat.GetByteCount(authzid) + 1 +
+                         EncodingCompat.GetByteCount(_username) + 1 +
+                         EncodingCompat.GetByteCount(_password);
 
         var result = new byte[totalBytes];
         var offset = 0;
 
-        offset += Encoding.UTF8.GetBytes(authzid, result.AsSpan(offset));
+        offset += EncodingCompat.GetBytes(authzid, result.AsSpan(offset));
         result[offset++] = 0; // NUL separator
-        offset += Encoding.UTF8.GetBytes(_username, result.AsSpan(offset));
+        offset += EncodingCompat.GetBytes(_username, result.AsSpan(offset));
         result[offset++] = 0; // NUL separator
-        Encoding.UTF8.GetBytes(_password, result.AsSpan(offset));
+        EncodingCompat.GetBytes(_password, result.AsSpan(offset));
 
         _complete = true;
         return result;

--- a/src/Dekaf/Serialization/BuiltInSerializers.cs
+++ b/src/Dekaf/Serialization/BuiltInSerializers.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Text;
+using Dekaf.Internal;
 
 namespace Dekaf.Serialization;
 
@@ -133,13 +134,13 @@ internal sealed class StringSerde : ISerde<string>
 #endif
     {
         var span = destination.GetSpan(checked(value.Length * 3));
-        var bytesWritten = Encoding.UTF8.GetBytes(value, span);
+        var bytesWritten = EncodingCompat.GetBytes(value, span);
         destination.Advance(bytesWritten);
     }
 
     public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
     {
-        return Encoding.UTF8.GetString(data.Span);
+        return EncodingCompat.GetString(data.Span);
     }
 }
 
@@ -155,7 +156,7 @@ internal sealed class NullableStringSerde : ISerde<string?>
             return;
 
         var span = destination.GetSpan(checked(value.Length * 3));
-        var bytesWritten = Encoding.UTF8.GetBytes(value, span);
+        var bytesWritten = EncodingCompat.GetBytes(value, span);
         destination.Advance(bytesWritten);
     }
 
@@ -167,7 +168,7 @@ internal sealed class NullableStringSerde : ISerde<string?>
         if (data.Length == 0)
             return string.Empty;
 
-        return Encoding.UTF8.GetString(data.Span);
+        return EncodingCompat.GetString(data.Span);
     }
 }
 

--- a/src/Dekaf/Serialization/Headers.cs
+++ b/src/Dekaf/Serialization/Headers.cs
@@ -287,7 +287,7 @@ public readonly record struct Header
     /// </summary>
     public string? GetValueAsString()
     {
-        return IsValueNull ? null : Encoding.UTF8.GetString(Value.Span);
+        return IsValueNull ? null : EncodingCompat.GetString(Value.Span);
     }
 
     /// <inheritdoc/>
@@ -317,7 +317,7 @@ public readonly record struct Header
         if (key.Length <= 128)
         {
             Span<byte> buffer = stackalloc byte[512];
-            var actualBytes = Encoding.UTF8.GetBytes(key, buffer);
+            var actualBytes = EncodingCompat.GetBytes(key, buffer);
             writer.WriteVarInt(actualBytes);
             if (actualBytes > 0)
             {
@@ -329,13 +329,13 @@ public readonly record struct Header
             return;
         }
 
-        var keyByteCount = Encoding.UTF8.GetByteCount(key);
+        var keyByteCount = EncodingCompat.GetByteCount(key);
         writer.WriteVarInt(keyByteCount);
         if (keyByteCount == 0)
             return;
 
         var span = writer.BufferWriter.GetSpan(keyByteCount);
-        Encoding.UTF8.GetBytes(key, span);
+        EncodingCompat.GetBytes(key, span);
         writer.BufferWriter.Advance(keyByteCount);
         writer.AddBytesWritten(keyByteCount);
     }
@@ -369,16 +369,16 @@ public readonly record struct Header
             // Single-pass encode for short keys (the common case): UTF-8 worst case is
             // 3 bytes per char, so 128 chars always fit in the 512-byte scratch buffer.
             Span<byte> buffer = stackalloc byte[512];
-            var keyByteCount = Encoding.UTF8.GetBytes(key, buffer);
+            var keyByteCount = EncodingCompat.GetBytes(key, buffer);
             Record.WriteVarInt(destination, ref offset, keyByteCount);
             buffer[..keyByteCount].CopyTo(destination[offset..]);
             offset += keyByteCount;
         }
         else
         {
-            var keyByteCount = Encoding.UTF8.GetByteCount(key);
+            var keyByteCount = EncodingCompat.GetByteCount(key);
             Record.WriteVarInt(destination, ref offset, keyByteCount);
-            Encoding.UTF8.GetBytes(key, destination[offset..]);
+            EncodingCompat.GetBytes(key, destination[offset..]);
             offset += keyByteCount;
         }
 
@@ -398,7 +398,7 @@ public readonly record struct Header
     {
         // ASCII keys (99%+ of cases): byte count == char count. Ascii.IsValid is
         // SIMD-optimized and much cheaper than UTF8.GetByteCount for this case.
-        var keyBytes = Ascii.IsValid(Key) ? Key.Length : Encoding.UTF8.GetByteCount(Key);
+        var keyBytes = Ascii.IsValid(Key) ? Key.Length : EncodingCompat.GetByteCount(Key);
         var size = Record.VarIntSize(keyBytes) + keyBytes;
 
         if (IsValueNull)

--- a/src/Dekaf/Telemetry/ClientTelemetryPayloadProvider.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryPayloadProvider.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using Dekaf.Compression;
+using Dekaf.Internal;
 using CompressionType = Dekaf.Protocol.Records.CompressionType;
 
 namespace Dekaf.Telemetry;
@@ -149,7 +150,7 @@ internal sealed class ClientTelemetryPayloadProvider : IClientTelemetryPayloadPr
         WriteTag(writer, fieldNumber, WireLengthDelimited);
         WriteVarint(writer, (ulong)byteCount);
         var span = writer.GetSpan(byteCount);
-        var written = System.Text.Encoding.UTF8.GetBytes(value, span);
+        var written = EncodingCompat.GetBytes(value, span);
         writer.Advance(written);
     }
 


### PR DESCRIPTION
Addresses #1543.

## Symptom

On the **netstandard2.0** asset consumed from net8, produce succeeds but the consumer never receives — consume times out (while the identical pattern works in <1s on net10). The ns2.0 consumer path is effectively non-functional.

## Root cause

On netstandard2.0 the span-based `Encoding.GetBytes(ReadOnlySpan<char>, Span<byte>)` / `GetString(ReadOnlySpan<byte>)` / `GetByteCount(ReadOnlySpan<char>)` overloads are supplied by the `Polyfill` package, whose implementation pins the source span with `fixed`:

```csharp
fixed (char* charsPtr = chars)        // empty span -> null pointer
    return target.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
```

Pinning an **empty** span yields a null pointer, and `UTF8Encoding` rejects it:

```
System.ArgumentNullException: Array cannot be null. (Parameter 'chars')
  at System.Text.UTF8Encoding.GetBytes(Char* chars, ...)
  at Polyfills.Polyfill.GetBytes(Encoding, ReadOnlySpan<char>, Span<byte>)
  at Dekaf.Protocol.KafkaProtocolWriter.WriteCompactStringValue(...)
  at Dekaf.Protocol.Messages.FetchRequest.Write(...)
  at Dekaf.Consumer.KafkaConsumer.PrefetchFromBrokerAsync(...)
```

The consumer's `FetchRequest.Write` writes an **empty** compact string (e.g. the empty client rack id), so on ns2.0 **every prefetch throws** and the subscriber receives nothing. net8.0/net9.0/net10.0/netstandard2.1 use the native, empty-safe overloads, so this is netstandard2.0-only.

## Fix

Adds `src/Dekaf/Internal/EncodingCompat.cs` — empty-safe `GetBytes`/`GetByteCount`/`GetString`:

```csharp
public static int GetBytes(ReadOnlySpan<char> chars, Span<byte> bytes)
{
#if NETSTANDARD2_0
    if (chars.IsEmpty)
        return 0;
#endif
    return Encoding.UTF8.GetBytes(chars, bytes);
}
```

The empty guard is `#if NETSTANDARD2_0`-gated and the methods are `AggressiveInlining`, so **net10.0 IL is unchanged (no regression)** — only the ns2.0 build gains the guard. The vulnerable span call sites are routed through it: `KafkaProtocolWriter`, `Headers`, `BuiltInSerializers`, `PlainAuthenticator` (empty SASL PLAIN authzid), and `ClientTelemetryPayloadProvider`. `KafkaProtocolReader` already guards `length == 0`.

## Validation

- Core builds 0 warnings / 0 errors on `net10.0` + `netstandard2.0` (Release).
- Verified against real Kafka brokers by running the end-to-end integration suite on a **net8.0 host consuming the netstandard2.0 asset**: 357/357 pass with the fix (all 33 failed before it). net10.0 RoundTrip 33/33 and net10.0 Protocol/Serialization unit tests remain green.

The net8→ns2.0 integration test harness that exercises this at runtime is kept separate from this change (per #1543, the test expansion can be contributed on its own); happy to follow up with it if you'd like it upstream.
