### PR TITLE
Add producer delivery diagnostics

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -86,6 +86,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private IRetryPolicy? _retryPolicy;
     private bool _enableAdaptiveConnections = true;
     private int _maxConnectionsPerBroker = 10;
+    private bool _enableDeliveryDiagnostics;
     private readonly Dictionary<string, ApplicationTelemetryMetric> _applicationMetrics = new(StringComparer.Ordinal);
 
     public ProducerBuilder()
@@ -850,6 +851,17 @@ public sealed class ProducerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Enables or disables live producer delivery diagnostics.
+    /// Disabled by default to avoid diagnostic bookkeeping in normal producer runs.
+    /// </summary>
+    /// <param name="enable">Whether to enable delivery diagnostics.</param>
+    internal ProducerBuilder<TKey, TValue> WithDeliveryDiagnostics(bool enable = true)
+    {
+        _enableDeliveryDiagnostics = enable;
+        return this;
+    }
+
+    /// <summary>
     /// Sets the request timeout for individual broker requests.
     /// Equivalent to Kafka's <c>request.timeout.ms</c>.
     /// Default is 30 seconds.
@@ -1198,6 +1210,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             RetryPolicy = _retryPolicy,
             EnableAdaptiveConnections = _enableAdaptiveConnections,
             MaxConnectionsPerBroker = _maxConnectionsPerBroker,
+            EnableDeliveryDiagnostics = _enableDeliveryDiagnostics,
             ApplicationMetrics = _applicationMetrics.Count > 0 ? _applicationMetrics.Values.ToArray() : []
         };
 

--- a/src/Dekaf/Dekaf.csproj
+++ b/src/Dekaf/Dekaf.csproj
@@ -16,6 +16,7 @@
     <InternalsVisibleTo Include="Dekaf.Tests.Integration" />
     <InternalsVisibleTo Include="Dekaf.Benchmarks" />
     <InternalsVisibleTo Include="Dekaf.Profiling" />
+    <InternalsVisibleTo Include="Dekaf.StressTests" />
     <InternalsVisibleTo Include="Dekaf.Compression.Brotli" />
     <InternalsVisibleTo Include="Dekaf.Compression.Lz4" />
     <InternalsVisibleTo Include="Dekaf.Extensions.Hosting" />

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -230,6 +230,55 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
 }
 
 /// <summary>
+/// Exposes live producer delivery diagnostics for test and stress harness troubleshooting.
+/// </summary>
+internal interface IProducerDiagnostics
+{
+    /// <summary>
+    /// Captures batches still tracked inside the producer pipeline.
+    /// </summary>
+    ProducerDeliveryDiagnosticsSnapshot GetDeliveryDiagnosticsSnapshot();
+}
+
+/// <summary>
+/// Snapshot of live batches still tracked by the producer delivery pipeline.
+/// </summary>
+internal sealed class ProducerDeliveryDiagnosticsSnapshot
+{
+    public bool DiagnosticsEnabled { get; init; }
+    public DateTimeOffset CapturedAtUtc { get; init; }
+    public long InFlightBatchCount { get; init; }
+    public List<ProducerBatchDeliveryDiagnostic> Batches { get; init; } = [];
+}
+
+/// <summary>
+/// Diagnostic state for a single producer batch.
+/// </summary>
+internal sealed class ProducerBatchDeliveryDiagnostic
+{
+    public required string Topic { get; init; }
+    public required int Partition { get; init; }
+    public required int RecordCount { get; init; }
+    public required int DataSize { get; init; }
+    public required int EncodedSize { get; init; }
+    public required int ReadyBatchId { get; init; }
+    public int? RecordBatchId { get; init; }
+    public int? ArenaId { get; init; }
+    public required int PipelineGeneration { get; init; }
+    public required int CurrentGeneration { get; init; }
+    public required string LifecycleState { get; init; }
+    public required string Trace { get; init; }
+    public required string LastTouchedBy { get; init; }
+    public required bool IsStale { get; init; }
+    public required bool IsPreSerialized { get; init; }
+    public required bool IsSendCompleted { get; init; }
+    public required bool IsDoneTaskCompleted { get; init; }
+    public required bool IsMemoryReleased { get; init; }
+    public required bool IsReturnedToPool { get; init; }
+    public required bool InFlightLinked { get; init; }
+}
+
+/// <summary>
 /// Flags controlling which producer messages are purged.
 /// </summary>
 [Flags]

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -22,7 +22,7 @@ namespace Dekaf.Producer;
 /// </summary>
 /// <typeparam name="TKey">Key type.</typeparam>
 /// <typeparam name="TValue">Value type.</typeparam>
-public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, TValue>, IProducerFastPath<TKey, TValue>, IBudgetedInstance
+public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, TValue>, IProducerDiagnostics, IProducerFastPath<TKey, TValue>, IBudgetedInstance
 {
     /// <summary>
     /// Sentinel return value from <see cref="TryProduceSyncCore"/> indicating that the
@@ -2520,6 +2520,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         return new TopicProducer<TKey, TValue>(this, topic, ownsProducer: false);
     }
 
+    ProducerDeliveryDiagnosticsSnapshot IProducerDiagnostics.GetDeliveryDiagnosticsSnapshot()
+        => _accumulator.GetDeliveryDiagnosticsSnapshot();
+
     private async Task SenderLoopAsync(CancellationToken cancellationToken)
     {
         // PER-BROKER SENDER ARCHITECTURE: Each broker gets a dedicated BrokerSender with its own
@@ -2577,7 +2580,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                             for (var i = 0; i < batchList.Count; i++)
                             {
                                 batchList[i].CompleteDelivery();
-                                batchList[i].AppendDiag('Q');
+                                if (_options.EnableDeliveryDiagnostics)
+                                    batchList[i].AppendDiag('Q');
                             }
 
                             try

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -519,6 +519,12 @@ public sealed class ProducerOptions
     public IReadOnlyList<ApplicationTelemetryMetric> ApplicationMetrics { get; init; } = [];
 
     /// <summary>
+    /// Enables troubleshooting-only delivery diagnostics for live producer batches.
+    /// Disabled by default to avoid diagnostic bookkeeping in normal producer runs.
+    /// </summary>
+    internal bool EnableDeliveryDiagnostics { get; init; }
+
+    /// <summary>
     /// Enable adaptive connection scaling based on buffer pressure.
     /// When enabled, the producer will automatically increase connections per broker
     /// when sustained buffer backpressure is detected, improving drain throughput.

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1475,7 +1475,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
             if (batch is not null)
             {
-                batch.AppendDiag('D');
+                if (_options.EnableDeliveryDiagnostics)
+                    batch.AppendDiag('D');
                 size += batch.EncodedSize;
                 ready.Add(batch);
             }
@@ -3836,9 +3837,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // and the list add, the sweep will miss it in the snapshot — but that's acceptable
         // because the sweep is defense-in-depth at 3× delivery timeout and the batch will
         // be caught on the next sweep interval.
+        if (_options.EnableDeliveryDiagnostics)
+        {
+            batch.EnableDeliveryDiagnostics();
+            batch.AppendDiag('E');
+        }
         Interlocked.Increment(ref _inFlightBatchCount);
         InFlightBatchListAdd(batch);
-        batch.AppendDiag('E');
     }
 
     /// <summary>
@@ -3860,7 +3865,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             0,
             (_, current) => Math.Max(0, current - batch.DataSize));
 
-        batch.AppendDiag('X');
+        if (_options.EnableDeliveryDiagnostics)
+            batch.AppendDiag('X');
         var count = Interlocked.Decrement(ref _inFlightBatchCount);
         Debug.Assert(count >= 0, $"In-flight batch count went negative ({count}) — mismatched Enter/Exit calls");
         if (count <= 0)
@@ -3966,6 +3972,60 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             if (lockTaken) _inFlightBatchLock.Exit();
         }
+    }
+
+    private void InFlightBatchDiagnosticSnapshot(List<DiagnosticBatchReference> target)
+    {
+        var lockTaken = false;
+        try
+        {
+            _inFlightBatchLock.Enter(ref lockTaken);
+
+            var current = _inFlightBatchHead;
+            while (current is not null)
+            {
+                target.Add(new DiagnosticBatchReference(current, current.Generation, current.TopicPartition));
+                current = current.InFlightNext;
+            }
+        }
+        finally
+        {
+            if (lockTaken) _inFlightBatchLock.Exit();
+        }
+    }
+
+    private readonly struct DiagnosticBatchReference(ReadyBatch batch, int generation, TopicPartition topicPartition)
+    {
+        public ReadyBatch Batch { get; } = batch;
+        public int Generation { get; } = generation;
+        public TopicPartition TopicPartition { get; } = topicPartition;
+    }
+
+    internal ProducerDeliveryDiagnosticsSnapshot GetDeliveryDiagnosticsSnapshot()
+    {
+        if (!_options.EnableDeliveryDiagnostics)
+        {
+            return new ProducerDeliveryDiagnosticsSnapshot
+            {
+                CapturedAtUtc = DateTimeOffset.UtcNow,
+                DiagnosticsEnabled = false
+            };
+        }
+
+        var batches = new List<DiagnosticBatchReference>();
+        InFlightBatchDiagnosticSnapshot(batches);
+
+        var snapshot = new ProducerDeliveryDiagnosticsSnapshot
+        {
+            DiagnosticsEnabled = true,
+            CapturedAtUtc = DateTimeOffset.UtcNow,
+            InFlightBatchCount = Volatile.Read(ref _inFlightBatchCount)
+        };
+
+        foreach (var batch in batches)
+            snapshot.Batches.Add(batch.Batch.CreateDeliveryDiagnostic(batch.Generation, batch.TopicPartition));
+
+        return snapshot;
     }
 
     /// <summary>
@@ -5710,6 +5770,13 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     // Guards against double-remove races.
     internal bool InFlightLinked;
 
+    private int _pipelineGeneration;
+
+    internal int PipelineGeneration => Volatile.Read(ref _pipelineGeneration);
+
+    internal void EnableDeliveryDiagnostics() =>
+        Volatile.Write(ref _pipelineGeneration, Generation);
+
     /// <summary>
     /// Lightweight lifecycle trace for diagnosing orphaned batches in Release builds.
     /// Tracks the last few transitions as single-char codes to keep overhead minimal.
@@ -5721,7 +5788,19 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         get
         {
             var len = Volatile.Read(ref _diagTraceLen);
-            return len > 0 ? new string(_diagTrace, 0, Math.Min(len, _diagTrace.Length)) : "";
+            if (len <= 0)
+                return "";
+
+            var count = Math.Min(len, _diagTrace.Length);
+            if (len <= _diagTrace.Length)
+                return new string(_diagTrace, 0, count);
+
+            var chars = new char[count];
+            var start = len - count;
+            for (var i = 0; i < count; i++)
+                chars[i] = _diagTrace[(start + i) % _diagTrace.Length];
+
+            return new string(chars);
         }
     }
     private readonly char[] _diagTrace = new char[32];
@@ -5731,8 +5810,137 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     internal void AppendDiag(char code)
     {
         var idx = Interlocked.Increment(ref _diagTraceLen) - 1;
-        if (idx < _diagTrace.Length)
-            _diagTrace[idx] = code;
+        _diagTrace[idx % _diagTrace.Length] = code;
+    }
+
+    internal ProducerBatchDeliveryDiagnostic CreateDeliveryDiagnostic(
+        int expectedGeneration,
+        TopicPartition capturedTopicPartition)
+    {
+        if (!TryAcquireResourcePin(expectedGeneration))
+            return CreateStaleDeliveryDiagnostic(capturedTopicPartition, expectedGeneration);
+
+        try
+        {
+            var recordBatch = _recordBatch;
+            var arena = _arena;
+            var trace = DiagTrace;
+            var pipelineGeneration = PipelineGeneration;
+            var isPreSerialized = IsPreSerialized;
+            var isSendCompleted = IsSendCompleted;
+            var isDoneTaskCompleted = Volatile.Read(ref _completed) != 0;
+            var isMemoryReleased = MemoryReleased;
+            var isReturnedToPool = IsReturnedToPool;
+            var inFlightLinked = InFlightLinked;
+
+            var diagnostic = new ProducerBatchDeliveryDiagnostic
+            {
+                Topic = _topicPartition.Topic ?? string.Empty,
+                Partition = _topicPartition.Partition,
+                RecordCount = recordBatch?.Records.Count ?? _completionSourcesCount,
+                DataSize = DataSize,
+                EncodedSize = EncodedSize,
+                ReadyBatchId = RuntimeHelpers.GetHashCode(this),
+                RecordBatchId = recordBatch is null ? null : RuntimeHelpers.GetHashCode(recordBatch),
+                ArenaId = arena is null ? null : RuntimeHelpers.GetHashCode(arena),
+                PipelineGeneration = pipelineGeneration,
+                CurrentGeneration = Generation,
+                LifecycleState = GetLifecycleState(
+                    isReturnedToPool,
+                    isSendCompleted,
+                    isMemoryReleased,
+                    inFlightLinked,
+                    isPreSerialized),
+                Trace = trace,
+                LastTouchedBy = DescribeLastTouchedBy(trace),
+                IsStale = false,
+                IsPreSerialized = isPreSerialized,
+                IsSendCompleted = isSendCompleted,
+                IsDoneTaskCompleted = isDoneTaskCompleted,
+                IsMemoryReleased = isMemoryReleased,
+                IsReturnedToPool = isReturnedToPool,
+                InFlightLinked = inFlightLinked
+            };
+
+            return IsCurrentIncarnation(expectedGeneration)
+                ? diagnostic
+                : CreateStaleDeliveryDiagnostic(capturedTopicPartition, expectedGeneration);
+        }
+        finally
+        {
+            ReleaseResourcePin();
+        }
+    }
+
+    private ProducerBatchDeliveryDiagnostic CreateStaleDeliveryDiagnostic(
+        TopicPartition capturedTopicPartition,
+        int expectedGeneration)
+        => new()
+        {
+            Topic = capturedTopicPartition.Topic ?? string.Empty,
+            Partition = capturedTopicPartition.Partition,
+            RecordCount = 0,
+            DataSize = 0,
+            EncodedSize = 0,
+            ReadyBatchId = RuntimeHelpers.GetHashCode(this),
+            RecordBatchId = null,
+            ArenaId = null,
+            PipelineGeneration = expectedGeneration,
+            CurrentGeneration = Generation,
+            LifecycleState = "stale",
+            Trace = "",
+            LastTouchedBy = "stale",
+            IsStale = true,
+            IsPreSerialized = false,
+            IsSendCompleted = false,
+            IsDoneTaskCompleted = false,
+            IsMemoryReleased = false,
+            IsReturnedToPool = false,
+            InFlightLinked = false
+        };
+
+    private static string GetLifecycleState(
+        bool isReturnedToPool,
+        bool isSendCompleted,
+        bool isMemoryReleased,
+        bool inFlightLinked,
+        bool isPreSerialized)
+    {
+        if (isReturnedToPool)
+            return "recycled";
+        if (isSendCompleted)
+            return "completed-send";
+        if (isMemoryReleased)
+            return "awaiting-response";
+        if (inFlightLinked)
+            return isPreSerialized ? "in-flight" : "appended";
+        return isPreSerialized ? "serialized" : "appended";
+    }
+
+    private static string DescribeLastTouchedBy(string trace)
+    {
+        if (trace.Length == 0)
+            return "none";
+
+        return trace[^1] switch
+        {
+            'E' => "RecordAccumulator.OnBatchEntersPipeline",
+            'D' => "RecordAccumulator.Drain",
+            'Q' => "KafkaProducer.SenderLoop.EnqueueBrokerSender",
+            'C' => "BrokerSender.CoalesceBatch",
+            'O' => "BrokerSender.CarryOver",
+            'S' => "BrokerSender.SendLoop",
+            'G' => "BrokerSender.GetConnection",
+            'W' => "BrokerSender.PendingResponse",
+            'P' => "BrokerSender.ProcessFaultedResponse",
+            'R' => "BrokerSender.ProcessResponse",
+            'H' => "BrokerSender.HandleRetriableBatch",
+            'T' => "BrokerSender.HandleTimedOutRequest",
+            'Z' => "BrokerSender.SendFailed",
+            'F' => "BrokerSender.FailAndCleanupBatch",
+            'X' => "RecordAccumulator.OnBatchExitsPipeline",
+            _ => "unknown"
+        };
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
@@ -450,6 +450,27 @@ public class ProducerBuilderValidationTests
         await Assert.That(result).IsSameReferenceAs(builder);
     }
 
+    [Test]
+    public async Task WithDeliveryDiagnostics_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+        var result = builder.WithDeliveryDiagnostics();
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task Build_WithDeliveryDiagnostics_EnablesDiagnosticsOption()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithDeliveryDiagnostics()
+            .Build();
+
+        var options = GetOptions(producer);
+
+        await Assert.That(options.EnableDeliveryDiagnostics).IsTrue();
+    }
+
     #endregion
 
     #region ConnectionsPerBroker Validation

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -1,0 +1,192 @@
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public sealed class ProducerDeliveryDiagnosticsTests
+{
+    private static ProducerOptions CreateOptions(bool enableDeliveryDiagnostics = false) => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        ClientId = "diagnostics-test",
+        BufferMemory = ulong.MaxValue,
+        BatchSize = 60,
+        LingerMs = 10_000,
+        EnableDeliveryDiagnostics = enableDeliveryDiagnostics
+    };
+
+    [Test]
+    public async Task SnapshotDeliveryDiagnostics_DefaultDisabled_ReturnsDisabledSnapshot()
+    {
+        await using var accumulator = new RecordAccumulator(CreateOptions());
+        var batches = await AppendAndDrainBatchesAsync(accumulator);
+
+        var snapshot = accumulator.GetDeliveryDiagnosticsSnapshot();
+
+        await Assert.That(snapshot.DiagnosticsEnabled).IsFalse();
+        await Assert.That(snapshot.InFlightBatchCount).IsEqualTo(0);
+        await Assert.That(snapshot.Batches.Count).IsEqualTo(0);
+        await Assert.That(batches[0].PipelineGeneration).IsEqualTo(0);
+
+        CompleteAndReturn(accumulator, batches);
+    }
+
+    [Test]
+    public async Task DeliveryDiagnostics_Disabled_DoesNotTrackTrace()
+    {
+        await using var accumulator = new RecordAccumulator(CreateOptions());
+        var batches = await AppendAndDrainBatchesAsync(accumulator);
+        var batch = batches[0];
+
+        await Assert.That(batch.PipelineGeneration).IsEqualTo(0);
+        await Assert.That(batch.DiagTrace).IsEqualTo("");
+
+        batch.CompleteSend(baseOffset: 42, DateTimeOffset.UtcNow);
+        accumulator.OnBatchExitsPipeline(batch);
+
+        await Assert.That(batch.DiagTrace).IsEqualTo("");
+
+        accumulator.ReturnReadyBatch(batch);
+        CompleteAndReturn(accumulator, batches, startIndex: 1);
+    }
+
+    [Test]
+    public async Task SnapshotDeliveryDiagnostics_CapturesLiveInFlightBatch()
+    {
+        await using var accumulator = new RecordAccumulator(CreateOptions(enableDeliveryDiagnostics: true));
+        var batches = await AppendAndDrainBatchesAsync(accumulator);
+
+        var snapshot = accumulator.GetDeliveryDiagnosticsSnapshot();
+        var diagnostic = snapshot.Batches.First();
+
+        await Assert.That(snapshot.DiagnosticsEnabled).IsTrue();
+        await Assert.That(snapshot.InFlightBatchCount).IsEqualTo(snapshot.Batches.Count);
+        await Assert.That(diagnostic.Topic).IsEqualTo("diagnostics-topic");
+        await Assert.That(diagnostic.Partition).IsEqualTo(2);
+        await Assert.That(diagnostic.RecordCount).IsGreaterThan(0);
+        await Assert.That(diagnostic.DataSize).IsGreaterThan(0);
+        await Assert.That(diagnostic.EncodedSize).IsGreaterThan(0);
+        await Assert.That(diagnostic.PipelineGeneration).IsEqualTo(diagnostic.CurrentGeneration);
+        await Assert.That(diagnostic.ReadyBatchId).IsNotEqualTo(0);
+        await Assert.That(diagnostic.RecordBatchId).IsNotNull();
+        await Assert.That(diagnostic.ArenaId).IsNotNull();
+        await Assert.That(diagnostic.Trace).Contains("E");
+        await Assert.That(diagnostic.LastTouchedBy).IsNotEqualTo("");
+        await Assert.That(diagnostic.LifecycleState).IsNotEqualTo("");
+        await Assert.That(diagnostic.IsStale).IsFalse();
+
+        CompleteAndReturn(accumulator, batches);
+    }
+
+    [Test]
+    public async Task SnapshotDeliveryDiagnostics_AfterBatchExitsPipeline_IsEmpty()
+    {
+        await using var accumulator = new RecordAccumulator(CreateOptions(enableDeliveryDiagnostics: true));
+        var batches = await AppendAndDrainBatchesAsync(accumulator);
+
+        CompleteAndReturn(accumulator, batches);
+
+        var snapshot = accumulator.GetDeliveryDiagnosticsSnapshot();
+
+        await Assert.That(snapshot.DiagnosticsEnabled).IsTrue();
+        await Assert.That(snapshot.InFlightBatchCount).IsEqualTo(0);
+        await Assert.That(snapshot.Batches.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SnapshotDeliveryDiagnostics_ThroughProducerDiagnosticsInterface_UsesProducerAccumulator()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithDeliveryDiagnostics()
+            .Build();
+
+        var diagnostics = (IProducerDiagnostics)producer;
+
+        var snapshot = diagnostics.GetDeliveryDiagnosticsSnapshot();
+
+        await Assert.That(snapshot.DiagnosticsEnabled).IsTrue();
+        await Assert.That(snapshot.InFlightBatchCount).IsEqualTo(0);
+        await Assert.That(snapshot.Batches.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CreateDeliveryDiagnostic_WhenBatchCannotBePinned_ReturnsStaleDiagnostic()
+    {
+        await using var accumulator = new RecordAccumulator(CreateOptions(enableDeliveryDiagnostics: true));
+        var batches = await AppendAndDrainBatchesAsync(accumulator);
+        var batch = batches[0];
+        var generation = batch.Generation;
+        var topicPartition = batch.TopicPartition;
+
+        batch.CompleteSend(baseOffset: 42, DateTimeOffset.UtcNow);
+
+        var diagnostic = batch.CreateDeliveryDiagnostic(generation, topicPartition);
+
+        await Assert.That(diagnostic.IsStale).IsTrue();
+        await Assert.That(diagnostic.LifecycleState).IsEqualTo("stale");
+        await Assert.That(diagnostic.Topic).IsEqualTo(topicPartition.Topic);
+        await Assert.That(diagnostic.Partition).IsEqualTo(topicPartition.Partition);
+
+        accumulator.OnBatchExitsPipeline(batch);
+        accumulator.ReturnReadyBatch(batch);
+        CompleteAndReturn(accumulator, batches, startIndex: 1);
+    }
+
+    [Test]
+    public async Task DiagTrace_KeepsMostRecentTransitionsWhenCapacityIsExceeded()
+    {
+        var batch = new ReadyBatch();
+        for (var i = 0; i < 39; i++)
+            batch.AppendDiag('D');
+        batch.AppendDiag('X');
+
+        var trace = batch.DiagTrace;
+
+        await Assert.That(trace.Length).IsEqualTo(32);
+        await Assert.That(trace[^1]).IsEqualTo('X');
+    }
+
+    private static async Task<List<ReadyBatch>> AppendAndDrainBatchesAsync(RecordAccumulator accumulator)
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        for (var i = 0; i < 3; i++)
+        {
+            var value = new byte[30];
+            value[0] = (byte)i;
+
+            var appended = await accumulator.AppendFromSpansAsync(
+                "diagnostics-topic",
+                partition: 2,
+                timestamp + i,
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                value,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 3);
+
+            await Assert.That(appended).IsTrue();
+        }
+
+        var batches = new List<ReadyBatch>();
+        while (accumulator.TryDrainBatch(out var batch))
+            batches.Add(batch);
+
+        await Assert.That(batches.Count).IsGreaterThan(0);
+        return batches;
+    }
+
+    private static void CompleteAndReturn(RecordAccumulator accumulator, List<ReadyBatch> batches, int startIndex = 0)
+    {
+        for (var i = startIndex; i < batches.Count; i++)
+        {
+            var batch = batches[i];
+            batch.CompleteSend(baseOffset: 42 + i, DateTimeOffset.UtcNow);
+            accumulator.OnBatchExitsPipeline(batch);
+            accumulator.ReturnReadyBatch(batch);
+        }
+    }
+}

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -19,6 +19,7 @@ namespace Dekaf.StressTests;
 ///   --client &lt;name&gt;         Run specific client: dekaf, confluent, all (default: all)
 ///   --output &lt;path&gt;         Output directory for results (default: ./results)
 ///   --brokers &lt;count&gt;      Number of Kafka brokers (default: 1, use 3 for multi-broker)
+///   --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message-loss failures
 ///   report --input &lt;path&gt;   Generate report from existing results
 ///
 /// Environment Variables:
@@ -77,6 +78,7 @@ public static class Program
         Console.WriteLine($"Client: {options.Client}");
         Console.WriteLine($"Compression: {options.Compression}");
         Console.WriteLine($"Brokers: {options.Brokers}");
+        Console.WriteLine($"Producer delivery diagnostics: {(options.EnableProducerDeliveryDiagnostics ? "enabled" : "disabled")}");
         if (options.ConnectionsPerBroker > 1)
             Console.WriteLine($"Multi-connection: {options.ConnectionsPerBroker} connections per broker (Dekaf only)");
         Console.WriteLine(new string('-', 50));
@@ -117,7 +119,8 @@ public static class Program
             BatchSize = options.BatchSize,
             Compression = options.Compression,
             BrokerCount = options.Brokers,
-            ConnectionsPerBroker = connectionsPerBroker
+            ConnectionsPerBroker = connectionsPerBroker,
+            EnableProducerDeliveryDiagnostics = options.EnableProducerDeliveryDiagnostics
         };
 
         if (options.ConnectionsPerBroker == 1)
@@ -257,10 +260,60 @@ public static class Program
             {
                 Console.WriteLine("    No exception samples captured for these errors.");
             }
+
+            if (failure.Lost > 0)
+            {
+                PrintProducerDeliveryDiagnostics(result.ProducerDeliveryDiagnostics);
+            }
         }
 
         return true;
     }
+
+    private static void PrintProducerDeliveryDiagnostics(ProducerDeliveryDiagnosticsSnapshot? snapshot)
+    {
+        Console.WriteLine("    Producer delivery diagnostics:");
+        if (snapshot is null)
+        {
+            Console.WriteLine("      Not captured. Pass --producer-delivery-diagnostics to enable.");
+            return;
+        }
+
+        if (!snapshot.DiagnosticsEnabled)
+        {
+            Console.WriteLine("      Disabled.");
+            return;
+        }
+
+        Console.WriteLine(
+            $"      capturedAtUtc={snapshot.CapturedAtUtc:O} " +
+            $"inFlight={snapshot.InFlightBatchCount:N0} batches={snapshot.Batches.Count:N0}");
+
+        if (snapshot.Batches.Count == 0)
+        {
+            Console.WriteLine("      No live in-flight batches remained when diagnostics were captured.");
+            return;
+        }
+
+        foreach (var batch in snapshot.Batches)
+        {
+            Console.WriteLine(
+                $"      - {batch.Topic}-{batch.Partition} " +
+                $"records={batch.RecordCount:N0} " +
+                $"dataSize={batch.DataSize:N0} encodedSize={batch.EncodedSize:N0} " +
+                $"state={batch.LifecycleState} trace={batch.Trace} last={batch.LastTouchedBy}");
+            Console.WriteLine(
+                $"        readyBatchId={batch.ReadyBatchId} recordBatchId={FormatNullableInt(batch.RecordBatchId)} " +
+                $"arenaId={FormatNullableInt(batch.ArenaId)} " +
+                $"generation={batch.PipelineGeneration}/{batch.CurrentGeneration} " +
+                $"stale={batch.IsStale} " +
+                $"preSerialized={batch.IsPreSerialized} sendCompleted={batch.IsSendCompleted} " +
+                $"doneTaskCompleted={batch.IsDoneTaskCompleted} memoryReleased={batch.IsMemoryReleased} " +
+                $"returnedToPool={batch.IsReturnedToPool} inFlightLinked={batch.InFlightLinked}");
+        }
+    }
+
+    private static string FormatNullableInt(int? value) => value?.ToString() ?? "null";
 
     private static void PrintErrorSamples(List<ThroughputErrorSample> samples)
     {
@@ -454,6 +507,9 @@ public static class Program
                         throw new ArgumentException("--seed-messages must be at least 1");
                     }
                     break;
+                case "--producer-delivery-diagnostics":
+                    options.EnableProducerDeliveryDiagnostics = true;
+                    break;
                 case "--help":
                 case "-h":
                     PrintHelp();
@@ -486,6 +542,7 @@ public static class Program
               --brokers <count>      Number of Kafka brokers (default: 1, use 3 for multi-broker)
               --connections-per-broker <n>  TCP connections per broker (default: 1, pass 3 for multi-connection comparison)
               --seed-messages <count> Messages pre-seeded into the consumer topic (default: 2000000)
+              --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message-loss failures
               report --input <path>   Generate report from existing results
 
             Environment Variables:
@@ -516,5 +573,6 @@ public static class Program
         public int Brokers { get; set; } = 1;
         public int ConnectionsPerBroker { get; set; } = 1;
         public int SeedMessages { get; set; } = 2_000_000;
+        public bool EnableProducerDeliveryDiagnostics { get; set; }
     }
 }

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Dekaf.Producer;
 using Dekaf.StressTests.Metrics;
 
 namespace Dekaf.StressTests.Reporting;
@@ -16,6 +17,7 @@ internal sealed class StressTestResult
     public LatencySnapshot? Latency { get; init; }
     public required GcSnapshot GcStats { get; init; }
     public int BrokerCount { get; init; } = 1;
+    public ProducerDeliveryDiagnosticsSnapshot? ProducerDeliveryDiagnostics { get; init; }
 
     /// <summary>
     /// Broker-confirmed message count, measured as the end-offset (high watermark)

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -21,4 +21,5 @@ internal sealed class StressTestOptions
     public string Compression { get; init; } = "none";
     public int BrokerCount { get; init; } = 1;
     public int ConnectionsPerBroker { get; init; } = 1;
+    public bool EnableProducerDeliveryDiagnostics { get; init; }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -38,6 +38,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             _ => builder
         };
 
+        StressTestHelpers.ConfigureProducerDeliveryDiagnostics(builder, options);
         var producer = await builder.BuildAsync(cancellationToken);
 
         Console.WriteLine($"  Warming up Dekaf acks-all producer...");
@@ -120,6 +121,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
         StressTestHelpers.LogResourceUsage("Final");
+        var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
 
         Console.WriteLine($"  Disposing producer...");
         try
@@ -150,7 +152,8 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             DeliveredMessages = delivered,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
-            CpuTimeSeconds = throughput.CpuTimeSeconds
+            CpuTimeSeconds = throughput.CpuTimeSeconds,
+            ProducerDeliveryDiagnostics = producerDiagnostics
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
@@ -40,6 +40,7 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
             _ => builder
         };
 
+        StressTestHelpers.ConfigureProducerDeliveryDiagnostics(builder, options);
         var producer = await builder.BuildAsync(cancellationToken);
 
         Console.WriteLine($"  Warming up Dekaf async idempotent producer...");
@@ -112,6 +113,7 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
         LogResourceUsage("Final");
+        var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
 
         Console.WriteLine($"  Disposing producer...");
         try
@@ -135,7 +137,8 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = latency.GetSnapshot(),
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            ProducerDeliveryDiagnostics = producerDiagnostics
         };
     }
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
@@ -40,6 +40,7 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
             _ => builder
         };
 
+        StressTestHelpers.ConfigureProducerDeliveryDiagnostics(builder, options);
         var producer = await builder.BuildAsync(cancellationToken);
 
         Console.WriteLine($"  Warming up Dekaf async producer...");
@@ -112,6 +113,7 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
         LogResourceUsage("Final");
+        var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
 
         Console.WriteLine($"  Disposing producer...");
         try
@@ -135,7 +137,8 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             Latency = latency.GetSnapshot(),
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            ProducerDeliveryDiagnostics = producerDiagnostics
         };
     }
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -37,6 +37,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             _ => builder
         };
 
+        StressTestHelpers.ConfigureProducerDeliveryDiagnostics(builder, options);
         var producer = await builder.BuildAsync(cancellationToken);
 
         Console.WriteLine($"  Warming up Dekaf idempotent producer...");
@@ -119,6 +120,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
         StressTestHelpers.LogResourceUsage("Final");
+        var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
 
         Console.WriteLine($"  Disposing producer...");
         try
@@ -149,7 +151,8 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             DeliveredMessages = delivered,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
-            CpuTimeSeconds = throughput.CpuTimeSeconds
+            CpuTimeSeconds = throughput.CpuTimeSeconds,
+            ProducerDeliveryDiagnostics = producerDiagnostics
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -38,6 +38,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
             _ => builder
         };
 
+        StressTestHelpers.ConfigureProducerDeliveryDiagnostics(builder, options);
         var producer = await builder.BuildAsync(cancellationToken);
 
         Console.WriteLine($"  Warming up Dekaf producer...");
@@ -123,6 +124,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
         StressTestHelpers.LogResourceUsage("Final");
+        var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
 
         Console.WriteLine($"  Disposing producer...");
         try
@@ -153,7 +155,8 @@ internal sealed class ProducerStressTest : IStressTestScenario
             DeliveredMessages = delivered,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
-            CpuTimeSeconds = throughput.CpuTimeSeconds
+            CpuTimeSeconds = throughput.CpuTimeSeconds,
+            ProducerDeliveryDiagnostics = producerDiagnostics
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Dekaf;
 using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
@@ -132,6 +133,34 @@ internal static class StressTestHelpers
         Console.WriteLine($"  Delivered (broker-confirmed): {delivered:N0} messages, {rate:N0} msg/sec " +
             $"({(accepted > 0 ? delivered * 100.0 / accepted : 0):F1}% of {accepted:N0} accepted)");
         return delivered;
+    }
+
+    internal static void ConfigureProducerDeliveryDiagnostics(
+        ProducerBuilder<string, string> builder,
+        StressTestOptions options)
+    {
+        if (options.EnableProducerDeliveryDiagnostics)
+            builder.WithDeliveryDiagnostics();
+    }
+
+    internal static ProducerDeliveryDiagnosticsSnapshot? CaptureProducerDeliveryDiagnostics(
+        IKafkaProducer<string, string> producer,
+        StressTestOptions options)
+    {
+        if (!options.EnableProducerDeliveryDiagnostics)
+            return null;
+
+        if (producer is not IProducerDiagnostics diagnostics)
+            return null;
+
+        var snapshot = diagnostics.GetDeliveryDiagnosticsSnapshot();
+        if (snapshot.Batches.Count > 0)
+        {
+            Console.WriteLine($"  Captured producer delivery diagnostics: " +
+                $"inFlight={snapshot.InFlightBatchCount:N0}, batches={snapshot.Batches.Count:N0}");
+        }
+
+        return snapshot;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add producer delivery diagnostics snapshot API for live in-flight batches.
- Capture diagnostics before stress producer disposal and print full batch state when message loss reports undelivered records.
- Cover snapshot content and cleanup behavior with unit tests.

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit --configuration Release
- [x] dotnet build tools/Dekaf.StressTests --configuration Release
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter /*/*/ProducerDeliveryDiagnosticsTests/*
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit --treenode-filter "/*/*/(ReadyBatchIncarnationTests|RecordAccumulatorReadyTests|RecordAccumulatorTests)/*"
- [x] ./tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit

Closes #1579
