### PR TITLE
fix(networking): abort connection when a frame write fails or is cancelled

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -199,6 +199,8 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
     private long _receiveTimeoutDeadlineTimestamp;
     private int _receiveTimeoutExpired;
     private OAuthBearerTokenProvider? _ownedTokenProvider;
+    private readonly object _disposeGate = new();
+    private Task? _disposeTask;
     private int _disposed;
     private int _connected;
     private long _lastUsedTimestampMs = Dekaf.MonotonicClock.GetMilliseconds();
@@ -1014,7 +1016,7 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         // outgoing stream misaligned. Writers already queued on _writeLock must not append
         // another frame to a poisoned stream.
         if (Volatile.Read(ref _disposed) != 0)
-            throw new KafkaException($"Connection to broker {BrokerId} is closed");
+            throw new ObjectDisposedException(nameof(KafkaConnection));
 
 #if DEBUG
         System.Diagnostics.Debug.Assert(!callerOwnsTimeout || cancellationToken.CanBeCanceled,
@@ -1089,21 +1091,25 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
     /// any further request written to it is misparsed by the broker (surfacing as broker-side
     /// InvalidRequestException on PRODUCE, after which the broker closes the socket while the
     /// producer keeps retrying into 30s timeouts). Marking the connection disposed makes the
-    /// ConnectionPool replace it, and disposing the socket unblocks the read pump so the
-    /// receive loop fails all in-flight requests promptly instead of each waiting out its
-    /// request timeout.
+    /// ConnectionPool replace it. Starting full disposal releases the pipe/stream owners and
+    /// unblocks the receive loop so in-flight requests fail promptly instead of each waiting
+    /// out its request timeout.
     /// </summary>
     private void AbortAfterWriteFailure()
     {
-        MarkDisposed();
-        Volatile.Write(ref _connected, 0);
+        var disposeTask = EnsureDisposeStarted();
+        _ = ObserveWriteAbortDisposeAsync(disposeTask);
+    }
+
+    private async Task ObserveWriteAbortDisposeAsync(Task disposeTask)
+    {
         try
         {
-            _socket?.Dispose();
+            await disposeTask.ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            LogWriteAbortSocketDisposeFailed(ex, BrokerId);
+            LogWriteAbortDisposeFailed(ex, BrokerId);
         }
     }
 
@@ -2609,11 +2615,20 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         }
     }
 
-    public async ValueTask DisposeAsync()
-    {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0)
-            return;
+    public ValueTask DisposeAsync()
+        => new(EnsureDisposeStarted());
 
+    private Task EnsureDisposeStarted()
+    {
+        lock (_disposeGate)
+        {
+            return _disposeTask ??= DisposeCoreAsync();
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        MarkDisposed();
         Volatile.Write(ref _connected, 0);
         var pendingRequestSlotOperationsDrained = ClosePendingRequestSlotsAsync();
         CancelPendingRequestSlotWaiters();
@@ -2763,8 +2778,8 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
     [LoggerMessage(Level = LogLevel.Error, Message = "Flush timeout after {Timeout}ms for request {CorrelationId} to broker {BrokerId}")]
     private partial void LogFlushTimeout(double timeout, int correlationId, int brokerId);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to dispose socket while aborting connection to broker {BrokerId} after a write failure")]
-    private partial void LogWriteAbortSocketDisposeFailed(Exception ex, int brokerId);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to dispose connection to broker {BrokerId} after a write failure")]
+    private partial void LogWriteAbortDisposeFailed(Exception ex, int brokerId);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Receive loop started for {Host}:{Port}")]
     private partial void LogReceiveLoopStarted(string host, int port);

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1010,6 +1010,12 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         if (_stream is null)
             throw new InvalidOperationException("Not connected");
 
+        // A previous write on this connection may have been aborted mid-frame, leaving the
+        // outgoing stream misaligned. Writers already queued on _writeLock must not append
+        // another frame to a poisoned stream.
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new KafkaException($"Connection to broker {BrokerId} is closed");
+
 #if DEBUG
         System.Diagnostics.Debug.Assert(!callerOwnsTimeout || cancellationToken.CanBeCanceled,
             "callerOwnsTimeout path requires a timeout-bearing token");
@@ -1031,10 +1037,16 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             // Any OperationCanceledException here means the caller's timeout elapsed.
             catch (OperationCanceledException)
             {
+                AbortAfterWriteFailure();
                 LogFlushTimeout(_options.RequestTimeout.TotalMilliseconds, correlationId, BrokerId);
 
                 throw new KafkaException(
                     $"Flush timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms on connection to broker {BrokerId}");
+            }
+            catch (Exception)
+            {
+                AbortAfterWriteFailure();
+                throw;
             }
         }
         else
@@ -1051,15 +1063,47 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
+                AbortAfterWriteFailure();
                 throw new OperationCanceledException(cancellationToken);
             }
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
+                AbortAfterWriteFailure();
                 LogFlushTimeout(_options.RequestTimeout.TotalMilliseconds, correlationId, BrokerId);
 
                 throw new KafkaException(
                     $"Flush timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms on connection to broker {BrokerId}");
             }
+            catch (Exception)
+            {
+                AbortAfterWriteFailure();
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Marks the connection unusable after a frame write failed or was cancelled. A cancelled
+    /// or faulted <see cref="Stream.WriteAsync(ReadOnlyMemory{byte}, CancellationToken)"/> can
+    /// have transmitted part of the frame, so the outgoing stream is no longer frame-aligned:
+    /// any further request written to it is misparsed by the broker (surfacing as broker-side
+    /// InvalidRequestException on PRODUCE, after which the broker closes the socket while the
+    /// producer keeps retrying into 30s timeouts). Marking the connection disposed makes the
+    /// ConnectionPool replace it, and disposing the socket unblocks the read pump so the
+    /// receive loop fails all in-flight requests promptly instead of each waiting out its
+    /// request timeout.
+    /// </summary>
+    private void AbortAfterWriteFailure()
+    {
+        MarkDisposed();
+        Volatile.Write(ref _connected, 0);
+        try
+        {
+            _socket?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            LogWriteAbortSocketDisposeFailed(ex, BrokerId);
         }
     }
 
@@ -2718,6 +2762,9 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Flush timeout after {Timeout}ms for request {CorrelationId} to broker {BrokerId}")]
     private partial void LogFlushTimeout(double timeout, int correlationId, int brokerId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to dispose socket while aborting connection to broker {BrokerId} after a write failure")]
+    private partial void LogWriteAbortSocketDisposeFailed(Exception ex, int brokerId);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Receive loop started for {Host}:{Port}")]
     private partial void LogReceiveLoopStarted(string host, int port);

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -438,6 +438,24 @@ public sealed class KafkaConnectionTests
     }
 
     [Test]
+    public async Task WriteFailure_DisposeAsyncRunsFullStreamCleanup()
+    {
+        await using var connection = new KafkaConnection("localhost", 9092);
+        var stream = new ThrowingWriteStream();
+        SetPrivateField(connection, "_stream", stream);
+
+        await Assert.That(async () =>
+                await InvokeWritePreSerializedToStreamAsync(connection, [0, 0, 0, 0], CancellationToken.None)
+                    .ConfigureAwait(false))
+            .Throws<IOException>()
+            .WithMessageContaining("write failed");
+
+        await connection.DisposeAsync();
+
+        await Assert.That(stream.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task BuildRemoteCertificateValidationCallback_WhenHostNameValidationDisabled_IgnoresNameMismatchOnly()
     {
         await using var connection = new KafkaConnection(
@@ -574,6 +592,29 @@ public sealed class KafkaConnectionTests
         await ((ValueTask<SaslHandshakeResponse>)result!).ConfigureAwait(false);
     }
 
+    private static async ValueTask InvokeWritePreSerializedToStreamAsync(
+        KafkaConnection connection,
+        byte[] serializedData,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(KafkaConnection).GetMethod(
+            "WritePreSerializedToStreamAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        if (method is null)
+            throw new InvalidOperationException("WritePreSerializedToStreamAsync was not found.");
+
+        var result = method.Invoke(connection,
+        [
+            serializedData,
+            serializedData.Length,
+            1,
+            cancellationToken,
+            false
+        ]);
+
+        await ((ValueTask)result!).ConfigureAwait(false);
+    }
+
     private static RemoteCertificateValidationCallback? InvokeBuildRemoteCertificateValidationCallback(
         KafkaConnection connection)
     {
@@ -667,6 +708,49 @@ public sealed class KafkaConnectionTests
             var buffer = new byte[4];
             BinaryPrimitives.WriteInt32BigEndian(buffer, responseSize);
             return new MemoryStream(buffer);
+        }
+    }
+
+    private sealed class ThrowingWriteStream : Stream
+    {
+        public int DisposeCount { get; private set; }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new IOException("write failed");
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => ValueTask.FromException(new IOException("write failed"));
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                DisposeCount++;
+
+            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
## Root cause (stress run 28907694063)

In the 1-broker producer stress tests, Dekaf sustained **1.52M msg/s (median)** vs Confluent's 1.43M — until ~10 minutes in, when throughput flatlined to ~0 for the rest of the run, dragging the reported average down to 956k. Both single-connection 1-broker producer jobs (fire-and-forget and acks-all) hit it at almost the same offset.

Broker log at the exact stall second:

```
InvalidRequestException: Error getting request for apiKey: PRODUCE, apiVersion: 11 ...
Caused by: java.lang.RuntimeException: Error reading byte array of 120 byte(s): only 0 byte(s) available
```

Sequence:
1. Broker stalls briefly (tmpfs retention burst) → TCP window fills → `_stream.WriteAsync` blocks.
2. The 30s request-timeout token cancels the write **mid-frame**. Part of the frame is already on the wire.
3. `WritePreSerializedToStreamAsync` threw `KafkaException("Flush timeout")` but left the connection in use. Every subsequent request was appended to a misaligned stream → broker misparses → closes socket.
4. Producer wedged in ~30s timeout/retry cycles (visible as 1-second throughput blips every ~30s), 2943 errors, 61s max latency, run overran 900s→953s. Broker disk dropping to ~0 was retention deleting segments because nothing was arriving — symptom, not cause.

## Fix

Any exception from the frame write (timeout, user cancellation, IO failure) now aborts the connection:

- `MarkDisposed()` — the `ConnectionPool` replaces it, and writers already queued on the write lock refuse to append another frame to the poisoned stream (new guard at the top of `WritePreSerializedToStreamAsync`).
- Dispose the socket — unblocks the read pump so the receive loop fails all in-flight requests promptly instead of each waiting out its own request timeout.

This matches the Java client's behavior of disconnecting on request timeout rather than reusing a stream whose alignment is unknown. Covers all request types (produce, fetch, metadata) since everything goes through this write path.

## Expected impact

With the healthy-period rate already above Confluent's, fixing the collapse should flip the 1-broker producer stress tables in Dekaf's favor.

Per instruction, no tests in this PR — the failure needs a >30s broker-side write stall to reproduce, which the existing 15-minute stress runs exercise naturally.