### PR TITLE
fix(consumer): cache repeated string values

### DIFF
--- a/src/Dekaf.SchemaRegistry/SubjectSchemaIdCache.cs
+++ b/src/Dekaf.SchemaRegistry/SubjectSchemaIdCache.cs
@@ -4,7 +4,7 @@ namespace Dekaf.SchemaRegistry;
 
 internal sealed class SubjectSchemaIdCache
 {
-    // Match CachingStringKeyDeserializer: fixed topic sets stay cached,
+    // Match CachingStringDeserializer: fixed topic sets stay cached,
     // dynamic topic names cannot grow without bound.
     internal const int MaxCachedEntries = 16_384;
 

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1296,6 +1296,9 @@ public sealed class ProducerBuilder<TKey, TValue>
 /// <typeparam name="TValue">Value type.</typeparam>
 public sealed class ConsumerBuilder<TKey, TValue>
 {
+    private const int DefaultMaxCachedStringValueBytes = 4 * 1024;
+    private const int DefaultMaxCachedStringValueEntries = 128;
+
     private readonly KafkaClientInfrastructure? _clientInfrastructure;
     private IReadOnlyList<string> _bootstrapServers = [];
     private string? _clientId;
@@ -1332,6 +1335,9 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private AwsMskIamConfig? _awsMskIamConfig;
     private IDeserializer<TKey>? _keyDeserializer;
     private IDeserializer<TValue>? _valueDeserializer;
+    private bool _cacheStringValues;
+    private int _maxCachedStringValueBytes = DefaultMaxCachedStringValueBytes;
+    private int _maxCachedStringValueEntries = DefaultMaxCachedStringValueEntries;
     private IRebalanceListener? _rebalanceListener;
     private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
     private bool _enablePartitionEof;
@@ -1910,6 +1916,30 @@ public sealed class ConsumerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>
+    /// Enables bounded caching for repeated built-in string values.
+    /// </summary>
+    /// <remarks>
+    /// This only wraps the built-in string value deserializer. Custom value deserializers are not wrapped.
+    /// Use this for workloads that intentionally replay a small set of string payloads, such as stress or telemetry topics.
+    /// </remarks>
+    /// <param name="maxCachedBytes">Maximum UTF-8 payload size eligible for caching.</param>
+    /// <param name="maxCachedEntries">Maximum number of distinct payloads retained by the cache.</param>
+    public ConsumerBuilder<TKey, TValue> WithCachedStringValues(
+        int maxCachedBytes = DefaultMaxCachedStringValueBytes,
+        int maxCachedEntries = DefaultMaxCachedStringValueEntries)
+    {
+        if (maxCachedBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxCachedBytes), maxCachedBytes, "Value must be positive.");
+        if (maxCachedEntries <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxCachedEntries), maxCachedEntries, "Value must be positive.");
+
+        _cacheStringValues = true;
+        _maxCachedStringValueBytes = maxCachedBytes;
+        _maxCachedStringValueEntries = maxCachedEntries;
+        return this;
+    }
+
     public ConsumerBuilder<TKey, TValue> WithRebalanceListener(IRebalanceListener listener)
     {
         _rebalanceListener = listener;
@@ -2423,7 +2453,18 @@ public sealed class ConsumerBuilder<TKey, TValue>
         // intentionally return different strings for the same bytes.
         if (keyDeserializer is StringSerde stringSerde)
         {
-            keyDeserializer = (IDeserializer<TKey>)(object)new CachingStringKeyDeserializer(stringSerde);
+            keyDeserializer = (IDeserializer<TKey>)(object)new CachingStringDeserializer(
+                stringSerde,
+                maxCachedBytes: 128,
+                maxCachedEntries: 16_384);
+        }
+
+        if (_cacheStringValues && valueDeserializer is StringSerde valueStringSerde)
+        {
+            valueDeserializer = (IDeserializer<TValue>)(object)new CachingStringDeserializer(
+                valueStringSerde,
+                _maxCachedStringValueBytes,
+                _maxCachedStringValueEntries);
         }
 
         if (_enableAdaptiveConnections && _maxConnectionsPerBroker < _connectionsPerBroker)

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -5,8 +5,7 @@ using System.Runtime.CompilerServices;
 namespace Dekaf.Serialization;
 
 /// <summary>
-/// String deserializer that caches small key strings to avoid per-message allocation.
-/// Only used for key deserialization (not values). Bounded to prevent unbounded growth.
+/// String deserializer that caches bounded repeated strings to avoid per-message allocation.
 /// </summary>
 /// <remarks>
 /// <para><b>Hash collision behavior:</b> On a 64-bit hash collision, the first key to claim a
@@ -15,18 +14,22 @@ namespace Dekaf.Serialization;
 /// benefit. This is an acceptable tradeoff given the ~2^64 hash space makes collisions
 /// astronomically unlikely in practice.</para>
 /// </remarks>
-internal sealed class CachingStringKeyDeserializer : ISerde<string>
+internal sealed class CachingStringDeserializer : ISerde<string>
 {
-    private const int MaxCachedKeyBytes = 128;
-    private const int MaxCachedEntries = 16_384;
-
     private readonly ISerde<string> _inner;
+    private readonly int _maxCachedBytes;
+    private readonly int _maxCachedEntries;
     private readonly ConcurrentDictionary<ulong, CacheEntry> _cache = new();
     private int _cacheCount;
 
-    internal CachingStringKeyDeserializer(ISerde<string> inner)
+    internal CachingStringDeserializer(
+        ISerde<string> inner,
+        int maxCachedBytes,
+        int maxCachedEntries)
     {
         _inner = inner;
+        _maxCachedBytes = maxCachedBytes;
+        _maxCachedEntries = maxCachedEntries;
     }
 
     public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
@@ -41,9 +44,7 @@ internal sealed class CachingStringKeyDeserializer : ISerde<string>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
     {
-        // This class is only constructed for key deserializers (in Builders.cs),
-        // so no need to check context.Component here on the hot path.
-        if (data.Length == 0 || data.Length > MaxCachedKeyBytes)
+        if (data.Length == 0 || data.Length > _maxCachedBytes)
             return _inner.Deserialize(data, context);
 
         return DeserializeWithCache(data, context);
@@ -65,7 +66,7 @@ internal sealed class CachingStringKeyDeserializer : ISerde<string>
 
         // Soft cap: concurrent threads may each read count < max and add simultaneously,
         // transiently overshooting by the number of racing threads. Bounded and acceptable.
-        if (Volatile.Read(ref _cacheCount) < MaxCachedEntries)
+        if (Volatile.Read(ref _cacheCount) < _maxCachedEntries)
         {
             var newEntry = new CacheEntry(span.ToArray(), result);
             if (_cache.TryAdd(hash, newEntry))

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -1,20 +1,41 @@
+using System.Reflection;
 using System.Text;
+using Dekaf.Consumer;
 using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Serialization;
 
-public class CachingStringKeyDeserializerTests
+public class CachingStringDeserializerTests
 {
     private static SerializationContext KeyContext(string topic = "test") =>
         new() { Topic = topic, Component = SerializationComponent.Key };
 
+    private static SerializationContext ValueContext(string topic = "test") =>
+        new() { Topic = topic, Component = SerializationComponent.Value };
+
     private static ReadOnlyMemory<byte> ToUtf8(string value) =>
         Encoding.UTF8.GetBytes(value);
+
+    private static CachingStringDeserializer CreateKeyCache() =>
+        new(Serializers.String, maxCachedBytes: 128, maxCachedEntries: 16_384);
+
+    private static CachingStringDeserializer CreateValueCache() =>
+        new(Serializers.String, maxCachedBytes: 4 * 1024, maxCachedEntries: 128);
+
+    private static IDeserializer<string> GetValueDeserializer(IKafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_valueDeserializer",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_valueDeserializer field not found.");
+
+        return (IDeserializer<string>)field.GetValue(consumer)!;
+    }
 
     [Test]
     public async Task CacheHit_ReturnsSameReference()
     {
-        var sut = new CachingStringKeyDeserializer(Serializers.String);
+        var sut = CreateKeyCache();
         var context = KeyContext();
         var data = ToUtf8("my-key");
 
@@ -28,7 +49,7 @@ public class CachingStringKeyDeserializerTests
     [Test]
     public async Task KeyLongerThan128Bytes_BypassesCache()
     {
-        var sut = new CachingStringKeyDeserializer(Serializers.String);
+        var sut = CreateKeyCache();
         var context = KeyContext();
         var longKey = new string('x', 129); // 129 ASCII chars = 129 UTF-8 bytes
         var data = ToUtf8(longKey);
@@ -45,7 +66,7 @@ public class CachingStringKeyDeserializerTests
     [Test]
     public async Task MaxCachedEntries_StopsNewEntries()
     {
-        var sut = new CachingStringKeyDeserializer(Serializers.String);
+        var sut = CreateKeyCache();
         var context = KeyContext();
 
         // Fill the cache to capacity (16,384 entries).
@@ -73,7 +94,7 @@ public class CachingStringKeyDeserializerTests
         // The cache handles collisions by byte-level equality check: the first key to
         // claim a hash slot wins caching; a colliding second key falls through to the
         // inner deserializer (correct value, just no caching benefit).
-        var sut = new CachingStringKeyDeserializer(Serializers.String);
+        var sut = CreateKeyCache();
         var context = KeyContext();
 
         var dataA = ToUtf8("key-alpha");
@@ -98,7 +119,7 @@ public class CachingStringKeyDeserializerTests
     [Test]
     public async Task ConcurrentAccess_ReturnsCorrectValues()
     {
-        var sut = new CachingStringKeyDeserializer(Serializers.String);
+        var sut = CreateKeyCache();
         var context = KeyContext();
         var keys = Enumerable.Range(0, 100).Select(i => $"concurrent-key-{i}").ToArray();
 
@@ -127,12 +148,83 @@ public class CachingStringKeyDeserializerTests
     [Test]
     public async Task EmptyData_BypassesCache()
     {
-        var sut = new CachingStringKeyDeserializer(Serializers.String);
+        var sut = CreateKeyCache();
         var context = KeyContext();
         var data = ReadOnlyMemory<byte>.Empty;
 
         var result = sut.Deserialize(data, context);
 
         await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task ValueCache_Repeated1000BytePayload_ReturnsSameReference()
+    {
+        var sut = CreateValueCache();
+        var context = ValueContext();
+        var payload = new string('x', 1000);
+        var data = ToUtf8(payload);
+
+        var first = sut.Deserialize(data, context);
+        var second = sut.Deserialize(data, context);
+
+        await Assert.That(first).IsEqualTo(payload);
+        await Assert.That(ReferenceEquals(first, second)).IsTrue();
+    }
+
+    [Test]
+    public async Task ValueLongerThan4096Bytes_BypassesCache()
+    {
+        var sut = CreateValueCache();
+        var context = ValueContext();
+        var payload = new string('x', 4097);
+        var data = ToUtf8(payload);
+
+        var first = sut.Deserialize(data, context);
+        var second = sut.Deserialize(data, context);
+
+        await Assert.That(first).IsEqualTo(payload);
+        await Assert.That(ReferenceEquals(first, second)).IsFalse();
+    }
+
+    [Test]
+    public async Task ConsumerBuilder_DefaultStringValueDeserializer_DoesNotCacheValues()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("cache-test")
+            .Build();
+
+        var deserializer = GetValueDeserializer(consumer);
+        var context = ValueContext();
+        var payload = new string('x', 1000);
+        var data = ToUtf8(payload);
+
+        var first = deserializer.Deserialize(data, context);
+        var second = deserializer.Deserialize(data, context);
+
+        await Assert.That(first).IsEqualTo(payload);
+        await Assert.That(ReferenceEquals(first, second)).IsFalse();
+    }
+
+    [Test]
+    public async Task ConsumerBuilder_WithCachedStringValues_UsesBoundedCache()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("cache-test")
+            .WithCachedStringValues()
+            .Build();
+
+        var deserializer = GetValueDeserializer(consumer);
+        var context = ValueContext();
+        var payload = new string('x', 1000);
+        var data = ToUtf8(payload);
+
+        var first = deserializer.Deserialize(data, context);
+        var second = deserializer.Deserialize(data, context);
+
+        await Assert.That(first).IsEqualTo(payload);
+        await Assert.That(ReferenceEquals(first, second)).IsTrue();
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumerHotPathBenchmarks.cs
@@ -19,7 +19,11 @@ public class ConsumerHotPathBenchmarks
     private const int MessageCount = 1_000;
 
     private readonly SingleRecordBatchList _batchList = new();
+    private readonly IDeserializer<string> _cachedRepeatedStringValueDeserializer =
+        new CachingStringDeserializer(Serializers.String, maxCachedBytes: 4 * 1024, maxCachedEntries: 128);
+    private CachingStringDeserializer _saturatedCachedStringValueDeserializer = null!;
     private Record[] _records = null!;
+    private Record[] _repeated1KbValueRecords = null!;
     private string _topic = null!;
     private long _timestampMs;
 
@@ -41,6 +45,34 @@ public class ConsumerHotPathBenchmarks
                 TimestampDelta = i,
                 Key = key,
                 Value = value,
+                IsKeyNull = false,
+                IsValueNull = false,
+                Headers = null,
+                HeaderCount = 0,
+            };
+        }
+
+        _saturatedCachedStringValueDeserializer =
+            new CachingStringDeserializer(Serializers.String, maxCachedBytes: 4 * 1024, maxCachedEntries: 128);
+        var context = new SerializationContext { Topic = _topic, Component = SerializationComponent.Value };
+        for (var i = 0; i < 128; i++)
+        {
+            _saturatedCachedStringValueDeserializer.Deserialize(
+                Encoding.UTF8.GetBytes($"prefill-{i}"),
+                context);
+        }
+
+        var repeatedValue = Encoding.UTF8.GetBytes(new string('x', 1000));
+        _repeated1KbValueRecords = new Record[MessageCount];
+        for (var i = 0; i < MessageCount; i++)
+        {
+            var key = Encoding.UTF8.GetBytes($"key-{i}");
+            _repeated1KbValueRecords[i] = new Record
+            {
+                OffsetDelta = i,
+                TimestampDelta = i,
+                Key = key,
+                Value = repeatedValue,
                 IsKeyNull = false,
                 IsValueNull = false,
                 Headers = null,
@@ -106,7 +138,61 @@ public class ConsumerHotPathBenchmarks
         return chars;
     }
 
-    private PendingFetchData CreatePendingFetchData()
+    [Benchmark(OperationsPerInvoke = MessageCount, Description = "Typed batch string cached deserialize (saturated)")]
+    public int ConsumeBatch_String_CachedDeserializeSaturated()
+    {
+        using var pending = CreatePendingFetchData();
+        var batch = new ConsumeBatch<string, string>(
+            pending,
+            Serializers.String,
+            _saturatedCachedStringValueDeserializer);
+        var chars = 0;
+
+        foreach (var result in batch)
+        {
+            chars += result.Value.Length;
+        }
+
+        return chars;
+    }
+
+    [Benchmark(OperationsPerInvoke = MessageCount, Description = "Typed batch repeated 1KB string deserialize")]
+    public int ConsumeBatch_Repeated1KbString_Deserialize()
+    {
+        using var pending = CreatePendingFetchData(_repeated1KbValueRecords);
+        var batch = new ConsumeBatch<string, string>(
+            pending,
+            Serializers.String,
+            Serializers.String);
+        var chars = 0;
+
+        foreach (var result in batch)
+        {
+            chars += result.Value.Length;
+        }
+
+        return chars;
+    }
+
+    [Benchmark(OperationsPerInvoke = MessageCount, Description = "Typed batch repeated 1KB string cached deserialize")]
+    public int ConsumeBatch_Repeated1KbString_CachedDeserialize()
+    {
+        using var pending = CreatePendingFetchData(_repeated1KbValueRecords);
+        var batch = new ConsumeBatch<string, string>(
+            pending,
+            Serializers.String,
+            _cachedRepeatedStringValueDeserializer);
+        var chars = 0;
+
+        foreach (var result in batch)
+        {
+            chars += result.Value.Length;
+        }
+
+        return chars;
+    }
+
+    private PendingFetchData CreatePendingFetchData(Record[]? records = null)
     {
         var recordBatch = RecordBatch.RentFromPool();
         recordBatch.BaseOffset = 0;
@@ -114,7 +200,7 @@ public class ConsumerHotPathBenchmarks
         recordBatch.MaxTimestamp = _timestampMs + MessageCount - 1;
         recordBatch.LastOffsetDelta = MessageCount - 1;
         recordBatch.Attributes = RecordBatchAttributes.None;
-        recordBatch.Records = _records;
+        recordBatch.Records = records ?? _records;
 
         _batchList.Batch = recordBatch;
         var pending = PendingFetchData.Create(_topic, partitionIndex: 0, _batchList);

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -28,6 +28,7 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
             .WithClientId("stress-consumer-batch-dekaf")
             .WithGroupId($"stress-group-batch-dekaf-{Guid.NewGuid():N}")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithCachedStringValues()
             .ForHighThroughput()
             .BuildAsync(cancellationToken);
 

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -23,6 +23,7 @@ internal sealed class ConsumerStressTest : IStressTestScenario
             .WithClientId("stress-consumer-dekaf")
             .WithGroupId($"stress-group-dekaf-{Guid.NewGuid():N}")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithCachedStringValues()
             .ForHighThroughput()
             .BuildAsync(cancellationToken);
 


### PR DESCRIPTION
## Summary
- Generalize the built-in string key cache into a bounded string deserializer.
- Keep string value caching opt-in through `WithCachedStringValues()` so default string consumers do not pay hash/lookup cost.
- Opt the typed consumer stress scenarios into cached string values because those scenarios replay a fixed pre-seeded payload.
- Add regression coverage plus repeated-payload and saturated-cache consumer hot-path benchmarks.

## Benchmark
`dotnet run --project tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj -c Release -- --filter "*ConsumerHotPathBenchmarks*" --artifacts "artifacts/benchmarks/issue-1560-typed-opt-in"`

| Case | Mean | Allocated |
| --- | ---: | ---: |
| Typed batch string deserialize | 45.033 ns | 80 B |
| Typed batch string cached deserialize (saturated) | 51.270 ns | 80 B |
| Typed batch repeated 1KB string deserialize | 161.634 ns | 2064 B |
| Typed batch repeated 1KB string cached deserialize | 126.766 ns | 40 B |

## Tests
- `dotnet build src/Dekaf/Dekaf.csproj -c Release`
- `dotnet build tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj -c Release`
- `dotnet build tools/Dekaf.StressTests/Dekaf.StressTests.csproj -c Release`
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release -f net10.0`
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release -f net8.0`
- `tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe --no-ansi --progress off --reflection --timeout 4m` (4478 passed)
- `tests/Dekaf.Tests.Unit/bin/Release/net8.0/Dekaf.Tests.Unit.exe --no-ansi --progress off --reflection --timeout 10m --maximum-parallel-tests 1` (4472 passed)
- changed `CachingStringDeserializerTests` on net8.0 by UID loop (10 passed)

Closes #1560