### PR TITLE
fix(stress): pair benchmark clients

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -7,6 +7,7 @@ from statistics import median
 SCENARIO_TITLES = {
     'producer': 'Producer (Fire-and-Forget)',
     'producer-idempotent': 'Producer (Fire-and-Forget, Idempotent)',
+    'producer-acks-all': 'Producer (Acks All)',
     'producer-async': 'Producer (Async)',
     'producer-async-idempotent': 'Producer (Async, Idempotent)',
     'consumer': 'Consumer',
@@ -132,6 +133,12 @@ def median_interval_rate(result):
     return median(finite_samples)
 
 
+def comparison_rate(result):
+    """Rate used for ranking and ratios: median interval rate when present, else headline rate."""
+    rate = median_interval_rate(result)
+    return rate if rate is not None else effective_rate(result)
+
+
 def allocated_per_message(result):
     """Heap allocation per application message, or None when unavailable."""
     serialized = result.get('allocatedBytesPerMessage')
@@ -150,18 +157,16 @@ def find_confluent_baseline(results):
     """Find Confluent throughput as a baseline for ratio calculations."""
     for r in results:
         if r.get('client', '').lower() == 'confluent':
-            rate = effective_rate(r)
+            rate = comparison_rate(r)
             if rate > 0:
                 return rate
-    return min((effective_rate(r) or 1 for r in results), default=1)
+    return min((comparison_rate(r) or 1 for r in results), default=1)
 
 
 def throughput_sort_key(result):
-    """CPU efficiency leads current reports; old results without CPU keep throughput order."""
+    """Median sampled throughput leads current reports; old results keep headline order."""
     cpu_us_per_msg = cpu_micros_per_message(result)
-    if cpu_us_per_msg is not None:
-        return 0, cpu_us_per_msg, -effective_rate(result)
-    return 1, 0, -effective_rate(result)
+    return -comparison_rate(result), cpu_us_per_msg if cpu_us_per_msg is not None else float('inf')
 
 
 def format_throughput_table(results, title, include_ratio=False):
@@ -177,8 +182,8 @@ def format_throughput_table(results, title, include_ratio=False):
     lines.append("")
 
     if include_ratio:
-        lines.append("| Client | CPU μs/msg | Messages/sec | Median msg/s | MB/sec | Accepted msg/s | Errors | Cores Used | Thru Ratio |")
-        lines.append("|--------|------------|--------------|--------------|--------|----------------|--------|------------|------------|")
+        lines.append("| Client | CPU μs/msg | Messages/sec | Median msg/s | MB/sec | Accepted msg/s | Errors | Cores Used | Comparison Ratio |")
+        lines.append("|--------|------------|--------------|--------------|--------|----------------|--------|------------|------------------|")
     else:
         lines.append("| Client | CPU μs/msg | Messages/sec | Median msg/s | MB/sec | Accepted msg/s | Errors | Cores Used |")
         lines.append("|--------|------------|--------------|--------------|--------|----------------|--------|------------|")
@@ -199,7 +204,7 @@ def format_throughput_table(results, title, include_ratio=False):
         cpu_us_per_msg, cores_used = format_cpu_columns(r)
 
         if include_ratio:
-            ratio = msg_sec / baseline if baseline > 0 else 1.0
+            ratio = comparison_rate(r) / baseline if baseline > 0 else 1.0
             lines.append(f"| {client} | {cpu_us_per_msg} | {msg_sec:,.0f} | {median_msg_sec} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} | {ratio:.2f}x |")
         else:
             lines.append(f"| {client} | {cpu_us_per_msg} | {msg_sec:,.0f} | {median_msg_sec} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} |")
@@ -208,6 +213,8 @@ def format_throughput_table(results, title, include_ratio=False):
 
     if any(median_interval_rate(r) is not None for r in results):
         lines.append("*Median msg/s is the median sampled client-side throughput interval; it shows steady-state throughput without letting a short late-run stall dominate the whole-run average.*")
+        lines.append("")
+        lines.append("*Rows and Comparison Ratio use Median msg/s when available; older result files without interval samples fall back to Messages/sec.*")
         lines.append("")
 
     if any(r.get('deliveredMessages') is not None for r in results):
@@ -227,8 +234,8 @@ def format_comparison_callout(results, title):
     if not (dekaf and confluent):
         return []
 
-    dekaf_rate = effective_rate(dekaf)
-    confluent_rate = effective_rate(confluent)
+    dekaf_rate = comparison_rate(dekaf)
+    confluent_rate = comparison_rate(confluent)
     if confluent_rate <= 0:
         return []
 
@@ -242,27 +249,27 @@ def format_comparison_callout(results, title):
         cpu_ratio = confluent_cpu / dekaf_cpu
         if cpu_ratio > 1.05:
             lines.append(":::tip")
-            lines.append(f"**Dekaf uses {cpu_ratio:.2f}x less CPU per message** than Confluent.Kafka for {label}; throughput is {throughput_ratio:.2f}x.")
+            lines.append(f"**Dekaf uses {cpu_ratio:.2f}x less CPU per message** than Confluent.Kafka for {label}; comparison throughput is {throughput_ratio:.2f}x.")
             lines.append(":::")
         elif cpu_ratio < 0.95:
             lines.append(":::note")
-            lines.append(f"Confluent.Kafka uses {1/cpu_ratio:.2f}x less CPU per message for {label}; throughput is {throughput_ratio:.2f}x.")
+            lines.append(f"Confluent.Kafka uses {1/cpu_ratio:.2f}x less CPU per message for {label}; comparison throughput is {throughput_ratio:.2f}x.")
             lines.append(":::")
         else:
             lines.append(":::note")
-            lines.append(f"Dekaf and Confluent.Kafka have similar CPU efficiency for {label}; throughput is {throughput_ratio:.2f}x.")
+            lines.append(f"Dekaf and Confluent.Kafka have similar CPU efficiency for {label}; comparison throughput is {throughput_ratio:.2f}x.")
             lines.append(":::")
     elif throughput_ratio > 1.05:
         lines.append(":::tip")
-        lines.append(f"**Dekaf is {throughput_ratio:.2f}x faster** than Confluent.Kafka for {label} throughput!")
+        lines.append(f"**Dekaf is {throughput_ratio:.2f}x faster** than Confluent.Kafka for {label} comparison throughput!")
         lines.append(":::")
     elif throughput_ratio < 0.95:
         lines.append(":::note")
-        lines.append(f"Confluent.Kafka is {1/throughput_ratio:.2f}x faster for {label} throughput.")
+        lines.append(f"Confluent.Kafka is {1/throughput_ratio:.2f}x faster for {label} comparison throughput.")
         lines.append(":::")
     else:
         lines.append(":::note")
-        lines.append(f"Dekaf and Confluent.Kafka have similar {label} performance.")
+        lines.append(f"Dekaf and Confluent.Kafka have similar {label} comparison throughput.")
         lines.append(":::")
 
     lines.append("")

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -1,0 +1,64 @@
+import unittest
+
+from stress_report import format_throughput_table
+
+
+def stress_result(client, effective_rate, median_rate=None):
+    result = {
+        "client": client,
+        "durationMinutes": 15,
+        "messageSizeBytes": 1000,
+        "effectiveMessagesPerSecond": effective_rate,
+        "effectiveMegabytesPerSecond": effective_rate * 1000 / (1024 * 1024),
+        "throughput": {
+            "averageMessagesPerSecond": effective_rate,
+            "averageMegabytesPerSecond": effective_rate * 1000 / (1024 * 1024),
+            "totalErrors": 0,
+            "totalMessages": 1000,
+            "elapsedSeconds": 1,
+            "messagesPerSecondSamples": [],
+        },
+    }
+
+    if median_rate is not None:
+        result["medianIntervalMessagesPerSecond"] = median_rate
+
+    return result
+
+
+class StressReportTests(unittest.TestCase):
+    def test_throughput_table_orders_and_ratios_by_median_when_available(self):
+        lines = format_throughput_table(
+            [
+                stress_result("Dekaf", effective_rate=2000, median_rate=900),
+                stress_result("Confluent", effective_rate=1000, median_rate=1200),
+            ],
+            "Producer Throughput",
+            include_ratio=True,
+        )
+
+        rows = [line for line in lines if line.startswith("| Dekaf") or line.startswith("| Confluent")]
+
+        self.assertTrue(rows[0].startswith("| Confluent"))
+        self.assertTrue(rows[1].startswith("| Dekaf"))
+        self.assertIn("Comparison Ratio", "\n".join(lines))
+        self.assertIn("| 0.75x |", rows[1])
+
+    def test_throughput_table_falls_back_to_headline_rate_without_median(self):
+        lines = format_throughput_table(
+            [
+                stress_result("Dekaf", effective_rate=2000),
+                stress_result("Confluent", effective_rate=1000),
+            ],
+            "Producer Throughput",
+            include_ratio=True,
+        )
+
+        rows = [line for line in lines if line.startswith("| Dekaf") or line.startswith("| Confluent")]
+
+        self.assertTrue(rows[0].startswith("| Dekaf"))
+        self.assertIn("| 2.00x |", rows[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -23,111 +23,90 @@ env:
   Deterministic: true
 
 jobs:
-  # Run each test scenario in parallel
+  # Run each scenario in parallel. Comparable clients run sequentially inside the
+  # same job/VM so published ratios share hardware and noisy-neighbor conditions.
   stress-test:
     strategy:
       fail-fast: false
       matrix:
         include:
           - scenario: producer
-            client: dekaf
+            client: all
             brokers: 1
-            name: Dekaf Producer
+            run_3conn: true
+            artifact_suffix: -with-3conn
+            timeout_minutes: 105
+            name: Producer (Paired)
           - scenario: producer
-            client: confluent
-            brokers: 1
-            name: Confluent Producer
+            client: all
+            brokers: 3
+            run_3conn: true
+            artifact_suffix: -with-3conn
+            timeout_minutes: 150
+            name: Producer (Paired, 3 Brokers)
           - scenario: producer-idempotent
-            client: dekaf
+            client: all
             brokers: 1
-            name: Dekaf Producer (Idempotent)
+            run_3conn: true
+            artifact_suffix: -with-3conn
+            timeout_minutes: 105
+            name: Producer Idempotent (Paired)
           - scenario: producer-idempotent
-            client: confluent
-            brokers: 1
-            name: Confluent Producer (Idempotent)
+            client: all
+            brokers: 3
+            run_3conn: true
+            artifact_suffix: -with-3conn
+            timeout_minutes: 150
+            name: Producer Idempotent (Paired, 3 Brokers)
           - scenario: producer-acks-all
-            client: dekaf
+            client: all
             brokers: 1
-            name: Dekaf Producer (Acks All)
+            run_3conn: false
+            artifact_suffix: ""
+            timeout_minutes: 80
+            name: Producer Acks All (Paired)
           - scenario: producer-acks-all
-            client: confluent
-            brokers: 1
-            name: Confluent Producer (Acks All)
+            client: all
+            brokers: 3
+            run_3conn: false
+            artifact_suffix: ""
+            timeout_minutes: 120
+            name: Producer Acks All (Paired, 3 Brokers)
           - scenario: consumer
-            client: dekaf
+            client: all
             brokers: 1
-            name: Dekaf Consumer
-          - scenario: consumer
-            client: confluent
-            brokers: 1
-            name: Confluent Consumer
+            run_3conn: false
+            artifact_suffix: ""
+            timeout_minutes: 90
+            name: Consumer (Paired)
           - scenario: consumer-batch
             client: dekaf
             brokers: 1
+            run_3conn: false
+            artifact_suffix: ""
+            timeout_minutes: 60
             name: Dekaf Consumer Batch
           - scenario: consumer-raw
             client: dekaf
             brokers: 1
+            run_3conn: false
+            artifact_suffix: ""
+            timeout_minutes: 60
             name: Dekaf Consumer Raw
           - scenario: consumer-raw-batch
             client: dekaf
             brokers: 1
+            run_3conn: false
+            artifact_suffix: ""
+            timeout_minutes: 60
             name: Dekaf Consumer Raw Batch
-          # Multi-broker: producer scenarios only — consumer throughput is unaffected by
-          # replication factor since Acks only applies to producers.
-          - scenario: producer
-            client: dekaf
-            brokers: 3
-            name: Dekaf Producer (3 Brokers)
-          - scenario: producer
-            client: confluent
-            brokers: 3
-            name: Confluent Producer (3 Brokers)
-          - scenario: producer-acks-all
-            client: dekaf
-            brokers: 3
-            name: Dekaf Producer Acks All (3 Brokers)
-          - scenario: producer-acks-all
-            client: confluent
-            brokers: 3
-            name: Confluent Producer Acks All (3 Brokers)
-          - scenario: producer-idempotent
-            client: dekaf
-            brokers: 3
-            name: Dekaf Producer Idempotent (3 Brokers)
-          - scenario: producer-idempotent
-            client: confluent
-            brokers: 3
-            name: Confluent Producer Idempotent (3 Brokers)
-          # Multi-connection variants: Dekaf-only with explicit 3 connections per broker.
-          # Tests whether explicit multi-connection config outperforms adaptive scaling.
-          - scenario: producer
-            client: dekaf
-            brokers: 1
-            connections_per_broker: 3
-            name: Dekaf Producer (3conn)
-          - scenario: producer
-            client: dekaf
-            brokers: 3
-            connections_per_broker: 3
-            name: Dekaf Producer (3conn, 3 Brokers)
-          - scenario: producer-idempotent
-            client: dekaf
-            brokers: 1
-            connections_per_broker: 3
-            name: Dekaf Producer Idempotent (3conn)
-          - scenario: producer-idempotent
-            client: dekaf
-            brokers: 3
-            connections_per_broker: 3
-            name: Dekaf Producer Idempotent (3conn, 3 Brokers)
 
     name: ${{ matrix.name }}
     # 8 vCPUs, split so the client under test is the measured bottleneck:
     # brokers are pinned to BROKER_CPUS, the client to CLIENT_CPUS. On a shared-core
     # runner both clients just saturate the broker and report identical numbers.
     runs-on: ubicloud-standard-8
-    timeout-minutes: ${{ matrix.brokers > 1 && 75 || 60 }}
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     env:
       BROKER_CPUS: 0-5
       CLIENT_CPUS: 6,7
@@ -233,20 +212,38 @@ jobs:
             done
           ' > "$GITHUB_WORKSPACE/broker-disk.log" 2>&1 &
           DISK_MONITOR_PID=$!
+          trap 'kill $DISK_MONITOR_PID 2>/dev/null || true' EXIT
 
           cd tools/Dekaf.StressTests
           # Client pinned to its own cores: whichever client pushes more through the
           # same cores is genuinely faster, instead of both saturating the broker.
+          if (( ${{ github.run_number }} % 2 == 0 )); then
+            export STRESS_CLIENT_ORDER=confluent-first
+          else
+            export STRESS_CLIENT_ORDER=dekaf-first
+          fi
+          echo "Client order: ${STRESS_CLIENT_ORDER}"
+
           taskset -c ${CLIENT_CPUS} dotnet run --configuration Release --no-build -- \
             --duration ${{ github.event.inputs.duration_minutes || '15' }} \
             --message-size ${{ github.event.inputs.message_size || '1000' }} \
             --scenario ${{ matrix.scenario }} \
             --client ${{ matrix.client }} \
             --brokers ${{ matrix.brokers }} \
-            --connections-per-broker ${{ matrix.connections_per_broker || '1' }} \
+            --connections-per-broker 1 \
             --output ./results
 
-          kill $DISK_MONITOR_PID 2>/dev/null || true
+          if [ "${{ matrix.run_3conn }}" = "true" ]; then
+            echo "Running Dekaf 3-connection variant on the same VM"
+            taskset -c ${CLIENT_CPUS} dotnet run --configuration Release --no-build -- \
+              --duration ${{ github.event.inputs.duration_minutes || '15' }} \
+              --message-size ${{ github.event.inputs.message_size || '1000' }} \
+              --scenario ${{ matrix.scenario }} \
+              --client dekaf \
+              --brokers ${{ matrix.brokers }} \
+              --connections-per-broker 3 \
+              --output ./results
+          fi
 
       - name: Broker Diagnostics
         if: always()
@@ -284,7 +281,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: results-${{ matrix.client }}-${{ matrix.scenario }}-${{ matrix.brokers }}brokers${{ matrix.connections_per_broker && format('-{0}conn', matrix.connections_per_broker) || '' }}
+          name: results-${{ matrix.scenario }}-${{ matrix.brokers }}brokers${{ matrix.artifact_suffix }}
           path: |
             tools/Dekaf.StressTests/results/
             broker-disk.log
@@ -514,12 +511,13 @@ jobs:
           output.append("- **CPU Isolation**: Brokers are pinned to dedicated cores and the client under test to its own cores, so the client — not the broker — is the measured bottleneck")
           output.append("- **RAM-backed Broker Logs**: Kafka log dirs are mounted on tmpfs so disk I/O never caps broker ingestion")
           output.append("- **Delivered Throughput**: producer tables report broker-confirmed throughput, measured as the end-offset delta across all partitions — not the client-side append rate, which can run far ahead of what the broker ever accepts")
-          output.append("- **Median Interval Throughput**: tables also show median sampled client-side msg/s, which is less sensitive to short late-run stalls than the whole-run mean")
+          output.append("- **Median Interval Throughput**: table order and comparison ratios use median sampled client-side msg/s when available, which is less sensitive to short late-run stalls than the whole-run mean")
+          output.append("- **Same-VM Pairing**: comparable Dekaf and Confluent scenarios run sequentially inside one job/VM, with client order alternating by workflow run number to reduce order bias")
           output.append("- **Backpressure Parity**: both producers are bounded to the same 512 MB local buffer (Dekaf BufferMemory, librdkafka queue.buffering.max) and block on a full buffer, so neither client can absorb an unbounded backlog into RAM")
           output.append("- **Consumer Loop Replay**: Consumer tests re-read a pre-seeded topic (seek to beginning when drained) instead of racing a live feeder, so the consumer itself is measured")
           output.append("- **Delivery Latency Sampling**: 1 in 1000 produced messages is awaited end-to-end to record true broker round-trip latency")
           output.append("- **CPU Efficiency**: CPU time per message differentiates client efficiency even at equal throughput")
-          output.append("- **Parallel Execution**: Each test runs in its own isolated environment")
+          output.append("- **Parallel Execution**: Each scenario runs in its own isolated environment")
           output.append("- **Both Clients**: Direct comparison between Dekaf and Confluent.Kafka")
           output.append("- **Memory Monitoring**: Tracks GC behavior and memory usage over time")
           output.append("- **Error Rates**: Ensures stability under load")

--- a/docs/docs/stress-tests.md
+++ b/docs/docs/stress-tests.md
@@ -41,7 +41,7 @@ They measure sustained performance over 15+ minutes with real Kafka instances.
 **Dekaf is 1.26x faster** than Confluent.Kafka for producer (fire-and-forget), 3 brokers throughput!
 :::
 
-## Producer (producer-acks-all) Throughput (15 minutes, 1000B messages)
+## Producer (Acks All) Throughput (15 minutes, 1000B messages)
 
 | Client | Messages/sec | MB/sec | Accepted msg/s | Errors | CPU μs/msg | Cores Used |
 |--------|--------------|--------|----------------|--------|------------|------------|
@@ -51,10 +51,10 @@ They measure sustained performance over 15+ minutes with real Kafka instances.
 *Messages/sec counts broker-confirmed deliveries (end-offset delta). Accepted msg/s is the client-side append rate — a large gap means messages were buffered or dropped without ever reaching the broker.*
 
 :::tip
-**Dekaf is 1.30x faster** than Confluent.Kafka for producer (producer-acks-all) throughput!
+**Dekaf is 1.30x faster** than Confluent.Kafka for producer (acks all) throughput!
 :::
 
-## Producer (producer-acks-all), 3 Brokers Throughput (15 minutes, 1000B messages)
+## Producer (Acks All), 3 Brokers Throughput (15 minutes, 1000B messages)
 
 | Client | Messages/sec | MB/sec | Accepted msg/s | Errors | CPU μs/msg | Cores Used |
 |--------|--------------|--------|----------------|--------|------------|------------|
@@ -64,7 +64,7 @@ They measure sustained performance over 15+ minutes with real Kafka instances.
 *Messages/sec counts broker-confirmed deliveries (end-offset delta). Accepted msg/s is the client-side append rate — a large gap means messages were buffered or dropped without ever reaching the broker.*
 
 :::tip
-**Dekaf is 1.15x faster** than Confluent.Kafka for producer (producer-acks-all), 3 brokers throughput!
+**Dekaf is 1.15x faster** than Confluent.Kafka for producer (acks all), 3 brokers throughput!
 :::
 
 ## Producer (Fire-and-Forget, Idempotent) Throughput (15 minutes, 1000B messages)
@@ -131,8 +131,8 @@ They measure sustained performance over 15+ minutes with real Kafka instances.
 | Confluent | Consumer | 474970 | 1 | 1 | 2240.16 GB | 2.38 KB |
 | Confluent | Producer (Fire-and-Forget) | 240595 | 1 | 1 | 1152.90 GB | 1.26 KB |
 | Confluent | Producer (Fire-and-Forget), 3 Brokers | 208960 | 0 | 0 | 976.92 GB | 1.26 KB |
-| Confluent | producer-acks-all | 225454 | 1 | 1 | 1169.49 GB | 1.26 KB |
-| Confluent | producer-acks-all, 3 Brokers | 183809 | 0 | 0 | 858.79 GB | 1.26 KB |
+| Confluent | Producer (Acks All) | 225454 | 1 | 1 | 1169.49 GB | 1.26 KB |
+| Confluent | Producer (Acks All), 3 Brokers | 183809 | 0 | 0 | 858.79 GB | 1.26 KB |
 | Confluent | Producer (Fire-and-Forget, Idempotent) | 300189 | 1 | 1 | 1415.86 GB | 1.26 KB |
 | Confluent | Producer (Fire-and-Forget, Idempotent), 3 Brokers | 199336 | 1 | 0 | 930.92 GB | 1.26 KB |
 | Dekaf | Consumer | 56245 | 32897 | 1556 | 2500.18 GB | 2.31 KB |
@@ -141,8 +141,8 @@ They measure sustained performance over 15+ minutes with real Kafka instances.
 | Dekaf | Consumer (Raw Batch) | 5879 | 5067 | 140 | 163.84 GB | 76 B |
 | Dekaf | Producer (Fire-and-Forget) | 516 | 137 | 67 | 34.13 GB | 30 B |
 | Dekaf | Producer (Fire-and-Forget), 3 Brokers | 236 | 15 | 14 | 1.73 GB | 2 B |
-| Dekaf | producer-acks-all | 527 | 113 | 57 | 26.45 GB | 22 B |
-| Dekaf | producer-acks-all, 3 Brokers | 449 | 336 | 20 | 7.56 GB | 10 B |
+| Dekaf | Producer (Acks All) | 527 | 113 | 57 | 26.45 GB | 22 B |
+| Dekaf | Producer (Acks All), 3 Brokers | 449 | 336 | 20 | 7.56 GB | 10 B |
 | Dekaf | Producer (Fire-and-Forget, Idempotent) | 299 | 19 | 17 | 1.89 GB | 1 B |
 | Dekaf | Producer (Fire-and-Forget, Idempotent), 3 Brokers | 444 | 24 | 22 | 2.86 GB | 4 B |
 | Dekaf (3conn) | Producer (Fire-and-Forget) | 377 | 6 | 5 | 1003.88 MB | 1 B |
@@ -162,11 +162,13 @@ Stress tests measure sustained performance over extended periods:
 - **CPU Isolation**: Brokers are pinned to dedicated cores and the client under test to its own cores, so the client — not the broker — is the measured bottleneck
 - **RAM-backed Broker Logs**: Kafka log dirs are mounted on tmpfs so disk I/O never caps broker ingestion
 - **Delivered Throughput**: producer tables report broker-confirmed throughput, measured as the end-offset delta across all partitions — not the client-side append rate, which can run far ahead of what the broker ever accepts
+- **Median Interval Throughput**: table order and comparison ratios use median sampled client-side msg/s when available, which is less sensitive to short late-run stalls than the whole-run mean
+- **Same-VM Pairing**: comparable Dekaf and Confluent scenarios run sequentially inside one job/VM, with client order alternating by workflow run number to reduce order bias
 - **Backpressure Parity**: both producers are bounded to the same 512 MB local buffer (Dekaf BufferMemory, librdkafka queue.buffering.max) and block on a full buffer, so neither client can absorb an unbounded backlog into RAM
 - **Consumer Loop Replay**: Consumer tests re-read a pre-seeded topic (seek to beginning when drained) instead of racing a live feeder, so the consumer itself is measured
 - **Delivery Latency Sampling**: 1 in 1000 produced messages is awaited end-to-end to record true broker round-trip latency
 - **CPU Efficiency**: CPU time per message differentiates client efficiency even at equal throughput
-- **Parallel Execution**: Each test runs in its own isolated environment
+- **Parallel Execution**: Each scenario runs in its own isolated environment
 - **Both Clients**: Direct comparison between Dekaf and Confluent.Kafka
 - **Memory Monitoring**: Tracks GC behavior and memory usage over time
 - **Error Rates**: Ensures stability under load

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -15,7 +15,7 @@ namespace Dekaf.StressTests;
 /// Options:
 ///   --duration &lt;minutes&gt;    Test duration in minutes (default: 15)
 ///   --message-size &lt;bytes&gt;  Message size in bytes (default: 1000)
-///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-async, producer-async-idempotent, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
+///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
 ///   --client &lt;name&gt;         Run specific client: dekaf, confluent, all (default: all)
 ///   --output &lt;path&gt;         Output directory for results (default: ./results)
 ///   --brokers &lt;count&gt;      Number of Kafka brokers (default: 1, use 3 for multi-broker)
@@ -76,6 +76,12 @@ public static class Program
         Console.WriteLine($"Message Size: {options.MessageSizeBytes} bytes");
         Console.WriteLine($"Scenario: {options.Scenario}");
         Console.WriteLine($"Client: {options.Client}");
+        if (options.Client.Equals("all", StringComparison.OrdinalIgnoreCase) &&
+            Environment.GetEnvironmentVariable("STRESS_CLIENT_ORDER") is { Length: > 0 } clientOrder)
+        {
+            Console.WriteLine($"Client Order: {clientOrder}");
+        }
+
         Console.WriteLine($"Compression: {options.Compression}");
         Console.WriteLine($"Brokers: {options.Brokers}");
         Console.WriteLine($"Producer delivery diagnostics: {(options.EnableProducerDeliveryDiagnostics ? "enabled" : "disabled")}");
@@ -409,10 +415,48 @@ public static class Program
             new ConfluentConsumerStressTest()
         };
 
-        return allScenarios
+        var scenarios = allScenarios
             .Where(s => options.Scenario == "all" || s.Name.Equals(options.Scenario, StringComparison.OrdinalIgnoreCase))
             .Where(s => options.Client == "all" || s.Client.Equals(options.Client, StringComparison.OrdinalIgnoreCase))
             .ToList();
+
+        return ApplyClientOrder(scenarios, options.Client);
+    }
+
+    private static List<IStressTestScenario> ApplyClientOrder(List<IStressTestScenario> scenarios, string requestedClient)
+    {
+        if (!requestedClient.Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            return scenarios;
+        }
+
+        var clientOrder = Environment.GetEnvironmentVariable("STRESS_CLIENT_ORDER");
+        if (!string.Equals(clientOrder, "confluent-first", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(clientOrder, "dekaf-first", StringComparison.OrdinalIgnoreCase))
+        {
+            return scenarios;
+        }
+
+        var confluentFirst = string.Equals(clientOrder, "confluent-first", StringComparison.OrdinalIgnoreCase);
+        return scenarios
+            .GroupBy(s => s.Name)
+            .SelectMany(group => group.OrderBy(s => ClientOrderIndex(s.Client, confluentFirst)))
+            .ToList();
+    }
+
+    private static int ClientOrderIndex(string client, bool confluentFirst)
+    {
+        if (client.Equals("Confluent", StringComparison.OrdinalIgnoreCase))
+        {
+            return confluentFirst ? 0 : 1;
+        }
+
+        if (client.Equals("Dekaf", StringComparison.OrdinalIgnoreCase))
+        {
+            return confluentFirst ? 1 : 0;
+        }
+
+        return 2;
     }
 
     private static async Task<int> RunReportAsync(CliOptions options)
@@ -533,7 +577,7 @@ public static class Program
             Options:
               --duration <minutes>    Test duration in minutes (default: 15)
               --message-size <bytes>  Message size in bytes (default: 1000)
-              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-async, producer-async-idempotent, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
+              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
               --client <name>         Run specific client: dekaf, confluent, all (default: all)
               --output <path>         Output directory for results (default: ./results)
               --partitions <count>    Number of topic partitions (default: 6)
@@ -548,6 +592,7 @@ public static class Program
 
             Environment Variables:
               KAFKA_BOOTSTRAP_SERVERS - Use external Kafka instead of Testcontainers
+              STRESS_CLIENT_ORDER      - For --client all, run paired clients as dekaf-first or confluent-first
               STRESS_BROKER_CPUSET    - Pin Testcontainers brokers to CPU cores (e.g. "0-5") so the client keeps dedicated cores
               STRESS_BROKER_TMPFS     - Mount broker log dirs on tmpfs of this size (e.g. "6g") so disk I/O never caps ingestion
 

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -79,23 +79,24 @@ internal static class MarkdownReporter
             var messageSizeKb = messageSize >= 1024 ? $"{messageSize / 1024.0:F1}KB" : $"{messageSize}B";
             sb.AppendLine($"## {title} ({durationMinutes} minutes, {messageSizeKb} messages)");
             sb.AppendLine();
-            sb.AppendLine($"| {"Client".PadRight(clientWidth)} | CPU μs/msg | Messages/sec | Median msg/s | MB/sec | Accepted msg/s | Errors | Cores Used | Thru Ratio |");
-            sb.AppendLine($"|{new string('-', clientWidth + 2)}|------------|--------------|--------------|--------|----------------|--------|------------|------------|");
+            sb.AppendLine($"| {"Client".PadRight(clientWidth)} | CPU μs/msg | Messages/sec | Median msg/s | MB/sec | Accepted msg/s | Errors | Cores Used | Comparison Ratio |");
+            sb.AppendLine($"|{new string('-', clientWidth + 2)}|------------|--------------|--------------|--------|----------------|--------|------------|------------------|");
 
             var baseline = sizeResults
                 .Where(r => r.Client.Equals("Confluent", StringComparison.OrdinalIgnoreCase))
-                .Select(r => r.EffectiveMessagesPerSecond)
+                .Select(ComparisonMessagesPerSecond)
                 .FirstOrDefault();
 
             if (baseline == 0)
             {
-                baseline = sizeResults.Min(r => r.EffectiveMessagesPerSecond);
+                baseline = sizeResults.Min(ComparisonMessagesPerSecond);
             }
 
             foreach (var result in OrderThroughputResults(sizeResults))
             {
                 var rate = result.EffectiveMessagesPerSecond;
-                var ratio = baseline > 0 ? rate / baseline : 1.0;
+                var comparisonRate = ComparisonMessagesPerSecond(result);
+                var ratio = baseline > 0 ? comparisonRate / baseline : 1.0;
                 var median = result.MedianIntervalMessagesPerSecond is { } medianRate ? medianRate.ToString("N0") : "-";
                 var accepted = result.AcceptedMessagesPerSecond is { } acceptedRate ? acceptedRate.ToString("N0") : "-";
                 var cpuPerMessage = result.CpuMicrosPerMessage is { } cpu ? $"{cpu:F2}" : "-";
@@ -108,6 +109,8 @@ internal static class MarkdownReporter
             if (sizeResults.Any(r => r.MedianIntervalMessagesPerSecond is not null))
             {
                 sb.AppendLine("*Median msg/s is the median sampled client-side throughput interval; it shows steady-state throughput without letting a short late-run stall dominate the whole-run average.*");
+                sb.AppendLine();
+                sb.AppendLine("*Rows and Comparison Ratio use Median msg/s when available; older result files without interval samples fall back to Messages/sec.*");
                 sb.AppendLine();
             }
 
@@ -129,11 +132,12 @@ internal static class MarkdownReporter
     }
 
     private static IOrderedEnumerable<StressTestResult> OrderThroughputResults(List<StressTestResult> results) =>
-        results.Any(r => r.CpuMicrosPerMessage is not null)
-            ? results
-                .OrderBy(r => r.CpuMicrosPerMessage ?? double.MaxValue)
-                .ThenByDescending(r => r.EffectiveMessagesPerSecond)
-            : results.OrderByDescending(r => r.EffectiveMessagesPerSecond);
+        results
+            .OrderByDescending(ComparisonMessagesPerSecond)
+            .ThenBy(r => r.CpuMicrosPerMessage ?? double.MaxValue);
+
+    private static double ComparisonMessagesPerSecond(StressTestResult result) =>
+        result.MedianIntervalMessagesPerSecond ?? result.EffectiveMessagesPerSecond;
 
     private static void GenerateLatencyTable(StringBuilder sb, List<StressTestResult> results, string title = "Latency Percentiles")
     {
@@ -206,6 +210,7 @@ internal static class MarkdownReporter
     {
         "producer" => "Producer (Fire-and-Forget) Throughput",
         "producer-idempotent" => "Producer (Fire-and-Forget, Idempotent) Throughput",
+        "producer-acks-all" => "Producer (Acks All) Throughput",
         "producer-async" => "Producer (Async) Throughput",
         "producer-async-idempotent" => "Producer (Async, Idempotent) Throughput",
         "consumer" => "Consumer Throughput",
@@ -219,6 +224,7 @@ internal static class MarkdownReporter
     {
         "producer" => "Fire-and-Forget",
         "producer-idempotent" => "Fire-and-Forget (Idempotent)",
+        "producer-acks-all" => "Acks All",
         "producer-async" => "Async",
         "producer-async-idempotent" => "Async (Idempotent)",
         "consumer" => "Consumer",


### PR DESCRIPTION
## Summary
- run paired Dekaf/Confluent stress scenarios in the same workflow job/VM, with client order alternating by run number
- rank stress summaries/docs by median interval throughput when samples exist, and make comparison ratios use the same metric
- add reporter tests and fix the acks-all scenario label

## Test plan
- [x] python .github/scripts/test_stress_report.py
- [x] dotnet build tools/Dekaf.StressTests --configuration Release
- [x] npm run build --prefix docs
- [x] parsed .github/workflows/stress-tests.yml with PyYAML

Closes #1585
