### PR TITLE
fix(producer): stop adaptive scale-down from losing batches; make scaled connections actually used

### DIFF
--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -315,15 +315,21 @@ public sealed partial class ConnectionPool : IConnectionPool
             throw new InvalidOperationException($"Unknown broker ID: {brokerId}");
         }
 
-        if (_connectionsPerBroker <= 1)
-        {
-            // Graceful degradation: when only one connection per broker is configured,
-            // fall back to the single-connection path, silently ignoring the requested index.
-            return await GetConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
-        }
-
+        // Adaptive scaling can grow a connection group beyond the configured
+        // ConnectionsPerBroker (ScaleConnectionGroupAsync creates the group on demand),
+        // so an existing group is authoritative for index routing regardless of the
+        // configured count. Without this, a producer configured with 1 connection that
+        // adaptively scaled up would have every index silently resolve to the same
+        // single connection — serializing all sends on one socket.
         if (!_connectionGroupsById.TryGetValue(brokerId, out var connections))
         {
+            if (_connectionsPerBroker <= 1)
+            {
+                // Graceful degradation: single-connection configuration with no scaled
+                // group yet — fall back to the single-connection path.
+                return await GetConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
+            }
+
             // CreateConnectionGroupAsync populates _connectionGroupsById and returns
             // the first connection. If it throws (timeout, broker unreachable), the
             // exception propagates — no null-dereference risk below.
@@ -1234,7 +1240,9 @@ public sealed partial class ConnectionPool : IConnectionPool
 
         if (_connectionGroupsById.TryRemove(brokerId, out var group))
         {
-            for (var i = 0; i < _connectionsPerBroker; i++)
+            // Iterate the group's actual size: adaptive scaling can grow a group beyond
+            // the configured ConnectionsPerBroker.
+            for (var i = 0; i < group.Length; i++)
             {
                 // Intentionally not disposed: a concurrent ReplaceConnectionInGroupAsync
                 // may be holding or waiting on it. Will be disposed during DisposeAsync.
@@ -1263,9 +1271,10 @@ public sealed partial class ConnectionPool : IConnectionPool
 
             var tasks = new List<ValueTask>();
 
-            // Close single connections (used when _connectionsPerBroker == 1)
-            // Note: Single connections and connection groups are mutually exclusive -
-            // GetConnectionAsync uses one path or the other based on _connectionsPerBroker
+            // Close single connections (the GetConnectionAsync path when
+            // _connectionsPerBroker == 1). A pool configured for one connection can hold
+            // BOTH a single connection and a connection group for the same broker once
+            // adaptive scaling creates a group — both collections are disposed below.
             foreach (var connection in _connectionsByEndpoint.Values)
             {
                 tasks.Add(connection.DisposeAsync());

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -374,8 +374,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     // Per-connection pending responses. Each list tracks in-flight requests for one connection.
-    // Single-threaded: only accessed by the send loop. Resized by adaptive connection scaling.
-    private List<PendingResponse>[] _pendingResponsesByConnection;
+    // Single-threaded: only accessed by the send loop. Pre-sized at the scaling ceiling.
+    private readonly List<PendingResponse>[] _pendingResponsesByConnection;
 
     // Batches that failed during SendCoalescedAsync (connection error, etc.) and need retry.
     // Must be thread-safe: with multi-connection sends, multiple Z handlers (catch blocks)
@@ -448,12 +448,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // All producers use partition affinity (partition % N) for CPU cache locality.
     // Idempotent producers additionally require affinity for per-partition sequence ordering;
     // during scaling, _migratingPartitions overrides the modulo to preserve ordering.
-    private IKafkaConnection?[] _pinnedConnections;
+    private readonly IKafkaConnection?[] _pinnedConnections;
     private int _connectionCount;
     private readonly bool _isIdempotent;
 
     // Adaptive connection scaling state (send-loop owned, single-threaded)
     private bool _adaptiveScalingEnabled;
+    private readonly bool _canPhysicallyShrinkConnections;
     private readonly int _minConnectionCount; // Initial ConnectionsPerBroker — never scale below this
     private readonly int _maxConnectionsPerBroker;
     private long _lastPressureSnapshot;
@@ -565,7 +566,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         Func<short>? getCurrentEpoch,
         Action<ReadyBatch, int>? rerouteBatch,
         Action<TopicPartition, long, DateTimeOffset, int, Exception?>? onAcknowledgement,
-        ILogger? logger)
+        ILogger? logger,
+        bool canPhysicallyShrinkConnections = true)
     {
         _brokerId = brokerId;
         _connectionPool = connectionPool;
@@ -607,6 +609,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Idempotent producers additionally need affinity for sequence ordering.
         // Transactions are excluded because coordinator requests require a single connection.
         _adaptiveScalingEnabled = options.EnableAdaptiveConnections && options.TransactionalId is null;
+        _canPhysicallyShrinkConnections = canPhysicallyShrinkConnections;
         _minConnectionCount = options.ConnectionsPerBroker;
         _maxConnectionsPerBroker = options.MaxConnectionsPerBroker;
         _scaleCooldownMs = options.ScaleCooldownMsOverride ?? ScaleCooldownMs;
@@ -771,12 +774,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     private void RerouteRejectedBatch(ReadyBatch batch, int expectedGeneration)
     {
-        if (_redeliverAfterLoopExit
-            && Volatile.Read(ref _disposed) == 0
-            && _rerouteBatch is not null)
+        if (_redeliverAfterLoopExit && _rerouteBatch is not null)
         {
             try
             {
+                // KafkaProducer disposes a crashed sender as soon as its first survivor
+                // creates the replacement. Callers that already captured this sender can
+                // still race in afterward; they must follow that same replacement path.
+                // Producer disposal is guarded by the reroute callback itself.
                 _rerouteBatch(batch, expectedGeneration);
                 return;
             }
@@ -3688,25 +3693,19 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         // Observe any in-flight shrink task and dispose the draining connection.
         // After the send loop exits, these won't be polled by MaybeScaleConnections.
-        if (_pendingShrinkTask is not null)
+        if (_pendingShrinkTask is { } pendingShrinkTask)
         {
-            if (_pendingShrinkTask.Status == TaskStatus.RanToCompletion)
-            {
-                var removedConn = _pendingShrinkTask.Result;
-                if (removedConn is not null)
-                {
-                    try { await removedConn.DisposeAsync().ConfigureAwait(false); }
-                    catch (Exception ex) { LogBatchCleanupStepFailed(ex, _brokerId); }
-                }
-            }
-            else if (_pendingShrinkTask.IsFaulted)
-            {
-                // Observe the exception to prevent UnobservedTaskException
-                LogBatchCleanupStepFailed(
-                    _pendingShrinkTask.Exception!.InnerException ?? _pendingShrinkTask.Exception, _brokerId);
-            }
-
             _pendingShrinkTask = null;
+            if (pendingShrinkTask.IsCompleted)
+            {
+                await DisposeShrinkResultAsync(pendingShrinkTask).ConfigureAwait(false);
+            }
+            else
+            {
+                // A test double or custom pool may ignore the cancelled lifetime token.
+                // Keep ownership of any connection removed after disposal returns.
+                _ = DisposeShrinkResultAsync(pendingShrinkTask);
+            }
         }
 
         if (_drainingConnection is not null)
@@ -3756,6 +3755,24 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         _cts.Dispose();
         _anyResponseCompleted.Dispose();
+    }
+
+    private async Task DisposeShrinkResultAsync(Task<IKafkaConnection?> shrinkTask)
+    {
+        try
+        {
+            var removedConnection = await shrinkTask.ConfigureAwait(false);
+            if (removedConnection is not null)
+                await removedConnection.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when sender lifetime cancellation reaches pool shrink.
+        }
+        catch (Exception ex)
+        {
+            LogBatchCleanupStepFailed(ex, _brokerId);
+        }
     }
 
     private async Task ObserveMetadataRefreshAsync(string topic, CancellationToken cancellationToken)
@@ -3951,6 +3968,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         _lastScaleTimeTicks = now;
         _lowUtilizationStartTicks = 0; // Reset for the next scale-down cycle
+
+        // KafkaClient shares one ConnectionPool across producers, consumers, and admin
+        // clients. This sender can reduce its own routing width, but cannot prove the
+        // shared pool slot is idle for every owner and therefore must not remove it.
+        if (!_canPhysicallyShrinkConnections)
+        {
+            _pinnedConnections[targetShrinkCount] = null;
+            LogAdaptiveScaleDown(_brokerId, targetShrinkCount + 1, targetShrinkCount);
+            return targetShrinkCount;
+        }
+
         _pendingShrinkTask = _connectionPool.ShrinkConnectionGroupAsync(
             _brokerId, targetShrinkCount, _cts.Token).AsTask();
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -455,6 +455,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // Adaptive connection scaling state (send-loop owned, single-threaded)
     private bool _adaptiveScalingEnabled;
     private readonly bool _canPhysicallyShrinkConnections;
+    private bool _hasScaledConnectionGroup;
     private readonly int _minConnectionCount; // Initial ConnectionsPerBroker — never scale below this
     private readonly int _maxConnectionsPerBroker;
     private long _lastPressureSnapshot;
@@ -3365,10 +3366,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (conn is not null && conn.IsConnected)
             return conn;
 
-        // Shared senders can retain an expanded pool group after reducing their local
-        // routing width to one. Keep slot 0 indexed so a reconnect cannot round-robin
-        // onto a different physical connection while an older request is still pending.
-        var connection = _connectionCount > 1 || !_canPhysicallyShrinkConnections
+        // Shared pools may retain an expanded group owned by another client. An owning
+        // sender also retains a one-slot group after scaling back down. Keep those slots
+        // indexed, while preserving the singleton path before this sender first scales up.
+        var connection = _connectionCount > 1 || !_canPhysicallyShrinkConnections || _hasScaledConnectionGroup
             ? await _connectionPool.GetConnectionByIndexAsync(_brokerId, connIdx, cancellationToken)
                 .ConfigureAwait(false)
             : await _connectionPool.GetConnectionAsync(_brokerId, cancellationToken)
@@ -3999,6 +4000,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         actualCount = Math.Min(actualCount, _pendingResponsesByConnection.Length);
 
         var oldCount = _connectionCount;
+        _hasScaledConnectionGroup = true;
         _connectionCount = actualCount;
         _totalMaxInFlight = _connectionCount * _maxInFlight;
         // Only reset on successful growth — intentional. If the pool returned fewer

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -124,7 +124,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly ProducerOptions _options;
     private readonly CompressionCodecRegistry _compressionCodecs;
     private readonly PartitionInflightTracker _inflightTracker;
-    private readonly Action<ReadyBatch>? _rerouteBatch;
+    private readonly Action<ReadyBatch, int>? _rerouteBatch;
     private readonly Action<TopicPartition, long, DateTimeOffset, int, Exception?>? _onAcknowledgement;
     private readonly Func<short, IReadOnlyCollection<TopicPartition>, (long ProducerId, short ProducerEpoch)>? _bumpEpoch;
     private readonly Func<short>? _getCurrentEpoch;
@@ -211,7 +211,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             BatchGeneration = batchGeneration;
         }
 
-        public static SendLoopEvent NewBatch(ReadyBatch batch) => new(SendLoopEventType.NewBatch, batch, batch.Generation);
+        public static SendLoopEvent NewBatch(ReadyBatch batch) => NewBatch(batch, batch.Generation);
+
+        public static SendLoopEvent NewBatch(ReadyBatch batch, int generation)
+            => new(SendLoopEventType.NewBatch, batch, generation);
 
         public BatchReference GetBatchReference() => new(Batch!, BatchGeneration);
 
@@ -273,6 +276,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         /// <summary>Add to back of partition queue (normal carry-over, new batches).</summary>
         public void Add(BatchReference batchRef)
         {
+            if (batchRef.Batch.IsLoopExitRedelivery)
+            {
+                AddLoopExitRedelivery(batchRef);
+                return;
+            }
+
             GetOrCreateQueue(batchRef.Batch.TopicPartition).Add(batchRef);
             _count++;
         }
@@ -283,6 +292,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         /// </summary>
         public void AddFirst(BatchReference batchRef)
         {
+            if (batchRef.Batch.IsLoopExitRedelivery)
+            {
+                AddLoopExitRedelivery(batchRef);
+                return;
+            }
+
             GetOrCreateQueue(batchRef.Batch.TopicPartition).Insert(0, batchRef);
             _count++;
         }
@@ -299,10 +314,29 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         /// </remarks>
         public void AddAfterRetries(BatchReference batchRef)
         {
+            if (batchRef.Batch.IsLoopExitRedelivery)
+            {
+                AddLoopExitRedelivery(batchRef);
+                return;
+            }
+
             var queue = GetOrCreateQueue(batchRef.Batch.TopicPartition);
 
             var insertIdx = 0;
             while (insertIdx < queue.Count && queue[insertIdx].Batch.IsRetry)
+                insertIdx++;
+
+            queue.Insert(insertIdx, batchRef);
+            _count++;
+        }
+
+        private void AddLoopExitRedelivery(BatchReference batchRef)
+        {
+            var queue = GetOrCreateQueue(batchRef.Batch.TopicPartition);
+            var insertIdx = 0;
+            while (insertIdx < queue.Count
+                && queue[insertIdx].Batch.IsLoopExitRedelivery
+                && queue[insertIdx].Batch.LoopExitRedeliveryOrder <= batchRef.Batch.LoopExitRedeliveryOrder)
                 insertIdx++;
 
             queue.Insert(insertIdx, batchRef);
@@ -357,6 +391,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // entry re-sends or fails a batch now owned by a different partition, which is the
     // root cause of the PRODUCE framing-guard failures in issue #1570.
     private readonly ConcurrentQueue<(ReadyBatch Batch, int Generation)> _sendFailedRetries = new();
+
+    // Batches recovered from an unexpectedly exited sender. These must run before both
+    // send-failure retries and normal channel backlog on the replacement sender. They use
+    // a separate queue because _sendFailedRetries is drained with AddFirst (which reverses
+    // FIFO order when multiple same-partition entries arrive together).
+    private readonly ConcurrentQueue<(ReadyBatch Batch, int Generation)> _loopExitRedeliveries = new();
+
+    // Partitions accepted while this sender is alive. Guarded with _loopExited so an
+    // unexpected exit can install every accumulator barrier before replacement is visible.
+    private readonly HashSet<TopicPartition> _enqueuedPartitions = [];
+    private readonly System.Threading.Lock _loopExitRedeliveryLock = new();
+    private long _nextLoopExitRedeliveryOrder;
 
     // Non-blocking in-flight request limiter. The send loop uses _totalPendingResponseCount
     // (which it exclusively owns) as the in-flight measure. No cross-thread signaling needed.
@@ -432,6 +478,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // reroute-redelivered — GetOrCreateBrokerSender must build a replacement, not return
     // this instance whose event channel is already completed.
     private volatile bool _loopExited;
+    private volatile bool _redeliverAfterLoopExit;
 
     // Per-partition migration fencing for idempotent producers: during a scale-UP,
     // partitions whose connection assignment changes (partition % oldCount != partition % newCount)
@@ -516,7 +563,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         Func<TopicPartition, CancellationToken, ValueTask>? ensurePartitionInTransaction,
         Func<short, IReadOnlyCollection<TopicPartition>, (long ProducerId, short ProducerEpoch)>? bumpEpoch,
         Func<short>? getCurrentEpoch,
-        Action<ReadyBatch>? rerouteBatch,
+        Action<ReadyBatch, int>? rerouteBatch,
         Action<TopicPartition, long, DateTimeOffset, int, Exception?>? onAcknowledgement,
         ILogger? logger)
     {
@@ -630,18 +677,41 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     public void EnqueueBulk(List<ReadyBatch> batches)
     {
         var writer = _eventChannel.Writer;
-        for (var i = 0; i < batches.Count; i++)
+        var rejectedIndex = -1;
+        var rerouteRejected = false;
+
+        lock (_loopExitRedeliveryLock)
         {
-            if (!writer.TryWrite(SendLoopEvent.NewBatch(batches[i])))
+            if (_loopExited)
             {
-                // Channel completed (disposal) — fail remaining batches.
-                // The caller's outer catch may also call FailAndCleanupBatch on these batches,
-                // but batch.Fail() is idempotent (guarded by Interlocked.Exchange on _sendCompleted)
-                // and TrySetMemoryReleased() is likewise atomic, so double-fail is safe.
-                for (var j = i; j < batches.Count; j++)
-                    FailEnqueuedBatch(batches[j]);
-                return;
+                rejectedIndex = 0;
+                rerouteRejected = true;
             }
+            else
+            {
+                for (var i = 0; i < batches.Count; i++)
+                {
+                    _enqueuedPartitions.Add(batches[i].TopicPartition);
+                    if (!writer.TryWrite(SendLoopEvent.NewBatch(batches[i])))
+                    {
+                        rejectedIndex = i;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (rejectedIndex < 0)
+            return;
+
+        // Channel completion during disposal keeps the existing fail behavior. A batch that
+        // raced an unexpected loop exit is handed to the replacement sender instead.
+        for (var i = rejectedIndex; i < batches.Count; i++)
+        {
+            if (rerouteRejected)
+                RerouteRejectedBatch(batches[i], batches[i].Generation);
+            else
+                FailEnqueuedBatch(batches[i], batches[i].Generation);
         }
     }
 
@@ -650,20 +720,97 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// when a retry discovers the leader moved). TryWrite on unbounded channel always succeeds
     /// unless the channel is completed.
     /// </summary>
-    public void Enqueue(ReadyBatch batch)
+    public void Enqueue(ReadyBatch batch) => Enqueue(batch, batch.Generation);
+
+    internal void Enqueue(ReadyBatch batch, int expectedGeneration)
     {
-        if (!_eventChannel.Writer.TryWrite(SendLoopEvent.NewBatch(batch)))
-            FailEnqueuedBatch(batch);
+        if (!batch.TryAcquireResourcePin(expectedGeneration))
+            return;
+
+        var reroute = false;
+        var enqueued = false;
+        try
+        {
+            lock (_loopExitRedeliveryLock)
+            {
+                if (_loopExited)
+                {
+                    reroute = true;
+                }
+                else
+                {
+                    var topicPartition = batch.TopicPartition;
+                    _enqueuedPartitions.Add(topicPartition);
+
+                    if (batch.IsLoopExitRedelivery)
+                    {
+                        // Recovery pre-dates normal work already owned by this sender.
+                        batch.LoopExitRedeliveryOrder = ++_nextLoopExitRedeliveryOrder;
+                        _loopExitRedeliveries.Enqueue((batch, expectedGeneration));
+                        _eventChannel.Writer.TryWrite(SendLoopEvent.Unmute());
+                        enqueued = true;
+                    }
+                    else
+                    {
+                        enqueued = _eventChannel.Writer.TryWrite(
+                            SendLoopEvent.NewBatch(batch, expectedGeneration));
+                    }
+                }
+            }
+        }
+        finally
+        {
+            batch.ReleaseResourcePin();
+        }
+
+        if (reroute)
+            RerouteRejectedBatch(batch, expectedGeneration);
+        else if (!enqueued)
+            FailEnqueuedBatch(batch, expectedGeneration);
     }
 
-    private void FailEnqueuedBatch(ReadyBatch batch)
+    private void RerouteRejectedBatch(ReadyBatch batch, int expectedGeneration)
     {
-        if (batch.IsRetry)
+        if (_redeliverAfterLoopExit
+            && Volatile.Read(ref _disposed) == 0
+            && _rerouteBatch is not null)
         {
-            batch.IsRetry = false;
-            UnmutePartition(batch.TopicPartition);
+            try
+            {
+                _rerouteBatch(batch, expectedGeneration);
+                return;
+            }
+            catch (Exception ex)
+            {
+                try { FailAndCleanupBatch(batch, expectedGeneration, ex); }
+                catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
+                return;
+            }
         }
-        FailAndCleanupBatch(batch, new ObjectDisposedException(nameof(BrokerSender)));
+
+        FailEnqueuedBatch(batch, expectedGeneration);
+    }
+
+    private void FailEnqueuedBatch(ReadyBatch batch, int expectedGeneration)
+    {
+        if (!batch.TryAcquireResourcePin(expectedGeneration))
+            return;
+
+        try
+        {
+            if (batch.IsRetry)
+            {
+                batch.IsRetry = false;
+                UnmutePartition(batch.TopicPartition);
+            }
+        }
+        finally
+        {
+            batch.ReleaseResourcePin();
+        }
+
+        FailAndCleanupBatch(batch, expectedGeneration,
+            new ObjectDisposedException(nameof(BrokerSender)));
     }
 
     /// <summary>
@@ -793,6 +940,19 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         carryOver.AddFirst(new BatchReference(retry.Batch, retry.Generation));
                     else
                         LogStaleRetryBatchSkipped(_instanceId, _brokerId);
+                }
+
+                // Crash-recovered batches predate all work already owned by this replacement
+                // sender. Persistent carry-over insertion preserves FIFO across loop cycles
+                // while keeping every recovery ahead of send-failure retries and normal work.
+                while (_loopExitRedeliveries.TryDequeue(out var redelivery))
+                {
+                    if (redelivery.Batch.IsCurrentIncarnation(redelivery.Generation))
+                        carryOver.Add(new BatchReference(redelivery.Batch, redelivery.Generation));
+                    else
+                    {
+                        LogStaleRetryBatchSkipped(_instanceId, _brokerId);
+                    }
                 }
 
                 // ── 3. Handle timed-out requests (Java handleTimedOutRequests pattern) ──
@@ -1006,7 +1166,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             }
 
                             if (!batch.IsRetry
-                                && _mutedPartitions.ContainsKey(batch.TopicPartition))
+                                && (_mutedPartitions.ContainsKey(batch.TopicPartition)
+                                    || _accumulator.IsMuted(batch.TopicPartition)))
                             {
                                 // Normal batch whose partition was muted during the in-flight
                                 // wait (a different batch for this partition triggered a retry).
@@ -1247,7 +1408,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                 // ── 7. Compute timeout and wait ──
                 var waitPendingCount = Volatile.Read(ref _totalPendingResponseCount);
-                if (carryOver.Count == 0 && waitPendingCount == 0 && _sendFailedRetries.IsEmpty)
+                if (carryOver.Count == 0
+                    && waitPendingCount == 0
+                    && _sendFailedRetries.IsEmpty
+                    && _loopExitRedeliveries.IsEmpty)
                 {
                     if (hasPendingSingleConnectionFireAndForgetSend && !eventReader.TryPeek(out _))
                         await AwaitPendingSingleConnectionFireAndForgetSendAsync().ConfigureAwait(false);
@@ -1312,7 +1476,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         await Task.Delay(Math.Min(wakeupMs, 100), cancellationToken).ConfigureAwait(false);
                     }
                 }
-                else if (_sendFailedRetries.IsEmpty && !eventReader.TryPeek(out _))
+                else if (_sendFailedRetries.IsEmpty
+                    && _loopExitRedeliveries.IsEmpty
+                    && !eventReader.TryPeek(out _))
                 {
                     // No carry-over, no pending responses, no retries, no events — wait for new batch.
                     if (!await eventReader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
@@ -1329,93 +1495,158 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
         finally
         {
+            var redeliver = crashed
+                && Volatile.Read(ref _disposed) == 0
+                && _rerouteBatch is not null;
+            List<TopicPartition>? crashBarriers = null;
+
             // Mark this sender dead BEFORE disposing surviving batches: when the loop exited
             // unexpectedly, batches are handed back through the reroute callback, which goes
             // via GetOrCreateBrokerSender — IsAlive must already be false there so a fresh
             // replacement is built instead of re-enqueueing into this completed channel.
-            _loopExited = true;
-
-            try { await AwaitPendingSingleConnectionFireAndForgetSendAsync().ConfigureAwait(false); }
-            catch (Exception ex) { LogSendLoopFailed(ex, _brokerId); }
-
-            sendTimeoutCts.Dispose();
-            for (var c = 0; c < singleConnectionFireAndForgetTimeoutCts.Length; c++)
-                singleConnectionFireAndForgetTimeoutCts[c].Dispose();
-            for (var c = 0; c < bucketTimeoutCts.Length; c++)
-                bucketTimeoutCts[c]?.Dispose();
-            _eventChannel.Writer.TryComplete();
-
-            var disposedException = new ObjectDisposedException(nameof(BrokerSender));
-
-            // Shutdown (close/disposal) permanently fails surviving batches — the producer
-            // is going away. An UNEXPECTED loop exit (escaped exception) must not drop them:
-            // the producer is still healthy and replaces this sender on the next drain, so
-            // every surviving batch is redelivered through the reroute callback instead.
-            // Idempotent sequencing keeps redelivery of already-written requests safe — the
-            // batch keeps its sequence and the broker dedupes.
-            var redeliver = crashed
-                && Volatile.Read(ref _disposed) == 0
-                && _rerouteBatch is not null;
-            if (redeliver)
-                LogSendLoopExitRedelivery(_brokerId);
-
-            // Disposition order preserves per-partition FIFO for redelivery:
-            // in-flight pending responses hold the oldest batches, then send-failed retries,
-            // then carry-over, then this pass's coalesced batches, then the channel backlog.
-            for (var connIdx = 0; connIdx < _pendingResponsesByConnection.Length; connIdx++)
+            lock (_loopExitRedeliveryLock)
             {
-                var pendingList = _pendingResponsesByConnection[connIdx];
-                for (var i = 0; i < pendingList.Count; i++)
+                if (redeliver)
                 {
-                    var pr = pendingList[i];
-                    for (var j = 0; j < pr.Count; j++)
+                    // Fence every partition accepted by this sender before publishing its
+                    // death. Replacement senders consult the accumulator mute, so newer work
+                    // cannot be sent during survivor discovery and handoff.
+                    crashBarriers = new List<TopicPartition>(_enqueuedPartitions.Count);
+                    foreach (var topicPartition in _enqueuedPartitions)
                     {
-                        if (pr.IsSameIncarnation(j))
-                            RedeliverOrFailOnLoopExit(pr.Batches[j], redeliver, disposedException);
+                        _accumulator.MutePartition(topicPartition);
+                        crashBarriers.Add(topicPartition);
                     }
-                    pr.ReturnBatchesArray();
                 }
-                Interlocked.Add(ref _totalPendingResponseCount, -pendingList.Count);
-                pendingList.Clear();
-                // No TrimExcess — lists are unreachable after disposal
+
+                _redeliverAfterLoopExit = redeliver;
+                _loopExited = true;
             }
 
-            while (_sendFailedRetries.TryDequeue(out var retry))
+            try
             {
-                if (retry.Batch.IsCurrentIncarnation(retry.Generation))
-                    RedeliverOrFailOnLoopExit(retry.Batch, redeliver, disposedException);
-            }
+                try { await AwaitPendingSingleConnectionFireAndForgetSendAsync().ConfigureAwait(false); }
+                catch (Exception ex) { LogSendLoopFailed(ex, _brokerId); }
 
-            DisposeCarryOverBatchesOnLoopExit(carryOver, redeliver, disposedException);
+                sendTimeoutCts.Dispose();
+                for (var c = 0; c < singleConnectionFireAndForgetTimeoutCts.Length; c++)
+                    singleConnectionFireAndForgetTimeoutCts[c].Dispose();
+                for (var c = 0; c < bucketTimeoutCts.Length; c++)
+                    bucketTimeoutCts[c]?.Dispose();
+                _eventChannel.Writer.TryComplete();
 
-            for (var i = 0; i < coalescedCount; i++)
-            {
-                if (coalescedBatches[i].IsCurrentIncarnation(coalescedGenerations[i]))
-                    RedeliverOrFailOnLoopExit(coalescedBatches[i], redeliver, disposedException);
-            }
-            Array.Clear(coalescedBatches, 0, coalescedCount);
-            Array.Clear(coalescedGenerations, 0, coalescedCount);
+                // Shutdown (close/disposal) permanently fails surviving batches — the producer
+                // is going away. An UNEXPECTED loop exit (escaped exception) must not drop them:
+                // the producer is still healthy and replaces this sender on the next drain, so
+                // every surviving batch is redelivered through the reroute callback instead.
+                // Idempotent sequencing keeps redelivery of already-written requests safe — the
+                // batch keeps its sequence and the broker dedupes.
+                if (redeliver)
+                    LogSendLoopExitRedelivery(_brokerId);
 
-            // Drain remaining events — only NewBatch events carry batches that need cleanup.
-            // ResponseReady and Unmute events are lightweight signals with no data.
-            while (eventReader.TryRead(out var evt))
-            {
-                if (evt.Type == SendLoopEventType.NewBatch)
+                var disposedException = new ObjectDisposedException(nameof(BrokerSender));
+                var recoveredBatches = redeliver ? new List<BatchReference>() : null;
+                var recoveredBatchSet = redeliver ? new HashSet<(ReadyBatch Batch, int Generation)>() : null;
+
+                // Disposition order preserves per-partition FIFO for redelivery:
+                // in-flight pending responses hold the oldest batches, then already-recovered work,
+                // send-failed retries, this pass's coalesced head, carry-over, and channel backlog.
+                for (var connIdx = 0; connIdx < _pendingResponsesByConnection.Length; connIdx++)
                 {
-                    var batchRef = evt.GetBatchReference();
-                    if (batchRef.IsCurrentIncarnation())
-                        RedeliverOrFailOnLoopExit(batchRef.Batch, redeliver, disposedException);
+                    var pendingList = _pendingResponsesByConnection[connIdx];
+                    for (var i = 0; i < pendingList.Count; i++)
+                    {
+                        var pr = pendingList[i];
+                        for (var j = 0; j < pr.Count; j++)
+                        {
+                            if (pr.IsSameIncarnation(j))
+                                CollectOrFailOnLoopExit(
+                                    new BatchReference(pr.Batches[j], pr.BatchGenerations[j]),
+                                    redeliver, disposedException,
+                                    recoveredBatches, recoveredBatchSet);
+                        }
+                        pr.ReturnBatchesArray();
+                    }
+                    Interlocked.Add(ref _totalPendingResponseCount, -pendingList.Count);
+                    pendingList.Clear();
+                    // No TrimExcess — lists are unreachable after disposal
+                }
+
+                while (_loopExitRedeliveries.TryDequeue(out var redelivery))
+                {
+                    if (redelivery.Batch.IsCurrentIncarnation(redelivery.Generation))
+                        CollectOrFailOnLoopExit(
+                            new BatchReference(redelivery.Batch, redelivery.Generation),
+                            redeliver, disposedException,
+                            recoveredBatches, recoveredBatchSet);
+                }
+
+                while (_sendFailedRetries.TryDequeue(out var retry))
+                {
+                    if (retry.Batch.IsCurrentIncarnation(retry.Generation))
+                        CollectOrFailOnLoopExit(
+                            new BatchReference(retry.Batch, retry.Generation),
+                            redeliver, disposedException,
+                            recoveredBatches, recoveredBatchSet);
+                }
+
+                for (var i = 0; i < coalescedCount; i++)
+                {
+                    if (coalescedBatches[i].IsCurrentIncarnation(coalescedGenerations[i]))
+                        CollectOrFailOnLoopExit(
+                            new BatchReference(coalescedBatches[i], coalescedGenerations[i]),
+                            redeliver, disposedException,
+                            recoveredBatches, recoveredBatchSet);
+                }
+                Array.Clear(coalescedBatches, 0, coalescedCount);
+                Array.Clear(coalescedGenerations, 0, coalescedCount);
+
+                DisposeCarryOverBatchesOnLoopExit(carryOver, redeliver, disposedException,
+                    recoveredBatches, recoveredBatchSet);
+
+                // Drain remaining events — only NewBatch events carry batches that need cleanup.
+                // ResponseReady and Unmute events are lightweight signals with no data.
+                while (eventReader.TryRead(out var evt))
+                {
+                    if (evt.Type == SendLoopEventType.NewBatch)
+                    {
+                        var batchRef = evt.GetBatchReference();
+                        if (batchRef.IsCurrentIncarnation())
+                            CollectOrFailOnLoopExit(batchRef, redeliver, disposedException,
+                                recoveredBatches, recoveredBatchSet);
+                    }
+                }
+
+                if (recoveredBatches is not null)
+                {
+                    // All recovery mute references were registered before the first callback,
+                    // so even synchronous completion cannot expose a later sibling or newer work.
+                    for (var i = 0; i < recoveredBatches.Count; i++)
+                    {
+                        var batchRef = recoveredBatches[i];
+                        if (batchRef.IsCurrentIncarnation())
+                            RedeliverOrFailOnLoopExit(batchRef.Batch, batchRef.Generation,
+                                redeliver: true, disposedException);
+                    }
                 }
             }
+            finally
+            {
+                if (crashBarriers is not null)
+                {
+                    for (var i = 0; i < crashBarriers.Count; i++)
+                        _accumulator.UnmutePartition(crashBarriers[i]);
+                }
 
-            // Unmute all partitions this BrokerSender had muted in the accumulator.
-            // Without this, partitions stay permanently muted after BrokerSender disposal,
-            // preventing Ready()/Drain() from ever picking up queued batches for those
-            // partitions. This causes orphaned batch timeouts on slow CI runners where
-            // transient connection errors kill the send loop while retries are pending.
-            foreach (var (tp, _) in _mutedPartitions)
-                _accumulator.UnmutePartition(tp);
-            _mutedPartitions.Clear();
+                // Unmute all partitions this BrokerSender had muted in the accumulator.
+                // Without this, partitions stay permanently muted after BrokerSender disposal,
+                // preventing Ready()/Drain() from ever picking up queued batches for those
+                // partitions. This causes orphaned batch timeouts on slow CI runners where
+                // transient connection errors kill the send loop while retries are pending.
+                foreach (var (tp, _) in _mutedPartitions)
+                    _accumulator.UnmutePartition(tp);
+                _mutedPartitions.Clear();
+            }
         }
     }
 
@@ -1485,10 +1716,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 {
                     // Leader moved to different broker — unmute and reroute
                     LogRetryRerouted(_brokerId, batch.TopicPartition.Topic, batch.TopicPartition.Partition, leader.NodeId);
-                    batch.IsRetry = false;
                     batch.RetryNotBefore = 0;
+                    if (!batch.IsLoopExitRedelivery)
+                        batch.IsRetry = false;
                     UnmutePartition(batch.TopicPartition);
-                    _rerouteBatch(batch);
+                    _rerouteBatch(batch, batchRef.Generation);
                     return;
                 }
             }
@@ -1515,8 +1747,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return;
         }
 
-        // Normal batch: skip muted partitions (retry in progress)
-        if (_mutedPartitions.ContainsKey(batch.TopicPartition))
+        // Normal batch: skip any local retry/recovery mute and crash barriers owned by
+        // another sender. The accumulator check closes the handoff gap before the first
+        // recovered batch reaches this replacement sender.
+        if (_mutedPartitions.ContainsKey(batch.TopicPartition)
+            || _accumulator.IsMuted(batch.TopicPartition))
         {
             LogPartitionMuted(_brokerId, batch.TopicPartition.Topic, batch.TopicPartition.Partition);
             batch.AppendDiag('O');
@@ -1661,8 +1896,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (batch.IsRetry)
             {
                 batch.IsRetry = false;
-                _mutedPartitions.TryRemove(batch.TopicPartition, out _);
-                _accumulator.UnmutePartition(batch.TopicPartition);
+                UnmutePartition(batch.TopicPartition);
             }
         }
     }
@@ -2176,8 +2410,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Mute partition so no newer batches overtake the retry (ordering guarantee).
         // Also mute in accumulator so Ready/Drain skips this partition — prevents the
         // sender loop from draining newer batches that would jump the retry queue.
-        _mutedPartitions.TryAdd(batch.TopicPartition, 0);
-        _accumulator.MutePartition(batch.TopicPartition);
+        if (!batch.IsLoopExitRedelivery)
+            MutePartition(batch.TopicPartition);
 
         var isEpochBumpError = errorCode is ErrorCode.OutOfOrderSequenceNumber
             or ErrorCode.InvalidProducerEpoch or ErrorCode.UnknownProducerId;
@@ -2571,8 +2805,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 {
                     for (var i = 0; i < count; i++)
                     {
-                        _mutedPartitions.TryAdd(batches[i].TopicPartition, 0);
-                        _accumulator.MutePartition(batches[i].TopicPartition);
+                        if (!batches[i].IsLoopExitRedelivery)
+                            MutePartition(batches[i].TopicPartition);
                     }
                 }
 
@@ -2658,8 +2892,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     else
                     {
                         // Mute partition (ordering guarantee) and queue for retry.
-                        _mutedPartitions.TryAdd(batch.TopicPartition, 0);
-                        _accumulator.MutePartition(batch.TopicPartition);
+                        if (!batch.IsLoopExitRedelivery)
+                            MutePartition(batch.TopicPartition);
                         batch.IsRetry = true;
                         batch.RetryNotBefore = Stopwatch.GetTimestamp() +
                             _options.RetryBackoffTicks;
@@ -3152,11 +3386,41 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// Idempotent: safe to call even if the partition was not muted.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void MutePartition(TopicPartition tp)
+    {
+        if (_mutedPartitions.TryAdd(tp, 0))
+            _accumulator.MutePartition(tp);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void UnmutePartition(TopicPartition tp)
     {
-        _mutedPartitions.TryRemove(tp, out _);
-        _accumulator.UnmutePartition(tp); // Also unmute in accumulator so Ready/Drain can pick up new batches
+        if (_mutedPartitions.TryRemove(tp, out _))
+            _accumulator.UnmutePartition(tp);
         _eventChannel.Writer.TryWrite(SendLoopEvent.Unmute());
+    }
+
+    private bool RegisterLoopExitRecovery(ReadyBatch batch, int expectedGeneration)
+        => _accumulator.TryRegisterLoopExitRecovery(batch, expectedGeneration);
+
+    private static bool PrepareLoopExitRedelivery(ReadyBatch batch, int expectedGeneration)
+    {
+        if (!batch.TryAcquireResourcePin(expectedGeneration))
+            return false;
+
+        try
+        {
+            if (!batch.IsCurrentIncarnation(expectedGeneration))
+                return false;
+
+            batch.IsRetry = true;
+            batch.AppendDiag('Y');
+            return batch.IsCurrentIncarnation(expectedGeneration);
+        }
+        finally
+        {
+            batch.ReleaseResourcePin();
+        }
     }
 
     /// <summary>
@@ -3206,7 +3470,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
     }
 
-    private void DisposeCarryOverBatchesOnLoopExit(PartitionCarryOver carryOver, bool redeliver, ObjectDisposedException disposedException)
+    private void DisposeCarryOverBatchesOnLoopExit(
+        PartitionCarryOver carryOver,
+        bool redeliver,
+        ObjectDisposedException disposedException,
+        List<BatchReference>? recoveredBatches,
+        HashSet<(ReadyBatch Batch, int Generation)>? recoveredBatchSet)
     {
         foreach (var kvp in carryOver.Partitions)
         {
@@ -3215,9 +3484,34 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 var batchRef = queue[i];
                 if (batchRef.IsCurrentIncarnation())
-                    RedeliverOrFailOnLoopExit(batchRef.Batch, redeliver, disposedException);
+                    CollectOrFailOnLoopExit(batchRef, redeliver, disposedException,
+                        recoveredBatches, recoveredBatchSet);
             }
         }
+    }
+
+    private void CollectOrFailOnLoopExit(
+        BatchReference batchRef,
+        bool redeliver,
+        ObjectDisposedException disposedException,
+        List<BatchReference>? recoveredBatches,
+        HashSet<(ReadyBatch Batch, int Generation)>? recoveredBatchSet)
+    {
+        if (!batchRef.IsCurrentIncarnation())
+            return;
+
+        if (!redeliver)
+        {
+            RedeliverOrFailOnLoopExit(batchRef.Batch, batchRef.Generation,
+                redeliver: false, disposedException);
+            return;
+        }
+
+        if (!recoveredBatchSet!.Add((batchRef.Batch, batchRef.Generation)))
+            return;
+
+        if (RegisterLoopExitRecovery(batchRef.Batch, batchRef.Generation))
+            recoveredBatches!.Add(batchRef);
     }
 
     /// <summary>
@@ -3230,12 +3524,22 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// batches always completes. Internal for testing.
     /// </summary>
     internal void RedeliverOrFailOnLoopExit(ReadyBatch batch, bool redeliver, ObjectDisposedException disposedException)
+        => RedeliverOrFailOnLoopExit(batch, batch.Generation, redeliver, disposedException);
+
+    private void RedeliverOrFailOnLoopExit(
+        ReadyBatch batch,
+        int expectedGeneration,
+        bool redeliver,
+        ObjectDisposedException disposedException)
     {
         try
         {
+            if (!batch.IsCurrentIncarnation(expectedGeneration))
+                return;
+
             if (!redeliver)
             {
-                FailAndCleanupBatch(batch, disposedException);
+                FailAndCleanupBatch(batch, expectedGeneration, disposedException);
                 return;
             }
 
@@ -3243,22 +3547,66 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks);
                 var configured = TimeSpan.FromMilliseconds(_options.DeliveryTimeoutMs);
-                FailAndCleanupBatch(batch, new KafkaTimeoutException(
+                FailAndCleanupBatch(batch, expectedGeneration, new KafkaTimeoutException(
                     TimeoutKind.Delivery, elapsed, configured,
                     $"Delivery timeout exceeded for {batch.TopicPartition} after send-loop exit"));
                 return;
             }
 
-            batch.AppendDiag('X'); // Redelivered after send-loop exit
-            _rerouteBatch!(batch);
+            if (!RegisterLoopExitRecovery(batch, expectedGeneration))
+                return;
+
+            if (!PrepareLoopExitRedelivery(batch, expectedGeneration))
+                return;
+            _rerouteBatch!(batch, expectedGeneration);
         }
         catch (Exception cleanupEx)
         {
+            try { FailAndCleanupBatch(batch, expectedGeneration, cleanupEx); }
+            catch (Exception failEx) { LogBatchCleanupStepFailed(failEx, _brokerId); }
             LogBatchCleanupStepFailed(cleanupEx, _brokerId);
         }
     }
 
     private void FailAndCleanupBatch(ReadyBatch batch, Exception ex)
+    {
+        FailBatch(batch, ex, sendCompletionClaimed: false);
+        try { CleanupBatch(batch); }
+        catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
+    }
+
+    private void FailAndCleanupBatch(ReadyBatch batch, int expectedGeneration, Exception ex)
+    {
+        if (!batch.TryAcquireResourcePin(expectedGeneration))
+            return;
+
+        var sendCompletionClaimed = false;
+        try
+        {
+            sendCompletionClaimed = batch.TryClaimSendCompletion(expectedGeneration);
+        }
+        finally
+        {
+            batch.ReleaseResourcePin();
+        }
+
+        if (!sendCompletionClaimed)
+            return;
+
+        try
+        {
+            FailBatch(batch, ex, sendCompletionClaimed: true);
+            try { CleanupBatchResources(batch); }
+            catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
+        }
+        finally
+        {
+            try { _accumulator.CompleteTerminalBookkeepingAndReturnReadyBatch(batch); }
+            catch (Exception returnEx) { LogBatchCleanupStepFailed(returnEx, _brokerId); }
+        }
+    }
+
+    private void FailBatch(ReadyBatch batch, Exception ex, bool sendCompletionClaimed)
     {
         batch.AppendDiag('F');
         // Every operation is wrapped in try/catch to guarantee we reach CleanupBatch.
@@ -3268,7 +3616,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // leaking their completion sources and causing producer hangs (deadlocks).
         try { CompleteInflightEntry(batch); }
         catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
-        try { batch.Fail(ex); }
+        try
+        {
+            if (sendCompletionClaimed)
+                batch.FailAfterSendCompletionClaimed(ex);
+            else
+                batch.Fail(ex);
+        }
         catch (Exception failEx) { LogBatchCleanupStepFailed(failEx, _brokerId); }
         try
         {
@@ -3276,12 +3630,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             batch.CompletionSourcesCount, ex);
         }
         catch (Exception ackEx) { LogBatchCleanupStepFailed(ackEx, _brokerId); }
-        try { CleanupBatch(batch); }
-        catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void CleanupBatch(ReadyBatch batch)
+    {
+        CleanupBatchResources(batch);
+
+        // ReturnReadyBatch is idempotent (atomic _returnedToPool flag), so this is safe
+        // even if ForceFailAllInFlightBatches races during disposal.
+        try { _accumulator.ReturnReadyBatch(batch); }
+        catch (Exception returnEx) { LogBatchCleanupStepFailed(returnEx, _brokerId); }
+    }
+
+    private void CleanupBatchResources(ReadyBatch batch)
     {
         // Release buffer memory at batch completion (matching Java's RecordAccumulator.deallocate()).
         // This is the primary release path: memory is held throughout the entire pipeline
@@ -3295,11 +3657,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // (e.g., SweepExpiredInFlightBatches), it returns false but we still return
         // the batch to the pool since the sweep defers pool return to BrokerSender.
         _accumulator.OnBatchExitsPipeline(batch);
-
-        // ReturnReadyBatch is idempotent (atomic _returnedToPool flag), so this is safe
-        // even if ForceFailAllInFlightBatches races during disposal.
-        try { _accumulator.ReturnReadyBatch(batch); }
-        catch (Exception returnEx) { LogBatchCleanupStepFailed(returnEx, _brokerId); }
     }
 
     public async ValueTask DisposeAsync()
@@ -3640,12 +3997,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// width (<see cref="_connectionCount"/>) was already reduced when the shrink was
     /// initiated, so no request has been able to target the removed slot since then and
     /// its pending list is expected to be empty. The removed connection is parked as
-    /// retiring; <see cref="MaybeDrainAndDisposeConnection"/> (Phase 0 of every iteration)
-    /// promotes it to draining/disposal once the slot's pending list is confirmed empty —
-    /// immediately on the next iteration in the normal case. Should a request ever be
-    /// found on the removed slot (invariant breach), it is logged and the connection stays
-    /// alive until the response completes: the response/timeout scans iterate the full
-    /// array, so nothing is dropped. Returns the (already reduced) connection count.
+    /// retiring; <see cref="MaybeDrainAndDisposeConnection"/> promotes it immediately when
+    /// the slot is empty, or during Phase 0 after an unexpected pending response completes.
+    /// Should a request ever be found on the removed slot (invariant breach), it is logged
+    /// and the connection stays alive until the response completes: the response/timeout
+    /// scans iterate the full array, so nothing is dropped. Returns the (already reduced)
+    /// connection count.
     /// </summary>
     private int ApplyScaleDown(IKafkaConnection removedConnection)
     {
@@ -3663,6 +4020,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // blocks all new scale events, so ApplyScaleDown is never called while a prior
         // retirement is in progress.
         _retiringConnection = removedConnection;
+        MaybeDrainAndDisposeConnection();
 
         LogAdaptiveScaleDown(_brokerId, removedIdx + 1, _connectionCount);
         return _connectionCount;

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3365,7 +3365,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (conn is not null && conn.IsConnected)
             return conn;
 
-        var connection = _connectionCount > 1
+        // Shared senders can retain an expanded pool group after reducing their local
+        // routing width to one. Keep slot 0 indexed so a reconnect cannot round-robin
+        // onto a different physical connection while an older request is still pending.
+        var connection = _connectionCount > 1 || !_canPhysicallyShrinkConnections
             ? await _connectionPool.GetConnectionByIndexAsync(_brokerId, connIdx, cancellationToken)
                 .ConfigureAwait(false)
             : await _connectionPool.GetConnectionAsync(_brokerId, cancellationToken)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -421,12 +421,25 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private Task<IKafkaConnection?>? _pendingShrinkTask; // Background shrink, polled by send loop
     private IKafkaConnection? _drainingConnection; // Connection being drained before disposal
 
-    // Per-partition migration fencing for idempotent producers: during a scale event,
+    // A connection removed from the pool by scale-down, parked until its pending-response
+    // list (slot _connectionCount — frozen while parked, because a parked connection blocks
+    // all new scale events) is confirmed empty, then promoted to _drainingConnection for
+    // disposal. The list is expected to already be empty when parked; a non-empty list
+    // means a request slipped in against the width-reduction invariant and is logged.
+    private IKafkaConnection? _retiringConnection;
+
+    // Set at send-loop finally entry so IsAlive turns false before surviving batches are
+    // reroute-redelivered — GetOrCreateBrokerSender must build a replacement, not return
+    // this instance whose event channel is already completed.
+    private volatile bool _loopExited;
+
+    // Per-partition migration fencing for idempotent producers: during a scale-UP,
     // partitions whose connection assignment changes (partition % oldCount != partition % newCount)
     // are fenced here if they have in-flight batches on the old connection. The partition
     // continues routing to the old connection until its in-flight clears, then is removed
     // from this dictionary and routes via the new partition % _connectionCount.
-    // Send-loop owned (single-threaded) — no synchronization needed.
+    // Scale-down never fences (its drain gates guarantee no in-flight) and clears any
+    // stale entries at initiation. Send-loop owned (single-threaded) — no synchronization needed.
     private readonly Dictionary<int, int> _migratingPartitions = new();
 
     // Scaling thresholds
@@ -441,6 +454,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // Scale-down thresholds
     private const double ScaleDownUtilizationThreshold = 0.3; // Buffer utilization below which scale-down is considered
     private const long ScaleDownSustainedMs = 120_000; // 2 minutes of sustained low utilization required
+
+    // Effective scaling timings: the constants above unless overridden via the internal
+    // ProducerOptions test knobs (so tests can drive scale cycles without waiting minutes).
+    // Readonly — set once in the constructor before the send loop starts.
+    private readonly long _scaleCooldownMs;
+    private readonly long _scaleDownSustainedMs;
 
     // Maintained counter for O(1) hot-path access. Incremented in SendCoalescedAsync
     // when a PendingResponse is added, decremented in ProcessCompletedResponses and
@@ -534,7 +553,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // locality. Idempotent producers additionally need affinity for sequence ordering.
         _connectionCount = options.ConnectionsPerBroker;
         _isIdempotent = options.EnableIdempotence;
-        _pinnedConnections = new IKafkaConnection?[_connectionCount];
         _totalMaxInFlight = _connectionCount * _maxInFlight;
 
         // Adaptive scaling: available for all non-transactional producers.
@@ -544,9 +562,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _adaptiveScalingEnabled = options.EnableAdaptiveConnections && options.TransactionalId is null;
         _minConnectionCount = options.ConnectionsPerBroker;
         _maxConnectionsPerBroker = options.MaxConnectionsPerBroker;
+        _scaleCooldownMs = options.ScaleCooldownMsOverride ?? ScaleCooldownMs;
+        _scaleDownSustainedMs = options.ScaleDownSustainedMsOverride ?? ScaleDownSustainedMs;
 
-        _pendingResponsesByConnection = new List<PendingResponse>[_connectionCount];
-        for (var i = 0; i < _connectionCount; i++)
+        // Per-connection arrays are allocated once at the adaptive-scaling ceiling and never
+        // resized: scale events change only _connectionCount, and slots beyond it sit unused.
+        // Response/timeout scans iterate the full array, so a slot that leaves the routing
+        // width during a scale-down keeps having its in-flight requests polled to completion
+        // instead of being dropped by an array truncation.
+        var connectionCapacity = _adaptiveScalingEnabled
+            ? Math.Max(_connectionCount, _maxConnectionsPerBroker)
+            : _connectionCount;
+        _pinnedConnections = new IKafkaConnection?[connectionCapacity];
+        _pendingResponsesByConnection = new List<PendingResponse>[connectionCapacity];
+        for (var i = 0; i < connectionCapacity; i++)
             _pendingResponsesByConnection[i] = new List<PendingResponse>();
 
         _responseCompletionCallback = () =>
@@ -566,7 +595,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// Returns true if the send loop is still running. When false, this BrokerSender
     /// should be replaced — its send loop has exited and it can no longer process batches.
     /// </summary>
-    internal bool IsAlive => !_sendLoopTask.IsCompleted;
+    internal bool IsAlive => !_loopExited && !_sendLoopTask.IsCompleted;
 
     /// <summary>
     /// Requests cancellation of this BrokerSender's send loop without waiting for it to exit.
@@ -675,13 +704,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             : Array.Empty<ProduceRequestScratch>();
 
         // Per-connection scratch and buckets for partition-affined multi-send.
-        // When _connectionCount == 1, single scratch and bucket — no grouping overhead.
-        var scratches = new ProduceRequestScratch[_connectionCount];
+        // Arrays are sized at the adaptive-scaling ceiling (matching the per-connection
+        // field arrays) so scale events never resize them — entries beyond the current
+        // connection count are created lazily on scale-up. When _connectionCount == 1,
+        // only slot 0 is populated — no grouping overhead.
+        var connectionCapacity = _pendingResponsesByConnection.Length;
+        var scratches = new ProduceRequestScratch[connectionCapacity];
         scratches[0] = requestScratch; // Reuse the existing one for index 0
         for (var c = 1; c < _connectionCount; c++)
             scratches[c] = new ProduceRequestScratch(_options, _compressionCodecs, maxCoalesce);
 
-        var connectionBuckets = new ConnectionBucket[_connectionCount];
+        var connectionBuckets = new ConnectionBucket[connectionCapacity];
         for (var c = 0; c < _connectionCount; c++)
         {
             connectionBuckets[c].Batches = new ReadyBatch[maxCoalesce];
@@ -703,20 +736,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Pre-allocated array for parallel multi-connection sends. Each entry holds
         // a pending SendConnectionBucketAsync ValueTask so connections can flush concurrently
         // instead of sequentially (overlaps TCP FlushAsync waits across connections).
-        var parallelSends = _connectionCount > 1
-            ? new ValueTask[_connectionCount]
+        var parallelSends = connectionCapacity > 1
+            ? new ValueTask[connectionCapacity]
             : Array.Empty<ValueTask>();
 
         // Per-connection timeout CTS for multi-connection mode, reused with TryReset()
         // to avoid per-send CTS allocation (same pattern as sendTimeoutCts for single-connection).
-        var bucketTimeoutCts = _connectionCount > 1
-            ? new CancellationTokenSource[_connectionCount]
+        // Entries beyond the current connection count are created lazily on scale-up.
+        var bucketTimeoutCts = connectionCapacity > 1
+            ? new CancellationTokenSource[connectionCapacity]
             : Array.Empty<CancellationTokenSource>();
-        if (_connectionCount > 1)
-        {
-            for (var c = 0; c < _connectionCount; c++)
-                bucketTimeoutCts[c] = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        }
+        for (var c = 0; c < _connectionCount && c < bucketTimeoutCts.Length; c++)
+            bucketTimeoutCts[c] = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         // Register shutdown token once — persists for the lifetime of the send loop.
         // Zero per-wait allocation: the signal uses an internal reusable timer for the
@@ -732,6 +763,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             pendingSingleConnectionFireAndForgetSend = default;
             hasPendingSingleConnectionFireAndForgetSend = false;
         }
+
+        // Records an UNEXPECTED loop exit (escaped exception) as opposed to shutdown —
+        // set at the one catch site that knows, rather than derived in the finally from
+        // shared state that a concurrent RequestCancellation mutates in two steps.
+        var crashed = false;
 
         try
         {
@@ -799,35 +835,21 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                     if (scaledToCount > 0)
                     {
-                        var newScratches = new ProduceRequestScratch[scaledToCount];
-                        Array.Copy(scratches, newScratches, Math.Min(scratches.Length, scaledToCount));
-                        for (var i = scratches.Length; i < scaledToCount; i++)
-                            newScratches[i] = new ProduceRequestScratch(_options, _compressionCodecs, maxCoalesce);
-                        scratches = newScratches;
-
-                        var newBuckets = new ConnectionBucket[scaledToCount];
-                        Array.Copy(connectionBuckets, newBuckets, Math.Min(connectionBuckets.Length, scaledToCount));
-                        for (var i = connectionBuckets.Length; i < scaledToCount; i++)
+                        // Arrays are pre-sized at the scaling ceiling (scale targets are
+                        // clamped to it) — just fill in any slots that have never been
+                        // used. Entries persist across a scale-down for reuse on the next
+                        // scale-up; the CTS entries are disposed in the send loop's
+                        // finally block (scratches and buckets are plain managed objects).
+                        for (var i = 0; i < scaledToCount; i++)
                         {
-                            newBuckets[i].Batches = new ReadyBatch[maxCoalesce];
-                            newBuckets[i].Generations = new int[maxCoalesce];
+                            scratches[i] ??= new ProduceRequestScratch(_options, _compressionCodecs, maxCoalesce);
+                            if (connectionBuckets[i].Batches is null)
+                            {
+                                connectionBuckets[i].Batches = new ReadyBatch[maxCoalesce];
+                                connectionBuckets[i].Generations = new int[maxCoalesce];
+                            }
+                            bucketTimeoutCts[i] ??= CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                         }
-                        connectionBuckets = newBuckets;
-
-                        var newBucketCts = new CancellationTokenSource[scaledToCount];
-                        if (bucketTimeoutCts.Length > 0)
-                            Array.Copy(bucketTimeoutCts, newBucketCts, Math.Min(bucketTimeoutCts.Length, scaledToCount));
-                        // Dispose trailing CTS entries on scale-down to release linked token registrations
-                        for (var i = scaledToCount; i < bucketTimeoutCts.Length; i++)
-                            bucketTimeoutCts[i].Dispose();
-                        for (var i = bucketTimeoutCts.Length; i < scaledToCount; i++)
-                            newBucketCts[i] = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                        bucketTimeoutCts = newBucketCts;
-
-                        // No Array.Copy needed: ValueTask is a struct and entries are overwritten
-                        // before each use. pendingSendCount bounds iteration so stale entries
-                        // beyond the new connection count are never accessed.
-                        parallelSends = new ValueTask[scaledToCount];
                     }
                 }
 
@@ -1300,9 +1322,19 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
         catch (OperationCanceledException) when (_cts.IsCancellationRequested) { }
         catch (ChannelClosedException) { }
-        catch (Exception ex) { LogSendLoopFailed(ex, _brokerId); }
+        catch (Exception ex)
+        {
+            LogSendLoopFailed(ex, _brokerId);
+            crashed = true;
+        }
         finally
         {
+            // Mark this sender dead BEFORE disposing surviving batches: when the loop exited
+            // unexpectedly, batches are handed back through the reroute callback, which goes
+            // via GetOrCreateBrokerSender — IsAlive must already be false there so a fresh
+            // replacement is built instead of re-enqueueing into this completed channel.
+            _loopExited = true;
+
             try { await AwaitPendingSingleConnectionFireAndForgetSendAsync().ConfigureAwait(false); }
             catch (Exception ex) { LogSendLoopFailed(ex, _brokerId); }
 
@@ -1310,20 +1342,26 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             for (var c = 0; c < singleConnectionFireAndForgetTimeoutCts.Length; c++)
                 singleConnectionFireAndForgetTimeoutCts[c].Dispose();
             for (var c = 0; c < bucketTimeoutCts.Length; c++)
-                bucketTimeoutCts[c].Dispose();
+                bucketTimeoutCts[c]?.Dispose();
             _eventChannel.Writer.TryComplete();
 
             var disposedException = new ObjectDisposedException(nameof(BrokerSender));
 
-            while (_sendFailedRetries.TryDequeue(out var retry))
-            {
-                if (!retry.Batch.IsCurrentIncarnation(retry.Generation))
-                    continue;
+            // Shutdown (close/disposal) permanently fails surviving batches — the producer
+            // is going away. An UNEXPECTED loop exit (escaped exception) must not drop them:
+            // the producer is still healthy and replaces this sender on the next drain, so
+            // every surviving batch is redelivered through the reroute callback instead.
+            // Idempotent sequencing keeps redelivery of already-written requests safe — the
+            // batch keeps its sequence and the broker dedupes.
+            var redeliver = crashed
+                && Volatile.Read(ref _disposed) == 0
+                && _rerouteBatch is not null;
+            if (redeliver)
+                LogSendLoopExitRedelivery(_brokerId);
 
-                try { FailAndCleanupBatch(retry.Batch, disposedException); }
-                catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
-            }
-
+            // Disposition order preserves per-partition FIFO for redelivery:
+            // in-flight pending responses hold the oldest batches, then send-failed retries,
+            // then carry-over, then this pass's coalesced batches, then the channel backlog.
             for (var connIdx = 0; connIdx < _pendingResponsesByConnection.Length; connIdx++)
             {
                 var pendingList = _pendingResponsesByConnection[connIdx];
@@ -1333,10 +1371,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     for (var j = 0; j < pr.Count; j++)
                     {
                         if (pr.IsSameIncarnation(j))
-                        {
-                            try { FailAndCleanupBatch(pr.Batches[j], disposedException); }
-                            catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
-                        }
+                            RedeliverOrFailOnLoopExit(pr.Batches[j], redeliver, disposedException);
                     }
                     pr.ReturnBatchesArray();
                 }
@@ -1345,15 +1380,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // No TrimExcess — lists are unreachable after disposal
             }
 
-            FailCarryOverBatches(carryOver);
+            while (_sendFailedRetries.TryDequeue(out var retry))
+            {
+                if (retry.Batch.IsCurrentIncarnation(retry.Generation))
+                    RedeliverOrFailOnLoopExit(retry.Batch, redeliver, disposedException);
+            }
+
+            DisposeCarryOverBatchesOnLoopExit(carryOver, redeliver, disposedException);
 
             for (var i = 0; i < coalescedCount; i++)
             {
                 if (coalescedBatches[i].IsCurrentIncarnation(coalescedGenerations[i]))
-                {
-                    try { FailAndCleanupBatch(coalescedBatches[i], disposedException); }
-                    catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
-                }
+                    RedeliverOrFailOnLoopExit(coalescedBatches[i], redeliver, disposedException);
             }
             Array.Clear(coalescedBatches, 0, coalescedCount);
             Array.Clear(coalescedGenerations, 0, coalescedCount);
@@ -1366,10 +1404,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 {
                     var batchRef = evt.GetBatchReference();
                     if (batchRef.IsCurrentIncarnation())
-                    {
-                        try { FailAndCleanupBatch(batchRef.Batch, disposedException); }
-                        catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
-                    }
+                        RedeliverOrFailOnLoopExit(batchRef.Batch, redeliver, disposedException);
                 }
             }
 
@@ -2985,13 +3020,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private bool HasInflightForPartition(int connectionIndex, int partitionIndex)
     {
+        if ((uint)connectionIndex >= (uint)_pendingResponsesByConnection.Length)
+            return false;
+
         var pendingList = _pendingResponsesByConnection[connectionIndex];
         for (var i = 0; i < pendingList.Count; i++)
         {
             var pr = pendingList[i];
             for (var j = 0; j < pr.Count; j++)
             {
-                if (pr.Batches[j].TopicPartition.Partition == partitionIndex)
+                // Entries within Count can legally be null: batches with stale generations
+                // are nulled out before PendingResponse.Create captures the array.
+                if (pr.Batches[j] is { } batch && batch.TopicPartition.Partition == partitionIndex)
                     return true;
             }
         }
@@ -3048,10 +3088,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     /// <summary>
-    /// Fences partitions whose connection assignment changes during a scale event.
+    /// Fences partitions whose connection assignment changes during a scale-up.
     /// For idempotent producers, partitions with in-flight batches on their old connection
     /// are added to <see cref="_migratingPartitions"/> so they continue routing to the old
     /// connection until in-flight clears, preventing OutOfOrderSequenceNumber errors.
+    /// Scale-down does not fence: its drain gates guarantee no in-flight batches whose
+    /// routing would change (all connections drained for idempotent producers).
     /// </summary>
     private void FenceAffectedPartitions(int oldConnCount, int newConnCount)
     {
@@ -3164,9 +3206,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
     }
 
-    private void FailCarryOverBatches(PartitionCarryOver carryOver)
+    private void DisposeCarryOverBatchesOnLoopExit(PartitionCarryOver carryOver, bool redeliver, ObjectDisposedException disposedException)
     {
-        var disposedException = new ObjectDisposedException(nameof(BrokerSender));
         foreach (var kvp in carryOver.Partitions)
         {
             var queue = kvp.Value;
@@ -3174,8 +3215,46 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 var batchRef = queue[i];
                 if (batchRef.IsCurrentIncarnation())
-                    FailAndCleanupBatch(batchRef.Batch, disposedException);
+                    RedeliverOrFailOnLoopExit(batchRef.Batch, redeliver, disposedException);
             }
+        }
+    }
+
+    /// <summary>
+    /// Disposes a batch that survived the send loop's exit. During shutdown the batch is
+    /// permanently failed. After an unexpected loop crash the batch is handed back to the
+    /// producer via the reroute callback, which routes it to a fresh replacement sender —
+    /// unless its delivery deadline has already passed, in which case it fails with a
+    /// delivery timeout (the bound that prevents endless redelivery cycles).
+    /// Never throws — failures are logged so the finally block's sweep over the remaining
+    /// batches always completes. Internal for testing.
+    /// </summary>
+    internal void RedeliverOrFailOnLoopExit(ReadyBatch batch, bool redeliver, ObjectDisposedException disposedException)
+    {
+        try
+        {
+            if (!redeliver)
+            {
+                FailAndCleanupBatch(batch, disposedException);
+                return;
+            }
+
+            if (Stopwatch.GetTimestamp() >= batch.StopwatchCreatedTicks + _options.DeliveryTimeoutTicks)
+            {
+                var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks);
+                var configured = TimeSpan.FromMilliseconds(_options.DeliveryTimeoutMs);
+                FailAndCleanupBatch(batch, new KafkaTimeoutException(
+                    TimeoutKind.Delivery, elapsed, configured,
+                    $"Delivery timeout exceeded for {batch.TopicPartition} after send-loop exit"));
+                return;
+            }
+
+            batch.AppendDiag('X'); // Redelivered after send-loop exit
+            _rerouteBatch!(batch);
+        }
+        catch (Exception cleanupEx)
+        {
+            LogBatchCleanupStepFailed(cleanupEx, _brokerId);
         }
     }
 
@@ -3280,6 +3359,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _drainingConnection = null;
         }
 
+        if (_retiringConnection is not null)
+        {
+            try { await _retiringConnection.DisposeAsync().ConfigureAwait(false); }
+            catch (Exception ex) { LogBatchCleanupStepFailed(ex, _brokerId); }
+            _retiringConnection = null;
+        }
+
         _migratingPartitions.Clear();
 
         var totalPending = _totalPendingResponseCount;
@@ -3380,10 +3466,19 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 {
                     return ApplyScaleDown(removedConnection);
                 }
+                // Nothing was removed (pool group already at or below target) —
+                // the reduced routing width stands on its own.
             }
             else if (task.Exception is not null)
             {
                 LogAdaptiveScaleDownFailed(task.Exception.InnerException ?? task.Exception, _brokerId, _connectionCount);
+
+                // The pool still owns the old connection count — restore the routing
+                // width so the extra connection isn't orphaned. _connectionCount cannot
+                // have changed since initiation: this Phase 1b poll runs before any
+                // other scale event can start.
+                _connectionCount++;
+                _totalMaxInFlight = _connectionCount * _maxInFlight;
             }
 
             return 0;
@@ -3392,7 +3487,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var now = Dekaf.MonotonicClock.GetMilliseconds();
 
         // Cooldown applies to both scale-up and scale-down
-        if (now - _lastScaleTimeTicks < ScaleCooldownMs)
+        if (now - _lastScaleTimeTicks < _scaleCooldownMs)
+            return 0;
+
+        // A previous scale-down is still retiring its removed connection — hold off on any
+        // new scale event until it drains, so slot indices stay unambiguous (a scale-up
+        // would re-activate the retiring slot while its old connection is still pinned).
+        if (_retiringConnection is not null)
             return 0;
 
         var utilization = _accumulator.BufferUtilization;
@@ -3412,6 +3513,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 return 0; // At ceiling — cannot scale up, but scale-down remains active
 
             var targetCount = ComputeScaleTarget(scalePressureDelta, _connectionCount, _maxConnectionsPerBroker);
+
+            // Partition affinity (partition % N) means connections beyond the partition
+            // count can never receive traffic — they'd sit idle and immediately arm
+            // scale-down churn. Cap the target at the partitions this broker serves.
+            if (_knownPartitions.Count > 0 && targetCount > _knownPartitions.Count)
+                targetCount = Math.Max(_connectionCount, _knownPartitions.Count);
+
+            if (targetCount <= _connectionCount)
+                return 0; // Cap left nothing to add
 
             // Launch connection creation in the background — send loop continues immediately
             _lastScaleTimeTicks = now;
@@ -3443,7 +3553,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return 0;
         }
 
-        if (now - _lowUtilizationStartTicks < ScaleDownSustainedMs)
+        if (now - _lowUtilizationStartTicks < _scaleDownSustainedMs)
             return 0; // Not sustained long enough
 
         // Idempotent producers require ALL connections to be drained before shrinking
@@ -3463,8 +3573,24 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 return 0; // Still has in-flight requests on last connection — wait
         }
 
-        // Sustained low utilization with no in-flight on last connection — initiate scale-down
+        // Sustained low utilization with no in-flight on the connection being removed —
+        // initiate scale-down.
         var targetShrinkCount = _connectionCount - 1;
+
+        // Reduce the routing width IMMEDIATELY, before the pool shrink runs in the background.
+        // This closes the race where sends later in this same iteration (or in iterations
+        // while the shrink task runs) pipeline a request onto the connection being removed:
+        // previously those pending responses were silently dropped when the arrays were
+        // truncated at apply time, stranding their batches with never-completing delivery
+        // tasks (#1578). From this instant no new request can target the removed slot, and
+        // its pending list stays in place because per-connection arrays are never resized.
+        _connectionCount = targetShrinkCount;
+        _totalMaxInFlight = targetShrinkCount * _maxInFlight;
+
+        // The drain gates above guarantee no in-flight batches that require routing to the
+        // removed slot, so any leftover migration fences are stale — clear them so no
+        // partition keeps routing outside the reduced width.
+        _migratingPartitions.Clear();
 
         _lastScaleTimeTicks = now;
         _lowUtilizationStartTicks = 0; // Reset for the next scale-down cycle
@@ -3480,6 +3606,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private int ApplyScaleUp(int actualCount)
     {
+        // A shared pool's group can exceed this sender's ceiling (another producer with a
+        // higher MaxConnectionsPerBroker may have grown it) — clamp to our array capacity.
+        actualCount = Math.Min(actualCount, _pendingResponsesByConnection.Length);
+
         var oldCount = _connectionCount;
         _connectionCount = actualCount;
         _totalMaxInFlight = _connectionCount * _maxInFlight;
@@ -3489,15 +3619,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _lastPressureSnapshot = _accumulator.BufferPressureEvents;
         _lastSendLoopPressureSnapshot = _sendLoopPressureEvents;
 
-        var newPinned = new IKafkaConnection?[actualCount];
-        Array.Copy(_pinnedConnections, newPinned, oldCount);
-        _pinnedConnections = newPinned;
-
-        var newPending = new List<PendingResponse>[actualCount];
-        Array.Copy(_pendingResponsesByConnection, newPending, oldCount);
-        for (var i = oldCount; i < actualCount; i++)
-            newPending[i] = new List<PendingResponse>();
-        _pendingResponsesByConnection = newPending;
+        // Per-connection arrays are pre-sized at the scaling ceiling — nothing to grow.
 
         // Reset low utilization tracking — we just scaled up
         _lowUtilizationStartTicks = 0;
@@ -3514,44 +3636,36 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     /// <summary>
-    /// Applies the scale-down by shrinking send-loop arrays and scheduling the removed
-    /// connection for draining. Returns the new connection count.
+    /// Finalizes a scale-down after the background pool shrink completes. The routing
+    /// width (<see cref="_connectionCount"/>) was already reduced when the shrink was
+    /// initiated, so no request has been able to target the removed slot since then and
+    /// its pending list is expected to be empty. The removed connection is parked as
+    /// retiring; <see cref="MaybeDrainAndDisposeConnection"/> (Phase 0 of every iteration)
+    /// promotes it to draining/disposal once the slot's pending list is confirmed empty —
+    /// immediately on the next iteration in the normal case. Should a request ever be
+    /// found on the removed slot (invariant breach), it is logged and the connection stays
+    /// alive until the response completes: the response/timeout scans iterate the full
+    /// array, so nothing is dropped. Returns the (already reduced) connection count.
     /// </summary>
     private int ApplyScaleDown(IKafkaConnection removedConnection)
     {
-        var oldCount = _connectionCount;
-        var newCount = oldCount - 1;
-
-        _connectionCount = newCount;
-        _totalMaxInFlight = newCount * _maxInFlight;
-
-        // Shrink _pinnedConnections — remove the last slot
-        var newPinned = new IKafkaConnection?[newCount];
-        Array.Copy(_pinnedConnections, newPinned, newCount);
-        _pinnedConnections = newPinned;
-
-        // Shrink _pendingResponsesByConnection — the last list should be empty
-        // (we checked in-flight count before initiating shrink)
-        var newPending = new List<PendingResponse>[newCount];
-        Array.Copy(_pendingResponsesByConnection, newPending, newCount);
-        _pendingResponsesByConnection = newPending;
+        var removedIdx = _connectionCount; // Width was reduced at initiation — removed slot is one past it.
 
         // Reset the sustained-low-utilization timer so the next scale-down cycle
-        // must observe 2 full minutes of low utilization from this point forward.
+        // must observe the full sustained window from this point forward.
         _lowUtilizationStartTicks = 0;
 
-        // Hand off to MaybeDrainAndDisposeConnection on the next send-loop iteration.
-        // Safe to set without checking the previous value: _pendingShrinkTask serializes
-        // scale-down attempts, so ApplyScaleDown is never called while a prior drain is
-        // in progress. The in-flight-count pre-check in the scale-down trigger (Phase 3)
-        // ensures no requests are assigned to the removed connection index, so
-        // MaybeDrainAndDisposeConnection can safely dispose it immediately.
-        _drainingConnection = removedConnection;
+        var pendingOnRemoved = _pendingResponsesByConnection[removedIdx].Count;
+        if (pendingOnRemoved > 0)
+            LogScaleDownSlotNotEmpty(_brokerId, removedIdx, pendingOnRemoved);
 
-        FenceAffectedPartitions(oldCount, newCount);
+        // Safe to set without checking the previous value: a parked retiring connection
+        // blocks all new scale events, so ApplyScaleDown is never called while a prior
+        // retirement is in progress.
+        _retiringConnection = removedConnection;
 
-        LogAdaptiveScaleDown(_brokerId, oldCount, newCount);
-        return newCount;
+        LogAdaptiveScaleDown(_brokerId, removedIdx + 1, _connectionCount);
+        return _connectionCount;
     }
 
     /// <summary>
@@ -3560,6 +3674,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private void MaybeDrainAndDisposeConnection()
     {
+        // Promote the retiring connection (removed from the pool by scale-down) to
+        // draining once its slot's pending list is confirmed empty — its slot index is
+        // _connectionCount, frozen while it is parked because a parked connection blocks
+        // all new scale events. Deferred while another connection is draining — retried
+        // next iteration.
+        if (_retiringConnection is not null
+            && _drainingConnection is null
+            && _pendingResponsesByConnection[_connectionCount].Count == 0)
+        {
+            _pinnedConnections[_connectionCount] = null;
+            _drainingConnection = _retiringConnection;
+            _retiringConnection = null;
+        }
+
         if (_drainingConnection is null)
             return;
 
@@ -3567,7 +3695,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _drainingConnection = null;
 
         // Fire-and-forget disposal with exception observation to prevent UnobservedTaskException.
-        // The connection has no in-flight requests (verified before shrink was initiated).
+        // The connection has no in-flight requests (its pending list was empty when it was
+        // promoted to draining).
         _ = connection.DisposeAsync().AsTask().ContinueWith(
             static (t, _) => { /* Observe exception — best-effort disposal */ },
             null,
@@ -3609,6 +3738,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Error, Message = "BrokerSender[{BrokerId}] send loop failed")]
     private partial void LogSendLoopFailed(Exception ex, int brokerId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "BrokerSender[{BrokerId}] send loop exited unexpectedly — redelivering surviving batches to a replacement sender")]
+    private partial void LogSendLoopExitRedelivery(int brokerId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "BrokerSender[{BrokerId}] scale-down found {PendingCount} pending responses on removed slot {SlotIndex} — width-reduction invariant breached; deferring disposal until drained")]
+    private partial void LogScaleDownSlotNotEmpty(int brokerId, int slotIndex, int pendingCount);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "BrokerSender[{BrokerId}] response failed")]
     private partial void LogResponseFailed(Exception ex, int brokerId);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2811,7 +2811,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             getCurrentEpoch: useEpochRecovery ? () => _producerEpoch : null,
             RerouteBatchToCurrentLeader,
             _interceptors is not null ? InvokeOnAcknowledgementForBatch : null,
-            _logger);
+            _logger,
+            canPhysicallyShrinkConnections: _ownsInfrastructure);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2682,9 +2682,51 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// </summary>
     private void FailAndCleanupBatch(ReadyBatch batch, Exception ex)
     {
+        FailBatch(batch, ex, sendCompletionClaimed: false);
+        try { _accumulator.ReturnReadyBatch(batch); }
+        catch (Exception returnEx) { LogBatchCleanupStepFailed(returnEx); }
+    }
+
+    private void FailAndCleanupBatch(ReadyBatch batch, int expectedGeneration, Exception ex)
+    {
+        if (!batch.TryAcquireResourcePin(expectedGeneration))
+            return;
+
+        var sendCompletionClaimed = false;
+        try
+        {
+            sendCompletionClaimed = batch.TryClaimSendCompletion(expectedGeneration);
+        }
+        finally
+        {
+            batch.ReleaseResourcePin();
+        }
+
+        if (!sendCompletionClaimed)
+            return;
+
+        try
+        {
+            FailBatch(batch, ex, sendCompletionClaimed: true);
+        }
+        finally
+        {
+            try { _accumulator.CompleteTerminalBookkeepingAndReturnReadyBatch(batch); }
+            catch (Exception returnEx) { LogBatchCleanupStepFailed(returnEx); }
+        }
+    }
+
+    private void FailBatch(ReadyBatch batch, Exception ex, bool sendCompletionClaimed)
+    {
         try { CompleteInflightEntry(batch); }
         catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx); }
-        try { batch.Fail(ex); }
+        try
+        {
+            if (sendCompletionClaimed)
+                batch.FailAfterSendCompletionClaimed(ex);
+            else
+                batch.Fail(ex);
+        }
         catch (Exception failEx) { LogBatchCleanupStepFailed(failEx); }
         try
         {
@@ -2698,8 +2740,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // (atomic _returnedToPool flag), so this is safe even if another path races.
         try { _accumulator.OnBatchExitsPipeline(batch); }
         catch (Exception exitEx) { LogBatchCleanupStepFailed(exitEx); }
-        try { _accumulator.ReturnReadyBatch(batch); }
-        catch (Exception returnEx) { LogBatchCleanupStepFailed(returnEx); }
     }
 
     /// <summary>
@@ -2778,37 +2818,57 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// Routes a batch to the current leader's BrokerSender.
     /// Used as a callback by BrokerSender when a retry discovers the leader has moved to a different broker.
     /// </summary>
-    private void RerouteBatchToCurrentLeader(ReadyBatch batch)
+    private void RerouteBatchToCurrentLeader(ReadyBatch batch, int expectedGeneration)
     {
+        if (!batch.TryAcquireResourcePin(expectedGeneration))
+            return;
+
+        TopicPartition topicPartition;
         try
         {
+            if (!batch.IsCurrentIncarnation(expectedGeneration))
+                return;
+            topicPartition = batch.TopicPartition;
+        }
+        finally
+        {
+            batch.ReleaseResourcePin();
+        }
+
+        try
+        {
+            if (!batch.IsCurrentIncarnation(expectedGeneration))
+                return;
+
             // During disposal, don't create new BrokerSenders — fail the batch instead.
             // Without this guard, retries that discover leader changes create new senders
             // via GetOrCreateBrokerSender after the disposal loop has already snapshotted
             // _brokerSenders, leaving orphaned send loops that prevent process exit.
             if (Volatile.Read(ref _disposed) != 0)
             {
-                LogRerouteBlockedByDisposal(batch.TopicPartition.Topic, batch.TopicPartition.Partition);
-                FailAndCleanupBatch(batch, new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>)));
+                LogRerouteBlockedByDisposal(topicPartition.Topic, topicPartition.Partition);
+                FailAndCleanupBatch(batch, expectedGeneration,
+                    new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>)));
                 return;
             }
 
             var leader = _metadataManager.Metadata.GetPartitionLeader(
-                batch.TopicPartition.Topic, batch.TopicPartition.Partition);
+                topicPartition.Topic, topicPartition.Partition);
 
             if (leader is null)
             {
-                FailAndCleanupBatch(batch, new KafkaException(ErrorCode.LeaderNotAvailable,
-                    $"No leader available for {batch.TopicPartition.Topic}-{batch.TopicPartition.Partition}"));
+                FailAndCleanupBatch(batch, expectedGeneration,
+                    new KafkaException(ErrorCode.LeaderNotAvailable,
+                        $"No leader available for {topicPartition.Topic}-{topicPartition.Partition}"));
                 return;
             }
 
-            LogReroutedBatch(batch.TopicPartition.Topic, batch.TopicPartition.Partition, leader.NodeId);
-            GetOrCreateBrokerSender(leader.NodeId).Enqueue(batch);
+            LogReroutedBatch(topicPartition.Topic, topicPartition.Partition, leader.NodeId);
+            GetOrCreateBrokerSender(leader.NodeId).Enqueue(batch, expectedGeneration);
         }
         catch (Exception ex)
         {
-            FailAndCleanupBatch(batch, ex);
+            FailAndCleanupBatch(batch, expectedGeneration, ex);
         }
     }
 

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -559,6 +559,19 @@ public sealed class ProducerOptions
     private readonly int _maxConnectionsPerBroker = 10;
 
     /// <summary>
+    /// Test-only override for the adaptive-scaling cooldown window (milliseconds).
+    /// Null uses the production constant. Internal so unit tests can drive scale
+    /// cycles without waiting minutes; not part of the public API.
+    /// </summary>
+    internal long? ScaleCooldownMsOverride { get; init; }
+
+    /// <summary>
+    /// Test-only override for the sustained-low-utilization window (milliseconds)
+    /// required before a scale-down. Null uses the production constant.
+    /// </summary>
+    internal long? ScaleDownSustainedMsOverride { get; init; }
+
+    /// <summary>
     /// Producer interceptors, called in order during the produce pipeline.
     /// Interceptors are called on the hot path (OnSend) and on acknowledgement (OnAcknowledgement).
     /// Interceptor exceptions are caught and logged, not propagated.

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -824,11 +824,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly ConcurrentDictionary<TopicPartition, PartitionDeque> _partitionDeques = new();
 
     /// <summary>
-    /// Muted partitions — skipped by Ready() and Drain().
-    /// ConcurrentDictionary for thread safety: BrokerSender threads call MutePartition/UnmutePartition
-    /// while the sender thread reads via Contains in Ready/Drain.
+    /// Muted partitions — skipped by Ready() and Drain(). The value is a reference count:
+    /// independent BrokerSenders and crash-recovery barriers may overlap for the same partition.
+    /// Updates are serialized by <see cref="_partitionMuteLock"/>, while Ready/Drain perform
+    /// lock-free presence checks.
     /// </summary>
-    private readonly ConcurrentDictionary<TopicPartition, byte> _mutedPartitions = new();
+    private readonly ConcurrentDictionary<TopicPartition, int> _mutedPartitions = new();
+    private readonly System.Threading.Lock _partitionMuteLock = new();
 
     /// <summary>
     /// Per-broker drain index for fair round-robin partition ordering.
@@ -1524,16 +1526,70 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         SignalWakeup();
     }
 
-    internal void MutePartition(TopicPartition tp) => _mutedPartitions.TryAdd(tp, 0);
+    internal void MutePartition(TopicPartition tp)
+    {
+        lock (_partitionMuteLock)
+        {
+            if (_mutedPartitions.TryGetValue(tp, out var count))
+                _mutedPartitions[tp] = count + 1;
+            else
+                _mutedPartitions[tp] = 1;
+        }
+    }
+
+    /// <summary>
+    /// Registers the batch's single crash-recovery mute reference without racing pool return.
+    /// A temporary mute reservation is taken before the token CAS; the loser rolls its
+    /// reservation back, and a winner that became stale releases only if ReturnReadyBatch
+    /// did not already consume the token.
+    /// </summary>
+    internal bool TryRegisterLoopExitRecovery(ReadyBatch batch, int expectedGeneration)
+    {
+        if (!batch.TryAcquireResourcePin(expectedGeneration))
+            return false;
+
+        try
+        {
+            var topicPartition = batch.TopicPartition;
+            MutePartition(topicPartition);
+
+            if (!batch.TryRegisterLoopExitRecovery())
+            {
+                UnmutePartition(topicPartition);
+                return batch.IsCurrentIncarnation(expectedGeneration)
+                    && batch.IsLoopExitRedelivery;
+            }
+
+            if (batch.IsCurrentIncarnation(expectedGeneration))
+                return true;
+
+            if (batch.TryCompleteLoopExitRecovery())
+                UnmutePartition(topicPartition);
+            return false;
+        }
+        finally
+        {
+            batch.ReleaseResourcePin();
+        }
+    }
 
     internal void UnmutePartition(TopicPartition tp)
     {
-        // TryRemove must precede Enqueue to ensure Ready() does not observe the notification
-        // but then find the partition still muted (which would cause a wasted re-enqueue cycle).
-        // This ordering is safe because Ready() is single-consumer (sender thread) and
-        // UnmutePartition is also called from the sender thread, so there is no concurrent
-        // race between the remove and the enqueue.
-        _mutedPartitions.TryRemove(tp, out _);
+        lock (_partitionMuteLock)
+        {
+            if (!_mutedPartitions.TryGetValue(tp, out var count))
+                return;
+
+            if (count > 1)
+            {
+                _mutedPartitions[tp] = count - 1;
+                return;
+            }
+
+            // Remove must precede notification so Ready() cannot consume the notification
+            // while the partition still appears muted.
+            _mutedPartitions.TryRemove(tp, out _);
+        }
 
         // Re-notify so Ready() picks up any sealed batches that were skipped while muted.
         if (_partitionDeques.TryGetValue(tp, out var pd))
@@ -1816,15 +1872,49 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     internal void ReturnReadyBatch(ReadyBatch batch)
     {
-        // Atomic guard: only the first caller returns the batch to the pool.
-        // Multiple paths may attempt to return the same batch (e.g., BrokerSender.CleanupBatch
-        // racing with ForceFailAllInFlightBatches during disposal). Double-return to the pool
-        // causes two renters to share the same object — silent data corruption.
-        if (Interlocked.Exchange(ref batch._returnedToPool, 1) != 0)
+        if (!TryClaimReadyBatchReturn(batch))
             return;
 
+        CompleteClaimedReadyBatchReturn(batch);
+    }
+
+    /// <summary>
+    /// Publishes completion of generation-safe terminal bookkeeping and returns the batch
+    /// without touching it after a racing return owner can recycle it.
+    /// </summary>
+    internal void CompleteTerminalBookkeepingAndReturnReadyBatch(ReadyBatch batch)
+    {
+        // Claim before publishing completion. If another path already owns the return, it is
+        // waiting on the bookkeeping flag and may recycle the object immediately after the
+        // volatile write below, so this method must not access batch again in that case.
+        var returnClaimed = TryClaimReadyBatchReturn(batch);
+        batch.CompleteTerminalBookkeeping();
+
+        if (returnClaimed)
+            CompleteClaimedReadyBatchReturn(batch);
+    }
+
+    private static bool TryClaimReadyBatchReturn(ReadyBatch batch)
+    {
+        // Atomic guard: only the first caller returns the batch to the pool.
+        // Multiple paths may race during disposal; a double-return lets two renters share
+        // the same object and causes silent data corruption.
+        return Interlocked.Exchange(ref batch._returnedToPool, 1) == 0;
+    }
+
+    private void CompleteClaimedReadyBatchReturn(ReadyBatch batch)
+    {
         batch.WaitForPreSerializationIfStarted();
+        batch.WaitForResourcePins();
         batch.WaitForCleanupIfStarted();
+        batch.WaitForTerminalBookkeeping();
+
+        // Registration is protected by a resource pin, so release recovery only after all
+        // pins and terminal bookkeeping finish. This also keeps newer work fenced until the
+        // recovered batch is fully disposed. Only the pool-return owner reaches this point.
+        if (batch.TryCompleteLoopExitRecovery())
+            UnmutePartition(batch.TopicPartition);
+
         _readyBatchPool.Return(batch);
     }
 
@@ -5781,7 +5871,8 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     /// Lightweight lifecycle trace for diagnosing orphaned batches in Release builds.
     /// Tracks the last few transitions as single-char codes to keep overhead minimal.
     /// Codes: E=EntersPipeline, D=Drained, Q=EnqueuedToBrokerSender, C=Coalesced,
-    /// O=CarriedOver, S=Sent, R=ResponseReceived, X=ExitsPipeline, F=Failed
+    /// O=CarriedOver, S=Sent, R=ResponseReceived, Y=LoopExitRedelivery,
+    /// X=ExitsPipeline, F=Failed
     /// </summary>
     internal string DiagTrace
     {
@@ -6026,6 +6117,25 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     internal bool IsRetry { get; set; }
 
     /// <summary>
+    /// True while this batch owns a crash-recovery mute reference. Kept separate from
+    /// <see cref="IsRetry"/> because the reference survives sender-to-sender reroutes and
+    /// is released only when the batch reaches a terminal state.
+    /// </summary>
+    internal bool IsLoopExitRedelivery => Volatile.Read(ref _loopExitRecoveryRegistered) != 0;
+    private int _loopExitRecoveryRegistered;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryRegisterLoopExitRecovery()
+        => Interlocked.CompareExchange(ref _loopExitRecoveryRegistered, 1, 0) == 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryCompleteLoopExitRecovery()
+        => Interlocked.CompareExchange(ref _loopExitRecoveryRegistered, 0, 1) == 1;
+
+    /// <summary>Replacement-sender FIFO position for loop-exit recovery ordering.</summary>
+    internal long LoopExitRedeliveryOrder { get; set; }
+
+    /// <summary>
     /// Stopwatch timestamp before which this retry batch should not be sent (backoff).
     /// Set by ProcessCompletedResponses when a retriable error occurs. The send loop
     /// skips batches where the backoff hasn't elapsed. 0 means no backoff.
@@ -6064,6 +6174,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     private int _activeResourcePins; // readers holding RecordBatch/arena stable during serialization
     private int _completed; // 0 = not completed, 1 = completed (prevents double-signal of _doneCore)
     private int _sendCompleted; // 0 = not done, 1 = done (prevents concurrent CompleteSend/Fail)
+    private int _terminalBookkeepingCompleted = 1; // generation-safe terminal owner finished post-Fail cleanup
     internal int _returnedToPool; // 0 = not returned, 1 = returned (prevents double pool return)
     private int _generation; // Incremented on each Initialize() — detects batch object recycling
     private Task? _preSerializationTask;
@@ -6128,6 +6239,16 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
             TryCleanupResources();
     }
 
+    internal void WaitForResourcePins()
+    {
+        if (Volatile.Read(ref _activeResourcePins) == 0)
+            return;
+
+        var sw = new SpinWait();
+        do { sw.SpinOnce(); }
+        while (Volatile.Read(ref _activeResourcePins) != 0);
+    }
+
     /// <summary>
     /// Creates an uninitialized ReadyBatch. Call Initialize() before use.
     /// </summary>
@@ -6170,6 +6291,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         Interlocked.Exchange(ref _activeResourcePins, 0);
         Interlocked.Exchange(ref _completed, 0);
         Interlocked.Exchange(ref _sendCompleted, 0);
+        Volatile.Write(ref _terminalBookkeepingCompleted, 1);
         Interlocked.Exchange(ref _returnedToPool, 0);
         Interlocked.Exchange(ref _memoryReleased, 0);
         Volatile.Write(ref _preSerialized, 0);
@@ -6238,6 +6360,8 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         // so stale references calling TrySetMemoryReleased() return false (safe no-op).
         // Cleared in Initialize() at the start of the next lifecycle.
         IsRetry = false;
+        Volatile.Write(ref _loopExitRecoveryRegistered, 0);
+        LoopExitRedeliveryOrder = 0;
         RetryNotBefore = 0;
         _diagTraceLen = 0;
 
@@ -6377,6 +6501,41 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     internal bool FailFromPreSerialization(Exception exception)
         => FailCore(exception, waitForPreSerialization: false);
 
+    /// <summary>
+    /// Claims terminal completion for the expected incarnation while its caller holds a
+    /// resource pin. Pool return waits for pins before evaluating cleanup state, so a
+    /// successful claim may safely finish after releasing the pin.
+    /// </summary>
+    internal bool TryClaimSendCompletion(int expectedGeneration)
+    {
+        if (!IsCurrentIncarnation(expectedGeneration)
+            || Interlocked.CompareExchange(ref _sendCompleted, 1, 0) != 0)
+        {
+            return false;
+        }
+
+        // Caller holds a resource pin. Any racing pool return must wait for that pin,
+        // then for this flag, before Reset can recycle fields used by post-Fail cleanup.
+        Volatile.Write(ref _terminalBookkeepingCompleted, 0);
+        return true;
+    }
+
+    internal void CompleteTerminalBookkeeping()
+        => Volatile.Write(ref _terminalBookkeepingCompleted, 1);
+
+    internal void WaitForTerminalBookkeeping()
+    {
+        if (Volatile.Read(ref _terminalBookkeepingCompleted) != 0)
+            return;
+
+        var sw = new SpinWait();
+        do { sw.SpinOnce(); }
+        while (Volatile.Read(ref _terminalBookkeepingCompleted) == 0);
+    }
+
+    internal void FailAfterSendCompletionClaimed(Exception exception)
+        => CompleteFailure(exception, waitForPreSerialization: true);
+
     private bool FailCore(Exception exception, bool waitForPreSerialization)
     {
         // Atomic entry guard: only one thread can execute Fail/CompleteSend.
@@ -6384,6 +6543,12 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         if (Interlocked.Exchange(ref _sendCompleted, 1) != 0)
             return false;
 
+        CompleteFailure(exception, waitForPreSerialization);
+        return true;
+    }
+
+    private void CompleteFailure(Exception exception, bool waitForPreSerialization)
+    {
         if (waitForPreSerialization)
             WaitForPreSerializationIfStarted();
 
@@ -6443,8 +6608,6 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         {
             Cleanup();
         }
-
-        return true;
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -6028,6 +6028,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
             'H' => "BrokerSender.HandleRetriableBatch",
             'T' => "BrokerSender.HandleTimedOutRequest",
             'Z' => "BrokerSender.SendFailed",
+            'Y' => "BrokerSender.LoopExitRedelivery",
             'F' => "BrokerSender.FailAndCleanupBatch",
             'X' => "RecordAccumulator.OnBatchExitsPipeline",
             _ => "unknown"

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -504,6 +504,46 @@ public sealed class ConnectionPoolTests
 
     [Test]
     [NotInParallel]
+    public async Task GetConnectionByIndexAsync_AfterAdaptiveScaleUp_UsesScaledGroup()
+    {
+        const int scaledCount = 3;
+        var captureScaledConnections = 0;
+        var scaledConnections = new IKafkaConnection?[scaledCount];
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 1,
+            connectionFactory: (brokerId, host, port, index, _) =>
+            {
+                var connection = CreateConnectedConnection(brokerId, host, port);
+                if (Volatile.Read(ref captureScaledConnections) != 0)
+                    scaledConnections[index] = connection;
+                return new ValueTask<IKafkaConnection>(connection);
+            });
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+
+            var originalSingleConnection = await pool.GetConnectionAsync(1);
+            Volatile.Write(ref captureScaledConnections, 1);
+            var actualScaledCount = await pool.ScaleConnectionGroupAsync(1, newCount: scaledCount);
+            Volatile.Write(ref captureScaledConnections, 0);
+
+            var connection0 = await pool.GetConnectionByIndexAsync(1, index: 0);
+            var connection1 = await pool.GetConnectionByIndexAsync(1, index: 1);
+            var connection2 = await pool.GetConnectionByIndexAsync(1, index: 2);
+
+            await Assert.That(actualScaledCount).IsEqualTo(scaledCount);
+            await Assert.That(connection0).IsSameReferenceAs(scaledConnections[0]);
+            await Assert.That(connection1).IsSameReferenceAs(scaledConnections[1]);
+            await Assert.That(connection2).IsSameReferenceAs(scaledConnections[2]);
+            await Assert.That(connection0).IsNotSameReferenceAs(originalSingleConnection);
+        }
+    }
+
+    [Test]
+    [NotInParallel]
     public async Task CreateConnectionGroup_AfterConnectionFailure_WaitsForReconnectBackoff()
     {
         const int connectionsPerBroker = 2;

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -1,0 +1,324 @@
+using System.Buffers;
+using Dekaf.Compression;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Regression tests for adaptive connection scale-down and unexpected send-loop exit.
+///
+/// Covers the failure modes from stress run 28972770086:
+/// - Scale-down previously shrank the per-connection arrays before fencing, crashing the
+///   send loop with IndexOutOfRangeException whenever a known partition mapped to the
+///   removed connection slot — the crash then permanently failed every queued and
+///   in-flight batch with ObjectDisposedException (12,844 messages lost).
+/// - Scale-down could silently drop a populated pending-response list, stranding batches
+///   whose delivery tasks never completed (#1578).
+/// - Batches surviving an unexpected send-loop exit are now redelivered to a replacement
+///   sender instead of being permanently failed.
+/// </summary>
+public sealed class AdaptiveScaleDownTests
+{
+    private const string Topic = "test-topic";
+    private const int PartitionCount = 8;
+
+    private static ProducerOptions CreateOptions(
+        bool idempotent,
+        int deliveryTimeoutMs = 30_000,
+        long? scaleCooldownMs = null,
+        long? scaleDownSustainedMs = null) => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        MaxInFlightRequestsPerConnection = 1,
+        Acks = Acks.All,
+        EnableIdempotence = idempotent,
+        DeliveryTimeoutMs = deliveryTimeoutMs,
+        RetryBackoffMs = 100,
+        RetryBackoffMaxMs = 1000,
+        RequestTimeoutMs = 30_000,
+        LingerMs = 0,
+        ConnectionsPerBroker = 1,
+        EnableAdaptiveConnections = true,
+        MaxConnectionsPerBroker = 4,
+        ScaleCooldownMsOverride = scaleCooldownMs,
+        ScaleDownSustainedMsOverride = scaleDownSustainedMs
+    };
+
+    private static ReadyBatch CreateTestBatch(
+        ValueTaskSourcePool<RecordMetadata> pool, int partition, int dataSize = 100)
+    {
+        var batch = new ReadyBatch();
+        var sources = ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(1);
+        sources[0] = pool.Rent();
+
+        batch.Initialize(
+            new TopicPartition(Topic, partition),
+            new RecordBatch { Records = Array.Empty<Record>() },
+            sources,
+            completionSourcesCount: 1,
+            dataSize: dataSize);
+
+        batch.TrySetMemoryReleased(); // Skip accumulator memory tracking in tests
+        return batch;
+    }
+
+    private static ProduceResponse CreateSuccessResponseForAllPartitions() =>
+        new()
+        {
+            TopicCount = 1,
+            Responses =
+            [
+                new ProduceResponseTopicData
+                {
+                    Name = Topic,
+                    PartitionCount = PartitionCount,
+                    PartitionResponses = Enumerable.Range(0, PartitionCount)
+                        .Select(partition => new ProduceResponsePartitionData
+                        {
+                            Index = partition,
+                            ErrorCode = ErrorCode.None,
+                            BaseOffset = partition + 1
+                        }).ToArray()
+                }
+            ]
+        };
+
+    private static BrokerSender CreateSender(
+        IConnectionPool pool,
+        ProducerOptions options,
+        RecordAccumulator accumulator,
+        Action<TopicPartition, long, DateTimeOffset, int, Exception?>? onAcknowledgement,
+        Action<ReadyBatch>? rerouteBatch = null) =>
+        new(
+            brokerId: 1, pool,
+            new MetadataManager(pool, options.BootstrapServers),
+            accumulator, options,
+            new CompressionCodecRegistry(),
+            inflightTracker: new PartitionInflightTracker(),
+            getProduceApiVersion: () => 9,
+            setProduceApiVersion: _ => { },
+            isTransactional: () => false,
+            ensurePartitionInTransaction: null,
+            bumpEpoch: null,
+            getCurrentEpoch: null,
+            rerouteBatch: rerouteBatch,
+            onAcknowledgement: onAcknowledgement,
+            logger: null);
+
+    /// <summary>
+    /// Drives a full scale-up → scale-down cycle through the live send loop with an
+    /// idempotent producer whose partitions span every connection slot, then keeps
+    /// producing. Under the pre-fix code the scale-down apply crashed the send loop
+    /// (fencing indexed the already-removed slot) and every subsequent batch failed
+    /// with ObjectDisposedException — so this test asserts zero failed acknowledgements
+    /// and that the removed connection is disposed only after the cycle completes.
+    /// </summary>
+    [Test]
+    [Timeout(120_000)]
+    public async Task ScaleDown_UnderContinuousIdempotentTraffic_LosesNoBatches(CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(idempotent: true, scaleCooldownMs: 25, scaleDownSustainedMs: 50);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+
+        var connection = new TestKafkaConnection();
+        connection.SendProducePipelinedAfterWrite = () =>
+            new ValueTask<Task<ProduceResponse>>(Task.FromResult(CreateSuccessResponseForAllPartitions()));
+
+        var removedConnection = new TestKafkaConnection();
+
+        var scaleUpApplied = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shrinkRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        pool.ScaleConnectionGroupAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var targetCount = (int)callInfo[1];
+                scaleUpApplied.TrySetResult(targetCount);
+                return new ValueTask<int>(targetCount);
+            });
+        pool.ShrinkConnectionGroupAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                shrinkRequested.TrySetResult();
+                return new ValueTask<IKafkaConnection?>(removedConnection);
+            });
+
+        var enqueued = 0;
+        var succeededAcks = 0;
+        var failedAcks = 0;
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, count, ex) =>
+        {
+            if (ex is null)
+                Interlocked.Add(ref succeededAcks, count);
+            else
+                Interlocked.Add(ref failedAcks, count);
+        });
+        try
+        {
+            // Wave 1: enough backlog across more partitions than connections to build
+            // send-loop pressure and trigger a scale-up.
+            for (var i = 0; i < 512; i++)
+            {
+                sender.Enqueue(CreateTestBatch(vtPool, i % PartitionCount));
+                enqueued++;
+            }
+
+            await scaleUpApplied.Task.WaitAsync(cancellationToken);
+
+            // Trickle: keep the loop iterating with near-zero buffer utilization so the
+            // sustained-low-utilization scale-down window elapses and a shrink fires.
+            while (!shrinkRequested.Task.IsCompleted)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                sender.Enqueue(CreateTestBatch(vtPool, enqueued % PartitionCount));
+                enqueued++;
+                await Task.Delay(5, cancellationToken);
+            }
+
+            // Wave 2: continued traffic through and after the scale-down apply. Under the
+            // pre-fix code the send loop is already dead at this point and every one of
+            // these fails with ObjectDisposedException.
+            for (var i = 0; i < 128; i++)
+            {
+                sender.Enqueue(CreateTestBatch(vtPool, i % PartitionCount));
+                enqueued++;
+                if (i % 16 == 0)
+                    await Task.Delay(1, cancellationToken);
+            }
+
+            // Every accepted batch must complete successfully.
+            while (Volatile.Read(ref succeededAcks) < enqueued && Volatile.Read(ref failedAcks) == 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+
+            await Assert.That(Volatile.Read(ref failedAcks)).IsEqualTo(0);
+            await Assert.That(Volatile.Read(ref succeededAcks)).IsEqualTo(enqueued);
+            await Assert.That(sender.IsAlive).IsTrue();
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+
+        // The removed connection must be disposed exactly once (drain path or sender disposal),
+        // never leaked.
+        await Assert.That(Volatile.Read(ref removedConnection.DisposeCalls)).IsEqualTo(1);
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task RedeliverOrFailOnLoopExit_Shutdown_FailsWithObjectDisposed(CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(idempotent: false);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var pool = Substitute.For<IConnectionPool>();
+
+        Exception? ackException = null;
+        var sender = CreateSender(pool, options, accumulator,
+            (_, _, _, _, ex) => ackException = ex);
+
+        try
+        {
+            var batch = CreateTestBatch(vtPool, partition: 0);
+            sender.RedeliverOrFailOnLoopExit(batch, redeliver: false,
+                new ObjectDisposedException(nameof(BrokerSender)));
+
+            await Assert.That(ackException).IsTypeOf<ObjectDisposedException>();
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task RedeliverOrFailOnLoopExit_UnexpectedExit_ReroutesBatchForRedelivery(CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(idempotent: false);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var pool = Substitute.For<IConnectionPool>();
+
+        Exception? ackException = null;
+        ReadyBatch? rerouted = null;
+        var sender = CreateSender(pool, options, accumulator,
+            (_, _, _, _, ex) => ackException = ex,
+            rerouteBatch: b => rerouted = b);
+
+        try
+        {
+            var batch = CreateTestBatch(vtPool, partition: 0);
+            sender.RedeliverOrFailOnLoopExit(batch, redeliver: true,
+                new ObjectDisposedException(nameof(BrokerSender)));
+
+            await Assert.That(rerouted).IsSameReferenceAs(batch);
+            await Assert.That(ackException).IsNull();
+
+            // The batch is still live — hand it back for cleanup so pooled sources
+            // aren't leaked by the test.
+            sender.RedeliverOrFailOnLoopExit(batch, redeliver: false,
+                new ObjectDisposedException(nameof(BrokerSender)));
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task RedeliverOrFailOnLoopExit_PastDeliveryDeadline_FailsWithTimeout(CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(idempotent: false, deliveryTimeoutMs: 1);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var pool = Substitute.For<IConnectionPool>();
+
+        Exception? ackException = null;
+        var reroutedCount = 0;
+        var sender = CreateSender(pool, options, accumulator,
+            (_, _, _, _, ex) => ackException = ex,
+            rerouteBatch: _ => reroutedCount++);
+
+        try
+        {
+            var batch = CreateTestBatch(vtPool, partition: 0);
+            await Task.Delay(20, cancellationToken); // Let the 1ms delivery deadline pass
+
+            sender.RedeliverOrFailOnLoopExit(batch, redeliver: true,
+                new ObjectDisposedException(nameof(BrokerSender)));
+
+            await Assert.That(reroutedCount).IsEqualTo(0);
+            await Assert.That(ackException).IsTypeOf<KafkaTimeoutException>();
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -350,6 +350,53 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
+    public async Task SharedPool_SingleLocalSlot_ReconnectsByIndex()
+    {
+        var options = CreateOptions(idempotent: true);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var disconnectedConnection = Substitute.For<IKafkaConnection>();
+        disconnectedConnection.IsConnected.Returns(false);
+        var unindexedConnection = Substitute.For<IKafkaConnection>();
+        var indexedConnection = Substitute.For<IKafkaConnection>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(unindexedConnection);
+        pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(indexedConnection);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: null,
+            canPhysicallyShrinkConnections: false);
+
+        try
+        {
+            var pinnedConnections = (IKafkaConnection?[])typeof(BrokerSender).GetField(
+                "_pinnedConnections",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(sender)!;
+            pinnedConnections[0] = disconnectedConnection;
+
+            var getConnectionAtIndexAsync = typeof(BrokerSender).GetMethod(
+                "GetConnectionAtIndexAsync",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var pendingConnection = (ValueTask<IKafkaConnection>)getConnectionAtIndexAsync.Invoke(
+                sender,
+                [0, CancellationToken.None])!;
+
+            var connection = await pendingConnection;
+
+            await Assert.That(connection).IsSameReferenceAs(indexedConnection);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     [Timeout(10_000)]
     public async Task DisposeAsync_LateShrinkCompletion_DisposesRemovedConnection(
         CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Reflection;
 using Dekaf.Compression;
 using Dekaf.Errors;
 using Dekaf.Metadata;
@@ -34,22 +35,22 @@ public sealed class AdaptiveScaleDownTests
         int deliveryTimeoutMs = 30_000,
         long? scaleCooldownMs = null,
         long? scaleDownSustainedMs = null) => new()
-    {
-        BootstrapServers = ["localhost:9092"],
-        MaxInFlightRequestsPerConnection = 1,
-        Acks = Acks.All,
-        EnableIdempotence = idempotent,
-        DeliveryTimeoutMs = deliveryTimeoutMs,
-        RetryBackoffMs = 100,
-        RetryBackoffMaxMs = 1000,
-        RequestTimeoutMs = 30_000,
-        LingerMs = 0,
-        ConnectionsPerBroker = 1,
-        EnableAdaptiveConnections = true,
-        MaxConnectionsPerBroker = 4,
-        ScaleCooldownMsOverride = scaleCooldownMs,
-        ScaleDownSustainedMsOverride = scaleDownSustainedMs
-    };
+        {
+            BootstrapServers = ["localhost:9092"],
+            MaxInFlightRequestsPerConnection = 1,
+            Acks = Acks.All,
+            EnableIdempotence = idempotent,
+            DeliveryTimeoutMs = deliveryTimeoutMs,
+            RetryBackoffMs = 100,
+            RetryBackoffMaxMs = 1000,
+            RequestTimeoutMs = 30_000,
+            LingerMs = 0,
+            ConnectionsPerBroker = 1,
+            EnableAdaptiveConnections = true,
+            MaxConnectionsPerBroker = 4,
+            ScaleCooldownMsOverride = scaleCooldownMs,
+            ScaleDownSustainedMsOverride = scaleDownSustainedMs
+        };
 
     private static ReadyBatch CreateTestBatch(
         ValueTaskSourcePool<RecordMetadata> pool, int partition, int dataSize = 100)
@@ -95,7 +96,7 @@ public sealed class AdaptiveScaleDownTests
         ProducerOptions options,
         RecordAccumulator accumulator,
         Action<TopicPartition, long, DateTimeOffset, int, Exception?>? onAcknowledgement,
-        Action<ReadyBatch>? rerouteBatch = null) =>
+        Action<ReadyBatch, int>? rerouteBatch = null) =>
         new(
             brokerId: 1, pool,
             new MetadataManager(pool, options.BootstrapServers),
@@ -264,27 +265,71 @@ public sealed class AdaptiveScaleDownTests
         ReadyBatch? rerouted = null;
         var sender = CreateSender(pool, options, accumulator,
             (_, _, _, _, ex) => ackException = ex,
-            rerouteBatch: b => rerouted = b);
+            rerouteBatch: (b, _) => rerouted = b);
 
         try
         {
             var batch = CreateTestBatch(vtPool, partition: 0);
+            var topicPartition = batch.TopicPartition;
+            const long retryNotBefore = 123;
+            batch.RetryNotBefore = retryNotBefore;
             sender.RedeliverOrFailOnLoopExit(batch, redeliver: true,
                 new ObjectDisposedException(nameof(BrokerSender)));
 
             await Assert.That(rerouted).IsSameReferenceAs(batch);
             await Assert.That(ackException).IsNull();
+            await Assert.That(batch.IsRetry).IsTrue();
+            await Assert.That(batch.RetryNotBefore).IsEqualTo(retryNotBefore);
+            await Assert.That(batch.DiagTrace).Contains("Y");
+            await Assert.That(accumulator.IsMuted(topicPartition)).IsTrue();
 
             // The batch is still live — hand it back for cleanup so pooled sources
             // aren't leaked by the test.
             sender.RedeliverOrFailOnLoopExit(batch, redeliver: false,
                 new ObjectDisposedException(nameof(BrokerSender)));
+            await Assert.That(accumulator.IsMuted(topicPartition)).IsFalse();
         }
         finally
         {
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task ApplyScaleDown_EmptyRemovedSlot_DisposesConnectionImmediately()
+    {
+        var options = CreateOptions(idempotent: false);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var disposeThreadId = 0;
+        var removedConnection = Substitute.For<IKafkaConnection>();
+        removedConnection.DisposeAsync().Returns(_ =>
+        {
+            Interlocked.CompareExchange(
+                ref disposeThreadId,
+                Environment.CurrentManagedThreadId,
+                comparand: 0);
+            return ValueTask.CompletedTask;
+        });
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        try
+        {
+            var applyScaleDown = typeof(BrokerSender).GetMethod(
+                "ApplyScaleDown",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+            var applyThreadId = Environment.CurrentManagedThreadId;
+            applyScaleDown.Invoke(sender, [removedConnection]);
+
+            await Assert.That(Volatile.Read(ref disposeThreadId)).IsEqualTo(applyThreadId);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
         }
     }
 
@@ -301,7 +346,7 @@ public sealed class AdaptiveScaleDownTests
         var reroutedCount = 0;
         var sender = CreateSender(pool, options, accumulator,
             (_, _, _, _, ex) => ackException = ex,
-            rerouteBatch: _ => reroutedCount++);
+            rerouteBatch: (_, _) => reroutedCount++);
 
         try
         {

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -96,7 +96,8 @@ public sealed class AdaptiveScaleDownTests
         ProducerOptions options,
         RecordAccumulator accumulator,
         Action<TopicPartition, long, DateTimeOffset, int, Exception?>? onAcknowledgement,
-        Action<ReadyBatch, int>? rerouteBatch = null) =>
+        Action<ReadyBatch, int>? rerouteBatch = null,
+        bool canPhysicallyShrinkConnections = true) =>
         new(
             brokerId: 1, pool,
             new MetadataManager(pool, options.BootstrapServers),
@@ -111,7 +112,8 @@ public sealed class AdaptiveScaleDownTests
             getCurrentEpoch: null,
             rerouteBatch: rerouteBatch,
             onAcknowledgement: onAcknowledgement,
-            logger: null);
+            logger: null,
+            canPhysicallyShrinkConnections: canPhysicallyShrinkConnections);
 
     /// <summary>
     /// Drives a full scale-up → scale-down cycle through the live send loop with an
@@ -295,6 +297,86 @@ public sealed class AdaptiveScaleDownTests
             await accumulator.DisposeAsync();
             await vtPool.DisposeAsync();
         }
+    }
+
+    [Test]
+    public async Task SharedInfrastructure_DoesNotShrinkConnectionGroup()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            scaleCooldownMs: 0,
+            scaleDownSustainedMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: null,
+            canPhysicallyShrinkConnections: false);
+
+        try
+        {
+            typeof(BrokerSender).GetField(
+                "_connectionCount",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(sender, 2);
+
+            var maybeScaleConnections = typeof(BrokerSender).GetMethod(
+                "MaybeScaleConnections",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+            // First pass starts low-utilization tracking; zero sustained window makes
+            // the second pass eligible to shrink if shared-pool protection is absent.
+            maybeScaleConnections.Invoke(sender, null);
+            maybeScaleConnections.Invoke(sender, null);
+
+            var connectionCount = (int)typeof(BrokerSender).GetField(
+                "_connectionCount",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(sender)!;
+
+            await pool.DidNotReceive().ShrinkConnectionGroupAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>());
+            await Assert.That(connectionCount).IsEqualTo(1);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task DisposeAsync_LateShrinkCompletion_DisposesRemovedConnection(
+        CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(idempotent: false);
+        await using var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var shrinkCompletion = new TaskCompletionSource<IKafkaConnection?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var removedConnection = new TestKafkaConnection();
+
+        typeof(BrokerSender).GetField(
+            "_pendingShrinkTask",
+            BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(sender, shrinkCompletion.Task);
+
+        await sender.DisposeAsync();
+
+        shrinkCompletion.SetResult(removedConnection);
+        while (Volatile.Read(ref removedConnection.DisposeCalls) == 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+        }
+
+        await Assert.That(Volatile.Read(ref removedConnection.DisposeCalls)).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -350,7 +350,13 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
-    public async Task SharedPool_SingleLocalSlot_ReconnectsByIndex()
+    [Arguments(false, false, true)]
+    [Arguments(true, true, true)]
+    [Arguments(true, false, false)]
+    public async Task SingleSlot_ReconnectsThroughExpectedPoolPath(
+        bool canPhysicallyShrinkConnections,
+        bool scaleBeforeReconnect,
+        bool expectsIndexedConnection)
     {
         var options = CreateOptions(idempotent: true);
         var accumulator = new RecordAccumulator(options);
@@ -368,10 +374,22 @@ public sealed class AdaptiveScaleDownTests
             options,
             accumulator,
             onAcknowledgement: null,
-            canPhysicallyShrinkConnections: false);
+            canPhysicallyShrinkConnections: canPhysicallyShrinkConnections);
 
         try
         {
+            if (scaleBeforeReconnect)
+            {
+                typeof(BrokerSender).GetMethod(
+                    "ApplyScaleUp",
+                    BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .Invoke(sender, [2]);
+                typeof(BrokerSender).GetField(
+                    "_connectionCount",
+                    BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .SetValue(sender, 1);
+            }
+
             var pinnedConnections = (IKafkaConnection?[])typeof(BrokerSender).GetField(
                 "_pinnedConnections",
                 BindingFlags.Instance | BindingFlags.NonPublic)!
@@ -387,7 +405,22 @@ public sealed class AdaptiveScaleDownTests
 
             var connection = await pendingConnection;
 
-            await Assert.That(connection).IsSameReferenceAs(indexedConnection);
+            await Assert.That(connection).IsSameReferenceAs(
+                expectsIndexedConnection ? indexedConnection : unindexedConnection);
+
+            if (expectsIndexedConnection)
+            {
+                await pool.DidNotReceive().GetConnectionAsync(
+                    Arg.Any<int>(),
+                    Arg.Any<CancellationToken>());
+            }
+            else
+            {
+                await pool.DidNotReceive().GetConnectionByIndexAsync(
+                    Arg.Any<int>(),
+                    Arg.Any<int>(),
+                    Arg.Any<CancellationToken>());
+            }
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -1048,7 +1048,7 @@ public sealed class BrokerSenderMuteOrderingTests
     /// </summary>
     [Test]
     [Timeout(30_000)]
-    public async Task UnexpectedLoopExit_RedeliveryPreemptsRejectedNewerBatch(CancellationToken ct)
+    public async Task UnexpectedLoopExit_AfterRetiredSenderDisposal_RedeliveryPreemptsRejectedNewerBatch(CancellationToken ct)
     {
         var responses = Enumerable.Range(0, 3)
             .Select(_ => new TaskCompletionSource<ProduceResponse>(
@@ -1112,8 +1112,12 @@ public sealed class BrokerSenderMuteOrderingTests
                 await Task.Yield();
             }
 
-            // This enqueue observes _loopExited and follows the rejected-enqueue handoff.
-            // The crash barrier/recovery references must keep it behind A and B.
+            // Production disposes the crashed sender as soon as the first survivor creates
+            // its replacement. A caller that already captured the old sender can still race
+            // in afterward; its rejected batch must follow the replacement handoff, not fail.
+            await exited.DisposeAsync();
+
+            // Crash recovery references must keep this newer batch behind A and B.
             exited.Enqueue(newer);
 
             await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(10), ct);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics;
 using System.Reflection;
 using Dekaf.Compression;
 using Dekaf.Metadata;
@@ -7,6 +8,7 @@ using Dekaf.Protocol;
 using Dekaf.Producer;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
+using Microsoft.Extensions.Logging;
 
 using NSubstitute;
 
@@ -88,6 +90,22 @@ public sealed class BrokerSenderMuteOrderingTests
 
         batch.TrySetMemoryReleased();
         return batch;
+    }
+
+    private static async Task WaitForDiagAsync(
+        ReadyBatch batch,
+        char marker,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var deadline = Stopwatch.GetTimestamp() + (long)(timeout.TotalSeconds * Stopwatch.Frequency);
+        while (!batch.DiagTrace.Contains(marker))
+        {
+            if (Stopwatch.GetTimestamp() >= deadline)
+                throw new TimeoutException($"Batch did not reach '{marker}': {batch.DiagTrace}");
+
+            await Task.Delay(1, cancellationToken);
+        }
     }
 
     private static ProduceResponse CreateSuccessResponse(string topic, int partition, long baseOffset) =>
@@ -200,7 +218,8 @@ public sealed class BrokerSenderMuteOrderingTests
         RecordAccumulator accumulator,
         Action<TopicPartition, long, DateTimeOffset, int, Exception?> onAcknowledgement,
         MetadataManager? metadataManager = null,
-        Action<ReadyBatch>? rerouteBatch = null) =>
+        Action<ReadyBatch, int>? rerouteBatch = null,
+        ILogger? logger = null) =>
         new(
             brokerId: 1, pool,
             metadataManager ?? new MetadataManager(pool, options.BootstrapServers),
@@ -215,7 +234,7 @@ public sealed class BrokerSenderMuteOrderingTests
             getCurrentEpoch: null,
             rerouteBatch: rerouteBatch,
             onAcknowledgement: onAcknowledgement,
-            logger: null);
+            logger: logger);
 
     private static object CreateCarryOver()
     {
@@ -450,7 +469,7 @@ public sealed class BrokerSenderMuteOrderingTests
             accumulator,
             onAcknowledgement: (_, _, _, _, _) => { },
             metadataManager,
-            rerouteBatch: batch => rerouted.TrySetResult(batch));
+            rerouteBatch: (batch, _) => rerouted.TrySetResult(batch));
 
         try
         {
@@ -1023,6 +1042,126 @@ public sealed class BrokerSenderMuteOrderingTests
     }
 
     /// <summary>
+    /// Verifies the actual unexpected-exit cleanup path publishes its partition barrier,
+    /// preserves survivor FIFO, and reroutes a newer batch rejected by the dead sender
+    /// behind both survivors.
+    /// </summary>
+    [Test]
+    [Timeout(30_000)]
+    public async Task UnexpectedLoopExit_RedeliveryPreemptsRejectedNewerBatch(CancellationToken ct)
+    {
+        var responses = Enumerable.Range(0, 3)
+            .Select(_ => new TaskCompletionSource<ProduceResponse>(
+                TaskCreationOptions.RunContinuationsAsynchronously))
+            .ToArray();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>(responses);
+        var sendSignals = Enumerable.Range(0, 3)
+            .Select(_ => new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously))
+            .ToArray();
+        var sendCount = 0;
+        var (pool, _) = CreateMockConnection(responseQueue, () =>
+        {
+            var index = Interlocked.Increment(ref sendCount) - 1;
+            if (index < sendSignals.Length)
+                sendSignals[index].TrySetResult();
+        });
+        var options = CreateOptions(maxInFlight: 1);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var acknowledgedMessageCounts = new List<int>();
+        var allAcknowledged = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var replacement = CreateSender(pool, options, accumulator, (tp, _, _, count, ex) =>
+        {
+            if (tp.Partition != 0 || ex is not null)
+                return;
+
+            lock (acknowledgedMessageCounts)
+            {
+                acknowledgedMessageCounts.Add(count);
+                if (acknowledgedMessageCounts.Count == 3)
+                    allAcknowledged.TrySetResult();
+            }
+        });
+        var crashLogger = new ThrowOnArmedIterationLogger();
+        var exited = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: (_, _, _, _, _) => { },
+            rerouteBatch: replacement.Enqueue,
+            logger: crashLogger);
+
+        try
+        {
+            var recoveredA = CreateTestBatch(vtPool, "test-topic", partition: 0, messageCount: 1);
+            var recoveredB = CreateTestBatch(vtPool, "test-topic", partition: 0, messageCount: 2);
+            var newer = CreateTestBatch(vtPool, "test-topic", partition: 0, messageCount: 3);
+            var topicPartition = recoveredA.TopicPartition;
+
+            // The logger holds the source at the first iteration boundary. Queue both batches
+            // while it is blocked, then release it to throw before either event is drained.
+            await crashLogger.FirstIteration.Task.WaitAsync(TimeSpan.FromSeconds(10), ct);
+            exited.EnqueueBulk([recoveredA, recoveredB]);
+            crashLogger.Arm();
+
+            while (exited.IsAlive)
+            {
+                ct.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+
+            // This enqueue observes _loopExited and follows the rejected-enqueue handoff.
+            // The crash barrier/recovery references must keep it behind A and B.
+            exited.Enqueue(newer);
+
+            await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(10), ct);
+            await WaitForDiagAsync(recoveredA, 'W', TimeSpan.FromSeconds(5), ct);
+            responses[0].SetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 10));
+            await sendSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(10), ct);
+            await WaitForDiagAsync(recoveredB, 'W', TimeSpan.FromSeconds(5), ct);
+            responses[1].SetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 11));
+            await sendSignals[2].Task.WaitAsync(TimeSpan.FromSeconds(10), ct);
+            await WaitForDiagAsync(newer, 'W', TimeSpan.FromSeconds(5), ct);
+            responses[2].SetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 12));
+
+            try
+            {
+                await allAcknowledged.Task.WaitAsync(TimeSpan.FromSeconds(10), ct);
+            }
+            catch (TimeoutException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Acknowledgements=[{string.Join(',', acknowledgedMessageCounts)}], " +
+                    $"sends={Volatile.Read(ref sendCount)}, queuedResponses={responseQueue.Count}, " +
+                    $"A={recoveredA.DiagTrace}, B={recoveredB.DiagTrace}, newer={newer.DiagTrace}", ex);
+            }
+
+            await Assert.That(acknowledgedMessageCounts).Count().IsEqualTo(3);
+            await Assert.That(acknowledgedMessageCounts[0]).IsEqualTo(1);
+            await Assert.That(acknowledgedMessageCounts[1]).IsEqualTo(2);
+            await Assert.That(acknowledgedMessageCounts[2]).IsEqualTo(3);
+
+            var unmuteDeadline = Stopwatch.GetTimestamp() + (5 * Stopwatch.Frequency);
+            while (accumulator.IsMuted(topicPartition) && Stopwatch.GetTimestamp() < unmuteDeadline)
+                await Task.Delay(1, ct);
+            await Assert.That(accumulator.IsMuted(topicPartition)).IsFalse();
+        }
+        finally
+        {
+            crashLogger.Arm();
+            for (var i = 0; i < responses.Length; i++)
+                responses[i].TrySetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 10 + i));
+
+            await exited.DisposeAsync();
+            await replacement.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    /// <summary>
     /// Verifies that when the in-flight wait processes a response that mutes a partition,
     /// any already-coalesced normal batch for that partition is moved back to carry-over
     /// (the muted partition filter added in the fix). Without this filter, the normal batch
@@ -1132,6 +1271,46 @@ public sealed class BrokerSenderMuteOrderingTests
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await vtPool.DisposeAsync();
+        }
+    }
+
+    private sealed class ThrowOnArmedIterationLogger : ILogger
+    {
+        private int _armed;
+        private int _thrown;
+        private readonly TaskCompletionSource _crashGate =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource FirstIteration { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Arm()
+        {
+            Volatile.Write(ref _armed, 1);
+            _crashGate.TrySetResult();
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (eventId.Name != "LogSendLoopIteration"
+                && !formatter(state, exception).Contains("send loop iteration", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            FirstIteration.TrySetResult();
+            _crashGate.Task.GetAwaiter().GetResult();
+            if (Volatile.Read(ref _armed) != 0 && Interlocked.Exchange(ref _thrown, 1) == 0)
+                throw new InvalidOperationException("Injected send-loop crash");
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -133,6 +133,21 @@ public sealed class ProducerDeliveryDiagnosticsTests
     }
 
     [Test]
+    public async Task CreateDeliveryDiagnostic_LoopExitRedelivery_DescribesRecoverySource()
+    {
+        await using var accumulator = new RecordAccumulator(CreateOptions(enableDeliveryDiagnostics: true));
+        var batches = await AppendAndDrainBatchesAsync(accumulator);
+        var batch = batches[0];
+        batch.AppendDiag('Y');
+
+        var diagnostic = batch.CreateDeliveryDiagnostic(batch.Generation, batch.TopicPartition);
+
+        await Assert.That(diagnostic.LastTouchedBy).IsEqualTo("BrokerSender.LoopExitRedelivery");
+
+        CompleteAndReturn(accumulator, batches);
+    }
+
+    [Test]
     public async Task DiagTrace_KeepsMostRecentTransitionsWhenCapacityIsExceeded()
     {
         var batch = new ReadyBatch();

--- a/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
@@ -16,6 +16,7 @@ internal sealed class TestKafkaConnection : IKafkaConnection, IKafkaPipelinedWri
     public int SendPipelinedAfterWriteCalls;
     public int SendPipelinedWithCallerTimeoutAfterWriteCalls;
     public int SendFireAndForgetWithCallerTimeoutCalls;
+    public int DisposeCalls;
 
     public Func<ValueTask<Task<ProduceResponse>>>? SendProducePipelinedAfterWrite { get; set; }
     public Func<ValueTask>? SendProduceFireAndForgetWithCallerTimeout { get; set; }
@@ -71,7 +72,11 @@ internal sealed class TestKafkaConnection : IKafkaConnection, IKafkaPipelinedWri
 
     public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync()
+    {
+        Interlocked.Increment(ref DisposeCalls);
+        return ValueTask.CompletedTask;
+    }
 
     public async ValueTask<Task<TResponse>> SendPipelinedAfterWriteAsync<TRequest, TResponse>(
         TRequest request,


### PR DESCRIPTION
## Summary

Fixes both failure modes of stress run [28972770086](https://github.com/thomhurst/Dekaf/actions/runs/28972770086) (12,844 messages lost with `ObjectDisposedException: 'BrokerSender'` in the idempotent paired job; one stranded DeliveryTask surfacing as `ObjectDisposedException: 'RecordAccumulator'` in the 3-broker job), plus the perf bug that kept default-config Dekaf on a single drain connection.

## Root causes

**1. Scale-down crashed the send loop (the 12,844-message loss).** `ApplyScaleDown` shrank `_pinnedConnections`/`_pendingResponsesByConnection` and *then* called `FenceAffectedPartitions(oldCount, newCount)`, which indexes the removed slot — a guaranteed `IndexOutOfRangeException` whenever any known partition mapped to it (always, with 6 partitions). The exception escaped to the send loop's catch-all, the loop died, and its `finally` block permanently failed every queued and in-flight batch with `ObjectDisposedException`. The +133.7s failure time matches the 120s sustained-low-utilization window exactly; #1586's send-loop-pressure trigger unlocked this latent path for low-utilization workloads.

**2. Scale-down silently dropped in-flight requests (the #1578 silent-loss signature).** The "last list should be empty" assumption in `ApplyScaleDown` was checked at shrink *initiation*, but sends later in the same iteration could still pipeline a request onto the connection being removed. The array truncation then dropped that pending-response list on the floor: the broker had (or would receive) the data, but `batch.CompleteSend` was never called — delivered messages whose DeliveryTasks never complete. This explains both the earlier run 28953453869 (`errors=0, undelivered=14,525`) and this run's stranded sample that sat ~100s until accumulator disposal failed it.

**3. Adaptive scaling never actually spread traffic in default config (perf).** `ConnectionPool.GetConnectionByIndexAsync` fell back to the single-connection path whenever the *configured* `ConnectionsPerBroker <= 1`, ignoring the index — so scale-up created real TCP connections that never received a byte. Empirically proven with an in-process repro: `sendsPerConn=[23444,0,0,...]` with the degradation vs. even spread without it. This is why the default-config producer pegs exactly one core and why p50 latency = BufferMemory ÷ drain rate (predicted 483ms; observed 473.85ms).

## Fixes

- **Per-connection arrays are allocated once at the scaling ceiling and never resized.** Scaling changes only `_connectionCount`. Response/timeout scans iterate the full array, so a slot leaving the routing width keeps draining to completion. This removes the resize bug class entirely.
- **Scale-down reduces the routing width at initiation**, before the background pool shrink — no new request can target the removed slot from that instant, closing the pipeline race. The removed connection is parked and only disposed once its slot is confirmed empty (warning logged if the invariant is ever breached — never silent).
- **Scale-down no longer fences partitions** (its drain gates guarantee no in-flight whose routing changes) and clears stale migration fences at initiation.
- **`HasInflightForPartition` guards null batch entries** (legal for stale generations) and out-of-range indices — a latent NRE reachable via `CompleteMigrations`.
- **An unexpected send-loop exit now redelivers surviving batches** to a replacement sender via the reroute callback instead of permanently failing them, bounded by the delivery timeout. Sequences are preserved, so the broker dedupes any already-written request (`DuplicateSequenceNumber` → success). Shutdown still fails batches as before, and the expected/unexpected distinction is recorded at the catch site rather than derived from racy shared state.
- **`GetConnectionByIndexAsync` treats an existing connection group as authoritative** regardless of configured count — adaptively scaled connections now receive traffic. Scale-up targets are capped at the partition count (connections beyond it can never receive traffic and only armed scale-down churn).

## Expected stress impact

- Idempotent/FnF/acks-all jobs: zero errors, zero undelivered (both loss mechanisms removed; any future loop crash redelivers instead of dropping).
- Default-config throughput should approach the 3conn variant numbers (which hit 1.4x Confluent with p50 of ~3ms in the same run) once scaling engages, directly attacking the 0.98x idempotent and 1.00x acks-all gaps and the 226–474ms p50 latencies (drain-limited queueing).

## Testing

- `AdaptiveScaleDownTests` (new): drives a live scale-up → scale-down cycle through the real send loop under continuous idempotent traffic across 8 partitions — deterministically crashed the loop before the fix — asserting zero failed acks, all batches delivered, sender alive, removed connection disposed exactly once. Plus direct coverage of the redeliver / deadline-fail / shutdown-fail dispositions.
- Full unit suite: 4513/4513 pass (3 consecutive runs). One unrelated test failed once immediately after recovering from a disk-full incident on my machine and never reproduced across 4 subsequent full runs + 15 targeted loops; name wasn't captured before the report was overwritten.
- Integration tests: Docker unavailable locally — relying on CI for this PR.

## Follow-ups (not in this PR)

- Extend #1551's build/write overlap to the acks=all/idempotent single-connection path (#1547) — removes the serial write stall before scaling kicks in.
- Pool split-brain: a configured-1 broker can now hold both a single connection and a group (one idle socket after scale-up); unify on "group of size 1".
- Stress harness attaches no ILoggerFactory, so scale events and client warnings are invisible in CI — the routing bug would have been visible a dozen runs ago.
- Test-harness dedup: BrokerSender test helpers are now copied across four files.