### PR TITLE
perf(producer): scale on send-loop pressure

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -411,6 +411,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly int _minConnectionCount; // Initial ConnectionsPerBroker — never scale below this
     private readonly int _maxConnectionsPerBroker;
     private long _lastPressureSnapshot;
+    private long _sendLoopPressureEvents;
+    private long _lastSendLoopPressureSnapshot;
     private long _lastScaleTimeTicks;
     private Task<int>? _pendingScaleTask; // Background connection creation, polled by send loop
 
@@ -884,6 +886,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 if (carryOver.Count > 0)
                     SweepExpiredCarryOver(carryOver);
 
+                if (carryOver.Count > 0 || coalescedCount == maxCoalesce)
+                    RecordSendLoopPressureIfScaleUseful();
+
                 // ── 5b. Micro-linger for small coalesced batches ──
                 // When very few batches are coalesced (e.g., broker has only 2 partitions in a
                 // multi-broker setup), sending immediately produces many small ProduceRequests.
@@ -927,7 +932,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 {
                     var pendingCount = Volatile.Read(ref _totalPendingResponseCount);
                     if (pendingCount >= _totalMaxInFlight)
+                    {
+                        RecordSendLoopPressureIfScaleUseful();
                         LogWaitingForInFlightCapacity(_brokerId, pendingCount, _totalMaxInFlight);
+                    }
 
                     while (pendingCount >= _totalMaxInFlight)
                     {
@@ -937,6 +945,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                         if (pendingCount >= _totalMaxInFlight)
                         {
+                            RecordSendLoopPressureIfScaleUseful();
+
                             // Handle timed-out requests (Java pattern) to free zombie entries.
                             // Without this, the send loop blocks forever when a response task
                             // never completes.
@@ -1619,6 +1629,19 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 _mutedPartitions.TryRemove(batch.TopicPartition, out _);
                 _accumulator.UnmutePartition(batch.TopicPartition);
             }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void RecordSendLoopPressureIfScaleUseful()
+    {
+        if (IsSendLoopPressureScaleUseful(
+            _adaptiveScalingEnabled,
+            _connectionCount,
+            _maxConnectionsPerBroker,
+            _knownPartitions.Count))
+        {
+            _sendLoopPressureEvents++;
         }
     }
 
@@ -3373,9 +3396,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return 0;
 
         var utilization = _accumulator.BufferUtilization;
+        var bufferPressureDelta = _accumulator.BufferPressureEvents - _lastPressureSnapshot;
+        var sendLoopPressureDelta = _sendLoopPressureEvents - _lastSendLoopPressureSnapshot;
+        var scalePressureDelta = ComputeScalePressureDelta(bufferPressureDelta, sendLoopPressureDelta);
+        var hasScalePressure = scalePressureDelta >= ScalePressureDeltaThreshold;
 
         // Phase 2: Check if we should start a new scale-up
-        if (utilization >= ScaleUtilizationThreshold)
+        if (sendLoopPressureDelta >= ScalePressureDeltaThreshold
+            || (utilization >= ScaleUtilizationThreshold && hasScalePressure))
         {
             // High utilization — reset low-utilization tracking
             _lowUtilizationStartTicks = 0;
@@ -3383,13 +3411,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (_connectionCount >= _maxConnectionsPerBroker)
                 return 0; // At ceiling — cannot scale up, but scale-down remains active
 
-            var currentPressure = _accumulator.BufferPressureEvents;
-            var pressureDelta = currentPressure - _lastPressureSnapshot;
-
-            if (pressureDelta < ScalePressureDeltaThreshold)
-                return 0;
-
-            var targetCount = ComputeScaleTarget(pressureDelta, _connectionCount, _maxConnectionsPerBroker);
+            var targetCount = ComputeScaleTarget(scalePressureDelta, _connectionCount, _maxConnectionsPerBroker);
 
             // Launch connection creation in the background — send loop continues immediately
             _lastScaleTimeTicks = now;
@@ -3465,6 +3487,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // connections than requested, stale pressure keeps accumulating so the next
         // cooldown window retries with the full delta rather than starting from zero.
         _lastPressureSnapshot = _accumulator.BufferPressureEvents;
+        _lastSendLoopPressureSnapshot = _sendLoopPressureEvents;
 
         var newPinned = new IKafkaConnection?[actualCount];
         Array.Copy(_pinnedConnections, newPinned, oldCount);
@@ -3566,6 +3589,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var step = (int)Math.Min(pressureDelta / ScalePressureDeltaThreshold, MaxScaleStep);
         return Math.Min(currentConnections + step, maxConnections);
     }
+
+    internal static long ComputeScalePressureDelta(long bufferPressureDelta, long sendLoopPressureDelta) =>
+        Math.Max(bufferPressureDelta, sendLoopPressureDelta);
+
+    internal static bool IsSendLoopPressureScaleUseful(
+        bool adaptiveScalingEnabled,
+        int connectionCount,
+        int maxConnectionsPerBroker,
+        int knownPartitionCount) =>
+        adaptiveScalingEnabled
+        && connectionCount < maxConnectionsPerBroker
+        && knownPartitionCount > connectionCount;
 
     #region Logging
 

--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -886,8 +886,9 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
             catch (OperationCanceledException) { }
         });
 
-        // Wait for consumer to get partition assignment before producing new message
-        // This ensures ListOffsets (which determines "latest") is called before our produce
+        // Wait for consumer to get partition assignment before producing new message.
+        // Assignment is published before position initialization, so also wait until
+        // the latest reset position reaches the current high watermark.
         var assignmentTimeout = TimeSpan.FromSeconds(15);
         var sw = System.Diagnostics.Stopwatch.StartNew();
         while (consumer.Assignment.Count == 0 && sw.Elapsed < assignmentTimeout)
@@ -900,8 +901,40 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
             throw new InvalidOperationException("Consumer did not receive assignment within timeout");
         }
 
-        // Small additional delay to ensure positions are initialized after assignment
-        await Task.Delay(500);
+        var assignedPartitions = consumer.Assignment.ToArray();
+        var positionTimeout = TimeSpan.FromSeconds(15);
+        sw.Restart();
+
+        while (true)
+        {
+            TopicPartition? pendingPartition = null;
+            long? pendingPosition = null;
+            long pendingHigh = 0;
+
+            foreach (var partition in assignedPartitions)
+            {
+                var position = consumer.GetPosition(partition);
+                var watermarks = await consumer.QueryWatermarkOffsetsAsync(partition, cts.Token);
+                if (position == watermarks.High)
+                    continue;
+
+                pendingPartition = partition;
+                pendingPosition = position;
+                pendingHigh = watermarks.High;
+                break;
+            }
+
+            if (pendingPartition is null)
+                break;
+
+            if (sw.Elapsed >= positionTimeout)
+            {
+                throw new InvalidOperationException(
+                    $"Consumer did not initialize latest position for {pendingPartition} within timeout (position={pendingPosition}, high={pendingHigh})");
+            }
+
+            await Task.Delay(100, cts.Token);
+        }
 
         await producer.ProduceAsync(new ProducerMessage<string, string>
         {

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScalingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScalingTests.cs
@@ -127,6 +127,50 @@ public class AdaptiveScalingTests
         await Assert.That(target).IsEqualTo(10);
     }
 
+    [Test]
+    public async Task ComputeScalePressureDelta_UsesSendLoopPressure_WhenBufferPressureIsQuiet()
+    {
+        var pressureDelta = BrokerSender.ComputeScalePressureDelta(
+            bufferPressureDelta: 0,
+            sendLoopPressureDelta: 250);
+
+        await Assert.That(pressureDelta).IsEqualTo(250);
+
+        var target = BrokerSender.ComputeScaleTarget(pressureDelta, currentConnections: 1, maxConnections: 10);
+        await Assert.That(target).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task ComputeScalePressureDelta_UsesLargestPressureSignal()
+    {
+        var pressureDelta = BrokerSender.ComputeScalePressureDelta(
+            bufferPressureDelta: 500,
+            sendLoopPressureDelta: 100);
+
+        await Assert.That(pressureDelta).IsEqualTo(500);
+    }
+
+    [Test]
+    [Arguments(true, 1, 10, 2, true)]
+    [Arguments(true, 1, 10, 1, false)]
+    [Arguments(true, 10, 10, 20, false)]
+    [Arguments(false, 1, 10, 20, false)]
+    public async Task IsSendLoopPressureScaleUseful_GatesOnAdaptiveCeilingAndPartitionFanout(
+        bool adaptiveScalingEnabled,
+        int connectionCount,
+        int maxConnectionsPerBroker,
+        int knownPartitionCount,
+        bool expected)
+    {
+        var isUseful = BrokerSender.IsSendLoopPressureScaleUseful(
+            adaptiveScalingEnabled,
+            connectionCount,
+            maxConnectionsPerBroker,
+            knownPartitionCount);
+
+        await Assert.That(isUseful).IsEqualTo(expected);
+    }
+
     #endregion
 
     #region Scale-Down Computation Tests

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -122,6 +122,27 @@ public sealed class BrokerSenderSendLoopTests
             ]
         };
 
+    private static ProduceResponse CreateSuccessResponseForPartitions(string topic, int partitionCount) =>
+        new()
+        {
+            TopicCount = 1,
+            Responses =
+            [
+                new ProduceResponseTopicData
+                {
+                    Name = topic,
+                    PartitionCount = partitionCount,
+                    PartitionResponses = Enumerable.Range(0, partitionCount)
+                        .Select(partition => new ProduceResponsePartitionData
+                        {
+                            Index = partition,
+                            ErrorCode = ErrorCode.None,
+                            BaseOffset = partition + 1
+                        }).ToArray()
+                }
+            ]
+        };
+
     /// <summary>
     /// Creates a BrokerSender with standard test defaults, reducing constructor boilerplate.
     /// </summary>
@@ -152,6 +173,59 @@ public sealed class BrokerSenderSendLoopTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             await Task.Yield();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task SendLoopPressure_ScalesConnections_WhenCoalescingBacklogPersists(CancellationToken cancellationToken)
+    {
+        const int partitionCount = 8;
+        const int batchCount = 512;
+
+        var options = CreateOptions(maxInFlight: 1);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var connection = new TestKafkaConnection();
+        var sendCount = 0;
+        connection.SendProducePipelinedAfterWrite = () =>
+        {
+            Interlocked.Increment(ref sendCount);
+            return new ValueTask<Task<ProduceResponse>>(
+                Task.FromResult(CreateSuccessResponseForPartitions("test-topic", partitionCount)));
+        };
+
+        var scaleRequested = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        pool.ScaleConnectionGroupAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var targetCount = (int)callInfo[1];
+                scaleRequested.TrySetResult(targetCount);
+                return new ValueTask<int>(targetCount);
+            });
+
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            for (var i = 0; i < batchCount; i++)
+                sender.Enqueue(CreateTestBatch(vtPool, "test-topic", i % partitionCount));
+
+            var targetCount = await scaleRequested.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(targetCount).IsGreaterThan(1);
+            await Assert.That(Volatile.Read(ref sendCount)).IsGreaterThan(0);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
         }
     }
 


### PR DESCRIPTION
## Summary
- add send-loop pressure tracking for producer adaptive connection scaling
- scale when coalescing backlog or in-flight saturation persists, even if buffer backpressure has not fired
- gate send-loop pressure on known partition spread so single-partition traffic does not scale pointlessly

## Test plan
- [x] dotnet build tests\Dekaf.Tests.Unit --configuration Release
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/AdaptiveScalingTests/*
- [x] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe --treenode-filter /*/*/BrokerSenderSendLoopTests/*
- [ ] .\tests\Dekaf.Tests.Unit\bin\Release\net10.0\Dekaf.Tests.Unit.exe (failed unrelated RecordBatch_Dispose_DisposesLazyRecordList and ConcurrentPushPop_NoDuplicatesOrLoss; both passed when rerun individually)

Closes #1584
