### PR TITLE
Run tests across net8 and net10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,12 @@ concurrency:
 
 jobs:
   build-and-unit-test:
-    name: Build & Unit Test
+    name: Build & Unit Test (${{ matrix.framework }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: [net8.0, net10.0]
     # Declaring permissions drops all other scopes to none; contents:write is the only scope any
     # step here needs (release/tag creation). NuGet push authenticates with an API-key secret, and
     # artifact upload uses the exposed Actions runtime token — neither relies on GITHUB_TOKEN scopes.
@@ -48,6 +52,12 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
           dotnet-quality: 'preview'
+
+      - name: Setup .NET 8 runtime
+        if: matrix.framework == 'net8.0'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v4
@@ -68,9 +78,10 @@ jobs:
 
       - name: Run Pipeline
         env:
+          NET_VERSION: ${{ matrix.framework }}
           SKIP_INTEGRATION_TESTS: 'true'
           SKIP_AOT_SMOKE_TESTS: 'true'
-          NuGet__ShouldPublish: ${{ inputs.publish_nuget == true && 'true' || 'false' }}
+          NuGet__ShouldPublish: ${{ matrix.framework == 'net10.0' && inputs.publish_nuget == true && 'true' || 'false' }}
           NuGet__ApiKey: ${{ secrets.NUGET__APIKEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Used by CreateReleaseModule when a publish ships packages
         run: dotnet run --project tools/Dekaf.Pipeline
@@ -79,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-results-unit
+          name: test-results-unit-${{ matrix.framework }}
           path: |
             **/TestResults/**
             **/test-results/**
@@ -87,6 +98,7 @@ jobs:
 
       - name: Upload Packages
         uses: actions/upload-artifact@v7
+        if: matrix.framework == 'net10.0'
         with:
           name: nuget-packages
           path: |
@@ -99,58 +111,11 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: hangdump-artifacts-${{ matrix.category }}
+          name: hangdump-artifacts-unit-${{ matrix.framework }}
           path: |
             **/*.dmp
           if-no-files-found: ignore
           retention-days: 7
-
-  netstandard-package-smoke:
-    name: netstandard2.0 Package Smoke (${{ matrix.framework }})
-    needs: build-and-unit-test
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        framework: [net8.0, net10.0]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          dotnet-quality: 'preview'
-
-      - name: Setup .NET 8 runtime
-        if: matrix.framework == 'net8.0'
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '8.0.x'
-
-      - name: Download Packages
-        uses: actions/download-artifact@v8
-        with:
-          name: nuget-packages
-          path: artifacts/downloaded-packages
-
-      - name: Prepare package source
-        shell: pwsh
-        run: |
-          $packageSource = "artifacts/package-source"
-          New-Item -ItemType Directory -Force $packageSource | Out-Null
-          $packages = @(Get-ChildItem "artifacts/downloaded-packages" -Recurse -Filter "*.nupkg")
-          if ($packages.Count -eq 0) {
-              throw "No NuGet packages were downloaded from the build artifact."
-          }
-
-          $packages | Copy-Item -Destination $packageSource -Force
-
-      - name: Run netstandard2.0 package smoke
-        shell: pwsh
-        run: ./scripts/RunNetStandardPackageSmoke.ps1 -PackageSource artifacts/package-source -RunnerFramework ${{ matrix.framework }}
 
   native-aot-smoke:
     name: NativeAOT Smoke (${{ matrix.name }})
@@ -237,11 +202,12 @@ jobs:
           retention-days: 7
 
   integration-tests:
-    name: Integration Tests (${{ matrix.category }})
+    name: Integration Tests (${{ matrix.category }}, ${{ matrix.framework }})
     needs: build-and-unit-test
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        framework: [net8.0, net10.0]
         category: [Producer, MultiInFlightProducer, Backpressure, Consumer, ConsumerLag, ConsumerGroup, Transaction, Admin, Authentication, Authorization, Tls, Serialization, Resilience, Messaging, MessagingPatterns, MessagingOrdering, Compression, Offsets, NetworkPartition, Retry, ShareConsumer, ShareConsumerAdmin, Telemetry]
       fail-fast: false
 
@@ -265,6 +231,12 @@ jobs:
           dotnet-version: ${{ env.DOTNET_VERSION }}
           dotnet-quality: 'preview'
 
+      - name: Setup .NET 8 runtime
+        if: matrix.framework == 'net8.0'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Expose GitHub Actions Runtime
         uses: actions/github-script@v9
         with:
@@ -274,6 +246,7 @@ jobs:
 
       - name: Run Pipeline
         env:
+          NET_VERSION: ${{ matrix.framework }}
           INTEGRATION_TEST_CATEGORY: ${{ matrix.category }}
           SKIP_UNIT_TESTS: 'true'
         run: dotnet run --project tools/Dekaf.Pipeline
@@ -282,7 +255,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-results-integration-${{ matrix.category }}
+          name: test-results-integration-${{ matrix.category }}-${{ matrix.framework }}
           path: |
             **/TestResults/**
             **/test-results/**
@@ -292,7 +265,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: hangdump-artifacts-${{ matrix.category }}
+          name: hangdump-artifacts-${{ matrix.category }}-${{ matrix.framework }}
           path: |
             **/*.dmp
           if-no-files-found: ignore

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -129,7 +129,10 @@ public sealed class AvroSchemaRegistrySerializer<
     /// For best performance, use <see cref="WarmupAsync"/> before starting production.
     /// </remarks>
     public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+        , allows ref struct
+#endif
     {
         ArgumentNullException.ThrowIfNull(value);
 
@@ -151,7 +154,10 @@ public sealed class AvroSchemaRegistrySerializer<
         ref TWriter destination,
         int schemaId,
         AvroSerializationThreadState codecState)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+        , allows ref struct
+#endif
     {
         var payloadSizeHint = codecState.PayloadSizeHint;
 
@@ -198,7 +204,10 @@ public sealed class AvroSchemaRegistrySerializer<
         SubjectSchemaIdCache.SubjectSchemaIdCacheEntry schemaEntry,
         int schemaId,
         AvroSerializationThreadState codecState)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+        , allows ref struct
+#endif
     {
         var memoryStream = codecState.BufferedStream;
         memoryStream.ResetForWriting(InitialAvroPayloadBufferSize);

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -74,7 +74,10 @@ public sealed class ProtobufSchemaRegistrySerializer<
 
     /// <inheritdoc />
     public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+        , allows ref struct
+#endif
     {
         ArgumentNullException.ThrowIfNull(value);
 

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -197,7 +197,10 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     }
 
     public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+        , allows ref struct
+#endif
     {
         var schemaEntry = GetSchemaForContext(context.Topic, context.Component == SerializationComponent.Key);
         var schemaId = schemaEntry.SchemaId;

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryKms.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryKms.cs
@@ -248,7 +248,7 @@ public sealed class LocalKmsProvider : ISchemaRegistryKmsProvider
         {
             return ValueTask.FromResult(UnwrapKey(kek, encryptedKeyMaterial.Span));
         }
-        catch (CryptographicException ex)
+        catch (Exception ex) when (ex is CryptographicException or ArgumentException)
         {
             throw new SchemaRegistryKmsException(
                 "Local KMS unwrap failed. The encrypted key material is invalid for the configured KEK.",
@@ -296,7 +296,7 @@ public sealed class LocalKmsProvider : ISchemaRegistryKmsProvider
     }
 
 #if !NET10_0_OR_GREATER
-    private static class AesKeyWrapWithPadding
+    internal static class AesKeyWrapWithPadding
     {
         private const uint AlternativeInitialValuePrefix = 0xA65959A6;
         private const int BlockSize = 8;

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryKms.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryKms.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 
@@ -222,9 +223,7 @@ public sealed class LocalKmsProvider : ISchemaRegistryKmsProvider
 
         try
         {
-            using var aes = Aes.Create();
-            aes.Key = kek;
-            return ValueTask.FromResult(aes.EncryptKeyWrapPadded(keyMaterial.Span));
+            return ValueTask.FromResult(WrapKey(kek, keyMaterial.Span));
         }
         catch (CryptographicException ex)
         {
@@ -247,9 +246,7 @@ public sealed class LocalKmsProvider : ISchemaRegistryKmsProvider
 
         try
         {
-            using var aes = Aes.Create();
-            aes.Key = kek;
-            return ValueTask.FromResult(aes.DecryptKeyWrapPadded(encryptedKeyMaterial.Span));
+            return ValueTask.FromResult(UnwrapKey(kek, encryptedKeyMaterial.Span));
         }
         catch (CryptographicException ex)
         {
@@ -275,6 +272,154 @@ public sealed class LocalKmsProvider : ISchemaRegistryKmsProvider
     }
 
     private static bool IsValidAesKeyLength(int length) => length is 16 or 24 or 32;
+
+    private static byte[] WrapKey(byte[] kek, ReadOnlySpan<byte> keyMaterial)
+    {
+        using var aes = Aes.Create();
+        aes.Key = kek;
+#if NET10_0_OR_GREATER
+        return aes.EncryptKeyWrapPadded(keyMaterial);
+#else
+        return AesKeyWrapWithPadding.Encrypt(aes, keyMaterial);
+#endif
+    }
+
+    private static byte[] UnwrapKey(byte[] kek, ReadOnlySpan<byte> encryptedKeyMaterial)
+    {
+        using var aes = Aes.Create();
+        aes.Key = kek;
+#if NET10_0_OR_GREATER
+        return aes.DecryptKeyWrapPadded(encryptedKeyMaterial);
+#else
+        return AesKeyWrapWithPadding.Decrypt(aes, encryptedKeyMaterial);
+#endif
+    }
+
+#if !NET10_0_OR_GREATER
+    private static class AesKeyWrapWithPadding
+    {
+        private const uint AlternativeInitialValuePrefix = 0xA65959A6;
+        private const int BlockSize = 8;
+        private const int AesBlockSize = 16;
+
+        internal static byte[] Encrypt(Aes aes, ReadOnlySpan<byte> plaintext)
+        {
+            var blockCount = checked((plaintext.Length + BlockSize - 1) / BlockSize);
+            var padded = new byte[checked(blockCount * BlockSize)];
+            plaintext.CopyTo(padded);
+
+            Span<byte> register = stackalloc byte[BlockSize];
+            WriteAlternativeInitialValue(register, plaintext.Length);
+
+            if (blockCount == 1)
+            {
+                Span<byte> block = stackalloc byte[AesBlockSize];
+                register.CopyTo(block);
+                padded.AsSpan().CopyTo(block[BlockSize..]);
+                return aes.EncryptEcb(block, PaddingMode.None);
+            }
+
+            Span<byte> input = stackalloc byte[AesBlockSize];
+            for (var round = 0; round < 6; round++)
+            {
+                for (var blockIndex = 1; blockIndex <= blockCount; blockIndex++)
+                {
+                    register.CopyTo(input);
+                    var currentBlock = padded.AsSpan((blockIndex - 1) * BlockSize, BlockSize);
+                    currentBlock.CopyTo(input[BlockSize..]);
+
+                    var output = aes.EncryptEcb(input, PaddingMode.None);
+                    output.AsSpan(0, BlockSize).CopyTo(register);
+                    XorWrapCounter(register, checked((ulong)(round * blockCount + blockIndex)));
+                    output.AsSpan(BlockSize, BlockSize).CopyTo(currentBlock);
+                }
+            }
+
+            var result = new byte[checked((blockCount + 1) * BlockSize)];
+            register.CopyTo(result);
+            padded.CopyTo(result.AsSpan(BlockSize));
+            return result;
+        }
+
+        internal static byte[] Decrypt(Aes aes, ReadOnlySpan<byte> ciphertext)
+        {
+            if (ciphertext.Length < AesBlockSize || ciphertext.Length % BlockSize != 0)
+                throw new CryptographicException("Invalid AES-KWP ciphertext length.");
+
+            var blockCount = (ciphertext.Length / BlockSize) - 1;
+            Span<byte> register = stackalloc byte[BlockSize];
+            byte[] padded;
+
+            if (blockCount == 1)
+            {
+                var decrypted = aes.DecryptEcb(ciphertext, PaddingMode.None);
+                decrypted.AsSpan(0, BlockSize).CopyTo(register);
+                padded = decrypted.AsSpan(BlockSize, BlockSize).ToArray();
+            }
+            else
+            {
+                ciphertext[..BlockSize].CopyTo(register);
+                padded = ciphertext[BlockSize..].ToArray();
+
+                Span<byte> input = stackalloc byte[AesBlockSize];
+                for (var round = 5; round >= 0; round--)
+                {
+                    for (var blockIndex = blockCount; blockIndex >= 1; blockIndex--)
+                    {
+                        register.CopyTo(input);
+                        XorWrapCounter(input[..BlockSize], checked((ulong)(round * blockCount + blockIndex)));
+
+                        var currentBlock = padded.AsSpan((blockIndex - 1) * BlockSize, BlockSize);
+                        currentBlock.CopyTo(input[BlockSize..]);
+
+                        var output = aes.DecryptEcb(input, PaddingMode.None);
+                        output.AsSpan(0, BlockSize).CopyTo(register);
+                        output.AsSpan(BlockSize, BlockSize).CopyTo(currentBlock);
+                    }
+                }
+            }
+
+            return RemovePadding(register, padded);
+        }
+
+        private static void WriteAlternativeInitialValue(Span<byte> destination, int messageLength)
+        {
+            BinaryPrimitives.WriteUInt32BigEndian(destination, AlternativeInitialValuePrefix);
+            BinaryPrimitives.WriteUInt32BigEndian(destination[4..], checked((uint)messageLength));
+        }
+
+        private static byte[] RemovePadding(ReadOnlySpan<byte> register, ReadOnlySpan<byte> padded)
+        {
+            if (BinaryPrimitives.ReadUInt32BigEndian(register) != AlternativeInitialValuePrefix)
+                throw new CryptographicException("Invalid AES-KWP alternative initial value.");
+
+            var messageLength = BinaryPrimitives.ReadUInt32BigEndian(register[4..]);
+            if (messageLength > padded.Length)
+                throw new CryptographicException("Invalid AES-KWP padding.");
+
+            var paddingLength = padded.Length - (int)messageLength;
+            if (paddingLength > 7)
+                throw new CryptographicException("Invalid AES-KWP padding.");
+
+            foreach (var paddingByte in padded[(int)messageLength..])
+            {
+                if (paddingByte != 0)
+                    throw new CryptographicException("Invalid AES-KWP padding.");
+            }
+
+            return padded[..(int)messageLength].ToArray();
+        }
+
+        private static void XorWrapCounter(Span<byte> register, ulong counter)
+        {
+            for (var index = BlockSize - 1; counter != 0; index--)
+            {
+                register[index] ^= (byte)counter;
+                counter >>= 8;
+            }
+        }
+    }
+#endif
 }
 
 /// <summary>

--- a/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
@@ -107,7 +107,10 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     }
 
     public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+        , allows ref struct
+#endif
     {
         var schemaEntry = GetSchemaForContext(context.Topic, context.Component == SerializationComponent.Key);
         var schemaId = schemaEntry.SchemaId;

--- a/src/Dekaf.Serialization.Json/JsonSerializer.cs
+++ b/src/Dekaf.Serialization.Json/JsonSerializer.cs
@@ -45,7 +45,10 @@ public sealed class JsonSerializer<T> : ISerde<T>
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = JsonSerializerAotMessages.ReflectionBranchJustification)]
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = JsonSerializerAotMessages.ReflectionBranchJustification)]
     public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
-        where TWriter : IBufferWriter<byte>, allows ref struct
+        where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+        , allows ref struct
+#endif
     {
         // Utf8JsonWriter cannot accept the generic TWriter directly because the
         // 'allows ref struct' constraint prevents boxing to IBufferWriter<byte>.

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -123,9 +123,23 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     public IConsumerOffsets Offsets => this;
 
+#if !NET10_0_OR_GREATER
+    IReadOnlyCollection<string> IKafkaConsumer<TKey, TValue>.Subscription => Subscription;
+
+    IReadOnlyCollection<TopicPartition> IKafkaConsumer<TKey, TValue>.Assignment => Assignment;
+
+    IReadOnlyCollection<TopicPartition> IKafkaConsumer<TKey, TValue>.Paused => Paused;
+#endif
+
+#if NET10_0_OR_GREATER
     IReadOnlySet<TopicPartition> IConsumerPartitions.Assignment => Assignment;
 
     IReadOnlySet<TopicPartition> IConsumerPartitions.Paused => Paused;
+#else
+    IReadOnlyCollection<TopicPartition> IConsumerPartitions.Assignment => Assignment;
+
+    IReadOnlyCollection<TopicPartition> IConsumerPartitions.Paused => Paused;
+#endif
 
     public ValueTask InitializeAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -84,6 +84,12 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
 
     public string? MemberId => _memberId;
 
+#if !NET10_0_OR_GREATER
+    IReadOnlyCollection<string> IKafkaShareConsumer<TKey, TValue>.Subscription => Subscription;
+
+    IReadOnlyCollection<TopicPartition> IKafkaShareConsumer<TKey, TValue>.Assignment => Assignment;
+#endif
+
     public ValueTask InitializeAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Dekaf/Dekaf.csproj
+++ b/src/Dekaf/Dekaf.csproj
@@ -32,6 +32,7 @@
     <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
     <PublishAot>false</PublishAot>
     <PolyArgumentExceptions>true</PolyArgumentExceptions>
+    <PolyUseEmbeddedAttribute>true</PolyUseEmbeddedAttribute>
   </PropertyGroup>
 
   <!-- Compatibility dependencies for the package's netstandard2.0 asset. -->

--- a/src/Dekaf/NetStandardPolyfillGaps.cs
+++ b/src/Dekaf/NetStandardPolyfillGaps.cs
@@ -1,6 +1,7 @@
 #if NETSTANDARD2_0
 namespace System.Buffers
 {
+[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
 internal sealed class ArrayBufferWriter<T> : IBufferWriter<T>
 {
     private const int DefaultInitialBufferSize = 256;
@@ -74,6 +75,7 @@ internal sealed class ArrayBufferWriter<T> : IBufferWriter<T>
     }
 }
 
+[global::Microsoft.CodeAnalysis.EmbeddedAttribute]
 internal ref struct SequenceReader<T>
 {
     private readonly ReadOnlySequence<T> _sequence;

--- a/src/Dekaf/NetStandardPolyfillGaps.cs
+++ b/src/Dekaf/NetStandardPolyfillGaps.cs
@@ -377,10 +377,35 @@ internal static class DnsCompat
 
 internal static class GCCompat
 {
+    private static readonly Func<long>? GetRuntimeTotalAvailableMemoryBytes = CreateRuntimeMemoryInfoAccessor();
+
     public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) => new T[length];
 
     public static GCMemoryInfoCompat GetGCMemoryInfo()
-        => new(0);
+        => new(GetRuntimeTotalAvailableMemoryBytes?.Invoke() ?? 0);
+
+    private static Func<long>? CreateRuntimeMemoryInfoAccessor()
+    {
+        var method = typeof(global::System.GC).GetMethod(
+            "GetGCMemoryInfo",
+            global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.Static,
+            binder: null,
+            types: Type.EmptyTypes,
+            modifiers: null);
+
+        var property = method?.ReturnType.GetProperty(
+            "TotalAvailableMemoryBytes",
+            global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.Instance);
+
+        if (method is null || property?.PropertyType != typeof(long))
+            return null;
+
+        return () =>
+        {
+            var value = method.Invoke(obj: null, parameters: null);
+            return value is null ? 0 : (long)property.GetValue(value)!;
+        };
+    }
 }
 
 internal readonly struct GCMemoryInfoCompat

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1941,7 +1941,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         else
         {
 #if NETSTANDARD2_0
-            throw new PlatformNotSupportedException("PEM CA certificate files require net10.0 or later. Use a PFX/P12 CA file for netstandard2.0.");
+            ImportCertificatesFromPemFile(collection, path);
 #else
             // Assume PEM format - can contain multiple certificates
             collection.ImportFromPemFile(path);
@@ -1989,7 +1989,19 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             else
             {
 #if NETSTANDARD2_0
-                throw new PlatformNotSupportedException("PEM client certificates require net10.0 or later. Use a PFX/P12 client certificate for netstandard2.0.");
+                if (!string.IsNullOrEmpty(tlsConfig.ClientKeyPassword))
+                {
+                    throw new PlatformNotSupportedException(
+                        "Encrypted PEM client certificates require net10.0 or later. Use a PFX/P12 client certificate for netstandard2.0.");
+                }
+
+                if (tlsConfig.ClientKeyPath is null)
+                {
+                    throw new InvalidOperationException(
+                        "Client key path is required when using PEM certificate format");
+                }
+
+                cert = CreateCertificateFromPemFile(certPath, tlsConfig.ClientKeyPath);
 #else
                 // PEM format - need separate key file
                 if (tlsConfig.ClientKeyPath is null)
@@ -2010,6 +2022,61 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
         return null;
     }
+
+#if NETSTANDARD2_0
+    private static void ImportCertificatesFromPemFile(X509Certificate2Collection collection, string path)
+    {
+        var method = typeof(X509Certificate2Collection).GetMethod(
+            "ImportFromPemFile",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
+            binder: null,
+            types: [typeof(string)],
+            modifiers: null);
+
+        if (method is null)
+        {
+            throw new PlatformNotSupportedException(
+                "PEM CA certificate files require a runtime with X509Certificate2Collection.ImportFromPemFile support. Use a PFX/P12 CA file instead.");
+        }
+
+        InvokeCertificateApi(() =>
+        {
+            method.Invoke(collection, [path]);
+            return null;
+        });
+    }
+
+    private static X509Certificate2 CreateCertificateFromPemFile(string certPath, string keyPath)
+    {
+        var method = typeof(X509Certificate2).GetMethod(
+            "CreateFromPemFile",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static,
+            binder: null,
+            types: [typeof(string), typeof(string)],
+            modifiers: null);
+
+        if (method is null)
+        {
+            throw new PlatformNotSupportedException(
+                "PEM client certificates require a runtime with X509Certificate2.CreateFromPemFile support. Use a PFX/P12 client certificate instead.");
+        }
+
+        return (X509Certificate2)InvokeCertificateApi(() => method.Invoke(obj: null, parameters: [certPath, keyPath]))!;
+    }
+
+    private static object? InvokeCertificateApi(Func<object?> action)
+    {
+        try
+        {
+            return action();
+        }
+        catch (System.Reflection.TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
+    }
+#endif
 
     private static bool ValidateServerCertificate(
         X509Certificate? certificate,

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -24,20 +24,31 @@ namespace Dekaf.Producer;
 internal sealed class CompatibilitySpinLock
 {
     private readonly object _gate = new();
+    private readonly bool _enableThreadOwnerTracking;
+    private int _ownerThreadId;
 
     public CompatibilitySpinLock(bool enableThreadOwnerTracking = false)
     {
-        _ = enableThreadOwnerTracking;
+        _enableThreadOwnerTracking = enableThreadOwnerTracking;
     }
+
+    public bool IsHeldByCurrentThread =>
+        _enableThreadOwnerTracking && _ownerThreadId == Environment.CurrentManagedThreadId;
 
     public void Enter(ref bool lockTaken)
     {
         Monitor.Enter(_gate);
+        if (_enableThreadOwnerTracking)
+            _ownerThreadId = Environment.CurrentManagedThreadId;
+
         lockTaken = true;
     }
 
     public void Exit()
     {
+        if (_enableThreadOwnerTracking)
+            _ownerThreadId = 0;
+
         Monitor.Exit(_gate);
     }
 }

--- a/src/Dekaf/Security/Sasl/OAuthBearerJwtAssertion.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerJwtAssertion.cs
@@ -289,13 +289,90 @@ internal static class OAuthBearerJwtAssertion
         byte[] signingInput,
         HashAlgorithmName hashAlgorithm)
     {
-#if NETSTANDARD2_0
-        throw new PlatformNotSupportedException("ECDSA JWT-bearer assertions require .NET APIs that are not available on netstandard2.0.");
-#else
         if (key is not ECDsa ecdsa)
             throw new InvalidOperationException("Selected JWT-bearer signing algorithm requires an ECDSA private key");
 
+#if NETSTANDARD2_0
+        var derSignature = ecdsa.SignData(signingInput, hashAlgorithm);
+        return DerEcdsaSignatureToIeeeP1363(derSignature, checked((ecdsa.KeySize + 7) / 8));
+#else
         return ecdsa.SignData(signingInput, hashAlgorithm, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
 #endif
     }
+
+#if NETSTANDARD2_0
+    private static byte[] DerEcdsaSignatureToIeeeP1363(ReadOnlySpan<byte> signature, int componentLength)
+    {
+        if (signature.Length == componentLength * 2)
+            return signature.ToArray();
+
+        var offset = 0;
+        if (ReadDerByte(signature, ref offset) != 0x30)
+            throw new CryptographicException("Invalid ECDSA signature sequence.");
+
+        var sequenceLength = ReadDerLength(signature, ref offset);
+        if (sequenceLength != signature.Length - offset)
+            throw new CryptographicException("Invalid ECDSA signature sequence length.");
+
+        var r = ReadDerInteger(signature, ref offset);
+        var s = ReadDerInteger(signature, ref offset);
+        if (offset != signature.Length)
+            throw new CryptographicException("Invalid trailing ECDSA signature data.");
+
+        var result = new byte[checked(componentLength * 2)];
+        CopyDerIntegerToFixedWidth(r, result.AsSpan(0, componentLength));
+        CopyDerIntegerToFixedWidth(s, result.AsSpan(componentLength, componentLength));
+        return result;
+    }
+
+    private static ReadOnlySpan<byte> ReadDerInteger(ReadOnlySpan<byte> source, ref int offset)
+    {
+        if (ReadDerByte(source, ref offset) != 0x02)
+            throw new CryptographicException("Invalid ECDSA signature integer.");
+
+        var length = ReadDerLength(source, ref offset);
+        if (length <= 0 || source.Length - offset < length)
+            throw new CryptographicException("Invalid ECDSA signature integer length.");
+
+        var value = source.Slice(offset, length);
+        offset += length;
+        return value;
+    }
+
+    private static int ReadDerLength(ReadOnlySpan<byte> source, ref int offset)
+    {
+        var first = ReadDerByte(source, ref offset);
+        if ((first & 0x80) == 0)
+            return first;
+
+        var byteCount = first & 0x7F;
+        if (byteCount is 0 or > 2 || source.Length - offset < byteCount)
+            throw new CryptographicException("Invalid ECDSA signature length.");
+
+        var length = 0;
+        for (var index = 0; index < byteCount; index++)
+            length = (length << 8) | ReadDerByte(source, ref offset);
+
+        return length;
+    }
+
+    private static int ReadDerByte(ReadOnlySpan<byte> source, ref int offset)
+    {
+        if (offset >= source.Length)
+            throw new CryptographicException("Truncated ECDSA signature.");
+
+        return source[offset++];
+    }
+
+    private static void CopyDerIntegerToFixedWidth(ReadOnlySpan<byte> source, Span<byte> destination)
+    {
+        while (source.Length > 0 && source[0] == 0)
+            source = source[1..];
+
+        if (source.Length > destination.Length)
+            throw new CryptographicException("ECDSA signature integer is too large.");
+
+        source.CopyTo(destination[^source.Length..]);
+    }
+#endif
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,11 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
+  <PropertyGroup Condition="'$(MSBuildProjectName)' != 'Dekaf'">
+    <TargetFramework Condition="'$(TargetFramework)' == 'net10.0' and '$(TargetFrameworks)' == ''"></TargetFramework>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net8.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+
   <!--
     Enable trim / Native AOT / single-file analyzers for every shipping library.
     Scoped to .NET 6.0+ target frameworks; IsTrimmable is unsupported on

--- a/tests/Dekaf.Tests.Integration/CustomSerializerErrorTests.cs
+++ b/tests/Dekaf.Tests.Integration/CustomSerializerErrorTests.cs
@@ -23,7 +23,10 @@ public class CustomSerializerErrorTests(KafkaTestContainer kafka) : KafkaIntegra
         public const string TriggerValue = "__THROW__";
 
         public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
-            where TWriter : IBufferWriter<byte>, allows ref struct
+            where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+            , allows ref struct
+#endif
         {
             if (value == TriggerValue)
             {

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -40,7 +40,7 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
 
     public async ValueTask DisposeAsync()
     {
-        foreach (var broker in _brokers.Reverse())
+        foreach (var broker in _brokers.AsEnumerable().Reverse())
         {
             if (broker is not null)
                 await broker.DisposeAsync().ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Integration/RealWorld/ConcurrentAccessPatternTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/ConcurrentAccessPatternTests.cs
@@ -390,10 +390,15 @@ public sealed class ConcurrentAccessPatternTests(KafkaTestContainer kafka) : Kaf
             }
         });
 
-        // Wait for either to signal completion or timeout
-        await Task.WhenAny(
-            Task.WhenAll(consumer1Task, consumer2Task),
-            Task.Delay(TimeSpan.FromSeconds(45)));
+        // Wait for consumers to signal completion or timeout.
+        try
+        {
+            await Task.WhenAll(consumer1Task, consumer2Task).WaitAsync(TimeSpan.FromSeconds(45));
+        }
+        catch (TimeoutException)
+        {
+            // The count assertion below gives the test-specific failure.
+        }
 
         cts.Cancel();
 

--- a/tests/Dekaf.Tests.Integration/Security/OAuthBearerKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/OAuthBearerKafkaContainer.cs
@@ -1,4 +1,3 @@
-using System.Buffers.Text;
 using System.Text;
 using Dekaf.Admin;
 using Dekaf.Security.Sasl;
@@ -113,7 +112,10 @@ public class OAuthBearerKafkaContainer : KafkaTestContainer
     }
 
     private static string Base64UrlEncode(string value) =>
-        Base64Url.EncodeToString(Encoding.UTF8.GetBytes(value));
+        Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
 
     /// <summary>
     /// After the broker is TCP-ready, poll until an OAUTHBEARER-authenticated admin client

--- a/tests/Dekaf.Tests.Integration/Security/TestCertificateGenerator.cs
+++ b/tests/Dekaf.Tests.Integration/Security/TestCertificateGenerator.cs
@@ -121,7 +121,7 @@ internal sealed class TestCertificateGenerator : IDisposable
             DateTimeOffset.UtcNow.AddYears(5));
 
         // Re-import to ensure private key is exportable
-        return X509CertificateLoader.LoadPkcs12(
+        return LoadPkcs12(
             cert.Export(X509ContentType.Pfx, StorePassword),
             StorePassword,
             X509KeyStorageFlags.Exportable);
@@ -199,7 +199,7 @@ internal sealed class TestCertificateGenerator : IDisposable
         using var certWithKey = cert.CopyWithPrivateKey(rsa);
 
         // Re-import to ensure private key is exportable
-        return X509CertificateLoader.LoadPkcs12(
+        return LoadPkcs12(
             certWithKey.Export(X509ContentType.Pfx, StorePassword),
             StorePassword,
             X509KeyStorageFlags.Exportable);
@@ -216,7 +216,7 @@ internal sealed class TestCertificateGenerator : IDisposable
         File.WriteAllBytes(ServerKeystorePath, serverP12);
 
         // Export truststore as PKCS12 (contains CA cert only, no private key)
-        using var caCertOnly = X509CertificateLoader.LoadCertificate(CaCertificate.RawData);
+        using var caCertOnly = LoadCertificate(CaCertificate.RawData);
         var truststoreP12 = caCertOnly.Export(X509ContentType.Pfx, StorePassword);
         File.WriteAllBytes(ServerTruststorePath, truststoreP12);
 
@@ -274,10 +274,28 @@ internal sealed class TestCertificateGenerator : IDisposable
             DateTimeOffset.UtcNow.AddMinutes(-5),
             DateTimeOffset.UtcNow.AddYears(1));
 
-        return X509CertificateLoader.LoadPkcs12(
+        return LoadPkcs12(
             cert.Export(X509ContentType.Pfx, "untrusted"),
             "untrusted",
             X509KeyStorageFlags.Exportable);
+    }
+
+    private static X509Certificate2 LoadCertificate(byte[] rawData)
+    {
+#if NET10_0_OR_GREATER
+        return X509CertificateLoader.LoadCertificate(rawData);
+#else
+        return new X509Certificate2(rawData);
+#endif
+    }
+
+    private static X509Certificate2 LoadPkcs12(byte[] rawData, string? password, X509KeyStorageFlags keyStorageFlags)
+    {
+#if NET10_0_OR_GREATER
+        return X509CertificateLoader.LoadPkcs12(rawData, password, keyStorageFlags);
+#else
+        return new X509Certificate2(rawData, password, keyStorageFlags);
+#endif
     }
 
     public void Dispose()

--- a/tests/Dekaf.Tests.Integration/TimeoutIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/TimeoutIntegrationTests.cs
@@ -108,7 +108,7 @@ public class TimeoutIntegrationTests(KafkaTestContainer kafka) : KafkaIntegratio
 
             // Dispose with timeout to ensure it doesn't hang
             var disposeTask = producer.DisposeAsync().AsTask();
-            var completedInTime = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(35))).ConfigureAwait(false) == disposeTask;
+            var completedInTime = await WaitForCompletionAsync(disposeTask, TimeSpan.FromSeconds(35)).ConfigureAwait(false);
 
             // Assert - Disposal completed within timeout (30s default + 5s buffer)
             await Assert.That(completedInTime).IsTrue();
@@ -392,7 +392,7 @@ public class TimeoutIntegrationTests(KafkaTestContainer kafka) : KafkaIntegratio
 
             // Act - Dispose after failed connection
             var disposeTask = producer.DisposeAsync().AsTask();
-            var completedInTime = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(10))).ConfigureAwait(false) == disposeTask;
+            var completedInTime = await WaitForCompletionAsync(disposeTask, TimeSpan.FromSeconds(10)).ConfigureAwait(false);
 
             // Assert - Should complete within timeout
             await Assert.That(completedInTime).IsTrue();
@@ -911,8 +911,21 @@ public class TimeoutIntegrationTests(KafkaTestContainer kafka) : KafkaIntegratio
         await producer.DisposeAsync().ConfigureAwait(false);
 
         // Assert - Should complete without hanging
-        var completed = await Task.WhenAny(produceTask, Task.Delay(5000)).ConfigureAwait(false) == produceTask;
+        var completed = await WaitForCompletionAsync(produceTask, TimeSpan.FromSeconds(5)).ConfigureAwait(false);
         await Assert.That(completed).IsTrue();
+    }
+
+    private static async Task<bool> WaitForCompletionAsync(Task task, TimeSpan timeout)
+    {
+        try
+        {
+            await task.WaitAsync(timeout).ConfigureAwait(false);
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -1097,12 +1097,13 @@ public sealed class PartitionedConsumerRuntimeTests
         private readonly Queue<ConsumeResult<string, string>> _records = [];
         private readonly HashSet<TopicPartition> _assignment = [];
         private readonly HashSet<TopicPartition> _paused = [];
+        private readonly HashSet<string> _subscription = new(StringComparer.Ordinal);
         private readonly List<IRebalanceListener> _rebalanceListeners = [];
         private readonly SemaphoreSlim _changed = new(0);
         private int _consumeOneCalls;
         private int _consumeBatchCalls;
 
-        public IReadOnlySet<string> Subscription => new HashSet<string>(StringComparer.Ordinal);
+        public IReadOnlySet<string> Subscription => _subscription;
 
         public string? SubscriptionPattern => null;
 
@@ -1155,9 +1156,23 @@ public sealed class PartitionedConsumerRuntimeTests
 
         public ILoggerFactory? LoggerFactory { get; init; }
 
+#if !NET10_0_OR_GREATER
+        IReadOnlyCollection<string> IKafkaConsumer<string, string>.Subscription => Subscription;
+
+        IReadOnlyCollection<TopicPartition> IKafkaConsumer<string, string>.Assignment => Assignment;
+
+        IReadOnlyCollection<TopicPartition> IKafkaConsumer<string, string>.Paused => Paused;
+#endif
+
+#if NET10_0_OR_GREATER
         IReadOnlySet<TopicPartition> IConsumerPartitions.Assignment => Assignment;
 
         IReadOnlySet<TopicPartition> IConsumerPartitions.Paused => Paused;
+#else
+        IReadOnlyCollection<TopicPartition> IConsumerPartitions.Assignment => Assignment;
+
+        IReadOnlyCollection<TopicPartition> IConsumerPartitions.Paused => Paused;
+#endif
 
         IDisposable IConsumerRebalanceEventSource.RegisterRuntimeRebalanceListener(IRebalanceListener listener)
         {

--- a/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsTests.cs
@@ -9,6 +9,7 @@ using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
+[NotInParallel]
 public sealed class QueryWatermarkOffsetsTests
 {
     private const string Topic = "watermark-topic";

--- a/tests/Dekaf.Tests.Unit/Internal/CancellationTokenSourcePoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/CancellationTokenSourcePoolTests.cs
@@ -76,7 +76,15 @@ public class CancellationTokenSourcePoolTests
         cts.CancelAfter(TimeSpan.FromMilliseconds(100));
 
         // Wait for cancellation event with generous timeout
-        var completed = await Task.WhenAny(cancelledTcs.Task, Task.Delay(TimeSpan.FromSeconds(10))) == cancelledTcs.Task;
+        var completed = true;
+        try
+        {
+            await cancelledTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        catch (TimeoutException)
+        {
+            completed = false;
+        }
 
         await Assert.That(completed).IsTrue();
         await Assert.That(cts.IsCancellationRequested).IsTrue();

--- a/tests/Dekaf.Tests.Unit/Producer/PooledBufferWriterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledBufferWriterTests.cs
@@ -384,14 +384,28 @@ public class PooledBufferWriterTests
     {
         var writer = new PooledBufferWriter(initialCapacity: 64);
 
+#if NET10_0_OR_GREATER
         // Test via generic method that accepts IBufferWriter constraint
         var writtenCount = WriteViaInterface(ref writer);
+#else
+        var span = writer.GetSpan(10);
+        span[0] = 42;
+        writer.Advance(1);
+
+        var memory = writer.GetMemory(10);
+        memory.Span[0] = 43;
+        writer.Advance(1);
+
+        var writtenCount = 2;
+#endif
         writer.Dispose();
 
         await Assert.That(writtenCount).IsEqualTo(2);
     }
 
-    private static int WriteViaInterface<T>(ref T writer) where T : IBufferWriter<byte>, allows ref struct
+#if NET10_0_OR_GREATER
+    private static int WriteViaInterface<T>(ref T writer)
+        where T : IBufferWriter<byte>, allows ref struct
     {
         var span = writer.GetSpan(10);
         span[0] = 42;
@@ -405,6 +419,7 @@ public class PooledBufferWriterTests
         // Since we advanced twice by 1, return 2
         return 2;
     }
+#endif
 
     [Test]
     public async Task WrittenCount_ReflectsAllAdvances()

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerAsyncPreparerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerAsyncPreparerTests.cs
@@ -187,7 +187,10 @@ public class ProducerAsyncPreparerTests
             => prepare(cancellationToken);
 
         public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
-            where TWriter : IBufferWriter<byte>, allows ref struct
+            where TWriter : IBufferWriter<byte>
+#if NET10_0_OR_GREATER
+            , allows ref struct
+#endif
             => Serializers.String.Serialize(value, ref destination, context);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3341,7 +3341,7 @@ public class RecordAccumulatorTests
     {
         var partitionDeque = GetPartitionDeque(accumulator, topicPartition);
         var lockField = partitionDeque.GetType().GetField("Lock");
-        lockField!.SetValue(partitionDeque, new SpinLock(enableThreadOwnerTracking: true));
+        lockField!.SetValue(partitionDeque, Activator.CreateInstance(lockField.FieldType, [true]));
     }
 
     private static PendingAppend CreatePendingAppend(RecordAccumulator accumulator, PendingAppendPool pool)
@@ -3437,12 +3437,21 @@ public class RecordAccumulatorTests
 
         public override Span<byte> GetSpan()
         {
-            var partitionLock = (SpinLock)_lockField.GetValue(partitionDeque)!;
-            if (partitionLock.IsHeldByCurrentThread)
+            var partitionLock = _lockField.GetValue(partitionDeque)!;
+            if (IsHeldByCurrentThread(partitionLock))
                 throw new InvalidOperationException("Record encode touched header value while holding the partition lock.");
 
             GetSpanCalls++;
             return buffer;
+        }
+
+        private static bool IsHeldByCurrentThread(object partitionLock)
+        {
+            if (partitionLock is SpinLock spinLock)
+                return spinLock.IsHeldByCurrentThread;
+
+            var property = partitionLock.GetType().GetProperty("IsHeldByCurrentThread");
+            return property is not null && (bool)property.GetValue(partitionLock)!;
         }
 
         public override MemoryHandle Pin(int elementIndex = 0) =>

--- a/tests/Dekaf.Tests.Unit/Protocol/ApiVersionsTaggedFieldsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ApiVersionsTaggedFieldsTests.cs
@@ -9,10 +9,12 @@ namespace Dekaf.Tests.Unit.Protocol;
 /// </summary>
 public sealed class ApiVersionsTaggedFieldsTests
 {
+    private delegate void TaggedFieldsWriter(ref KafkaProtocolWriter writer);
+
     /// <summary>
     /// Builds a minimal ApiVersions v3 response with the given tagged fields appended.
     /// </summary>
-    private static byte[] BuildApiVersionsV3Response(Action<KafkaProtocolWriter>? writeTaggedFields = null)
+    private static byte[] BuildApiVersionsV3Response(TaggedFieldsWriter? writeTaggedFields = null)
     {
         var buffer = new ArrayBufferWriter<byte>();
         var writer = new KafkaProtocolWriter(buffer);
@@ -34,7 +36,7 @@ public sealed class ApiVersionsTaggedFieldsTests
         // Response-level tagged fields
         if (writeTaggedFields is not null)
         {
-            writeTaggedFields(writer);
+            writeTaggedFields(ref writer);
         }
         else
         {
@@ -62,7 +64,7 @@ public sealed class ApiVersionsTaggedFieldsTests
     [Test]
     public async Task V3_SupportedFeatures_Tag0_ParsedCorrectly()
     {
-        var data = BuildApiVersionsV3Response(writer =>
+        var data = BuildApiVersionsV3Response((ref KafkaProtocolWriter writer) =>
         {
             // 1 tagged field
             writer.WriteUnsignedVarInt(1);
@@ -97,7 +99,7 @@ public sealed class ApiVersionsTaggedFieldsTests
     [Test]
     public async Task V3_FinalizedFeaturesEpoch_Tag1_ParsedCorrectly()
     {
-        var data = BuildApiVersionsV3Response(writer =>
+        var data = BuildApiVersionsV3Response((ref KafkaProtocolWriter writer) =>
         {
             writer.WriteUnsignedVarInt(1); // 1 tagged field
             writer.WriteUnsignedVarInt(1); // Tag 1 = FinalizedFeaturesEpoch
@@ -114,7 +116,7 @@ public sealed class ApiVersionsTaggedFieldsTests
     [Test]
     public async Task V3_ZkMigrationReady_Tag3_ParsedCorrectly()
     {
-        var data = BuildApiVersionsV3Response(writer =>
+        var data = BuildApiVersionsV3Response((ref KafkaProtocolWriter writer) =>
         {
             writer.WriteUnsignedVarInt(1); // 1 tagged field
             writer.WriteUnsignedVarInt(3); // Tag 3 = ZkMigrationReady
@@ -131,7 +133,7 @@ public sealed class ApiVersionsTaggedFieldsTests
     [Test]
     public async Task V3_ZkMigrationReady_False()
     {
-        var data = BuildApiVersionsV3Response(writer =>
+        var data = BuildApiVersionsV3Response((ref KafkaProtocolWriter writer) =>
         {
             writer.WriteUnsignedVarInt(1); // 1 tagged field
             writer.WriteUnsignedVarInt(3); // Tag 3 = ZkMigrationReady
@@ -148,7 +150,7 @@ public sealed class ApiVersionsTaggedFieldsTests
     [Test]
     public async Task V3_UnknownTag_SkippedCorrectly()
     {
-        var data = BuildApiVersionsV3Response(writer =>
+        var data = BuildApiVersionsV3Response((ref KafkaProtocolWriter writer) =>
         {
             writer.WriteUnsignedVarInt(1); // 1 tagged field
             writer.WriteUnsignedVarInt(99); // Unknown tag
@@ -167,7 +169,7 @@ public sealed class ApiVersionsTaggedFieldsTests
     [Test]
     public async Task V3_AllTags_ParsedCorrectly()
     {
-        var data = BuildApiVersionsV3Response(writer =>
+        var data = BuildApiVersionsV3Response((ref KafkaProtocolWriter writer) =>
         {
             // 4 tagged fields
             writer.WriteUnsignedVarInt(4);
@@ -213,7 +215,7 @@ public sealed class ApiVersionsTaggedFieldsTests
     [Test]
     public async Task V3_PartialTags_OnlySomePresent()
     {
-        var data = BuildApiVersionsV3Response(writer =>
+        var data = BuildApiVersionsV3Response((ref KafkaProtocolWriter writer) =>
         {
             // Only tag 1 and tag 3
             writer.WriteUnsignedVarInt(2);

--- a/tests/Dekaf.Tests.Unit/Protocol/Crc32CTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/Crc32CTests.cs
@@ -66,6 +66,7 @@ public class Crc32CTests
         }
     }
 
+#if NET10_0_OR_GREATER
     [Test]
     public async Task ComputeHardwareX86_WhenSupported_MatchesBitwiseReference()
     {
@@ -155,6 +156,7 @@ public class Crc32CTests
             await Assert.That(Crc32C.ComputeHardwareArmOptimized(data)).IsEqualTo(expected);
         }
     }
+#endif
 
     private static byte[] CreateDeterministicBytes(int length)
     {

--- a/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolWriterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/KafkaProtocolWriterTests.cs
@@ -158,7 +158,10 @@ public class KafkaProtocolWriterTests
         foreach (var method in methods)
         {
             await Assert.That(method).IsNotNull();
-            await Assert.That(method!.IsDefined(typeof(SkipLocalsInitAttribute), inherit: false)).IsTrue();
+            var hasSkipLocalsInitAttribute = method!.GetCustomAttributes(inherit: false)
+                .Any(attribute => attribute.GetType().FullName == typeof(SkipLocalsInitAttribute).FullName);
+
+            await Assert.That(hasSkipLocalsInitAttribute).IsTrue();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Protocol/TelemetryProtocolMessageTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/TelemetryProtocolMessageTests.cs
@@ -158,13 +158,13 @@ public sealed class TelemetryProtocolMessageTests
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
-        return TRequest.GetRequestHeaderVersion(version);
+        return KafkaMessageMetadata<TRequest, TResponse>.GetRequestHeaderVersion(version);
     }
 
     private static short GetResponseHeaderVersion<TRequest, TResponse>(short version)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
-        return TRequest.GetResponseHeaderVersion(version);
+        return KafkaMessageMetadata<TRequest, TResponse>.GetResponseHeaderVersion(version);
     }
 }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryKmsTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SchemaRegistryKmsTests.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Text;
 using Dekaf.SchemaRegistry;
 
@@ -12,6 +13,9 @@ public sealed class SchemaRegistryKmsTests
         0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
         0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F
     ];
+
+    private static readonly byte[] Rfc5649Kek =
+        Convert.FromHexString("5840DF6E29B02AF1AB493B705BF16EA1AE8338F4DCC176A8");
 
     [Test]
     public async Task LocalKmsProvider_WrapIsDeterministicAndUnwrapRestoresPlaintext()
@@ -28,6 +32,99 @@ public sealed class SchemaRegistryKmsTests
         await Assert.That(wrapped1).IsNotEquivalentTo(plaintext);
         await Assert.That(unwrapped).IsEquivalentTo(plaintext);
     }
+
+    [Test]
+    public async Task LocalKmsProvider_WrapUnwrap_ShortPlaintextRestoresPlaintext()
+    {
+        var provider = CreateLocalProvider();
+        var keyReference = CreateKeyReference();
+        var plaintext = "short"u8.ToArray();
+
+        var wrapped = await provider.WrapKeyAsync(plaintext, keyReference);
+        var unwrapped = await provider.UnwrapKeyAsync(wrapped, keyReference);
+
+        await Assert.That(wrapped.Length).IsEqualTo(16);
+        await Assert.That(unwrapped).IsEquivalentTo(plaintext);
+    }
+
+    [Test]
+    public async Task LocalKmsProvider_UnwrapRejectsTamperedCiphertext()
+    {
+        var provider = CreateLocalProvider();
+        var keyReference = CreateKeyReference();
+        var plaintext = "schema-registry-dek"u8.ToArray();
+        var wrapped = await provider.WrapKeyAsync(plaintext, keyReference);
+        wrapped[0] ^= 0x80;
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            async () => await provider.UnwrapKeyAsync(wrapped, keyReference));
+
+        await Assert.That(exception!.InnerException).IsTypeOf<CryptographicException>();
+    }
+
+    [Test]
+    public async Task LocalKmsProvider_UnwrapRejectsTruncatedCiphertext()
+    {
+        var provider = CreateLocalProvider();
+        var keyReference = CreateKeyReference();
+        var plaintext = "schema-registry-dek"u8.ToArray();
+        var wrapped = await provider.WrapKeyAsync(plaintext, keyReference);
+        var truncated = wrapped[..^1];
+
+        var exception = await Assert.ThrowsAsync<SchemaRegistryKmsException>(
+            async () => await provider.UnwrapKeyAsync(truncated, keyReference));
+
+        await Assert.That(exception!.Message).Contains("invalid");
+    }
+
+#if !NET10_0_OR_GREATER
+    [Test]
+    public async Task AesKeyWrapWithPadding_EncryptDecrypt_MatchesRfc5649TwentyOctetVector()
+    {
+        using var aes = Aes.Create();
+        aes.Key = Rfc5649Kek;
+        var plaintext = Convert.FromHexString("C37B7E6492584340BED12207808941155068F738");
+        var expectedCiphertext = Convert.FromHexString(
+            "138BDEAA9B8FA7FC61F97742E72248EE5AE6AE5360D1AE6A5F54F373FA543B6A");
+
+        var wrapped = LocalKmsProvider.AesKeyWrapWithPadding.Encrypt(aes, plaintext);
+        var unwrapped = LocalKmsProvider.AesKeyWrapWithPadding.Decrypt(aes, wrapped);
+
+        await Assert.That(wrapped).IsEquivalentTo(expectedCiphertext);
+        await Assert.That(unwrapped).IsEquivalentTo(plaintext);
+    }
+
+    [Test]
+    public async Task AesKeyWrapWithPadding_EncryptDecrypt_MatchesRfc5649SevenOctetVector()
+    {
+        using var aes = Aes.Create();
+        aes.Key = Rfc5649Kek;
+        var plaintext = Convert.FromHexString("466F7250617369");
+        var expectedCiphertext = Convert.FromHexString("AFBEB0F07DFBF5419200F2CCB50BB24F");
+
+        var wrapped = LocalKmsProvider.AesKeyWrapWithPadding.Encrypt(aes, plaintext);
+        var unwrapped = LocalKmsProvider.AesKeyWrapWithPadding.Decrypt(aes, wrapped);
+
+        await Assert.That(wrapped).IsEquivalentTo(expectedCiphertext);
+        await Assert.That(unwrapped).IsEquivalentTo(plaintext);
+    }
+
+    [Test]
+    public async Task AesKeyWrapWithPadding_DecryptRejectsInvalidCiphertext()
+    {
+        using var aes = Aes.Create();
+        aes.Key = Rfc5649Kek;
+        var wrapped = Convert.FromHexString("AFBEB0F07DFBF5419200F2CCB50BB24F");
+        var tampered = wrapped.ToArray();
+        tampered[0] ^= 0x80;
+        var truncated = wrapped[..^1];
+
+        await Assert.That(() => LocalKmsProvider.AesKeyWrapWithPadding.Decrypt(aes, tampered))
+            .Throws<CryptographicException>();
+        await Assert.That(() => LocalKmsProvider.AesKeyWrapWithPadding.Decrypt(aes, truncated))
+            .Throws<CryptographicException>();
+    }
+#endif
 
     [Test]
     public async Task ProviderRegistry_WrapUnwrap_RoutesByKmsType()

--- a/tests/Dekaf.Tests.Unit/Security/CertificateLoadingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/CertificateLoadingTests.cs
@@ -163,8 +163,8 @@ public class CertificateLoadingTests : IDisposable
         using var cert = TestCertificateHelper.CreateSelfSignedCertificateWithKey("CN=Test");
         var pfxPath = WriteCertificateToPfx(cert, "test.pfx", "mypassword");
 
-        // Verify the PFX can be loaded with the correct password using modern API
-        using var loadedCert = X509CertificateLoader.LoadPkcs12FromFile(pfxPath, "mypassword");
+        // Verify the PFX can be loaded with the correct password.
+        using var loadedCert = TestCertificateHelper.LoadPkcs12FromFile(pfxPath, "mypassword");
 
         await Assert.That(loadedCert.Subject).IsEqualTo("CN=Test");
         await Assert.That(loadedCert.HasPrivateKey).IsTrue();
@@ -177,7 +177,7 @@ public class CertificateLoadingTests : IDisposable
         var pfxPath = WriteCertificateToPfx(cert, "test.pfx", "correctpassword");
 
         // Verify that wrong password throws
-        await Assert.That(() => X509CertificateLoader.LoadPkcs12FromFile(pfxPath, "wrongpassword"))
+        await Assert.That(() => TestCertificateHelper.LoadPkcs12FromFile(pfxPath, "wrongpassword"))
             .Throws<CryptographicException>();
     }
 

--- a/tests/Dekaf.Tests.Unit/Security/CertificateLoadingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/CertificateLoadingTests.cs
@@ -1,5 +1,7 @@
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using Dekaf.Networking;
 using Dekaf.Security;
 
 namespace Dekaf.Tests.Unit.Security;
@@ -136,6 +138,48 @@ public class CertificateLoadingTests : IDisposable
     }
 
     [Test]
+    public async Task KafkaConnection_LoadCertificatesFromPemFile_LoadsMultipleCerts()
+    {
+        using var ca1 = TestCertificateHelper.CreateSelfSignedCertificate("CN=CA1");
+        using var ca2 = TestCertificateHelper.CreateSelfSignedCertificate("CN=CA2");
+
+        var pemPath = WriteMultipleCertificatesToPem([ca1, ca2], "connection-ca-bundle.pem");
+        var collection = InvokeLoadCertificatesFromFile(pemPath);
+
+        try
+        {
+            await Assert.That(collection.Count).IsEqualTo(2);
+        }
+        finally
+        {
+            foreach (var cert in collection)
+            {
+                cert.Dispose();
+            }
+        }
+    }
+
+    [Test]
+    public async Task KafkaConnection_LoadClientCertificateWithPemFiles_LoadsPrivateKey()
+    {
+        using var clientCert = TestCertificateHelper.CreateSelfSignedCertificateWithKey("CN=Test Client");
+        var (certPath, keyPath) = WriteCertificateAndKeyToPem(clientCert, "connection-client.pem", "connection-client.key");
+
+        await using var connection = new KafkaConnection("localhost", 9092);
+        var loaded = InvokeLoadClientCertificateWithOwnership(
+            connection,
+            new TlsConfig
+            {
+                ClientCertificatePath = certPath,
+                ClientKeyPath = keyPath
+            });
+
+        await Assert.That(loaded).IsNotNull();
+        await Assert.That(loaded!.Subject).IsEqualTo(clientCert.Subject);
+        await Assert.That(loaded.HasPrivateKey).IsTrue();
+    }
+
+    [Test]
     public async Task CreateMutualTls_WithFilePaths_SetsAllPaths()
     {
         // Create test certificates
@@ -226,5 +270,27 @@ public class CertificateLoadingTests : IDisposable
         }
 
         return (certPath, keyPath);
+    }
+
+    private static X509Certificate2Collection InvokeLoadCertificatesFromFile(string path)
+    {
+        var method = typeof(KafkaConnection).GetMethod(
+            "LoadCertificatesFromFile",
+            BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("LoadCertificatesFromFile was not found.");
+
+        return (X509Certificate2Collection)method.Invoke(obj: null, parameters: [path])!;
+    }
+
+    private static X509Certificate2? InvokeLoadClientCertificateWithOwnership(
+        KafkaConnection connection,
+        TlsConfig tlsConfig)
+    {
+        var method = typeof(KafkaConnection).GetMethod(
+            "LoadClientCertificateWithOwnership",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("LoadClientCertificateWithOwnership was not found.");
+
+        return (X509Certificate2?)method.Invoke(connection, [tlsConfig]);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Security/GssapiAuthenticatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/GssapiAuthenticatorTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Errors;
 using Dekaf.Security.Sasl;
 
@@ -49,6 +50,13 @@ public class GssapiAuthenticatorTests
         var config = new GssapiConfig();
         using var authenticator = new GssapiAuthenticator(config, "broker.example.com");
 
+        if (UsesNetStandardGssapiShim())
+        {
+            await Assert.That(() => authenticator.GetInitialResponse())
+                .Throws<PlatformNotSupportedException>();
+            return;
+        }
+
         // First call may succeed or fail depending on Kerberos availability,
         // but we need to handle both cases
         try
@@ -73,6 +81,13 @@ public class GssapiAuthenticatorTests
     {
         var config = new GssapiConfig();
         using var authenticator = new GssapiAuthenticator(config, "broker.example.com");
+
+        if (UsesNetStandardGssapiShim())
+        {
+            await Assert.That(() => authenticator.EvaluateChallenge([]))
+                .Throws<PlatformNotSupportedException>();
+            return;
+        }
 
         var exception = await Assert.That(() => authenticator.EvaluateChallenge([]))
             .Throws<InvalidOperationException>();
@@ -109,6 +124,10 @@ public class GssapiAuthenticatorTests
         {
             // Expected on systems without Kerberos configured
         }
+        catch (PlatformNotSupportedException) when (UsesNetStandardGssapiShim())
+        {
+            // Expected for the netstandard2.0 asset.
+        }
 
         // Dispose should not throw even after authentication attempt
         authenticator.Dispose();
@@ -116,6 +135,9 @@ public class GssapiAuthenticatorTests
         // Test passes if no exception thrown
         return Task.CompletedTask;
     }
+
+    private static bool UsesNetStandardGssapiShim() =>
+        typeof(GssapiAuthenticator).GetField("_auth", BindingFlags.NonPublic | BindingFlags.Instance) is null;
 }
 
 public class GssapiConfigTests

--- a/tests/Dekaf.Tests.Unit/Security/GssapiAuthenticatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/GssapiAuthenticatorTests.cs
@@ -192,6 +192,7 @@ public class GssapiConfigTests
         await Assert.That(config.BuildSpn("broker.example.com")).IsEqualTo("kafka/broker.example.com@EXAMPLE.COM");
     }
 
+#if NET10_0_OR_GREATER
     [Test]
     public async Task CreateClientOptions_DefaultsToKafkaAuthOnly()
     {
@@ -232,6 +233,7 @@ public class GssapiConfigTests
         await Assert.That(options.Credential.Domain).IsEqualTo("REALM.COM");
         await Assert.That(options.TargetName).IsEqualTo("kafka/broker.example.com@REALM.COM");
     }
+#endif
 
     [Test]
     public async Task ValidateForBuild_GssapiWithoutConfig_Throws()

--- a/tests/Dekaf.Tests.Unit/Security/TestCertificateHelper.cs
+++ b/tests/Dekaf.Tests.Unit/Security/TestCertificateHelper.cs
@@ -52,7 +52,25 @@ internal static class TestCertificateHelper
     internal static X509Certificate2 CreateSelfSignedCertificate(string subjectName)
     {
         using var withKey = CreateSelfSignedCertificateWithKey(subjectName);
-        return X509CertificateLoader.LoadCertificate(withKey.RawData);
+        return LoadCertificate(withKey.RawData);
+    }
+
+    internal static X509Certificate2 LoadCertificate(byte[] rawData)
+    {
+#if NET10_0_OR_GREATER
+        return X509CertificateLoader.LoadCertificate(rawData);
+#else
+        return new X509Certificate2(rawData);
+#endif
+    }
+
+    internal static X509Certificate2 LoadPkcs12FromFile(string path, string? password)
+    {
+#if NET10_0_OR_GREATER
+        return X509CertificateLoader.LoadPkcs12FromFile(path, password);
+#else
+        return new X509Certificate2(path, password);
+#endif
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Telemetry/ClientTelemetryManagerTests.cs
@@ -9,6 +9,7 @@ using Dekaf.Telemetry;
 
 namespace Dekaf.Tests.Unit.Telemetry;
 
+[NotInParallel]
 public sealed class ClientTelemetryManagerTests
 {
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/AsyncEnumerableTestExtensions.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/AsyncEnumerableTestExtensions.cs
@@ -1,0 +1,18 @@
+#if !NET10_0_OR_GREATER
+namespace Dekaf.Tests.Unit.Testing;
+
+internal static class AsyncEnumerableTestExtensions
+{
+    internal static async ValueTask<T> FirstAsync<T>(
+        this IAsyncEnumerable<T> source,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+            return item;
+
+        throw new InvalidOperationException("Sequence contains no elements.");
+    }
+}
+#endif

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,6 +2,8 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFramework)' == 'net10.0' and '$(TargetFrameworks)' == ''"></TargetFramework>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net8.0;net10.0</TargetFrameworks>
     <!-- Allow underscores in test method names -->
     <NoWarn>$(NoWarn);CA1707</NoWarn>
     <!-- Enable new Microsoft Testing Platform experience -->

--- a/tools/Dekaf.Pipeline/Modules/RunIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunIntegrationTestsModule.cs
@@ -73,6 +73,7 @@ public abstract class RunIntegrationTestsModule : Module<IReadOnlyList<CommandRe
         // Process-level timeout as safety fallback (matches TestBaseModule pattern)
         using var timeoutCts = new CancellationTokenSource(ProcessTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var framework = TestBaseModule.GetTargetFramework();
 
         try
         {
@@ -81,7 +82,7 @@ public abstract class RunIntegrationTestsModule : Module<IReadOnlyList<CommandRe
                 {
                     NoBuild = true,
                     Configuration = "Release",
-                    Framework = "net10.0",
+                    Framework = framework,
                     Arguments = arguments
                 },
                 new CommandExecutionOptions
@@ -89,7 +90,7 @@ public abstract class RunIntegrationTestsModule : Module<IReadOnlyList<CommandRe
                     WorkingDirectory = project.Folder!.Path,
                     EnvironmentVariables = new Dictionary<string, string?>
                     {
-                        ["NET_VERSION"] = "net10.0",
+                        ["NET_VERSION"] = framework,
                         ["DOTNET_GCConserveMemory"] = "9", // Aggressive GC to reduce memory pressure on CI
                     }
                 },

--- a/tools/Dekaf.Pipeline/Modules/TestBaseModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/TestBaseModule.cs
@@ -21,7 +21,7 @@ public abstract class TestBaseModule : Module<IReadOnlyList<CommandResult>>
         }
     }
 
-    protected static string GetTargetFramework()
+    internal static string GetTargetFramework()
     {
         var framework = Environment.GetEnvironmentVariable("NET_VERSION");
         return string.IsNullOrWhiteSpace(framework) ? "net10.0" : framework;

--- a/tools/Dekaf.Pipeline/Modules/TestBaseModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/TestBaseModule.cs
@@ -17,8 +17,14 @@ public abstract class TestBaseModule : Module<IReadOnlyList<CommandResult>>
     {
         get
         {
-            yield return "net10.0";
+            yield return GetTargetFramework();
         }
+    }
+
+    protected static string GetTargetFramework()
+    {
+        var framework = Environment.GetEnvironmentVariable("NET_VERSION");
+        return string.IsNullOrWhiteSpace(framework) ? "net10.0" : framework;
     }
 
     protected override ModuleConfiguration Configure()


### PR DESCRIPTION
## Summary
- run the unit and integration pipeline rows across `net8.0` and `net10.0`
- move test/source defaults to `TargetFrameworks` so `net8.0` tests consume the `Dekaf` `netstandard2.0` asset
- remove the separate netstandard package smoke job in favor of the full matrix
- keep public signatures intact; net8-specific interface shape fixes are explicit interface implementations or conditional constraints

## Validation
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net8.0 -p:EnforceCodeStyleInBuild=false -p:TreatWarningsAsErrors=true`
- `dotnet build tests\Dekaf.Tests.Unit\Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0 -p:EnforceCodeStyleInBuild=false -p:TreatWarningsAsErrors=true`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release --framework net8.0 -p:EnforceCodeStyleInBuild=false -p:TreatWarningsAsErrors=true`
- `dotnet build tests\Dekaf.Tests.Integration\Dekaf.Tests.Integration.csproj --configuration Release --framework net10.0 -p:EnforceCodeStyleInBuild=false -p:TreatWarningsAsErrors=true`

Full runtime matrix is intended to run in CI.
