### PR TITLE
Add netstandard package smoke matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
-      - name: Run netstandard2.0 package smoke
-        shell: pwsh
-        run: ./scripts/RunNetStandardPackageSmoke.ps1
-
       - name: Upload HangDump artifacts
         uses: actions/upload-artifact@v7
         if: always()
@@ -108,6 +104,53 @@ jobs:
             **/*.dmp
           if-no-files-found: ignore
           retention-days: 7
+
+  netstandard-package-smoke:
+    name: netstandard2.0 Package Smoke (${{ matrix.framework }})
+    needs: build-and-unit-test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: [net8.0, net10.0]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-quality: 'preview'
+
+      - name: Setup .NET 8 runtime
+        if: matrix.framework == 'net8.0'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Download Packages
+        uses: actions/download-artifact@v8
+        with:
+          name: nuget-packages
+          path: artifacts/downloaded-packages
+
+      - name: Prepare package source
+        shell: pwsh
+        run: |
+          $packageSource = "artifacts/package-source"
+          New-Item -ItemType Directory -Force $packageSource | Out-Null
+          $packages = @(Get-ChildItem "artifacts/downloaded-packages" -Recurse -Filter "*.nupkg")
+          if ($packages.Count -eq 0) {
+              throw "No NuGet packages were downloaded from the build artifact."
+          }
+
+          $packages | Copy-Item -Destination $packageSource -Force
+
+      - name: Run netstandard2.0 package smoke
+        shell: pwsh
+        run: ./scripts/RunNetStandardPackageSmoke.ps1 -PackageSource artifacts/package-source -RunnerFramework ${{ matrix.framework }}
 
   native-aot-smoke:
     name: NativeAOT Smoke (${{ matrix.name }})

--- a/samples/PackageSmoke/Dekaf.PackageSmoke.Runner/Dekaf.PackageSmoke.Runner.csproj
+++ b/samples/PackageSmoke/Dekaf.PackageSmoke.Runner/Dekaf.PackageSmoke.Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/scripts/RunNetStandardPackageSmoke.ps1
+++ b/scripts/RunNetStandardPackageSmoke.ps1
@@ -1,7 +1,9 @@
 [CmdletBinding()]
 param(
     [string]$PackageVersion = '',
-    [string]$Configuration = 'Release'
+    [string]$Configuration = 'Release',
+    [string]$PackageSource = '',
+    [string]$RunnerFramework = 'net10.0'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -44,7 +46,14 @@ function Assert-PackageEntry {
 }
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
-$packageSource = Join-Path $repoRoot "src/Dekaf/bin/$Configuration"
+if ($PackageSource) {
+    $packageSource = (Resolve-Path -LiteralPath $PackageSource).Path
+    $packageSearchRoot = $packageSource
+}
+else {
+    $packageSource = Join-Path $repoRoot "src/Dekaf/bin/$Configuration"
+    $packageSearchRoot = Join-Path $repoRoot 'src'
+}
 
 if (-not (Test-Path -LiteralPath $packageSource)) {
     throw "Package source directory not found: $packageSource"
@@ -60,6 +69,7 @@ if ($PackageVersion) {
 }
 else {
     $corePackage = Get-ChildItem -LiteralPath $packageSource -Filter 'Dekaf.*.nupkg' |
+        Where-Object { $_.BaseName -match '^Dekaf\.\d' } |
         Sort-Object LastWriteTimeUtc -Descending |
         Select-Object -First 1
 
@@ -82,8 +92,8 @@ finally {
     $zip.Dispose()
 }
 
-$otherPackages = Get-ChildItem -Path (Join-Path $repoRoot 'src') -Recurse -Filter 'Dekaf*.nupkg' |
-    Where-Object { $_.FullName -ne $corePackage.FullName }
+$otherPackages = Get-ChildItem -Path $packageSearchRoot -Recurse -Filter 'Dekaf*.nupkg' |
+    Where-Object { $_.FullName -ne $corePackage.FullName -and $_.BaseName -notmatch '^Dekaf\.\d' }
 
 foreach ($package in $otherPackages) {
     $otherZip = [System.IO.Compression.ZipFile]::OpenRead($package.FullName)
@@ -122,9 +132,12 @@ try {
         $smokeProject,
         '--configuration',
         $Configuration,
+        '--framework',
+        $RunnerFramework,
         '--no-restore',
         "-p:DekafPackageVersion=$PackageVersion",
-        '-p:TreatWarningsAsErrors=true'
+        '-p:TreatWarningsAsErrors=true',
+        '-p:EnforceCodeStyleInBuild=false'
     )
 
     Invoke-DotNet -Step 'package smoke run' -Arguments @(
@@ -134,7 +147,7 @@ try {
         '--configuration',
         $Configuration,
         '--framework',
-        'net10.0',
+        $RunnerFramework,
         '--no-build'
     )
 }

--- a/src/Dekaf/Dekaf.csproj
+++ b/src/Dekaf/Dekaf.csproj
@@ -36,6 +36,7 @@
 
   <!-- Compatibility dependencies for the package's netstandard2.0 asset. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageReference Include="Polyfill" Version="10.11.2" PrivateAssets="all" />
     <PackageReference Include="System.IO.Pipelines" Version="10.0.9" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />


### PR DESCRIPTION
## What changed

- Added `net8.0` alongside `net10.0` for the package smoke runner so a modern consumer is forced onto the `Dekaf` `netstandard2.0` package asset.
- Moved the netstandard package smoke check into its own GitHub Actions matrix job that downloads the packages from the build job and runs both framework rows.
- Added `Microsoft.Bcl.AsyncInterfaces` as an explicit `netstandard2.0` dependency of the core package.

## Why

The previous smoke check only ran through a `net10.0` host. That did not cover a lower modern runtime consuming the `netstandard2.0` package asset, and the new `net8.0` smoke caught a missing runtime dependency.

## Root cause

`Dekaf` exposes async interfaces and ValueTask-based APIs from its `netstandard2.0` assembly, but `Microsoft.Bcl.AsyncInterfaces` only arrived transitively through other packages' netstandard dependency groups. A `net8.0` consumer selects those packages' net8 assets, which pruned that dependency and left the `Dekaf` netstandard asset without the runtime assembly it needs.

## Validation

- `dotnet pack src\Dekaf\Dekaf.csproj --configuration Release -p:Version=1.0.1 -p:PackageVersion=1.0.1 -p:TreatWarningsAsErrors=true -p:EnforceCodeStyleInBuild=false`
- `./scripts/RunNetStandardPackageSmoke.ps1 -RunnerFramework net8.0`
- `./scripts/RunNetStandardPackageSmoke.ps1 -RunnerFramework net10.0`
- `./scripts/RunNetStandardPackageSmoke.ps1 -PackageSource src\Dekaf\bin\Release -RunnerFramework net8.0`
- `git diff --check`

Note: local pack used `-p:EnforceCodeStyleInBuild=false` because the installed .NET 11 preview SDK reports broad default style analyzer diagnostics unrelated to this change. The smoke script itself also disables code-style enforcement for the sample build while keeping compiler warnings as errors.


Closes #1543
