### PR TITLE
perf(producer): raise non-idempotent in-flight

### DIFF
--- a/docs/docs/producer/basics.md
+++ b/docs/docs/producer/basics.md
@@ -155,6 +155,12 @@ With idempotence enabled:
 - Messages are delivered in order
 - Requires `Acks.All` (set automatically)
 
+## In-Flight Requests and Ordering
+
+`MaxInFlightRequestsPerConnection` controls how many produce requests can be outstanding on one broker connection. Idempotent and transactional producers are capped at 5, which is the Kafka protocol limit for sequence tracking.
+
+When idempotence is disabled, Dekaf defaults to 100 in-flight requests per connection so fire-and-forget and `Acks.Leader` workloads can keep the broker pipeline full. With retries enabled, non-idempotent producers using more than 1 in-flight request can reorder messages if an earlier request is retried after a later request succeeds. Set `MaxInFlightRequestsPerConnection` to 1, or keep idempotence enabled, when strict per-partition ordering matters.
+
 ## Error Handling
 
 `ProduceAsync` throws exceptions for delivery failures:

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -775,7 +775,8 @@ internal static class DekafOptionsBinding
         builder.WithLinger(TimeSpan.FromMilliseconds(options.LingerMs));
         builder.WithBatchSize(options.BatchSize);
         builder.WithBufferMemory(options.BufferMemory);
-        builder.WithMaxInFlightRequestsPerConnection(options.MaxInFlightRequestsPerConnection);
+        if (options.EnableIdempotence || options.IsMaxInFlightRequestsPerConnectionConfigured)
+            builder.WithMaxInFlightRequestsPerConnection(options.MaxInFlightRequestsPerConnection);
         builder.WithRetries(options.Retries);
         builder.WithRetryBackoff(TimeSpan.FromMilliseconds(options.RetryBackoffMs));
         builder.WithRetryBackoffMax(TimeSpan.FromMilliseconds(options.RetryBackoffMaxMs));

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -34,7 +34,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private bool _enableTwoPhaseCommit;
     private Protocol.Records.CompressionType _compressionType = Protocol.Records.CompressionType.None;
     private int? _compressionLevel;
-    private int _maxInFlightRequestsPerConnection = 5;
+    private int? _maxInFlightRequestsPerConnection;
     private int _retries = int.MaxValue;
     private int _retryBackoffMs = 100;
     private int _retryBackoffMaxMs = 1000;
@@ -947,6 +947,9 @@ public sealed class ProducerBuilder<TKey, TValue>
     {
         ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfLessThan(maxInFlightRequestsPerConnection, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            maxInFlightRequestsPerConnection,
+            ProducerOptions.MaxAllowedMaxInFlightRequestsPerConnection);
         _maxInFlightRequestsPerConnection = maxInFlightRequestsPerConnection;
         return this;
     }
@@ -1130,6 +1133,10 @@ public sealed class ProducerBuilder<TKey, TValue>
 
         var memoryBudget = _clientInfrastructure?.MemoryBudget ?? DekafMemoryBudget.Global;
 
+        var maxInFlightRequestsPerConnection = ProducerOptions.ResolveMaxInFlightRequestsPerConnection(
+            _maxInFlightRequestsPerConnection,
+            _enableIdempotence);
+
         var options = new ProducerOptions
         {
             BootstrapServers = _bootstrapServers,
@@ -1139,7 +1146,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             BatchSize = _batchSize,
             BufferMemory = _bufferMemory ?? memoryBudget.PreviewProducerLimit(),
             IsAutoTuned = _bufferMemory is null,
-            MaxInFlightRequestsPerConnection = _maxInFlightRequestsPerConnection,
+            MaxInFlightRequestsPerConnection = maxInFlightRequestsPerConnection,
             Retries = _retries,
             RetryBackoffMs = _retryBackoffMs,
             RetryBackoffMaxMs = _retryBackoffMaxMs,

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -81,7 +81,7 @@ internal static class PoolSizing
         var bufferDerivedEntries = (long)maxBatches * InflightEntriesPerBatch;
         var inflightEntries = Math.Max(peakInflightEntries, bufferDerivedEntries);
 
-        var pendingAppends = Math.Clamp(clampedMaxConns * clampedMaxInFlight * 4, 64, 1024);
+        var pendingAppends = (int)Math.Clamp((long)clampedMaxConns * clampedMaxInFlight * 4, 64L, 1024L);
 
         return new ProducerPoolSizes
         {
@@ -95,12 +95,13 @@ internal static class PoolSizing
 
     internal static ConnectionPoolSizes ForConnection(int maxInFlightRequestsPerConnection)
     {
-        var pendingRequests = Math.Clamp(maxInFlightRequestsPerConnection * 4, 64, 1024);
+        var clampedMaxInFlight = Math.Max(1, maxInFlightRequestsPerConnection);
+        var pendingRequests = (int)Math.Clamp((long)clampedMaxInFlight * 4, 64L, 1024L);
 
         return new ConnectionPoolSizes
         {
             PendingRequests = pendingRequests,
-            CancellationTokenSources = Math.Clamp(maxInFlightRequestsPerConnection * 8, 64, 2048),
+            CancellationTokenSources = (int)Math.Clamp((long)clampedMaxInFlight * 8, 64L, 2048L),
         };
     }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -108,6 +108,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private const int MicroLingerMaxSpins = 20;
 
+    /// <summary>
+    /// Maximum batches coalesced into one send-loop pass. The in-flight limit can be very
+    /// high for non-idempotent producers, but coalescing capacity should stay bounded.
+    /// </summary>
+    private const int MaxCoalescedBatchesPerPass = 1024;
+
     private static int s_instanceCounter;
     private readonly int _instanceId = Interlocked.Increment(ref s_instanceCounter);
 
@@ -614,7 +620,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private async Task SendLoopAsync(CancellationToken cancellationToken)
     {
         var eventReader = _eventChannel.Reader;
-        var maxCoalesce = _options.MaxInFlightRequestsPerConnection * 4;
+        var maxCoalesce = (int)Math.Clamp(
+            (long)_options.MaxInFlightRequestsPerConnection * 4,
+            4L,
+            MaxCoalescedBatchesPerPass);
 
         var coalescedPartitions = new HashSet<TopicPartition>();
         var carryOver = new PartitionCarryOver();

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -15,6 +15,10 @@ namespace Dekaf.Producer;
 /// </summary>
 public sealed class ProducerOptions
 {
+    internal const int IdempotentMaxInFlightRequestsPerConnection = 5;
+    internal const int NonIdempotentDefaultMaxInFlightRequestsPerConnection = 100;
+    internal const int MaxAllowedMaxInFlightRequestsPerConnection = 1_000_000;
+
     /// <summary>
     /// Bootstrap servers (host:port,host:port).
     /// </summary>
@@ -150,13 +154,44 @@ public sealed class ProducerOptions
     /// </summary>
     public int? CompressionLevel { get; init; }
 
+    private int _maxInFlightRequestsPerConnection = IdempotentMaxInFlightRequestsPerConnection;
+    private bool _isMaxInFlightRequestsPerConnectionConfigured;
+
     /// <summary>
     /// Maximum in-flight requests per connection.
     /// For idempotent producers (the default), values greater than 1 allow multiple batches
-    /// per partition to be in-flight simultaneously, improving throughput. Ordering is
-    /// guaranteed by Kafka's idempotent sequence numbers. Default is 5.
+    /// per partition to be in-flight simultaneously. Kafka caps idempotent and transactional
+    /// producers at 5. When idempotence is disabled and this value is not explicitly set,
+    /// Dekaf uses 100 to keep the non-idempotent pipeline full.
+    /// <para>
+    /// Non-idempotent producers with retries enabled and more than 1 in-flight request may
+    /// reorder messages if an earlier request is retried after a later one succeeds. Set this
+    /// to 1, or keep idempotence enabled, when strict per-partition ordering matters.
+    /// </para>
     /// </summary>
-    public int MaxInFlightRequestsPerConnection { get; init; } = 5;
+    public int MaxInFlightRequestsPerConnection
+    {
+        get => _maxInFlightRequestsPerConnection;
+        init
+        {
+            _maxInFlightRequestsPerConnection = value;
+            _isMaxInFlightRequestsPerConnectionConfigured = true;
+        }
+    }
+
+    internal bool IsMaxInFlightRequestsPerConnectionConfigured => _isMaxInFlightRequestsPerConnectionConfigured;
+
+    internal static int ResolveMaxInFlightRequestsPerConnection(int? configuredMaxInFlight, bool enableIdempotence)
+    {
+        var maxInFlight = configuredMaxInFlight
+            ?? (enableIdempotence
+                ? IdempotentMaxInFlightRequestsPerConnection
+                : NonIdempotentDefaultMaxInFlightRequestsPerConnection);
+
+        return enableIdempotence
+            ? Math.Min(maxInFlight, IdempotentMaxInFlightRequestsPerConnection)
+            : maxInFlight;
+    }
 
     /// <summary>
     /// Number of connections to maintain per broker for parallel request handling.

--- a/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
@@ -2,6 +2,9 @@ namespace Dekaf.Tests.Unit.Builder;
 
 public class ProducerBuilderValidationTests
 {
+    private const int DefaultIdempotentMaxInFlight = 5;
+    private const int DefaultNonIdempotentMaxInFlight = 100;
+
     #region Build Validation
 
     [Test]
@@ -388,6 +391,58 @@ public class ProducerBuilderValidationTests
     }
 
     [Test]
+    public async Task Build_WithDefaultIdempotence_DefaultsMaxInFlightTo5()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+
+        var options = GetOptions(producer);
+
+        await Assert.That(options.MaxInFlightRequestsPerConnection).IsEqualTo(DefaultIdempotentMaxInFlight);
+    }
+
+    [Test]
+    public async Task Build_WithIdempotenceDisabled_DefaultsMaxInFlightTo100()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithIdempotence(false)
+            .Build();
+
+        var options = GetOptions(producer);
+
+        await Assert.That(options.MaxInFlightRequestsPerConnection).IsEqualTo(DefaultNonIdempotentMaxInFlight);
+    }
+
+    [Test]
+    public async Task Build_WithIdempotenceDisabledAndExplicitMaxInFlight_PreservesValue()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithIdempotence(false)
+            .WithMaxInFlightRequestsPerConnection(12)
+            .Build();
+
+        var options = GetOptions(producer);
+
+        await Assert.That(options.MaxInFlightRequestsPerConnection).IsEqualTo(12);
+    }
+
+    [Test]
+    public async Task Build_WithIdempotenceEnabledAndHighMaxInFlight_CapsAt5()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithMaxInFlightRequestsPerConnection(100)
+            .Build();
+
+        var options = GetOptions(producer);
+
+        await Assert.That(options.MaxInFlightRequestsPerConnection).IsEqualTo(DefaultIdempotentMaxInFlight);
+    }
+
+    [Test]
     public async Task WithIdempotence_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateProducer<string, string>();
@@ -518,4 +573,12 @@ public class ProducerBuilderValidationTests
     }
 
     #endregion
+
+    private static Dekaf.Producer.ProducerOptions GetOptions<TKey, TValue>(
+        Dekaf.Producer.IKafkaProducer<TKey, TValue> producer)
+    {
+        var field = producer.GetType().GetField("_options", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Could not find _options field");
+        return (Dekaf.Producer.ProducerOptions)field.GetValue(producer)!;
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -194,6 +194,53 @@ public class DependencyInjectionTests
     }
 
     [Test]
+    public async Task AddProducer_WithTypedOptionsAndIdempotenceDisabled_UsesNonIdempotentMaxInFlightDefault()
+    {
+        var services = new ServiceCollection();
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["broker1:9092"],
+            EnableIdempotence = false
+        };
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>(options);
+        });
+
+        var provider = services.BuildServiceProvider();
+        var producer = provider.GetRequiredService<IKafkaProducer<string, string>>();
+        var boundOptions = GetProducerOptions(producer);
+
+        await Assert.That(boundOptions.MaxInFlightRequestsPerConnection)
+            .IsEqualTo(ProducerOptions.NonIdempotentDefaultMaxInFlightRequestsPerConnection);
+    }
+
+    [Test]
+    public async Task AddProducer_WithTypedOptionsAndExplicitDefaultMaxInFlight_PreservesValue()
+    {
+        var services = new ServiceCollection();
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["broker1:9092"],
+            EnableIdempotence = false,
+            MaxInFlightRequestsPerConnection = ProducerOptions.IdempotentMaxInFlightRequestsPerConnection
+        };
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>(options);
+        });
+
+        var provider = services.BuildServiceProvider();
+        var producer = provider.GetRequiredService<IKafkaProducer<string, string>>();
+        var boundOptions = GetProducerOptions(producer);
+
+        await Assert.That(boundOptions.MaxInFlightRequestsPerConnection)
+            .IsEqualTo(ProducerOptions.IdempotentMaxInFlightRequestsPerConnection);
+    }
+
+    [Test]
     public async Task AddProducer_WithTypedOptionsAndMismatchedInterceptor_ThrowsInvalidOperationException()
     {
         var services = new ServiceCollection();

--- a/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
@@ -115,6 +115,17 @@ public class PoolSizingTests
         await Assert.That(sizes.InflightEntries).IsLessThanOrEqualTo(16384);
     }
 
+    [Test]
+    public async Task ForProducer_PathologicalMaxInFlight_ClampsPendingAppendsWithoutOverflow()
+    {
+        var sizes = PoolSizing.ForProducer(
+            bufferMemory: 256UL * 1024 * 1024,
+            batchSize: 1024 * 1024,
+            maxInFlightRequestsPerConnection: int.MaxValue);
+
+        await Assert.That(sizes.PendingAppends).IsEqualTo(1024);
+    }
+
     // --- ForConnection tests ---
 
     [Test]
@@ -139,6 +150,15 @@ public class PoolSizingTests
         var sizes = PoolSizing.ForConnection(maxInFlightRequestsPerConnection: 500);
 
         await Assert.That(sizes.PendingRequests).IsLessThanOrEqualTo(1024);
+    }
+
+    [Test]
+    public async Task ForConnection_PathologicalMaxInFlight_ClampsWithoutOverflow()
+    {
+        var sizes = PoolSizing.ForConnection(maxInFlightRequestsPerConnection: int.MaxValue);
+
+        await Assert.That(sizes.PendingRequests).IsEqualTo(1024);
+        await Assert.That(sizes.CancellationTokenSources).IsEqualTo(2048);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- default non-idempotent producer max in-flight requests to 100 while keeping idempotent/transactional producers capped at 5
- cap coalescing and pool sizing math for very high explicit in-flight limits
- document non-idempotent retry reordering caveat

## Test plan
- [x] dotnet build tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --configuration Release
- [x] tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ProducerBuilderValidationTests/*"
- [x] tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PoolSizingTests/*"
- [x] tests\\Dekaf.Tests.Unit\\bin\\Release\\net10.0\\Dekaf.Tests.Unit.exe
- [x] npm run build --prefix docs
- [ ] stress-tests.yml workflow_dispatch after PR CI is available

Closes #1548
