### PR TITLE
test(stress): add produce-consume round-trip verification

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -121,6 +121,9 @@ def accepted_messages_per_second(result):
 
 def median_interval_rate(result):
     """Median sampled client-side interval throughput, or None for old result files."""
+    if result.get('isMessageBounded'):
+        return None
+
     rate = result.get('medianIntervalMessagesPerSecond')
     if rate is not None:
         return rate

--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -11,6 +11,7 @@ SCENARIO_TITLES = {
     'producer-async': 'Producer (Async)',
     'producer-async-idempotent': 'Producer (Async, Idempotent)',
     'producer-transactional': 'Producer (Transactional EOS)',
+    'producer-roundtrip': 'Producer → Consumer Round-Trip',
     'consumer': 'Consumer',
     'consumer-batch': 'Consumer (Batch)',
     'consumer-raw': 'Consumer (Raw Bytes)',
@@ -359,6 +360,40 @@ def format_transaction_verification(results):
     return lines
 
 
+def format_roundtrip_validation_table(results):
+    """Generate strict content/order validation results when present."""
+    validation_results = [r for r in results if r.get('roundTripValidation') is not None]
+    if not validation_results:
+        return []
+
+    lines = [
+        "### Round-Trip Validation",
+        "",
+        "| Client | Expected | Consumed | Missing | Duplicates | Corrupt | Out of Order | Wrong Partition | Unexpected | Timed Out | Result |",
+        "|--------|----------|----------|---------|------------|---------|--------------|-----------------|------------|-----------|--------|",
+    ]
+
+    for result in sorted(validation_results, key=lambda item: item.get('client', '')):
+        validation = result['roundTripValidation']
+        success = validation.get('isSuccess', False)
+        lines.append(
+            f"| {result.get('client', 'Unknown')} | "
+            f"{validation.get('expectedMessages', 0):,} | "
+            f"{validation.get('consumedMessages', 0):,} | "
+            f"{validation.get('missingMessages', 0):,} | "
+            f"{validation.get('duplicateMessages', 0):,} | "
+            f"{validation.get('corruptMessages', 0):,} | "
+            f"{validation.get('outOfOrderMessages', 0):,} | "
+            f"{validation.get('mispartitionedMessages', 0):,} | "
+            f"{validation.get('unexpectedMessages', 0):,} | "
+            f"{'yes' if validation.get('timedOut', False) else 'no'} | "
+            f"{'PASS' if success else 'FAIL'} |"
+        )
+
+    lines.append("")
+    return lines
+
+
 def generate_scenario_tables(results, include_ratio=False, include_callout=False):
     """Generate per-scenario throughput tables for all results."""
     producer_scenarios, consumer_scenarios = group_by_scenario(results)
@@ -370,6 +405,7 @@ def generate_scenario_tables(results, include_ratio=False, include_callout=False
             scenario_results = scenarios[scenario_key]
             output.extend(format_throughput_table(scenario_results, f"{title} Throughput", include_ratio=include_ratio))
             output.extend(format_transaction_verification(scenario_results))
+            output.extend(format_roundtrip_validation_table(scenario_results))
             if include_callout:
                 output.extend(format_comparison_callout(scenario_results, title))
 

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -21,6 +21,7 @@ _IDENTITY_FIELDS = (
     "brokerCount",
     "durationMinutes",
     "messageSizeBytes",
+    "roundTripMessages",
 )
 
 _METRICS = {
@@ -41,6 +42,13 @@ def _finite_number(value):
     return isinstance(value, (int, float)) and not isinstance(value, bool) and isfinite(value)
 
 
+def _roundtrip_messages(result):
+    validation = result.get("roundTripValidation")
+    if isinstance(validation, dict):
+        return validation.get("expectedMessages", result.get("roundTripMessages"))
+    return result.get("roundTripMessages")
+
+
 def _identity(result):
     return (
         str(result.get("scenario", "unknown")).casefold(),
@@ -48,6 +56,7 @@ def _identity(result):
         result.get("brokerCount", 1),
         result.get("durationMinutes"),
         result.get("messageSizeBytes"),
+        _roundtrip_messages(result),
     )
 
 
@@ -107,11 +116,15 @@ def _limit_observations_per_identity(runs):
 
 def _scenario_label(result):
     brokers = result.get("brokerCount", 1)
-    return (
+    label = (
         f"{result.get('scenario', 'unknown')} / {result.get('client', 'unknown')} / "
         f"{brokers} broker{'s' if brokers != 1 else ''} / "
         f"{result.get('messageSizeBytes', '?')}B / {result.get('durationMinutes', '?')}m"
     )
+    roundtrip_messages = _roundtrip_messages(result)
+    if roundtrip_messages is not None:
+        label += f" / {roundtrip_messages} messages"
+    return label
 
 
 def _metric_status(value, baseline, lower_is_regression):
@@ -154,6 +167,7 @@ def evaluate_and_update(history, current_results, run_started_at):
         prior = _matching_observations(baseline_runs, result)
         observation = {field: result.get(field) for field in _IDENTITY_FIELDS}
         observation["brokerCount"] = result.get("brokerCount", 1)
+        observation["roundTripMessages"] = _roundtrip_messages(result)
 
         for metric, definition in _METRICS.items():
             value = definition["extract"](result)

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -1,5 +1,4 @@
 import unittest
-from pathlib import Path
 
 from stress_report import (
     format_roundtrip_validation_table,
@@ -32,33 +31,6 @@ def stress_result(client, effective_rate, median_rate=None):
 
 
 class StressReportTests(unittest.TestCase):
-    def test_confluent_roundtrip_produce_wait_is_bounded(self):
-        scenario_path = (
-            Path(__file__).parents[2]
-            / "tools"
-            / "Dekaf.StressTests"
-            / "Scenarios"
-            / "ProducerRoundTripStressTest.cs"
-        )
-        source = scenario_path.read_text(encoding="utf-8")
-        confluent_source = source.split(
-            "internal sealed class ConfluentProducerRoundTripStressTest", maxsplit=1
-        )[1]
-
-        self.assertIn(
-            "CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)",
-            confluent_source,
-        )
-        self.assertIn(
-            "produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options))",
-            confluent_source,
-        )
-        self.assertIn("produceTimeout.Token", confluent_source)
-        self.assertIn(
-            "catch (OperationCanceledException) when (produceTimeout.IsCancellationRequested)",
-            confluent_source,
-        )
-
     def test_throughput_table_orders_and_ratios_by_median_when_available(self):
         lines = format_throughput_table(
             [

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -1,6 +1,10 @@
 import unittest
 
-from stress_report import format_throughput_table, generate_scenario_tables
+from stress_report import (
+    format_roundtrip_validation_table,
+    format_throughput_table,
+    generate_scenario_tables,
+)
 
 
 def stress_result(client, effective_rate, median_rate=None):
@@ -83,6 +87,27 @@ class StressReportTests(unittest.TestCase):
         self.assertIn("Producer (Transactional EOS)", report)
         self.assertIn("Transaction Verification", report)
         self.assertIn("| Dekaf | 1,000 | 750 | 250 | 750 | 0 | 0 | 0 | 0 | 0 | PASS |", report)
+
+    def test_roundtrip_validation_table_reports_strict_failures(self):
+        result = stress_result("Dekaf", effective_rate=1000)
+        result["roundTripValidation"] = {
+            "expectedMessages": 100,
+            "consumedMessages": 99,
+            "missingMessages": 1,
+            "duplicateMessages": 0,
+            "corruptMessages": 0,
+            "outOfOrderMessages": 0,
+            "mispartitionedMessages": 0,
+            "unexpectedMessages": 0,
+            "timedOut": False,
+            "isSuccess": False,
+        }
+
+        lines = format_roundtrip_validation_table([result])
+
+        self.assertIn("Round-Trip Validation", "\n".join(lines))
+        self.assertIn("| Dekaf | 100 | 99 | 1 |", "\n".join(lines))
+        self.assertIn("| FAIL |", "\n".join(lines))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 
 from stress_report import (
     format_roundtrip_validation_table,
@@ -31,6 +32,33 @@ def stress_result(client, effective_rate, median_rate=None):
 
 
 class StressReportTests(unittest.TestCase):
+    def test_confluent_roundtrip_produce_wait_is_bounded(self):
+        scenario_path = (
+            Path(__file__).parents[2]
+            / "tools"
+            / "Dekaf.StressTests"
+            / "Scenarios"
+            / "ProducerRoundTripStressTest.cs"
+        )
+        source = scenario_path.read_text(encoding="utf-8")
+        confluent_source = source.split(
+            "internal sealed class ConfluentProducerRoundTripStressTest", maxsplit=1
+        )[1]
+
+        self.assertIn(
+            "CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)",
+            confluent_source,
+        )
+        self.assertIn(
+            "produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options))",
+            confluent_source,
+        )
+        self.assertIn("produceTimeout.Token", confluent_source)
+        self.assertIn(
+            "catch (OperationCanceledException) when (produceTimeout.IsCancellationRequested)",
+            confluent_source,
+        )
+
     def test_throughput_table_orders_and_ratios_by_median_when_available(self):
         lines = format_throughput_table(
             [

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -7,13 +7,14 @@ from stress_report import (
 )
 
 
-def stress_result(client, effective_rate, median_rate=None):
+def stress_result(client, effective_rate, median_rate=None, is_message_bounded=False):
     result = {
         "client": client,
         "durationMinutes": 15,
         "messageSizeBytes": 1000,
         "effectiveMessagesPerSecond": effective_rate,
         "effectiveMegabytesPerSecond": effective_rate * 1000 / (1024 * 1024),
+        "isMessageBounded": is_message_bounded,
         "throughput": {
             "averageMessagesPerSecond": effective_rate,
             "averageMegabytesPerSecond": effective_rate * 1000 / (1024 * 1024),
@@ -61,6 +62,33 @@ class StressReportTests(unittest.TestCase):
         rows = [line for line in lines if line.startswith("| Dekaf") or line.startswith("| Confluent")]
 
         self.assertTrue(rows[0].startswith("| Dekaf"))
+        self.assertIn("| 2.00x |", rows[0])
+
+    def test_message_bounded_table_ignores_producer_only_median(self):
+        lines = format_throughput_table(
+            [
+                stress_result(
+                    "Dekaf",
+                    effective_rate=2000,
+                    median_rate=900,
+                    is_message_bounded=True,
+                ),
+                stress_result(
+                    "Confluent",
+                    effective_rate=1000,
+                    median_rate=1200,
+                    is_message_bounded=True,
+                ),
+            ],
+            "Producer Round-Trip",
+            include_ratio=True,
+        )
+
+        rows = [line for line in lines if line.startswith("| Dekaf") or line.startswith("| Confluent")]
+        dekaf_columns = [column.strip() for column in rows[0].strip("|").split("|")]
+
+        self.assertTrue(rows[0].startswith("| Dekaf"))
+        self.assertEqual("-", dekaf_columns[3])
         self.assertIn("| 2.00x |", rows[0])
 
     def test_transactional_scenario_reports_verification_counts(self):

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -187,6 +187,33 @@ class StressTrendTests(unittest.TestCase):
         self.assertFalse(should_fail)
         self.assertEqual({"insufficient-history"}, {item["status"] for item in evaluations})
 
+    def test_different_roundtrip_bound_does_not_supply_baseline(self):
+        history = {
+            "version": 1,
+            "runs": [
+                history_run(
+                    i,
+                    scenario="producer-roundtrip",
+                    roundTripMessages=250_000,
+                )
+                for i in range(1, 4)
+            ],
+        }
+
+        evaluations, updated, should_fail = evaluate_and_update(
+            history,
+            [result(
+                messages_per_second=100.0,
+                scenario="producer-roundtrip",
+                roundTripValidation={"expectedMessages": 1_000},
+            )],
+            "2026-07-01T02:00:00Z",
+        )
+
+        self.assertFalse(should_fail)
+        self.assertEqual({"insufficient-history"}, {item["status"] for item in evaluations})
+        self.assertEqual(1_000, updated["runs"][-1]["results"][0]["roundTripMessages"])
+
     def test_history_is_bounded_and_same_run_is_replaced(self):
         runs = [history_run(i) for i in range(1, HISTORY_LIMIT + 1)]
         duplicate_timestamp = runs[-1]["runStartedAtUtc"]

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -88,7 +88,7 @@ jobs:
             brokers: 1
             run_3conn: false
             artifact_suffix: ""
-            timeout_minutes: 60
+            timeout_minutes: 90
             name: Producer → Consumer Round-Trip (Paired)
           - scenario: consumer
             client: all

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -88,7 +88,7 @@ jobs:
             brokers: 1
             run_3conn: false
             artifact_suffix: ""
-            timeout_minutes: 30
+            timeout_minutes: 60
             name: Producer → Consumer Round-Trip (Paired)
           - scenario: consumer
             client: all

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -13,6 +13,10 @@ on:
         description: 'Message size in bytes'
         required: false
         default: '1000'
+      roundtrip_messages:
+        description: 'Bounded message count for round-trip correctness scenario'
+        required: false
+        default: '250000'
 
 concurrency:
   group: stress-tests
@@ -79,6 +83,13 @@ jobs:
             artifact_suffix: ""
             timeout_minutes: 150
             name: Dekaf Transactional EOS (3 Brokers)
+          - scenario: producer-roundtrip
+            client: all
+            brokers: 1
+            run_3conn: false
+            artifact_suffix: ""
+            timeout_minutes: 30
+            name: Producer → Consumer Round-Trip (Paired)
           - scenario: consumer
             client: all
             brokers: 1
@@ -246,6 +257,7 @@ jobs:
             --brokers ${{ matrix.brokers }} \
             --connections-per-broker 1 \
             --producer-delivery-diagnostics \
+            --roundtrip-messages ${{ github.event.inputs.roundtrip_messages || '250000' }} \
             --output ./results
 
           if [ "${{ matrix.run_3conn }}" = "true" ]; then
@@ -258,6 +270,7 @@ jobs:
               --brokers ${{ matrix.brokers }} \
               --connections-per-broker 3 \
               --producer-delivery-diagnostics \
+              --roundtrip-messages ${{ github.event.inputs.roundtrip_messages || '250000' }} \
               --output ./results
           fi
 
@@ -557,6 +570,7 @@ jobs:
           output.append("- **Backpressure Parity**: both producers are bounded to the same 512 MB local buffer (Dekaf BufferMemory, librdkafka queue.buffering.max) and block on a full buffer, so neither client can absorb an unbounded backlog into RAM")
           output.append("- **Consumer Loop Replay**: Consumer tests re-read a pre-seeded topic (seek to beginning when drained) instead of racing a live feeder, so the consumer itself is measured")
           output.append("- **Delivery Latency Sampling**: 1 in 1000 produced messages is awaited end-to-end to record true broker round-trip latency")
+          output.append("- **Round-Trip Correctness**: Bounded sequenced payloads are consumed back and checked for corruption, wrong partitions, gaps, duplicates, and reordering")
           output.append("- **CPU Efficiency**: CPU time per message differentiates client efficiency even at equal throughput")
           output.append("- **Noise-Aware Trends**: each scenario is compared with its last 10 matching runs using a median ± 2×MAD band; one adverse excursion warns and two consecutive regressions fail the workflow")
           output.append("- **Parallel Execution**: Each scenario runs in its own isolated environment")

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -41,8 +41,6 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Protocol\ResponseFixtures\*.bin" />
-    <Compile Include="..\..\tools\Dekaf.StressTests\Scenarios\RoundTripMessageCodec.cs" Link="Stress\RoundTripMessageCodec.cs" />
-    <Compile Include="..\..\tools\Dekaf.StressTests\StressRunCompletionPolicy.cs" Link="Stress\StressRunCompletionPolicy.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Protocol\ResponseFixtures\*.bin" />
+    <Compile Include="..\..\tools\Dekaf.StressTests\Scenarios\RoundTripMessageCodec.cs" Link="Stress\RoundTripMessageCodec.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Protocol\ResponseFixtures\*.bin" />
     <Compile Include="..\..\tools\Dekaf.StressTests\Scenarios\RoundTripMessageCodec.cs" Link="Stress\RoundTripMessageCodec.cs" />
+    <Compile Include="..\..\tools\Dekaf.StressTests\StressRunCompletionPolicy.cs" Link="Stress\StressRunCompletionPolicy.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <Compile Remove="Stress\**\*.cs" />
     <Compile Remove="StressTests\**\*.cs" />
   </ItemGroup>
 

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -1,3 +1,4 @@
+using Dekaf.Diagnostics;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Scenarios;
 using ConfluentKafka = Confluent.Kafka;
@@ -216,6 +217,19 @@ public class RoundTripMessageCodecTests
             new ConfluentKafka.Error(ConfluentKafka.ErrorCode.Local_MsgTimedOut));
 
         await Assert.That(throughput.DeliveryErrorCount).IsEqualTo(1);
+        await Assert.That(throughput.ErrorCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("MeterListener")]
+    public async Task DekafDeliveryMetricFailure_CountsAsRoundTripDeliveryError()
+    {
+        var throughput = new ThroughputTracker();
+        using var listener = ProducerRoundTripStressTest.CreateDeliveryErrorListener(throughput);
+
+        DekafMetrics.ProduceErrors.Add(2);
+
+        await Assert.That(throughput.DeliveryErrorCount).IsEqualTo(2);
         await Assert.That(throughput.ErrorCount).IsEqualTo(0);
     }
 

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -1,5 +1,7 @@
+using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Diagnostics;
+using Dekaf.Serialization;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Scenarios;
 using NSubstitute;
@@ -270,11 +272,80 @@ public class RoundTripMessageCodecTests
         await Assert.That(error.Message).IsEqualTo("consume failed");
     }
 
+    [Test]
+    public async Task DekafConsume_UntrackedPartition_RecordsUnexpectedWithoutDecoding()
+    {
+        var factory = new RoundTripMessageFactory("untracked-partition", partitionCount: 1, payloadSize: 128);
+        var message = factory.Create(partition: 0);
+        var consumer = Substitute.For<IKafkaConsumer<string, byte[]>>();
+        consumer.Partitions.Returns(Substitute.For<IConsumerPartitions>());
+        consumer.ConsumeAsync(Arg.Any<CancellationToken>())
+            .Returns(CreateConsumeResults(
+                CreateConsumeResult(message, partition: 1, offset: 0),
+                CreateConsumeResult(message, partition: 0, offset: 0)));
+        var validator = new RoundTripValidator(factory.ExpectedPerPartition);
+        var options = new StressTestOptions
+        {
+            BootstrapServers = "localhost:9092",
+            Topic = "roundtrip-untracked-partition",
+            Partitions = 1,
+            DurationMinutes = 1,
+            MessageSizeBytes = 128,
+            ProgressWatchdog = null!
+        };
+
+        var timedOut = await ProducerRoundTripStressTest.ConsumeAndValidateAsync(
+            consumer,
+            options,
+            startOffsets: [0],
+            endOffsets: [1],
+            validator,
+            new ThroughputTracker(),
+            CancellationToken.None);
+
+        var snapshot = validator.CreateSnapshot(timedOut);
+        await Assert.That(timedOut).IsFalse();
+        await Assert.That(snapshot.ConsumedMessages).IsEqualTo(2);
+        await Assert.That(snapshot.UnexpectedMessages).IsEqualTo(1);
+        await Assert.That(snapshot.DuplicateMessages).IsEqualTo(0);
+        await Assert.That(snapshot.MispartitionedMessages).IsEqualTo(0);
+        await Assert.That(snapshot.MissingMessages).IsEqualTo(0);
+    }
+
     private static async IAsyncEnumerable<ConsumeResult<string, byte[]>> ThrowConsumeFailure()
     {
         await Task.FromException(new InvalidOperationException("consume failed"));
         yield break;
     }
+
+    private static async IAsyncEnumerable<ConsumeResult<string, byte[]>> CreateConsumeResults(
+        params ConsumeResult<string, byte[]>[] records)
+    {
+        foreach (var record in records)
+        {
+            yield return record;
+            await Task.Yield();
+        }
+    }
+
+    private static ConsumeResult<string, byte[]> CreateConsumeResult(
+        RoundTripMessage message,
+        int partition,
+        long offset) =>
+        new(
+            topic: "roundtrip-untracked-partition",
+            partition,
+            offset,
+            keyData: Encoding.UTF8.GetBytes(message.Key),
+            isKeyNull: false,
+            valueData: message.Value,
+            isValueNull: false,
+            headers: null,
+            timestampMs: 0,
+            timestampType: TimestampType.CreateTime,
+            leaderEpoch: null,
+            keyDeserializer: Serializers.String,
+            valueDeserializer: Serializers.ByteArray);
 
     [Test]
     public async Task RoundTripResult_ConfiguresDiagnosticsAndMessageBound()

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -1,3 +1,4 @@
+using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Scenarios;
 
 namespace Dekaf.Tests.Unit.Stress;
@@ -151,5 +152,56 @@ public class RoundTripMessageCodecTests
         await Assert.That(tracker.IsComplete).IsFalse();
         await Assert.That(tracker.Record(partition: 1, offset: 6)).IsTrue();
         await Assert.That(tracker.IsComplete).IsTrue();
+    }
+
+    [Test]
+    public async Task TryRecordProduceTimeout_WhenDeadlineExpires_RecordsHardError()
+    {
+        var throughput = new ThroughputTracker();
+
+        var timedOut = RoundTripScenarioHelpers.TryRecordProduceTimeout(
+            true,
+            throughput,
+            client: "Dekaf",
+            ordinal: 42,
+            cancellationToken: CancellationToken.None);
+
+        await Assert.That(timedOut).IsTrue();
+        await Assert.That(throughput.ErrorCount).IsEqualTo(1);
+        await Assert.That(throughput.GetSnapshot().ErrorSamples.Single().Message)
+            .IsEqualTo("Dekaf round-trip produce phase exceeded its timeout.");
+    }
+
+    [Test]
+    public async Task TryRecordProduceTimeout_BeforeDeadline_DoesNothing()
+    {
+        var throughput = new ThroughputTracker();
+
+        var timedOut = RoundTripScenarioHelpers.TryRecordProduceTimeout(
+            false,
+            throughput,
+            client: "Dekaf",
+            ordinal: 0,
+            cancellationToken: CancellationToken.None);
+
+        await Assert.That(timedOut).IsFalse();
+        await Assert.That(throughput.ErrorCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task TryRecordProduceTimeout_WhenRunIsCancelled_PropagatesCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var throughput = new ThroughputTracker();
+
+        await Assert.That(() => RoundTripScenarioHelpers.TryRecordProduceTimeout(
+                true,
+                throughput,
+                client: "Dekaf",
+                ordinal: 42,
+                cancellationToken: cancellation.Token))
+            .Throws<OperationCanceledException>();
+        await Assert.That(throughput.ErrorCount).IsEqualTo(0);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -234,7 +234,7 @@ public class RoundTripMessageCodecTests
     }
 
     [Test]
-    public async Task DeliveryDiagnostics_RoundTripBytePayload_IsConfiguredAndReturned()
+    public async Task RoundTripResult_ConfiguresDiagnosticsAndMessageBound()
     {
         var options = new StressTestOptions
         {
@@ -278,5 +278,6 @@ public class RoundTripMessageCodecTests
             snapshot);
 
         await Assert.That(result.ProducerDeliveryDiagnostics).IsSameReferenceAs(snapshot);
+        await Assert.That(result.IsMessageBounded).IsTrue();
     }
 }

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -3,6 +3,7 @@ using Dekaf.Consumer;
 using Dekaf.Diagnostics;
 using Dekaf.Serialization;
 using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
 using Dekaf.StressTests.Scenarios;
 using NSubstitute;
 using ConfluentKafka = Confluent.Kafka;
@@ -413,5 +414,41 @@ public class RoundTripMessageCodecTests
 
         await Assert.That(result.ProducerDeliveryDiagnostics).IsSameReferenceAs(snapshot);
         await Assert.That(result.IsMessageBounded).IsTrue();
+    }
+
+    [Test]
+    public async Task RoundTripResult_ExcludesProducerOnlyMedianRate()
+    {
+        var now = DateTime.UtcNow;
+        var result = new StressTestResult
+        {
+            Scenario = "producer-roundtrip",
+            Client = "Dekaf",
+            DurationMinutes = 15,
+            MessageSizeBytes = 1_000,
+            StartedAtUtc = now,
+            CompletedAtUtc = now.AddSeconds(30),
+            Throughput = new ThroughputSnapshot
+            {
+                TotalMessages = 1_000,
+                TotalBytes = 1_000_000,
+                TotalErrors = 0,
+                ElapsedSeconds = 30,
+                AverageMessagesPerSecond = 33.3,
+                AverageMegabytesPerSecond = 0.03,
+                MessagesPerSecondSamples = [1_000, 1_100],
+                ErrorSamples = []
+            },
+            GcStats = new GcSnapshot
+            {
+                Gen0Collections = 0,
+                Gen1Collections = 0,
+                Gen2Collections = 0,
+                AllocatedBytes = 0
+            },
+            IsMessageBounded = true
+        };
+
+        await Assert.That(result.MedianIntervalMessagesPerSecond).IsNull();
     }
 }

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -212,6 +212,26 @@ public class RoundTripMessageCodecTests
     }
 
     [Test]
+    public async Task StartSampler_WhenOperationThrows_StopsSamplerAndRethrows()
+    {
+        var throughput = new ThroughputTracker();
+        throughput.Start();
+
+        var runTask = RunFailingOperationAsync(throughput);
+
+        await Assert.That(async () => await runTask.WaitAsync(TimeSpan.FromSeconds(2)))
+            .Throws<InvalidOperationException>()
+            .WithMessage("operation failed");
+
+        static async Task RunFailingOperationAsync(ThroughputTracker throughput)
+        {
+            await using var sampler = StressTestHelpers.StartSampler(throughput, CancellationToken.None);
+            await Task.Yield();
+            throw new InvalidOperationException("operation failed");
+        }
+    }
+
+    [Test]
     public async Task ConfluentDeliveryReportFailure_CountsAsDeliveryError()
     {
         var throughput = new ThroughputTracker();

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -213,6 +213,64 @@ public class RoundTripMessageCodecTests
     }
 
     [Test]
+    public async Task TryQueryEndOffsets_WhenQueryFails_RecordsErrorAndReturnsNull()
+    {
+        var throughput = new ThroughputTracker();
+
+        var offsets = await RoundTripScenarioHelpers.TryQueryEndOffsetsAsync(
+            _ => Task.FromException<long[]>(new InvalidOperationException("query failed")),
+            throughput,
+            TimeSpan.FromSeconds(1),
+            CancellationToken.None);
+
+        var error = throughput.GetSnapshot().ErrorSamples.Single();
+        await Assert.That(offsets).IsNull();
+        await Assert.That(throughput.ErrorCount).IsEqualTo(1);
+        await Assert.That(error.Operation).IsEqualTo("Round-trip end offset query");
+        await Assert.That(error.Message).IsEqualTo("query failed");
+    }
+
+    [Test]
+    public async Task TryQueryEndOffsets_WhenQueryHangs_RecordsTimeoutAndReturnsNull()
+    {
+        var throughput = new ThroughputTracker();
+        var neverCompletes = new TaskCompletionSource<long[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var offsets = await RoundTripScenarioHelpers.TryQueryEndOffsetsAsync(
+                _ => neverCompletes.Task,
+                throughput,
+                TimeSpan.Zero,
+                CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(2));
+
+        var error = throughput.GetSnapshot().ErrorSamples.Single();
+        await Assert.That(offsets).IsNull();
+        await Assert.That(throughput.ErrorCount).IsEqualTo(1);
+        await Assert.That(error.ExceptionType).IsEqualTo(typeof(TimeoutException).FullName);
+        await Assert.That(error.Operation).IsEqualTo("Round-trip end offset query");
+    }
+
+    [Test]
+    public async Task TryQueryEndOffsets_WhenRunIsCancelled_PropagatesCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var throughput = new ThroughputTracker();
+
+        await Assert.That(async () => await RoundTripScenarioHelpers.TryQueryEndOffsetsAsync(
+                async token =>
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                    return [];
+                },
+                throughput,
+                TimeSpan.FromSeconds(1),
+                cancellation.Token))
+            .Throws<OperationCanceledException>();
+        await Assert.That(throughput.ErrorCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task StartSampler_WhenOperationThrows_StopsSamplerAndRethrows()
     {
         var throughput = new ThroughputTracker();

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -218,4 +218,51 @@ public class RoundTripMessageCodecTests
         await Assert.That(throughput.DeliveryErrorCount).IsEqualTo(1);
         await Assert.That(throughput.ErrorCount).IsEqualTo(0);
     }
+
+    [Test]
+    public async Task DeliveryDiagnostics_RoundTripBytePayload_IsConfiguredAndReturned()
+    {
+        var options = new StressTestOptions
+        {
+            BootstrapServers = "localhost:9092",
+            Topic = "roundtrip-diagnostics",
+            DurationMinutes = 1,
+            MessageSizeBytes = 128,
+            EnableProducerDeliveryDiagnostics = true,
+            ProgressWatchdog = null!
+        };
+        var builder = Kafka.CreateProducer<string, byte[]>()
+            .WithBootstrapServers(options.BootstrapServers);
+        StressTestHelpers.ConfigureProducerDeliveryDiagnostics(builder, options);
+
+        await using var producer = builder.Build();
+        var snapshot = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
+
+        await Assert.That(snapshot).IsNotNull();
+        await Assert.That(snapshot!.DiagnosticsEnabled).IsTrue();
+
+        var result = RoundTripScenarioHelpers.CreateResult(
+            "producer-roundtrip",
+            "Dekaf",
+            options,
+            DateTime.UtcNow,
+            new ThroughputTracker(),
+            new GcStats(),
+            delivered: 0,
+            new RoundTripValidationSnapshot
+            {
+                ExpectedMessages = 0,
+                ConsumedMessages = 0,
+                MissingMessages = 0,
+                DuplicateMessages = 0,
+                CorruptMessages = 0,
+                OutOfOrderMessages = 0,
+                MispartitionedMessages = 0,
+                UnexpectedMessages = 0,
+                TimedOut = false
+            },
+            snapshot);
+
+        await Assert.That(result.ProducerDeliveryDiagnostics).IsSameReferenceAs(snapshot);
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -1,5 +1,6 @@
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Scenarios;
+using ConfluentKafka = Confluent.Kafka;
 
 namespace Dekaf.Tests.Unit.Stress;
 
@@ -202,6 +203,19 @@ public class RoundTripMessageCodecTests
                 ordinal: 42,
                 cancellationToken: cancellation.Token))
             .Throws<OperationCanceledException>();
+        await Assert.That(throughput.ErrorCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ConfluentDeliveryReportFailure_CountsAsDeliveryError()
+    {
+        var throughput = new ThroughputTracker();
+
+        ConfluentProducerRoundTripStressTest.RecordDeliveryReportError(
+            throughput,
+            new ConfluentKafka.Error(ConfluentKafka.ErrorCode.Local_MsgTimedOut));
+
+        await Assert.That(throughput.DeliveryErrorCount).IsEqualTo(1);
         await Assert.That(throughput.ErrorCount).IsEqualTo(0);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -1,6 +1,8 @@
+using Dekaf.Consumer;
 using Dekaf.Diagnostics;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Scenarios;
+using NSubstitute;
 using ConfluentKafka = Confluent.Kafka;
 
 namespace Dekaf.Tests.Unit.Stress;
@@ -231,6 +233,47 @@ public class RoundTripMessageCodecTests
 
         await Assert.That(throughput.DeliveryErrorCount).IsEqualTo(2);
         await Assert.That(throughput.ErrorCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DekafConsumeFailure_IsRecordedWithoutAbortingTheResult()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, byte[]>>();
+        consumer.Partitions.Returns(Substitute.For<IConsumerPartitions>());
+        consumer.ConsumeAsync(Arg.Any<CancellationToken>())
+            .Returns(ThrowConsumeFailure());
+        var throughput = new ThroughputTracker();
+        var validator = new RoundTripValidator([1]);
+        var options = new StressTestOptions
+        {
+            BootstrapServers = "localhost:9092",
+            Topic = "roundtrip-consume-failure",
+            Partitions = 1,
+            DurationMinutes = 1,
+            MessageSizeBytes = 128,
+            ProgressWatchdog = null!
+        };
+
+        var timedOut = await ProducerRoundTripStressTest.ConsumeAndValidateAsync(
+            consumer,
+            options,
+            startOffsets: [0],
+            endOffsets: [1],
+            validator,
+            throughput,
+            CancellationToken.None);
+
+        var error = throughput.GetSnapshot().ErrorSamples.Single();
+        await Assert.That(timedOut).IsFalse();
+        await Assert.That(throughput.ErrorCount).IsEqualTo(1);
+        await Assert.That(error.Operation).IsEqualTo("Round-trip consume");
+        await Assert.That(error.Message).IsEqualTo("consume failed");
+    }
+
+    private static async IAsyncEnumerable<ConsumeResult<string, byte[]>> ThrowConsumeFailure()
+    {
+        await Task.FromException(new InvalidOperationException("consume failed"));
+        yield break;
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -1,0 +1,139 @@
+using Dekaf.StressTests.Scenarios;
+
+namespace Dekaf.Tests.Unit.Stress;
+
+public class RoundTripMessageCodecTests
+{
+    [Test]
+    public async Task ExpectedPartition_MatchesJavaMurmur2Vector()
+    {
+        await Assert.That(RoundTripMessageCodec.GetExpectedPartition("user-123", partitionCount: 10))
+            .IsEqualTo(8);
+    }
+
+    [Test]
+    public async Task CreateAndDecode_RoundTripsMetadataAtRequestedSize()
+    {
+        const int partitionCount = 6;
+        const int payloadSize = 256;
+        var factory = new RoundTripMessageFactory("test-run", partitionCount, payloadSize);
+
+        var message = factory.Create(partition: 4);
+        var decoded = RoundTripMessageCodec.TryDecode(message.Key, message.Value, out var metadata);
+
+        await Assert.That(decoded).IsTrue();
+        await Assert.That(message.Value).Count().IsEqualTo(payloadSize);
+        await Assert.That(message.ExpectedPartition).IsEqualTo(4);
+        await Assert.That(RoundTripMessageCodec.GetExpectedPartition(message.Key, partitionCount)).IsEqualTo(4);
+        await Assert.That(metadata.Partition).IsEqualTo(4);
+        await Assert.That(metadata.Sequence).IsEqualTo(0);
+        await Assert.That(metadata.Ordinal).IsEqualTo(4);
+        await Assert.That(factory.ExpectedPerPartition.Sum()).IsEqualTo(1);
+        await Assert.That(factory.ExpectedPerPartition[4]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TryDecode_WhenPayloadOrKeyChanges_RejectsMessage()
+    {
+        var factory = new RoundTripMessageFactory("test-run", partitionCount: 3, payloadSize: 128);
+        var message = factory.Create(partition: 2);
+        var corruptedValue = message.Value.ToArray();
+        corruptedValue[RoundTripMessageCodec.HeaderSize] ^= 0x5a;
+
+        var valueDecoded = RoundTripMessageCodec.TryDecode(message.Key, corruptedValue, out _);
+        var keyDecoded = RoundTripMessageCodec.TryDecode($"{message.Key}-changed", message.Value, out _);
+
+        await Assert.That(valueDecoded).IsFalse();
+        await Assert.That(keyDecoded).IsFalse();
+    }
+
+    [Test]
+    public async Task Validator_ReportsGapsDuplicatesReorderingAndMispartitioning()
+    {
+        var factory = new RoundTripMessageFactory("validator-run", partitionCount: 2, payloadSize: 128);
+        var sequenceZero = factory.Create(partition: 0);
+        var sequenceOne = factory.Create(partition: 0);
+        _ = factory.Create(partition: 0);
+        var sequenceThree = factory.Create(partition: 0);
+        var validator = new RoundTripValidator(factory.ExpectedPerPartition);
+
+        validator.Record(sequenceOne.Key, sequenceOne.Value, actualPartition: 0, actualOffset: 0);
+        validator.Record(sequenceZero.Key, sequenceZero.Value, actualPartition: 0, actualOffset: 1);
+        validator.Record(sequenceOne.Key, sequenceOne.Value, actualPartition: 0, actualOffset: 2);
+        validator.Record(sequenceThree.Key, sequenceThree.Value, actualPartition: 1, actualOffset: 0);
+
+        var snapshot = validator.CreateSnapshot(timedOut: false);
+
+        await Assert.That(snapshot.ExpectedMessages).IsEqualTo(4);
+        await Assert.That(snapshot.ConsumedMessages).IsEqualTo(4);
+        await Assert.That(snapshot.MissingMessages).IsEqualTo(1);
+        await Assert.That(snapshot.DuplicateMessages).IsEqualTo(1);
+        await Assert.That(snapshot.OutOfOrderMessages).IsEqualTo(1);
+        await Assert.That(snapshot.MispartitionedMessages).IsEqualTo(1);
+        await Assert.That(snapshot.IsSuccess).IsFalse();
+    }
+
+    [Test]
+    public async Task Validator_AcceptsEverySequenceExactlyOnceInOffsetOrder()
+    {
+        var factory = new RoundTripMessageFactory("complete-run", partitionCount: 3, payloadSize: 128);
+        var messages = Enumerable.Range(0, 3)
+            .SelectMany(_ => Enumerable.Range(0, 3).Select(factory.Create))
+            .ToArray();
+        var validator = new RoundTripValidator(factory.ExpectedPerPartition);
+        var offsets = new long[3];
+
+        foreach (var message in messages)
+        {
+            validator.Record(
+                message.Key,
+                message.Value,
+                message.ExpectedPartition,
+                offsets[message.ExpectedPartition]++);
+        }
+
+        var snapshot = validator.CreateSnapshot(timedOut: false);
+
+        await Assert.That(snapshot.ExpectedMessages).IsEqualTo(9);
+        await Assert.That(snapshot.ConsumedMessages).IsEqualTo(9);
+        await Assert.That(snapshot.MissingMessages).IsEqualTo(0);
+        await Assert.That(snapshot.IsSuccess).IsTrue();
+    }
+
+    [Test]
+    public async Task Validator_WhenOrdinalDoesNotMatchPartitionSequence_ReportsCorruption()
+    {
+        var factory = new RoundTripMessageFactory("ordinal-run", partitionCount: 2, payloadSize: 128);
+        var message = factory.Create(partition: 0);
+        var payload = RoundTripMessageCodec.Encode(
+            message.Key,
+            partition: 0,
+            sequence: 0,
+            ordinal: 9,
+            payloadSize: 128);
+        var validator = new RoundTripValidator(factory.ExpectedPerPartition);
+
+        validator.Record(message.Key, payload, actualPartition: 0, actualOffset: 0);
+
+        var snapshot = validator.CreateSnapshot(timedOut: false);
+        await Assert.That(snapshot.CorruptMessages).IsEqualTo(1);
+        await Assert.That(snapshot.MissingMessages).IsEqualTo(1);
+        await Assert.That(snapshot.IsSuccess).IsFalse();
+    }
+
+    [Test]
+    public async Task CompletionTracker_HandlesEmptyRangesAndUnexpectedPartitions()
+    {
+        var tracker = new RoundTripCompletionTracker(
+            startOffsets: [0, 5],
+            endOffsets: [0, 7]);
+
+        await Assert.That(tracker.RemainingPartitions).IsEqualTo(1);
+        await Assert.That(tracker.Record(partition: 9, offset: 0)).IsFalse();
+        await Assert.That(tracker.Record(partition: 1, offset: 4)).IsFalse();
+        await Assert.That(tracker.Record(partition: 1, offset: 5)).IsTrue();
+        await Assert.That(tracker.IsComplete).IsFalse();
+        await Assert.That(tracker.Record(partition: 1, offset: 6)).IsTrue();
+        await Assert.That(tracker.IsComplete).IsTrue();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -122,6 +122,22 @@ public class RoundTripMessageCodecTests
     }
 
     [Test]
+    public async Task Validator_RecordUnexpected_CountsOutOfWindowRecordAsFailure()
+    {
+        var factory = new RoundTripMessageFactory("unexpected-run", partitionCount: 1, payloadSize: 128);
+        _ = factory.Create(partition: 0);
+        var validator = new RoundTripValidator(factory.ExpectedPerPartition);
+
+        validator.RecordUnexpected();
+
+        var snapshot = validator.CreateSnapshot(timedOut: false);
+        await Assert.That(snapshot.ConsumedMessages).IsEqualTo(1);
+        await Assert.That(snapshot.UnexpectedMessages).IsEqualTo(1);
+        await Assert.That(snapshot.MissingMessages).IsEqualTo(1);
+        await Assert.That(snapshot.IsSuccess).IsFalse();
+    }
+
+    [Test]
     public async Task CompletionTracker_HandlesEmptyRangesAndUnexpectedPartitions()
     {
         var tracker = new RoundTripCompletionTracker(

--- a/tests/Dekaf.Tests.Unit/Stress/StressRunCompletionPolicyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/StressRunCompletionPolicyTests.cs
@@ -1,0 +1,28 @@
+using Dekaf.StressTests;
+
+namespace Dekaf.Tests.Unit.Stress;
+
+public sealed class StressRunCompletionPolicyTests
+{
+    [Test]
+    public async Task EndedEarly_MessageBoundedRun_DoesNotRequireConfiguredDuration()
+    {
+        var endedEarly = StressRunCompletionPolicy.EndedEarly(
+            elapsedSeconds: 30,
+            configuredDurationMinutes: 15,
+            isMessageBounded: true);
+
+        await Assert.That(endedEarly).IsFalse();
+    }
+
+    [Test]
+    public async Task EndedEarly_DurationBoundedRun_RequiresNinetyPercentOfConfiguredDuration()
+    {
+        var endedEarly = StressRunCompletionPolicy.EndedEarly(
+            elapsedSeconds: 809,
+            configuredDurationMinutes: 15,
+            isMessageBounded: false);
+
+        await Assert.That(endedEarly).IsTrue();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Stress/StressRunCompletionPolicyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/StressRunCompletionPolicyTests.cs
@@ -25,4 +25,15 @@ public sealed class StressRunCompletionPolicyTests
 
         await Assert.That(endedEarly).IsTrue();
     }
+
+    [Test]
+    public async Task EndedEarly_DurationBoundedRun_AfterThreshold_IsFalse()
+    {
+        var endedEarly = StressRunCompletionPolicy.EndedEarly(
+            elapsedSeconds: 900,
+            configuredDurationMinutes: 15,
+            isMessageBounded: false);
+
+        await Assert.That(endedEarly).IsFalse();
+    }
 }

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -430,7 +430,7 @@ public static class Program
             if (StressRunCompletionPolicy.EndedEarly(
                     result.Throughput.ElapsedSeconds,
                     result.DurationMinutes,
-                    isMessageBounded: result.RoundTripValidation is not null))
+                    isMessageBounded: result.IsMessageBounded))
             {
                 var expectedSeconds = result.DurationMinutes * 60;
                 reasons.Add(

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -19,11 +19,12 @@ namespace Dekaf.StressTests;
 /// Options:
 ///   --duration &lt;minutes&gt;    Test duration in minutes (default: 15)
 ///   --message-size &lt;bytes&gt;  Message size in bytes (default: 1000)
-///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
+///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
 ///   --client &lt;name&gt;         Run specific client: dekaf, confluent, all (default: all)
 ///   --output &lt;path&gt;         Output directory for results (default: ./results)
 ///   --brokers &lt;count&gt;      Number of Kafka brokers (default: 1, use 3 for multi-broker)
 ///   --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message loss and watchdog stalls
+///   --roundtrip-messages &lt;count&gt;  Bounded message count for producer-roundtrip (default: 250000)
 ///   report --input &lt;path&gt;   Generate report from existing results
 ///   fault [options]          Run fault-injection correctness suite
 ///
@@ -139,6 +140,7 @@ public static class Program
         var producerTopic = $"stress-producer-{Guid.NewGuid():N}";
         var consumerTopic = $"stress-consumer-{Guid.NewGuid():N}";
         string? transactionalTopic = null;
+        var roundTripTopic = $"stress-roundtrip-{Guid.NewGuid():N}";
 
         var replicationFactor = Math.Min(options.Brokers, 3);
         var replayTopicConfigs = new Dictionary<string, string>
@@ -164,6 +166,17 @@ public static class Program
             replicationFactor,
             replayTopicConfigs).ConfigureAwait(false);
 
+        if (options.Scenario is "producer-roundtrip" or "all")
+        {
+            // Round-trip validation must consume every produced byte. Keep this topic
+            // retention-free, but cap its disk use with --roundtrip-messages.
+            await kafka.CreateTopicAsync(roundTripTopic, options.Partitions, replicationFactor, new Dictionary<string, string>
+            {
+                ["retention.ms"] = "-1",
+                ["retention.bytes"] = "-1"
+            }).ConfigureAwait(false);
+        }
+
         if (options.Scenario is "consumer" or "consumer-batch" or "consumer-raw" or "consumer-raw-batch" or "all")
         {
             await SeedConsumerTopicAsync(kafka.BootstrapServers, consumerTopic, options).ConfigureAwait(false);
@@ -177,6 +190,9 @@ public static class Program
         {
             if (scenarioName.Equals("producer-transactional", StringComparison.OrdinalIgnoreCase))
                 return transactionalTopic ?? throw new InvalidOperationException("Transactional topic was not created.");
+
+            if (scenarioName.Equals("producer-roundtrip", StringComparison.OrdinalIgnoreCase))
+                return roundTripTopic;
 
             return UsesProducerTopic(scenarioName)
                 ? producerTopic
@@ -195,6 +211,7 @@ public static class Program
             Compression = options.Compression,
             BrokerCount = options.Brokers,
             ConnectionsPerBroker = connectionsPerBroker,
+            RoundTripMessages = options.RoundTripMessages,
             EnableProducerDeliveryDiagnostics = options.EnableProducerDeliveryDiagnostics,
             ProgressWatchdog = progressWatchdog,
             SoakMessagesPerSecond = options.SoakMessagesPerSecond,
@@ -345,6 +362,7 @@ public static class Program
     /// - Duplicate delivery in idempotent scenarios (delivered exceeding accepted), which
     ///   means broker-side deduplication of retries is broken. Non-idempotent scenarios
     ///   skip this check because retry duplicates are legitimate there.
+    /// - Round-trip checksum, partition, sequence, duplicate, gap, and timeout violations.
     /// - A run that ended measurably earlier than its configured duration (a swallowed
     ///   cancellation or crashed loop would otherwise pass with a fraction of the load).
     /// - A sustained mid-run stall (see <see cref="StallThresholdSeconds"/>).
@@ -403,6 +421,11 @@ public static class Program
                 }
             }
 
+            if (result.RoundTripValidation is { IsSuccess: false })
+            {
+                reasons.Add("round-trip validation failed");
+            }
+
             var expectedSeconds = result.DurationMinutes * 60;
             if (result.Throughput.ElapsedSeconds < expectedSeconds * 0.9)
             {
@@ -451,6 +474,11 @@ public static class Program
             if (transactionVerification is { IsSuccessful: false })
             {
                 PrintTransactionVerificationFailure(transactionVerification);
+            }
+
+            if (result.RoundTripValidation is { } validation)
+            {
+                PrintRoundTripValidation(validation);
             }
         }
 
@@ -520,6 +548,17 @@ public static class Program
         {
             Console.WriteLine($"      - {sample}");
         }
+    }
+
+    private static void PrintRoundTripValidation(RoundTripValidationSnapshot validation)
+    {
+        Console.WriteLine(
+            $"    round-trip: expected={validation.ExpectedMessages:N0}, " +
+            $"consumed={validation.ConsumedMessages:N0}, missing={validation.MissingMessages:N0}, " +
+            $"duplicates={validation.DuplicateMessages:N0}, corrupt={validation.CorruptMessages:N0}, " +
+            $"out-of-order={validation.OutOfOrderMessages:N0}, " +
+            $"mispartitioned={validation.MispartitionedMessages:N0}, " +
+            $"unexpected={validation.UnexpectedMessages:N0}, timed-out={validation.TimedOut}");
     }
 
     private static void PrintProducerDeliveryDiagnostics(ProducerDeliveryDiagnosticsSnapshot? snapshot)
@@ -670,6 +709,8 @@ public static class Program
             new ProducerAsyncIdempotentStressTest(),
             new ConfluentProducerAsyncIdempotentStressTest(),
             new TransactionalProducerStressTest(),
+            new ProducerRoundTripStressTest(),
+            new ConfluentProducerRoundTripStressTest(),
             new ConsumerStressTest(),
             new ConsumerBatchStressTest(),
             new ConsumerRawStressTest(),
@@ -810,6 +851,13 @@ public static class Program
                         throw new ArgumentException("--seed-messages must be at least 1");
                     }
                     break;
+                case "--roundtrip-messages":
+                    options.RoundTripMessages = int.Parse(args[++i]);
+                    if (options.RoundTripMessages < 1)
+                    {
+                        throw new ArgumentException("--roundtrip-messages must be at least 1");
+                    }
+                    break;
                 case "--producer-delivery-diagnostics":
                     options.EnableProducerDeliveryDiagnostics = true;
                     break;
@@ -912,7 +960,7 @@ public static class Program
             Options:
               --duration <minutes>    Test duration in minutes (default: 15)
               --message-size <bytes>  Message size in bytes (default: 1000)
-              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, consumer, consumer-batch, consumer-raw, consumer-raw-batch, soak, all (default: all; all excludes soak)
+              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip, consumer, consumer-batch, consumer-raw, consumer-raw-batch, soak, all (default: all; all excludes soak)
               --client <name>         Run specific client: dekaf, confluent, all (default: all)
               --output <path>         Output directory for results (default: ./results)
               --partitions <count>    Number of topic partitions (default: 6)
@@ -931,6 +979,7 @@ public static class Program
               --max-gc-heap-slope-mib-per-hour <n>      GC-heap growth limit (default: 4)
               --max-loh-slope-mib-per-hour <n>          LOH growth limit (default: 4)
               --max-throughput-decay-percent-per-hour <n> Throughput decay limit (default: 5)
+              --roundtrip-messages <count>  Bounded message count for producer-roundtrip (default: 250000)
               report --input <path>   Generate report from existing results
 
             Fault injection:
@@ -976,6 +1025,7 @@ public static class Program
         public int Brokers { get; set; } = 1;
         public int ConnectionsPerBroker { get; set; } = 1;
         public int SeedMessages { get; set; } = 2_000_000;
+        public int RoundTripMessages { get; set; } = 250_000;
         public bool EnableProducerDeliveryDiagnostics { get; set; }
         public string FaultProfile { get; set; } = "all";
         public int FaultDurationSeconds { get; set; } = 5;

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -363,8 +363,9 @@ public static class Program
     ///   means broker-side deduplication of retries is broken. Non-idempotent scenarios
     ///   skip this check because retry duplicates are legitimate there.
     /// - Round-trip checksum, partition, sequence, duplicate, gap, and timeout violations.
-    /// - A run that ended measurably earlier than its configured duration (a swallowed
-    ///   cancellation or crashed loop would otherwise pass with a fraction of the load).
+    /// - A duration-bounded run that ended measurably earlier than its configured duration
+    ///   (a swallowed cancellation or crashed loop would otherwise pass with a fraction of
+    ///   the load). Message-bounded round-trip runs are exempt from this duration guard.
     /// - A sustained mid-run stall (see <see cref="StallThresholdSeconds"/>).
     /// - Task exceptions nobody observed, surfaced after a final finalizer sweep.
     /// Results are already saved at this point; the non-zero exit only fails the CI job.
@@ -426,9 +427,12 @@ public static class Program
                 reasons.Add("round-trip validation failed");
             }
 
-            var expectedSeconds = result.DurationMinutes * 60;
-            if (result.Throughput.ElapsedSeconds < expectedSeconds * 0.9)
+            if (StressRunCompletionPolicy.EndedEarly(
+                    result.Throughput.ElapsedSeconds,
+                    result.DurationMinutes,
+                    isMessageBounded: result.RoundTripValidation is not null))
             {
+                var expectedSeconds = result.DurationMinutes * 60;
                 reasons.Add(
                     $"run ended early ({result.Throughput.ElapsedSeconds:N0}s of {expectedSeconds:N0}s)");
             }

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -43,6 +43,12 @@ internal static class MarkdownReporter
             if (resultsWithResourceTrends.Count > 0)
                 GenerateResourceTrendTable(sb, resultsWithResourceTrends, $"Resource Trends - {label}");
 
+            var roundTripResults = groupResults
+                .Where(r => r.RoundTripValidation is not null)
+                .ToList();
+            if (roundTripResults.Count > 0)
+                GenerateRoundTripValidationTable(sb, roundTripResults, $"Round-Trip Validation - {label}");
+
             var resultsWithErrorSamples = groupResults
                 .Where(r => r.Throughput.ErrorSamples.Count > 0)
                 .ToList();
@@ -285,6 +291,33 @@ internal static class MarkdownReporter
         sb.AppendLine();
     }
 
+    private static void GenerateRoundTripValidationTable(
+        StringBuilder sb,
+        List<StressTestResult> results,
+        string title)
+    {
+        var clientWidth = GetClientColumnWidth(results);
+
+        sb.AppendLine($"## {title}");
+        sb.AppendLine();
+        sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Expected | Consumed | Missing | Duplicates | Corrupt | Out of Order | Wrong Partition | Unexpected | Timed Out | Result |");
+        sb.AppendLine($"|{new string('-', clientWidth + 2)}|----------|----------|---------|------------|---------|--------------|-----------------|------------|-----------|--------|");
+
+        foreach (var result in results.OrderBy(r => r.Client))
+        {
+            var validation = result.RoundTripValidation!;
+            sb.AppendLine(
+                $"| {result.Client.PadRight(clientWidth)} | {validation.ExpectedMessages,8:N0} | " +
+                $"{validation.ConsumedMessages,8:N0} | {validation.MissingMessages,7:N0} | " +
+                $"{validation.DuplicateMessages,10:N0} | {validation.CorruptMessages,7:N0} | " +
+                $"{validation.OutOfOrderMessages,12:N0} | {validation.MispartitionedMessages,15:N0} | " +
+                $"{validation.UnexpectedMessages,10:N0} | {(validation.TimedOut ? "yes" : "no"),9} | " +
+                $"{(validation.IsSuccess ? "PASS" : "FAIL")} |");
+        }
+
+        sb.AppendLine();
+    }
+
     private static string FormatScenarioTitle(string scenario) => scenario switch
     {
         "producer" => "Producer (Fire-and-Forget) Throughput",
@@ -293,6 +326,7 @@ internal static class MarkdownReporter
         "producer-async" => "Producer (Async) Throughput",
         "producer-async-idempotent" => "Producer (Async, Idempotent) Throughput",
         "producer-transactional" => "Producer (Transactional EOS) Throughput",
+        "producer-roundtrip" => "Producer → Consumer Round-Trip Throughput",
         "consumer" => "Consumer Throughput",
         "consumer-batch" => "Consumer (Batch) Throughput",
         "consumer-raw" => "Consumer (Raw Bytes) Throughput",
@@ -309,6 +343,7 @@ internal static class MarkdownReporter
         "producer-async" => "Async",
         "producer-async-idempotent" => "Async (Idempotent)",
         "producer-transactional" => "Transactional EOS",
+        "producer-roundtrip" => "Producer → Consumer Round-Trip",
         "consumer" => "Consumer",
         "consumer-batch" => "Consumer (Batch)",
         "consumer-raw" => "Consumer (Raw Bytes)",

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -78,12 +78,12 @@ internal sealed class StressTestResult
         DeliveredMegabytesPerSecond ?? Throughput.AverageMegabytesPerSecond;
 
     /// <summary>
-    /// Median of sampled client-side throughput intervals. This is less sensitive than
-    /// the whole-run mean to a brief late-run stall, and lets reports show the steady
-    /// state beside the end-to-end average.
+    /// Median of sampled client-side throughput intervals. Message-bounded round-trip
+    /// scenarios sample only their producer phase, while the headline rate includes
+    /// validation, so exposing that partial-window median would make comparisons invalid.
     /// </summary>
     public double? MedianIntervalMessagesPerSecond =>
-        GetMedian(Throughput.MessagesPerSecondSamples);
+        IsMessageBounded ? null : GetMedian(Throughput.MessagesPerSecondSamples);
 
     /// <summary>
     /// Client-side append rate, reported only when it is distinct from the headline

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Dekaf.Producer;
 using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Scenarios;
 
 namespace Dekaf.StressTests.Reporting;
 
@@ -18,6 +19,8 @@ internal sealed class StressTestResult
     public required GcSnapshot GcStats { get; init; }
     public int BrokerCount { get; init; } = 1;
     public ProducerDeliveryDiagnosticsSnapshot? ProducerDeliveryDiagnostics { get; init; }
+    public RoundTripValidationSnapshot? RoundTripValidation { get; init; }
+
     /// <summary>
     /// Whether the scenario's producer ran with idempotence enabled. Must mirror the
     /// producer configuration a few lines above where each scenario sets it. The failure

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -22,6 +22,12 @@ internal sealed class StressTestResult
     public RoundTripValidationSnapshot? RoundTripValidation { get; init; }
 
     /// <summary>
+    /// Whether a fixed message count, rather than <see cref="DurationMinutes"/>, defines
+    /// successful scenario completion. Message-bounded runs may finish before the duration.
+    /// </summary>
+    public bool IsMessageBounded { get; init; }
+
+    /// <summary>
     /// Whether the scenario's producer ran with idempotence enabled. Must mirror the
     /// producer configuration a few lines above where each scenario sets it. The failure
     /// policy in Program.CheckForFailures derives duplicate-delivery enforcement from

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
@@ -212,8 +212,8 @@ internal static class ConfluentStressTestHelpers
     /// timeout: a flush that cannot drain against a healthy broker means the client is
     /// stuck, and the leftover messages will surface as undelivered loss.
     /// </summary>
-    internal static void FlushWithTimeout(
-        ConfluentKafka.IProducer<string, string> producer,
+    internal static void FlushWithTimeout<TKey, TValue>(
+        ConfluentKafka.IProducer<TKey, TValue> producer,
         ThroughputTracker throughput)
     {
         var remaining = producer.Flush(StressTestHelpers.OperationTimeout);

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
@@ -108,11 +108,11 @@ internal static class ConfluentStressTestHelpers
     /// queue-full messages are silently dropped and counted as errors, which makes
     /// throughput numbers incomparable (drops vs. delivered goodput).
     /// </summary>
-    internal static void ProduceWithBackpressure(
-        ConfluentKafka.IProducer<string, string> producer,
+    internal static void ProduceWithBackpressure<TKey, TValue>(
+        ConfluentKafka.IProducer<TKey, TValue> producer,
         string topic,
-        ConfluentKafka.Message<string, string> message,
-        Action<ConfluentKafka.DeliveryReport<string, string>>? deliveryHandler,
+        ConfluentKafka.Message<TKey, TValue> message,
+        Action<ConfluentKafka.DeliveryReport<TKey, TValue>>? deliveryHandler,
         CancellationToken cancellationToken)
         => ConfluentProducerBackpressure.ProduceWithBackpressure(
             producer,

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -23,6 +23,7 @@ internal sealed class StressTestOptions
     public string Compression { get; init; } = "none";
     public int BrokerCount { get; init; } = 1;
     public int ConnectionsPerBroker { get; init; } = 1;
+    public int RoundTripMessages { get; init; } = 250_000;
     public bool EnableProducerDeliveryDiagnostics { get; init; }
     public required ProgressWatchdog ProgressWatchdog { get; init; }
     public int SoakMessagesPerSecond { get; init; } = 5_000;

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -250,15 +250,7 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
             produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
 
             Action<ConfluentKafka.DeliveryReport<string, byte[]>> deliveryHandler = report =>
-            {
-                if (report.Error.IsError)
-                {
-                    throughput.RecordError(
-                        "Confluent.Kafka.Error",
-                        report.Error.ToString(),
-                        "Round-trip delivery report");
-                }
-            };
+                RecordDeliveryReportError(throughput, report.Error);
 
             Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Confluent.Kafka...");
             for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
@@ -343,6 +335,19 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
             gcStats,
             delivered,
             validation);
+    }
+
+    internal static void RecordDeliveryReportError(ThroughputTracker throughput, ConfluentKafka.Error error)
+    {
+        if (!error.IsError)
+        {
+            return;
+        }
+
+        throughput.RecordDeliveryError(
+            "Confluent.Kafka.Error",
+            error.ToString(),
+            "Round-trip delivery report");
     }
 
     private static bool ConsumeAndValidate(

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -110,6 +110,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
             producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
         }
+        await sampler.StopAsync().ConfigureAwait(false);
 
         var endOffsets = await StressTestHelpers.QueryEndOffsetsAsync(
             consumer,
@@ -128,7 +129,6 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             cancellationToken).ConfigureAwait(false);
 
         throughput.Stop();
-        await sampler.StopAsync().ConfigureAwait(false);
 
         gcStats.Capture();
         var validation = validator.CreateSnapshot(timedOut);
@@ -323,6 +323,7 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
 
             ConfluentStressTestHelpers.FlushWithTimeout(producer, throughput);
         }
+        await sampler.StopAsync().ConfigureAwait(false);
 
         var endOffsets = ConfluentStressTestHelpers.QueryEndOffsets(
             consumer,
@@ -341,7 +342,6 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
             cancellationToken);
 
         throughput.Stop();
-        await sampler.StopAsync().ConfigureAwait(false);
 
         gcStats.Capture();
         var validation = validator.CreateSnapshot(timedOut);

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -508,6 +508,7 @@ internal static class RoundTripScenarioHelpers
             Latency = null,
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds,
+            IsMessageBounded = true,
             RoundTripValidation = validation,
             ProducerDeliveryDiagnostics = producerDeliveryDiagnostics
         };

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -55,6 +55,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             "zstd" => builder.UseZstdCompression(),
             _ => builder
         };
+        StressTestHelpers.ConfigureProducerDeliveryDiagnostics(builder, options);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -63,6 +64,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         var gcStats = new GcStats();
         throughput.Start();
 
+        ProducerDeliveryDiagnosticsSnapshot? producerDiagnostics;
         await using (var producer = await builder.BuildAsync(cancellationToken))
         {
             using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -99,6 +101,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             }
 
             await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
+            producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
         }
 
         var endOffsets = await StressTestHelpers.QueryEndOffsetsAsync(
@@ -129,7 +132,8 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             throughput,
             gcStats,
             delivered,
-            validation);
+            validation,
+            producerDiagnostics);
     }
 
     private static async Task<bool> ConsumeAndValidateAsync(
@@ -334,7 +338,8 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
             throughput,
             gcStats,
             delivered,
-            validation);
+            validation,
+            producerDeliveryDiagnostics: null);
     }
 
     internal static void RecordDeliveryReportError(ThroughputTracker throughput, ConfluentKafka.Error error)
@@ -483,7 +488,8 @@ internal static class RoundTripScenarioHelpers
         ThroughputTracker throughput,
         GcStats gcStats,
         long delivered,
-        RoundTripValidationSnapshot validation) =>
+        RoundTripValidationSnapshot validation,
+        ProducerDeliveryDiagnosticsSnapshot? producerDeliveryDiagnostics) =>
         new()
         {
             Scenario = scenario,
@@ -498,6 +504,7 @@ internal static class RoundTripScenarioHelpers
             Latency = null,
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds,
-            RoundTripValidation = validation
+            RoundTripValidation = validation,
+            ProducerDeliveryDiagnostics = producerDeliveryDiagnostics
         };
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -233,6 +233,9 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
 
         using (var producer = new ConfluentKafka.ProducerBuilder<string, byte[]>(producerConfig).Build())
         {
+            using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
+
             Action<ConfluentKafka.DeliveryReport<string, byte[]>> deliveryHandler = report =>
             {
                 if (report.Error.IsError)
@@ -250,6 +253,7 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
                 var message = factory.Create(ordinal % options.Partitions);
                 try
                 {
+                    produceTimeout.Token.ThrowIfCancellationRequested();
                     ConfluentStressTestHelpers.ProduceWithBackpressure(
                         producer,
                         options.Topic,
@@ -259,8 +263,17 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
                             Value = message.Value
                         },
                         deliveryHandler,
-                        cancellationToken);
+                        produceTimeout.Token);
                     throughput.RecordMessage(message.Value.Length);
+                }
+                catch (OperationCanceledException) when (produceTimeout.IsCancellationRequested)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    throughput.RecordError(
+                        new TimeoutException("Confluent round-trip produce phase exceeded its timeout."),
+                        "Round-trip produce",
+                        ordinal);
+                    break;
                 }
                 catch (Exception ex)
                 {

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -112,21 +112,29 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         }
         await sampler.StopAsync().ConfigureAwait(false);
 
-        var endOffsets = await StressTestHelpers.QueryEndOffsetsAsync(
-            consumer,
-            options.Topic,
-            options.Partitions,
-            cancellationToken);
+        var queriedEndOffsets = await RoundTripScenarioHelpers.TryQueryEndOffsetsAsync(
+            token => StressTestHelpers.QueryEndOffsetsAsync(
+                consumer,
+                options.Topic,
+                options.Partitions,
+                token),
+            throughput,
+            StressTestHelpers.OperationTimeout,
+            cancellationToken).ConfigureAwait(false);
+        // Empty ranges let reporting preserve the produce/flush errors and delivery
+        // diagnostics; timedOut below still makes the unverifiable validation fail.
+        var endOffsets = queriedEndOffsets ?? startOffsets;
         var delivered = RoundTripScenarioHelpers.CountRecords(startOffsets, endOffsets);
         var validator = new RoundTripValidator(factory.ExpectedPerPartition);
-        var timedOut = await ConsumeAndValidateAsync(
-            consumer,
-            options,
-            startOffsets,
-            endOffsets,
-            validator,
-            throughput,
-            cancellationToken).ConfigureAwait(false);
+        var timedOut = queriedEndOffsets is null || await ConsumeAndValidateAsync(
+                consumer,
+                options,
+                startOffsets,
+                endOffsets,
+                validator,
+                throughput,
+                cancellationToken)
+            .ConfigureAwait(false);
 
         throughput.Stop();
 
@@ -455,6 +463,43 @@ internal static class RoundTripScenarioHelpers
             "Round-trip produce",
             ordinal);
         return true;
+    }
+
+    public static async Task<long[]?> TryQueryEndOffsetsAsync(
+        Func<CancellationToken, Task<long[]>> query,
+        ThroughputTracker throughput,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        using var queryTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        try
+        {
+            return await query(queryTimeout.Token)
+                .WaitAsync(timeout, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (TimeoutException ex)
+        {
+            queryTimeout.Cancel();
+            throughput.RecordError(
+                new TimeoutException(
+                    $"Round-trip end offset query did not complete within {timeout.TotalSeconds:N0} seconds.",
+                    ex),
+                "Round-trip end offset query");
+            return null;
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            throughput.RecordError(ex, "Round-trip end offset query");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throughput.RecordError(ex, "Round-trip end offset query");
+            return null;
+        }
     }
 
     public static long CountRecords(long[] startOffsets, long[] endOffsets)

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -65,9 +65,22 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
 
         await using (var producer = await builder.BuildAsync(cancellationToken))
         {
+            using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
+
             Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Dekaf...");
             for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
             {
+                if (RoundTripScenarioHelpers.TryRecordProduceTimeout(
+                        produceTimeout.IsCancellationRequested,
+                        throughput,
+                        client: "Dekaf",
+                        ordinal: ordinal,
+                        cancellationToken: cancellationToken))
+                {
+                    break;
+                }
+
                 var message = factory.Create(ordinal % options.Partitions);
                 try
                 {
@@ -250,10 +263,19 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
             Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Confluent.Kafka...");
             for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
             {
+                if (RoundTripScenarioHelpers.TryRecordProduceTimeout(
+                        produceTimeout.IsCancellationRequested,
+                        throughput,
+                        client: "Confluent",
+                        ordinal: ordinal,
+                        cancellationToken: cancellationToken))
+                {
+                    break;
+                }
+
                 var message = factory.Create(ordinal % options.Partitions);
                 try
                 {
-                    produceTimeout.Token.ThrowIfCancellationRequested();
                     ConfluentStressTestHelpers.ProduceWithBackpressure(
                         producer,
                         options.Topic,
@@ -268,11 +290,12 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
                 }
                 catch (OperationCanceledException) when (produceTimeout.IsCancellationRequested)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    throughput.RecordError(
-                        new TimeoutException("Confluent round-trip produce phase exceeded its timeout."),
-                        "Round-trip produce",
-                        ordinal);
+                    _ = RoundTripScenarioHelpers.TryRecordProduceTimeout(
+                        produceTimeout.IsCancellationRequested,
+                        throughput,
+                        client: "Confluent",
+                        ordinal: ordinal,
+                        cancellationToken: cancellationToken);
                     break;
                 }
                 catch (Exception ex)
@@ -392,6 +415,26 @@ internal static class RoundTripScenarioHelpers
 
     public static TimeSpan GetTimeout(StressTestOptions options) =>
         TimeSpan.FromMinutes(Math.Max(5, options.DurationMinutes));
+
+    public static bool TryRecordProduceTimeout(
+        bool timeoutExpired,
+        ThroughputTracker throughput,
+        string client,
+        long ordinal,
+        CancellationToken cancellationToken)
+    {
+        if (!timeoutExpired)
+        {
+            return false;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        throughput.RecordError(
+            new TimeoutException($"{client} round-trip produce phase exceeded its timeout."),
+            "Round-trip produce",
+            ordinal);
+        return true;
+    }
 
     public static long CountRecords(long[] startOffsets, long[] endOffsets)
     {

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -287,14 +287,7 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
                 }
             }
 
-            var remaining = producer.Flush(TimeSpan.FromMinutes(2));
-            if (remaining > 0)
-            {
-                throughput.RecordError(
-                    "Confluent.Kafka.FlushTimeout",
-                    $"{remaining:N0} messages remained after flush",
-                    "Round-trip flush");
-            }
+            ConfluentStressTestHelpers.FlushWithTimeout(producer, throughput);
         }
 
         var endOffsets = ConfluentStressTestHelpers.QueryEndOffsets(

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -176,12 +176,6 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             await foreach (var record in consumer.ConsumeAsync(timeout.Token).ConfigureAwait(false))
             {
                 var partition = record.Partition;
-                if (!completion.IsTrackedPartition(partition))
-                {
-                    validator.Record(record.Key, record.Value, partition, record.Offset);
-                    continue;
-                }
-
                 if (completion.Record(partition, record.Offset))
                 {
                     validator.Record(record.Key, record.Value, partition, record.Offset);
@@ -415,12 +409,6 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
 
                 var partition = record.Partition.Value;
                 var offset = record.Offset.Value;
-                if (!completion.IsTrackedPartition(partition))
-                {
-                    validator.Record(record.Message.Key, record.Message.Value, partition, offset);
-                    continue;
-                }
-
                 if (completion.Record(partition, offset))
                 {
                     validator.Record(record.Message.Key, record.Message.Value, partition, offset);

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -1,0 +1,441 @@
+using Dekaf.Compression.Lz4;
+using Dekaf.Compression.Snappy;
+using Dekaf.Compression.Zstd;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
+using ConfluentKafka = Confluent.Kafka;
+
+namespace Dekaf.StressTests.Scenarios;
+
+internal sealed class ProducerRoundTripStressTest : IStressTestScenario
+{
+    public string Name => "producer-roundtrip";
+    public string Client => "Dekaf";
+
+    public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
+    {
+        RoundTripScenarioHelpers.ValidateOptions(options);
+
+        var throughput = new ThroughputTracker();
+        var factory = new RoundTripMessageFactory(Guid.NewGuid().ToString("N"), options.Partitions, options.MessageSizeBytes);
+        var startedAt = DateTime.UtcNow;
+
+        await using var consumer = await Kafka.CreateConsumer<string, byte[]>()
+            .WithBootstrapServers(options.BootstrapServers)
+            .WithClientId("stress-roundtrip-consumer-dekaf")
+            .WithGroupId($"stress-roundtrip-dekaf-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .BuildAsync(cancellationToken);
+
+        var startOffsets = await StressTestHelpers.QueryEndOffsetsAsync(
+            consumer,
+            options.Topic,
+            options.Partitions,
+            cancellationToken);
+
+        var builder = Kafka.CreateProducer<string, byte[]>()
+            .WithBootstrapServers(options.BootstrapServers)
+            .WithClientId("stress-roundtrip-producer-dekaf")
+            // Deliberately exercise retry duplicate detection; idempotent producers
+            // would suppress the failure class this scenario is meant to expose.
+            .WithIdempotence(false)
+            .WithAcks(Acks.All)
+            .WithPartitioner(PartitionerType.Murmur2)
+            .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
+            .WithBatchSize(options.BatchSize)
+            .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
+
+        _ = options.Compression switch
+        {
+            "lz4" => builder.UseLz4Compression(),
+            "snappy" => builder.UseSnappyCompression(),
+            "zstd" => builder.UseZstdCompression(),
+            _ => builder
+        };
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var gcStats = new GcStats();
+        throughput.Start();
+
+        await using (var producer = await builder.BuildAsync(cancellationToken))
+        {
+            Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Dekaf...");
+            for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
+            {
+                var message = factory.Create(ordinal % options.Partitions);
+                try
+                {
+                    await producer.FireAsync(options.Topic, message.Key, message.Value).ConfigureAwait(false);
+                    throughput.RecordMessage(message.Value.Length);
+                }
+                catch (Exception ex)
+                {
+                    throughput.RecordError(ex, "Round-trip produce", ordinal);
+                }
+
+                if ((ordinal + 1) % 50_000 == 0)
+                {
+                    Console.WriteLine($"  Produced {ordinal + 1:N0} / {options.RoundTripMessages:N0}");
+                }
+            }
+
+            await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var endOffsets = await StressTestHelpers.QueryEndOffsetsAsync(
+            consumer,
+            options.Topic,
+            options.Partitions,
+            cancellationToken);
+        var delivered = RoundTripScenarioHelpers.CountRecords(startOffsets, endOffsets);
+        var validator = new RoundTripValidator(factory.ExpectedPerPartition);
+        var timedOut = await ConsumeAndValidateAsync(
+            consumer,
+            options,
+            startOffsets,
+            endOffsets,
+            validator,
+            cancellationToken).ConfigureAwait(false);
+
+        throughput.Stop();
+        gcStats.Capture();
+        var validation = validator.CreateSnapshot(timedOut);
+        RoundTripScenarioHelpers.LogValidation(validation);
+
+        return RoundTripScenarioHelpers.CreateResult(
+            Name,
+            Client,
+            options,
+            startedAt,
+            throughput,
+            gcStats,
+            delivered,
+            validation);
+    }
+
+    private static async Task<bool> ConsumeAndValidateAsync(
+        IKafkaConsumer<string, byte[]> consumer,
+        StressTestOptions options,
+        long[] startOffsets,
+        long[] endOffsets,
+        RoundTripValidator validator,
+        CancellationToken cancellationToken)
+    {
+        var completion = new RoundTripCompletionTracker(startOffsets, endOffsets);
+        if (completion.IsComplete)
+        {
+            return false;
+        }
+
+        consumer.IncrementalAssign(Enumerable.Range(0, options.Partitions)
+            .Select(partition => new TopicPartitionOffset(options.Topic, partition, startOffsets[partition])));
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
+
+        try
+        {
+            await foreach (var record in consumer.ConsumeAsync(timeout.Token).ConfigureAwait(false))
+            {
+                var partition = record.Partition;
+                if (!completion.IsTrackedPartition(partition))
+                {
+                    validator.Record(record.Key, record.Value, partition, record.Offset);
+                    continue;
+                }
+
+                if (completion.Record(partition, record.Offset))
+                {
+                    validator.Record(record.Key, record.Value, partition, record.Offset);
+                }
+
+                if (completion.IsComplete)
+                {
+                    return false;
+                }
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return true;
+        }
+
+        return !completion.IsComplete;
+    }
+}
+
+internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
+{
+    public string Name => "producer-roundtrip";
+    public string Client => "Confluent";
+
+    public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
+    {
+        RoundTripScenarioHelpers.ValidateOptions(options);
+
+        var throughput = new ThroughputTracker();
+        var factory = new RoundTripMessageFactory(Guid.NewGuid().ToString("N"), options.Partitions, options.MessageSizeBytes);
+        var startedAt = DateTime.UtcNow;
+
+        var consumerConfig = new ConfluentKafka.ConsumerConfig
+        {
+            BootstrapServers = options.BootstrapServers,
+            ClientId = "stress-roundtrip-consumer-confluent",
+            GroupId = $"stress-roundtrip-confluent-{Guid.NewGuid():N}",
+            AutoOffsetReset = ConfluentKafka.AutoOffsetReset.Earliest,
+            EnableAutoCommit = false
+        };
+
+        using var consumer = new ConfluentKafka.ConsumerBuilder<string, byte[]>(consumerConfig).Build();
+        var startOffsets = ConfluentStressTestHelpers.QueryEndOffsets(
+            consumer,
+            options.Topic,
+            options.Partitions,
+            TimeSpan.FromSeconds(30));
+
+        var producerConfig = new ConfluentKafka.ProducerConfig
+        {
+            BootstrapServers = options.BootstrapServers,
+            ClientId = "stress-roundtrip-producer-confluent",
+            // Match Dekaf's non-idempotent retry semantics so duplicate detection is exercised.
+            EnableIdempotence = false,
+            Acks = ConfluentKafka.Acks.All,
+            Partitioner = ConfluentKafka.Partitioner.Murmur2,
+            LingerMs = options.LingerMs,
+            BatchSize = options.BatchSize,
+            QueueBufferingMaxKbytes = ConfluentStressTestHelpers.QueueBufferingMaxKbytes,
+            QueueBufferingMaxMessages = ConfluentStressTestHelpers.QueueBufferingMaxMessages,
+            CompressionType = options.Compression switch
+            {
+                "lz4" => ConfluentKafka.CompressionType.Lz4,
+                "snappy" => ConfluentKafka.CompressionType.Snappy,
+                "zstd" => ConfluentKafka.CompressionType.Zstd,
+                _ => ConfluentKafka.CompressionType.None
+            }
+        };
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var gcStats = new GcStats();
+        throughput.Start();
+
+        using (var producer = new ConfluentKafka.ProducerBuilder<string, byte[]>(producerConfig).Build())
+        {
+            Action<ConfluentKafka.DeliveryReport<string, byte[]>> deliveryHandler = report =>
+            {
+                if (report.Error.IsError)
+                {
+                    throughput.RecordError(
+                        "Confluent.Kafka.Error",
+                        report.Error.ToString(),
+                        "Round-trip delivery report");
+                }
+            };
+
+            Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Confluent.Kafka...");
+            for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
+            {
+                var message = factory.Create(ordinal % options.Partitions);
+                try
+                {
+                    ConfluentStressTestHelpers.ProduceWithBackpressure(
+                        producer,
+                        options.Topic,
+                        new ConfluentKafka.Message<string, byte[]>
+                        {
+                            Key = message.Key,
+                            Value = message.Value
+                        },
+                        deliveryHandler,
+                        cancellationToken);
+                    throughput.RecordMessage(message.Value.Length);
+                }
+                catch (Exception ex)
+                {
+                    throughput.RecordError(ex, "Round-trip produce", ordinal);
+                }
+
+                if ((ordinal + 1) % 50_000 == 0)
+                {
+                    Console.WriteLine($"  Produced {ordinal + 1:N0} / {options.RoundTripMessages:N0}");
+                    await Task.Yield();
+                }
+            }
+
+            var remaining = producer.Flush(TimeSpan.FromMinutes(2));
+            if (remaining > 0)
+            {
+                throughput.RecordError(
+                    "Confluent.Kafka.FlushTimeout",
+                    $"{remaining:N0} messages remained after flush",
+                    "Round-trip flush");
+            }
+        }
+
+        var endOffsets = ConfluentStressTestHelpers.QueryEndOffsets(
+            consumer,
+            options.Topic,
+            options.Partitions,
+            TimeSpan.FromSeconds(30));
+        var delivered = RoundTripScenarioHelpers.CountRecords(startOffsets, endOffsets);
+        var validator = new RoundTripValidator(factory.ExpectedPerPartition);
+        var timedOut = ConsumeAndValidate(
+            consumer,
+            options,
+            startOffsets,
+            endOffsets,
+            validator,
+            throughput,
+            cancellationToken);
+
+        throughput.Stop();
+        gcStats.Capture();
+        var validation = validator.CreateSnapshot(timedOut);
+        RoundTripScenarioHelpers.LogValidation(validation);
+
+        return RoundTripScenarioHelpers.CreateResult(
+            Name,
+            Client,
+            options,
+            startedAt,
+            throughput,
+            gcStats,
+            delivered,
+            validation);
+    }
+
+    private static bool ConsumeAndValidate(
+        ConfluentKafka.IConsumer<string, byte[]> consumer,
+        StressTestOptions options,
+        long[] startOffsets,
+        long[] endOffsets,
+        RoundTripValidator validator,
+        ThroughputTracker throughput,
+        CancellationToken cancellationToken)
+    {
+        var completion = new RoundTripCompletionTracker(startOffsets, endOffsets);
+        if (completion.IsComplete)
+        {
+            return false;
+        }
+
+        consumer.Assign(Enumerable.Range(0, options.Partitions)
+            .Select(partition => new ConfluentKafka.TopicPartitionOffset(
+                options.Topic,
+                partition,
+                startOffsets[partition])));
+
+        var deadline = DateTime.UtcNow + RoundTripScenarioHelpers.GetTimeout(options);
+        while (!completion.IsComplete && DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(100));
+                if (record is null)
+                {
+                    continue;
+                }
+
+                var partition = record.Partition.Value;
+                var offset = record.Offset.Value;
+                if (!completion.IsTrackedPartition(partition))
+                {
+                    validator.Record(record.Message.Key, record.Message.Value, partition, offset);
+                    continue;
+                }
+
+                if (completion.Record(partition, offset))
+                {
+                    validator.Record(record.Message.Key, record.Message.Value, partition, offset);
+                }
+            }
+            catch (ConfluentKafka.ConsumeException ex)
+            {
+                throughput.RecordError(ex, "Round-trip consume");
+            }
+        }
+
+        return !completion.IsComplete;
+    }
+}
+
+internal static class RoundTripScenarioHelpers
+{
+    public static void ValidateOptions(StressTestOptions options)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.RoundTripMessages, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.MessageSizeBytes, RoundTripMessageCodec.MinimumPayloadSize);
+    }
+
+    public static TimeSpan GetTimeout(StressTestOptions options) =>
+        TimeSpan.FromMinutes(Math.Max(5, options.DurationMinutes));
+
+    public static long CountRecords(long[] startOffsets, long[] endOffsets)
+    {
+        if (startOffsets.Length != endOffsets.Length)
+        {
+            throw new ArgumentException("Start and end offset arrays must have the same length.");
+        }
+
+        var count = 0L;
+        for (var partition = 0; partition < startOffsets.Length; partition++)
+        {
+            if (startOffsets[partition] < 0 || endOffsets[partition] < startOffsets[partition])
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(endOffsets),
+                    "Every offset range must be non-negative and end at or after its start.");
+            }
+
+            count += endOffsets[partition] - startOffsets[partition];
+        }
+
+        return count;
+    }
+
+    public static void LogValidation(RoundTripValidationSnapshot validation)
+    {
+        Console.WriteLine(
+            $"  Round-trip validation: expected={validation.ExpectedMessages:N0}, " +
+            $"consumed={validation.ConsumedMessages:N0}, missing={validation.MissingMessages:N0}, " +
+            $"duplicates={validation.DuplicateMessages:N0}, corrupt={validation.CorruptMessages:N0}, " +
+            $"out-of-order={validation.OutOfOrderMessages:N0}, " +
+            $"mispartitioned={validation.MispartitionedMessages:N0}, " +
+            $"unexpected={validation.UnexpectedMessages:N0}, timed-out={validation.TimedOut}");
+    }
+
+    public static StressTestResult CreateResult(
+        string scenario,
+        string client,
+        StressTestOptions options,
+        DateTime startedAt,
+        ThroughputTracker throughput,
+        GcStats gcStats,
+        long delivered,
+        RoundTripValidationSnapshot validation) =>
+        new()
+        {
+            Scenario = scenario,
+            Client = client,
+            DurationMinutes = options.DurationMinutes,
+            BrokerCount = options.BrokerCount,
+            MessageSizeBytes = options.MessageSizeBytes,
+            StartedAtUtc = startedAt,
+            CompletedAtUtc = DateTime.UtcNow,
+            Throughput = throughput.GetSnapshot(),
+            DeliveredMessages = delivered,
+            Latency = null,
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds,
+            RoundTripValidation = validation
+        };
+}

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -64,8 +64,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         var gcStats = new GcStats();
         using var deliveryErrorListener = CreateDeliveryErrorListener(throughput);
         throughput.Start();
-        using var samplerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, samplerCts.Token);
+        await using var sampler = StressTestHelpers.StartSampler(throughput, cancellationToken);
 
         ProducerDeliveryDiagnosticsSnapshot? producerDiagnostics;
         await using (var producer = await builder.BuildAsync(cancellationToken))
@@ -111,8 +110,6 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
             producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
         }
-        samplerCts.Cancel();
-        await samplerTask.ConfigureAwait(false);
 
         var endOffsets = await StressTestHelpers.QueryEndOffsetsAsync(
             consumer,
@@ -131,6 +128,8 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             cancellationToken).ConfigureAwait(false);
 
         throughput.Stop();
+        await sampler.StopAsync().ConfigureAwait(false);
+
         gcStats.Capture();
         var validation = validator.CreateSnapshot(timedOut);
         RoundTripScenarioHelpers.LogValidation(validation);
@@ -261,8 +260,7 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
 
         var gcStats = new GcStats();
         throughput.Start();
-        using var samplerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, samplerCts.Token);
+        await using var sampler = StressTestHelpers.StartSampler(throughput, cancellationToken);
 
         using (var producer = new ConfluentKafka.ProducerBuilder<string, byte[]>(producerConfig).Build())
         {
@@ -325,8 +323,6 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
 
             ConfluentStressTestHelpers.FlushWithTimeout(producer, throughput);
         }
-        samplerCts.Cancel();
-        await samplerTask.ConfigureAwait(false);
 
         var endOffsets = ConfluentStressTestHelpers.QueryEndOffsets(
             consumer,
@@ -345,6 +341,8 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
             cancellationToken);
 
         throughput.Stop();
+        await sampler.StopAsync().ConfigureAwait(false);
+
         gcStats.Capture();
         var validation = validator.CreateSnapshot(timedOut);
         RoundTripScenarioHelpers.LogValidation(validation);

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -266,6 +266,7 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
 
         using (var producer = new ConfluentKafka.ProducerBuilder<string, byte[]>(producerConfig).Build())
         {
+            using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
             using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -64,6 +64,8 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         var gcStats = new GcStats();
         using var deliveryErrorListener = CreateDeliveryErrorListener(throughput);
         throughput.Start();
+        using var samplerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, samplerCts.Token);
 
         ProducerDeliveryDiagnosticsSnapshot? producerDiagnostics;
         await using (var producer = await builder.BuildAsync(cancellationToken))
@@ -109,6 +111,8 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
             producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
         }
+        samplerCts.Cancel();
+        await samplerTask.ConfigureAwait(false);
 
         var endOffsets = await StressTestHelpers.QueryEndOffsetsAsync(
             consumer,
@@ -263,6 +267,8 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
 
         var gcStats = new GcStats();
         throughput.Start();
+        using var samplerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, samplerCts.Token);
 
         using (var producer = new ConfluentKafka.ProducerBuilder<string, byte[]>(producerConfig).Build())
         {
@@ -325,6 +331,8 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
 
             ConfluentStressTestHelpers.FlushWithTimeout(producer, throughput);
         }
+        samplerCts.Cancel();
+        await samplerTask.ConfigureAwait(false);
 
         var endOffsets = ConfluentStressTestHelpers.QueryEndOffsets(
             consumer,

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -85,7 +85,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
                 }
             }
 
-            await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
+            await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
         }
 
         var endOffsets = await StressTestHelpers.QueryEndOffsetsAsync(
@@ -153,6 +153,10 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
                 if (completion.Record(partition, record.Offset))
                 {
                     validator.Record(record.Key, record.Value, partition, record.Offset);
+                }
+                else
+                {
+                    validator.RecordUnexpected();
                 }
 
                 if (completion.IsComplete)
@@ -356,6 +360,10 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
                 if (completion.Record(partition, offset))
                 {
                     validator.Record(record.Message.Key, record.Message.Value, partition, offset);
+                }
+                else
+                {
+                    validator.RecordUnexpected();
                 }
             }
             catch (ConfluentKafka.ConsumeException ex)

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -118,6 +118,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             startOffsets,
             endOffsets,
             validator,
+            throughput,
             cancellationToken).ConfigureAwait(false);
 
         throughput.Stop();
@@ -140,12 +141,13 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
     internal static DekafDeliveryErrorListener CreateDeliveryErrorListener(ThroughputTracker throughput) =>
         new(throughput);
 
-    private static async Task<bool> ConsumeAndValidateAsync(
+    internal static async Task<bool> ConsumeAndValidateAsync(
         IKafkaConsumer<string, byte[]> consumer,
         StressTestOptions options,
         long[] startOffsets,
         long[] endOffsets,
         RoundTripValidator validator,
+        ThroughputTracker throughput,
         CancellationToken cancellationToken)
     {
         var completion = new RoundTripCompletionTracker(startOffsets, endOffsets);
@@ -189,6 +191,11 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
             return true;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throughput.RecordError(ex, "Round-trip consume");
+            return false;
         }
 
         return !completion.IsComplete;

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -68,6 +68,11 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         ProducerDeliveryDiagnosticsSnapshot? producerDiagnostics;
         await using (var producer = await builder.BuildAsync(cancellationToken))
         {
+            using var watchdog = options.ProgressWatchdog.Track(
+                throughput,
+                Client,
+                Name,
+                () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options));
             using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -62,6 +62,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         GC.Collect();
 
         var gcStats = new GcStats();
+        using var deliveryErrorListener = CreateDeliveryErrorListener(throughput);
         throughput.Start();
 
         ProducerDeliveryDiagnosticsSnapshot? producerDiagnostics;
@@ -135,6 +136,9 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             validation,
             producerDiagnostics);
     }
+
+    internal static DekafDeliveryErrorListener CreateDeliveryErrorListener(ThroughputTracker throughput) =>
+        new(throughput);
 
     private static async Task<bool> ConsumeAndValidateAsync(
         IKafkaConsumer<string, byte[]> consumer,

--- a/tools/Dekaf.StressTests/Scenarios/RoundTripMessageCodec.cs
+++ b/tools/Dekaf.StressTests/Scenarios/RoundTripMessageCodec.cs
@@ -335,6 +335,12 @@ internal sealed class RoundTripValidator
         }
     }
 
+    public void RecordUnexpected()
+    {
+        _consumedMessages++;
+        _unexpectedMessages++;
+    }
+
     public RoundTripValidationSnapshot CreateSnapshot(bool timedOut)
     {
         var expectedMessages = _expectedPerPartition.Sum();

--- a/tools/Dekaf.StressTests/Scenarios/RoundTripMessageCodec.cs
+++ b/tools/Dekaf.StressTests/Scenarios/RoundTripMessageCodec.cs
@@ -1,0 +1,438 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.IO.Hashing;
+using System.Text;
+
+namespace Dekaf.StressTests.Scenarios;
+
+internal readonly record struct RoundTripMessage(
+    string Key,
+    byte[] Value,
+    int ExpectedPartition,
+    long Sequence);
+
+internal readonly record struct RoundTripMessageMetadata(
+    int Partition,
+    long Sequence,
+    long Ordinal);
+
+internal sealed class RoundTripMessageFactory
+{
+    private readonly int _partitionCount;
+    private readonly int _payloadSize;
+    private readonly string[] _partitionKeys;
+    private readonly long[] _nextSequences;
+    private readonly long[] _expectedPerPartition;
+
+    public RoundTripMessageFactory(string runId, int partitionCount, int payloadSize)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+        ArgumentOutOfRangeException.ThrowIfLessThan(partitionCount, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(payloadSize, RoundTripMessageCodec.MinimumPayloadSize);
+
+        _partitionCount = partitionCount;
+        _payloadSize = payloadSize;
+        _partitionKeys = Enumerable.Range(0, partitionCount)
+            .Select(partition => RoundTripMessageCodec.FindKeyForPartition(runId, partition, partitionCount))
+            .ToArray();
+        _nextSequences = new long[partitionCount];
+        _expectedPerPartition = new long[partitionCount];
+    }
+
+    public IReadOnlyList<long> ExpectedPerPartition => _expectedPerPartition;
+
+    public RoundTripMessage Create(int partition)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(partition);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(partition, _partitionCount);
+
+        var key = _partitionKeys[partition];
+        var sequence = _nextSequences[partition]++;
+        var ordinal = checked((sequence * _partitionCount) + partition);
+        _expectedPerPartition[partition]++;
+
+        return new RoundTripMessage(
+            key,
+            RoundTripMessageCodec.Encode(key, partition, sequence, ordinal, _payloadSize),
+            partition,
+            sequence);
+    }
+}
+
+internal static class RoundTripMessageCodec
+{
+    private const uint Magic = 0x54524b44; // "DKRT" in little-endian byte order
+    private const byte Version = 1;
+    private const int PartitionOffset = 5;
+    private const int SequenceOffset = 9;
+    private const int OrdinalOffset = 17;
+    private const int KeyChecksumOffset = 25;
+    private const int ChecksumSize = sizeof(uint);
+    private const uint Murmur2Seed = 0x9747b28c;
+    private const uint Murmur2Multiplier = 0x5bd1e995;
+    private const int Murmur2Shift = 24;
+
+    internal const int HeaderSize = 29;
+    internal const int MinimumPayloadSize = HeaderSize + ChecksumSize;
+
+    public static string FindKeyForPartition(string runId, int partition, int partitionCount)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+        ArgumentOutOfRangeException.ThrowIfNegative(partition);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(partition, partitionCount);
+
+        for (var candidate = 0L; ; candidate++)
+        {
+            var key = $"roundtrip-{runId}-p{partition:D4}-{candidate:D8}";
+            if (GetExpectedPartition(key, partitionCount) == partition)
+            {
+                return key;
+            }
+        }
+    }
+
+    public static int GetExpectedPartition(string key, int partitionCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(partitionCount, 1);
+
+        var byteCount = Encoding.UTF8.GetByteCount(key);
+        byte[]? rented = null;
+        Span<byte> keyBytes = byteCount <= 256
+            ? stackalloc byte[byteCount]
+            : (rented = ArrayPool<byte>.Shared.Rent(byteCount));
+
+        try
+        {
+            var written = Encoding.UTF8.GetBytes(key, keyBytes);
+            return GetMurmur2Partition(keyBytes[..written], partitionCount);
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+
+    private static int GetMurmur2Partition(ReadOnlySpan<byte> key, int partitionCount)
+    {
+        var remaining = key.Length;
+        var hash = Murmur2Seed ^ (uint)remaining;
+        var offset = 0;
+
+        while (remaining >= sizeof(uint))
+        {
+            var value = BinaryPrimitives.ReadUInt32LittleEndian(key[offset..]);
+            value *= Murmur2Multiplier;
+            value ^= value >> Murmur2Shift;
+            value *= Murmur2Multiplier;
+
+            hash *= Murmur2Multiplier;
+            hash ^= value;
+            offset += sizeof(uint);
+            remaining -= sizeof(uint);
+        }
+
+        switch (remaining)
+        {
+            case 3:
+                hash ^= (uint)key[offset + 2] << 16;
+                goto case 2;
+            case 2:
+                hash ^= (uint)key[offset + 1] << 8;
+                goto case 1;
+            case 1:
+                hash ^= key[offset];
+                hash *= Murmur2Multiplier;
+                break;
+        }
+
+        hash ^= hash >> 13;
+        hash *= Murmur2Multiplier;
+        hash ^= hash >> 15;
+
+        return (int)((hash & 0x7fff_ffff) % (uint)partitionCount);
+    }
+
+    public static byte[] Encode(
+        string key,
+        int partition,
+        long sequence,
+        long ordinal,
+        int payloadSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(partition);
+        ArgumentOutOfRangeException.ThrowIfNegative(sequence);
+        ArgumentOutOfRangeException.ThrowIfNegative(ordinal);
+        ArgumentOutOfRangeException.ThrowIfLessThan(payloadSize, MinimumPayloadSize);
+
+        var payload = new byte[payloadSize];
+        var span = payload.AsSpan();
+
+        BinaryPrimitives.WriteUInt32LittleEndian(span, Magic);
+        span[sizeof(uint)] = Version;
+        BinaryPrimitives.WriteInt32LittleEndian(span[PartitionOffset..], partition);
+        BinaryPrimitives.WriteInt64LittleEndian(span[SequenceOffset..], sequence);
+        BinaryPrimitives.WriteInt64LittleEndian(span[OrdinalOffset..], ordinal);
+        BinaryPrimitives.WriteUInt32LittleEndian(span[KeyChecksumOffset..], ComputeUtf8Checksum(key));
+
+        var checksumOffset = payloadSize - ChecksumSize;
+        for (var index = HeaderSize; index < checksumOffset; index++)
+        {
+            span[index] = unchecked((byte)((ordinal * 31) + (partition * 13) + (index * 17)));
+        }
+
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            span[checksumOffset..],
+            Crc32.HashToUInt32(span[..checksumOffset]));
+
+        return payload;
+    }
+
+    public static bool TryDecode(
+        string? key,
+        byte[]? payload,
+        out RoundTripMessageMetadata metadata)
+    {
+        metadata = default;
+        if (key is null || payload is null || payload.Length < MinimumPayloadSize)
+        {
+            return false;
+        }
+
+        var span = payload.AsSpan();
+        if (BinaryPrimitives.ReadUInt32LittleEndian(span) != Magic || span[sizeof(uint)] != Version)
+        {
+            return false;
+        }
+
+        var checksumOffset = span.Length - ChecksumSize;
+        var expectedPayloadChecksum = BinaryPrimitives.ReadUInt32LittleEndian(span[checksumOffset..]);
+        if (Crc32.HashToUInt32(span[..checksumOffset]) != expectedPayloadChecksum)
+        {
+            return false;
+        }
+
+        var expectedKeyChecksum = BinaryPrimitives.ReadUInt32LittleEndian(span[KeyChecksumOffset..]);
+        if (ComputeUtf8Checksum(key) != expectedKeyChecksum)
+        {
+            return false;
+        }
+
+        metadata = new RoundTripMessageMetadata(
+            BinaryPrimitives.ReadInt32LittleEndian(span[PartitionOffset..]),
+            BinaryPrimitives.ReadInt64LittleEndian(span[SequenceOffset..]),
+            BinaryPrimitives.ReadInt64LittleEndian(span[OrdinalOffset..]));
+        return true;
+    }
+
+    private static uint ComputeUtf8Checksum(string value)
+    {
+        var byteCount = Encoding.UTF8.GetByteCount(value);
+        byte[]? rented = null;
+        Span<byte> bytes = byteCount <= 256
+            ? stackalloc byte[byteCount]
+            : (rented = ArrayPool<byte>.Shared.Rent(byteCount));
+
+        try
+        {
+            var written = Encoding.UTF8.GetBytes(value, bytes);
+            return Crc32.HashToUInt32(bytes[..written]);
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+}
+
+internal sealed class RoundTripValidator
+{
+    private readonly long[] _expectedPerPartition;
+    private readonly bool[][] _seen;
+    private readonly long[] _lastSequence;
+    private readonly long[] _lastOffset;
+    private long _consumedMessages;
+    private long _uniqueMessages;
+    private long _duplicateMessages;
+    private long _corruptMessages;
+    private long _outOfOrderMessages;
+    private long _mispartitionedMessages;
+    private long _unexpectedMessages;
+
+    public RoundTripValidator(IReadOnlyList<long> expectedPerPartition)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(expectedPerPartition.Count, 1);
+
+        _expectedPerPartition = [.. expectedPerPartition];
+        _seen = new bool[_expectedPerPartition.Length][];
+        _lastSequence = new long[_expectedPerPartition.Length];
+        _lastOffset = new long[_expectedPerPartition.Length];
+        Array.Fill(_lastSequence, -1);
+        Array.Fill(_lastOffset, -1);
+
+        for (var partition = 0; partition < _expectedPerPartition.Length; partition++)
+        {
+            _seen[partition] = new bool[checked((int)_expectedPerPartition[partition])];
+        }
+    }
+
+    public void Record(string? key, byte[]? payload, int actualPartition, long actualOffset)
+    {
+        _consumedMessages++;
+
+        if (!RoundTripMessageCodec.TryDecode(key, payload, out var message))
+        {
+            _corruptMessages++;
+            return;
+        }
+
+        if (message.Partition < 0 || message.Partition >= _expectedPerPartition.Length ||
+            message.Sequence < 0 || message.Sequence >= _expectedPerPartition[message.Partition])
+        {
+            _unexpectedMessages++;
+            return;
+        }
+
+        var expectedOrdinal = checked((message.Sequence * _expectedPerPartition.Length) + message.Partition);
+        if (message.Ordinal != expectedOrdinal)
+        {
+            _corruptMessages++;
+            return;
+        }
+
+        var expectedPartition = RoundTripMessageCodec.GetExpectedPartition(key!, _expectedPerPartition.Length);
+        var actualPartitionInRange = actualPartition >= 0 && actualPartition < _expectedPerPartition.Length;
+        if (message.Partition != expectedPartition || actualPartition != expectedPartition)
+        {
+            _mispartitionedMessages++;
+        }
+
+        var sequence = checked((int)message.Sequence);
+        if (_seen[message.Partition][sequence])
+        {
+            _duplicateMessages++;
+        }
+        else
+        {
+            _seen[message.Partition][sequence] = true;
+            _uniqueMessages++;
+        }
+
+        if (actualPartitionInRange && actualPartition == message.Partition)
+        {
+            if (message.Sequence < _lastSequence[actualPartition] || actualOffset <= _lastOffset[actualPartition])
+            {
+                _outOfOrderMessages++;
+            }
+
+            _lastSequence[actualPartition] = Math.Max(_lastSequence[actualPartition], message.Sequence);
+            _lastOffset[actualPartition] = Math.Max(_lastOffset[actualPartition], actualOffset);
+        }
+    }
+
+    public RoundTripValidationSnapshot CreateSnapshot(bool timedOut)
+    {
+        var expectedMessages = _expectedPerPartition.Sum();
+        return new RoundTripValidationSnapshot
+        {
+            ExpectedMessages = expectedMessages,
+            ConsumedMessages = _consumedMessages,
+            MissingMessages = Math.Max(0, expectedMessages - _uniqueMessages),
+            DuplicateMessages = _duplicateMessages,
+            CorruptMessages = _corruptMessages,
+            OutOfOrderMessages = _outOfOrderMessages,
+            MispartitionedMessages = _mispartitionedMessages,
+            UnexpectedMessages = _unexpectedMessages,
+            TimedOut = timedOut
+        };
+    }
+}
+
+internal sealed class RoundTripCompletionTracker
+{
+    private readonly long[] _startOffsets;
+    private readonly long[] _endOffsets;
+    private readonly bool[] _completed;
+
+    public RoundTripCompletionTracker(long[] startOffsets, long[] endOffsets)
+    {
+        ArgumentNullException.ThrowIfNull(startOffsets);
+        ArgumentNullException.ThrowIfNull(endOffsets);
+
+        if (startOffsets.Length == 0 || startOffsets.Length != endOffsets.Length)
+        {
+            throw new ArgumentException("Start and end offset arrays must have the same non-zero length.");
+        }
+
+        _startOffsets = [.. startOffsets];
+        _endOffsets = [.. endOffsets];
+        _completed = new bool[startOffsets.Length];
+
+        for (var partition = 0; partition < startOffsets.Length; partition++)
+        {
+            if (startOffsets[partition] < 0 || endOffsets[partition] < startOffsets[partition])
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(endOffsets),
+                    "Every offset range must be non-negative and end at or after its start.");
+            }
+
+            _completed[partition] = startOffsets[partition] >= endOffsets[partition];
+            if (!_completed[partition])
+            {
+                RemainingPartitions++;
+            }
+        }
+    }
+
+    public int RemainingPartitions { get; private set; }
+
+    public bool IsComplete => RemainingPartitions == 0;
+
+    public bool IsTrackedPartition(int partition) =>
+        (uint)partition < (uint)_completed.Length;
+
+    public bool Record(int partition, long offset)
+    {
+        if (!IsTrackedPartition(partition))
+        {
+            return false;
+        }
+
+        var inRange = offset >= _startOffsets[partition] && offset < _endOffsets[partition];
+        if (!_completed[partition] && inRange && offset >= _endOffsets[partition] - 1)
+        {
+            _completed[partition] = true;
+            RemainingPartitions--;
+        }
+
+        return inRange;
+    }
+}
+
+internal sealed class RoundTripValidationSnapshot
+{
+    public required long ExpectedMessages { get; init; }
+    public required long ConsumedMessages { get; init; }
+    public required long MissingMessages { get; init; }
+    public required long DuplicateMessages { get; init; }
+    public required long CorruptMessages { get; init; }
+    public required long OutOfOrderMessages { get; init; }
+    public required long MispartitionedMessages { get; init; }
+    public required long UnexpectedMessages { get; init; }
+    public required bool TimedOut { get; init; }
+
+    public bool IsSuccess =>
+        !TimedOut &&
+        MissingMessages == 0 &&
+        DuplicateMessages == 0 &&
+        CorruptMessages == 0 &&
+        OutOfOrderMessages == 0 &&
+        MispartitionedMessages == 0 &&
+        UnexpectedMessages == 0;
+}

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -251,8 +251,8 @@ internal static class StressTestHelpers
     /// in 30 seconds against a healthy broker means the producer is stuck, and any
     /// still-buffered messages will surface as undelivered loss.
     /// </summary>
-    internal static async Task FlushWithTimeoutAsync(
-        IKafkaProducer<string, string> producer,
+    internal static async Task FlushWithTimeoutAsync<TKey, TValue>(
+        IKafkaProducer<TKey, TValue> producer,
         ThroughputTracker throughput)
     {
         try

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -387,6 +387,41 @@ internal static class StressTestHelpers
         }
     }
 
+    internal static ThroughputSampler StartSampler(
+        ThroughputTracker throughput,
+        CancellationToken cancellationToken) =>
+        new(throughput, cancellationToken);
+
+    internal sealed class ThroughputSampler : IAsyncDisposable
+    {
+        private readonly CancellationTokenSource _cancellation;
+        private readonly Task _samplerTask;
+
+        internal ThroughputSampler(ThroughputTracker throughput, CancellationToken cancellationToken)
+        {
+            _cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _samplerTask = RunSamplerAsync(throughput, _cancellation.Token);
+        }
+
+        internal async ValueTask StopAsync()
+        {
+            _cancellation.Cancel();
+            await _samplerTask.ConfigureAwait(false);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await StopAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _cancellation.Dispose();
+            }
+        }
+    }
+
     internal static async Task RunSamplerAsync(ThroughputTracker throughput, CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -323,16 +323,16 @@ internal static class StressTestHelpers
         return delivered;
     }
 
-    internal static void ConfigureProducerDeliveryDiagnostics(
-        ProducerBuilder<string, string> builder,
+    internal static void ConfigureProducerDeliveryDiagnostics<TKey, TValue>(
+        ProducerBuilder<TKey, TValue> builder,
         StressTestOptions options)
     {
         if (options.EnableProducerDeliveryDiagnostics)
             builder.WithDeliveryDiagnostics();
     }
 
-    internal static ProducerDeliveryDiagnosticsSnapshot? CaptureProducerDeliveryDiagnostics(
-        IKafkaProducer<string, string> producer,
+    internal static ProducerDeliveryDiagnosticsSnapshot? CaptureProducerDeliveryDiagnostics<TKey, TValue>(
+        IKafkaProducer<TKey, TValue> producer,
         StressTestOptions options)
     {
         if (!options.EnableProducerDeliveryDiagnostics)

--- a/tools/Dekaf.StressTests/StressRunCompletionPolicy.cs
+++ b/tools/Dekaf.StressTests/StressRunCompletionPolicy.cs
@@ -1,0 +1,13 @@
+namespace Dekaf.StressTests;
+
+internal static class StressRunCompletionPolicy
+{
+    private const double MinimumDurationRatio = 0.9;
+
+    internal static bool EndedEarly(
+        double elapsedSeconds,
+        int configuredDurationMinutes,
+        bool isMessageBounded) =>
+        !isMessageBounded &&
+        elapsedSeconds < configuredDurationMinutes * 60 * MinimumDurationRatio;
+}

--- a/tools/Shared/ConfluentProducerBackpressure.cs
+++ b/tools/Shared/ConfluentProducerBackpressure.cs
@@ -7,11 +7,11 @@ internal static class ConfluentProducerBackpressure
 {
     internal const int QueueBufferingMaxMessages = 10_000_000;
 
-    internal static void ProduceWithBackpressure(
-        ConfluentKafka.IProducer<string, string> producer,
+    internal static void ProduceWithBackpressure<TKey, TValue>(
+        ConfluentKafka.IProducer<TKey, TValue> producer,
         string topic,
-        ConfluentKafka.Message<string, string> message,
-        Action<ConfluentKafka.DeliveryReport<string, string>>? deliveryHandler,
+        ConfluentKafka.Message<TKey, TValue> message,
+        Action<ConfluentKafka.DeliveryReport<TKey, TValue>>? deliveryHandler,
         CancellationToken cancellationToken,
         TimeSpan? retryTimeout = null)
     {
@@ -24,7 +24,7 @@ internal static class ConfluentProducerBackpressure
                 producer.Produce(topic, message, deliveryHandler);
                 return;
             }
-            catch (ConfluentKafka.ProduceException<string, string> ex)
+            catch (ConfluentKafka.ProduceException<TKey, TValue> ex)
                 when (ex.Error.Code == ConfluentKafka.ErrorCode.Local_QueueFull &&
                       ShouldRetry(startedAt, retryTimeout))
             {


### PR DESCRIPTION
## Summary
- add a bounded `producer-roundtrip` scenario for Dekaf and Confluent.Kafka
- generate per-partition Murmur2 keys with sequenced, checksummed payloads
- fail on gaps, duplicates, corruption, reordering, wrong partitions, unexpected records, or timeout
- publish validation results and run the paired scenario in weekly stress CI

## Test plan
- [x] `dotnet build Dekaf.sln --configuration Release`
- [x] 4,516 net10.0 unit tests
- [x] 7 focused round-trip codec/validator tests
- [x] Python stress-report tests
- [x] workflow YAML parse
- [x] real Kafka smoke: 600 messages per client across 3 partitions, all invariants clean
- [x] post-simplify real Kafka smoke: 60 messages per client, all invariants clean

Closes #1593
