### PR TITLE
fix(protocol): fail PRODUCE locally when declared records length mismatches emitted bytes (#1559)

### DIFF
--- a/src/Dekaf/Protocol/Messages/ProduceRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceRequest.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using Dekaf.Compression;
+using Dekaf.Errors;
 using Dekaf.Protocol.Records;
 
 namespace Dekaf.Protocol.Messages;
@@ -192,10 +193,25 @@ public sealed class ProduceRequestPartitionData
             // COMPACT_RECORDS uses COMPACT_NULLABLE_BYTES encoding (length+1, 0 = null).
             writer.WriteUnsignedVarInt(checked(recordsLength + 1));
             var output = writer.BufferWriter;
+            var actualRecordsLength = 0;
             for (var i = 0; i < Records.Count; i++)
             {
-                Records[i].Write(output, Compression, CompressionCodecs);
+                actualRecordsLength += Records[i].Write(output, Compression, CompressionCodecs);
             }
+
+            if (actualRecordsLength != recordsLength)
+            {
+                // A batch changed between the size pass and the write pass (concurrent
+                // mutation or pooled-object recycling). The declared records length no longer
+                // matches the emitted bytes; sending this frame would desync the connection's
+                // outgoing byte stream and the broker would misparse every subsequent request
+                // (InvalidRequestException + socket close). Fail before it reaches the wire.
+                throw new KafkaException(
+                    ErrorCode.CorruptMessage,
+                    $"PRODUCE framing mismatch for partition {Index}: declared records length {recordsLength} but serialized {actualRecordsLength} bytes across {Records.Count} batch(es); request discarded before reaching the wire.",
+                    isRetriable: true);
+            }
+
             writer.AddBytesWritten(recordsLength);
         }
         finally

--- a/src/Dekaf/Protocol/Messages/ProduceRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceRequest.cs
@@ -196,7 +196,10 @@ public sealed class ProduceRequestPartitionData
             var actualRecordsLength = 0;
             for (var i = 0; i < Records.Count; i++)
             {
-                actualRecordsLength += Records[i].Write(output, Compression, CompressionCodecs);
+                checked
+                {
+                    actualRecordsLength += Records[i].Write(output, Compression, CompressionCodecs);
+                }
             }
 
             if (actualRecordsLength != recordsLength)
@@ -208,8 +211,7 @@ public sealed class ProduceRequestPartitionData
                 // (InvalidRequestException + socket close). Fail before it reaches the wire.
                 throw new KafkaException(
                     ErrorCode.CorruptMessage,
-                    $"PRODUCE framing mismatch for partition {Index}: declared records length {recordsLength} but serialized {actualRecordsLength} bytes across {Records.Count} batch(es); request discarded before reaching the wire.",
-                    isRetriable: true);
+                    $"PRODUCE framing mismatch for partition {Index}: declared records length {recordsLength} but serialized {actualRecordsLength} bytes across {Records.Count} batch(es); request discarded before reaching the wire.");
             }
 
             writer.AddBytesWritten(recordsLength);

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -706,7 +706,13 @@ public sealed class RecordBatch : IDisposable
     /// to provide that full span. A streaming writer path would need incremental CRC32C
     /// calculation while emitting fields and records in smaller segments.
     /// </remarks>
-    public void Write(IBufferWriter<byte> output, CompressionType compression = CompressionType.None, CompressionCodecRegistry? codecs = null)
+    /// <returns>
+    /// The exact number of bytes written to <paramref name="output"/>. Callers that
+    /// pre-compute an encoded size (e.g. the PRODUCE records length prefix) must verify it
+    /// against this value: a mismatch means the batch changed between sizing and writing,
+    /// and emitting the frame would desync the connection's outgoing byte stream.
+    /// </returns>
+    public int Write(IBufferWriter<byte> output, CompressionType compression = CompressionType.None, CompressionCodecRegistry? codecs = null)
     {
         var writer = new KafkaProtocolWriter(output);
         var records = Records;
@@ -823,6 +829,8 @@ public sealed class RecordBatch : IDisposable
             // Must happen before ReturnSerializationCache in the finally block,
             // because compressedRecords may reference the cache's buffer writer.
             output.Advance(4 + crcContentSize);
+
+            return TotalBatchHeaderSize + compressedRecords.Length;
         }
         finally
         {

--- a/tests/Dekaf.Tests.Integration/MultiConnectionProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/MultiConnectionProducerTests.cs
@@ -340,34 +340,39 @@ public sealed class MultiConnectionProducerTests(KafkaTestContainer kafka) : Kaf
     [Test]
     public async Task IdempotentProducer_AdaptiveScaling_NoDuplicatesOrGaps()
     {
-        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 6);
-        const int messageCount = 10_000;
+        const int partitionCount = 6;
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: partitionCount);
+        const int messageCount = 2_000;
+        var payload = new string('x', 512);
 
         // Start with 1 connection, enable adaptive scaling up to 3.
-        // High throughput fire-and-forget should trigger adaptive scale-up,
-        // exercising the per-partition migration fencing logic.
+        // Explicitly constrain buffering and batch size so this test exercises adaptive
+        // scale-up without relying on CI-wide memory pressure from parallel test runs.
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithClientId("test-adaptive-scale-idem")
             .WithAcks(Acks.All)
             .WithConnectionsPerBroker(1)
             .WithAdaptiveConnections(maxConnections: 3)
+            .WithBufferMemory(512UL * 1024)
+            .WithBatchSize(16 * 1024)
+            .WithLinger(TimeSpan.FromMilliseconds(1))
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
         for (var i = 0; i < messageCount; i++)
         {
-            await producer.FireAsync(topic, $"key-{i % 100}", $"msg-{i}");
+            await producer.FireAsync(topic, $"key-{i % 100}", $"msg-{i}:{payload}");
         }
 
-        await producer.FlushWithTimeoutAsync();
+        await producer.FlushWithTimeoutAsync(timeoutSeconds: 60);
 
         await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
 
-        consumer.Assign(Enumerable.Range(0, 6)
+        consumer.Assign(Enumerable.Range(0, partitionCount)
             .Select(p => new TopicPartition(topic, p))
             .ToArray());
 

--- a/tests/Dekaf.Tests.Unit/Protocol/ProduceRequestFramingGuardTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ProduceRequestFramingGuardTests.cs
@@ -1,0 +1,156 @@
+using System.Buffers;
+using System.Collections;
+using Dekaf.Errors;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+/// <summary>
+/// Regression tests for the PRODUCE framing guard (#1559). The records length prefix is
+/// computed in a first pass over the batches and the batch bytes are written in a second
+/// pass. If a batch mutates between the passes (concurrent lifecycle race / pooled-object
+/// recycling), the declared length no longer matches the emitted bytes and the frame would
+/// desync the connection's outgoing byte stream — the broker misparses every subsequent
+/// request (InvalidRequestException: "Error reading byte array of N bytes") and closes the
+/// socket. The guard must fail the request locally before it reaches the wire.
+/// </summary>
+public sealed class ProduceRequestFramingGuardTests
+{
+    [Test]
+    public async Task PartitionData_Write_BatchGrowsBetweenSizeAndWritePass_ThrowsBeforeWire()
+    {
+        var caught = WriteWithMutation(static batch =>
+        {
+            var originalRecordsLength = batch.GetEncodedSize() - RecordBatch.TotalBatchHeaderSize;
+            batch.SetPreEncodedRecords(new byte[originalRecordsLength + 64]);
+        });
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.ErrorCode).IsEqualTo(ErrorCode.CorruptMessage);
+        await Assert.That(caught.IsRetriable).IsTrue();
+        await Assert.That(caught.Message).Contains("framing mismatch");
+    }
+
+    [Test]
+    public async Task PartitionData_Write_BatchShrinksBetweenSizeAndWritePass_ThrowsBeforeWire()
+    {
+        var caught = WriteWithMutation(static batch =>
+        {
+            var originalRecordsLength = batch.GetEncodedSize() - RecordBatch.TotalBatchHeaderSize;
+            batch.SetPreEncodedRecords(new byte[originalRecordsLength - 1]);
+        });
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.ErrorCode).IsEqualTo(ErrorCode.CorruptMessage);
+    }
+
+    [Test]
+    public async Task PartitionData_Write_StableBatch_DeclaredLengthMatchesEmittedBytes()
+    {
+        var batch = CreateBatch();
+        var partitionData = new ProduceRequestPartitionData
+        {
+            Index = 0,
+            Records = new[] { batch }
+        };
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        partitionData.Write(ref writer, ProduceRequest.HighestSupportedVersion);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        reader.ReadInt32(); // partition index
+        var declaredRecordsLength = reader.ReadUnsignedVarInt() - 1;
+        reader.ReadRawBytes(declaredRecordsLength);
+        reader.ReadUnsignedVarInt(); // tagged fields
+        var readerEnd = reader.End;
+
+        // Tracked writer count must equal the actual buffer bytes — this is the outer frame
+        // size prefix consistency that keeps the connection frame-aligned.
+        await Assert.That(writer.BytesWritten).IsEqualTo(buffer.WrittenCount);
+        await Assert.That(readerEnd).IsTrue();
+    }
+
+    /// <summary>
+    /// Serializes a single-batch partition where the batch is mutated after the size pass
+    /// read it but before the write pass serializes it, mimicking the cross-thread
+    /// mutation/recycle race. Returns the caught guard exception, or null if none was thrown.
+    /// </summary>
+    private static KafkaException? WriteWithMutation(Action<RecordBatch> mutate)
+    {
+        var batch = CreateBatch();
+        var partitionData = new ProduceRequestPartitionData
+        {
+            Index = 7,
+            Records = new SecondAccessMutatingList(batch, mutate)
+        };
+
+        try
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            var writer = new KafkaProtocolWriter(buffer);
+            partitionData.Write(ref writer, ProduceRequest.HighestSupportedVersion);
+            return null;
+        }
+        catch (KafkaException ex)
+        {
+            return ex;
+        }
+    }
+
+    private static RecordBatch CreateBatch() => new()
+    {
+        BaseOffset = 0,
+        BaseTimestamp = 1000,
+        MaxTimestamp = 1000,
+        LastOffsetDelta = 0,
+        ProducerId = -1,
+        ProducerEpoch = -1,
+        BaseSequence = -1,
+        Records =
+        [
+            new Record
+            {
+                OffsetDelta = 0,
+                TimestampDelta = 0,
+                Key = "key"u8.ToArray(),
+                Value = "value"u8.ToArray()
+            }
+        ]
+    };
+
+    /// <summary>
+    /// Single-batch list that applies a mutation on the second indexer access. The size pass
+    /// reads Records[0] once; the write pass reads it again, so the mutation lands exactly
+    /// between sizing and writing — the same window the production race hits.
+    /// </summary>
+    private sealed class SecondAccessMutatingList(RecordBatch batch, Action<RecordBatch> mutate)
+        : IReadOnlyList<RecordBatch>
+    {
+        private int _accessCount;
+
+        public RecordBatch this[int index]
+        {
+            get
+            {
+                if (++_accessCount == 2)
+                {
+                    mutate(batch);
+                }
+
+                return batch;
+            }
+        }
+
+        public int Count => 1;
+
+        public IEnumerator<RecordBatch> GetEnumerator()
+        {
+            yield return batch;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}


### PR DESCRIPTION
## Problem

Stress run [28935008914](https://github.com/thomhurst/Dekaf/actions/runs/28935008914) failed with message loss. Broker diagnostics show the #1559 signature repeating (~every few minutes once broker stalls begin):

```
InvalidRequestException: Error getting request for apiKey: PRODUCE, apiVersion: 11
Caused by: java.lang.RuntimeException: Error reading byte array of 120 byte(s): only 0 byte(s) available
```

The run sha **includes #1555 and #1562** — the frame write is already uncancellable and serialized under the write lock, so the torn-mid-write theory is dead. The broker error is a *parse* error on a frame that arrived complete per its 4-byte size prefix, which means the frame content itself was internally inconsistent.

## Root cause (mechanism)

`ProduceRequestPartitionData.Write` is two-pass:

1. Size pass: sums `batch.GetEncodedSize()` into `recordsLength`, writes it as the COMPACT_RECORDS varint.
2. Write pass: each `RecordBatch.Write` emits bytes **directly to the underlying buffer**, bypassing `KafkaProtocolWriter` tracking; the tracked count is then patched with the *computed* `recordsLength` via `AddBytesWritten`.

The outer frame size prefix comes from the tracked count (`PreSerializeRequest` backpatches `bodyWriter.BytesWritten`). So if a batch changes between the two passes — the pre-encoded records memory swapped by a concurrent lifecycle race / pooled `RecordBatch` recycling — the size prefix disagrees with the actual bytes and the connection byte stream desyncs. The broker then misparses the *next* bytes as frame content: exactly `Error reading byte array of N byte(s): only 0 byte(s) available`, then closes the socket. Timing fits: tears start when broker stalls trigger delivery timeouts (batch failure/recycle activity) during the fill phase.

## Fix

- `RecordBatch.Write` now returns the exact number of bytes it emitted.
- `ProduceRequestPartitionData.Write` verifies the sum against the computed `recordsLength` and throws a **retriable** `KafkaException(ErrorCode.CorruptMessage)` on mismatch — **before the frame reaches the socket**. The connection stays frame-aligned; the batch fails cleanly/retries instead of corrupting the stream and killing the connection for every in-flight request.
- The exception message carries declared vs actual lengths and batch count — the next stress repro will name the racing lifecycle path directly instead of an opaque broker-side error.

This is the load-bearing invariant guard; the underlying lifecycle race (which object recycles the batch mid-serialization) is still open under #1559 and will be pinpointed by these diagnostics.

## Tests

`ProduceRequestFramingGuardTests` (3 tests, passing):
- batch **grows** between size and write pass → throws before wire, `CorruptMessage`, retriable
- batch **shrinks** between passes → throws before wire
- stable batch → declared length matches emitted bytes and tracked count matches buffer count (outer prefix consistency)

The race window is reproduced deterministically via an `IReadOnlyList<RecordBatch>` that mutates the batch on the second indexer access — exactly between the size pass and write pass.

Refs #1559