### PR TITLE
feat(stress): report median interval throughput

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -1,6 +1,8 @@
 """Shared utilities for stress test result reporting."""
 
 from collections import defaultdict
+from math import isfinite
+from statistics import median
 
 SCENARIO_TITLES = {
     'producer': 'Producer (Fire-and-Forget)',
@@ -50,10 +52,36 @@ def format_bytes(num_bytes):
         return f"{num_bytes / (1024 * 1024 * 1024):.2f} GB"
 
 
-def format_cpu_columns(result):
-    """Format the serialized CPU-per-message / cores-used values, or '-' when not recorded."""
+def cpu_micros_per_message(result):
+    """CPU microseconds per message, derived when older result files omit it."""
     cpu_us_per_msg = result.get('cpuMicrosPerMessage')
+    if cpu_us_per_msg is not None:
+        return cpu_us_per_msg
+
+    cpu_time_seconds = result.get('cpuTimeSeconds')
+    total_messages = result.get('throughput', {}).get('totalMessages', 0)
+    if cpu_time_seconds is None or not total_messages:
+        return None
+    return cpu_time_seconds * 1_000_000 / total_messages
+
+
+def average_cores_used(result):
+    """Average cores used, derived when older result files omit it."""
     cores_used = result.get('averageCoresUsed')
+    if cores_used is not None:
+        return cores_used
+
+    cpu_time_seconds = result.get('cpuTimeSeconds')
+    elapsed_seconds = result.get('throughput', {}).get('elapsedSeconds', 0)
+    if cpu_time_seconds is None or not elapsed_seconds:
+        return None
+    return cpu_time_seconds / elapsed_seconds
+
+
+def format_cpu_columns(result):
+    """Format CPU-per-message / cores-used values, or '-' when not recorded."""
+    cpu_us_per_msg = cpu_micros_per_message(result)
+    cores_used = average_cores_used(result)
     return (
         f"{cpu_us_per_msg:.2f}" if cpu_us_per_msg is not None else '-',
         f"{cores_used:.2f}" if cores_used is not None else '-',
@@ -76,6 +104,32 @@ def effective_mb_rate(result):
     if rate is not None:
         return rate
     return result.get('throughput', {}).get('averageMegabytesPerSecond', 0)
+
+
+def accepted_messages_per_second(result):
+    """Client-side mean rate for producer results with delivered throughput."""
+    accepted = result.get('acceptedMessagesPerSecond')
+    if accepted is not None:
+        return accepted
+    if result.get('deliveredMessages') is not None:
+        return result.get('throughput', {}).get('averageMessagesPerSecond')
+    return None
+
+
+def median_interval_rate(result):
+    """Median sampled client-side interval throughput, or None for old result files."""
+    rate = result.get('medianIntervalMessagesPerSecond')
+    if rate is not None:
+        return rate
+
+    samples = result.get('throughput', {}).get('messagesPerSecondSamples') or []
+    finite_samples = [
+        sample for sample in samples
+        if isinstance(sample, (int, float)) and isfinite(sample)
+    ]
+    if not finite_samples:
+        return None
+    return median(finite_samples)
 
 
 def allocated_per_message(result):
@@ -102,6 +156,14 @@ def find_confluent_baseline(results):
     return min((effective_rate(r) or 1 for r in results), default=1)
 
 
+def throughput_sort_key(result):
+    """CPU efficiency leads current reports; old results without CPU keep throughput order."""
+    cpu_us_per_msg = cpu_micros_per_message(result)
+    if cpu_us_per_msg is not None:
+        return 0, cpu_us_per_msg, -effective_rate(result)
+    return 1, 0, -effective_rate(result)
+
+
 def format_throughput_table(results, title, include_ratio=False):
     """Generate a markdown throughput table for a single scenario group."""
     if not results:
@@ -115,32 +177,38 @@ def format_throughput_table(results, title, include_ratio=False):
     lines.append("")
 
     if include_ratio:
-        lines.append("| Client | Messages/sec | MB/sec | Accepted msg/s | Errors | CPU μs/msg | Cores Used | Ratio |")
-        lines.append("|--------|--------------|--------|----------------|--------|------------|------------|-------|")
+        lines.append("| Client | CPU μs/msg | Messages/sec | Median msg/s | MB/sec | Accepted msg/s | Errors | Cores Used | Thru Ratio |")
+        lines.append("|--------|------------|--------------|--------------|--------|----------------|--------|------------|------------|")
     else:
-        lines.append("| Client | Messages/sec | MB/sec | Accepted msg/s | Errors | CPU μs/msg | Cores Used |")
-        lines.append("|--------|--------------|--------|----------------|--------|------------|------------|")
+        lines.append("| Client | CPU μs/msg | Messages/sec | Median msg/s | MB/sec | Accepted msg/s | Errors | Cores Used |")
+        lines.append("|--------|------------|--------------|--------------|--------|----------------|--------|------------|")
 
     baseline = find_confluent_baseline(results) if include_ratio else 0
-    sorted_results = sorted(results, key=effective_rate, reverse=True)
+    sorted_results = sorted(results, key=throughput_sort_key)
 
     for r in sorted_results:
         client = r.get('client', 'Unknown')
         throughput = r.get('throughput', {})
         msg_sec = effective_rate(r)
         mb_sec = effective_mb_rate(r)
-        accepted_rate = r.get('acceptedMessagesPerSecond')
+        median_rate = median_interval_rate(r)
+        median_msg_sec = f"{median_rate:,.0f}" if median_rate is not None else '-'
+        accepted_rate = accepted_messages_per_second(r)
         accepted = f"{accepted_rate:,.0f}" if accepted_rate is not None else '-'
         errors = throughput.get('totalErrors', 0)
         cpu_us_per_msg, cores_used = format_cpu_columns(r)
 
         if include_ratio:
             ratio = msg_sec / baseline if baseline > 0 else 1.0
-            lines.append(f"| {client} | {msg_sec:,.0f} | {mb_sec:.2f} | {accepted} | {errors} | {cpu_us_per_msg} | {cores_used} | {ratio:.2f}x |")
+            lines.append(f"| {client} | {cpu_us_per_msg} | {msg_sec:,.0f} | {median_msg_sec} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} | {ratio:.2f}x |")
         else:
-            lines.append(f"| {client} | {msg_sec:,.0f} | {mb_sec:.2f} | {accepted} | {errors} | {cpu_us_per_msg} | {cores_used} |")
+            lines.append(f"| {client} | {cpu_us_per_msg} | {msg_sec:,.0f} | {median_msg_sec} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} |")
 
     lines.append("")
+
+    if any(median_interval_rate(r) is not None for r in results):
+        lines.append("*Median msg/s is the median sampled client-side throughput interval; it shows steady-state throughput without letting a short late-run stall dominate the whole-run average.*")
+        lines.append("")
 
     if any(r.get('deliveredMessages') is not None for r in results):
         lines.append("*Messages/sec counts broker-confirmed deliveries (end-offset delta). "
@@ -165,16 +233,32 @@ def format_comparison_callout(results, title):
         return []
 
     lines = []
-    ratio = dekaf_rate / confluent_rate
+    throughput_ratio = dekaf_rate / confluent_rate
+    dekaf_cpu = cpu_micros_per_message(dekaf)
+    confluent_cpu = cpu_micros_per_message(confluent)
     label = title.lower()
 
-    if ratio > 1.05:
+    if dekaf_cpu is not None and confluent_cpu is not None and dekaf_cpu > 0 and confluent_cpu > 0:
+        cpu_ratio = confluent_cpu / dekaf_cpu
+        if cpu_ratio > 1.05:
+            lines.append(":::tip")
+            lines.append(f"**Dekaf uses {cpu_ratio:.2f}x less CPU per message** than Confluent.Kafka for {label}; throughput is {throughput_ratio:.2f}x.")
+            lines.append(":::")
+        elif cpu_ratio < 0.95:
+            lines.append(":::note")
+            lines.append(f"Confluent.Kafka uses {1/cpu_ratio:.2f}x less CPU per message for {label}; throughput is {throughput_ratio:.2f}x.")
+            lines.append(":::")
+        else:
+            lines.append(":::note")
+            lines.append(f"Dekaf and Confluent.Kafka have similar CPU efficiency for {label}; throughput is {throughput_ratio:.2f}x.")
+            lines.append(":::")
+    elif throughput_ratio > 1.05:
         lines.append(":::tip")
-        lines.append(f"**Dekaf is {ratio:.2f}x faster** than Confluent.Kafka for {label} throughput!")
+        lines.append(f"**Dekaf is {throughput_ratio:.2f}x faster** than Confluent.Kafka for {label} throughput!")
         lines.append(":::")
-    elif ratio < 0.95:
+    elif throughput_ratio < 0.95:
         lines.append(":::note")
-        lines.append(f"Confluent.Kafka is {1/ratio:.2f}x faster for {label} throughput.")
+        lines.append(f"Confluent.Kafka is {1/throughput_ratio:.2f}x faster for {label} throughput.")
         lines.append(":::")
     else:
         lines.append(":::note")

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -514,6 +514,7 @@ jobs:
           output.append("- **CPU Isolation**: Brokers are pinned to dedicated cores and the client under test to its own cores, so the client — not the broker — is the measured bottleneck")
           output.append("- **RAM-backed Broker Logs**: Kafka log dirs are mounted on tmpfs so disk I/O never caps broker ingestion")
           output.append("- **Delivered Throughput**: producer tables report broker-confirmed throughput, measured as the end-offset delta across all partitions — not the client-side append rate, which can run far ahead of what the broker ever accepts")
+          output.append("- **Median Interval Throughput**: tables also show median sampled client-side msg/s, which is less sensitive to short late-run stalls than the whole-run mean")
           output.append("- **Backpressure Parity**: both producers are bounded to the same 512 MB local buffer (Dekaf BufferMemory, librdkafka queue.buffering.max) and block on a full buffer, so neither client can absorb an unbounded backlog into RAM")
           output.append("- **Consumer Loop Replay**: Consumer tests re-read a pre-seeded topic (seek to beginning when drained) instead of racing a live feeder, so the consumer itself is measured")
           output.append("- **Delivery Latency Sampling**: 1 in 1000 produced messages is awaited end-to-end to record true broker round-trip latency")

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -73,8 +73,8 @@ internal static class MarkdownReporter
             var messageSizeKb = messageSize >= 1024 ? $"{messageSize / 1024.0:F1}KB" : $"{messageSize}B";
             sb.AppendLine($"## {title} ({durationMinutes} minutes, {messageSizeKb} messages)");
             sb.AppendLine();
-            sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Messages/sec | MB/sec | Accepted msg/s | Errors | CPU μs/msg | Cores Used | Ratio |");
-            sb.AppendLine($"|{new string('-', clientWidth + 2)}|--------------|--------|----------------|--------|------------|------------|-------|");
+            sb.AppendLine($"| {"Client".PadRight(clientWidth)} | CPU μs/msg | Messages/sec | Median msg/s | MB/sec | Accepted msg/s | Errors | Cores Used | Thru Ratio |");
+            sb.AppendLine($"|{new string('-', clientWidth + 2)}|------------|--------------|--------------|--------|----------------|--------|------------|------------|");
 
             var baseline = sizeResults
                 .Where(r => r.Client.Equals("Confluent", StringComparison.OrdinalIgnoreCase))
@@ -86,17 +86,24 @@ internal static class MarkdownReporter
                 baseline = sizeResults.Min(r => r.EffectiveMessagesPerSecond);
             }
 
-            foreach (var result in sizeResults.OrderByDescending(r => r.EffectiveMessagesPerSecond))
+            foreach (var result in OrderThroughputResults(sizeResults))
             {
                 var rate = result.EffectiveMessagesPerSecond;
                 var ratio = baseline > 0 ? rate / baseline : 1.0;
+                var median = result.MedianIntervalMessagesPerSecond is { } medianRate ? medianRate.ToString("N0") : "-";
                 var accepted = result.AcceptedMessagesPerSecond is { } acceptedRate ? acceptedRate.ToString("N0") : "-";
                 var cpuPerMessage = result.CpuMicrosPerMessage is { } cpu ? $"{cpu:F2}" : "-";
                 var coresUsed = result.AverageCoresUsed is { } cores ? $"{cores:F2}" : "-";
-                sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {rate,12:N0} | {result.EffectiveMegabytesPerSecond,6:F2} | {accepted,14} | {result.Throughput.TotalErrors,6} | {cpuPerMessage,10} | {coresUsed,10} | {ratio:F2}x |");
+                sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {cpuPerMessage,10} | {rate,12:N0} | {median,12} | {result.EffectiveMegabytesPerSecond,6:F2} | {accepted,14} | {result.Throughput.TotalErrors,6} | {coresUsed,10} | {ratio:F2}x |");
             }
 
             sb.AppendLine();
+
+            if (sizeResults.Any(r => r.MedianIntervalMessagesPerSecond is not null))
+            {
+                sb.AppendLine("*Median msg/s is the median sampled client-side throughput interval; it shows steady-state throughput without letting a short late-run stall dominate the whole-run average.*");
+                sb.AppendLine();
+            }
 
             if (sizeResults.Any(r => r.DeliveredMessages is not null))
             {
@@ -107,6 +114,13 @@ internal static class MarkdownReporter
             }
         }
     }
+
+    private static IOrderedEnumerable<StressTestResult> OrderThroughputResults(List<StressTestResult> results) =>
+        results.Any(r => r.CpuMicrosPerMessage is not null)
+            ? results
+                .OrderBy(r => r.CpuMicrosPerMessage ?? double.MaxValue)
+                .ThenByDescending(r => r.EffectiveMessagesPerSecond)
+            : results.OrderByDescending(r => r.EffectiveMessagesPerSecond);
 
     private static void GenerateLatencyTable(StringBuilder sb, List<StressTestResult> results, string title = "Latency Percentiles")
     {

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -52,6 +52,19 @@ internal sealed class StressTestResult
         DeliveredMegabytesPerSecond ?? Throughput.AverageMegabytesPerSecond;
 
     /// <summary>
+    /// Median of sampled client-side throughput intervals. This is less sensitive than
+    /// the whole-run mean to a brief late-run stall, and lets reports show the steady
+    /// state beside the end-to-end average.
+    /// </summary>
+    public double? MedianIntervalMessagesPerSecond =>
+        GetMedian(Throughput.MessagesPerSecondSamples);
+
+    public double? MedianIntervalMegabytesPerSecond =>
+        MedianIntervalMessagesPerSecond is { } rate
+            ? rate * MessageSizeBytes / (1024.0 * 1024.0)
+            : null;
+
+    /// <summary>
     /// Client-side append rate, reported only when it is distinct from the headline
     /// number (i.e. when delivered throughput was measured). Null means the headline
     /// already is the client-side rate.
@@ -81,6 +94,21 @@ internal sealed class StressTestResult
         GcStats.AllocatedBytes is { } allocated && Throughput.TotalMessages > 0
             ? (double)allocated / Throughput.TotalMessages
             : null;
+
+    private static double? GetMedian(List<double> samples)
+    {
+        var sorted = samples
+            .Where(double.IsFinite)
+            .Order()
+            .ToArray();
+
+        return sorted.Length switch
+        {
+            0 => null,
+            var count when count % 2 == 1 => sorted[count / 2],
+            var count => (sorted[(count / 2) - 1] + sorted[count / 2]) / 2.0
+        };
+    }
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -59,11 +59,6 @@ internal sealed class StressTestResult
     public double? MedianIntervalMessagesPerSecond =>
         GetMedian(Throughput.MessagesPerSecondSamples);
 
-    public double? MedianIntervalMegabytesPerSecond =>
-        MedianIntervalMessagesPerSecond is { } rate
-            ? rate * MessageSizeBytes / (1024.0 * 1024.0)
-            : null;
-
     /// <summary>
     /// Client-side append rate, reported only when it is distinct from the headline
     /// number (i.e. when delivered throughput was measured). Null means the headline


### PR DESCRIPTION
## Summary
- serialize median sampled interval throughput in stress results
- show CPU microseconds per message first while keeping mean, median, accepted rate, errors, and throughput ratio visible
- update generated docs callouts to prefer CPU efficiency when CPU data exists

## Test plan
- [x] dotnet build tools/Dekaf.StressTests --configuration Release
- [x] python -m py_compile .github/scripts/stress_report.py
- [x] synthetic C# report generation from sample stress results
- [x] synthetic Python report generation from sample stress results

Closes #1561
