### PR TITLE
Improve stress test error diagnostics

### DIFF
--- a/tools/Dekaf.StressTests/Metrics/ThroughputTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/ThroughputTracker.cs
@@ -8,12 +8,16 @@ namespace Dekaf.StressTests.Metrics;
 /// </summary>
 internal sealed class ThroughputTracker
 {
+    private const int MaxErrorSamples = 5;
+
     private long _messageCount;
     private long _byteCount;
     private long _errorCount;
     private readonly Stopwatch _stopwatch = new();
     private readonly List<double> _messagesPerSecondSamples = [];
     private readonly object _samplesLock = new();
+    private readonly List<ThroughputErrorSample> _errorSamples = [];
+    private readonly object _errorsLock = new();
     private long _lastSampleMessageCount;
     private DateTime _lastSampleTime;
     private TimeSpan _cpuTimeStart;
@@ -59,7 +63,57 @@ internal sealed class ThroughputTracker
 
     public void RecordError()
     {
-        Interlocked.Increment(ref _errorCount);
+        RecordErrorCore(errorType: null, message: null, details: null, operation: null, messageIndex: null);
+    }
+
+    public void RecordError(Exception exception, string? operation = null, long? messageIndex = null)
+    {
+        RecordErrorCore(
+            exception.GetType().FullName ?? exception.GetType().Name,
+            exception.Message,
+            exception.ToString(),
+            operation,
+            messageIndex);
+    }
+
+    public void RecordError(string errorType, string? message, string? operation = null, long? messageIndex = null)
+    {
+        RecordErrorCore(errorType, message, details: null, operation, messageIndex);
+    }
+
+    private void RecordErrorCore(
+        string? errorType,
+        string? message,
+        string? details,
+        string? operation,
+        long? messageIndex)
+    {
+        var errorNumber = Interlocked.Increment(ref _errorCount);
+        if (string.IsNullOrWhiteSpace(errorType) && string.IsNullOrWhiteSpace(message) && string.IsNullOrWhiteSpace(details))
+        {
+            return;
+        }
+
+        lock (_errorsLock)
+        {
+            if (_errorSamples.Count >= MaxErrorSamples)
+            {
+                return;
+            }
+
+            _errorSamples.Add(new ThroughputErrorSample
+            {
+                ErrorNumber = errorNumber,
+                OccurredAtUtc = DateTime.UtcNow,
+                ElapsedSeconds = _stopwatch.Elapsed.TotalSeconds,
+                AcceptedMessagesAtError = MessageCount,
+                MessageIndex = messageIndex,
+                Operation = string.IsNullOrWhiteSpace(operation) ? null : operation,
+                ExceptionType = string.IsNullOrWhiteSpace(errorType) ? "Unknown" : errorType,
+                Message = string.IsNullOrWhiteSpace(message) ? null : message,
+                Details = string.IsNullOrWhiteSpace(details) ? null : details
+            });
+        }
     }
 
     public void TakeSample()
@@ -116,6 +170,12 @@ internal sealed class ThroughputTracker
             samplesCopy = [.. _messagesPerSecondSamples];
         }
 
+        List<ThroughputErrorSample> errorSamplesCopy;
+        lock (_errorsLock)
+        {
+            errorSamplesCopy = [.. _errorSamples];
+        }
+
         return new ThroughputSnapshot
         {
             TotalMessages = MessageCount,
@@ -124,7 +184,8 @@ internal sealed class ThroughputTracker
             ElapsedSeconds = _stopwatch.Elapsed.TotalSeconds,
             AverageMessagesPerSecond = GetAverageMessagesPerSecond(),
             AverageMegabytesPerSecond = GetAverageMegabytesPerSecond(),
-            MessagesPerSecondSamples = samplesCopy
+            MessagesPerSecondSamples = samplesCopy,
+            ErrorSamples = errorSamplesCopy
         };
     }
 }
@@ -138,4 +199,18 @@ internal sealed class ThroughputSnapshot
     public required double AverageMessagesPerSecond { get; init; }
     public required double AverageMegabytesPerSecond { get; init; }
     public required List<double> MessagesPerSecondSamples { get; init; }
+    public List<ThroughputErrorSample> ErrorSamples { get; init; } = [];
+}
+
+internal sealed class ThroughputErrorSample
+{
+    public required long ErrorNumber { get; init; }
+    public required DateTime OccurredAtUtc { get; init; }
+    public required double ElapsedSeconds { get; init; }
+    public required long AcceptedMessagesAtError { get; init; }
+    public long? MessageIndex { get; init; }
+    public string? Operation { get; init; }
+    public required string ExceptionType { get; init; }
+    public string? Message { get; init; }
+    public string? Details { get; init; }
 }

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -1,5 +1,6 @@
 using Dekaf.Producer;
 using Dekaf.StressTests.Infrastructure;
+using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 using Dekaf.StressTests.Scenarios;
 
@@ -209,23 +210,21 @@ public static class Program
     /// </summary>
     private static bool CheckForMessageLoss(List<StressTestResult> results)
     {
-        var failures = new List<string>();
+        var failures = new List<(StressTestResult Result, long Errors, long? Delivered, long Lost)>();
 
         foreach (var result in results)
         {
             var errors = result.Throughput.TotalErrors;
-            if (errors > 0)
-            {
-                failures.Add($"{result.Client} {result.Scenario}: {errors:N0} errors");
-            }
+            var lost = 0L;
 
             if (result.DeliveredMessages is { } delivered)
             {
-                var lost = result.Throughput.TotalMessages - delivered - errors;
-                if (lost > 0)
-                {
-                    failures.Add($"{result.Client} {result.Scenario}: {lost:N0} messages accepted but never delivered");
-                }
+                lost = Math.Max(0, result.Throughput.TotalMessages - delivered - errors);
+            }
+
+            if (errors > 0 || lost > 0)
+            {
+                failures.Add((result, errors, result.DeliveredMessages, lost));
             }
         }
 
@@ -235,13 +234,62 @@ public static class Program
         }
 
         Console.WriteLine();
-        Console.WriteLine("MESSAGE LOSS DETECTED — failing the run:");
+        Console.WriteLine("MESSAGE LOSS DETECTED - failing the run:");
         foreach (var failure in failures)
         {
-            Console.WriteLine($"  {failure}");
+            var result = failure.Result;
+            var delivered = failure.Delivered is { } deliveredMessages
+                ? deliveredMessages.ToString("N0")
+                : "unknown";
+
+            Console.WriteLine(
+                $"  {result.Client} {result.Scenario}: " +
+                $"accepted={result.Throughput.TotalMessages:N0}, " +
+                $"delivered={delivered}, " +
+                $"errors={failure.Errors:N0}, " +
+                $"undelivered={failure.Lost:N0}");
+
+            if (result.Throughput.ErrorSamples.Count > 0)
+            {
+                PrintErrorSamples(result.Throughput.ErrorSamples);
+            }
+            else if (failure.Errors > 0)
+            {
+                Console.WriteLine("    No exception samples captured for these errors.");
+            }
         }
 
         return true;
+    }
+
+    private static void PrintErrorSamples(List<ThroughputErrorSample> samples)
+    {
+        Console.WriteLine($"    Error samples (first {samples.Count:N0}):");
+        foreach (var sample in samples)
+        {
+            var messageIndex = sample.MessageIndex is { } index ? index.ToString("N0") : "unknown";
+            var operation = string.IsNullOrWhiteSpace(sample.Operation) ? "unknown" : sample.Operation;
+
+            Console.WriteLine(
+                $"    - error #{sample.ErrorNumber:N0} at +{sample.ElapsedSeconds:F3}s " +
+                $"accepted={sample.AcceptedMessagesAtError:N0} " +
+                $"messageIndex={messageIndex} operation={operation}");
+            Console.WriteLine($"      {sample.ExceptionType}: {sample.Message}");
+
+            if (!string.IsNullOrWhiteSpace(sample.Details))
+            {
+                Console.WriteLine("      Details:");
+                WriteIndentedBlock(sample.Details, "        ");
+            }
+        }
+    }
+
+    private static void WriteIndentedBlock(string text, string indent)
+    {
+        foreach (var line in text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n'))
+        {
+            Console.WriteLine($"{indent}{line}");
+        }
     }
 
     private static async Task SeedConsumerTopicAsync(string bootstrapServers, string topic, CliOptions options)

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -32,6 +32,12 @@ internal static class MarkdownReporter
                 GenerateLatencyTable(sb, resultsWithLatency, $"Latency - {label}");
 
             GenerateGcTable(sb, groupResults, $"GC Statistics - {label}");
+
+            var resultsWithErrorSamples = groupResults
+                .Where(r => r.Throughput.ErrorSamples.Count > 0)
+                .ToList();
+            if (resultsWithErrorSamples.Count > 0)
+                GenerateErrorSamplesTable(sb, resultsWithErrorSamples, $"Error Samples - {label}");
         }
 
         if (results.Results.Any(r => r.Client.Equals("Confluent", StringComparison.OrdinalIgnoreCase)))
@@ -160,6 +166,35 @@ internal static class MarkdownReporter
         sb.AppendLine();
     }
 
+    private static void GenerateErrorSamplesTable(StringBuilder sb, List<StressTestResult> results, string title)
+    {
+        var clientWidth = GetClientColumnWidth(results);
+
+        sb.AppendLine($"## {title}");
+        sb.AppendLine();
+        sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Error # | At | Message Index | Operation | Type | Message |");
+        sb.AppendLine($"|{new string('-', clientWidth + 2)}|---------|----|---------------|-----------|------|---------|");
+
+        foreach (var result in results.OrderBy(r => r.Client))
+        {
+            foreach (var sample in result.Throughput.ErrorSamples)
+            {
+                var messageIndex = sample.MessageIndex is { } index ? index.ToString("N0") : "-";
+                var operation = EscapeTableCell(sample.Operation ?? "-");
+                var type = EscapeTableCell(sample.ExceptionType);
+                var message = EscapeTableCell(Truncate(sample.Message ?? "-", 180));
+
+                sb.AppendLine(
+                    $"| {result.Client.PadRight(clientWidth)} | {sample.ErrorNumber:N0} | " +
+                    $"+{sample.ElapsedSeconds:F3}s | {messageIndex} | {operation} | {type} | {message} |");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("*Full exception details are serialized in the JSON results and printed in the failing CI log.*");
+        sb.AppendLine();
+    }
+
     private static string FormatScenarioTitle(string scenario) => scenario switch
     {
         "producer" => "Producer (Fire-and-Forget) Throughput",
@@ -193,6 +228,17 @@ internal static class MarkdownReporter
         < 1024 * 1024 * 1024 => $"{numBytes / (1024.0 * 1024):F2} MB",
         _ => $"{numBytes / (1024.0 * 1024 * 1024):F2} GB"
     };
+
+    private static string EscapeTableCell(string value) =>
+        value
+            .Replace("\\", "\\\\")
+            .Replace("|", "\\|")
+            .Replace("\r\n", "<br>")
+            .Replace("\n", "<br>")
+            .Replace("\r", "<br>");
+
+    private static string Truncate(string value, int maxLength) =>
+        value.Length <= maxLength ? value : $"{value[..Math.Max(0, maxLength - 3)]}...";
 
     private static string FormatLatencyUs(double us)
     {

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
@@ -92,9 +92,9 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
                         }
                     }
                 }
-                catch (ConfluentKafka.ConsumeException)
+                catch (ConfluentKafka.ConsumeException ex)
                 {
-                    throughput.RecordError();
+                    throughput.RecordError(ex, "Confluent consume loop");
                 }
             }
         }

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
@@ -77,7 +77,7 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
 
                 if (messageIndex % StressTestHelpers.LatencySampleInterval == 0)
                 {
-                    ConfluentStressTestHelpers.SampleDeliveryLatency(producer, options.Topic, message, latency, throughput, cts.Token);
+                    ConfluentStressTestHelpers.SampleDeliveryLatency(producer, options.Topic, message, latency, throughput, cts.Token, messageIndex);
                 }
                 else
                 {
@@ -97,9 +97,9 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
             {
                 break;
             }
-            catch
+            catch (Exception ex)
             {
-                throughput.RecordError();
+                throughput.RecordError(ex, "Produce loop", messageIndex);
             }
         }
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncIdempotentStressTest.cs
@@ -98,9 +98,9 @@ internal sealed class ConfluentProducerAsyncIdempotentStressTest : IStressTestSc
             {
                 break;
             }
-            catch
+            catch (Exception ex)
             {
-                throughput.RecordError();
+                throughput.RecordError(ex, "ProduceAsync loop", messageIndex);
             }
         }
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncStressTest.cs
@@ -97,9 +97,9 @@ internal sealed class ConfluentProducerAsyncStressTest : IStressTestScenario
             {
                 break;
             }
-            catch
+            catch (Exception ex)
             {
-                throughput.RecordError();
+                throughput.RecordError(ex, "ProduceAsync loop", messageIndex);
             }
         }
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerIdempotentStressTest.cs
@@ -79,7 +79,7 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
 
                 if (messageIndex % StressTestHelpers.LatencySampleInterval == 0)
                 {
-                    ConfluentStressTestHelpers.SampleDeliveryLatency(producer, options.Topic, message, latency, throughput, cts.Token);
+                    ConfluentStressTestHelpers.SampleDeliveryLatency(producer, options.Topic, message, latency, throughput, cts.Token, messageIndex);
                 }
                 else
                 {
@@ -108,9 +108,9 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
             {
                 break;
             }
-            catch
+            catch (Exception ex)
             {
-                throughput.RecordError();
+                throughput.RecordError(ex, "Produce loop", messageIndex);
             }
         }
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerStressTest.cs
@@ -78,7 +78,7 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
 
                 if (messageIndex % StressTestHelpers.LatencySampleInterval == 0)
                 {
-                    ConfluentStressTestHelpers.SampleDeliveryLatency(producer, options.Topic, message, latency, throughput, cts.Token);
+                    ConfluentStressTestHelpers.SampleDeliveryLatency(producer, options.Topic, message, latency, throughput, cts.Token, messageIndex);
                 }
                 else
                 {
@@ -107,9 +107,9 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
             {
                 break;
             }
-            catch
+            catch (Exception ex)
             {
-                throughput.RecordError();
+                throughput.RecordError(ex, "Produce loop", messageIndex);
             }
         }
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
@@ -132,14 +132,19 @@ internal static class ConfluentStressTestHelpers
         ConfluentKafka.Message<string, string> message,
         LatencyTracker latency,
         ThroughputTracker throughput,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        long? messageIndex = null)
     {
         var start = Stopwatch.GetTimestamp();
         ProduceWithBackpressure(producer, topic, message, report =>
         {
             if (report.Error.IsError)
             {
-                throughput.RecordError();
+                throughput.RecordError(
+                    "Confluent.Kafka.Error",
+                    report.Error.ToString(),
+                    "SampleDeliveryLatency delivery report",
+                    messageIndex);
             }
             else
             {

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -88,7 +88,7 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
         catch (Exception ex)
         {
             Console.WriteLine($"  Consumer error: {ex}");
-            throughput.RecordError();
+            throughput.RecordError(ex, "ConsumeBatch loop");
         }
 
         throughput.Stop();

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -88,7 +88,7 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
         catch (Exception ex)
         {
             Console.WriteLine($"  Consumer error: {ex}");
-            throughput.RecordError();
+            throughput.RecordError(ex, "ConsumeRawBatch loop");
         }
 
         throughput.Stop();

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -84,7 +84,7 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
         catch (Exception ex)
         {
             Console.WriteLine($"  Consumer error: {ex}");
-            throughput.RecordError();
+            throughput.RecordError(ex, "ConsumeRaw loop");
         }
 
         throughput.Stop();

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -77,7 +77,7 @@ internal sealed class ConsumerStressTest : IStressTestScenario
         catch (Exception ex)
         {
             Console.WriteLine($"  Consumer error: {ex}");
-            throughput.RecordError();
+            throughput.RecordError(ex, "Consume loop");
         }
 
         throughput.Stop();

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -75,7 +75,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             {
                 if (messageIndex % StressTestHelpers.LatencySampleInterval == 0)
                 {
-                    StressTestHelpers.SampleDeliveryLatency(producer, options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue, latency, throughput);
+                    StressTestHelpers.SampleDeliveryLatency(producer, options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue, latency, throughput, messageIndex);
                 }
                 else
                 {
@@ -95,9 +95,9 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             {
                 break;
             }
-            catch
+            catch (Exception ex)
             {
-                throughput.RecordError();
+                throughput.RecordError(ex, "Produce loop", messageIndex);
             }
         }
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
@@ -97,9 +97,9 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
             {
                 break;
             }
-            catch
+            catch (Exception ex)
             {
-                throughput.RecordError();
+                throughput.RecordError(ex, "ProduceAsync loop", messageIndex);
             }
         }
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
@@ -97,9 +97,9 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
             {
                 break;
             }
-            catch
+            catch (Exception ex)
             {
-                throughput.RecordError();
+                throughput.RecordError(ex, "ProduceAsync loop", messageIndex);
             }
         }
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -74,7 +74,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             {
                 if (messageIndex % StressTestHelpers.LatencySampleInterval == 0)
                 {
-                    StressTestHelpers.SampleDeliveryLatency(producer, options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue, latency, throughput);
+                    StressTestHelpers.SampleDeliveryLatency(producer, options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue, latency, throughput, messageIndex);
                 }
                 else
                 {
@@ -94,9 +94,9 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             {
                 break;
             }
-            catch
+            catch (Exception ex)
             {
-                throughput.RecordError();
+                throughput.RecordError(ex, "Produce loop", messageIndex);
             }
         }
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -78,7 +78,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
             {
                 if (messageIndex % StressTestHelpers.LatencySampleInterval == 0)
                 {
-                    StressTestHelpers.SampleDeliveryLatency(producer, options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue, latency, throughput);
+                    StressTestHelpers.SampleDeliveryLatency(producer, options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue, latency, throughput, messageIndex);
                 }
                 else
                 {
@@ -98,9 +98,9 @@ internal sealed class ProducerStressTest : IStressTestScenario
             {
                 break;
             }
-            catch
+            catch (Exception ex)
             {
-                throughput.RecordError();
+                throughput.RecordError(ex, "Produce loop", messageIndex);
             }
         }
 

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -147,7 +147,8 @@ internal static class StressTestHelpers
         string key,
         string value,
         LatencyTracker latency,
-        ThroughputTracker throughput)
+        ThroughputTracker throughput,
+        long? messageIndex = null)
     {
         _ = SampleAsync();
 
@@ -159,9 +160,9 @@ internal static class StressTestHelpers
                 await producer.ProduceAsync(topic, key, value).ConfigureAwait(false);
                 latency.RecordTicks(Stopwatch.GetTimestamp() - start);
             }
-            catch
+            catch (Exception ex)
             {
-                throughput.RecordError();
+                throughput.RecordError(ex, "SampleDeliveryLatency", messageIndex);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Capture bounded stress-test error samples with exception type, message, stack/details, operation, message index, and accepted-message count.
- Print sampled exception details when message loss fails a run.
- Include concise error sample tables in generated Markdown reports while preserving full details in JSON artifacts.

## Root Cause

Stress scenarios were catching exceptions and only incrementing `TotalErrors`. The failing job therefore reported aggregate counts like `25 errors` without enough context to identify the underlying exception.

## Validation

- `dotnet build tools/Dekaf.StressTests --configuration Release`
- `dotnet run --project tools/Dekaf.StressTests --configuration Release -- report --input .tmp\actions\results-dekaf-producer-acks-all-1brokers\tools\Dekaf.StressTests\results`
- `dotnet build --configuration Release`
- `git diff --check`

Closes #1573