### PR TITLE
fix(networking): never cancel a frame write mid-frame — abandon the wait instead

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -975,119 +975,165 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
     {
         var (serializedArray, serializedLength) = PreSerializeRequest<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion);
         var clearSerializedArray = KafkaMessageMetadata<TRequest, TResponse>.ApiKey == ApiKey.SaslAuthenticate;
-        byte[]? arrayToReturn = serializedArray;
         try
         {
             await SemaphoreHelper.AcquireOrThrowDisposedAsync(_writeLock, nameof(KafkaConnection), cancellationToken)
                 .ConfigureAwait(false);
-            try
-            {
-                await WritePreSerializedToStreamAsync(
-                        serializedArray,
-                        serializedLength,
-                        correlationId,
-                        cancellationToken,
-                        callerOwnsTimeout)
-                    .ConfigureAwait(false);
-            }
-            finally
-            {
-                SemaphoreHelper.ReleaseSafely(_writeLock);
-            }
+        }
+        catch
+        {
+            // Lock never acquired: no bytes written, so the buffer can be returned here.
+            DekafPools.SerializationBuffers.Return(serializedArray, clearArray: clearSerializedArray);
+            throw;
+        }
+
+        // From here the frame write owns both the lock and the buffer; WriteFrameHoldingLockAsync
+        // releases them itself so a timed-out caller can abandon the wait without cancelling the
+        // socket write mid-frame (see AwaitFrameWriteAsync).
+        var writeTask = WriteFrameHoldingLockAsync(serializedArray, serializedLength, clearSerializedArray);
+        await AwaitFrameWriteAsync(writeTask, correlationId, callerOwnsTimeout, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Writes one complete frame while holding the write lock, then releases the lock and
+    /// returns the serialization buffer. The socket write is deliberately not cancellable:
+    /// cancelling <see cref="Stream.WriteAsync(ReadOnlyMemory{byte}, CancellationToken)"/>
+    /// mid-frame can leave a partial frame on the wire, desyncing the outgoing stream so the
+    /// broker misparses it (broker-side InvalidRequestException on PRODUCE followed by a socket
+    /// close). Callers that time out abandon the await instead (<see cref="AwaitFrameWriteAsync"/>);
+    /// the frame finishes in the background and the connection stays frame-aligned and usable.
+    /// </summary>
+    private async Task WriteFrameHoldingLockAsync(byte[] serializedData, int length, bool clearArray)
+    {
+        try
+        {
+            if (_stream is null)
+                throw new InvalidOperationException("Not connected");
+
+            // A previous write on this connection may have faulted mid-frame, leaving the
+            // outgoing stream misaligned. Writers already queued on _writeLock must not append
+            // another frame to a poisoned stream.
+            if (Volatile.Read(ref _disposed) != 0)
+                throw new ObjectDisposedException(nameof(KafkaConnection));
+
+            await _stream.WriteAsync(serializedData.AsMemory(0, length), CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+            // The write faulted (or the connection was already unusable): part of the frame may
+            // have been transmitted, so the outgoing stream can no longer be trusted.
+            AbortAfterWriteFailure();
+            throw;
         }
         finally
         {
-            if (arrayToReturn is not null)
-                DekafPools.SerializationBuffers.Return(arrayToReturn, clearArray: clearSerializedArray);
+            DekafPools.SerializationBuffers.Return(serializedData, clearArray: clearArray);
+            SemaphoreHelper.ReleaseSafely(_writeLock);
         }
     }
 
-    private async ValueTask WritePreSerializedToStreamAsync(
-        byte[] serializedData,
-        int length,
+    /// <summary>
+    /// Awaits a frame write with timeout/cancellation semantics. On timeout or caller
+    /// cancellation the wait is abandoned — never cancelled — so the frame either completes in
+    /// the background (connection stays usable; a transient broker stall no longer tears the
+    /// connection down) or faults (connection aborts). A background observer gives an abandoned
+    /// write one further request timeout to finish before forcibly aborting the connection to
+    /// unblock a socket write stuck on a dead broker.
+    /// </summary>
+    private async ValueTask AwaitFrameWriteAsync(
+        Task writeTask,
         int correlationId,
-        CancellationToken cancellationToken,
-        bool callerOwnsTimeout = false)
+        bool callerOwnsTimeout,
+        CancellationToken cancellationToken)
     {
-        if (_stream is null)
-            throw new InvalidOperationException("Not connected");
-
-        // A previous write on this connection may have been aborted mid-frame, leaving the
-        // outgoing stream misaligned. Writers already queued on _writeLock must not append
-        // another frame to a poisoned stream.
-        if (Volatile.Read(ref _disposed) != 0)
-            throw new ObjectDisposedException(nameof(KafkaConnection));
-
 #if DEBUG
         System.Diagnostics.Debug.Assert(!callerOwnsTimeout || cancellationToken.CanBeCanceled,
             "callerOwnsTimeout path requires a timeout-bearing token");
 #endif
 
-        var memory = serializedData.AsMemory(0, length);
-
-        // Apply timeout to the write operation.
         // When callerOwnsTimeout is true, the caller's cancellationToken already carries
-        // a timeout (e.g. BrokerSender's sendTimeoutCts), so we skip the per-write CTS
-        // rent and CancellationTokenRegistration allocation — a hot-path optimization.
+        // a timeout (e.g. BrokerSender's sendTimeoutCts), so we skip the WaitAsync timer
+        // allocation — a hot-path optimization.
         if (callerOwnsTimeout)
         {
             try
             {
-                await _stream.WriteAsync(memory, cancellationToken).ConfigureAwait(false);
+                await writeTask.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
             // callerOwnsTimeout contract: token fires only on timeout, never explicit user cancellation.
             // Any OperationCanceledException here means the caller's timeout elapsed.
             catch (OperationCanceledException)
             {
-                AbortAfterWriteFailure();
+                AbandonFrameWrite(writeTask, correlationId);
                 LogFlushTimeout(_options.RequestTimeout.TotalMilliseconds, correlationId, BrokerId);
 
                 throw new KafkaException(
                     $"Flush timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms on connection to broker {BrokerId}");
-            }
-            catch (Exception)
-            {
-                AbortAfterWriteFailure();
-                throw;
             }
         }
         else
         {
-            using var timeoutCts = _timeoutCtsPool.Rent();
-            timeoutCts.CancelAfter(_options.RequestTimeout);
-            using var reg = cancellationToken.CanBeCanceled
-                ? cancellationToken.Register(static s => ((CancellationTokenSource)s!).Cancel(), timeoutCts)
-                : default;
-
             try
             {
-                await _stream.WriteAsync(memory, timeoutCts.Token).ConfigureAwait(false);
+                await writeTask.WaitAsync(_options.RequestTimeout, cancellationToken).ConfigureAwait(false);
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException)
             {
-                AbortAfterWriteFailure();
+                AbandonFrameWrite(writeTask, correlationId);
                 throw new OperationCanceledException(cancellationToken);
             }
-            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            catch (TimeoutException)
             {
-                AbortAfterWriteFailure();
+                AbandonFrameWrite(writeTask, correlationId);
                 LogFlushTimeout(_options.RequestTimeout.TotalMilliseconds, correlationId, BrokerId);
 
                 throw new KafkaException(
                     $"Flush timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms on connection to broker {BrokerId}");
             }
-            catch (Exception)
+        }
+    }
+
+    private void AbandonFrameWrite(Task writeTask, int correlationId)
+        => _ = ObserveAbandonedFrameWriteAsync(writeTask, correlationId);
+
+    private async Task ObserveAbandonedFrameWriteAsync(Task writeTask, int correlationId)
+    {
+        try
+        {
+            await writeTask.WaitAsync(_options.RequestTimeout).ConfigureAwait(false);
+
+            // Completed after the caller gave up: the frame is intact, the outgoing stream is
+            // still frame-aligned, and the connection remains usable. Any late response is
+            // dropped by DispatchResponse as an unknown correlation id.
+            LogAbandonedWriteCompleted(correlationId, BrokerId);
+        }
+        catch (TimeoutException)
+        {
+            // Stuck for a full further request timeout: the broker is not draining the socket.
+            // Abort the connection; disposing the socket unblocks the pending write, which then
+            // faults and is observed below.
+            LogAbandonedWriteStuck(_options.RequestTimeout.TotalMilliseconds, correlationId, BrokerId);
+            AbortAfterWriteFailure();
+            try
             {
-                AbortAfterWriteFailure();
-                throw;
+                await writeTask.ConfigureAwait(false);
             }
+            catch
+            {
+                // Exception observed; the connection is already aborted.
+            }
+        }
+        catch
+        {
+            // The write faulted after the caller abandoned it; WriteFrameHoldingLockAsync
+            // already aborted the connection. Nothing to do beyond observing the exception.
         }
     }
 
     /// <summary>
-    /// Marks the connection unusable after a frame write failed or was cancelled. A cancelled
-    /// or faulted <see cref="Stream.WriteAsync(ReadOnlyMemory{byte}, CancellationToken)"/> can
-    /// have transmitted part of the frame, so the outgoing stream is no longer frame-aligned:
+    /// Marks the connection unusable after a frame write faulted or stayed stuck past its grace
+    /// period. A faulted <see cref="Stream.WriteAsync(ReadOnlyMemory{byte}, CancellationToken)"/>
+    /// can have transmitted part of the frame, so the outgoing stream is no longer frame-aligned:
     /// any further request written to it is misparsed by the broker (surfacing as broker-side
     /// InvalidRequestException on PRODUCE, after which the broker closes the socket while the
     /// producer keeps retrying into 30s timeouts). Marking the connection disposed makes the
@@ -2847,6 +2893,12 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to dispose connection to broker {BrokerId} after a write failure")]
     private partial void LogWriteAbortDisposeFailed(Exception ex, int brokerId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Abandoned frame write for request {CorrelationId} to broker {BrokerId} completed; connection remains usable")]
+    private partial void LogAbandonedWriteCompleted(int correlationId, int brokerId);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Abandoned frame write for request {CorrelationId} to broker {BrokerId} still incomplete after a further {Timeout}ms; aborting connection")]
+    private partial void LogAbandonedWriteStuck(double timeout, int correlationId, int brokerId);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Receive loop started for {Host}:{Port}")]
     private partial void LogReceiveLoopStarted(string host, int port);

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -2830,7 +2830,8 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         _reauthTimer?.Dispose();
         _reauthLock.Dispose();
         _connectLock.Dispose();
-        _writeLock.Dispose();
+        // Do not dispose _writeLock here. A frame write may still be unwinding after
+        // stream/socket disposal unblocks it; its finally block must release the lock.
         _timeoutCtsPool.Clear();
         _ownedTokenProvider?.Dispose();
 

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -493,6 +493,37 @@ public sealed class KafkaConnectionTests
     }
 
     [Test]
+    [Timeout(5_000)]
+    public async Task WriteTimeout_AbandonedWriteStuckPastGracePeriod_AbortsConnectionAndReleasesWriteLock(
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new KafkaConnection(
+            "localhost",
+            9092,
+            options: new ConnectionOptions { RequestTimeout = TimeSpan.FromMilliseconds(50) });
+        var stream = new PendingWriteStream();
+        SetPrivateField(connection, "_stream", stream);
+
+        var (writeTask, writeLock) = await StartFrameWriteAsync(connection);
+        await Assert.That(writeTask.IsCompleted).IsFalse();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.That(async () =>
+                await InvokeAwaitFrameWriteAsync(connection, writeTask, callerOwnsTimeout: true, cts.Token))
+            .Throws<KafkaException>()
+            .WithMessageContaining("Flush timeout");
+
+        await TestWait.UntilAsync(() => writeTask.IsCompleted, TimeSpan.FromSeconds(2));
+
+        await Assert.That(GetPrivateField<int>(connection, "_disposed")).IsNotEqualTo(0);
+        await Assert.That(stream.DisposeCount).IsEqualTo(1);
+        await Assert.That(writeTask.IsFaulted).IsTrue();
+        await Assert.That(writeLock.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task BuildRemoteCertificateValidationCallback_WhenHostNameValidationDisabled_IgnoresNameMismatchOnly()
     {
         await using var connection = new KafkaConnection(
@@ -763,6 +794,8 @@ public sealed class KafkaConnectionTests
     {
         private readonly TaskCompletionSource _pendingWrite = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        public int DisposeCount { get; private set; }
+
         public void CompletePendingWrite() => _pendingWrite.TrySetResult();
 
         public override bool CanRead => false;
@@ -792,10 +825,28 @@ public sealed class KafkaConnectionTests
         public override void Write(byte[] buffer, int offset, int count)
             => throw new NotSupportedException();
 
+        public override Task WriteAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken)
+            => _pendingWrite.Task;
+
         // Deliberately ignores cancellationToken: models an in-flight socket send stalled
         // on a full TCP window, which the connection must never cancel mid-frame.
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
             => new(_pendingWrite.Task);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeCount++;
+                _pendingWrite.TrySetException(new IOException("write aborted"));
+            }
+
+            base.Dispose(disposing);
+        }
     }
 
     private sealed class ThrowingWriteStream : Stream

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -444,15 +444,52 @@ public sealed class KafkaConnectionTests
         var stream = new ThrowingWriteStream();
         SetPrivateField(connection, "_stream", stream);
 
-        await Assert.That(async () =>
-                await InvokeWritePreSerializedToStreamAsync(connection, [0, 0, 0, 0], CancellationToken.None)
-                    .ConfigureAwait(false))
+        var (writeTask, writeLock) = await StartFrameWriteAsync(connection);
+
+        await Assert.That(async () => await writeTask)
             .Throws<IOException>()
             .WithMessageContaining("write failed");
+
+        // A faulted frame write may have left partial bytes on the wire: the connection
+        // must abort itself and release the write lock.
+        await Assert.That(GetPrivateField<int>(connection, "_disposed")).IsNotEqualTo(0);
+        await Assert.That(writeLock.CurrentCount).IsEqualTo(1);
 
         await connection.DisposeAsync();
 
         await Assert.That(stream.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task WriteTimeout_AbandonedWriteCompletes_ConnectionStaysUsable()
+    {
+        await using var connection = new KafkaConnection("localhost", 9092);
+        var stream = new PendingWriteStream();
+        SetPrivateField(connection, "_stream", stream);
+
+        var (writeTask, writeLock) = await StartFrameWriteAsync(connection);
+        await Assert.That(writeTask.IsCompleted).IsFalse();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // The caller's timeout fires while the frame is in flight: the wait is abandoned,
+        // but the socket write itself must never be cancelled mid-frame.
+        await Assert.That(async () =>
+                await InvokeAwaitFrameWriteAsync(connection, writeTask, callerOwnsTimeout: true, cts.Token))
+            .Throws<KafkaException>()
+            .WithMessageContaining("Flush timeout");
+
+        await Assert.That(writeTask.IsCompleted).IsFalse();
+        await Assert.That(GetPrivateField<int>(connection, "_disposed")).IsEqualTo(0);
+
+        // The stalled write drains after the caller gave up: the frame is intact, so the
+        // connection stays frame-aligned and usable instead of being torn down.
+        stream.CompletePendingWrite();
+        await writeTask;
+
+        await Assert.That(GetPrivateField<int>(connection, "_disposed")).IsEqualTo(0);
+        await Assert.That(writeLock.CurrentCount).IsEqualTo(1);
     }
 
     [Test]
@@ -592,26 +629,37 @@ public sealed class KafkaConnectionTests
         await ((ValueTask<SaslHandshakeResponse>)result!).ConfigureAwait(false);
     }
 
-    private static async ValueTask InvokeWritePreSerializedToStreamAsync(
+    private static async Task<(Task WriteTask, SemaphoreSlim WriteLock)> StartFrameWriteAsync(KafkaConnection connection)
+    {
+        // WriteFrameHoldingLockAsync expects the caller to have acquired the write lock;
+        // it releases the lock and returns the pooled buffer itself.
+        var writeLock = GetPrivateField<SemaphoreSlim>(connection, "_writeLock");
+        await writeLock.WaitAsync();
+
+        var buffer = DekafPools.SerializationBuffers.Rent(16);
+        var method = typeof(KafkaConnection).GetMethod(
+            "WriteFrameHoldingLockAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        if (method is null)
+            throw new InvalidOperationException("WriteFrameHoldingLockAsync was not found.");
+
+        var writeTask = (Task)method.Invoke(connection, [buffer, 4, false])!;
+        return (writeTask, writeLock);
+    }
+
+    private static async ValueTask InvokeAwaitFrameWriteAsync(
         KafkaConnection connection,
-        byte[] serializedData,
+        Task writeTask,
+        bool callerOwnsTimeout,
         CancellationToken cancellationToken)
     {
         var method = typeof(KafkaConnection).GetMethod(
-            "WritePreSerializedToStreamAsync",
+            "AwaitFrameWriteAsync",
             BindingFlags.NonPublic | BindingFlags.Instance);
         if (method is null)
-            throw new InvalidOperationException("WritePreSerializedToStreamAsync was not found.");
+            throw new InvalidOperationException("AwaitFrameWriteAsync was not found.");
 
-        var result = method.Invoke(connection,
-        [
-            serializedData,
-            serializedData.Length,
-            1,
-            cancellationToken,
-            false
-        ]);
-
+        var result = method.Invoke(connection, [writeTask, 1, callerOwnsTimeout, cancellationToken]);
         await ((ValueTask)result!).ConfigureAwait(false);
     }
 
@@ -709,6 +757,45 @@ public sealed class KafkaConnectionTests
             BinaryPrimitives.WriteInt32BigEndian(buffer, responseSize);
             return new MemoryStream(buffer);
         }
+    }
+
+    private sealed class PendingWriteStream : Stream
+    {
+        private readonly TaskCompletionSource _pendingWrite = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void CompletePendingWrite() => _pendingWrite.TrySetResult();
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        // Deliberately ignores cancellationToken: models an in-flight socket send stalled
+        // on a full TCP window, which the connection must never cancel mid-frame.
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => new(_pendingWrite.Task);
     }
 
     private sealed class ThrowingWriteStream : Stream


### PR DESCRIPTION
Fixes #1559

## Problem

#1555 stopped a torn frame from poisoning subsequent writes, but the torn frame itself still hit the wire: a request timeout cancelled `Stream.WriteAsync` mid-frame, so the broker always saw a partial PRODUCE frame (`InvalidRequestException: Error reading byte array of 120 byte(s): only 0 byte(s) available`, socket closed), and any transient broker stall cost the whole connection plus all in-flight requests. Reproduced in stress run 28911368290 with #1555 merged: 1069 errors at minute ~14, throughput dip on reconnect.

## Fix

Frame writes are no longer cancellable. `WriteFrameHoldingLockAsync` writes the complete frame with `CancellationToken.None` while holding the write lock, and owns lock release + pooled buffer return. Timeout/cancellation semantics move to `AwaitFrameWriteAsync`, which **abandons the wait instead of cancelling the write** (`Task.WaitAsync`):

- Write completes late → stream still frame-aligned, connection stays usable, zero errors. A transient stall (the stress-run case) no longer tears the connection down. Late responses are already dropped by `DispatchResponse` as unknown correlation ids.
- Write faults → `AbortAfterWriteFailure()` as before (partial frame may be on the wire).
- Write stuck past a further request-timeout grace period → background observer force-aborts the connection; disposing the socket unblocks the pending write on a dead broker.

Caller-visible exceptions are unchanged (`KafkaException` flush timeout / `OperationCanceledException`). The non-`callerOwnsTimeout` path drops the pooled CTS + registration in favour of `WaitAsync(timeout, token)`.

## Tests

- `WriteTimeout_AbandonedWriteCompletes_ConnectionStaysUsable` — deterministic (TCS-backed stream, no delays): caller times out, write must not be cancelled, connection must not be disposed once the write drains, write lock released exactly once.
- `WriteFailure_DisposeAsyncRunsFullStreamCleanup` — rewired to the new entry point; now also asserts the faulted write self-aborts the connection and releases the lock.

Behaviour change to note: a genuinely dead broker now costs one extra request timeout (grace period) before the connection is replaced; a transiently stalled broker costs nothing instead of a connection teardown.