### PR TITLE
feat(stress): fail the run when any message is dropped or lost

### DIFF
--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -196,7 +196,52 @@ public static class Program
         Console.WriteLine();
         Console.WriteLine(MarkdownReporter.Generate(allResults));
 
-        return 0;
+        return CheckForMessageLoss(results) ? 1 : 0;
+    }
+
+    /// <summary>
+    /// The stress environment (healthy broker, tmpfs logs, no restarts) never justifies a
+    /// dropped message, so any produce/consume error or any accepted-but-never-delivered
+    /// message is a correctness bug and fails the run. Delivered can legitimately exceed
+    /// accepted-minus-errors when non-idempotent retries duplicate a batch, so only the
+    /// shortfall counts as loss. Results are already saved at this point; the non-zero
+    /// exit only fails the CI job.
+    /// </summary>
+    private static bool CheckForMessageLoss(List<StressTestResult> results)
+    {
+        var failures = new List<string>();
+
+        foreach (var result in results)
+        {
+            var errors = result.Throughput.TotalErrors;
+            if (errors > 0)
+            {
+                failures.Add($"{result.Client} {result.Scenario}: {errors:N0} errors");
+            }
+
+            if (result.DeliveredMessages is { } delivered)
+            {
+                var lost = result.Throughput.TotalMessages - delivered - errors;
+                if (lost > 0)
+                {
+                    failures.Add($"{result.Client} {result.Scenario}: {lost:N0} messages accepted but never delivered");
+                }
+            }
+        }
+
+        if (failures.Count == 0)
+        {
+            return false;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("MESSAGE LOSS DETECTED — failing the run:");
+        foreach (var failure in failures)
+        {
+            Console.WriteLine($"  {failure}");
+        }
+
+        return true;
     }
 
     private static async Task SeedConsumerTopicAsync(string bootstrapServers, string topic, CliOptions options)


### PR DESCRIPTION
Stress runs now exit non-zero when any scenario reports message loss, failing the CI job:

- **Errors > 0** — the stress environment (healthy broker, tmpfs logs, no restarts) never justifies a failed delivery, so any produce/consume error is a correctness bug. Run 28911368290 published Dekaf FnF with 1,069 errors as a normal table row; with this gate that run goes red instead.
- **Silent loss** — messages accepted by the client but never confirmed by the broker end-offset delta (`accepted - delivered - errors > 0`). Delivered can legitimately exceed accepted-minus-errors when non-idempotent retries duplicate a batch, so only the shortfall counts.

The check runs after results are saved, and the workflow uploads artifacts and generates the summary with `if: always()`, so diagnostics remain available on failed runs. `publish-to-docs` already requires `stress-test` success, so a lossy run no longer updates the public benchmark tables — same policy as the existing broker-died guard.

Related: #1559 (the torn-frame bug this gate would have caught), #1562 (the fix).