### PR TITLE
test(stress): fail hard on every silent-loss path; surface fire-and-forget delivery errors

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -224,6 +224,8 @@ jobs:
           fi
           echo "Client order: ${STRESS_CLIENT_ORDER}"
 
+          # Delivery diagnostics are always on in CI so a message-loss failure ships the
+          # in-flight batch dump needed to debug it, instead of "Not captured".
           taskset -c ${CLIENT_CPUS} dotnet run --configuration Release --no-build -- \
             --duration ${{ github.event.inputs.duration_minutes || '15' }} \
             --message-size ${{ github.event.inputs.message_size || '1000' }} \
@@ -231,6 +233,7 @@ jobs:
             --client ${{ matrix.client }} \
             --brokers ${{ matrix.brokers }} \
             --connections-per-broker 1 \
+            --producer-delivery-diagnostics \
             --output ./results
 
           if [ "${{ matrix.run_3conn }}" = "true" ]; then
@@ -242,6 +245,7 @@ jobs:
               --client dekaf \
               --brokers ${{ matrix.brokers }} \
               --connections-per-broker 3 \
+              --producer-delivery-diagnostics \
               --output ./results
           fi
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5517,7 +5517,8 @@ internal sealed class PartitionBatch
                 _arena,
                 _callbacks,
                 _callbackCount,
-                _arrayReuseQueue);
+                _arrayReuseQueue,
+                _recordCount);
 
             _completedBatch = readyBatch;
 
@@ -5747,6 +5748,10 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     private PooledValueTaskSource<RecordMetadata>[]? _completionSourcesArray;
     private int _completionSourcesCount;
 
+    // Total records sealed into this batch, captured at Initialize because the
+    // RecordBatch's record list may already be recycled when Fail needs the count.
+    private int _recordCount;
+
     // Reuse queue for returning working arrays back to PartitionBatch without ArrayPool round-trip
     private BatchArrayReuseQueue? _arrayReuseQueue;
     private BatchArena? _arena; // Arena holding the batch's encoded record bytes
@@ -5837,7 +5842,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
             {
                 Topic = _topicPartition.Topic ?? string.Empty,
                 Partition = _topicPartition.Partition,
-                RecordCount = recordBatch?.Records.Count ?? _completionSourcesCount,
+                RecordCount = _recordCount > 0 ? _recordCount : _completionSourcesCount,
                 DataSize = DataSize,
                 EncodedSize = EncodedSize,
                 ReadyBatchId = RuntimeHelpers.GetHashCode(this),
@@ -6148,7 +6153,8 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         BatchArena? arena = null,
         Action<RecordMetadata, Exception?>?[]? callbacks = null,
         int callbackCount = 0,
-        BatchArrayReuseQueue? arrayReuseQueue = null)
+        BatchArrayReuseQueue? arrayReuseQueue = null,
+        int recordCount = 0)
     {
         // The generation increment must happen BEFORE the lifecycle flags are cleared.
         // Stale-reference holders validate liveness by reading _returnedToPool first and
@@ -6179,6 +6185,9 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         _recordBatch = recordBatch;
         _completionSourcesArray = completionSourcesArray;
         _completionSourcesCount = completionSourcesCount;
+        // Captured at seal time because the RecordBatch's record list may be recycled or
+        // never materialized by the time a (possibly stale) Fail needs the count.
+        _recordCount = recordCount;
         DataSize = dataSize;
         EncodedSize = dataSize;
         _arena = arena;
@@ -6390,6 +6399,19 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         try
         {
             ProducerDebugCounters.RecordBatchFailed();
+
+            // Records without a completion source (fire-and-forget and callback appends) have
+            // no awaiter that will observe this failure, so count them here — otherwise
+            // messaging.client.sent.errors never reflects fire-and-forget delivery failures.
+            // ProduceAsync records are excluded: each awaiter increments the counter itself.
+            var unobservedRecords = _recordCount - _completionSourcesCount;
+            if (Diagnostics.DekafMetrics.ProduceErrors.Enabled && unobservedRecords > 0)
+            {
+                Diagnostics.DekafMetrics.ProduceErrors.Add(unobservedRecords, new TagList
+                {
+                    { Diagnostics.DekafDiagnostics.MessagingDestinationName, _topicPartition.Topic }
+                });
+            }
 
             // Fail per-message completion sources - these throw for ProduceAsync callers
             if (_completionSourcesCount > 0 && _completionSourcesArray is not null)

--- a/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Shared reflection helpers for tests that drive RecordAccumulator internals.
+/// RecordAccumulatorTests and KafkaProducerFastPathTests carry older private copies of
+/// the same batch-sealing dance; new tests should use this instead of adding a fourth.
+/// </summary>
+internal static class AccumulatorTestHelpers
+{
+    /// <summary>
+    /// Seals the partition's current batch via reflection and returns the ReadyBatch.
+    /// </summary>
+    public static ReadyBatch CompleteCurrentBatch(RecordAccumulator accumulator, string topic, int partition = 0)
+    {
+        var topicPartition = new TopicPartition(topic, partition);
+
+        var dequesField = typeof(RecordAccumulator).GetField("_partitionDeques",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        var deques = dequesField!.GetValue(accumulator)!;
+
+        var tryGetValueMethod = deques.GetType().GetMethod("TryGetValue");
+        var parameters = new object[] { topicPartition, null! };
+        tryGetValueMethod!.Invoke(deques, parameters);
+        var partitionDeque = parameters[1]
+            ?? throw new InvalidOperationException($"No partition deque exists for {topicPartition}; append a record first.");
+        var currentBatchField = partitionDeque.GetType().GetField("CurrentBatch");
+        var partitionBatch = currentBatchField!.GetValue(partitionDeque)
+            ?? throw new InvalidOperationException($"Partition deque for {topicPartition} has no current batch.");
+
+        var completeMethod = partitionBatch.GetType().GetMethod("Complete");
+        return (ReadyBatch)completeMethod!.Invoke(partitionBatch, null)!;
+    }
+
+    /// <summary>
+    /// Extracts a tag value from a metric measurement's tag span by key.
+    /// </summary>
+    public static string? GetTag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string key)
+    {
+        foreach (var tag in tags)
+        {
+            if (tag.Key == key)
+                return tag.Value?.ToString();
+        }
+
+        return null;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/FireAndForgetDeliveryErrorMetricTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/FireAndForgetDeliveryErrorMetricTests.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics.Metrics;
+using Dekaf.Diagnostics;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Fire-and-forget records have no completion source, so a failed batch used to vanish
+/// without any signal: no exception, no callback, and no metric. These tests pin the fix —
+/// ReadyBatch.Fail must count records without completion sources on
+/// messaging.client.sent.errors so fire-and-forget delivery failures are observable.
+/// </summary>
+public sealed class FireAndForgetDeliveryErrorMetricTests
+{
+    [Test]
+    [NotInParallel("MeterListener")]
+    public async Task Fail_FireAndForgetRecords_CountsProduceErrors()
+    {
+        var topic = $"fnf-errors-{Guid.NewGuid():N}";
+        long produceErrors = 0;
+
+        using var listener = CreateProduceErrorListener(topic, v => produceErrors += v);
+
+        var options = CreateTestOptions();
+        var accumulator = new RecordAccumulator(options);
+
+        try
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                await AppendFireAndForgetAsync(accumulator, topic);
+            }
+
+            var readyBatch = AccumulatorTestHelpers.CompleteCurrentBatch(accumulator, topic);
+            readyBatch.Fail(new InvalidOperationException("Simulated delivery failure"));
+
+            await Assert.That(produceErrors).IsEqualTo(3);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [NotInParallel("MeterListener")]
+    public async Task Fail_MixedBatch_CountsOnlyRecordsWithoutCompletionSources()
+    {
+        var topic = $"fnf-errors-{Guid.NewGuid():N}";
+        long produceErrors = 0;
+
+        using var listener = CreateProduceErrorListener(topic, v => produceErrors += v);
+
+        var options = CreateTestOptions();
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            // Two awaited records (completion sources observe the failure themselves and
+            // the ProduceAsync awaiter increments the metric) plus one fire-and-forget
+            // record that only ReadyBatch.Fail can account for.
+            var completions = new[] { pool.Rent(), pool.Rent() };
+            foreach (var completion in completions)
+            {
+                var appended = accumulator.TryAppendWithCompletion(
+                    topic,
+                    partition: 0,
+                    DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    new PooledMemory(null, 0, isNull: true),
+                    new PooledMemory(null, 0, isNull: true),
+                    null,
+                    0,
+                    completion);
+                await Assert.That(appended).IsTrue();
+            }
+
+            await AppendFireAndForgetAsync(accumulator, topic);
+
+            var readyBatch = AccumulatorTestHelpers.CompleteCurrentBatch(accumulator, topic);
+            readyBatch.Fail(new InvalidOperationException("Simulated delivery failure"));
+
+            await Assert.That(produceErrors).IsEqualTo(1);
+
+            // Observe the completion source exceptions so they don't surface elsewhere.
+            foreach (var completion in completions)
+            {
+                await Assert.That(async () => await completion.Task).Throws<InvalidOperationException>();
+            }
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    private static ProducerOptions CreateTestOptions() => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        ClientId = "fnf-delivery-error-metric-test",
+        LingerMs = 60_000
+    };
+
+    private static MeterListener CreateProduceErrorListener(
+        string topic,
+        Action<long> record)
+    {
+        // Resolved before the listener starts: touching DekafMetrics inside the
+        // InstrumentPublished callback can re-enter its static initializer and
+        // poison the type for the whole test process.
+        var produceErrorsName = DekafMetrics.ProduceErrors.Name;
+
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, meterListener) =>
+            {
+                if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
+                    instrument.Name == produceErrorsName)
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+        {
+            if (AccumulatorTestHelpers.GetTag(tags, DekafDiagnostics.MessagingDestinationName) == topic)
+            {
+                record(measurement);
+            }
+        });
+
+        listener.Start();
+        return listener;
+    }
+
+    private static async Task AppendFireAndForgetAsync(RecordAccumulator accumulator, string topic)
+    {
+        var appended = await accumulator.AppendAsync(
+            topic,
+            partition: 0,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            new PooledMemory(null, 0, isNull: true),
+            new PooledMemory(null, 0, isNull: true),
+            null,
+            0,
+            completionSource: null,
+            callback: null,
+            CancellationToken.None);
+        await Assert.That(appended).IsTrue();
+    }
+}

--- a/tools/Dekaf.StressTests/Metrics/DekafDeliveryErrorListener.cs
+++ b/tools/Dekaf.StressTests/Metrics/DekafDeliveryErrorListener.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics.Metrics;
+using Dekaf.Diagnostics;
+
+namespace Dekaf.StressTests.Metrics;
+
+/// <summary>
+/// Counts Dekaf delivery failures into a <see cref="ThroughputTracker"/> by listening to
+/// the producer's <c>messaging.client.sent.errors</c> metric. Fire-and-forget appends have
+/// no awaiter or callback, so this metric is the only signal that an accepted message was
+/// never delivered — without it a produce run can lose messages with a zero error count.
+/// Cost: free on the FireAsync hot path (failures are counted once per failed batch), but
+/// enabling the instrument routes awaited ProduceAsync calls through the producer's
+/// metrics-emitting await path — cheap next to the broker round-trip they already await,
+/// and in the fire-and-forget scenarios only the 1-in-1000 sampled sends take that path.
+/// </summary>
+internal sealed class DekafDeliveryErrorListener : IDisposable
+{
+    private readonly MeterListener _listener;
+
+    public DekafDeliveryErrorListener(ThroughputTracker throughput)
+    {
+        // Resolved before the listener starts: touching DekafMetrics inside the
+        // InstrumentPublished callback can re-enter its static initializer (the callback
+        // fires while the instruments are being constructed) and poison the type.
+        var produceErrorsName = DekafMetrics.ProduceErrors.Name;
+
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
+                    instrument.Name == produceErrorsName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        _listener.SetMeasurementEventCallback<long>(
+            (_, measurement, _, _) => throughput.RecordDeliveryErrors(measurement));
+        _listener.Start();
+    }
+
+    public void Dispose() => _listener.Dispose();
+}

--- a/tools/Dekaf.StressTests/Metrics/ThroughputTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/ThroughputTracker.cs
@@ -13,11 +13,15 @@ internal sealed class ThroughputTracker
     private long _messageCount;
     private long _byteCount;
     private long _errorCount;
+    private long _deliveryErrorCount;
     private readonly Stopwatch _stopwatch = new();
     private readonly List<double> _messagesPerSecondSamples = [];
     private readonly object _samplesLock = new();
     private readonly List<ThroughputErrorSample> _errorSamples = [];
     private readonly object _errorsLock = new();
+    // Lock-free fast path once the sample list is full, so error storms don't contend
+    // the produce loop just to discard samples.
+    private volatile bool _errorSamplesFull;
     private long _lastSampleMessageCount;
     private DateTime _lastSampleTime;
     private TimeSpan _cpuTimeStart;
@@ -26,6 +30,7 @@ internal sealed class ThroughputTracker
     public long MessageCount => Interlocked.Read(ref _messageCount);
     public long ByteCount => Interlocked.Read(ref _byteCount);
     public long ErrorCount => Interlocked.Read(ref _errorCount);
+    public long DeliveryErrorCount => Interlocked.Read(ref _deliveryErrorCount);
     public TimeSpan Elapsed => _stopwatch.Elapsed;
 
     /// <summary>
@@ -68,17 +73,41 @@ internal sealed class ThroughputTracker
 
     public void RecordError(Exception exception, string? operation = null, long? messageIndex = null)
     {
-        RecordErrorCore(
-            exception.GetType().FullName ?? exception.GetType().Name,
-            exception.Message,
-            exception.ToString(),
-            operation,
-            messageIndex);
+        AddErrorSample(Interlocked.Increment(ref _errorCount), exception, operation, messageIndex);
     }
 
     public void RecordError(string errorType, string? message, string? operation = null, long? messageIndex = null)
     {
         RecordErrorCore(errorType, message, details: null, operation, messageIndex);
+    }
+
+    /// <summary>
+    /// Records broker-side delivery failures of messages this client had already accepted
+    /// (i.e. counted in <see cref="MessageCount"/>). Kept separate from <see cref="RecordError"/>:
+    /// loop errors happen before a message is accepted, delivery errors after — the distinction
+    /// is what lets undelivered loss be computed as accepted - delivered - deliveryErrors.
+    /// Count-only overload for metric listeners that observe failures in bulk (per batch).
+    /// </summary>
+    public void RecordDeliveryErrors(long count)
+    {
+        Interlocked.Add(ref _deliveryErrorCount, count);
+    }
+
+    /// <summary>
+    /// Records a single delivery failure with exception detail for the failure report.
+    /// </summary>
+    public void RecordDeliveryError(string errorType, string? message, string? operation = null, long? messageIndex = null)
+    {
+        AddErrorSample(Interlocked.Increment(ref _deliveryErrorCount), errorType, message, details: null, operation, messageIndex);
+    }
+
+    /// <summary>
+    /// Records exception detail for a delivery failure whose count is already tracked
+    /// elsewhere (e.g. via the producer's error metric), without double-counting.
+    /// </summary>
+    public void RecordDeliveryErrorDetail(Exception exception, string? operation = null, long? messageIndex = null)
+    {
+        AddErrorSample(DeliveryErrorCount, exception, operation, messageIndex);
     }
 
     private void RecordErrorCore(
@@ -89,6 +118,40 @@ internal sealed class ThroughputTracker
         long? messageIndex)
     {
         var errorNumber = Interlocked.Increment(ref _errorCount);
+        AddErrorSample(errorNumber, errorType, message, details, operation, messageIndex);
+    }
+
+    private void AddErrorSample(long errorNumber, Exception exception, string? operation, long? messageIndex)
+    {
+        // Checked before formatting: rendering a stack trace per message during an
+        // error storm would contend the produce loop for nothing once samples are full.
+        if (_errorSamplesFull)
+        {
+            return;
+        }
+
+        AddErrorSample(
+            errorNumber,
+            exception.GetType().FullName ?? exception.GetType().Name,
+            exception.Message,
+            exception.ToString(),
+            operation,
+            messageIndex);
+    }
+
+    private void AddErrorSample(
+        long errorNumber,
+        string? errorType,
+        string? message,
+        string? details,
+        string? operation,
+        long? messageIndex)
+    {
+        if (_errorSamplesFull)
+        {
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(errorType) && string.IsNullOrWhiteSpace(message) && string.IsNullOrWhiteSpace(details))
         {
             return;
@@ -98,6 +161,7 @@ internal sealed class ThroughputTracker
         {
             if (_errorSamples.Count >= MaxErrorSamples)
             {
+                _errorSamplesFull = true;
                 return;
             }
 
@@ -181,6 +245,7 @@ internal sealed class ThroughputTracker
             TotalMessages = MessageCount,
             TotalBytes = ByteCount,
             TotalErrors = ErrorCount,
+            TotalDeliveryErrors = DeliveryErrorCount,
             ElapsedSeconds = _stopwatch.Elapsed.TotalSeconds,
             AverageMessagesPerSecond = GetAverageMessagesPerSecond(),
             AverageMegabytesPerSecond = GetAverageMegabytesPerSecond(),
@@ -195,6 +260,13 @@ internal sealed class ThroughputSnapshot
     public required long TotalMessages { get; init; }
     public required long TotalBytes { get; init; }
     public required long TotalErrors { get; init; }
+
+    /// <summary>
+    /// Broker-side delivery failures of accepted messages. Absent from older result
+    /// files, so it defaults to zero on deserialization.
+    /// </summary>
+    public long TotalDeliveryErrors { get; init; }
+
     public required double ElapsedSeconds { get; init; }
     public required double AverageMessagesPerSecond { get; init; }
     public required double AverageMegabytesPerSecond { get; init; }

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Dekaf.Producer;
 using Dekaf.StressTests.Infrastructure;
 using Dekaf.StressTests.Metrics;
@@ -32,11 +33,21 @@ namespace Dekaf.StressTests;
 /// </summary>
 public static class Program
 {
+    private static readonly ConcurrentQueue<Exception> UnobservedTaskExceptions = new();
+
     public static async Task<int> Main(string[] args)
     {
         AppDomain.CurrentDomain.UnhandledException += (_, e) =>
         {
             Console.WriteLine($"UNHANDLED EXCEPTION: {e.ExceptionObject}");
+        };
+
+        // A task exception nobody awaited means a background failure escaped every
+        // error path — collected here and escalated to a run failure at the end.
+        TaskScheduler.UnobservedTaskException += (_, e) =>
+        {
+            UnobservedTaskExceptions.Enqueue(e.Exception);
+            e.SetObserved();
         };
 
         Console.CancelKeyPress += (_, e) =>
@@ -206,75 +217,161 @@ public static class Program
         Console.WriteLine();
         Console.WriteLine(MarkdownReporter.Generate(allResults));
 
-        return CheckForMessageLoss(results) ? 1 : 0;
+        return CheckForFailures(results) ? 1 : 0;
     }
 
     /// <summary>
-    /// The stress environment (healthy broker, tmpfs logs, no restarts) never justifies
-    /// a dropped message, so any produce/consume error fails the run. Delivered can
-    /// legitimately exceed accepted-minus-errors when non-idempotent retries duplicate a
-    /// batch, so only the shortfall counts as loss. Leader-ack producer scenarios do not
-    /// treat high-watermark lag as loss because followers can trail successful leader
-    /// acknowledgements. Results are already saved at this point; the non-zero exit only
-    /// fails the CI job.
+    /// Maximum consecutive seconds with zero client progress before the run is failed as
+    /// stalled. A healthy broker never starves a producer or consumer for 30 straight
+    /// seconds; a stall that long is a hang that happened to recover. Converted to a
+    /// sample count via <see cref="StressTestHelpers.SamplerIntervalSeconds"/>.
     /// </summary>
-    private static bool CheckForMessageLoss(List<StressTestResult> results)
+    private const int StallThresholdSeconds = 30;
+
+    private const int StallThresholdSamples = StallThresholdSeconds / StressTestHelpers.SamplerIntervalSeconds;
+
+    /// <summary>
+    /// The stress environment (healthy broker, tmpfs logs, no restarts) never justifies a
+    /// dropped message, an error, a stall, or a hung shutdown, so all of them fail the run:
+    /// - Any loop error (append/consume failures) or delivery error (broker-side failure of
+    ///   an accepted message, observed via the producer error metric or delivery reports).
+    /// - Undelivered shortfall: accepted minus broker-confirmed delivered minus delivery
+    ///   errors. The post-run drain wait already absorbs follower high-watermark lag, so
+    ///   every producer scenario treats a remaining shortfall as loss — no exemptions.
+    /// - Duplicate delivery in idempotent scenarios (delivered exceeding accepted), which
+    ///   means broker-side deduplication of retries is broken. Non-idempotent scenarios
+    ///   skip this check because retry duplicates are legitimate there.
+    /// - A run that ended measurably earlier than its configured duration (a swallowed
+    ///   cancellation or crashed loop would otherwise pass with a fraction of the load).
+    /// - A sustained mid-run stall (see <see cref="StallThresholdSeconds"/>).
+    /// - Task exceptions nobody observed, surfaced after a final finalizer sweep.
+    /// Results are already saved at this point; the non-zero exit only fails the CI job.
+    /// </summary>
+    private static bool CheckForFailures(List<StressTestResult> results)
     {
-        var failures = new List<(StressTestResult Result, long Errors, long? Delivered, long Lost)>();
+        var anyFailure = false;
+
+        void MarkFailure()
+        {
+            if (!anyFailure)
+            {
+                Console.WriteLine();
+                Console.WriteLine("CORRECTNESS FAILURES DETECTED - failing the run:");
+                anyFailure = true;
+            }
+        }
 
         foreach (var result in results)
         {
+            var reasons = new List<string>();
             var errors = result.Throughput.TotalErrors;
+            var deliveryErrors = result.Throughput.TotalDeliveryErrors;
+            var accepted = result.Throughput.TotalMessages;
             var lost = 0L;
+
+            if (errors > 0)
+            {
+                reasons.Add($"{errors:N0} errors");
+            }
+
+            if (deliveryErrors > 0)
+            {
+                reasons.Add($"{deliveryErrors:N0} delivery errors");
+            }
 
             if (result.DeliveredMessages is { } delivered)
             {
-                lost = Math.Max(0, result.Throughput.TotalMessages - delivered - errors);
+                lost = Math.Max(0, accepted - delivered - deliveryErrors);
+                if (lost > 0)
+                {
+                    reasons.Add($"{lost:N0} undelivered messages");
+                }
+
+                // Idempotent producers rely on broker-side retry deduplication, so any
+                // overage means that guarantee is broken.
+                if (result.Idempotent && delivered > accepted)
+                {
+                    reasons.Add($"{delivered - accepted:N0} duplicate deliveries (idempotence violated)");
+                }
             }
 
-            if (errors > 0 || (lost > 0 && result.FailOnDeliveredShortfall))
+            var expectedSeconds = result.DurationMinutes * 60;
+            if (result.Throughput.ElapsedSeconds < expectedSeconds * 0.9)
             {
-                failures.Add((result, errors, result.DeliveredMessages, lost));
+                reasons.Add(
+                    $"run ended early ({result.Throughput.ElapsedSeconds:N0}s of {expectedSeconds:N0}s)");
             }
-        }
 
-        if (failures.Count == 0)
-        {
-            return false;
-        }
+            var maxStall = MaxConsecutiveZeroSamples(result.Throughput.MessagesPerSecondSamples);
+            if (maxStall >= StallThresholdSamples)
+            {
+                reasons.Add($"stalled for {maxStall * StressTestHelpers.SamplerIntervalSeconds:N0} consecutive seconds with zero progress");
+            }
 
-        Console.WriteLine();
-        Console.WriteLine("MESSAGE LOSS DETECTED - failing the run:");
-        foreach (var failure in failures)
-        {
-            var result = failure.Result;
-            var delivered = failure.Delivered is { } deliveredMessages
-                ? deliveredMessages.ToString("N0")
-                : "unknown";
+            if (reasons.Count == 0)
+            {
+                continue;
+            }
 
+            MarkFailure();
+
+            var deliveredText = result.DeliveredMessages is { } d ? d.ToString("N0") : "n/a";
             Console.WriteLine(
-                $"  {result.Client} {result.Scenario}: " +
-                $"accepted={result.Throughput.TotalMessages:N0}, " +
-                $"delivered={delivered}, " +
-                $"errors={failure.Errors:N0}, " +
-                $"undelivered={failure.Lost:N0}");
+                $"  {result.Client} {result.Scenario}: {string.Join("; ", reasons)} " +
+                $"[accepted={accepted:N0}, delivered={deliveredText}, " +
+                $"errors={errors:N0}, deliveryErrors={deliveryErrors:N0}]");
 
             if (result.Throughput.ErrorSamples.Count > 0)
             {
                 PrintErrorSamples(result.Throughput.ErrorSamples);
             }
-            else if (failure.Errors > 0)
+            else if (errors > 0 || deliveryErrors > 0)
             {
                 Console.WriteLine("    No exception samples captured for these errors.");
             }
 
-            if (failure.Lost > 0)
+            if (lost > 0)
             {
                 PrintProducerDeliveryDiagnostics(result.ProducerDeliveryDiagnostics);
             }
         }
 
-        return true;
+        // Drain finalizers so exceptions from abandoned tasks surface before the verdict.
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        if (!UnobservedTaskExceptions.IsEmpty)
+        {
+            MarkFailure();
+
+            Console.WriteLine($"  {UnobservedTaskExceptions.Count:N0} unobserved task exception(s):");
+            var printed = 0;
+            foreach (var exception in UnobservedTaskExceptions)
+            {
+                Console.WriteLine($"    - {exception}");
+                if (++printed >= 5)
+                {
+                    Console.WriteLine("    (further exceptions omitted)");
+                    break;
+                }
+            }
+        }
+
+        return anyFailure;
+    }
+
+    private static int MaxConsecutiveZeroSamples(List<double> samples)
+    {
+        var max = 0;
+        var current = 0;
+        foreach (var sample in samples)
+        {
+            current = sample <= 0 ? current + 1 : 0;
+            max = Math.Max(max, current);
+        }
+
+        return max;
     }
 
     private static void PrintProducerDeliveryDiagnostics(ProducerDeliveryDiagnosticsSnapshot? snapshot)

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -101,7 +101,14 @@ internal static class MarkdownReporter
                 var accepted = result.AcceptedMessagesPerSecond is { } acceptedRate ? acceptedRate.ToString("N0") : "-";
                 var cpuPerMessage = result.CpuMicrosPerMessage is { } cpu ? $"{cpu:F2}" : "-";
                 var coresUsed = result.AverageCoresUsed is { } cores ? $"{cores:F2}" : "-";
-                sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {cpuPerMessage,10} | {rate,12:N0} | {median,12} | {result.EffectiveMegabytesPerSecond,6:F2} | {accepted,14} | {result.Throughput.TotalErrors,6} | {coresUsed,10} | {ratio:F2}x |");
+                // Errors column includes broker-side delivery failures so a run that lost
+                // accepted messages can never render a clean zero; the "dlv" suffix keeps
+                // "client loop broke" distinguishable from "broker rejected accepted messages".
+                var deliveryErrors = result.Throughput.TotalDeliveryErrors;
+                var errors = deliveryErrors > 0
+                    ? $"{result.Throughput.TotalErrors} (+{deliveryErrors} dlv)"
+                    : result.Throughput.TotalErrors.ToString()!;
+                sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {cpuPerMessage,10} | {rate,12:N0} | {median,12} | {result.EffectiveMegabytesPerSecond,6:F2} | {accepted,14} | {errors,6} | {coresUsed,10} | {ratio:F2}x |");
             }
 
             sb.AppendLine();
@@ -118,15 +125,9 @@ internal static class MarkdownReporter
             {
                 sb.AppendLine("*Messages/sec counts broker-confirmed deliveries (end-offset delta). " +
                     "Accepted msg/s is the client-side append rate — a large gap means messages were " +
-                    "buffered or dropped without ever reaching the broker.*");
+                    "buffered or dropped without ever reaching the broker. Every producer run fails " +
+                    "on an unexplained shortfall between accepted and delivered.*");
                 sb.AppendLine();
-
-                if (sizeResults.Any(r => !r.FailOnDeliveredShortfall))
-                {
-                    sb.AppendLine("*Leader-ack producer runs report end-offset lag but do not fail on that " +
-                        "shortfall; acks-all/idempotent runs enforce it as a correctness failure.*");
-                    sb.AppendLine();
-                }
             }
         }
     }

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -18,7 +18,15 @@ internal sealed class StressTestResult
     public required GcSnapshot GcStats { get; init; }
     public int BrokerCount { get; init; } = 1;
     public ProducerDeliveryDiagnosticsSnapshot? ProducerDeliveryDiagnostics { get; init; }
-    public bool FailOnDeliveredShortfall { get; init; } = true;
+
+    /// <summary>
+    /// Whether the scenario's producer ran with idempotence enabled. Must mirror the
+    /// producer configuration a few lines above where each scenario sets it. The failure
+    /// policy in Program.CheckForFailures derives duplicate-delivery enforcement from
+    /// this fact: idempotent runs fail when delivered exceeds accepted (broker-side
+    /// retry deduplication broken); non-idempotent runs tolerate retry duplicates.
+    /// </summary>
+    public bool Idempotent { get; init; }
 
     /// <summary>
     /// Broker-confirmed message count, measured as the end-offset (high watermark)
@@ -26,10 +34,10 @@ internal sealed class StressTestResult
     /// scenarios count client-side appends in <see cref="Throughput"/>; when the client
     /// buffers faster than the broker accepts (or the broker degrades mid-run), accepted
     /// and delivered diverge — this is the honest throughput number.
-    /// Leader-ack producer scenarios can report a shortfall while followers are still
-    /// advancing the high watermark; they set <see cref="FailOnDeliveredShortfall"/> to
-    /// false so this remains a visibility metric instead of a correctness failure.
-    /// Null when the scenario doesn't measure it or the watermark query failed.
+    /// Every producer scenario fails the run when delivered falls short of accepted
+    /// minus recorded delivery errors: the post-run drain wait already absorbs follower
+    /// high-watermark lag, so a remaining shortfall is message loss.
+    /// Null when the scenario doesn't measure it (consumers).
     /// </summary>
     public long? DeliveredMessages { get; init; }
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
@@ -98,9 +98,14 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
         {
-            // Expected
+            // Expected — duration timer expired
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"  Consumer error: {ex}");
+            throughput.RecordError(ex, "Confluent consume loop");
         }
 
         throughput.Stop();

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
@@ -37,14 +37,11 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
 
         using var producer = new ConfluentKafka.ProducerBuilder<string, string>(config).Build();
 
-        Console.WriteLine($"  Warming up Confluent acks-all producer...");
-        for (var i = 0; i < 1000; i++)
-        {
-            producer.Produce(options.Topic, new ConfluentKafka.Message<string, string> { Key = "warmup", Value = "warmup" });
-        }
-        producer.Flush(TimeSpan.FromSeconds(30));
-
-        var startOffset = ConfluentStressTestHelpers.QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
+        var startOffset = await ConfluentStressTestHelpers.WarmUpProducerAndQueryStartOffsetAsync(
+            producer,
+            options,
+            "Confluent acks-all producer",
+            throughput);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -93,7 +90,7 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
                     progress.RecordMessage();
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
             {
                 break;
             }
@@ -103,15 +100,21 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
             }
         }
 
-        producer.Flush(TimeSpan.FromSeconds(30));
+        ConfluentStressTestHelpers.FlushWithTimeout(producer, throughput);
         throughput.Stop();
         gcStats.Capture();
 
         // Queried after the final flush — and outside the measurement window, so a slow
         // query against a degraded broker can't skew elapsed/CPU stats — so the delta
         // reflects what the broker actually accepted rather than what librdkafka's local
-        // queue absorbed.
-        var endOffset = ConfluentStressTestHelpers.QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
+        // queue absorbed. The drain wait absorbs follower high-watermark lag before the
+        // always-fatal shortfall check.
+        var endOffset = await ConfluentStressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync(
+            options,
+            startOffset,
+            throughput.MessageCount,
+            throughput,
+            "Post-run drain");
 
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncIdempotentStressTest.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 using ConfluentKafka = Confluent.Kafka;
@@ -8,8 +7,6 @@ namespace Dekaf.StressTests.Scenarios;
 
 internal sealed class ConfluentProducerAsyncIdempotentStressTest : IStressTestScenario
 {
-    private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
-
     public string Name => "producer-async-idempotent";
     public string Client => "Confluent";
 
@@ -39,11 +36,14 @@ internal sealed class ConfluentProducerAsyncIdempotentStressTest : IStressTestSc
 
         using var producer = new ConfluentKafka.ProducerBuilder<string, string>(config).Build();
 
-        Console.WriteLine($"  Warming up Confluent async idempotent producer...");
-        for (var i = 0; i < 1000; i++)
-        {
-            await producer.ProduceAsync(options.Topic, new ConfluentKafka.Message<string, string> { Key = "warmup", Value = "warmup" }, cancellationToken).ConfigureAwait(false);
-        }
+        // Even though every ProduceAsync is awaited, the broker-confirmed end-offset
+        // delta is still verified: a client bug that completes the delivery task
+        // without the broker persisting the message would otherwise be invisible.
+        var startOffset = await ConfluentStressTestHelpers.WarmUpProducerAndQueryStartOffsetAsync(
+            producer,
+            options,
+            "Confluent async idempotent producer",
+            throughput);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -55,15 +55,15 @@ internal sealed class ConfluentProducerAsyncIdempotentStressTest : IStressTestSc
 
         Console.WriteLine($"  Running Confluent async idempotent producer stress test for {options.DurationMinutes} minutes...");
         Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
-        LogResourceUsage("Initial");
+        StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
         var messageIndex = 0L;
         var lastStatusTime = DateTime.UtcNow;
         var lastStatusMessageCount = 0L;
 
-        var samplerTask = RunSamplerAsync(throughput, cts.Token);
-        var resourceMonitorTask = RunResourceMonitorAsync(cts.Token);
+        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
+        var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
 
         while (!cts.Token.IsCancellationRequested)
         {
@@ -72,7 +72,7 @@ internal sealed class ConfluentProducerAsyncIdempotentStressTest : IStressTestSc
                 var start = Stopwatch.GetTimestamp();
                 await producer.ProduceAsync(options.Topic, new ConfluentKafka.Message<string, string>
                 {
-                    Key = GetKey(messageIndex),
+                    Key = StressTestHelpers.GetKey(messageIndex),
                     Value = messageValue
                 }, cts.Token).ConfigureAwait(false);
                 latency.RecordTicks(Stopwatch.GetTimestamp() - start);
@@ -94,7 +94,7 @@ internal sealed class ConfluentProducerAsyncIdempotentStressTest : IStressTestSc
                     }
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
             {
                 break;
             }
@@ -112,7 +112,17 @@ internal sealed class ConfluentProducerAsyncIdempotentStressTest : IStressTestSc
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
-        LogResourceUsage("Final");
+        StressTestHelpers.LogResourceUsage("Final");
+
+        // The drain wait absorbs follower high-watermark lag before the always-fatal
+        // shortfall check.
+        var endOffset = await ConfluentStressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync(
+            options,
+            startOffset,
+            throughput.MessageCount,
+            throughput,
+            "Post-run drain");
+        var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
 
         return new StressTestResult
         {
@@ -124,72 +134,11 @@ internal sealed class ConfluentProducerAsyncIdempotentStressTest : IStressTestSc
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
+            DeliveredMessages = delivered,
+            Idempotent = true,
             Latency = latency.GetSnapshot(),
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
-    }
-
-    private static async Task RunSamplerAsync(ThroughputTracker throughput, CancellationToken cancellationToken)
-    {
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
-                throughput.TakeSample();
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-    }
-
-    private static string[] CreatePreAllocatedKeys(int count)
-    {
-        var keys = new string[count];
-        for (var i = 0; i < count; i++)
-        {
-            keys[i] = $"key-{i}";
-        }
-        return keys;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
-
-    private static async Task RunResourceMonitorAsync(CancellationToken cancellationToken)
-    {
-        var process = Process.GetCurrentProcess();
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(5000, cancellationToken).ConfigureAwait(false);
-                LogResourceUsage("Monitor", process);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-    }
-
-    private static void LogResourceUsage(string label, Process? process = null)
-    {
-        process ??= Process.GetCurrentProcess();
-        process.Refresh();
-
-        var workingSet = process.WorkingSet64 / (1024.0 * 1024.0);
-        var privateMemory = process.PrivateMemorySize64 / (1024.0 * 1024.0);
-        var gcHeap = GC.GetTotalMemory(forceFullCollection: false) / (1024.0 * 1024.0);
-        var threadCount = process.Threads.Count;
-        var gen0 = GC.CollectionCount(0);
-        var gen1 = GC.CollectionCount(1);
-        var gen2 = GC.CollectionCount(2);
-
-        Console.WriteLine($"  [{DateTime.UtcNow:HH:mm:ss}] {label} Resources: " +
-            $"WorkingSet={workingSet:F1}MB, Private={privateMemory:F1}MB, GCHeap={gcHeap:F1}MB, " +
-            $"Threads={threadCount}, GC=[{gen0}/{gen1}/{gen2}]");
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncStressTest.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 using ConfluentKafka = Confluent.Kafka;
@@ -8,8 +7,6 @@ namespace Dekaf.StressTests.Scenarios;
 
 internal sealed class ConfluentProducerAsyncStressTest : IStressTestScenario
 {
-    private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
-
     public string Name => "producer-async";
     public string Client => "Confluent";
 
@@ -38,11 +35,14 @@ internal sealed class ConfluentProducerAsyncStressTest : IStressTestScenario
 
         using var producer = new ConfluentKafka.ProducerBuilder<string, string>(config).Build();
 
-        Console.WriteLine($"  Warming up Confluent async producer...");
-        for (var i = 0; i < 1000; i++)
-        {
-            await producer.ProduceAsync(options.Topic, new ConfluentKafka.Message<string, string> { Key = "warmup", Value = "warmup" }, cancellationToken).ConfigureAwait(false);
-        }
+        // Even though every ProduceAsync is awaited, the broker-confirmed end-offset
+        // delta is still verified: a client bug that completes the delivery task
+        // without the broker persisting the message would otherwise be invisible.
+        var startOffset = await ConfluentStressTestHelpers.WarmUpProducerAndQueryStartOffsetAsync(
+            producer,
+            options,
+            "Confluent async producer",
+            throughput);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -54,15 +54,15 @@ internal sealed class ConfluentProducerAsyncStressTest : IStressTestScenario
 
         Console.WriteLine($"  Running Confluent async producer stress test for {options.DurationMinutes} minutes...");
         Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
-        LogResourceUsage("Initial");
+        StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
         var messageIndex = 0L;
         var lastStatusTime = DateTime.UtcNow;
         var lastStatusMessageCount = 0L;
 
-        var samplerTask = RunSamplerAsync(throughput, cts.Token);
-        var resourceMonitorTask = RunResourceMonitorAsync(cts.Token);
+        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
+        var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
 
         while (!cts.Token.IsCancellationRequested)
         {
@@ -71,7 +71,7 @@ internal sealed class ConfluentProducerAsyncStressTest : IStressTestScenario
                 var start = Stopwatch.GetTimestamp();
                 await producer.ProduceAsync(options.Topic, new ConfluentKafka.Message<string, string>
                 {
-                    Key = GetKey(messageIndex),
+                    Key = StressTestHelpers.GetKey(messageIndex),
                     Value = messageValue
                 }, cts.Token).ConfigureAwait(false);
                 latency.RecordTicks(Stopwatch.GetTimestamp() - start);
@@ -93,7 +93,7 @@ internal sealed class ConfluentProducerAsyncStressTest : IStressTestScenario
                     }
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
             {
                 break;
             }
@@ -111,7 +111,17 @@ internal sealed class ConfluentProducerAsyncStressTest : IStressTestScenario
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
-        LogResourceUsage("Final");
+        StressTestHelpers.LogResourceUsage("Final");
+
+        // The drain wait absorbs follower high-watermark lag before the always-fatal
+        // shortfall check.
+        var endOffset = await ConfluentStressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync(
+            options,
+            startOffset,
+            throughput.MessageCount,
+            throughput,
+            "Post-run drain");
+        var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
 
         return new StressTestResult
         {
@@ -123,72 +133,10 @@ internal sealed class ConfluentProducerAsyncStressTest : IStressTestScenario
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
+            DeliveredMessages = delivered,
             Latency = latency.GetSnapshot(),
-            GcStats = gcStats.ToSnapshot()
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds
         };
-    }
-
-    private static async Task RunSamplerAsync(ThroughputTracker throughput, CancellationToken cancellationToken)
-    {
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
-                throughput.TakeSample();
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-    }
-
-    private static string[] CreatePreAllocatedKeys(int count)
-    {
-        var keys = new string[count];
-        for (var i = 0; i < count; i++)
-        {
-            keys[i] = $"key-{i}";
-        }
-        return keys;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
-
-    private static async Task RunResourceMonitorAsync(CancellationToken cancellationToken)
-    {
-        var process = Process.GetCurrentProcess();
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(5000, cancellationToken).ConfigureAwait(false);
-                LogResourceUsage("Monitor", process);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-    }
-
-    private static void LogResourceUsage(string label, Process? process = null)
-    {
-        process ??= Process.GetCurrentProcess();
-        process.Refresh();
-
-        var workingSet = process.WorkingSet64 / (1024.0 * 1024.0);
-        var privateMemory = process.PrivateMemorySize64 / (1024.0 * 1024.0);
-        var gcHeap = GC.GetTotalMemory(forceFullCollection: false) / (1024.0 * 1024.0);
-        var threadCount = process.Threads.Count;
-        var gen0 = GC.CollectionCount(0);
-        var gen1 = GC.CollectionCount(1);
-        var gen2 = GC.CollectionCount(2);
-
-        Console.WriteLine($"  [{DateTime.UtcNow:HH:mm:ss}] {label} Resources: " +
-            $"WorkingSet={workingSet:F1}MB, Private={privateMemory:F1}MB, GCHeap={gcHeap:F1}MB, " +
-            $"Threads={threadCount}, GC=[{gen0}/{gen1}/{gen2}]");
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerIdempotentStressTest.cs
@@ -38,14 +38,11 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
 
         using var producer = new ConfluentKafka.ProducerBuilder<string, string>(config).Build();
 
-        Console.WriteLine($"  Warming up Confluent idempotent producer...");
-        for (var i = 0; i < 1000; i++)
-        {
-            producer.Produce(options.Topic, new ConfluentKafka.Message<string, string> { Key = "warmup", Value = "warmup" });
-        }
-        producer.Flush(TimeSpan.FromSeconds(30));
-
-        var startOffset = ConfluentStressTestHelpers.QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
+        var startOffset = await ConfluentStressTestHelpers.WarmUpProducerAndQueryStartOffsetAsync(
+            producer,
+            options,
+            "Confluent idempotent producer",
+            throughput);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -104,7 +101,7 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
                     }
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
             {
                 break;
             }
@@ -114,15 +111,21 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
             }
         }
 
-        producer.Flush(TimeSpan.FromSeconds(30));
+        ConfluentStressTestHelpers.FlushWithTimeout(producer, throughput);
         throughput.Stop();
         gcStats.Capture();
 
         // Queried after the final flush — and outside the measurement window, so a slow
         // query against a degraded broker can't skew elapsed/CPU stats — so the delta
         // reflects what the broker actually accepted rather than what librdkafka's local
-        // queue absorbed.
-        var endOffset = ConfluentStressTestHelpers.QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
+        // queue absorbed. The drain wait absorbs follower high-watermark lag before the
+        // always-fatal shortfall check.
+        var endOffset = await ConfluentStressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync(
+            options,
+            startOffset,
+            throughput.MessageCount,
+            throughput,
+            "Post-run drain");
 
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
@@ -144,6 +147,7 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             DeliveredMessages = delivered,
+            Idempotent = true,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerStressTest.cs
@@ -37,14 +37,11 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
 
         using var producer = new ConfluentKafka.ProducerBuilder<string, string>(config).Build();
 
-        Console.WriteLine($"  Warming up Confluent producer...");
-        for (var i = 0; i < 1000; i++)
-        {
-            producer.Produce(options.Topic, new ConfluentKafka.Message<string, string> { Key = "warmup", Value = "warmup" });
-        }
-        producer.Flush(TimeSpan.FromSeconds(30));
-
-        var startOffset = ConfluentStressTestHelpers.QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
+        var startOffset = await ConfluentStressTestHelpers.WarmUpProducerAndQueryStartOffsetAsync(
+            producer,
+            options,
+            "Confluent producer",
+            throughput);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -103,7 +100,7 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
                     }
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
             {
                 break;
             }
@@ -113,15 +110,21 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
             }
         }
 
-        producer.Flush(TimeSpan.FromSeconds(30));
+        ConfluentStressTestHelpers.FlushWithTimeout(producer, throughput);
         throughput.Stop();
         gcStats.Capture();
 
         // Queried after the final flush — and outside the measurement window, so a slow
         // query against a degraded broker can't skew elapsed/CPU stats — so the delta
         // reflects what the broker actually accepted rather than what librdkafka's local
-        // queue absorbed.
-        var endOffset = ConfluentStressTestHelpers.QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
+        // queue absorbed. The drain wait absorbs follower high-watermark lag before the
+        // always-fatal shortfall check.
+        var endOffset = await ConfluentStressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync(
+            options,
+            startOffset,
+            throughput.MessageCount,
+            throughput,
+            "Post-run drain");
 
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
@@ -143,7 +146,6 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             DeliveredMessages = delivered,
-            FailOnDeliveredShortfall = false,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
@@ -140,7 +140,12 @@ internal static class ConfluentStressTestHelpers
         {
             if (report.Error.IsError)
             {
-                throughput.RecordError(
+                // The message was already accepted into MessageCount when enqueued, so a
+                // failed delivery report is a delivery error, not a loop error. Unsampled
+                // fire-and-forget messages carry no report handler (the per-message handler
+                // shim would skew the throughput comparison), so their failures surface via
+                // the always-fatal delivered-vs-accepted shortfall check instead.
+                throughput.RecordDeliveryError(
                     "Confluent.Kafka.Error",
                     report.Error.ToString(),
                     "SampleDeliveryLatency delivery report",
@@ -151,5 +156,72 @@ internal static class ConfluentStressTestHelpers
                 latency.RecordTicks(Stopwatch.GetTimestamp() - start);
             }
         }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Warms up the producer and snapshots the pre-run end offset, waiting for the
+    /// warmup messages to drain first — mirroring
+    /// <see cref="StressTestHelpers.WarmUpProducerAndQueryStartOffsetAsync"/>. Without the
+    /// drain wait, warmup messages landing after the snapshot inflate the run's delivered
+    /// count and can mask real loss.
+    /// </summary>
+    internal static async Task<long?> WarmUpProducerAndQueryStartOffsetAsync(
+        ConfluentKafka.IProducer<string, string> producer,
+        StressTestOptions options,
+        string producerName,
+        ThroughputTracker throughput)
+    {
+        var warmupStartOffset = QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
+
+        Console.WriteLine($"  Warming up {producerName}...");
+        for (var i = 0; i < StressTestHelpers.ProducerWarmupMessageCount; i++)
+        {
+            producer.Produce(options.Topic, new ConfluentKafka.Message<string, string> { Key = "warmup", Value = "warmup" });
+        }
+        FlushWithTimeout(producer, throughput);
+
+        return await QueryTotalEndOffsetAfterProducerDrainAsync(
+            options,
+            warmupStartOffset,
+            StressTestHelpers.ProducerWarmupMessageCount,
+            throughput,
+            "Warmup drain").ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Confluent counterpart of
+    /// <see cref="StressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync"/>: same
+    /// shared catch-up loop, Confluent-only watermark query so these scenarios stay
+    /// Dekaf-free end to end.
+    /// </summary>
+    internal static Task<long?> QueryTotalEndOffsetAfterProducerDrainAsync(
+        StressTestOptions options,
+        long? startOffset,
+        long acceptedMessages,
+        ThroughputTracker throughput,
+        string operation)
+        => StressTestHelpers.WaitForEndOffsetCatchUpAsync(
+            () => Task.FromResult(QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions)),
+            startOffset,
+            acceptedMessages,
+            throughput,
+            operation);
+
+    /// <summary>
+    /// Flushes the producer, recording an error when messages remain queued after the
+    /// timeout: a flush that cannot drain against a healthy broker means the client is
+    /// stuck, and the leftover messages will surface as undelivered loss.
+    /// </summary>
+    internal static void FlushWithTimeout(
+        ConfluentKafka.IProducer<string, string> producer,
+        ThroughputTracker throughput)
+    {
+        var remaining = producer.Flush(StressTestHelpers.OperationTimeout);
+        if (remaining > 0)
+        {
+            var message = $"Flush timed out with {remaining:N0} messages still queued";
+            Console.WriteLine($"  Error: {message}");
+            throughput.RecordError("FlushTimeout", message, "Flush");
+        }
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -81,7 +81,7 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
         {
             // Expected — duration timer expired
         }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -81,7 +81,7 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
         {
             // Expected — duration timer expired
         }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -77,7 +77,7 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
         {
             // Expected — duration timer expired
         }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -70,7 +70,7 @@ internal sealed class ConsumerStressTest : IStressTestScenario
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
         {
             // Expected — duration timer expired
         }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -16,6 +16,9 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
     {
         var messageValue = new string('x', options.MessageSizeBytes);
         var throughput = new ThroughputTracker();
+        // Fire-and-forget messages have no awaiter; the error metric is the only signal
+        // that an accepted message failed delivery.
+        using var deliveryErrorListener = new DekafDeliveryErrorListener(throughput);
         var latency = StressTestHelpers.CreateDeliveryLatencyTracker();
         var startedAt = DateTime.UtcNow;
 
@@ -45,6 +48,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             producer,
             options,
             "Dekaf acks-all producer",
+            throughput,
             cancellationToken);
 
         GC.Collect();
@@ -88,7 +92,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
                     progress.RecordMessage();
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
             {
                 break;
             }
@@ -99,14 +103,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
         }
 
         Console.WriteLine($"  Flushing remaining messages...");
-        try
-        {
-            await producer.FlushAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None).ConfigureAwait(false);
-        }
-        catch (TimeoutException)
-        {
-            Console.WriteLine($"  Warning: Flush timed out after 30 seconds");
-        }
+        await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput);
 
         throughput.Stop();
         gcStats.Capture();
@@ -120,15 +117,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
         var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
 
         Console.WriteLine($"  Disposing producer...");
-        try
-        {
-            await producer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None).ConfigureAwait(false);
-            Console.WriteLine($"  Producer disposed successfully");
-        }
-        catch (TimeoutException)
-        {
-            Console.WriteLine($"  Warning: Dispose timed out after 30 seconds");
-        }
+        await StressTestHelpers.DisposeWithTimeoutAsync(producer, throughput);
 
         // Queried after dispose so all delivery attempts (including the final flush)
         // have finished — the delta is what the broker actually accepted.
@@ -137,7 +126,9 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             options.Topic,
             options.Partitions,
             startOffset,
-            throughput.MessageCount);
+            throughput.MessageCount,
+            throughput,
+            "Post-run drain");
         var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
 
         return new StressTestResult

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Dekaf.Compression.Lz4;
 using Dekaf.Compression.Snappy;
 using Dekaf.Compression.Zstd;
@@ -11,8 +10,6 @@ namespace Dekaf.StressTests.Scenarios;
 
 internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
 {
-    private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
-
     public string Name => "producer-async-idempotent";
     public string Client => "Dekaf";
 
@@ -43,11 +40,15 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
         StressTestHelpers.ConfigureProducerDeliveryDiagnostics(builder, options);
         var producer = await builder.BuildAsync(cancellationToken);
 
-        Console.WriteLine($"  Warming up Dekaf async idempotent producer...");
-        for (var i = 0; i < 1000; i++)
-        {
-            await producer.ProduceAsync(options.Topic, "warmup", "warmup", cancellationToken).ConfigureAwait(false);
-        }
+        // Even though every ProduceAsync is awaited, the broker-confirmed end-offset
+        // delta is still verified: a client bug that completes the delivery task
+        // without the broker persisting the message would otherwise be invisible.
+        var startOffset = await StressTestHelpers.WarmUpProducerAndQueryStartOffsetAsync(
+            producer,
+            options,
+            "Dekaf async idempotent producer",
+            throughput,
+            cancellationToken);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -59,22 +60,22 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
 
         Console.WriteLine($"  Running Dekaf async idempotent producer stress test for {options.DurationMinutes} minutes...");
         Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
-        LogResourceUsage("Initial");
+        StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
         var messageIndex = 0L;
         var lastStatusTime = DateTime.UtcNow;
         var lastStatusMessageCount = 0L;
 
-        var samplerTask = RunSamplerAsync(throughput, cts.Token);
-        var resourceMonitorTask = RunResourceMonitorAsync(cts.Token);
+        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
+        var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
 
         while (!cts.Token.IsCancellationRequested)
         {
             try
             {
                 var start = Stopwatch.GetTimestamp();
-                await producer.ProduceAsync(options.Topic, GetKey(messageIndex), messageValue, cts.Token).ConfigureAwait(false);
+                await producer.ProduceAsync(options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue, cts.Token).ConfigureAwait(false);
                 latency.RecordTicks(Stopwatch.GetTimestamp() - start);
                 throughput.RecordMessage(options.MessageSizeBytes);
                 messageIndex++;
@@ -94,7 +95,7 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
                     }
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
             {
                 break;
             }
@@ -112,19 +113,23 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
-        LogResourceUsage("Final");
+        StressTestHelpers.LogResourceUsage("Final");
         var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
 
         Console.WriteLine($"  Disposing producer...");
-        try
-        {
-            await producer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None).ConfigureAwait(false);
-            Console.WriteLine($"  Producer disposed successfully");
-        }
-        catch (TimeoutException)
-        {
-            Console.WriteLine($"  Warning: Dispose timed out after 30 seconds");
-        }
+        await StressTestHelpers.DisposeWithTimeoutAsync(producer, throughput);
+
+        // Queried after dispose so all delivery attempts have finished — the delta is
+        // what the broker actually accepted.
+        var endOffset = await StressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync(
+            options.BootstrapServers,
+            options.Topic,
+            options.Partitions,
+            startOffset,
+            throughput.MessageCount,
+            throughput,
+            "Post-run drain");
+        var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
 
         return new StressTestResult
         {
@@ -136,73 +141,12 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
+            DeliveredMessages = delivered,
+            Idempotent = true,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds,
             ProducerDeliveryDiagnostics = producerDiagnostics
         };
-    }
-
-    private static async Task RunSamplerAsync(ThroughputTracker throughput, CancellationToken cancellationToken)
-    {
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
-                throughput.TakeSample();
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-    }
-
-    private static string[] CreatePreAllocatedKeys(int count)
-    {
-        var keys = new string[count];
-        for (var i = 0; i < count; i++)
-        {
-            keys[i] = $"key-{i}";
-        }
-        return keys;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
-
-    private static async Task RunResourceMonitorAsync(CancellationToken cancellationToken)
-    {
-        var process = Process.GetCurrentProcess();
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(5000, cancellationToken).ConfigureAwait(false);
-                LogResourceUsage("Monitor", process);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-    }
-
-    private static void LogResourceUsage(string label, Process? process = null)
-    {
-        process ??= Process.GetCurrentProcess();
-        process.Refresh();
-
-        var workingSet = process.WorkingSet64 / (1024.0 * 1024.0);
-        var privateMemory = process.PrivateMemorySize64 / (1024.0 * 1024.0);
-        var gcHeap = GC.GetTotalMemory(forceFullCollection: false) / (1024.0 * 1024.0);
-        var threadCount = process.Threads.Count;
-        var gen0 = GC.CollectionCount(0);
-        var gen1 = GC.CollectionCount(1);
-        var gen2 = GC.CollectionCount(2);
-
-        Console.WriteLine($"  [{DateTime.UtcNow:HH:mm:ss}] {label} Resources: " +
-            $"WorkingSet={workingSet:F1}MB, Private={privateMemory:F1}MB, GCHeap={gcHeap:F1}MB, " +
-            $"Threads={threadCount}, GC=[{gen0}/{gen1}/{gen2}]");
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Dekaf.Compression.Lz4;
 using Dekaf.Compression.Snappy;
 using Dekaf.Compression.Zstd;
@@ -11,8 +10,6 @@ namespace Dekaf.StressTests.Scenarios;
 
 internal sealed class ProducerAsyncStressTest : IStressTestScenario
 {
-    private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
-
     public string Name => "producer-async";
     public string Client => "Dekaf";
 
@@ -43,11 +40,15 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
         StressTestHelpers.ConfigureProducerDeliveryDiagnostics(builder, options);
         var producer = await builder.BuildAsync(cancellationToken);
 
-        Console.WriteLine($"  Warming up Dekaf async producer...");
-        for (var i = 0; i < 1000; i++)
-        {
-            await producer.ProduceAsync(options.Topic, "warmup", "warmup", cancellationToken).ConfigureAwait(false);
-        }
+        // Even though every ProduceAsync is awaited, the broker-confirmed end-offset
+        // delta is still verified: a client bug that completes the delivery task
+        // without the broker persisting the message would otherwise be invisible.
+        var startOffset = await StressTestHelpers.WarmUpProducerAndQueryStartOffsetAsync(
+            producer,
+            options,
+            "Dekaf async producer",
+            throughput,
+            cancellationToken);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -59,22 +60,22 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
 
         Console.WriteLine($"  Running Dekaf async producer stress test for {options.DurationMinutes} minutes...");
         Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
-        LogResourceUsage("Initial");
+        StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
         var messageIndex = 0L;
         var lastStatusTime = DateTime.UtcNow;
         var lastStatusMessageCount = 0L;
 
-        var samplerTask = RunSamplerAsync(throughput, cts.Token);
-        var resourceMonitorTask = RunResourceMonitorAsync(cts.Token);
+        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
+        var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
 
         while (!cts.Token.IsCancellationRequested)
         {
             try
             {
                 var start = Stopwatch.GetTimestamp();
-                await producer.ProduceAsync(options.Topic, GetKey(messageIndex), messageValue, cts.Token).ConfigureAwait(false);
+                await producer.ProduceAsync(options.Topic, StressTestHelpers.GetKey(messageIndex), messageValue, cts.Token).ConfigureAwait(false);
                 latency.RecordTicks(Stopwatch.GetTimestamp() - start);
                 throughput.RecordMessage(options.MessageSizeBytes);
                 messageIndex++;
@@ -94,7 +95,7 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
                     }
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
             {
                 break;
             }
@@ -112,19 +113,23 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
-        LogResourceUsage("Final");
+        StressTestHelpers.LogResourceUsage("Final");
         var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
 
         Console.WriteLine($"  Disposing producer...");
-        try
-        {
-            await producer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None).ConfigureAwait(false);
-            Console.WriteLine($"  Producer disposed successfully");
-        }
-        catch (TimeoutException)
-        {
-            Console.WriteLine($"  Warning: Dispose timed out after 30 seconds");
-        }
+        await StressTestHelpers.DisposeWithTimeoutAsync(producer, throughput);
+
+        // Queried after dispose so all delivery attempts have finished — the delta is
+        // what the broker actually accepted.
+        var endOffset = await StressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync(
+            options.BootstrapServers,
+            options.Topic,
+            options.Partitions,
+            startOffset,
+            throughput.MessageCount,
+            throughput,
+            "Post-run drain");
+        var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
 
         return new StressTestResult
         {
@@ -136,73 +141,11 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
+            DeliveredMessages = delivered,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds,
             ProducerDeliveryDiagnostics = producerDiagnostics
         };
-    }
-
-    private static async Task RunSamplerAsync(ThroughputTracker throughput, CancellationToken cancellationToken)
-    {
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
-                throughput.TakeSample();
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-    }
-
-    private static string[] CreatePreAllocatedKeys(int count)
-    {
-        var keys = new string[count];
-        for (var i = 0; i < count; i++)
-        {
-            keys[i] = $"key-{i}";
-        }
-        return keys;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static string GetKey(long index) => PreAllocatedKeys[index % PreAllocatedKeys.Length];
-
-    private static async Task RunResourceMonitorAsync(CancellationToken cancellationToken)
-    {
-        var process = Process.GetCurrentProcess();
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(5000, cancellationToken).ConfigureAwait(false);
-                LogResourceUsage("Monitor", process);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-    }
-
-    private static void LogResourceUsage(string label, Process? process = null)
-    {
-        process ??= Process.GetCurrentProcess();
-        process.Refresh();
-
-        var workingSet = process.WorkingSet64 / (1024.0 * 1024.0);
-        var privateMemory = process.PrivateMemorySize64 / (1024.0 * 1024.0);
-        var gcHeap = GC.GetTotalMemory(forceFullCollection: false) / (1024.0 * 1024.0);
-        var threadCount = process.Threads.Count;
-        var gen0 = GC.CollectionCount(0);
-        var gen1 = GC.CollectionCount(1);
-        var gen2 = GC.CollectionCount(2);
-
-        Console.WriteLine($"  [{DateTime.UtcNow:HH:mm:ss}] {label} Resources: " +
-            $"WorkingSet={workingSet:F1}MB, Private={privateMemory:F1}MB, GCHeap={gcHeap:F1}MB, " +
-            $"Threads={threadCount}, GC=[{gen0}/{gen1}/{gen2}]");
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -16,6 +16,9 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
     {
         var messageValue = new string('x', options.MessageSizeBytes);
         var throughput = new ThroughputTracker();
+        // Fire-and-forget messages have no awaiter; the error metric is the only signal
+        // that an accepted message failed delivery.
+        using var deliveryErrorListener = new DekafDeliveryErrorListener(throughput);
         var latency = StressTestHelpers.CreateDeliveryLatencyTracker();
         var startedAt = DateTime.UtcNow;
 
@@ -44,6 +47,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             producer,
             options,
             "Dekaf idempotent producer",
+            throughput,
             cancellationToken);
 
         GC.Collect();
@@ -87,7 +91,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
                     progress.RecordMessage();
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
             {
                 break;
             }
@@ -98,14 +102,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
         }
 
         Console.WriteLine($"  Flushing remaining messages...");
-        try
-        {
-            await producer.FlushAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None).ConfigureAwait(false);
-        }
-        catch (TimeoutException)
-        {
-            Console.WriteLine($"  Warning: Flush timed out after 30 seconds");
-        }
+        await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput);
 
         throughput.Stop();
         gcStats.Capture();
@@ -119,15 +116,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
         var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
 
         Console.WriteLine($"  Disposing producer...");
-        try
-        {
-            await producer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None).ConfigureAwait(false);
-            Console.WriteLine($"  Producer disposed successfully");
-        }
-        catch (TimeoutException)
-        {
-            Console.WriteLine($"  Warning: Dispose timed out after 30 seconds");
-        }
+        await StressTestHelpers.DisposeWithTimeoutAsync(producer, throughput);
 
         // Queried after dispose so all delivery attempts (including the final flush)
         // have finished — the delta is what the broker actually accepted.
@@ -136,7 +125,9 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             options.Topic,
             options.Partitions,
             startOffset,
-            throughput.MessageCount);
+            throughput.MessageCount,
+            throughput,
+            "Post-run drain");
         var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
 
         return new StressTestResult
@@ -150,6 +141,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             DeliveredMessages = delivered,
+            Idempotent = true,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds,

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -16,6 +16,9 @@ internal sealed class ProducerStressTest : IStressTestScenario
     {
         var messageValue = new string('x', options.MessageSizeBytes);
         var throughput = new ThroughputTracker();
+        // Fire-and-forget messages have no awaiter; the error metric is the only signal
+        // that an accepted message failed delivery.
+        using var deliveryErrorListener = new DekafDeliveryErrorListener(throughput);
         var latency = StressTestHelpers.CreateDeliveryLatencyTracker();
         var startedAt = DateTime.UtcNow;
 
@@ -45,6 +48,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
             producer,
             options,
             "Dekaf producer",
+            throughput,
             cancellationToken);
 
         GC.Collect();
@@ -88,7 +92,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
                     progress.RecordMessage();
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
             {
                 break;
             }
@@ -99,14 +103,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
         }
 
         Console.WriteLine($"  Flushing remaining messages...");
-        try
-        {
-            await producer.FlushAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None).ConfigureAwait(false);
-        }
-        catch (TimeoutException)
-        {
-            Console.WriteLine($"  Warning: Flush timed out after 30 seconds");
-        }
+        await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput);
 
         throughput.Stop();
         gcStats.Capture();
@@ -120,15 +117,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
         var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
 
         Console.WriteLine($"  Disposing producer...");
-        try
-        {
-            await producer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None).ConfigureAwait(false);
-            Console.WriteLine($"  Producer disposed successfully");
-        }
-        catch (TimeoutException)
-        {
-            Console.WriteLine($"  Warning: Dispose timed out after 30 seconds");
-        }
+        await StressTestHelpers.DisposeWithTimeoutAsync(producer, throughput);
 
         // Queried after dispose so all delivery attempts (including the final flush)
         // have finished — the delta is what the broker actually accepted.
@@ -137,7 +126,9 @@ internal sealed class ProducerStressTest : IStressTestScenario
             options.Topic,
             options.Partitions,
             startOffset,
-            throughput.MessageCount);
+            throughput.MessageCount,
+            throughput,
+            "Post-run drain");
         var delivered = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
 
         return new StressTestResult
@@ -151,7 +142,6 @@ internal sealed class ProducerStressTest : IStressTestScenario
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),
             DeliveredMessages = delivered,
-            FailOnDeliveredShortfall = false,
             Latency = latency.GetSnapshot(),
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds,

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -28,7 +28,21 @@ internal static class StressTestHelpers
     /// </summary>
     internal const ulong ProducerBufferMemoryBytes = 512UL * 1024 * 1024;
 
-    private const int ProducerWarmupMessageCount = 1000;
+    /// <summary>
+    /// Shared with <see cref="ConfluentStressTestHelpers"/> so both clients drain the
+    /// same warmup target — a mismatch would corrupt one side's start-offset arithmetic
+    /// and surface as a phantom shortfall on that client only.
+    /// </summary>
+    internal const int ProducerWarmupMessageCount = 1000;
+
+    /// <summary>
+    /// Throughput sampler tick. The stall detector in Program.CheckForFailures converts
+    /// its seconds threshold using this, so changing the tick rescales nothing silently.
+    /// </summary>
+    internal const int SamplerIntervalSeconds = 1;
+
+    internal static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(30);
+
     private static readonly string[] PreAllocatedKeys = CreatePreAllocatedKeys(10_000);
     private static readonly TimeSpan ProducerEndOffsetCatchUpTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan ProducerEndOffsetCatchUpDelay = TimeSpan.FromMilliseconds(500);
@@ -121,6 +135,7 @@ internal static class StressTestHelpers
         IKafkaProducer<string, string> producer,
         StressTestOptions options,
         string producerName,
+        ThroughputTracker throughput,
         CancellationToken cancellationToken)
     {
         var warmupStartOffset = await QueryTotalEndOffsetAsync(
@@ -139,12 +154,17 @@ internal static class StressTestHelpers
         }
 
         await producer.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+        // A stale start snapshot is a correctness hazard, not just noise: warmup messages
+        // landing after the snapshot would inflate the run's delivered count and mask real
+        // loss, so a catch-up timeout here is recorded as an error via the tracker.
         return await QueryTotalEndOffsetAfterProducerDrainAsync(
             options.BootstrapServers,
             options.Topic,
             options.Partitions,
             warmupStartOffset,
-            ProducerWarmupMessageCount).ConfigureAwait(false);
+            ProducerWarmupMessageCount,
+            throughput,
+            "Warmup drain").ConfigureAwait(false);
     }
 
     /// <summary>
@@ -152,16 +172,37 @@ internal static class StressTestHelpers
     /// trail leader-ack writes briefly. Wait for the post-run watermark snapshot to
     /// reach the accepted-message target before returning the final snapshot.
     /// </summary>
-    internal static async Task<long?> QueryTotalEndOffsetAfterProducerDrainAsync(
+    internal static Task<long?> QueryTotalEndOffsetAfterProducerDrainAsync(
         string bootstrapServers,
         string topic,
         int partitionCount,
         long? startOffset,
-        long acceptedMessages)
+        long acceptedMessages,
+        ThroughputTracker throughput,
+        string operation)
+        => WaitForEndOffsetCatchUpAsync(
+            () => QueryTotalEndOffsetAsync(bootstrapServers, topic, partitionCount),
+            startOffset,
+            acceptedMessages,
+            throughput,
+            operation);
+
+    /// <summary>
+    /// Client-agnostic catch-up loop shared by the Dekaf and Confluent scenarios; each
+    /// side supplies its own watermark query so Confluent runs stay Dekaf-free. A catch-up
+    /// timeout is recorded as an error on <paramref name="throughput"/> because a lagging
+    /// snapshot either masks loss (warmup) or is loss (post-run).
+    /// </summary>
+    internal static async Task<long?> WaitForEndOffsetCatchUpAsync(
+        Func<Task<long?>> queryTotalEndOffset,
+        long? startOffset,
+        long acceptedMessages,
+        ThroughputTracker throughput,
+        string operation)
     {
         if (startOffset is not { } start || acceptedMessages <= 0)
         {
-            return await QueryTotalEndOffsetAsync(bootstrapServers, topic, partitionCount).ConfigureAwait(false);
+            return await queryTotalEndOffset().ConfigureAwait(false);
         }
 
         var expectedEndOffset = start + acceptedMessages;
@@ -170,7 +211,7 @@ internal static class StressTestHelpers
 
         while (true)
         {
-            var endOffset = await QueryTotalEndOffsetAsync(bootstrapServers, topic, partitionCount).ConfigureAwait(false);
+            var endOffset = await queryTotalEndOffset().ConfigureAwait(false);
             if (endOffset is null || endOffset >= expectedEndOffset)
             {
                 if (loggedWait && endOffset is not null)
@@ -184,10 +225,12 @@ internal static class StressTestHelpers
             var lag = expectedEndOffset - endOffset.Value;
             if (DateTime.UtcNow >= deadline)
             {
-                Console.WriteLine(
-                    $"  Warning: end offsets still lag accepted messages after " +
+                var message =
+                    $"end offsets still lag accepted messages after " +
                     $"{ProducerEndOffsetCatchUpTimeout.TotalSeconds:N0}s: observed {endOffset:N0}, " +
-                    $"target {expectedEndOffset:N0}, lag {lag:N0}");
+                    $"target {expectedEndOffset:N0}, lag {lag:N0}";
+                Console.WriteLine($"  Error: {message}");
+                throughput.RecordError("EndOffsetCatchUpTimeout", message, operation);
                 return endOffset;
             }
 
@@ -200,6 +243,50 @@ internal static class StressTestHelpers
             }
 
             await Task.Delay(ProducerEndOffsetCatchUpDelay, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Flushes the producer, recording a timeout as an error: a flush that cannot drain
+    /// in 30 seconds against a healthy broker means the producer is stuck, and any
+    /// still-buffered messages will surface as undelivered loss.
+    /// </summary>
+    internal static async Task FlushWithTimeoutAsync(
+        IKafkaProducer<string, string> producer,
+        ThroughputTracker throughput)
+    {
+        try
+        {
+            await producer.FlushAsync(CancellationToken.None).AsTask()
+                .WaitAsync(OperationTimeout, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            var message = $"Flush did not complete within {OperationTimeout.TotalSeconds:N0} seconds";
+            Console.WriteLine($"  Error: {message}");
+            throughput.RecordError("FlushTimeout", message, "FlushAsync");
+        }
+    }
+
+    /// <summary>
+    /// Disposes the producer, recording a timeout as an error — a hung dispose is a
+    /// shutdown bug even when every message was already delivered.
+    /// </summary>
+    internal static async Task DisposeWithTimeoutAsync(
+        IKafkaProducer<string, string> producer,
+        ThroughputTracker throughput)
+    {
+        try
+        {
+            await producer.DisposeAsync().AsTask()
+                .WaitAsync(OperationTimeout, CancellationToken.None).ConfigureAwait(false);
+            Console.WriteLine($"  Producer disposed successfully");
+        }
+        catch (TimeoutException)
+        {
+            var message = $"Dispose did not complete within {OperationTimeout.TotalSeconds:N0} seconds";
+            Console.WriteLine($"  Error: {message}");
+            throughput.RecordError("DisposeTimeout", message, "DisposeAsync");
         }
     }
 
@@ -286,7 +373,10 @@ internal static class StressTestHelpers
             }
             catch (Exception ex)
             {
-                throughput.RecordError(ex, "SampleDeliveryLatency", messageIndex);
+                // Detail only: the failure count is already captured via the producer's
+                // messaging.client.sent.errors metric (DekafDeliveryErrorListener), and
+                // this message was accepted into MessageCount before delivery failed.
+                throughput.RecordDeliveryErrorDetail(ex, "SampleDeliveryLatency", messageIndex);
             }
         }
     }
@@ -297,7 +387,7 @@ internal static class StressTestHelpers
         {
             try
             {
-                await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromSeconds(SamplerIntervalSeconds), cancellationToken).ConfigureAwait(false);
                 throughput.TakeSample();
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
## Summary

Hardens stress-test failure detection so the suite lives up to zero tolerance for data loss and avoidable errors. Before this change, the flagship fire-and-forget `producer` scenario could silently lose messages and still pass CI green (errors=0), because delivery failures of fire-and-forget messages were observable nowhere and the delivered-vs-accepted shortfall check was disabled for leader-ack scenarios.

### Library

- **`messaging.client.sent.errors` now counts fire-and-forget delivery failures.** `ReadyBatch.Fail` emits the produce-errors counter for records without completion sources (per failed batch, tagged by topic). Previously the metric only fired for awaited `ProduceAsync` — fire-and-forget failures had no signal at all: no exception, no callback, no metric. Awaited records stay excluded (their awaiters count themselves), so there is no double-counting.
- The sealed record count is captured on `ReadyBatch.Initialize` (`recordCount`), because the `RecordBatch` record list can be recycled or never materialized by the time a stale `Fail` runs — exactly the batch-recycle race window of #1578. The delivery-diagnostics snapshot reuses the same field.
- Zero hot-path cost: nothing changes on the `FireAsync` path; the counter add runs once per **failed** batch behind the enabled check.

### Stress harness — every silent-loss path now fails the run

- **Shortfall is always fatal.** `FailOnDeliveredShortfall=false` is gone; leader-ack fire-and-forget runs now fail on unexplained `accepted − delivered − deliveryErrors > 0` like every other producer scenario. The post-run/warmup drain catch-up (shared client-agnostic loop; Confluent scenarios stay Dekaf-free via their own watermark query) absorbs follower HW lag first, and a catch-up timeout is itself recorded as an error since a stale warmup snapshot would otherwise inflate delivered counts and mask loss.
- **Delivery errors are captured and separated from loop errors.** Dekaf scenarios attach a `MeterListener` on the producer error metric (`DekafDeliveryErrorListener`); Confluent sampled sends record delivery-report errors. New `TotalDeliveryErrors` on the snapshot feeds both the failure check and the loss arithmetic; the docs table can no longer render a clean zero for a run that lost accepted messages.
- **Idempotent scenarios fail on duplicates.** New `Idempotent` result flag: `delivered > accepted` on an idempotent run means broker-side dedup is broken → run fails.
- **`producer-async` (+ idempotent, both clients) now verify broker-confirmed offsets.** Previously they trusted the client ack entirely — an ack-without-persist bug was invisible.
- **Hung shutdowns are errors.** Flush/dispose/warmup-drain timeouts now `RecordError` instead of printing a warning and passing.
- **Early exits and stalls fail.** `OperationCanceledException` catches are guarded by the duration token (a stray internal OCE now surfaces as an error instead of quietly ending the run); runs that end before 90% of the configured duration fail; 30+ consecutive seconds of zero throughput samples fail as a recovered hang.
- **Unobserved task exceptions fail the run** after a final finalizer sweep.
- Consolidated the per-scenario copies of `GetKey`/`RunSamplerAsync`/`RunResourceMonitorAsync`/`LogResourceUsage` onto `StressTestHelpers` (−~250 lines).

### CI

- `--producer-delivery-diagnostics` is now always on in the stress workflow, so a loss failure ships the in-flight batch dump instead of "Not captured".

## Testing

- New unit tests (`FireAndForgetDeliveryErrorMetricTests`) pin the metric contract: FnF-only batch counts all records, mixed batch counts only records without completion sources.
- Full unit suite: 4511/4511 green.
- 1-minute Docker smoke run of the `producer` scenario for both clients exercised the whole pipeline end to end: warmup drain, delivery-error listener, post-dispose offset verification (delivered == accepted for both clients: Dekaf 884,254/884,254, Confluent 984,655/984,655), and the new failure reporting. The run correctly **failed** with `FlushTimeout` on both clients — the local Docker NAT caps broker ingestion far below the append rate (the documented reason local stress numbers are meaningless), so a ~480 MB backlog can't flush in 30s. On the CI runners (tmpfs broker, dedicated cores) the same backlog drains in seconds; locally, that failure is the fail-hard behavior working as intended.
- Note: `ProducerAsyncPreparerTests` activity-status tests flake under parallel runs on unmodified main (~2/5) — pre-existing, tracked in #1609, unrelated to this change.

## Related

Detection-side complement to the #1578/#1579 loss investigations. Remaining robustness work tracked in #1593–#1601, #1603–#1608.
