### PR TITLE
perf(producer): overlap single-conn writes

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -628,9 +628,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var responseLookup = new Dictionary<(string Topic, int Partition), ProduceResponsePartitionData>();
 
         // Pre-allocate reusable ProduceRequest structures.
-        // The send loop is single-threaded and awaits each send before reusing,
-        // so these can be safely reused without synchronization.
+        // The send loop is single-threaded. Acks.None single-connection sends can be
+        // one write ahead, so that path gets a second scratch slot before reuse.
         var requestScratch = new ProduceRequestScratch(_options, _compressionCodecs, maxCoalesce);
+        var singleConnectionFireAndForgetScratches = _options.Acks == Acks.None
+            ? new[] { requestScratch, new ProduceRequestScratch(_options, _compressionCodecs, maxCoalesce) }
+            : Array.Empty<ProduceRequestScratch>();
 
         // Per-connection scratch and buckets for partition-affined multi-send.
         // When _connectionCount == 1, single scratch and bucket — no grouping overhead.
@@ -644,6 +647,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             connectionBuckets[c].Batches = new ReadyBatch[maxCoalesce];
 
         var sendTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var singleConnectionFireAndForgetTimeoutCts = _options.Acks == Acks.None
+            ? new[]
+            {
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken),
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+            }
+            : Array.Empty<CancellationTokenSource>();
+        var pendingSingleConnectionFireAndForgetSend = default(ValueTask);
+        var hasPendingSingleConnectionFireAndForgetSend = false;
+        var nextSingleConnectionFireAndForgetSlot = 0;
 
         // Pre-allocated array for parallel multi-connection sends. Each entry holds
         // a pending SendConnectionBucketAsync ValueTask so connections can flush concurrently
@@ -667,6 +680,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Zero per-wait allocation: the signal uses an internal reusable timer for the
         // 100ms poll timeout, and this one-time registration handles shutdown cancellation.
         _anyResponseCompleted.RegisterShutdownToken(cancellationToken);
+
+        async ValueTask AwaitPendingSingleConnectionFireAndForgetSendAsync()
+        {
+            if (!hasPendingSingleConnectionFireAndForgetSend)
+                return;
+
+            await pendingSingleConnectionFireAndForgetSend.ConfigureAwait(false);
+            pendingSingleConnectionFireAndForgetSend = default;
+            hasPendingSingleConnectionFireAndForgetSend = false;
+        }
 
         try
         {
@@ -757,6 +780,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         parallelSends = new ValueTask[scaledToCount];
                     }
                 }
+
+                if (_connectionCount > 1)
+                    await AwaitPendingSingleConnectionFireAndForgetSendAsync().ConfigureAwait(false);
 
                 // ── 5. Coalesce ──
                 coalescedPartitions.Clear();
@@ -954,16 +980,51 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             Array.Clear(coalescedBatches, 0, coalescedCount);
                             coalescedCount = 0;
 
-                            if (!sendTimeoutCts.TryReset())
+                            if (_options.Acks == Acks.None)
                             {
-                                sendTimeoutCts.Dispose();
-                                sendTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                            }
-                            sendTimeoutCts.CancelAfter(SendCoalescedTimeoutMs);
+                                var slot = nextSingleConnectionFireAndForgetSlot;
+                                nextSingleConnectionFireAndForgetSlot = 1 - nextSingleConnectionFireAndForgetSlot;
 
-                            await SendCoalescedAsync(batchesToSend, countToSend,
-                                    scratches[0], 0, sendTimeoutCts.Token)
-                                .ConfigureAwait(false);
+                                ResetBucketTimeout(ref singleConnectionFireAndForgetTimeoutCts[slot],
+                                    cancellationToken);
+
+                                var currentSend = SendCoalescedAsync(
+                                    batchesToSend,
+                                    countToSend,
+                                    singleConnectionFireAndForgetScratches[slot],
+                                    0,
+                                    singleConnectionFireAndForgetTimeoutCts[slot].Token);
+
+                                if (hasPendingSingleConnectionFireAndForgetSend)
+                                {
+                                    try
+                                    {
+                                        await pendingSingleConnectionFireAndForgetSend.ConfigureAwait(false);
+                                    }
+                                    catch
+                                    {
+                                        try { await currentSend.ConfigureAwait(false); }
+                                        catch { }
+                                        throw;
+                                    }
+                                }
+
+                                pendingSingleConnectionFireAndForgetSend = currentSend;
+                                hasPendingSingleConnectionFireAndForgetSend = true;
+                            }
+                            else
+                            {
+                                if (!sendTimeoutCts.TryReset())
+                                {
+                                    sendTimeoutCts.Dispose();
+                                    sendTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                                }
+                                sendTimeoutCts.CancelAfter(SendCoalescedTimeoutMs);
+
+                                await SendCoalescedAsync(batchesToSend, countToSend,
+                                        scratches[0], 0, sendTimeoutCts.Token)
+                                    .ConfigureAwait(false);
+                            }
                             sentThisIteration = true;
                         }
                         else
@@ -1065,6 +1126,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 var waitPendingCount = Volatile.Read(ref _totalPendingResponseCount);
                 if (carryOver.Count == 0 && waitPendingCount == 0 && _sendFailedRetries.IsEmpty)
                 {
+                    if (hasPendingSingleConnectionFireAndForgetSend && !eventReader.TryPeek(out _))
+                        await AwaitPendingSingleConnectionFireAndForgetSendAsync().ConfigureAwait(false);
+
                     // Fully idle — wait for any event (new batch, response, unmute).
                     if (!await eventReader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
                         break;
@@ -1138,7 +1202,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         catch (Exception ex) { LogSendLoopFailed(ex, _brokerId); }
         finally
         {
+            try { await AwaitPendingSingleConnectionFireAndForgetSendAsync().ConfigureAwait(false); }
+            catch (Exception ex) { LogSendLoopFailed(ex, _brokerId); }
+
             sendTimeoutCts.Dispose();
+            for (var c = 0; c < singleConnectionFireAndForgetTimeoutCts.Length; c++)
+                singleConnectionFireAndForgetTimeoutCts[c].Dispose();
             for (var c = 0; c < bucketTimeoutCts.Length; c++)
                 bucketTimeoutCts[c].Dispose();
             _eventChannel.Writer.TryComplete();
@@ -2111,11 +2180,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // Add to _pendingResponsesByConnection for the send loop to process inline (like Java's client.poll()).
             // No fire-and-forget — responses are processed in the single-threaded send loop,
             // making retry ordering deterministic by construction.
-            // Use the caller-timeout overload to avoid per-write
-            // CancellationTokenSource + CancellationTokenRegistration allocations.
-            // The cancellationToken already carries BrokerSender's sendTimeoutCts timeout.
-            var responseTask = connection.SendPipelinedWithCallerTimeoutAsync<ProduceRequest, ProduceResponse>(
-                request, (short)apiVersion, cancellationToken);
+            //
+            // Use the connection-owned timeout path for pipelined sends. The send loop can
+            // have multiple responses in flight on this connection; a reusable caller-owned
+            // CTS would let a later send reset or cancel an earlier response timeout.
+            var responseTask = connection.SendPipelinedAsync<ProduceRequest, ProduceResponse>(
+                request, (short)apiVersion, _cts.Token);
 
             // Clear batch references from scratch arrays (see ClearReferences() doc for exception-path semantics)
             scratch.ClearReferences();
@@ -2274,8 +2344,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     /// <summary>
     /// Pre-allocated scratch space for building ProduceRequest without per-send allocations.
-    /// The send loop is single-threaded and awaits each send before reusing, so all
-    /// arrays and objects are safe to reuse without synchronization.
+    /// The send loop is single-threaded; callers keep one scratch per potentially
+    /// outstanding send so arrays and objects are not reused while a write still needs them.
     /// Uses internal array slices so ProduceRequest can serialize scratch data without boxing ArraySegment&lt;T&gt;.
     /// </summary>
     private sealed class ProduceRequestScratch

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -52,14 +52,19 @@ public sealed class BrokerSenderMuteOrderingTests
         connection.IsConnected.Returns(true);
         connection.BrokerId.Returns(1);
 
+        Task<ProduceResponse> DequeueResponse()
+        {
+            var task = responseQueue.Dequeue().Task;
+            onSend?.Invoke();
+            return task;
+        }
+
         connection.SendPipelinedWithCallerTimeoutAsync<ProduceRequest, ProduceResponse>(
                 Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
-            .Returns(_ =>
-            {
-                var task = responseQueue.Dequeue().Task;
-                onSend?.Invoke();
-                return task;
-            });
+            .Returns(_ => DequeueResponse());
+        connection.SendPipelinedAsync<ProduceRequest, ProduceResponse>(
+                Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(_ => DequeueResponse());
 
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -52,14 +52,19 @@ public sealed class BrokerSenderSendLoopTests
         connection.IsConnected.Returns(true);
         connection.BrokerId.Returns(1);
 
+        Task<ProduceResponse> DequeueResponse()
+        {
+            var task = responseQueue.Dequeue().Task;
+            onSend?.Invoke();
+            return task;
+        }
+
         connection.SendPipelinedWithCallerTimeoutAsync<ProduceRequest, ProduceResponse>(
                 Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
-            .Returns(_ =>
-            {
-                var task = responseQueue.Dequeue().Task;
-                onSend?.Invoke();
-                return task;
-            });
+            .Returns(_ => DequeueResponse());
+        connection.SendPipelinedAsync<ProduceRequest, ProduceResponse>(
+                Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(_ => DequeueResponse());
 
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
@@ -143,6 +148,61 @@ public sealed class BrokerSenderSendLoopTests
             rerouteBatch: null,
             onAcknowledgement: onAcknowledgement,
             logger: null);
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task SendLoop_PipelinedProduce_UsesConnectionOwnedTimeoutsForConcurrentSends(CancellationToken cancellationToken)
+    {
+        var tcs1 = new TaskCompletionSource<ProduceResponse>();
+        var tcs2 = new TaskCompletionSource<ProduceResponse>();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
+        responseQueue.Enqueue(tcs1);
+        responseQueue.Enqueue(tcs2);
+
+        var sendCount = 0;
+        var sendSignals = new[] { new TaskCompletionSource(), new TaskCompletionSource() };
+        var (pool, connection) = CreateMockConnection(responseQueue, onSend: () =>
+        {
+            var idx = Interlocked.Increment(ref sendCount) - 1;
+            if (idx < sendSignals.Length)
+                sendSignals[idx].TrySetResult();
+        });
+        var options = CreateOptions(maxInFlight: 5);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+
+        var acknowledgedCount = 0;
+        var allAcknowledged = new TaskCompletionSource();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, ex) =>
+        {
+            if (ex is null && Interlocked.Increment(ref acknowledgedCount) == 2)
+                allAcknowledged.TrySetResult();
+        });
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(vtPool, "test-topic", 0));
+
+            await sendSignals[0].Task.WaitAsync(cancellationToken);
+            sender.Enqueue(CreateTestBatch(vtPool, "test-topic", 1));
+            await sendSignals[1].Task.WaitAsync(cancellationToken);
+
+            await connection.Received(2).SendPipelinedAsync<ProduceRequest, ProduceResponse>(
+                Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
+            await connection.DidNotReceive().SendPipelinedWithCallerTimeoutAsync<ProduceRequest, ProduceResponse>(
+                Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
+
+            tcs1.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 42));
+            tcs2.SetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 43));
+            await allAcknowledged.Task.WaitAsync(cancellationToken);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
 
     [Test]
     [Timeout(120_000)]
@@ -580,6 +640,81 @@ public sealed class BrokerSenderSendLoopTests
 
     [Test]
     [Timeout(120_000)]
+    public async Task SendLoop_FireAndForget_StartsSecondWriteBeforeFirstFlushCompletes(CancellationToken cancellationToken)
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.IsConnected.Returns(true);
+        connection.BrokerId.Returns(1);
+
+        var firstWrite = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondWrite = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondWriteStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sendCount = 0;
+        BrokerSender? sender = null;
+
+        var options = CreateOptions(acks: Acks.None, maxInFlight: 5);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var secondBatch = CreateTestBatch(vtPool, "test-topic", 1);
+
+        connection.SendFireAndForgetWithCallerTimeoutAsync<ProduceRequest, ProduceResponse>(
+                Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var current = Interlocked.Increment(ref sendCount);
+                if (current == 1)
+                {
+                    sender!.Enqueue(secondBatch);
+                    return new ValueTask(firstWrite.Task);
+                }
+
+                if (current == 2)
+                {
+                    secondWriteStarted.TrySetResult();
+                    return new ValueTask(secondWrite.Task);
+                }
+
+                return ValueTask.CompletedTask;
+            });
+
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+
+        var acknowledgedCount = 0;
+        var allAcknowledged = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        sender = CreateSender(pool, options, accumulator, (_, _, _, _, ex) =>
+        {
+            if (ex is null && Interlocked.Increment(ref acknowledgedCount) == 2)
+                allAcknowledged.TrySetResult();
+        });
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(vtPool, "test-topic", 0));
+
+            await secondWriteStarted.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(firstWrite.Task.IsCompleted).IsFalse();
+            await Assert.That(Volatile.Read(ref sendCount)).IsEqualTo(2);
+
+            firstWrite.SetResult();
+            secondWrite.SetResult();
+
+            await allAcknowledged.Task.WaitAsync(cancellationToken);
+        }
+        finally
+        {
+            if (sender is not null)
+                await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
     public async Task SendLoop_FaultedResponseDuringInFlightWait_RetryBatchSurvivesCarryOverSwap(CancellationToken cancellationToken)
     {
         // Regression test for the carry-over list swap bug:
@@ -692,7 +827,7 @@ public sealed class BrokerSenderSendLoopTests
         connection.IsConnected.Returns(true);
         connection.BrokerId.Returns(1);
 
-        connection.SendPipelinedWithCallerTimeoutAsync<ProduceRequest, ProduceResponse>(
+        connection.SendPipelinedAsync<ProduceRequest, ProduceResponse>(
                 Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(successResponse));
 


### PR DESCRIPTION
## Summary
- overlap single-connection `Acks.None` request build with the previous socket write by keeping one fire-and-forget send in flight and awaiting it when the next request is ready
- use a second `ProduceRequestScratch` and timeout CTS slot for the bounded 2-deep single-connection fire-and-forget path, so scratch/timeout reuse stays safe
- keep pipelined produce responses on the connection-owned timeout path so concurrent in-flight sends do not share the send-loop CTS
- strengthen send-loop tests for two concurrent pipelined sends and fire-and-forget write overlap

## Test plan
- [x] dotnet build tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --configuration Release
- [x] dotnet run --project tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --treenode-filter "/*/*/BrokerSenderSendLoopTests/SendLoop_FireAndForget_StartsSecondWriteBeforeFirstFlushCompletes|/*/*/BrokerSenderSendLoopTests/SendLoop_PipelinedProduce_UsesConnectionOwnedTimeoutsForConcurrentSends" --minimum-expected-tests 2 --output Detailed --progress off
- [x] dotnet run --project tests\\Dekaf.Tests.Unit\\Dekaf.Tests.Unit.csproj --configuration Release --no-build -- --output Normal --progress off
- [ ] stress-tests.yml workflow_dispatch after PR CI is available

Closes #1547
