### PR TITLE
feat(stress): capture diagnostics during stalls

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -236,7 +236,6 @@ jobs:
             --client ${{ matrix.client }} \
             --brokers ${{ matrix.brokers }} \
             --connections-per-broker 1 \
-            --producer-delivery-diagnostics \
             --output ./results
 
           if [ "${{ matrix.run_3conn }}" = "true" ]; then
@@ -248,7 +247,6 @@ jobs:
               --client dekaf \
               --brokers ${{ matrix.brokers }} \
               --connections-per-broker 3 \
-              --producer-delivery-diagnostics \
               --output ./results
           fi
 

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -127,6 +127,9 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Install stack diagnostics
+        run: dotnet tool install --global dotnet-stack --version 9.0.661903
+
       - name: Build Stress Tests
         run: dotnet build tools/Dekaf.StressTests --configuration Release
 
@@ -231,6 +234,7 @@ jobs:
             --client ${{ matrix.client }} \
             --brokers ${{ matrix.brokers }} \
             --connections-per-broker 1 \
+            --producer-delivery-diagnostics \
             --output ./results
 
           if [ "${{ matrix.run_3conn }}" = "true" ]; then
@@ -242,6 +246,7 @@ jobs:
               --client dekaf \
               --brokers ${{ matrix.brokers }} \
               --connections-per-broker 3 \
+              --producer-delivery-diagnostics \
               --output ./results
           fi
 

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -128,7 +128,9 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Install stack diagnostics
-        run: dotnet tool install --global dotnet-stack --version 9.0.661903
+        run: |
+          dotnet tool install --global dotnet-stack --version 9.0.661903
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
       - name: Build Stress Tests
         run: dotnet build tools/Dekaf.StressTests --configuration Release

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -344,8 +344,8 @@ jobs:
           from datetime import datetime
           from stress_report import generate_scenario_tables, format_gc_table
 
-          # Find all JSON result files
-          json_files = glob.glob("all-results/**/*.json", recursive=True)
+          # Parse only result envelopes; watchdog diagnostics are separate JSON artifacts.
+          json_files = glob.glob("all-results/**/stress-test-results*.json", recursive=True)
           print(f"Found {len(json_files)} result files")
 
           if not json_files:
@@ -479,8 +479,8 @@ jobs:
           output.append(":::")
           output.append("")
 
-          # Find and parse JSON results
-          json_files = glob.glob("results/**/*.json", recursive=True)
+          # Parse only result envelopes; watchdog diagnostics are separate JSON artifacts.
+          json_files = glob.glob("results/**/stress-test-results*.json", recursive=True)
 
           if json_files:
               # Use the most recent file

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -20,6 +20,11 @@
     <ProjectReference Include="..\..\src\Dekaf.Extensions.Hosting\Dekaf.Extensions.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.OpenTelemetry\Dekaf.OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Extensions.HealthChecks\Dekaf.Extensions.HealthChecks.csproj" />
+    <ProjectReference Include="..\..\tools\Dekaf.StressTests\Dekaf.StressTests.csproj" Condition="'$(TargetFramework)' == 'net10.0'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <Compile Remove="StressTests\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dekaf.Tests.Unit/StressTests/ProgressWatchdogTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ProgressWatchdogTests.cs
@@ -1,0 +1,89 @@
+using Dekaf.Producer;
+using Dekaf.StressTests.Diagnostics;
+using Dekaf.StressTests.Metrics;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class ProgressWatchdogTests
+{
+    [Test]
+    public async Task Track_Stall_CapturesStacksAndProducerDiagnosticsThenExits()
+    {
+        var outputDirectory = CreateOutputDirectory();
+        try
+        {
+            var exited = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var throughput = new ThroughputTracker();
+            throughput.Start();
+
+            using var watchdog = new ProgressWatchdog(
+                outputDirectory,
+                captureAfter: TimeSpan.FromMilliseconds(40),
+                exitAfter: TimeSpan.FromMilliseconds(500),
+                pollInterval: TimeSpan.FromMilliseconds(10),
+                exitProcess: code => exited.TrySetResult(code),
+                captureManagedStackReport: () => "fake managed stack");
+            using var registration = watchdog.Track(
+                throughput,
+                "Dekaf",
+                "producer",
+                () => new ProducerDeliveryDiagnosticsSnapshot
+                {
+                    DiagnosticsEnabled = true,
+                    CapturedAtUtc = DateTimeOffset.UtcNow
+                });
+
+            var exitCode = await exited.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(exitCode).IsEqualTo(1);
+            var stackArtifacts = Directory.GetFiles(outputDirectory, "*-stacks.txt");
+            var producerArtifacts = Directory.GetFiles(outputDirectory, "*-producer.json");
+            await Assert.That(stackArtifacts.Length).IsEqualTo(2);
+            await Assert.That(producerArtifacts.Length).IsEqualTo(2);
+            await Assert.That(await File.ReadAllTextAsync(stackArtifacts[0])).Contains("fake managed stack");
+            await Assert.That(await File.ReadAllTextAsync(producerArtifacts[0])).Contains("\"DiagnosticsEnabled\": true");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Track_FatalStall_ExitsWhenStackCaptureFails()
+    {
+        var outputDirectory = CreateOutputDirectory();
+        try
+        {
+            var exited = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var throughput = new ThroughputTracker();
+            throughput.Start();
+
+            using var watchdog = new ProgressWatchdog(
+                outputDirectory,
+                captureAfter: TimeSpan.FromMilliseconds(20),
+                exitAfter: TimeSpan.FromMilliseconds(60),
+                pollInterval: TimeSpan.FromMilliseconds(10),
+                exitProcess: code => exited.TrySetResult(code),
+                captureManagedStackReport: () => throw new InvalidOperationException("capture unavailable"));
+            using var registration = watchdog.Track(throughput, "Dekaf", "consumer");
+
+            var exitCode = await exited.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(exitCode).IsEqualTo(1);
+            var fatalArtifact = Directory.GetFiles(outputDirectory, "*-fatal-stacks.txt").Single();
+            await Assert.That(await File.ReadAllTextAsync(fatalArtifact)).Contains("capture unavailable");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    private static string CreateOutputDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"dekaf-watchdog-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/StressTests/ProgressWatchdogTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ProgressWatchdogTests.cs
@@ -80,6 +80,53 @@ public sealed class ProgressWatchdogTests
         }
     }
 
+    [Test]
+    public async Task Track_FatalStall_ExitsWhenProducerDiagnosticsBlocks()
+    {
+        var outputDirectory = CreateOutputDirectory();
+        using var releaseCapture = new ManualResetEventSlim(initialState: false);
+        using var capturesCompleted = new CountdownEvent(initialCount: 2);
+        try
+        {
+            var exited = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var throughput = new ThroughputTracker();
+            throughput.Start();
+
+            using var watchdog = new ProgressWatchdog(
+                outputDirectory,
+                captureAfter: TimeSpan.FromMilliseconds(20),
+                exitAfter: TimeSpan.FromMilliseconds(100),
+                pollInterval: TimeSpan.FromMilliseconds(10),
+                exitProcess: code => exited.TrySetResult(code),
+                captureManagedStackReport: () => "fake managed stack",
+                producerDiagnosticsTimeout: TimeSpan.FromMilliseconds(30));
+            using var registration = watchdog.Track(
+                throughput,
+                "Dekaf",
+                "producer",
+                () =>
+                {
+                    releaseCapture.Wait();
+                    capturesCompleted.Signal();
+                    return null;
+                });
+
+            var exitCode = await exited.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(exitCode).IsEqualTo(1);
+            var fatalStackArtifact = Directory.GetFiles(outputDirectory, "*-fatal-stacks.txt").Single();
+            var fatalProducerArtifact = Directory.GetFiles(outputDirectory, "*-fatal-producer.json").Single();
+            await Assert.That(await File.ReadAllTextAsync(fatalStackArtifact)).Contains("fake managed stack");
+            await Assert.That(await File.ReadAllTextAsync(fatalProducerArtifact)).Contains("timed out");
+        }
+        finally
+        {
+            releaseCapture.Set();
+            capturesCompleted.Wait(TimeSpan.FromSeconds(5));
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
     private static string CreateOutputDirectory()
     {
         var path = Path.Combine(Path.GetTempPath(), $"dekaf-watchdog-tests-{Guid.NewGuid():N}");

--- a/tests/Dekaf.Tests.Unit/StressTests/ProgressWatchdogTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ProgressWatchdogTests.cs
@@ -36,12 +36,14 @@ public sealed class ProgressWatchdogTests
             var exitCode = await exited.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             await Assert.That(exitCode).IsEqualTo(1);
-            var stackArtifacts = Directory.GetFiles(outputDirectory, "*-stacks.txt");
-            var producerArtifacts = Directory.GetFiles(outputDirectory, "*-producer.json");
+            var diagnosticsDirectory = GetDiagnosticsDirectory(outputDirectory);
+            var stackArtifacts = Directory.GetFiles(diagnosticsDirectory, "*-stacks.txt");
+            var producerArtifacts = Directory.GetFiles(diagnosticsDirectory, "*-producer.json");
             await Assert.That(stackArtifacts.Length).IsEqualTo(2);
             await Assert.That(producerArtifacts.Length).IsEqualTo(2);
+            await Assert.That(Directory.GetFiles(outputDirectory, "*.json")).IsEmpty();
             await Assert.That(await File.ReadAllTextAsync(stackArtifacts[0])).Contains("fake managed stack");
-            await Assert.That(await File.ReadAllTextAsync(producerArtifacts[0])).Contains("\"DiagnosticsEnabled\": true");
+            await Assert.That(await File.ReadAllTextAsync(producerArtifacts[0])).Contains("\"diagnosticsEnabled\": true");
         }
         finally
         {
@@ -71,7 +73,9 @@ public sealed class ProgressWatchdogTests
             var exitCode = await exited.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             await Assert.That(exitCode).IsEqualTo(1);
-            var fatalArtifact = Directory.GetFiles(outputDirectory, "*-fatal-stacks.txt").Single();
+            var fatalArtifact = Directory.GetFiles(
+                GetDiagnosticsDirectory(outputDirectory),
+                "*-fatal-stacks.txt").Single();
             await Assert.That(await File.ReadAllTextAsync(fatalArtifact)).Contains("capture unavailable");
         }
         finally
@@ -114,8 +118,9 @@ public sealed class ProgressWatchdogTests
             var exitCode = await exited.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             await Assert.That(exitCode).IsEqualTo(1);
-            var fatalStackArtifact = Directory.GetFiles(outputDirectory, "*-fatal-stacks.txt").Single();
-            var fatalProducerArtifact = Directory.GetFiles(outputDirectory, "*-fatal-producer.json").Single();
+            var diagnosticsDirectory = GetDiagnosticsDirectory(outputDirectory);
+            var fatalStackArtifact = Directory.GetFiles(diagnosticsDirectory, "*-fatal-stacks.txt").Single();
+            var fatalProducerArtifact = Directory.GetFiles(diagnosticsDirectory, "*-fatal-producer.json").Single();
             await Assert.That(await File.ReadAllTextAsync(fatalStackArtifact)).Contains("fake managed stack");
             await Assert.That(await File.ReadAllTextAsync(fatalProducerArtifact)).Contains("timed out");
         }
@@ -133,4 +138,7 @@ public sealed class ProgressWatchdogTests
         Directory.CreateDirectory(path);
         return path;
     }
+
+    private static string GetDiagnosticsDirectory(string outputDirectory) =>
+        Path.Combine(outputDirectory, ProgressWatchdog.ArtifactsDirectoryName);
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/StallDetectorTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/StallDetectorTests.cs
@@ -50,7 +50,7 @@ public sealed class StallDetectorTests
     }
 
     [Test]
-    public async Task Watchdog_Stall_CapturesProducerDiagnosticsBeforeThreadStacks()
+    public async Task Watchdog_Stall_CapturesThreadStacksBeforeProducerDiagnostics()
     {
         var outputDirectory = CreateOutputDirectory();
         try
@@ -90,8 +90,8 @@ public sealed class StallDetectorTests
 
             var order = captureOrder.ToArray();
             await Assert.That(order.Length).IsEqualTo(2);
-            await Assert.That(order[0]).IsEqualTo("producer");
-            await Assert.That(order[1]).IsEqualTo("stacks");
+            await Assert.That(order[0]).IsEqualTo("stacks");
+            await Assert.That(order[1]).IsEqualTo("producer");
             await Assert.That(File.ReadAllText(Directory.GetFiles(outputDirectory, "*-stacks.txt").Single()))
                 .Contains("test managed stack");
             await Assert.That(File.ReadAllText(Directory.GetFiles(outputDirectory, "*-producer.json").Single()))

--- a/tests/Dekaf.Tests.Unit/StressTests/StallDetectorTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/StallDetectorTests.cs
@@ -1,0 +1,140 @@
+using System.Collections.Concurrent;
+using Dekaf.StressTests.Diagnostics;
+using Dekaf.StressTests.Metrics;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class StallDetectorTests
+{
+    private static readonly TimeSpan CaptureAfter = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan ExitAfter = TimeSpan.FromMinutes(5);
+
+    [Test]
+    public async Task Observe_BeforeCaptureThreshold_DoesNothing()
+    {
+        var detector = new StallDetector(CaptureAfter, ExitAfter);
+        detector.Reset(messageCount: 42, TimeSpan.Zero);
+
+        var action = detector.Observe(messageCount: 42, TimeSpan.FromSeconds(29));
+
+        await Assert.That(action).IsEqualTo(StallAction.None);
+    }
+
+    [Test]
+    public async Task Observe_Stalled_CapturesOnceUntilProgressResumes()
+    {
+        var detector = new StallDetector(CaptureAfter, ExitAfter);
+        detector.Reset(messageCount: 42, TimeSpan.Zero);
+
+        var first = detector.Observe(messageCount: 42, CaptureAfter);
+        var repeated = detector.Observe(messageCount: 42, TimeSpan.FromMinutes(1));
+        var resumed = detector.Observe(messageCount: 43, TimeSpan.FromMinutes(2));
+        var secondStall = detector.Observe(messageCount: 43, TimeSpan.FromMinutes(2.5));
+
+        await Assert.That(first).IsEqualTo(StallAction.Capture);
+        await Assert.That(repeated).IsEqualTo(StallAction.None);
+        await Assert.That(resumed).IsEqualTo(StallAction.None);
+        await Assert.That(secondStall).IsEqualTo(StallAction.Capture);
+    }
+
+    [Test]
+    public async Task Observe_AtExitThreshold_CapturesAndExits()
+    {
+        var detector = new StallDetector(CaptureAfter, ExitAfter);
+        detector.Reset(messageCount: 42, TimeSpan.Zero);
+        _ = detector.Observe(messageCount: 42, CaptureAfter);
+
+        var action = detector.Observe(messageCount: 42, ExitAfter);
+
+        await Assert.That(action).IsEqualTo(StallAction.CaptureAndExit);
+    }
+
+    [Test]
+    public async Task Watchdog_Stall_CapturesProducerDiagnosticsBeforeThreadStacks()
+    {
+        var outputDirectory = CreateOutputDirectory();
+        try
+        {
+            var throughput = new ThroughputTracker();
+            var captureOrder = new ConcurrentQueue<string>();
+            var producerCaptured = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var stacksCaptured = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var watchdog = new ProgressWatchdog(
+                outputDirectory,
+                captureAfter: TimeSpan.FromMilliseconds(40),
+                exitAfter: TimeSpan.FromSeconds(10),
+                pollInterval: TimeSpan.FromMilliseconds(5),
+                captureManagedStackReport: () =>
+                {
+                    captureOrder.Enqueue("stacks");
+                    stacksCaptured.TrySetResult();
+                    return "test managed stack";
+                });
+            using var registration = watchdog.Track(
+                throughput,
+                "Dekaf",
+                "producer",
+                () =>
+                {
+                    captureOrder.Enqueue("producer");
+                    producerCaptured.TrySetResult();
+                    return null;
+                });
+
+            await Task.WhenAll(producerCaptured.Task, stacksCaptured.Task)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(() => Directory.GetFiles(outputDirectory, "*-stacks.txt").Length)
+                .Eventually(count => count.IsEqualTo(1), TimeSpan.FromSeconds(5));
+            await Assert.That(() => Directory.GetFiles(outputDirectory, "*-producer.json").Length)
+                .Eventually(count => count.IsEqualTo(1), TimeSpan.FromSeconds(5));
+
+            var order = captureOrder.ToArray();
+            await Assert.That(order.Length).IsEqualTo(2);
+            await Assert.That(order[0]).IsEqualTo("producer");
+            await Assert.That(order[1]).IsEqualTo("stacks");
+            await Assert.That(File.ReadAllText(Directory.GetFiles(outputDirectory, "*-stacks.txt").Single()))
+                .Contains("test managed stack");
+            await Assert.That(File.ReadAllText(Directory.GetFiles(outputDirectory, "*-producer.json").Single()))
+                .Contains("ProducerDeliveryDiagnostics");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Watchdog_FatalStall_CapturesStacksBeforeNonZeroExit()
+    {
+        var outputDirectory = CreateOutputDirectory();
+        try
+        {
+            var exitCode = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var watchdog = new ProgressWatchdog(
+                outputDirectory,
+                captureAfter: TimeSpan.FromMilliseconds(30),
+                exitAfter: TimeSpan.FromMilliseconds(80),
+                pollInterval: TimeSpan.FromMilliseconds(5),
+                exitProcess: code => exitCode.TrySetResult(code),
+                captureManagedStackReport: () => "test managed stack");
+            using var registration = watchdog.Track(new ThroughputTracker(), "Dekaf", "consumer");
+
+            var actualExitCode = await exitCode.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(actualExitCode).IsEqualTo(1);
+            await Assert.That(() => Directory.GetFiles(outputDirectory, "*-fatal-stacks.txt").Length)
+                .Eventually(count => count.IsEqualTo(1), TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    private static string CreateOutputDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"dekaf-watchdog-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/StressTests/StallDetectorTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/StallDetectorTests.cs
@@ -59,11 +59,13 @@ public sealed class StallDetectorTests
             var captureOrder = new ConcurrentQueue<string>();
             var producerCaptured = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var stacksCaptured = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var unexpectedExit = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
             using var watchdog = new ProgressWatchdog(
                 outputDirectory,
                 captureAfter: TimeSpan.FromMilliseconds(40),
                 exitAfter: TimeSpan.FromSeconds(10),
                 pollInterval: TimeSpan.FromMilliseconds(5),
+                exitProcess: code => unexpectedExit.TrySetResult(code),
                 captureManagedStackReport: () =>
                 {
                     captureOrder.Enqueue("stacks");
@@ -83,19 +85,21 @@ public sealed class StallDetectorTests
 
             await Task.WhenAll(producerCaptured.Task, stacksCaptured.Task)
                 .WaitAsync(TimeSpan.FromSeconds(5));
-            await Assert.That(() => Directory.GetFiles(outputDirectory, "*-stacks.txt").Length)
+            var diagnosticsDirectory = Path.Combine(outputDirectory, ProgressWatchdog.ArtifactsDirectoryName);
+            await Assert.That(() => Directory.GetFiles(diagnosticsDirectory, "*-stacks.txt").Length)
                 .Eventually(count => count.IsEqualTo(1), TimeSpan.FromSeconds(5));
-            await Assert.That(() => Directory.GetFiles(outputDirectory, "*-producer.json").Length)
+            await Assert.That(() => Directory.GetFiles(diagnosticsDirectory, "*-producer.json").Length)
                 .Eventually(count => count.IsEqualTo(1), TimeSpan.FromSeconds(5));
 
             var order = captureOrder.ToArray();
             await Assert.That(order.Length).IsEqualTo(2);
             await Assert.That(order[0]).IsEqualTo("stacks");
             await Assert.That(order[1]).IsEqualTo("producer");
-            await Assert.That(File.ReadAllText(Directory.GetFiles(outputDirectory, "*-stacks.txt").Single()))
+            await Assert.That(File.ReadAllText(Directory.GetFiles(diagnosticsDirectory, "*-stacks.txt").Single()))
                 .Contains("test managed stack");
-            await Assert.That(File.ReadAllText(Directory.GetFiles(outputDirectory, "*-producer.json").Single()))
-                .Contains("ProducerDeliveryDiagnostics");
+            await Assert.That(File.ReadAllText(Directory.GetFiles(diagnosticsDirectory, "*-producer.json").Single()))
+                .Contains("producerDeliveryDiagnostics");
+            await Assert.That(unexpectedExit.Task.IsCompleted).IsFalse();
         }
         finally
         {
@@ -122,7 +126,8 @@ public sealed class StallDetectorTests
             var actualExitCode = await exitCode.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             await Assert.That(actualExitCode).IsEqualTo(1);
-            await Assert.That(() => Directory.GetFiles(outputDirectory, "*-fatal-stacks.txt").Length)
+            var diagnosticsDirectory = Path.Combine(outputDirectory, ProgressWatchdog.ArtifactsDirectoryName);
+            await Assert.That(() => Directory.GetFiles(diagnosticsDirectory, "*-fatal-stacks.txt").Length)
                 .Eventually(count => count.IsEqualTo(1), TimeSpan.FromSeconds(5));
         }
         finally

--- a/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
+++ b/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Dekaf.Tests.Unit" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Snappy\Dekaf.Compression.Snappy.csproj" />

--- a/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
+++ b/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
@@ -1,0 +1,398 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Dekaf.Producer;
+using Dekaf.StressTests.Metrics;
+
+namespace Dekaf.StressTests.Diagnostics;
+
+internal enum StallAction
+{
+    None,
+    Capture,
+    CaptureAndExit
+}
+
+internal sealed class StallDetector
+{
+    private readonly TimeSpan _captureAfter;
+    private readonly TimeSpan _exitAfter;
+    private long _lastMessageCount;
+    private TimeSpan _lastProgressAt;
+    private bool _captured;
+    private bool _exited;
+
+    internal StallDetector(TimeSpan captureAfter, TimeSpan exitAfter)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(captureAfter, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(exitAfter, captureAfter);
+
+        _captureAfter = captureAfter;
+        _exitAfter = exitAfter;
+    }
+
+    internal void Reset(long messageCount, TimeSpan now)
+    {
+        _lastMessageCount = messageCount;
+        _lastProgressAt = now;
+        _captured = false;
+        _exited = false;
+    }
+
+    internal StallAction Observe(long messageCount, TimeSpan now)
+    {
+        if (messageCount != _lastMessageCount)
+        {
+            Reset(messageCount, now);
+            return StallAction.None;
+        }
+
+        var stalledFor = now - _lastProgressAt;
+        if (stalledFor >= _exitAfter && !_exited)
+        {
+            _exited = true;
+            return StallAction.CaptureAndExit;
+        }
+
+        if (stalledFor >= _captureAfter && !_captured)
+        {
+            _captured = true;
+            return StallAction.Capture;
+        }
+
+        return StallAction.None;
+    }
+
+    internal TimeSpan GetStallDuration(TimeSpan now) => now - _lastProgressAt;
+}
+
+/// <summary>
+/// Watches active stress-scenario progress from a dedicated thread, independent of
+/// thread-pool health. A prolonged stall captures managed stacks and live producer
+/// diagnostics into the normal results directory. A five-minute stall captures a
+/// final snapshot, then terminates the process before the CI timeout loses evidence.
+/// </summary>
+internal sealed class ProgressWatchdog : IDisposable
+{
+    internal static readonly TimeSpan DefaultCaptureAfter = TimeSpan.FromSeconds(30);
+    internal static readonly TimeSpan DefaultExitAfter = TimeSpan.FromMinutes(5);
+
+    private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan StackCaptureTimeout = TimeSpan.FromMinutes(1);
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private readonly string _outputDirectory;
+    private readonly TimeSpan _captureAfter;
+    private readonly TimeSpan _exitAfter;
+    private readonly TimeSpan _pollInterval;
+    private readonly Action<int> _exitProcess;
+    private readonly Func<string> _captureManagedStackReport;
+    private readonly Stopwatch _clock = Stopwatch.StartNew();
+    private readonly AutoResetEvent _wakeUp = new(initialState: false);
+    private readonly object _sync = new();
+    private readonly Thread _thread;
+    private ActiveRun? _activeRun;
+    private long _nextRegistrationId;
+    private int _captureSequence;
+    private bool _disposed;
+
+    internal ProgressWatchdog(
+        string outputDirectory,
+        TimeSpan? captureAfter = null,
+        TimeSpan? exitAfter = null,
+        TimeSpan? pollInterval = null,
+        Action<int>? exitProcess = null,
+        Func<string>? captureManagedStackReport = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputDirectory);
+
+        _outputDirectory = Path.GetFullPath(outputDirectory);
+        _captureAfter = captureAfter ?? DefaultCaptureAfter;
+        _exitAfter = exitAfter ?? DefaultExitAfter;
+        _pollInterval = pollInterval ?? DefaultPollInterval;
+        _exitProcess = exitProcess ?? Environment.Exit;
+        _captureManagedStackReport = captureManagedStackReport ?? CaptureManagedStackReport;
+
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_captureAfter, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_exitAfter, _captureAfter);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_pollInterval, TimeSpan.Zero);
+
+        Directory.CreateDirectory(_outputDirectory);
+        _thread = new Thread(Run)
+        {
+            IsBackground = true,
+            Name = "Dekaf stress progress watchdog"
+        };
+        _thread.Start();
+    }
+
+    internal IDisposable Track(
+        ThroughputTracker throughput,
+        string client,
+        string scenario,
+        Func<ProducerDeliveryDiagnosticsSnapshot?>? captureProducerDiagnostics = null)
+    {
+        ArgumentNullException.ThrowIfNull(throughput);
+        ArgumentException.ThrowIfNullOrWhiteSpace(client);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scenario);
+
+        lock (_sync)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_activeRun is not null)
+                throw new InvalidOperationException("Progress watchdog already tracks an active scenario.");
+
+            var detector = new StallDetector(_captureAfter, _exitAfter);
+            detector.Reset(throughput.MessageCount, _clock.Elapsed);
+            var registrationId = ++_nextRegistrationId;
+            _activeRun = new ActiveRun(
+                registrationId,
+                throughput,
+                client,
+                scenario,
+                captureProducerDiagnostics,
+                detector);
+            _wakeUp.Set();
+            return new Registration(this, registrationId);
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_sync)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _activeRun = null;
+            _wakeUp.Set();
+        }
+
+        if (_thread.Join(StackCaptureTimeout + TimeSpan.FromSeconds(5)))
+            _wakeUp.Dispose();
+    }
+
+    private void Run()
+    {
+        while (true)
+        {
+            _wakeUp.WaitOne(_pollInterval);
+
+            ActiveRun? activeRun;
+            lock (_sync)
+            {
+                if (_disposed)
+                    return;
+
+                activeRun = _activeRun;
+            }
+
+            if (activeRun is null)
+                continue;
+
+            var now = _clock.Elapsed;
+            var action = activeRun.Detector.Observe(activeRun.Throughput.MessageCount, now);
+            if (action == StallAction.None || !IsCurrent(activeRun.RegistrationId))
+                continue;
+
+            try
+            {
+                CaptureDiagnostics(activeRun, action, activeRun.Detector.GetStallDuration(now));
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine($"PROGRESS WATCHDOG: diagnostic capture failed: {exception}");
+            }
+
+            if (action == StallAction.CaptureAndExit)
+                _exitProcess(1);
+        }
+    }
+
+    private bool IsCurrent(long registrationId)
+    {
+        lock (_sync)
+            return _activeRun?.RegistrationId == registrationId;
+    }
+
+    private void StopTracking(long registrationId)
+    {
+        lock (_sync)
+        {
+            if (_activeRun?.RegistrationId != registrationId)
+                return;
+
+            _activeRun = null;
+            _wakeUp.Set();
+        }
+    }
+
+    private void CaptureDiagnostics(ActiveRun activeRun, StallAction action, TimeSpan stalledFor)
+    {
+        var capturedAt = DateTimeOffset.UtcNow;
+        var sequence = Interlocked.Increment(ref _captureSequence);
+        var kind = action == StallAction.CaptureAndExit ? "fatal" : "stall";
+        var prefix = Path.Combine(
+            _outputDirectory,
+            $"watchdog-{Sanitize(activeRun.Client)}-{Sanitize(activeRun.Scenario)}-{capturedAt:yyyyMMdd-HHmmss}-{sequence:D2}-{kind}");
+
+        Console.Error.WriteLine(
+            $"PROGRESS WATCHDOG: {activeRun.Client} {activeRun.Scenario} made no message progress " +
+            $"for {stalledFor.TotalSeconds:F0}s; capturing {kind} diagnostics in {_outputDirectory}");
+
+        // Snapshot in-process state first: dotnet-stack may take up to a minute,
+        // during which the stall can resolve and erase the evidence we need.
+        CaptureProducerDiagnostics($"{prefix}-producer.json", activeRun, capturedAt, stalledFor);
+        CaptureManagedStacks(
+            $"{prefix}-stacks.txt",
+            activeRun,
+            capturedAt,
+            stalledFor,
+            _captureManagedStackReport);
+
+        if (action == StallAction.CaptureAndExit)
+        {
+            Console.Error.WriteLine(
+                $"PROGRESS WATCHDOG: stall exceeded {_exitAfter.TotalMinutes:F0} minutes; exiting with code 1.");
+        }
+    }
+
+    private static void CaptureManagedStacks(
+        string path,
+        ActiveRun activeRun,
+        DateTimeOffset capturedAt,
+        TimeSpan stalledFor,
+        Func<string> captureManagedStackReport)
+    {
+        var header = new StringBuilder()
+            .AppendLine("Dekaf stress progress watchdog managed thread stacks")
+            .AppendLine($"CapturedAtUtc: {capturedAt:O}")
+            .AppendLine($"ProcessId: {Environment.ProcessId}")
+            .AppendLine($"Client: {activeRun.Client}")
+            .AppendLine($"Scenario: {activeRun.Scenario}")
+            .AppendLine($"MessageCount: {activeRun.Throughput.MessageCount}")
+            .AppendLine($"StalledFor: {stalledFor}")
+            .AppendLine()
+            .ToString();
+
+        try
+        {
+            WriteArtifact(path, header + captureManagedStackReport());
+        }
+        catch (Exception exception)
+        {
+            WriteArtifact(path, $"{header}dotnet-stack capture failed:{Environment.NewLine}{exception}");
+            Console.Error.WriteLine($"PROGRESS WATCHDOG: managed stack capture failed: {exception.Message}");
+        }
+    }
+
+    private static string CaptureManagedStackReport()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet-stack",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        startInfo.ArgumentList.Add("report");
+        startInfo.ArgumentList.Add("--process-id");
+        startInfo.ArgumentList.Add(Environment.ProcessId.ToString());
+
+        using var process = new Process { StartInfo = startInfo };
+        if (!process.Start())
+            throw new InvalidOperationException("dotnet-stack failed to start.");
+
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit((int)StackCaptureTimeout.TotalMilliseconds);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+
+        Task.WaitAll(standardOutput, standardError);
+        var body = new StringBuilder(standardOutput.Result);
+        if (!string.IsNullOrWhiteSpace(standardError.Result))
+            body.AppendLine().AppendLine("dotnet-stack stderr:").Append(standardError.Result);
+        if (!exited)
+            body.AppendLine().AppendLine($"dotnet-stack timed out after {StackCaptureTimeout}.");
+
+        return body.ToString();
+    }
+
+    private static void CaptureProducerDiagnostics(
+        string path,
+        ActiveRun activeRun,
+        DateTimeOffset capturedAt,
+        TimeSpan stalledFor)
+    {
+        if (activeRun.CaptureProducerDiagnostics is null)
+            return;
+
+        try
+        {
+            var snapshot = activeRun.CaptureProducerDiagnostics();
+            var artifact = new
+            {
+                CapturedAtUtc = capturedAt,
+                activeRun.Client,
+                activeRun.Scenario,
+                MessageCount = activeRun.Throughput.MessageCount,
+                StalledFor = stalledFor,
+                ProducerDeliveryDiagnostics = snapshot
+            };
+            WriteArtifact(path, JsonSerializer.Serialize(artifact, JsonOptions));
+        }
+        catch (Exception exception)
+        {
+            WriteArtifact(path, JsonSerializer.Serialize(new
+            {
+                CapturedAtUtc = capturedAt,
+                activeRun.Client,
+                activeRun.Scenario,
+                Error = exception.ToString()
+            }, JsonOptions));
+            Console.Error.WriteLine($"PROGRESS WATCHDOG: producer diagnostics capture failed: {exception.Message}");
+        }
+    }
+
+    private static void WriteArtifact(string path, string contents)
+    {
+        try
+        {
+            File.WriteAllText(path, contents);
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine($"PROGRESS WATCHDOG: failed to write {path}: {exception.Message}");
+        }
+    }
+
+    private static string Sanitize(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(value.Length);
+        foreach (var character in value)
+            builder.Append(invalid.Contains(character) || char.IsWhiteSpace(character) ? '-' : char.ToLowerInvariant(character));
+        return builder.ToString();
+    }
+
+    private sealed record ActiveRun(
+        long RegistrationId,
+        ThroughputTracker Throughput,
+        string Client,
+        string Scenario,
+        Func<ProducerDeliveryDiagnosticsSnapshot?>? CaptureProducerDiagnostics,
+        StallDetector Detector);
+
+    private sealed class Registration(ProgressWatchdog owner, long registrationId) : IDisposable
+    {
+        private ProgressWatchdog? _owner = owner;
+
+        public void Dispose() => Interlocked.Exchange(ref _owner, null)?.StopTracking(registrationId);
+    }
+}

--- a/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
+++ b/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
@@ -69,20 +69,26 @@ internal sealed class StallDetector
 /// <summary>
 /// Watches active stress-scenario progress from a dedicated thread, independent of
 /// thread-pool health. A prolonged stall captures managed stacks and live producer
-/// diagnostics into the normal results directory. A five-minute stall captures a
-/// final snapshot, then terminates the process before the CI timeout loses evidence.
+/// diagnostics into a dedicated watchdog subdirectory. A five-minute stall captures
+/// a final snapshot, then terminates the process before the CI timeout loses evidence.
 /// </summary>
 internal sealed class ProgressWatchdog : IDisposable
 {
+    internal const string ArtifactsDirectoryName = "watchdog";
+
     internal static readonly TimeSpan DefaultCaptureAfter = TimeSpan.FromSeconds(30);
     internal static readonly TimeSpan DefaultExitAfter = TimeSpan.FromMinutes(5);
 
     private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan StackCaptureTimeout = TimeSpan.FromMinutes(1);
     private static readonly TimeSpan DefaultProducerDiagnosticsTimeout = TimeSpan.FromSeconds(5);
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
 
-    private readonly string _outputDirectory;
+    private readonly string _diagnosticsDirectory;
     private readonly TimeSpan _captureAfter;
     private readonly TimeSpan _exitAfter;
     private readonly TimeSpan _pollInterval;
@@ -109,7 +115,7 @@ internal sealed class ProgressWatchdog : IDisposable
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(outputDirectory);
 
-        _outputDirectory = Path.GetFullPath(outputDirectory);
+        _diagnosticsDirectory = Path.Combine(Path.GetFullPath(outputDirectory), ArtifactsDirectoryName);
         _captureAfter = captureAfter ?? DefaultCaptureAfter;
         _exitAfter = exitAfter ?? DefaultExitAfter;
         _pollInterval = pollInterval ?? DefaultPollInterval;
@@ -122,7 +128,7 @@ internal sealed class ProgressWatchdog : IDisposable
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_pollInterval, TimeSpan.Zero);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_producerDiagnosticsTimeout, TimeSpan.Zero);
 
-        Directory.CreateDirectory(_outputDirectory);
+        Directory.CreateDirectory(_diagnosticsDirectory);
         _thread = new Thread(Run)
         {
             IsBackground = true,
@@ -239,12 +245,12 @@ internal sealed class ProgressWatchdog : IDisposable
         var sequence = Interlocked.Increment(ref _captureSequence);
         var kind = action == StallAction.CaptureAndExit ? "fatal" : "stall";
         var prefix = Path.Combine(
-            _outputDirectory,
+            _diagnosticsDirectory,
             $"watchdog-{Sanitize(activeRun.Client)}-{Sanitize(activeRun.Scenario)}-{capturedAt:yyyyMMdd-HHmmss}-{sequence:D2}-{kind}");
 
         Console.Error.WriteLine(
             $"PROGRESS WATCHDOG: {activeRun.Client} {activeRun.Scenario} made no message progress " +
-            $"for {stalledFor.TotalSeconds:F0}s; capturing {kind} diagnostics in {_outputDirectory}");
+            $"for {stalledFor.TotalSeconds:F0}s; capturing {kind} diagnostics in {_diagnosticsDirectory}");
 
         // Capture stacks first because the producer snapshot can contend on the lock
         // responsible for the stall. Its bounded capture runs afterwards so the fatal

--- a/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
+++ b/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
@@ -79,6 +79,7 @@ internal sealed class ProgressWatchdog : IDisposable
 
     private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan StackCaptureTimeout = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan DefaultProducerDiagnosticsTimeout = TimeSpan.FromSeconds(5);
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     private readonly string _outputDirectory;
@@ -87,6 +88,7 @@ internal sealed class ProgressWatchdog : IDisposable
     private readonly TimeSpan _pollInterval;
     private readonly Action<int> _exitProcess;
     private readonly Func<string> _captureManagedStackReport;
+    private readonly TimeSpan _producerDiagnosticsTimeout;
     private readonly Stopwatch _clock = Stopwatch.StartNew();
     private readonly AutoResetEvent _wakeUp = new(initialState: false);
     private readonly object _sync = new();
@@ -102,7 +104,8 @@ internal sealed class ProgressWatchdog : IDisposable
         TimeSpan? exitAfter = null,
         TimeSpan? pollInterval = null,
         Action<int>? exitProcess = null,
-        Func<string>? captureManagedStackReport = null)
+        Func<string>? captureManagedStackReport = null,
+        TimeSpan? producerDiagnosticsTimeout = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(outputDirectory);
 
@@ -112,10 +115,12 @@ internal sealed class ProgressWatchdog : IDisposable
         _pollInterval = pollInterval ?? DefaultPollInterval;
         _exitProcess = exitProcess ?? Environment.Exit;
         _captureManagedStackReport = captureManagedStackReport ?? CaptureManagedStackReport;
+        _producerDiagnosticsTimeout = producerDiagnosticsTimeout ?? DefaultProducerDiagnosticsTimeout;
 
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_captureAfter, TimeSpan.Zero);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_exitAfter, _captureAfter);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_pollInterval, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_producerDiagnosticsTimeout, TimeSpan.Zero);
 
         Directory.CreateDirectory(_outputDirectory);
         _thread = new Thread(Run)
@@ -169,7 +174,7 @@ internal sealed class ProgressWatchdog : IDisposable
             _wakeUp.Set();
         }
 
-        if (_thread.Join(StackCaptureTimeout + TimeSpan.FromSeconds(5)))
+        if (_thread.Join(StackCaptureTimeout + _producerDiagnosticsTimeout + TimeSpan.FromSeconds(5)))
             _wakeUp.Dispose();
     }
 
@@ -241,15 +246,16 @@ internal sealed class ProgressWatchdog : IDisposable
             $"PROGRESS WATCHDOG: {activeRun.Client} {activeRun.Scenario} made no message progress " +
             $"for {stalledFor.TotalSeconds:F0}s; capturing {kind} diagnostics in {_outputDirectory}");
 
-        // Snapshot in-process state first: dotnet-stack may take up to a minute,
-        // during which the stall can resolve and erase the evidence we need.
-        CaptureProducerDiagnostics($"{prefix}-producer.json", activeRun, capturedAt, stalledFor);
+        // Capture stacks first because the producer snapshot can contend on the lock
+        // responsible for the stall. Its bounded capture runs afterwards so the fatal
+        // exit path remains reachable even when that lock never becomes available.
         CaptureManagedStacks(
             $"{prefix}-stacks.txt",
             activeRun,
             capturedAt,
             stalledFor,
             _captureManagedStackReport);
+        CaptureProducerDiagnostics($"{prefix}-producer.json", activeRun, capturedAt, stalledFor);
 
         if (action == StallAction.CaptureAndExit)
         {
@@ -324,7 +330,7 @@ internal sealed class ProgressWatchdog : IDisposable
         return body.ToString();
     }
 
-    private static void CaptureProducerDiagnostics(
+    private void CaptureProducerDiagnostics(
         string path,
         ActiveRun activeRun,
         DateTimeOffset capturedAt,
@@ -333,32 +339,65 @@ internal sealed class ProgressWatchdog : IDisposable
         if (activeRun.CaptureProducerDiagnostics is null)
             return;
 
-        try
+        ProducerDeliveryDiagnosticsSnapshot? snapshot = null;
+        Exception? captureException = null;
+        var captureThread = new Thread(() =>
         {
-            var snapshot = activeRun.CaptureProducerDiagnostics();
-            var artifact = new
+            try
             {
-                CapturedAtUtc = capturedAt,
-                activeRun.Client,
-                activeRun.Scenario,
-                MessageCount = activeRun.Throughput.MessageCount,
-                StalledFor = stalledFor,
-                ProducerDeliveryDiagnostics = snapshot
-            };
-            WriteArtifact(path, JsonSerializer.Serialize(artifact, JsonOptions));
-        }
-        catch (Exception exception)
+                snapshot = activeRun.CaptureProducerDiagnostics();
+            }
+            catch (Exception exception)
+            {
+                captureException = exception;
+            }
+        })
         {
-            WriteArtifact(path, JsonSerializer.Serialize(new
-            {
-                CapturedAtUtc = capturedAt,
-                activeRun.Client,
-                activeRun.Scenario,
-                Error = exception.ToString()
-            }, JsonOptions));
-            Console.Error.WriteLine($"PROGRESS WATCHDOG: producer diagnostics capture failed: {exception.Message}");
+            IsBackground = true,
+            Name = "Dekaf producer diagnostics capture"
+        };
+        captureThread.Start();
+
+        if (!captureThread.Join(_producerDiagnosticsTimeout))
+        {
+            var error = $"Producer diagnostics capture timed out after {_producerDiagnosticsTimeout}.";
+            WriteProducerDiagnosticsError(path, activeRun, capturedAt, error);
+            Console.Error.WriteLine($"PROGRESS WATCHDOG: {error}");
+            return;
         }
+
+        if (captureException is not null)
+        {
+            WriteProducerDiagnosticsError(path, activeRun, capturedAt, captureException.ToString());
+            Console.Error.WriteLine(
+                $"PROGRESS WATCHDOG: producer diagnostics capture failed: {captureException.Message}");
+            return;
+        }
+
+        var artifact = new
+        {
+            CapturedAtUtc = capturedAt,
+            activeRun.Client,
+            activeRun.Scenario,
+            MessageCount = activeRun.Throughput.MessageCount,
+            StalledFor = stalledFor,
+            ProducerDeliveryDiagnostics = snapshot
+        };
+        WriteArtifact(path, JsonSerializer.Serialize(artifact, JsonOptions));
     }
+
+    private static void WriteProducerDiagnosticsError(
+        string path,
+        ActiveRun activeRun,
+        DateTimeOffset capturedAt,
+        string error) =>
+        WriteArtifact(path, JsonSerializer.Serialize(new
+        {
+            CapturedAtUtc = capturedAt,
+            activeRun.Client,
+            activeRun.Scenario,
+            Error = error
+        }, JsonOptions));
 
     private static void WriteArtifact(string path, string contents)
     {

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -466,10 +466,10 @@ public static class Program
     {
         Console.WriteLine($"Generating report from: {options.InputPath}");
 
-        var jsonFiles = Directory.GetFiles(options.InputPath, "*.json");
+        var jsonFiles = Directory.GetFiles(options.InputPath, "stress-test-results*.json");
         if (jsonFiles.Length == 0)
         {
-            Console.WriteLine("No JSON result files found");
+            Console.WriteLine("No stress-test result JSON files found");
             return 1;
         }
 

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -1,4 +1,5 @@
 using Dekaf.Producer;
+using Dekaf.StressTests.Diagnostics;
 using Dekaf.StressTests.Infrastructure;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
@@ -19,7 +20,7 @@ namespace Dekaf.StressTests;
 ///   --client &lt;name&gt;         Run specific client: dekaf, confluent, all (default: all)
 ///   --output &lt;path&gt;         Output directory for results (default: ./results)
 ///   --brokers &lt;count&gt;      Number of Kafka brokers (default: 1, use 3 for multi-broker)
-///   --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message-loss failures
+///   --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message loss and watchdog stalls
 ///   report --input &lt;path&gt;   Generate report from existing results
 ///
 /// Environment Variables:
@@ -85,9 +86,14 @@ public static class Program
         Console.WriteLine($"Compression: {options.Compression}");
         Console.WriteLine($"Brokers: {options.Brokers}");
         Console.WriteLine($"Producer delivery diagnostics: {(options.EnableProducerDeliveryDiagnostics ? "enabled" : "disabled")}");
+        Console.WriteLine($"Progress watchdog: stacks at {ProgressWatchdog.DefaultCaptureAfter.TotalSeconds:F0}s; " +
+            $"fail at {ProgressWatchdog.DefaultExitAfter.TotalMinutes:F0} minutes");
         if (options.ConnectionsPerBroker > 1)
             Console.WriteLine($"Multi-connection: {options.ConnectionsPerBroker} connections per broker (Dekaf only)");
         Console.WriteLine(new string('-', 50));
+
+        Directory.CreateDirectory(options.OutputPath);
+        using var progressWatchdog = new ProgressWatchdog(options.OutputPath);
 
         await using var kafka = await KafkaEnvironment.CreateAsync(options.Brokers).ConfigureAwait(false);
 
@@ -126,7 +132,8 @@ public static class Program
             Compression = options.Compression,
             BrokerCount = options.Brokers,
             ConnectionsPerBroker = connectionsPerBroker,
-            EnableProducerDeliveryDiagnostics = options.EnableProducerDeliveryDiagnostics
+            EnableProducerDeliveryDiagnostics = options.EnableProducerDeliveryDiagnostics,
+            ProgressWatchdog = progressWatchdog
         };
 
         if (options.ConnectionsPerBroker == 1)
@@ -179,10 +186,6 @@ public static class Program
         };
 
         var outputDir = options.OutputPath;
-        if (!Directory.Exists(outputDir))
-        {
-            Directory.CreateDirectory(outputDir);
-        }
 
         // Broker/connection counts are part of the name so runs of the same
         // client+scenario (e.g. 1-broker vs 3-broker CI matrix jobs, which can start
@@ -587,7 +590,7 @@ public static class Program
               --brokers <count>      Number of Kafka brokers (default: 1, use 3 for multi-broker)
               --connections-per-broker <n>  TCP connections per broker (default: 1, pass 3 for multi-connection comparison)
               --seed-messages <count> Messages pre-seeded into the consumer topic (default: 2000000)
-              --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message-loss failures
+              --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message loss and watchdog stalls
               report --input <path>   Generate report from existing results
 
             Environment Variables:

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
@@ -64,6 +64,7 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
         var progress = new PeriodicProgressReporter(throughput);
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
@@ -59,6 +59,7 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
         var messageIndex = 0L;
         var progress = new PeriodicProgressReporter(throughput);
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncIdempotentStressTest.cs
@@ -58,6 +58,7 @@ internal sealed class ConfluentProducerAsyncIdempotentStressTest : IStressTestSc
         LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
         var messageIndex = 0L;
         var lastStatusTime = DateTime.UtcNow;
         var lastStatusMessageCount = 0L;

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncStressTest.cs
@@ -57,6 +57,7 @@ internal sealed class ConfluentProducerAsyncStressTest : IStressTestScenario
         LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
         var messageIndex = 0L;
         var lastStatusTime = DateTime.UtcNow;
         var lastStatusMessageCount = 0L;

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerIdempotentStressTest.cs
@@ -60,6 +60,7 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
         LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
         var messageIndex = 0L;
         var lastStatusTime = DateTime.UtcNow;
         var lastStatusMessageCount = 0L;

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerStressTest.cs
@@ -59,6 +59,7 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
         LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
         var messageIndex = 0L;
         var lastStatusTime = DateTime.UtcNow;
         var lastStatusMessageCount = 0L;

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -57,6 +57,7 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
         var progress = new PeriodicProgressReporter(throughput);
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -57,6 +57,7 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
         var progress = new PeriodicProgressReporter(throughput);
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -59,6 +59,7 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
         var progress = new PeriodicProgressReporter(throughput);
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -52,6 +52,7 @@ internal sealed class ConsumerStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
         var progress = new PeriodicProgressReporter(throughput);
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -1,3 +1,4 @@
+using Dekaf.StressTests.Diagnostics;
 using Dekaf.StressTests.Reporting;
 
 namespace Dekaf.StressTests.Scenarios;
@@ -22,4 +23,5 @@ internal sealed class StressTestOptions
     public int BrokerCount { get; init; } = 1;
     public int ConnectionsPerBroker { get; init; } = 1;
     public bool EnableProducerDeliveryDiagnostics { get; init; }
+    public required ProgressWatchdog ProgressWatchdog { get; init; }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -60,6 +60,11 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(
+            throughput,
+            Client,
+            Name,
+            () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options));
         var messageIndex = 0L;
         var progress = new PeriodicProgressReporter(throughput);
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
@@ -62,6 +62,11 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
         LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(
+            throughput,
+            Client,
+            Name,
+            () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options));
         var messageIndex = 0L;
         var lastStatusTime = DateTime.UtcNow;
         var lastStatusMessageCount = 0L;

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
@@ -62,6 +62,11 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
         LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(
+            throughput,
+            Client,
+            Name,
+            () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options));
         var messageIndex = 0L;
         var lastStatusTime = DateTime.UtcNow;
         var lastStatusMessageCount = 0L;

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -59,6 +59,11 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(
+            throughput,
+            Client,
+            Name,
+            () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options));
         var messageIndex = 0L;
         var progress = new PeriodicProgressReporter(throughput);
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -60,6 +60,11 @@ internal sealed class ProducerStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
+        using var watchdog = options.ProgressWatchdog.Track(
+            throughput,
+            Client,
+            Name,
+            () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options));
         var messageIndex = 0L;
         var progress = new PeriodicProgressReporter(throughput);
 


### PR DESCRIPTION
## Summary
- add a dedicated progress-watchdog thread for every stress scenario
- capture live producer delivery diagnostics and all managed thread stacks after 30 seconds without message progress
- capture again and exit non-zero after a five-minute stall, before the CI timeout loses evidence
- install `dotnet-stack` in stress CI and keep watchdog artifacts in the uploaded results directory

## Test plan
- [x] `dotnet build tools/Dekaf.StressTests/Dekaf.StressTests.csproj --configuration Release`
- [x] watchdog-focused net10 tests (7 tests, repeated 5 times)
- [x] full net10 unit suite (4,516 tests)
- [x] full net8 unit suite (4,503 tests)
- [x] parse `.github/workflows/stress-tests.yml`
- [x] verify `dotnet-stack report` against a live managed process

Closes #1606
