### PR TITLE
Fix producer batch recycling during produce writes

### DIFF
--- a/src/Dekaf/Networking/IKafkaConnection.cs
+++ b/src/Dekaf/Networking/IKafkaConnection.cs
@@ -101,3 +101,20 @@ public interface IKafkaConnection : IAsyncDisposable
     /// </summary>
     ValueTask ConnectAsync(CancellationToken cancellationToken = default);
 }
+
+internal interface IKafkaPipelinedWriteCompletionConnection
+{
+    ValueTask<Task<TResponse>> SendPipelinedAfterWriteAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        CancellationToken cancellationToken = default)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse;
+
+    ValueTask<Task<TResponse>> SendPipelinedWithCallerTimeoutAfterWriteAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        CancellationToken cancellationToken = default)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse;
+}

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -131,7 +131,10 @@ internal static class ConnectionHelper
 /// <summary>
 /// A multiplexed connection to a Kafka broker using System.IO.Pipelines.
 /// </summary>
-public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafkaConnection
+public sealed partial class KafkaConnection :
+    IKafkaConnection,
+    IIdleTrackedKafkaConnection,
+    IKafkaPipelinedWriteCompletionConnection
 {
     private readonly string _host;
     private readonly int _port;
@@ -686,7 +689,11 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         CancellationToken cancellationToken = default)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
-        => SendPipelinedCoreAsync<TRequest, TResponse>(request, apiVersion, callerOwnsTimeout: false, cancellationToken);
+        => SendPipelinedCoreAsync<TRequest, TResponse>(
+            request,
+            apiVersion,
+            callerOwnsTimeout: false,
+            cancellationToken);
 
     /// <summary>
     /// Pipelined overload that skips the per-write CancellationTokenSource rent and
@@ -705,9 +712,51 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
         CancellationToken cancellationToken = default)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
-        => SendPipelinedCoreAsync<TRequest, TResponse>(request, apiVersion, callerOwnsTimeout: true, cancellationToken);
+        => SendPipelinedCoreAsync<TRequest, TResponse>(
+            request,
+            apiVersion,
+            callerOwnsTimeout: true,
+            cancellationToken);
+
+    ValueTask<Task<TResponse>> IKafkaPipelinedWriteCompletionConnection.SendPipelinedAfterWriteAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        CancellationToken cancellationToken)
+        => SendPipelinedAfterWriteCoreAsync<TRequest, TResponse>(
+            request,
+            apiVersion,
+            callerOwnsTimeout: false,
+            cancellationToken);
+
+    ValueTask<Task<TResponse>>
+        IKafkaPipelinedWriteCompletionConnection.SendPipelinedWithCallerTimeoutAfterWriteAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken)
+        => SendPipelinedAfterWriteCoreAsync<TRequest, TResponse>(
+            request,
+            apiVersion,
+            callerOwnsTimeout: true,
+            cancellationToken);
 
     private async Task<TResponse> SendPipelinedCoreAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        bool callerOwnsTimeout,
+        CancellationToken cancellationToken)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        var responseTask = await SendPipelinedAfterWriteCoreAsync<TRequest, TResponse>(
+            request,
+            apiVersion,
+            callerOwnsTimeout,
+            cancellationToken).ConfigureAwait(false);
+
+        return await responseTask.ConfigureAwait(false);
+    }
+
+    private async ValueTask<Task<TResponse>> SendPipelinedAfterWriteCoreAsync<TRequest, TResponse>(
         TRequest request,
         short apiVersion,
         bool callerOwnsTimeout,
@@ -749,12 +798,13 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
             await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken, callerOwnsTimeout)
                 .ConfigureAwait(false);
 
-            // Response phase: await response with timeout, then parse
-            var response = await AwaitAndParseResponseAsync<TRequest, TResponse>(
-                pending, correlationId, apiVersion, callerOwnsTimeout, cancellationToken).ConfigureAwait(false);
-            Touch();
-            _telemetryMetricCollector?.RecordRequestLatency(BrokerId, telemetryStartTimestamp);
-            return response;
+            return AwaitPipelinedResponseAsync<TRequest, TResponse>(
+                pending,
+                correlationId,
+                apiVersion,
+                callerOwnsTimeout,
+                telemetryStartTimestamp,
+                cancellationToken);
         }
         catch
         {
@@ -766,6 +816,27 @@ public sealed partial class KafkaConnection : IKafkaConnection, IIdleTrackedKafk
 
             throw;
         }
+    }
+
+    private async Task<TResponse> AwaitPipelinedResponseAsync<TRequest, TResponse>(
+        PooledPendingRequest pending,
+        int correlationId,
+        short apiVersion,
+        bool callerOwnsTimeout,
+        long telemetryStartTimestamp,
+        CancellationToken cancellationToken)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        var response = await AwaitAndParseResponseAsync<TRequest, TResponse>(
+            pending,
+            correlationId,
+            apiVersion,
+            callerOwnsTimeout,
+            cancellationToken).ConfigureAwait(false);
+        Touch();
+        _telemetryMetricCollector?.RecordRequestLatency(BrokerId, telemetryStartTimestamp);
+        return response;
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1550,6 +1550,57 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         return writeIdx;
     }
 
+    private int AcquireResourcePins(ReadyBatch[] batches, int[] generations, int count)
+    {
+        var writeIdx = 0;
+        for (var readIdx = 0; readIdx < count; readIdx++)
+        {
+            var batch = batches[readIdx];
+            var generation = generations[readIdx];
+            if (!batch.TryAcquireResourcePin(generation))
+            {
+                LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+                continue;
+            }
+
+            batches[writeIdx] = batch;
+            generations[writeIdx] = generation;
+            writeIdx++;
+        }
+
+        for (var i = writeIdx; i < count; i++)
+        {
+            batches[i] = null!;
+            generations[i] = 0;
+        }
+
+        return writeIdx;
+    }
+
+    private static void ReleaseResourcePins(ReadyBatch[] batches, int count)
+    {
+        for (var i = 0; i < count; i++)
+            batches[i]?.ReleaseResourcePin();
+    }
+
+    private ValueTask<Task<ProduceResponse>> SendPipelinedAfterWriteAsync(
+        IKafkaConnection connection,
+        ProduceRequest request,
+        short apiVersion)
+    {
+        if (connection is IKafkaPipelinedWriteCompletionConnection writeCompletionConnection)
+        {
+            return writeCompletionConnection.SendPipelinedAfterWriteAsync<ProduceRequest, ProduceResponse>(
+                request,
+                apiVersion,
+                _cts.Token);
+        }
+
+        throw new InvalidOperationException(
+            $"{nameof(BrokerSender)} requires {nameof(IKafkaPipelinedWriteCompletionConnection)} for pipelined produce sends; " +
+            $"connection type '{connection.GetType().FullName}' cannot safely hold batch resources until the socket write completes.");
+    }
+
     /// <summary>
     /// Finalizes retry batches that have been coalesced and are about to be sent.
     /// Called after the epoch bump check passes to ensure retry state is only cleared
@@ -2311,24 +2362,90 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
             }
 
-            // Build coalesced ProduceRequest (reuses pre-allocated scratch structures)
-            var request = scratch.Build(batches, generations, count);
+            count = AcquireResourcePins(batches, generations, count);
+            if (count == 0)
+            {
+                ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
+                return;
+            }
+
+            var resourcePinCount = count;
 
             var requestStartTime = Stopwatch.GetTimestamp();
 
-            // Handle Acks.None (fire-and-forget)
-            if (_options.Acks == Acks.None)
+            try
             {
-                // Use the caller-timeout overload to avoid per-write
-                // CancellationTokenSource + CancellationTokenRegistration allocations.
-                // The cancellationToken already carries BrokerSender's sendTimeoutCts timeout.
-                await connection.SendFireAndForgetWithCallerTimeoutAsync<ProduceRequest, ProduceResponse>(
-                    request, (short)apiVersion, cancellationToken).ConfigureAwait(false);
+                // Build coalesced ProduceRequest (reuses pre-allocated scratch structures)
+                var request = scratch.Build(batches, generations, count);
+
+                // Handle Acks.None (fire-and-forget)
+                if (_options.Acks == Acks.None)
+                {
+                    // Use the caller-timeout overload to avoid per-write
+                    // CancellationTokenSource + CancellationTokenRegistration allocations.
+                    // The cancellationToken already carries BrokerSender's sendTimeoutCts timeout.
+                    await connection.SendFireAndForgetWithCallerTimeoutAsync<ProduceRequest, ProduceResponse>(
+                        request, (short)apiVersion, cancellationToken).ConfigureAwait(false);
+
+                    // Clear batch references from scratch arrays (see ClearReferences() doc for exception-path semantics)
+                    scratch.ClearReferences();
+                    ReleaseResourcePins(batches, resourcePinCount);
+                    resourcePinCount = 0;
+
+                    var fireAndForgetTimestamp = DateTimeOffset.UtcNow;
+                    for (var i = 0; i < count; i++)
+                    {
+                        var batch = batches[i];
+                        if (!batch.IsCurrentIncarnation(generations[i]))
+                        {
+                            LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+                            batches[i] = null!;
+                            continue;
+                        }
+
+                        CompleteInflightEntry(batch);
+                        batch.CompleteSend(-1, fireAndForgetTimestamp);
+                        try { _onAcknowledgement?.Invoke(batch.TopicPartition, -1, fireAndForgetTimestamp, batch.CompletionSourcesCount, null); }
+                        catch (Exception ackEx) { LogBatchCleanupStepFailed(ackEx, _brokerId); }
+                    }
+
+                    // Release everything synchronously (no pipelined response — fire-and-forget
+                    // doesn't add to _pendingResponsesByConnection, so no in-flight slot to release)
+                    for (var i = 0; i < count; i++)
+                    {
+                        if (batches[i] is not null)
+                            CleanupBatch(batches[i]);
+                    }
+
+                    ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
+                    return;
+                }
+
+                // Pipelined send: write request, get response task.
+                // Add to _pendingResponsesByConnection for the send loop to process inline (like Java's client.poll()).
+                // No fire-and-forget — responses are processed in the single-threaded send loop,
+                // making retry ordering deterministic by construction.
+                //
+                // Use the connection-owned timeout path for pipelined sends. The send loop can
+                // have multiple responses in flight on this connection; a reusable caller-owned
+                // CTS would let a later send reset or cancel an earlier response timeout.
+                var responseTask = await SendPipelinedAfterWriteAsync(
+                    connection,
+                    request,
+                    (short)apiVersion).ConfigureAwait(false);
 
                 // Clear batch references from scratch arrays (see ClearReferences() doc for exception-path semantics)
                 scratch.ClearReferences();
+                ReleaseResourcePins(batches, resourcePinCount);
+                resourcePinCount = 0;
 
-                var fireAndForgetTimestamp = DateTimeOffset.UtcNow;
+                // Release buffer memory now that data is written to the TCP buffer.
+                // The untracked gap (between release and response) is bounded by
+                // MaxInFlightRequestsPerConnection × BatchSize (e.g. 5 × 1MB = 5MB).
+                // This is safe because: (1) the kernel has a copy in the TCP send buffer,
+                // (2) the gap is bounded and small, (3) it unblocks producers waiting on
+                // BufferMemory without the unbounded growth caused by drain-time release.
+                // CleanupBatch still releases for error paths where TCP send wasn't reached.
                 for (var i = 0; i < count; i++)
                 {
                     var batch = batches[i];
@@ -2339,118 +2456,81 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         continue;
                     }
 
-                    CompleteInflightEntry(batch);
-                    batch.CompleteSend(-1, fireAndForgetTimestamp);
-                    try { _onAcknowledgement?.Invoke(batch.TopicPartition, -1, fireAndForgetTimestamp, batch.CompletionSourcesCount, null); }
-                    catch (Exception ackEx) { LogBatchCleanupStepFailed(ackEx, _brokerId); }
+                    if (batch.TrySetMemoryReleased())
+                    {
+                        _accumulator.ReleaseMemory(batch.DataSize);
+                    }
                 }
 
-                // Release everything synchronously (no pipelined response — fire-and-forget
-                // doesn't add to _pendingResponsesByConnection, so no in-flight slot to release)
+                var pendingResponse = PendingResponse.Create(responseTask, batches, generations, count, requestStartTime);
+                _pendingResponsesByConnection[connectionIndex].Add(pendingResponse);
+                pendingResponseAdded = true; // Array ownership transferred to PendingResponse
+                Interlocked.Increment(ref _totalPendingResponseCount);
+
+                // Diagnostic: log instance+task+partitions at PendingResponse creation time.
+                // This traces which batches are paired with which response task.
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    var pipelinedPartitions = string.Join(", ",
+                        Enumerable.Range(0, count)
+                            .Where(i => batches[i] is not null)
+                            .Select(i => $"{batches[i].TopicPartition.Topic}-{batches[i].TopicPartition.Partition}"));
+                    LogPendingResponseCreated(_instanceId, _brokerId, responseTask.Id, count, pipelinedPartitions);
+                }
+
+                // Diagnostic: mark batches as successfully pipelined to _pendingResponsesByConnection.
+                // If an orphan trace shows 'S' but no 'W' (Wire), the batch never reached here.
                 for (var i = 0; i < count; i++)
+                    batches[i].AppendDiag('W');
+
+                // Signal the send loop to wake up and poll when the response arrives.
+                // Only a lightweight signal — actual processing happens in ProcessCompletedResponses.
+                // Two signal paths: (1) channel write for the main WaitToReadAsync path,
+                // (2) AsyncAutoResetSignal for the direct response-wait paths (replaces Task.WhenAny).
+                //
+                // Uses UnsafeOnCompleted with a cached Action delegate instead of ContinueWith
+                // to avoid allocating a continuation Task on every pipelined send. The callback
+                // is pre-allocated once in the constructor and reused for all response tasks.
+                if (responseTask.IsCompleted)
                 {
-                    if (batches[i] is not null)
-                        CleanupBatch(batches[i]);
+                    // Already completed — signal inline without registering a continuation.
+                    _responseCompletionCallback();
+                }
+                else
+                {
+                    // Unlike ContinueWith(ExecuteSynchronously), UnsafeOnCompleted schedules the
+                    // callback on the ThreadPool rather than running inline on the completing thread.
+                    // This is intentional — it keeps the I/O completion thread free.
+                    responseTask.ConfigureAwait(false).GetAwaiter()
+                        .UnsafeOnCompleted(_responseCompletionCallback);
                 }
 
-                ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
-                return;
-            }
-
-            // Pipelined send: write request, get response task.
-            // Add to _pendingResponsesByConnection for the send loop to process inline (like Java's client.poll()).
-            // No fire-and-forget — responses are processed in the single-threaded send loop,
-            // making retry ordering deterministic by construction.
-            //
-            // Use the connection-owned timeout path for pipelined sends. The send loop can
-            // have multiple responses in flight on this connection; a reusable caller-owned
-            // CTS would let a later send reset or cancel an earlier response timeout.
-            var responseTask = connection.SendPipelinedAsync<ProduceRequest, ProduceResponse>(
-                request, (short)apiVersion, _cts.Token);
-
-            // Clear batch references from scratch arrays (see ClearReferences() doc for exception-path semantics)
-            scratch.ClearReferences();
-
-            // Release buffer memory now that data is written to the TCP buffer.
-            // The untracked gap (between release and response) is bounded by
-            // MaxInFlightRequestsPerConnection × BatchSize (e.g. 5 × 1MB = 5MB).
-            // This is safe because: (1) the kernel has a copy in the TCP send buffer,
-            // (2) the gap is bounded and small, (3) it unblocks producers waiting on
-            // BufferMemory without the unbounded growth caused by drain-time release.
-            // CleanupBatch still releases for error paths where TCP send wasn't reached.
-            for (var i = 0; i < count; i++)
-            {
-                var batch = batches[i];
-                if (!batch.IsCurrentIncarnation(generations[i]))
+                // Mute partitions at send time when limited to 1 in-flight request.
+                // This ensures at most one batch per partition in-flight across all requests.
+                // When maxInFlight > 1, sequence numbers guarantee ordering instead,
+                // and retry-time muting handles error recovery.
+                if (_muteOnSend)
                 {
-                    LogStaleBatchInSendSkipped(_instanceId, _brokerId);
-                    batches[i] = null!;
-                    continue;
+                    for (var i = 0; i < count; i++)
+                    {
+                        _mutedPartitions.TryAdd(batches[i].TopicPartition, 0);
+                        _accumulator.MutePartition(batches[i].TopicPartition);
+                    }
                 }
 
-                if (batch.TrySetMemoryReleased())
+                LogPipelinedSend(_brokerId, count, _totalPendingResponseCount);
+            }
+            catch
+            {
+                scratch.ClearReferences();
+                if (resourcePinCount > 0)
                 {
-                    _accumulator.ReleaseMemory(batch.DataSize);
+                    ReleaseResourcePins(batches, resourcePinCount);
+                    resourcePinCount = 0;
                 }
+
+                throw;
             }
-
-            var pendingResponse = PendingResponse.Create(responseTask, batches, generations, count, requestStartTime);
-            _pendingResponsesByConnection[connectionIndex].Add(pendingResponse);
-            pendingResponseAdded = true; // Array ownership transferred to PendingResponse
-            Interlocked.Increment(ref _totalPendingResponseCount);
-
-            // Diagnostic: log instance+task+partitions at PendingResponse creation time.
-            // This traces which batches are paired with which response task.
-            if (_logger.IsEnabled(LogLevel.Debug))
-            {
-                var pipelinedPartitions = string.Join(", ",
-                    Enumerable.Range(0, count)
-                        .Where(i => batches[i] is not null)
-                        .Select(i => $"{batches[i].TopicPartition.Topic}-{batches[i].TopicPartition.Partition}"));
-                LogPendingResponseCreated(_instanceId, _brokerId, responseTask.Id, count, pipelinedPartitions);
-            }
-
-            // Diagnostic: mark batches as successfully pipelined to _pendingResponsesByConnection.
-            // If an orphan trace shows 'S' but no 'W' (Wire), the batch never reached here.
-            for (var i = 0; i < count; i++)
-                batches[i].AppendDiag('W');
-
-            // Signal the send loop to wake up and poll when the response arrives.
-            // Only a lightweight signal — actual processing happens in ProcessCompletedResponses.
-            // Two signal paths: (1) channel write for the main WaitToReadAsync path,
-            // (2) AsyncAutoResetSignal for the direct response-wait paths (replaces Task.WhenAny).
-            //
-            // Uses UnsafeOnCompleted with a cached Action delegate instead of ContinueWith
-            // to avoid allocating a continuation Task on every pipelined send. The callback
-            // is pre-allocated once in the constructor and reused for all response tasks.
-            if (responseTask.IsCompleted)
-            {
-                // Already completed — signal inline without registering a continuation.
-                _responseCompletionCallback();
-            }
-            else
-            {
-                // Unlike ContinueWith(ExecuteSynchronously), UnsafeOnCompleted schedules the
-                // callback on the ThreadPool rather than running inline on the completing thread.
-                // This is intentional — it keeps the I/O completion thread free.
-                responseTask.ConfigureAwait(false).GetAwaiter()
-                    .UnsafeOnCompleted(_responseCompletionCallback);
-            }
-
-            // Mute partitions at send time when limited to 1 in-flight request.
-            // This ensures at most one batch per partition in-flight across all requests.
-            // When maxInFlight > 1, sequence numbers guarantee ordering instead,
-            // and retry-time muting handles error recovery.
-            if (_muteOnSend)
-            {
-                for (var i = 0; i < count; i++)
-                {
-                    _mutedPartitions.TryAdd(batches[i].TopicPartition, 0);
-                    _accumulator.MutePartition(batches[i].TopicPartition);
-                }
-            }
-
-            LogPipelinedSend(_brokerId, count, _totalPendingResponseCount);
         }
         catch (OperationCanceledException) when (_cts.IsCancellationRequested)
         {

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3250,29 +3250,36 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     private bool PrepareBatchForPublish(ReadyBatch readyBatch, int generation)
     {
-        if (!readyBatch.IsCurrentIncarnation(generation))
+        if (!readyBatch.TryAcquireResourcePin(generation))
             return false;
 
-        Exception? failure = null;
         try
         {
-            readyBatch.RecordBatch.PreCompress(_options.CompressionType, _compressionCodecs);
-            readyBatch.SetEncodedSize(readyBatch.RecordBatch.GetEncodedSize(_options.CompressionType));
+            Exception? failure = null;
+            try
+            {
+                readyBatch.RecordBatch.PreCompress(_options.CompressionType, _compressionCodecs);
+                readyBatch.SetEncodedSize(readyBatch.RecordBatch.GetEncodedSize(_options.CompressionType));
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+
+            if (!readyBatch.IsCurrentIncarnation(generation))
+                return false;
+
+            // Mark pre-serialization complete so the drain loop can pick up this batch.
+            readyBatch.MarkPreSerialized();
+            if (failure is null)
+                return !readyBatch.IsSendCompleted && readyBatch.IsCurrentIncarnation(generation);
+
+            return readyBatch.IsCurrentIncarnation(generation) && readyBatch.FailFromPreSerialization(failure);
         }
-        catch (Exception ex)
+        finally
         {
-            failure = ex;
+            readyBatch.ReleaseResourcePin();
         }
-
-        if (!readyBatch.IsCurrentIncarnation(generation))
-            return false;
-
-        // Mark pre-serialization complete so the drain loop can pick up this batch.
-        readyBatch.MarkPreSerialized();
-        if (failure is null)
-            return !readyBatch.IsSendCompleted && readyBatch.IsCurrentIncarnation(generation);
-
-        return readyBatch.IsCurrentIncarnation(generation) && readyBatch.FailFromPreSerialization(failure);
     }
 
     /// <summary>
@@ -5845,6 +5852,8 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     private ManualResetValueTaskSourceCore<bool> _doneCore = new() { RunContinuationsAsynchronously = true };
 
     private int _cleanedUp; // 0 = not cleaned, 1 = cleaned (prevents double-cleanup in Cleanup())
+    private int _resourcesCleanedUp; // 0 = pooled resources retained, 1 = arena/RecordBatch returned
+    private int _activeResourcePins; // readers holding RecordBatch/arena stable during serialization
     private int _completed; // 0 = not completed, 1 = completed (prevents double-signal of _doneCore)
     private int _sendCompleted; // 0 = not done, 1 = done (prevents concurrent CompleteSend/Fail)
     internal int _returnedToPool; // 0 = not returned, 1 = returned (prevents double pool return)
@@ -5884,6 +5893,33 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     internal bool IsCurrentIncarnation(int expectedGeneration)
         => !IsReturnedToPool && Generation == expectedGeneration;
 
+    internal bool TryAcquireResourcePin(int expectedGeneration)
+    {
+        while (true)
+        {
+            if (!IsCurrentIncarnation(expectedGeneration) || Volatile.Read(ref _cleanedUp) != 0)
+                return false;
+
+            var current = Volatile.Read(ref _activeResourcePins);
+            if (Interlocked.CompareExchange(ref _activeResourcePins, current + 1, current) == current)
+            {
+                if (IsCurrentIncarnation(expectedGeneration) && Volatile.Read(ref _cleanedUp) == 0)
+                    return true;
+
+                ReleaseResourcePin();
+                return false;
+            }
+        }
+    }
+
+    internal void ReleaseResourcePin()
+    {
+        var remaining = Interlocked.Decrement(ref _activeResourcePins);
+        Debug.Assert(remaining >= 0, "ReadyBatch resource pin count went negative");
+        if (remaining == 0 && Volatile.Read(ref _cleanedUp) != 0)
+            TryCleanupResources();
+    }
+
     /// <summary>
     /// Creates an uninitialized ReadyBatch. Call Initialize() before use.
     /// </summary>
@@ -5922,6 +5958,8 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         // _memoryReleased follows the same pattern: stale references seeing 1 (released)
         // will skip the release, which is the safe/defensive behavior.
         Interlocked.Exchange(ref _cleanedUp, 0);
+        Interlocked.Exchange(ref _resourcesCleanedUp, 0);
+        Interlocked.Exchange(ref _activeResourcePins, 0);
         Interlocked.Exchange(ref _completed, 0);
         Interlocked.Exchange(ref _sendCompleted, 0);
         Interlocked.Exchange(ref _returnedToPool, 0);
@@ -5970,6 +6008,8 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
             // Cleanup() is idempotent (uses Interlocked.Exchange), so double-call is safe.
             Cleanup();
         }
+
+        WaitForCleanupIfStarted();
 
         // Clear all references to allow GC
         _topicPartition = default;
@@ -6209,9 +6249,8 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     /// (because BrokerSender's CompleteSend won it), then immediately returns the batch
     /// to pool via ReturnReadyBatch — before CompleteSend reaches its finally { Cleanup() }.
     /// Reset() would see _cleanedUp == 0 and fire the safety net, corrupting completion
-    /// sources that CompleteSend is still iterating.
-    /// Resolves in microseconds typically; under thread starvation SpinWait yields to the OS.
-    /// Bounded at 1000 iterations (~1ms) as defense against a stuck Cleanup thread.
+    /// sources that CompleteSend is still iterating. If cleanup is deferred behind active
+    /// resource pins, also waits until the final pin returns the arena and RecordBatch to pools.
     /// </remarks>
     internal void WaitForCleanupIfStarted()
     {
@@ -6219,15 +6258,35 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         {
             var sw = new SpinWait();
             do { sw.SpinOnce(); }
-            while (Volatile.Read(ref _cleanedUp) == 0 && sw.Count < 1000);
+            while (Volatile.Read(ref _cleanedUp) == 0);
+        }
+
+        if (Volatile.Read(ref _cleanedUp) != 0 && Volatile.Read(ref _resourcesCleanedUp) == 0)
+        {
+            // Reset must wait for deferred resource cleanup; otherwise it can recycle fields
+            // while the last serialization pin is still returning the old RecordBatch/arena.
+            var sw = new SpinWait();
+            do { sw.SpinOnce(); }
+            while (Volatile.Read(ref _resourcesCleanedUp) == 0);
         }
     }
 
     private void Cleanup()
     {
-        // Guard against double-cleanup: If cleanup has already been performed, return immediately.
-        // This prevents double-return of pooled arrays which would corrupt ArrayPool.
+        // Guard against double-cleanup request. Actual pooled-resource return may be
+        // deferred until active serialization pins release.
         if (Interlocked.Exchange(ref _cleanedUp, 1) != 0)
+            return;
+
+        TryCleanupResources();
+    }
+
+    private void TryCleanupResources()
+    {
+        if (Volatile.Read(ref _activeResourcePins) != 0)
+            return;
+
+        if (Interlocked.Exchange(ref _resourcesCleanedUp, 1) != 0)
             return;
 
         // Return the working (container) array: either to the reuse queue for fast recycling

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -48,13 +48,11 @@ public sealed class BrokerSenderMuteOrderingTests
             LingerMs = 0
         };
 
-    private static (IConnectionPool pool, IKafkaConnection connection) CreateMockConnection(
+    private static (IConnectionPool pool, TestKafkaConnection connection) CreateMockConnection(
         Queue<TaskCompletionSource<ProduceResponse>> responseQueue,
         Action? onSend = null)
     {
-        var connection = Substitute.For<IKafkaConnection>();
-        connection.IsConnected.Returns(true);
-        connection.BrokerId.Returns(1);
+        var connection = new TestKafkaConnection();
 
         Task<ProduceResponse> DequeueResponse()
         {
@@ -63,12 +61,7 @@ public sealed class BrokerSenderMuteOrderingTests
             return task;
         }
 
-        connection.SendPipelinedWithCallerTimeoutAsync<ProduceRequest, ProduceResponse>(
-                Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
-            .Returns(_ => DequeueResponse());
-        connection.SendPipelinedAsync<ProduceRequest, ProduceResponse>(
-                Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
-            .Returns(_ => DequeueResponse());
+        connection.SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(DequeueResponse());
 
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -39,18 +39,16 @@ public sealed class BrokerSenderSendLoopTests
 
     /// <summary>
     /// Creates a mock connection pool that returns a controllable mock connection.
-    /// The mock connection queues response tasks so each SendPipelinedAsync call
+    /// The mock connection queues response tasks so each SendPipelinedAfterWriteAsync call
     /// returns the next TaskCompletionSource's task from the queue.
-    /// The optional onSend callback fires each time SendPipelinedAsync is called,
+    /// The optional onSend callback fires each time SendPipelinedAfterWriteAsync is called,
     /// enabling deterministic synchronization without Task.Delay.
     /// </summary>
-    private static (IConnectionPool pool, IKafkaConnection connection) CreateMockConnection(
+    private static (IConnectionPool pool, TestKafkaConnection connection) CreateMockConnection(
         Queue<TaskCompletionSource<ProduceResponse>> responseQueue,
         Action? onSend = null)
     {
-        var connection = Substitute.For<IKafkaConnection>();
-        connection.IsConnected.Returns(true);
-        connection.BrokerId.Returns(1);
+        var connection = new TestKafkaConnection();
 
         Task<ProduceResponse> DequeueResponse()
         {
@@ -59,12 +57,7 @@ public sealed class BrokerSenderSendLoopTests
             return task;
         }
 
-        connection.SendPipelinedWithCallerTimeoutAsync<ProduceRequest, ProduceResponse>(
-                Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
-            .Returns(_ => DequeueResponse());
-        connection.SendPipelinedAsync<ProduceRequest, ProduceResponse>(
-                Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
-            .Returns(_ => DequeueResponse());
+        connection.SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(DequeueResponse());
 
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
@@ -79,7 +72,8 @@ public sealed class BrokerSenderSendLoopTests
     /// </summary>
     private static ReadyBatch CreateTestBatch(
         ValueTaskSourcePool<RecordMetadata> pool,
-        string topic, int partition, int messageCount = 1)
+        string topic, int partition, int messageCount = 1,
+        bool markMemoryReleased = true, int dataSize = 100)
     {
         var batch = new ReadyBatch();
         var sources = ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(messageCount);
@@ -91,10 +85,13 @@ public sealed class BrokerSenderSendLoopTests
             new RecordBatch { Records = Array.Empty<Record>() },
             sources,
             messageCount,
-            dataSize: 100);
+            dataSize: dataSize);
 
-        // Skip accumulator memory tracking in tests
-        batch.TrySetMemoryReleased();
+        if (markMemoryReleased)
+        {
+            // Skip accumulator memory tracking in tests
+            batch.TrySetMemoryReleased();
+        }
 
         return batch;
     }
@@ -149,6 +146,15 @@ public sealed class BrokerSenderSendLoopTests
             onAcknowledgement: onAcknowledgement,
             logger: null);
 
+    private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken cancellationToken)
+    {
+        while (!predicate())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+        }
+    }
+
     [Test]
     [Timeout(120_000)]
     public async Task SendLoop_PipelinedProduce_UsesConnectionOwnedTimeoutsForConcurrentSends(CancellationToken cancellationToken)
@@ -187,14 +193,75 @@ public sealed class BrokerSenderSendLoopTests
             sender.Enqueue(CreateTestBatch(vtPool, "test-topic", 1));
             await sendSignals[1].Task.WaitAsync(cancellationToken);
 
-            await connection.Received(2).SendPipelinedAsync<ProduceRequest, ProduceResponse>(
-                Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
-            await connection.DidNotReceive().SendPipelinedWithCallerTimeoutAsync<ProduceRequest, ProduceResponse>(
-                Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>());
+            await Assert.That(Volatile.Read(ref connection.SendPipelinedAfterWriteCalls)).IsEqualTo(2);
+            await Assert.That(Volatile.Read(ref connection.SendPipelinedWithCallerTimeoutCalls)).IsEqualTo(0);
+            await Assert.That(Volatile.Read(ref connection.SendPipelinedWithCallerTimeoutAfterWriteCalls)).IsEqualTo(0);
+            await Assert.That(Volatile.Read(ref connection.SendPipelinedCalls)).IsEqualTo(0);
 
             tcs1.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 42));
             tcs2.SetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 43));
             await allAcknowledged.Task.WaitAsync(cancellationToken);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task SendLoop_PipelinedProduce_ReleasesBufferMemoryOnlyAfterWriteCompletes(CancellationToken cancellationToken)
+    {
+        var responseTcs = new TaskCompletionSource<ProduceResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var writeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var writeCanComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var connection = new TestKafkaConnection();
+
+        async ValueTask<Task<ProduceResponse>> CompleteAfterWriteGate()
+        {
+            writeStarted.TrySetResult();
+            await writeCanComplete.Task.ConfigureAwait(false);
+            return responseTcs.Task;
+        }
+
+        connection.SendProducePipelinedAfterWrite = CompleteAfterWriteGate;
+
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+
+        var acknowledged = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, ex) =>
+        {
+            if (ex is null)
+                acknowledged.TrySetResult();
+        });
+
+        try
+        {
+            var batch = CreateTestBatch(vtPool, "test-topic", 0, markMemoryReleased: false, dataSize: 0);
+            await Assert.That(batch.MemoryReleased).IsFalse();
+
+            sender.Enqueue(batch);
+            await writeStarted.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(batch.MemoryReleased).IsFalse();
+            await Assert.That(acknowledged.Task.IsCompleted).IsFalse();
+
+            writeCanComplete.SetResult();
+            await WaitUntilAsync(() => batch.MemoryReleased, cancellationToken);
+
+            await Assert.That(acknowledged.Task.IsCompleted).IsFalse();
+
+            responseTcs.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 42));
+            await acknowledged.Task.WaitAsync(cancellationToken);
         }
         finally
         {
@@ -823,13 +890,10 @@ public sealed class BrokerSenderSendLoopTests
 
         var successResponse = CreateSuccessResponse("test-topic", 0, baseOffset: 77);
 
-        var connection = Substitute.For<IKafkaConnection>();
-        connection.IsConnected.Returns(true);
-        connection.BrokerId.Returns(1);
-
-        connection.SendPipelinedAsync<ProduceRequest, ProduceResponse>(
-                Arg.Any<ProduceRequest>(), Arg.Any<short>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(successResponse));
+        var connection = new TestKafkaConnection
+        {
+            SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(Task.FromResult(successResponse))
+        };
 
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())

--- a/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
@@ -26,6 +26,11 @@ public sealed class ReadyBatchIncarnationTests
         "ProduceRequestScratch",
         BindingFlags.NonPublic)!;
 
+    private static int GetReadyBatchInt32(ReadyBatch batch, string fieldName)
+        => (int)typeof(ReadyBatch)
+            .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(batch)!;
+
     private static ReadyBatch CreateInitializedBatch(string topic = "t", int partition = 0)
     {
         var batch = new ReadyBatch();
@@ -60,6 +65,45 @@ public sealed class ReadyBatchIncarnationTests
         var batch = CreateInitializedBatch();
 
         await Assert.That(batch.IsCurrentIncarnation(batch.Generation)).IsTrue();
+    }
+
+    [Test]
+    public async Task Cleanup_WithActiveResourcePin_DefersPooledResourceReturnUntilPinRelease()
+    {
+        var batch = new ReadyBatch();
+        var recordBatch = RecordBatch.RentFromPool();
+        recordBatch.Records = Array.Empty<Record>();
+        var arena = BatchArena.RentOrCreate(128);
+        batch.Initialize(
+            new TopicPartition("test-topic", 0),
+            recordBatch,
+            completionSourcesArray: null,
+            completionSourcesCount: 0,
+            dataSize: 100,
+            arena: arena);
+        var generation = batch.Generation;
+
+        await Assert.That(batch.TryAcquireResourcePin(generation)).IsTrue();
+
+        batch.CompleteSend(0, DateTimeOffset.UtcNow);
+
+        await Assert.That(GetReadyBatchInt32(batch, "_cleanedUp")).IsEqualTo(1);
+        await Assert.That(GetReadyBatchInt32(batch, "_resourcesCleanedUp")).IsEqualTo(0);
+
+        batch.ReleaseResourcePin();
+
+        await Assert.That(GetReadyBatchInt32(batch, "_resourcesCleanedUp")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TryAcquireResourcePin_AfterCleanupRequested_ReturnsFalse()
+    {
+        var batch = CreateInitializedBatch();
+        var generation = batch.Generation;
+
+        batch.CompleteSend(0, DateTimeOffset.UtcNow);
+
+        await Assert.That(batch.TryAcquireResourcePin(generation)).IsFalse();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
@@ -1,0 +1,106 @@
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+internal sealed class TestKafkaConnection : IKafkaConnection, IKafkaPipelinedWriteCompletionConnection
+{
+    public int BrokerId { get; init; } = 1;
+    public string Host { get; init; } = "localhost";
+    public int Port { get; init; } = 9092;
+    public bool IsConnected { get; set; } = true;
+
+    public int SendPipelinedCalls;
+    public int SendPipelinedWithCallerTimeoutCalls;
+    public int SendPipelinedAfterWriteCalls;
+    public int SendPipelinedWithCallerTimeoutAfterWriteCalls;
+    public int SendFireAndForgetWithCallerTimeoutCalls;
+
+    public Func<ValueTask<Task<ProduceResponse>>>? SendProducePipelinedAfterWrite { get; set; }
+    public Func<ValueTask>? SendProduceFireAndForgetWithCallerTimeout { get; set; }
+
+    public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        CancellationToken cancellationToken = default)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+        => throw new NotSupportedException();
+
+    public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        CancellationToken cancellationToken = default)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+        => SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+
+    public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        CancellationToken cancellationToken = default)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        Interlocked.Increment(ref SendPipelinedCalls);
+        throw new NotSupportedException();
+    }
+
+    public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        CancellationToken cancellationToken = default)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        Interlocked.Increment(ref SendFireAndForgetWithCallerTimeoutCalls);
+        return SendProduceFireAndForgetWithCallerTimeout?.Invoke() ?? ValueTask.CompletedTask;
+    }
+
+    public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        CancellationToken cancellationToken = default)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        Interlocked.Increment(ref SendPipelinedWithCallerTimeoutCalls);
+        throw new NotSupportedException();
+    }
+
+    public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public async ValueTask<Task<TResponse>> SendPipelinedAfterWriteAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        CancellationToken cancellationToken = default)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        Interlocked.Increment(ref SendPipelinedAfterWriteCalls);
+
+        if (SendProducePipelinedAfterWrite is null)
+            throw new NotSupportedException();
+
+        var responseTask = await SendProducePipelinedAfterWrite().ConfigureAwait(false);
+        return CastResponseTask<TResponse>(responseTask);
+    }
+
+    public async ValueTask<Task<TResponse>> SendPipelinedWithCallerTimeoutAfterWriteAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        CancellationToken cancellationToken = default)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        Interlocked.Increment(ref SendPipelinedWithCallerTimeoutAfterWriteCalls);
+        throw new NotSupportedException();
+    }
+
+    private static async Task<TResponse> CastResponseTask<TResponse>(Task<ProduceResponse> responseTask)
+        where TResponse : IKafkaResponse
+        => (TResponse)(IKafkaResponse)await responseTask.ConfigureAwait(false);
+}


### PR DESCRIPTION
## Summary
- keep producer request scratch data live until pipelined produce writes finish
- pin ReadyBatch pooled resources while pre-serialization and produce request serialization read RecordBatch/BatchArena data
- defer ReadyBatch resource cleanup until active pins release

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit --configuration Release
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter "/*/*/ReadyBatchIncarnationTests/*"
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter "/*/*/BrokerSenderSendLoopTests/*"
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter "/*/*/KafkaConnectionPipelinedTests/*"
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit

Closes #1574
