### PR TITLE
fix(producer): validate batch generation before acting on pooled ReadyBatch references

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -161,7 +161,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         /// that was present when this PendingResponse was created.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IsSameIncarnation(int i) => Batches[i] is not null && Batches[i].Generation == BatchGenerations[i];
+        public bool IsSameIncarnation(int i)
+            => Batches[i] is not null && Batches[i].IsCurrentIncarnation(BatchGenerations[i]);
 
         /// <summary>
         /// Clears batch references and returns pooled arrays to <see cref="ArrayPool{T}.Shared"/>.
@@ -181,19 +182,38 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         Unmute
     }
 
+    private readonly struct BatchReference
+    {
+        public readonly ReadyBatch Batch;
+        public readonly int Generation;
+
+        public BatchReference(ReadyBatch batch, int generation)
+        {
+            Batch = batch;
+            Generation = generation;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsCurrentIncarnation() => Batch.IsCurrentIncarnation(Generation);
+    }
+
     [StructLayout(LayoutKind.Auto)]
     private readonly struct SendLoopEvent
     {
         public readonly SendLoopEventType Type;
         public readonly ReadyBatch? Batch;
+        public readonly int BatchGeneration;
 
-        private SendLoopEvent(SendLoopEventType type, ReadyBatch? batch = null)
+        private SendLoopEvent(SendLoopEventType type, ReadyBatch? batch = null, int batchGeneration = 0)
         {
             Type = type;
             Batch = batch;
+            BatchGeneration = batchGeneration;
         }
 
-        public static SendLoopEvent NewBatch(ReadyBatch batch) => new(SendLoopEventType.NewBatch, batch);
+        public static SendLoopEvent NewBatch(ReadyBatch batch) => new(SendLoopEventType.NewBatch, batch, batch.Generation);
+
+        public BatchReference GetBatchReference() => new(Batch!, BatchGeneration);
 
         public static SendLoopEvent ResponseReady() => new(SendLoopEventType.ResponseReady);
 
@@ -207,11 +227,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private struct ConnectionBucket
     {
         public ReadyBatch[] Batches;
+        public int[] Generations;
         public int Count;
 
         public void Clear()
         {
             Array.Clear(Batches, 0, Count);
+            Array.Clear(Generations, 0, Count);
             Count = 0;
         }
 
@@ -225,33 +247,33 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// Single-threaded: only accessed by the send loop.
     /// </summary>
     /// <remarks>
-    /// Uses List&lt;ReadyBatch&gt; instead of LinkedList&lt;ReadyBatch&gt; to avoid per-operation
+    /// Uses List&lt;BatchReference&gt; instead of LinkedList&lt;BatchReference&gt; to avoid per-operation
     /// LinkedListNode heap allocations. Carry-over queues are typically small (1-3 items per
     /// partition), so List.Insert(0, item) O(n) shifts are negligible compared to the GC
     /// pressure from LinkedListNode allocations at high throughput.
     /// </remarks>
     private sealed class PartitionCarryOver
     {
-        private readonly Dictionary<TopicPartition, List<ReadyBatch>> _partitions = new();
+        private readonly Dictionary<TopicPartition, List<BatchReference>> _partitions = new();
         private int _count;
 
         public int Count => _count;
-        public Dictionary<TopicPartition, List<ReadyBatch>> Partitions => _partitions;
+        public Dictionary<TopicPartition, List<BatchReference>> Partitions => _partitions;
 
-        private List<ReadyBatch> GetOrCreateQueue(TopicPartition tp)
+        private List<BatchReference> GetOrCreateQueue(TopicPartition tp)
         {
             if (!_partitions.TryGetValue(tp, out var queue))
             {
-                queue = new List<ReadyBatch>(4);
+                queue = new List<BatchReference>(4);
                 _partitions[tp] = queue;
             }
             return queue;
         }
 
         /// <summary>Add to back of partition queue (normal carry-over, new batches).</summary>
-        public void Add(ReadyBatch batch)
+        public void Add(BatchReference batchRef)
         {
-            GetOrCreateQueue(batch.TopicPartition).Add(batch);
+            GetOrCreateQueue(batchRef.Batch.TopicPartition).Add(batchRef);
             _count++;
         }
 
@@ -259,9 +281,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         /// Add to front of partition queue (retries, epoch bump — older batches first).
         /// Matches Java's Deque.addFirst() for reenqueue.
         /// </summary>
-        public void AddFirst(ReadyBatch batch)
+        public void AddFirst(BatchReference batchRef)
         {
-            GetOrCreateQueue(batch.TopicPartition).Insert(0, batch);
+            GetOrCreateQueue(batchRef.Batch.TopicPartition).Insert(0, batchRef);
             _count++;
         }
 
@@ -275,15 +297,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         /// The scan + insert is O(n^2) worst case, but acceptable given typical
         /// per-partition queue sizes of 1-3 items.
         /// </remarks>
-        public void AddAfterRetries(ReadyBatch batch)
+        public void AddAfterRetries(BatchReference batchRef)
         {
-            var queue = GetOrCreateQueue(batch.TopicPartition);
+            var queue = GetOrCreateQueue(batchRef.Batch.TopicPartition);
 
             var insertIdx = 0;
-            while (insertIdx < queue.Count && queue[insertIdx].IsRetry)
+            while (insertIdx < queue.Count && queue[insertIdx].Batch.IsRetry)
                 insertIdx++;
 
-            queue.Insert(insertIdx, batch);
+            queue.Insert(insertIdx, batchRef);
             _count++;
         }
 
@@ -291,7 +313,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         /// Drains all batches to the destination in per-partition FIFO order, then clears.
         /// Used before coalescing to iterate in deterministic per-partition order.
         /// </summary>
-        public void DrainTo(List<ReadyBatch> destination)
+        public void DrainTo(List<BatchReference> destination)
         {
             foreach (var kvp in _partitions)
             {
@@ -310,7 +332,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _count = 0;
         }
 
-        public void RemoveAt(List<ReadyBatch> queue, int index)
+        public void RemoveAt(List<BatchReference> queue, int index)
         {
             queue.RemoveAt(index);
             _count--;
@@ -632,9 +654,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         var coalescedPartitions = new HashSet<TopicPartition>();
         var carryOver = new PartitionCarryOver();
-        var drainList = new List<ReadyBatch>();
+        var drainList = new List<BatchReference>();
 
         var coalescedBatches = new ReadyBatch[maxCoalesce];
+        var coalescedGenerations = new int[maxCoalesce];
         var coalescedCount = 0;
 
         // Pre-allocate reusable response lookup dictionary to avoid per-response allocation.
@@ -658,7 +681,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         var connectionBuckets = new ConnectionBucket[_connectionCount];
         for (var c = 0; c < _connectionCount; c++)
+        {
             connectionBuckets[c].Batches = new ReadyBatch[maxCoalesce];
+            connectionBuckets[c].Generations = new int[maxCoalesce];
+        }
 
         var sendTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var singleConnectionFireAndForgetTimeoutCts = _options.Acks == Acks.None
@@ -726,7 +752,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 while (_sendFailedRetries.TryDequeue(out var retry))
                 {
                     if (retry.Batch.IsCurrentIncarnation(retry.Generation))
-                        carryOver.AddFirst(retry.Batch);
+                        carryOver.AddFirst(new BatchReference(retry.Batch, retry.Generation));
                     else
                         LogStaleRetryBatchSkipped(_instanceId, _brokerId);
                 }
@@ -780,7 +806,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         var newBuckets = new ConnectionBucket[scaledToCount];
                         Array.Copy(connectionBuckets, newBuckets, Math.Min(connectionBuckets.Length, scaledToCount));
                         for (var i = connectionBuckets.Length; i < scaledToCount; i++)
+                        {
                             newBuckets[i].Batches = new ReadyBatch[maxCoalesce];
+                            newBuckets[i].Generations = new int[maxCoalesce];
+                        }
                         connectionBuckets = newBuckets;
 
                         var newBucketCts = new CancellationTokenSource[scaledToCount];
@@ -816,7 +845,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                 for (var i = 0; i < drainList.Count; i++)
                 {
-                    CoalesceBatch(drainList[i], coalescedBatches, ref coalescedCount,
+                    CoalesceBatch(drainList[i], coalescedBatches, coalescedGenerations, ref coalescedCount,
                         coalescedPartitions, carryOver);
                 }
 
@@ -839,7 +868,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         {
                             var carryBefore = carryOver.Count;
                             channelReads++;
-                            CoalesceBatch(evt.Batch!, coalescedBatches, ref coalescedCount,
+                            CoalesceBatch(evt.GetBatchReference(), coalescedBatches, coalescedGenerations, ref coalescedCount,
                                 coalescedPartitions, carryOver);
                             if (carryOver.Count > carryBefore)
                             {
@@ -884,7 +913,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                         if (evt.Type == SendLoopEventType.NewBatch)
                         {
-                            CoalesceBatch(evt.Batch!, coalescedBatches, ref coalescedCount,
+                            CoalesceBatch(evt.GetBatchReference(), coalescedBatches, coalescedGenerations, ref coalescedCount,
                                 coalescedPartitions, carryOver);
                             if (coalescedCount > MicroLingerBatchThreshold)
                                 break;
@@ -935,24 +964,37 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         var dst = 0;
                         for (var src = 0; src < coalescedCount; src++)
                         {
-                            if (!coalescedBatches[src].IsRetry
-                                && _mutedPartitions.ContainsKey(coalescedBatches[src].TopicPartition))
+                            var batch = coalescedBatches[src];
+                            var generation = coalescedGenerations[src];
+
+                            if (!batch.IsCurrentIncarnation(generation))
+                            {
+                                LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+                                continue;
+                            }
+
+                            if (!batch.IsRetry
+                                && _mutedPartitions.ContainsKey(batch.TopicPartition))
                             {
                                 // Normal batch whose partition was muted during the in-flight
                                 // wait (a different batch for this partition triggered a retry).
                                 // Must not send — it would arrive after the retry, violating order.
-                                carryOver.AddAfterRetries(coalescedBatches[src]);
+                                carryOver.AddAfterRetries(new BatchReference(batch, generation));
                             }
                             else
                             {
-                                coalescedBatches[dst] = coalescedBatches[src];
+                                coalescedBatches[dst] = batch;
+                                coalescedGenerations[dst] = generation;
                                 dst++;
                             }
                         }
 
                         // Clear trailing slots so we don't hold stale references
                         for (var i = dst; i < coalescedCount; i++)
+                        {
                             coalescedBatches[i] = null!;
+                            coalescedGenerations[i] = 0;
+                        }
 
                         coalescedCount = dst;
                     }
@@ -971,18 +1013,31 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         // newer data to be sent before older retry data after the partition unmutes.
                         for (var i = 0; i < coalescedCount; i++)
                         {
-                            if (coalescedBatches[i].IsRetry)
-                                carryOver.AddFirst(coalescedBatches[i]);
+                            var batch = coalescedBatches[i];
+                            var generation = coalescedGenerations[i];
+                            if (!batch.IsCurrentIncarnation(generation))
+                            {
+                                LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+                                continue;
+                            }
+
+                            if (batch.IsRetry)
+                                carryOver.AddFirst(new BatchReference(batch, generation));
                             else
-                                carryOver.AddAfterRetries(coalescedBatches[i]);
+                                carryOver.AddAfterRetries(new BatchReference(batch, generation));
                         }
                         Array.Clear(coalescedBatches, 0, coalescedCount);
+                        Array.Clear(coalescedGenerations, 0, coalescedCount);
                         coalescedCount = 0;
                         continue;
                     }
 
                     if (coalescedCount > 0)
                     {
+                        coalescedCount = CompactCurrentBatches(coalescedBatches, coalescedGenerations, coalescedCount);
+                        if (coalescedCount == 0)
+                            continue;
+
                         // Finalize retry batches now that we know they will actually be sent
                         // (epoch bump check passed). Clear IsRetry and unmute partitions.
                         FinalizeCoalescedRetries(coalescedBatches, coalescedCount);
@@ -994,10 +1049,24 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         {
                             // === Single-connection fast path (no grouping overhead) ===
                             var batchesToSend = ArrayPool<ReadyBatch>.Shared.Rent(coalescedCount);
-                            coalescedBatches.AsSpan(0, coalescedCount).CopyTo(batchesToSend);
-                            var countToSend = coalescedCount;
+                            var countToSend = 0;
+                            for (var i = 0; i < coalescedCount; i++)
+                            {
+                                var batch = coalescedBatches[i];
+                                if (batch.IsCurrentIncarnation(coalescedGenerations[i]))
+                                    batchesToSend[countToSend++] = batch;
+                                else
+                                    LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+                            }
                             Array.Clear(coalescedBatches, 0, coalescedCount);
+                            Array.Clear(coalescedGenerations, 0, coalescedCount);
                             coalescedCount = 0;
+
+                            if (countToSend == 0)
+                            {
+                                ArrayPool<ReadyBatch>.Shared.Return(batchesToSend, clearArray: true);
+                                continue;
+                            }
 
                             if (_options.Acks == Acks.None)
                             {
@@ -1061,9 +1130,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             {
                                 var connIdx = GetConnectionForPartition(coalescedBatches[i].TopicPartition.Partition);
                                 ref var bucket = ref connectionBuckets[connIdx];
-                                bucket.Batches[bucket.Count++] = coalescedBatches[i];
+                                bucket.Batches[bucket.Count] = coalescedBatches[i];
+                                bucket.Generations[bucket.Count] = coalescedGenerations[i];
+                                bucket.Count++;
                             }
                             Array.Clear(coalescedBatches, 0, coalescedCount);
+                            Array.Clear(coalescedGenerations, 0, coalescedCount);
                             coalescedCount = 0;
 
                             // Count buckets with batches to avoid O(N) scans in the wait loop.
@@ -1267,10 +1339,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             for (var i = 0; i < coalescedCount; i++)
             {
-                try { FailAndCleanupBatch(coalescedBatches[i], disposedException); }
-                catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
+                if (coalescedBatches[i].IsCurrentIncarnation(coalescedGenerations[i]))
+                {
+                    try { FailAndCleanupBatch(coalescedBatches[i], disposedException); }
+                    catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
+                }
             }
             Array.Clear(coalescedBatches, 0, coalescedCount);
+            Array.Clear(coalescedGenerations, 0, coalescedCount);
 
             // Drain remaining events — only NewBatch events carry batches that need cleanup.
             // ResponseReady and Unmute events are lightweight signals with no data.
@@ -1278,8 +1354,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 if (evt.Type == SendLoopEventType.NewBatch)
                 {
-                    try { FailAndCleanupBatch(evt.Batch!, disposedException); }
-                    catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
+                    var batchRef = evt.GetBatchReference();
+                    if (batchRef.IsCurrentIncarnation())
+                    {
+                        try { FailAndCleanupBatch(batchRef.Batch, disposedException); }
+                        catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
+                    }
                 }
             }
 
@@ -1301,16 +1381,23 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void CoalesceBatch(
-        ReadyBatch batch,
+        BatchReference batchRef,
         ReadyBatch[] coalescedBatches,
+        int[] coalescedGenerations,
         ref int coalescedCount,
         HashSet<TopicPartition> coalescedPartitions,
         PartitionCarryOver carryOver)
     {
-        // Batch may have been returned to pool by a racing ForceFailAllInFlightBatches
-        // call during disposal — skip silently, it's already been failed.
-        if (batch.IsReturnedToPool)
+        // Batch may have been returned to pool or re-rented by a racing owner before
+        // the send loop sees this reference. Skip silently; the original owner already
+        // failed/completed it, and the current owner must not be touched.
+        if (!batchRef.IsCurrentIncarnation())
+        {
+            LogStaleBatchInSendSkipped(_instanceId, _brokerId);
             return;
+        }
+
+        var batch = batchRef.Batch;
 
         // Track distinct partitions this broker serves for MicroLinger skip optimization.
         _knownPartitions.Add(batch.TopicPartition);
@@ -1340,7 +1427,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // Check backoff — carry over if backoff hasn't elapsed
             if (batch.RetryNotBefore > 0 && now < batch.RetryNotBefore)
             {
-                carryOver.Add(batch);
+                carryOver.Add(batchRef);
                 return;
             }
 
@@ -1368,18 +1455,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // carry-over — they must retain their retry state and mute status.
             batch.RetryNotBefore = 0;
 
-            if (CarryOverIfCoalescedFull(batch, coalescedBatches, coalescedCount, carryOver))
+            if (CarryOverIfCoalescedFull(batchRef, coalescedBatches, coalescedCount, carryOver))
                 return;
 
             if (!coalescedPartitions.Add(batch.TopicPartition))
             {
                 // Same partition already in this request (shouldn't happen — only one
                 // retry per partition at a time). Carry over as safety net.
-                carryOver.Add(batch);
+                carryOver.Add(batchRef);
                 return;
             }
 
-            AddCoalescedBatch(batch, coalescedBatches, ref coalescedCount);
+            AddCoalescedBatch(batchRef, coalescedBatches, coalescedGenerations, ref coalescedCount);
             return;
         }
 
@@ -1388,27 +1475,27 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         {
             LogPartitionMuted(_brokerId, batch.TopicPartition.Topic, batch.TopicPartition.Partition);
             batch.AppendDiag('O');
-            carryOver.Add(batch);
+            carryOver.Add(batchRef);
             return;
         }
 
-        if (CarryOverIfCoalescedFull(batch, coalescedBatches, coalescedCount, carryOver))
+        if (CarryOverIfCoalescedFull(batchRef, coalescedBatches, coalescedCount, carryOver))
             return;
 
         // Ensure at most one batch per partition per coalesced request
         if (!coalescedPartitions.Add(batch.TopicPartition))
         {
             batch.AppendDiag('O');
-            carryOver.Add(batch);
+            carryOver.Add(batchRef);
             return;
         }
 
-        AddCoalescedBatch(batch, coalescedBatches, ref coalescedCount);
+        AddCoalescedBatch(batchRef, coalescedBatches, coalescedGenerations, ref coalescedCount);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool CarryOverIfCoalescedFull(
-        ReadyBatch batch,
+        BatchReference batchRef,
         ReadyBatch[] coalescedBatches,
         int coalescedCount,
         PartitionCarryOver carryOver)
@@ -1416,20 +1503,51 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (coalescedCount < coalescedBatches.Length)
             return false;
 
+        var batch = batchRef.Batch;
         batch.AppendDiag('O');
-        carryOver.Add(batch);
+        carryOver.Add(batchRef);
         return true;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void AddCoalescedBatch(
-        ReadyBatch batch,
+        BatchReference batchRef,
         ReadyBatch[] coalescedBatches,
+        int[] coalescedGenerations,
         ref int coalescedCount)
     {
+        var batch = batchRef.Batch;
         batch.AppendDiag('C');
         coalescedBatches[coalescedCount] = batch;
+        coalescedGenerations[coalescedCount] = batchRef.Generation;
         coalescedCount++;
+    }
+
+    private int CompactCurrentBatches(ReadyBatch[] batches, int[] generations, int count)
+    {
+        var writeIdx = 0;
+        for (var readIdx = 0; readIdx < count; readIdx++)
+        {
+            var batch = batches[readIdx];
+            var generation = generations[readIdx];
+            if (!batch.IsCurrentIncarnation(generation))
+            {
+                LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+                continue;
+            }
+
+            batches[writeIdx] = batch;
+            generations[writeIdx] = generation;
+            writeIdx++;
+        }
+
+        for (var i = writeIdx; i < count; i++)
+        {
+            batches[i] = null!;
+            generations[i] = 0;
+        }
+
+        return writeIdx;
     }
 
     /// <summary>
@@ -1502,7 +1620,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             batches[j].AppendDiag('P'); // Faulted/cancelled response processed
                             try
                             {
-                                HandleRetriableBatch(batches[j], ErrorCode.NetworkException,
+                                HandleRetriableBatch(batches[j], pending.BatchGenerations[j], ErrorCode.NetworkException,
                                     carryOver, cancellationToken);
                             }
                             catch (Exception batchEx)
@@ -1646,7 +1764,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         : "(null)";
                     LogNoResponseForPartition(_instanceId, expectedTopic, expectedPartition,
                         responseTopicCount, responseKeys, count, responseTaskId, batch.DiagTrace);
-                    HandleRetriableBatch(batch, ErrorCode.NetworkException,
+                    HandleRetriableBatch(batch, pending.BatchGenerations[j], ErrorCode.NetworkException,
                         carryOver, cancellationToken);
                     batches[j] = null!;
                     continue;
@@ -1667,7 +1785,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             batch.RecordBatch.BaseSequence, batch.RecordBatch.Records.Count,
                             batch.RecordBatch.ProducerEpoch, batch.RecordBatch.ProducerId);
 
-                        HandleRetriableBatch(batch, partitionResponse.ErrorCode,
+                        HandleRetriableBatch(batch, pending.BatchGenerations[j], partitionResponse.ErrorCode,
                             partitionResponse.CurrentLeader, nodeEndpoints,
                             carryOver, cancellationToken);
                         batches[j] = null!;
@@ -1817,7 +1935,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     {
                         try
                         {
-                            HandleRetriableBatch(batch, ErrorCode.NetworkException,
+                            HandleRetriableBatch(batch, pending.BatchGenerations[j], ErrorCode.NetworkException,
                                 carryOver, cancellationToken);
                         }
                         catch (Exception batchEx)
@@ -1878,7 +1996,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var queue = kvp.Value;
             for (var i = 0; i < queue.Count; i++)
             {
-                var batch = queue[i];
+                var batchRef = queue[i];
+                if (!batchRef.IsCurrentIncarnation())
+                    continue;
+
+                var batch = batchRef.Batch;
                 if (batch.RetryNotBefore > 0 && batch.RetryNotBefore < earliestTicks)
                     earliestTicks = batch.RetryNotBefore;
 
@@ -1903,18 +2025,25 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// mutes the partition, signals epoch bump if needed, sets backoff, and adds to carry-over.
     /// Called inline from ProcessCompletedResponses in the single-threaded send loop.
     /// </summary>
-    private void HandleRetriableBatch(ReadyBatch batch, ErrorCode errorCode,
+    private void HandleRetriableBatch(ReadyBatch batch, int generation, ErrorCode errorCode,
         PartitionCarryOver carryOver, CancellationToken cancellationToken)
-        => HandleRetriableBatch(batch, errorCode, null, [], carryOver, cancellationToken);
+        => HandleRetriableBatch(batch, generation, errorCode, null, [], carryOver, cancellationToken);
 
     private void HandleRetriableBatch(
         ReadyBatch batch,
+        int generation,
         ErrorCode errorCode,
         LeaderIdAndEpoch? currentLeader,
         IReadOnlyList<NodeEndpoint> nodeEndpoints,
         PartitionCarryOver carryOver,
         CancellationToken cancellationToken)
     {
+        if (!batch.IsCurrentIncarnation(generation))
+        {
+            LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+            return;
+        }
+
         // Check delivery deadline
         var deliveryDeadlineTicks = batch.StopwatchCreatedTicks +
             _options.DeliveryTimeoutTicks;
@@ -2008,7 +2137,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // retries for the same partition to preserve FIFO ordering.
         batch.IsRetry = true;
         batch.AppendDiag('H'); // HandleRetriableBatch → carry-over
-        carryOver.AddAfterRetries(batch);
+        carryOver.AddAfterRetries(new BatchReference(batch, generation));
     }
 
     private bool TryApplyInlineLeader(
@@ -2062,10 +2191,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         CancellationToken cancellationToken)
     {
         // Snapshot batch generations before the first await, while this send still has
-        // exclusive ownership handed over by the send loop's coalesce step. Every later
-        // touch of a batch (completion, cleanup, retry enqueue, pending-response matching)
-        // validates against this snapshot via IsCurrentIncarnation — a mismatch means the
-        // pooled ReadyBatch was recycled by another owner and must not be acted on.
+        // exclusive ownership handed over by the send loop's coalesce step. If the request
+        // builder sorts batches in place, it sorts this generation array in lockstep so
+        // every later liveness check still compares the matching batch/generation pair.
         var generations = ArrayPool<int>.Shared.Rent(count);
         for (var i = 0; i < count; i++)
             generations[i] = batches[i].Generation;
@@ -2151,6 +2279,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var connection = await GetConnectionAtIndexAsync(connectionIndex, cancellationToken)
                 .ConfigureAwait(false);
 
+            count = CompactCurrentBatches(batches, generations, count);
+            if (count == 0)
+            {
+                ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
+                return;
+            }
+
             // Diagnostic: mark batches as having acquired a connection.
             // If orphan trace shows 'S' but no 'G' (Got connection), the hang is at
             // GetConnectionAtIndexAsync (connection creation or write lock contention).
@@ -2167,10 +2302,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     await _ensurePartitionInTransaction(batches[i].TopicPartition, cancellationToken)
                         .ConfigureAwait(false);
                 }
+
+                count = CompactCurrentBatches(batches, generations, count);
+                if (count == 0)
+                {
+                    ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
+                    return;
+                }
             }
 
             // Build coalesced ProduceRequest (reuses pre-allocated scratch structures)
-            var request = scratch.Build(batches, count);
+            var request = scratch.Build(batches, generations, count);
 
             var requestStartTime = Stopwatch.GetTimestamp();
 
@@ -2238,9 +2380,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // CleanupBatch still releases for error paths where TCP send wasn't reached.
             for (var i = 0; i < count; i++)
             {
-                if (batches[i].TrySetMemoryReleased())
+                var batch = batches[i];
+                if (!batch.IsCurrentIncarnation(generations[i]))
                 {
-                    _accumulator.ReleaseMemory(batches[i].DataSize);
+                    LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+                    batches[i] = null!;
+                    continue;
+                }
+
+                if (batch.TrySetMemoryReleased())
+                {
+                    _accumulator.ReleaseMemory(batch.DataSize);
                 }
             }
 
@@ -2254,7 +2404,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (_logger.IsEnabled(LogLevel.Debug))
             {
                 var pipelinedPartitions = string.Join(", ",
-                    Enumerable.Range(0, count).Select(i => $"{batches[i].TopicPartition.Topic}-{batches[i].TopicPartition.Partition}"));
+                    Enumerable.Range(0, count)
+                        .Where(i => batches[i] is not null)
+                        .Select(i => $"{batches[i].TopicPartition.Topic}-{batches[i].TopicPartition.Partition}"));
                 LogPendingResponseCreated(_instanceId, _brokerId, responseTask.Id, count, pipelinedPartitions);
             }
 
@@ -2438,22 +2590,23 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
         }
 
-#if NETSTANDARD2_0
-        private sealed class ReadyBatchTopicComparer : IComparer<ReadyBatch>
+        private sealed class ReadyBatchTopicComparer : IComparer<ReadyBatch>, System.Collections.IComparer
         {
             public static readonly ReadyBatchTopicComparer Instance = new();
 
             public int Compare(ReadyBatch? x, ReadyBatch? y)
                 => string.Compare(x?.TopicPartition.Topic, y?.TopicPartition.Topic, StringComparison.Ordinal);
+
+            int System.Collections.IComparer.Compare(object? x, object? y)
+                => Compare((ReadyBatch?)x, (ReadyBatch?)y);
         }
-#endif
 
         /// <summary>
         /// Populates the reusable request from the given batches. Returns the same
         /// ProduceRequest instance each time — callers must not hold references past
         /// the next call.
         /// </summary>
-        public ProduceRequest Build(ReadyBatch[] batches, int count)
+        public ProduceRequest Build(ReadyBatch[] batches, int[] generations, int count)
         {
             // Sort batches by topic name so equal topics are contiguous.
             // Fast-path: skip the O(n log n) sort when count <= 1 or already sorted.
@@ -2485,12 +2638,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // batches are rare; the common case (single topic or already sorted) skips the sort.
             if (!alreadySorted)
             {
-#if NETSTANDARD2_0
-                System.Array.Sort(batches, 0, count, ReadyBatchTopicComparer.Instance);
-#else
-                batchesSpan.Sort(static (a, b) =>
-                    string.Compare(a.TopicPartition.Topic, b.TopicPartition.Topic, StringComparison.Ordinal));
-#endif
+                System.Array.Sort((System.Array)batches, (System.Array)generations, 0, count, ReadyBatchTopicComparer.Instance);
 
                 // Discard the partial topicCount from the pre-scan and recount from scratch.
                 // Post-sort, topics are contiguous so simple != equality suffices (no need for
@@ -2646,9 +2794,22 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     {
         ref var bucket = ref connectionBuckets[connIdx];
         var batchesToSend = ArrayPool<ReadyBatch>.Shared.Rent(bucket.Count);
-        bucket.Batches.AsSpan(0, bucket.Count).CopyTo(batchesToSend);
-        var countToSend = bucket.Count;
+        var countToSend = 0;
+        for (var i = 0; i < bucket.Count; i++)
+        {
+            var batch = bucket.Batches[i];
+            if (batch.IsCurrentIncarnation(bucket.Generations[i]))
+                batchesToSend[countToSend++] = batch;
+            else
+                LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+        }
         bucket.Clear();
+
+        if (countToSend == 0)
+        {
+            ArrayPool<ReadyBatch>.Shared.Return(batchesToSend, clearArray: true);
+            return;
+        }
 
         await SendCoalescedAsync(batchesToSend, countToSend, scratch, connIdx, cancellationToken)
             .ConfigureAwait(false);
@@ -2868,7 +3029,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var queue = kvp.Value;
             for (var i = queue.Count - 1; i >= 0; i--)
             {
-                var batch = queue[i];
+                var batchRef = queue[i];
+                if (!batchRef.IsCurrentIncarnation())
+                {
+                    carryOver.RemoveAt(queue, i);
+                    continue;
+                }
+
+                var batch = batchRef.Batch;
                 if (now < batch.StopwatchCreatedTicks + deliveryTimeoutTicks)
                     continue;
 
@@ -2901,7 +3069,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var queue = kvp.Value;
             for (var i = 0; i < queue.Count; i++)
             {
-                FailAndCleanupBatch(queue[i], disposedException);
+                var batchRef = queue[i];
+                if (batchRef.IsCurrentIncarnation())
+                    FailAndCleanupBatch(batchRef.Batch, disposedException);
             }
         }
     }

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -146,18 +146,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         long RequestStartTime)
     {
         /// <summary>
-        /// Snapshots batch generations at creation time. Must be called immediately after
-        /// populating the Batches array — the generations detect batch object recycling
-        /// between send and response processing.
+        /// Wraps a pipelined response with the batch-generation snapshot the send captured
+        /// at send start (before its first await) — the generations detect batch object
+        /// recycling between send and response processing. Ownership of the rented
+        /// <paramref name="generations"/> array transfers to this PendingResponse;
+        /// it is returned by <see cref="ReturnBatchesArray"/>.
         /// </summary>
         public static PendingResponse Create(
-            Task<ProduceResponse> responseTask, ReadyBatch[] batches, int count, long requestStartTime)
-        {
-            var generations = ArrayPool<int>.Shared.Rent(count);
-            for (var i = 0; i < count; i++)
-                generations[i] = batches[i].Generation;
-            return new PendingResponse(responseTask, batches, generations, count, requestStartTime);
-        }
+            Task<ProduceResponse> responseTask, ReadyBatch[] batches, int[] generations, int count, long requestStartTime)
+            => new(responseTask, batches, generations, count, requestStartTime);
 
         /// <summary>
         /// Returns true if the batch at index <paramref name="i"/> is the same incarnation
@@ -329,7 +326,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // can Enqueue simultaneously from different thread-pool threads. ConcurrentQueue provides
     // FIFO ordering (matching the old List iteration order) and is optimized for the
     // cross-thread producer-consumer pattern used here.
-    private readonly ConcurrentQueue<ReadyBatch> _sendFailedRetries = new();
+    //
+    // Each entry carries the batch's generation captured at send start. ReadyBatch objects
+    // are pooled, so a reference sitting in this queue can be completed and recycled by
+    // another owner before the send loop dequeues it. IsReturnedToPool alone cannot detect
+    // that (the flag is reset on re-rent); the generation comparison can. Dequeuers must
+    // validate with IsCurrentIncarnation before acting on the batch — acting on a recycled
+    // entry re-sends or fails a batch now owned by a different partition, which is the
+    // root cause of the PRODUCE framing-guard failures in issue #1570.
+    private readonly ConcurrentQueue<(ReadyBatch Batch, int Generation)> _sendFailedRetries = new();
 
     // Non-blocking in-flight request limiter. The send loop uses _totalPendingResponseCount
     // (which it exclusively owns) as the in-flight measure. No cross-thread signaling needed.
@@ -718,8 +723,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // FIFO dequeue + AddFirst reverses the enqueue order, but this is intentional:
                 // each retry batch goes before all existing carry-over for its partition,
                 // matching Java's Deque.addFirst semantics for retry priority.
-                while (_sendFailedRetries.TryDequeue(out var retryBatch))
-                    carryOver.AddFirst(retryBatch);
+                while (_sendFailedRetries.TryDequeue(out var retry))
+                {
+                    if (retry.Batch.IsCurrentIncarnation(retry.Generation))
+                        carryOver.AddFirst(retry.Batch);
+                    else
+                        LogStaleRetryBatchSkipped(_instanceId, _brokerId);
+                }
 
                 // ── 3. Handle timed-out requests (Java handleTimedOutRequests pattern) ──
                 HandleTimedOutRequests(carryOver, cancellationToken);
@@ -1223,9 +1233,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             var disposedException = new ObjectDisposedException(nameof(BrokerSender));
 
-            while (_sendFailedRetries.TryDequeue(out var retryBatch))
+            while (_sendFailedRetries.TryDequeue(out var retry))
             {
-                try { FailAndCleanupBatch(retryBatch, disposedException); }
+                if (!retry.Batch.IsCurrentIncarnation(retry.Generation))
+                    continue;
+
+                try { FailAndCleanupBatch(retry.Batch, disposedException); }
                 catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
             }
 
@@ -2048,10 +2061,19 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         int connectionIndex,
         CancellationToken cancellationToken)
     {
+        // Snapshot batch generations before the first await, while this send still has
+        // exclusive ownership handed over by the send loop's coalesce step. Every later
+        // touch of a batch (completion, cleanup, retry enqueue, pending-response matching)
+        // validates against this snapshot via IsCurrentIncarnation — a mismatch means the
+        // pooled ReadyBatch was recycled by another owner and must not be acted on.
+        var generations = ArrayPool<int>.Shared.Rent(count);
+        for (var i = 0; i < count; i++)
+            generations[i] = batches[i].Generation;
+
         // Tracks whether PendingResponse was added to _pendingResponsesByConnection.
-        // Once added, ProcessCompletedResponses owns the batches array — catch blocks
-        // must NOT return it to ArrayPool, or the array will be recycled while
-        // PendingResponse still references it (causing cross-request batch contamination).
+        // Once added, ProcessCompletedResponses owns the batches array AND the generations
+        // array — catch blocks must NOT return them to ArrayPool, or they will be recycled
+        // while PendingResponse still references them (causing cross-request batch contamination).
         var pendingResponseAdded = false;
         try
         {
@@ -2168,6 +2190,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 for (var i = 0; i < count; i++)
                 {
                     var batch = batches[i];
+                    if (!batch.IsCurrentIncarnation(generations[i]))
+                    {
+                        LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+                        batches[i] = null!;
+                        continue;
+                    }
+
                     CompleteInflightEntry(batch);
                     batch.CompleteSend(-1, fireAndForgetTimestamp);
                     try { _onAcknowledgement?.Invoke(batch.TopicPartition, -1, fireAndForgetTimestamp, batch.CompletionSourcesCount, null); }
@@ -2178,7 +2207,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // doesn't add to _pendingResponsesByConnection, so no in-flight slot to release)
                 for (var i = 0; i < count; i++)
                 {
-                    CleanupBatch(batches[i]);
+                    if (batches[i] is not null)
+                        CleanupBatch(batches[i]);
                 }
 
                 ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
@@ -2214,7 +2244,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
             }
 
-            var pendingResponse = PendingResponse.Create(responseTask, batches, count, requestStartTime);
+            var pendingResponse = PendingResponse.Create(responseTask, batches, generations, count, requestStartTime);
             _pendingResponsesByConnection[connectionIndex].Add(pendingResponse);
             pendingResponseAdded = true; // Array ownership transferred to PendingResponse
             Interlocked.Increment(ref _totalPendingResponseCount);
@@ -2277,7 +2307,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // the parameter may be a linked timeout CTS. On timeout, we want retry (Z path),
             // not permanent failure — only true shutdown should permanently fail batches.
             for (var i = 0; i < count; i++)
-                FailAndCleanupBatch(batches[i], new ObjectDisposedException(nameof(BrokerSender)));
+            {
+                var batch = batches[i];
+
+                // Skip batches recycled by a racing owner (e.g. ForceFailAllInFlightBatches
+                // during disposal) — failing a re-rented batch would fail its new owner's data.
+                if (batch is null || !batch.IsCurrentIncarnation(generations[i]))
+                    continue;
+
+                FailAndCleanupBatch(batch, new ObjectDisposedException(nameof(BrokerSender)));
+            }
 
             scratch.ClearReferences();
 
@@ -2297,8 +2336,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 var batch = batches[i];
 
-                // Batch may have been returned to pool by a racing disposal — skip, already failed.
-                if (batch is null || batch.IsReturnedToPool)
+                // Batch may have been recycled by a racing owner (disposal ForceFail, or a
+                // completion that outran this handler). IsReturnedToPool alone is insufficient —
+                // the flag resets when the pooled object is re-rented — so compare against the
+                // generation snapshot taken at send start (#1570).
+                if (batch is null || !batch.IsCurrentIncarnation(generations[i]))
                     continue;
 
                 batch.AppendDiag('Z'); // Diagnostic: send failed, entering retry/fail path
@@ -2331,7 +2373,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         batch.IsRetry = true;
                         batch.RetryNotBefore = Stopwatch.GetTimestamp() +
                             _options.RetryBackoffTicks;
-                        _sendFailedRetries.Enqueue(batch);
+                        _sendFailedRetries.Enqueue((batch, generations[i]));
                     }
                 }
                 catch (Exception batchEx)
@@ -2348,6 +2390,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             if (!pendingResponseAdded)
                 ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
+        }
+        finally
+        {
+            // The generations snapshot transfers to PendingResponse along with the batches
+            // array; ReturnBatchesArray returns both. On every other path it is owned here.
+            if (!pendingResponseAdded)
+                ArrayPool<int>.Shared.Return(generations);
         }
     }
 
@@ -3368,6 +3417,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "BS#{InstanceId} response task={ResponseTaskId}: batch already returned to pool (count={Count}, trace={DiagTrace}), skipping")]
     private partial void LogBatchAlreadyReturnedToPool(int instanceId, int responseTaskId, int count, string diagTrace);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "BS#{InstanceId} broker {BrokerId}: send-failed retry batch was recycled while queued (generation mismatch), skipping")]
+    private partial void LogStaleRetryBatchSkipped(int instanceId, int brokerId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "BS#{InstanceId} broker {BrokerId}: batch recycled during send (generation mismatch), skipping completion")]
+    private partial void LogStaleBatchInSendSkipped(int instanceId, int brokerId);
 
     #endregion
 }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3034,7 +3034,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 if (preSerialize)
                 {
                     if (_options.CompressionType == CompressionType.None)
-                        PrepareBatchForPublish(readyBatch);
+                        PrepareBatchForPublish(readyBatch, readyBatch.Generation);
                     else
                         readyBatch.SetPreSerializationTask(CreatePreSerializationTask(readyBatch));
                 }
@@ -3207,30 +3207,34 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     private Task CreatePreSerializationTask(ReadyBatch readyBatch)
     {
+        var generation = readyBatch.Generation;
         return new Task(
             static state =>
             {
                 var workItem = (PreSerializationWorkItem)state!;
-                workItem.Accumulator.PreSerializeAndPublishBatch(workItem.Batch);
+                workItem.Accumulator.PreSerializeAndPublishBatch(workItem.Batch, workItem.Generation);
             },
-            new PreSerializationWorkItem(this, readyBatch),
+            new PreSerializationWorkItem(this, readyBatch, generation),
             CancellationToken.None,
             TaskCreationOptions.DenyChildAttach);
     }
 
-    private void PreSerializeAndPublishBatch(ReadyBatch readyBatch)
+    private void PreSerializeAndPublishBatch(ReadyBatch readyBatch, int generation)
     {
-        if (PrepareBatchForPublish(readyBatch) && !readyBatch.IsReturnedToPool)
+        if (PrepareBatchForPublish(readyBatch, generation) && readyBatch.IsCurrentIncarnation(generation))
             PublishSealedBatch(readyBatch);
     }
 
     private sealed class PreSerializationWorkItem(
         RecordAccumulator accumulator,
-        ReadyBatch batch)
+        ReadyBatch batch,
+        int generation)
     {
         public RecordAccumulator Accumulator { get; } = accumulator;
 
         public ReadyBatch Batch { get; } = batch;
+
+        public int Generation { get; } = generation;
     }
 
     /// <summary>
@@ -3244,8 +3248,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// batches where <see cref="ReadyBatch.IsPreSerialized"/> is false, so the sender only
     /// picks up wire-ready batches.
     /// </summary>
-    private bool PrepareBatchForPublish(ReadyBatch readyBatch)
+    private bool PrepareBatchForPublish(ReadyBatch readyBatch, int generation)
     {
+        if (!readyBatch.IsCurrentIncarnation(generation))
+            return false;
+
         Exception? failure = null;
         try
         {
@@ -3257,12 +3264,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             failure = ex;
         }
 
+        if (!readyBatch.IsCurrentIncarnation(generation))
+            return false;
+
         // Mark pre-serialization complete so the drain loop can pick up this batch.
         readyBatch.MarkPreSerialized();
         if (failure is null)
-            return !readyBatch.IsSendCompleted;
+            return !readyBatch.IsSendCompleted && readyBatch.IsCurrentIncarnation(generation);
 
-        return readyBatch.FailFromPreSerialization(failure);
+        return readyBatch.IsCurrentIncarnation(generation) && readyBatch.FailFromPreSerialization(failure);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5858,6 +5858,23 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     internal int Generation => Volatile.Read(ref _generation);
 
     /// <summary>
+    /// Returns true if this batch is still the live incarnation the caller captured
+    /// <paramref name="expectedGeneration"/> from. Unlike <see cref="IsReturnedToPool"/>
+    /// alone — whose flag is reset when the object is re-rented, making a recycled batch
+    /// indistinguishable from a live one — this also compares the generation stamp, which
+    /// only ever moves forward.
+    /// </summary>
+    /// <remarks>
+    /// Read order matters and must not be changed: <see cref="IsReturnedToPool"/> is read
+    /// before <see cref="Generation"/>. Initialize() increments the generation before it
+    /// clears <c>_returnedToPool</c>, so a reader that observes the cleared flag is
+    /// guaranteed to observe the new generation and fail the comparison. Reading in the
+    /// opposite order reintroduces the window where both checks pass on a recycled batch.
+    /// </remarks>
+    internal bool IsCurrentIncarnation(int expectedGeneration)
+        => !IsReturnedToPool && Generation == expectedGeneration;
+
+    /// <summary>
     /// Creates an uninitialized ReadyBatch. Call Initialize() before use.
     /// </summary>
     public ReadyBatch()
@@ -5879,6 +5896,16 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         int callbackCount = 0,
         BatchArrayReuseQueue? arrayReuseQueue = null)
     {
+        // The generation increment must happen BEFORE the lifecycle flags are cleared.
+        // Stale-reference holders validate liveness by reading _returnedToPool first and
+        // _generation second (see IsCurrentIncarnation). With the increment ordered first,
+        // a stale holder that observes _returnedToPool == 0 (this re-initialization already
+        // cleared it) is guaranteed to also observe the new generation and bail on the
+        // mismatch. With the old order (flags first), a holder could see _returnedToPool == 0
+        // while still reading its own stale generation — passing both checks and acting on
+        // a batch now owned by someone else.
+        Interlocked.Increment(ref _generation);
+
         // Reset lifecycle flags at the START of a new lifecycle (not in Reset()).
         // This ensures stale references from a previous lifecycle see _cleanedUp=1
         // and return early from CompleteSend/Fail, preventing pool corruption.
@@ -5891,7 +5918,6 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         Interlocked.Exchange(ref _memoryReleased, 0);
         Volatile.Write(ref _preSerialized, 0);
         Volatile.Write(ref _preSerializationTask, null);
-        Interlocked.Increment(ref _generation);
 
         _topicPartition = topicPartition;
         _recordBatch = recordBatch;

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -30,6 +30,10 @@ public sealed class BrokerSenderMuteOrderingTests
         "PartitionCarryOver",
         BindingFlags.NonPublic)!;
 
+    private static readonly Type BatchReferenceType = typeof(BrokerSender).GetNestedType(
+        "BatchReference",
+        BindingFlags.NonPublic)!;
+
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 0, int retryBackoffMaxMs = 0,
         int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000) => new()
@@ -230,25 +234,45 @@ public sealed class BrokerSenderMuteOrderingTests
         return (int)PartitionCarryOverType.GetProperty("Count")!.GetValue(carryOver)!;
     }
 
+    private static object CreateBatchReference(ReadyBatch batch, int generation)
+    {
+        return Activator.CreateInstance(BatchReferenceType, batch, generation)!;
+    }
+
     private static void InvokeCoalesceBatch(
         BrokerSender sender,
         ReadyBatch batch,
         ReadyBatch[] coalescedBatches,
+        int[] coalescedGenerations,
         ref int coalescedCount,
         HashSet<TopicPartition> coalescedPartitions,
-        object carryOver)
+        object carryOver,
+        int? capturedGeneration = null)
     {
         var args = new object?[]
         {
-            batch,
+            CreateBatchReference(batch, capturedGeneration ?? batch.Generation),
             coalescedBatches,
+            coalescedGenerations,
             coalescedCount,
             coalescedPartitions,
             carryOver
         };
 
         CoalesceBatchMethod.Invoke(sender, args);
-        coalescedCount = (int)args[2]!;
+        coalescedCount = (int)args[3]!;
+    }
+
+    private static ReadyBatch CreateMinimalBatch(string topic, int partition)
+    {
+        var batch = new ReadyBatch();
+        batch.Initialize(
+            new TopicPartition(topic, partition),
+            new RecordBatch { Records = Array.Empty<Record>() },
+            completionSourcesArray: null,
+            completionSourcesCount: 0,
+            dataSize: 100);
+        return batch;
     }
 
     [Test]
@@ -266,6 +290,7 @@ public sealed class BrokerSenderMuteOrderingTests
             var firstBatch = CreateTestBatch(vtPool, "test-topic", 0);
             var overflowBatch = CreateTestBatch(vtPool, "test-topic", 1);
             var coalescedBatches = new[] { firstBatch };
+            var coalescedGenerations = new[] { firstBatch.Generation };
             var coalescedCount = 1;
             var coalescedPartitions = new HashSet<TopicPartition> { firstBatch.TopicPartition };
             var carryOver = CreateCarryOver();
@@ -274,6 +299,7 @@ public sealed class BrokerSenderMuteOrderingTests
                 sender,
                 overflowBatch,
                 coalescedBatches,
+                coalescedGenerations,
                 ref coalescedCount,
                 coalescedPartitions,
                 carryOver);
@@ -288,6 +314,54 @@ public sealed class BrokerSenderMuteOrderingTests
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task CoalesceBatch_StaleGenerationSkipsReRentedBatch()
+    {
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
+        var (pool, _) = CreateMockConnection(responseQueue);
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            var batch = CreateMinimalBatch("old-topic", 0);
+            var staleGeneration = batch.Generation;
+            Interlocked.Exchange(ref batch._returnedToPool, 1);
+            batch.Initialize(
+                new TopicPartition("new-topic", 1),
+                new RecordBatch { Records = Array.Empty<Record>() },
+                completionSourcesArray: null,
+                completionSourcesCount: 0,
+                dataSize: 100);
+
+            var coalescedBatches = new ReadyBatch[4];
+            var coalescedGenerations = new int[4];
+            var coalescedCount = 0;
+            var coalescedPartitions = new HashSet<TopicPartition>();
+            var carryOver = CreateCarryOver();
+
+            InvokeCoalesceBatch(
+                sender,
+                batch,
+                coalescedBatches,
+                coalescedGenerations,
+                ref coalescedCount,
+                coalescedPartitions,
+                carryOver,
+                staleGeneration);
+
+            await Assert.That(coalescedCount).IsEqualTo(0);
+            await Assert.That(GetCarryOverCount(carryOver)).IsEqualTo(0);
+            await Assert.That(coalescedPartitions.Contains(batch.TopicPartition)).IsFalse();
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
         }
     }
 
@@ -308,6 +382,7 @@ public sealed class BrokerSenderMuteOrderingTests
             overflowBatch.IsRetry = true;
 
             var coalescedBatches = new[] { firstBatch };
+            var coalescedGenerations = new[] { firstBatch.Generation };
             var coalescedCount = 1;
             var coalescedPartitions = new HashSet<TopicPartition> { firstBatch.TopicPartition };
             var carryOver = CreateCarryOver();
@@ -316,6 +391,7 @@ public sealed class BrokerSenderMuteOrderingTests
                 sender,
                 overflowBatch,
                 coalescedBatches,
+                coalescedGenerations,
                 ref coalescedCount,
                 coalescedPartitions,
                 carryOver);

--- a/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
@@ -1,5 +1,9 @@
+using System.Diagnostics;
+using System.Reflection;
+using Dekaf.Compression;
 using Dekaf.Metadata;
 using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
 
 namespace Dekaf.Tests.Unit.Producer;
@@ -14,6 +18,14 @@ namespace Dekaf.Tests.Unit.Producer;
 /// </summary>
 public sealed class ReadyBatchIncarnationTests
 {
+    private static readonly Type PendingResponseType = typeof(BrokerSender).GetNestedType(
+        "PendingResponse",
+        BindingFlags.NonPublic)!;
+
+    private static readonly Type ProduceRequestScratchType = typeof(BrokerSender).GetNestedType(
+        "ProduceRequestScratch",
+        BindingFlags.NonPublic)!;
+
     private static ReadyBatch CreateInitializedBatch(string topic = "t", int partition = 0)
     {
         var batch = new ReadyBatch();
@@ -98,5 +110,47 @@ public sealed class ReadyBatchIncarnationTests
 
         await Assert.That(batch.IsReturnedToPool).IsFalse();
         await Assert.That(batch.Generation).IsNotEqualTo(staleGeneration);
+    }
+
+    [Test]
+    public async Task PendingResponse_IsSameIncarnation_ReturnedToPool_ReturnsFalse()
+    {
+        var batch = CreateInitializedBatch();
+        var capturedGeneration = batch.Generation;
+        var batches = new[] { batch };
+        var generations = new[] { capturedGeneration };
+        var responseTask = Task.FromResult(new ProduceResponse());
+        var create = PendingResponseType.GetMethod("Create", BindingFlags.Public | BindingFlags.Static)!;
+        var pending = create.Invoke(null, [responseTask, batches, generations, 1, Stopwatch.GetTimestamp()])!;
+        var isSameIncarnation = PendingResponseType.GetMethod("IsSameIncarnation")!;
+
+        Interlocked.Exchange(ref batch._returnedToPool, 1);
+
+        var result = (bool)isSameIncarnation.Invoke(pending, [0])!;
+
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task ProduceRequestScratch_Build_WhenSortingBatches_PermutesGenerations()
+    {
+        var laterTopicBatch = CreateInitializedBatch("z-topic", 0);
+        InitializeBatch(laterTopicBatch, "z-topic", 0);
+        var earlierTopicBatch = CreateInitializedBatch("a-topic", 1);
+        var batches = new[] { laterTopicBatch, earlierTopicBatch };
+        var generations = new[] { laterTopicBatch.Generation, earlierTopicBatch.Generation };
+        var scratch = Activator.CreateInstance(
+            ProduceRequestScratchType,
+            new ProducerOptions { BootstrapServers = ["localhost:9092"] },
+            new CompressionCodecRegistry(),
+            4)!;
+        var build = ProduceRequestScratchType.GetMethod("Build")!;
+
+        build.Invoke(scratch, [batches, generations, 2]);
+
+        await Assert.That(batches[0]).IsSameReferenceAs(earlierTopicBatch);
+        await Assert.That(generations[0]).IsEqualTo(earlierTopicBatch.Generation);
+        await Assert.That(batches[1]).IsSameReferenceAs(laterTopicBatch);
+        await Assert.That(generations[1]).IsEqualTo(laterTopicBatch.Generation);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
@@ -1,0 +1,102 @@
+using Dekaf.Metadata;
+using Dekaf.Producer;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Regression tests for issue #1570: pooled ReadyBatch objects are recycled while stale
+/// references still sit in retry queues. The old staleness check (IsReturnedToPool alone)
+/// is unsound because the flag resets when the object is re-rented — a stale holder then
+/// treats a batch owned by another partition as its own, which surfaced as PRODUCE framing
+/// guard failures (declared/emitted length mismatch) and message loss in stress runs.
+/// IsCurrentIncarnation combines the flag with a monotonic generation stamp to close this.
+/// </summary>
+public sealed class ReadyBatchIncarnationTests
+{
+    private static ReadyBatch CreateInitializedBatch(string topic = "t", int partition = 0)
+    {
+        var batch = new ReadyBatch();
+        InitializeBatch(batch, topic, partition);
+        return batch;
+    }
+
+    private static void InitializeBatch(ReadyBatch batch, string topic = "t", int partition = 0)
+    {
+        batch.Initialize(
+            new TopicPartition(topic, partition),
+            new RecordBatch { Records = Array.Empty<Record>() },
+            completionSourcesArray: null,
+            completionSourcesCount: 0,
+            dataSize: 100);
+    }
+
+    [Test]
+    public async Task Initialize_IncrementsGeneration()
+    {
+        var batch = CreateInitializedBatch();
+        var firstGeneration = batch.Generation;
+
+        InitializeBatch(batch, "other-topic", 1);
+
+        await Assert.That(batch.Generation).IsNotEqualTo(firstGeneration);
+    }
+
+    [Test]
+    public async Task IsCurrentIncarnation_LiveBatch_ReturnsTrue()
+    {
+        var batch = CreateInitializedBatch();
+
+        await Assert.That(batch.IsCurrentIncarnation(batch.Generation)).IsTrue();
+    }
+
+    [Test]
+    public async Task IsCurrentIncarnation_ReturnedToPool_ReturnsFalse()
+    {
+        var batch = CreateInitializedBatch();
+        var capturedGeneration = batch.Generation;
+
+        // Simulate ReturnReadyBatch marking the batch as returned (still in the pool,
+        // not yet re-rented). The generation is unchanged, so only the flag catches this.
+        Interlocked.Exchange(ref batch._returnedToPool, 1);
+
+        await Assert.That(batch.IsCurrentIncarnation(capturedGeneration)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsCurrentIncarnation_RecycledAndReRented_ReturnsFalse()
+    {
+        // The exact sequence from #1570: a stale reference (e.g. in _sendFailedRetries)
+        // captured the generation, then the batch completed, went back to the pool, and
+        // was re-rented for a different partition. Re-initialization resets
+        // _returnedToPool to 0, so the flag check alone passes — only the generation
+        // comparison detects that this is a different incarnation.
+        var batch = CreateInitializedBatch("original-topic", 0);
+        var staleGeneration = batch.Generation;
+
+        Interlocked.Exchange(ref batch._returnedToPool, 1); // returned to pool
+        InitializeBatch(batch, "new-owner-topic", 3);       // re-rented by a new owner
+
+        await Assert.That(batch.IsReturnedToPool).IsFalse();       // flag check alone would pass
+        await Assert.That(batch.IsCurrentIncarnation(staleGeneration)).IsFalse(); // generation catches it
+        await Assert.That(batch.IsCurrentIncarnation(batch.Generation)).IsTrue(); // new owner unaffected
+    }
+
+    [Test]
+    public async Task Initialize_GenerationIncrementVisibleBeforeFlagClear()
+    {
+        // Initialize() must bump the generation BEFORE clearing _returnedToPool.
+        // IsCurrentIncarnation reads the flag first and the generation second, so this
+        // write order guarantees a reader that sees the cleared flag also sees the new
+        // generation. This test pins the observable end state; the ordering itself is
+        // enforced by the write sequence in Initialize() (see comment there).
+        var batch = CreateInitializedBatch();
+        var staleGeneration = batch.Generation;
+
+        Interlocked.Exchange(ref batch._returnedToPool, 1);
+        InitializeBatch(batch);
+
+        await Assert.That(batch.IsReturnedToPool).IsFalse();
+        await Assert.That(batch.Generation).IsNotEqualTo(staleGeneration);
+    }
+}


### PR DESCRIPTION
Fixes #1570

## Problem

Stress run [28939906458](https://github.com/thomhurst/Dekaf/actions/runs/28939906458) failed with 56 errors and 48,704 accepted-but-never-delivered messages — exactly 56 batches. Each error was the #1568 framing guard firing (`declared records length != emitted bytes`), which is only possible when a pooled `RecordBatch` is recycled and re-rented mid-serialization.

The staleness defense for pooled `ReadyBatch` references was `IsReturnedToPool` — but `Initialize()` resets that flag on re-rent. A stale reference sitting in `_sendFailedRetries` (or held by a send task racing a disposal/completion) that inspects a re-rented object sees "not returned" and acts on a batch now owned by a different partition: re-sending it (framing mismatch, previously wire corruption), completing it (foreign batch falsely acknowledged), or failing it (foreign batch falsely failed → message loss).

## Fix

Extend the generation-stamp pattern already used by `PendingResponse.IsSameIncarnation` to every place a `ReadyBatch` reference can outlive ownership:

- **`ReadyBatch.IsCurrentIncarnation(int)`** — combines the pool flag with the monotonic generation stamp. Read order (flag, then generation) pairs with the new write order in `Initialize()` (generation increment **before** flag clear) so a reader can never observe a cleared flag with a stale generation.
- **`SendCoalescedAsync`** snapshots generations before its first await, while ownership handed over by the coalesce step is still exclusive. All later touches validate against the snapshot: fire-and-forget completion/cleanup loops, the shutdown fail path, and the send-failure retry path.
- **`_sendFailedRetries`** entries now carry the captured generation; both dequeue sites (retry pickup and disposal drain) validate before acting.
- **`PendingResponse.Create`** now receives the send-start snapshot instead of re-capturing after the send — a later capture can stamp a foreign incarnation and then complete it when the response arrives.

Stale entries are skipped with a warning log (`LogStaleRetryBatchSkipped` / `LogStaleBatchInSendSkipped`) so future stress runs surface any remaining double-ownership path by name instead of by corruption.

## Testing

- New `ReadyBatchIncarnationTests` (5 tests, passing) pin the regression: a returned-and-re-rented batch passes the old `IsReturnedToPool` check but fails `IsCurrentIncarnation`, and `Initialize()` ordering keeps the flag/generation observable states consistent.
- Full test suites + stress validation left to CI per request. The real validation is the next scheduled stress run: the framing guard + these skip logs should report zero occurrences.

## Notes

- Allocation impact: one pooled `int[]` rent/return per coalesced send (per-batch-group, not per-message); the rent that previously happened in `PendingResponse.Create` moved to send start, so the acks!=None path count is unchanged.
