### PR TITLE
ci: add focused mutation testing

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-stryker": {
+      "version": "4.16.0",
+      "commands": [
+        "dotnet-stryker"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/scripts/mutation_report.py
+++ b/.github/scripts/mutation_report.py
@@ -1,0 +1,186 @@
+"""Summarize Stryker.NET JSON and gate only material score regressions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+
+DETECTED_STATUSES = frozenset({"Killed", "Timeout"})
+UNDETECTED_STATUSES = frozenset({"Survived", "NoCoverage"})
+BACKLOG_PRIORITY = {"Survived": 0, "NoCoverage": 1}
+OUTCOME_ORDER = ("Killed", "Timeout", "Survived", "NoCoverage", "CompileError", "RuntimeError", "Ignored")
+
+
+@dataclass(frozen=True)
+class BacklogEntry:
+    status: str
+    path: str
+    line: int
+    mutator: str
+    replacement: str
+
+
+@dataclass(frozen=True)
+class MutationSummary:
+    score: float
+    detected: int
+    undetected: int
+    statuses: Counter[str]
+    backlog: tuple[BacklogEntry, ...]
+
+
+def _line(mutant: dict[str, Any]) -> int:
+    return int(mutant.get("location", {}).get("start", {}).get("line", 0))
+
+
+def summarize(report: dict[str, Any]) -> MutationSummary:
+    statuses: Counter[str] = Counter()
+    backlog: list[BacklogEntry] = []
+
+    files = report.get("files")
+    if not isinstance(files, dict):
+        raise ValueError("Stryker report has no 'files' object")
+
+    for path, source_file in files.items():
+        for mutant in source_file.get("mutants", []):
+            status = mutant.get("status", "Unknown")
+            statuses[status] += 1
+            if status in BACKLOG_PRIORITY:
+                backlog.append(
+                    BacklogEntry(
+                        status=status,
+                        path=path,
+                        line=_line(mutant),
+                        mutator=mutant.get("mutatorName", "unknown"),
+                        replacement=mutant.get("replacement", ""),
+                    )
+                )
+
+    detected = sum(statuses[status] for status in DETECTED_STATUSES)
+    undetected = sum(statuses[status] for status in UNDETECTED_STATUSES)
+    scored = detected + undetected
+    score = 100.0 * detected / scored if scored else 100.0
+    backlog.sort(
+        key=lambda entry: (
+            BACKLOG_PRIORITY[entry.status],
+            entry.path,
+            entry.line,
+            entry.mutator,
+        )
+    )
+
+    return MutationSummary(
+        score=score,
+        detected=detected,
+        undetected=undetected,
+        statuses=statuses,
+        backlog=tuple(backlog),
+    )
+
+
+def _markdown_cell(value: object) -> str:
+    return str(value).replace("|", "\\|").replace("\r", " ").replace("\n", " ")
+
+
+def render_markdown(
+    current: MutationSummary,
+    previous: MutationSummary | None,
+    max_drop: float,
+    backlog_limit: int = 50,
+) -> tuple[str, bool]:
+    if max_drop <= 0:
+        raise ValueError("max_drop must be greater than zero")
+
+    lines = ["# Mutation testing", "", f"- Current score: **{current.score:.2f}%**"]
+    failed = False
+
+    if previous is None:
+        lines.append("- Previous score: unavailable (first retained run)")
+        lines.append("- Large-drop gate: passed (no baseline)")
+    else:
+        delta = current.score - previous.score
+        failed = delta <= -max_drop
+        lines.append(f"- Previous score: **{previous.score:.2f}%**")
+        lines.append(f"- Trend: **{delta:+.2f} percentage points**")
+        lines.append(
+            f"- Large-drop gate: {'failed' if failed else 'passed'} "
+            f"(fails at a drop of {max_drop:.2f} points or more)"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Mutant outcomes",
+            "",
+            "| Outcome | Count |",
+            "|---|---:|",
+        ]
+    )
+    for status in OUTCOME_ORDER:
+        lines.append(f"| {status} | {current.statuses[status]} |")
+
+    lines.extend(["", "## Prioritized test backlog", ""])
+    if not current.backlog:
+        lines.append("No surviving or uncovered mutants.")
+    else:
+        lines.extend(
+            [
+                "Survived mutants lead uncovered mutants because existing tests execute them but fail to detect the behavior change.",
+                "",
+                "| Priority | Status | Location | Mutator | Replacement |",
+                "|---:|---|---|---|---|",
+            ]
+        )
+        for index, entry in enumerate(current.backlog[:backlog_limit], start=1):
+            location = f"{entry.path}:{entry.line}" if entry.line else entry.path
+            lines.append(
+                f"| {index} | {entry.status} | {_markdown_cell(location)} | "
+                f"{_markdown_cell(entry.mutator)} | `{_markdown_cell(entry.replacement)}` |"
+            )
+        omitted = len(current.backlog) - backlog_limit
+        if omitted > 0:
+            lines.extend(["", f"{omitted} more entries remain in uploaded HTML/JSON reports."])
+
+    return "\n".join(lines) + "\n", failed
+
+
+def _load(path: Path) -> MutationSummary:
+    with path.open(encoding="utf-8") as stream:
+        return summarize(json.load(stream))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("current", type=Path, help="Current Stryker JSON report")
+    parser.add_argument("--previous", type=Path, help="Previous successful main-branch JSON report")
+    parser.add_argument("--max-drop", type=float, default=5.0, help="Maximum allowed score drop in points")
+    parser.add_argument("--summary", type=Path, help="Write GitHub-flavored Markdown summary here")
+    parser.add_argument("--backlog-limit", type=int, default=50)
+    args = parser.parse_args(argv)
+
+    current = _load(args.current)
+    previous = _load(args.previous) if args.previous else None
+    markdown, failed = render_markdown(current, previous, args.max_drop, args.backlog_limit)
+
+    if args.summary:
+        args.summary.parent.mkdir(parents=True, exist_ok=True)
+        args.summary.write_text(markdown, encoding="utf-8")
+    else:
+        print(markdown, end="")
+
+    if failed:
+        print(
+            f"::error::Mutation score dropped from {previous.score:.2f}% to {current.score:.2f}% "
+            f"(limit: {args.max_drop:.2f} percentage points)"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_mutation_report.py
+++ b/.github/scripts/test_mutation_report.py
@@ -80,6 +80,32 @@ class MutationReportTests(unittest.TestCase):
         _, small_drop_failed = mutation_report.render_markdown(previous, previous, max_drop=5.0)
         self.assertFalse(small_drop_failed)
 
+    def test_render_without_baseline_passes_and_explains_first_run(self):
+        current = mutation_report.summarize(report_with(mutant("Killed", 1)))
+
+        markdown, failed = mutation_report.render_markdown(current, None, max_drop=5.0)
+
+        self.assertFalse(failed)
+        self.assertIn("Previous score: unavailable (first retained run)", markdown)
+        self.assertIn("Large-drop gate: passed (no baseline)", markdown)
+
+    def test_report_without_files_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "no 'files' object"):
+            mutation_report.summarize({})
+
+    def test_non_positive_max_drop_is_rejected(self):
+        current = mutation_report.summarize(report_with(mutant("Killed", 1)))
+
+        with self.assertRaisesRegex(ValueError, "greater than zero"):
+            mutation_report.render_markdown(current, None, max_drop=0)
+
+    def test_workflow_only_appends_summary_when_reporter_created_it(self):
+        workflow_path = Path(__file__).parents[1] / "workflows" / "mutation-tests.yml"
+        workflow = workflow_path.read_text(encoding="utf-8")
+
+        self.assertIn('if [ -f artifacts/mutation-summary.md ]; then', workflow)
+        self.assertIn('cat artifacts/mutation-summary.md >> "$GITHUB_STEP_SUMMARY"', workflow)
+
     def test_cli_writes_summary_and_returns_failure_for_large_drop(self):
         current = report_with(mutant("Killed", 1), mutant("Survived", 2))
         previous = report_with(mutant("Killed", 1), mutant("Killed", 2))

--- a/.github/scripts/test_mutation_report.py
+++ b/.github/scripts/test_mutation_report.py
@@ -106,6 +106,12 @@ class MutationReportTests(unittest.TestCase):
         self.assertIn('if [ -f artifacts/mutation-summary.md ]; then', workflow)
         self.assertIn('cat artifacts/mutation-summary.md >> "$GITHUB_STEP_SUMMARY"', workflow)
 
+    def test_workflow_installs_stryker_target_runtime(self):
+        workflow_path = Path(__file__).parents[1] / "workflows" / "mutation-tests.yml"
+        workflow = workflow_path.read_text(encoding="utf-8")
+
+        self.assertIn("dotnet-version: |\n            8.0.x\n            10.0.x", workflow)
+
     def test_cli_writes_summary_and_returns_failure_for_large_drop(self):
         current = report_with(mutant("Killed", 1), mutant("Survived", 2))
         previous = report_with(mutant("Killed", 1), mutant("Killed", 2))

--- a/.github/scripts/test_mutation_report.py
+++ b/.github/scripts/test_mutation_report.py
@@ -112,6 +112,27 @@ class MutationReportTests(unittest.TestCase):
 
         self.assertIn("dotnet-version: |\n            8.0.x\n            10.0.x", workflow)
 
+    def test_producer_mutation_host_presizes_thread_pool(self):
+        project_path = (
+            Path(__file__).parents[2]
+            / "tests"
+            / "Dekaf.Tests.Mutation.Producer"
+            / "Dekaf.Tests.Mutation.Producer.csproj"
+        )
+
+        self.assertIn(
+            "ThreadPoolConfiguration.cs",
+            project_path.read_text(encoding="utf-8"),
+        )
+
+    def test_workflow_finds_baseline_per_campaign_artifact(self):
+        workflow_path = Path(__file__).parents[1] / "workflows" / "mutation-tests.yml"
+        workflow = workflow_path.read_text(encoding="utf-8")
+
+        self.assertIn("ARTIFACT_NAME: mutation-results-${{ matrix.campaign }}", workflow)
+        self.assertIn("actions/artifacts?name=${ARTIFACT_NAME}", workflow)
+        self.assertNotIn("--status success", workflow)
+
     def test_cli_writes_summary_and_returns_failure_for_large_drop(self):
         current = report_with(mutant("Killed", 1), mutant("Survived", 2))
         previous = report_with(mutant("Killed", 1), mutant("Killed", 2))

--- a/.github/scripts/test_mutation_report.py
+++ b/.github/scripts/test_mutation_report.py
@@ -135,6 +135,14 @@ class MutationReportTests(unittest.TestCase):
         self.assertIn("name: mutation-baseline-${{ matrix.campaign }}", workflow)
         self.assertIn("name: mutation-results-${{ matrix.campaign }}", workflow)
 
+    def test_workflow_fails_closed_when_baseline_download_fails(self):
+        workflow_path = Path(__file__).parents[1] / "workflows" / "mutation-tests.yml"
+        workflow = workflow_path.read_text(encoding="utf-8")
+        download_step = workflow.split("- name: Download previous mutation result", 1)[1]
+        download_step = download_step.split("- name: Run focused mutation tests", 1)[0]
+
+        self.assertNotIn("continue-on-error", download_step)
+
     def test_cli_writes_summary_and_returns_failure_for_large_drop(self):
         current = report_with(mutant("Killed", 1), mutant("Survived", 2))
         previous = report_with(mutant("Killed", 1), mutant("Killed", 2))

--- a/.github/scripts/test_mutation_report.py
+++ b/.github/scripts/test_mutation_report.py
@@ -125,13 +125,15 @@ class MutationReportTests(unittest.TestCase):
             project_path.read_text(encoding="utf-8"),
         )
 
-    def test_workflow_finds_baseline_per_campaign_artifact(self):
+    def test_workflow_finds_only_successful_campaign_baselines(self):
         workflow_path = Path(__file__).parents[1] / "workflows" / "mutation-tests.yml"
         workflow = workflow_path.read_text(encoding="utf-8")
 
-        self.assertIn("ARTIFACT_NAME: mutation-results-${{ matrix.campaign }}", workflow)
+        self.assertIn("ARTIFACT_NAME: mutation-baseline-${{ matrix.campaign }}", workflow)
         self.assertIn("actions/artifacts?name=${ARTIFACT_NAME}", workflow)
-        self.assertNotIn("--status success", workflow)
+        self.assertIn("- name: Upload successful mutation baseline\n        if: success()", workflow)
+        self.assertIn("name: mutation-baseline-${{ matrix.campaign }}", workflow)
+        self.assertIn("name: mutation-results-${{ matrix.campaign }}", workflow)
 
     def test_cli_writes_summary_and_returns_failure_for_large_drop(self):
         current = report_with(mutant("Killed", 1), mutant("Survived", 2))

--- a/.github/scripts/test_mutation_report.py
+++ b/.github/scripts/test_mutation_report.py
@@ -1,0 +1,118 @@
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import mutation_report
+
+
+def report_with(*mutants):
+    return {
+        "files": {
+            "src/Dekaf/Protocol/KafkaProtocolReader.cs": {
+                "mutants": list(mutants),
+            }
+        }
+    }
+
+
+def mutant(status, line, *, name="logical", replacement="false"):
+    return {
+        "id": str(line),
+        "mutatorName": name,
+        "replacement": replacement,
+        "status": status,
+        "location": {
+            "start": {"line": line, "column": 1},
+            "end": {"line": line, "column": 2},
+        },
+    }
+
+
+class MutationReportTests(unittest.TestCase):
+    def test_summarize_counts_scored_mutants_and_prioritizes_backlog(self):
+        report = report_with(
+            mutant("Killed", 10),
+            mutant("Timeout", 11),
+            mutant("Survived", 30, name="equality", replacement="!= target"),
+            mutant("NoCoverage", 20, name="boolean", replacement="true"),
+            mutant("Ignored", 40),
+            mutant("CompileError", 41),
+            mutant("RuntimeError", 42),
+        )
+
+        summary = mutation_report.summarize(report)
+
+        self.assertEqual(50.0, summary.score)
+        self.assertEqual(2, summary.detected)
+        self.assertEqual(2, summary.undetected)
+        self.assertEqual(1, summary.statuses["Survived"])
+        self.assertEqual(1, summary.statuses["NoCoverage"])
+        self.assertEqual(
+            ["Survived", "NoCoverage"],
+            [entry.status for entry in summary.backlog],
+        )
+        self.assertEqual(30, summary.backlog[0].line)
+
+    def test_render_reports_delta_and_flags_only_large_drop(self):
+        previous = mutation_report.summarize(
+            report_with(
+                *[mutant("Killed", line) for line in range(1, 10)],
+                mutant("Survived", 20),
+            )
+        )
+        current = mutation_report.summarize(
+            report_with(
+                *[mutant("Killed", line) for line in range(1, 8)],
+                *[mutant("Survived", line) for line in range(20, 23)],
+            )
+        )
+
+        markdown, failed = mutation_report.render_markdown(current, previous, max_drop=5.0)
+
+        self.assertTrue(failed)
+        self.assertIn("70.00%", markdown)
+        self.assertIn("-20.00 percentage points", markdown)
+        self.assertIn("large-drop gate: failed", markdown.lower())
+
+        _, small_drop_failed = mutation_report.render_markdown(previous, previous, max_drop=5.0)
+        self.assertFalse(small_drop_failed)
+
+    def test_cli_writes_summary_and_returns_failure_for_large_drop(self):
+        current = report_with(mutant("Killed", 1), mutant("Survived", 2))
+        previous = report_with(mutant("Killed", 1), mutant("Killed", 2))
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            current_path = root / "current.json"
+            previous_path = root / "previous.json"
+            summary_path = root / "summary.md"
+            current_path.write_text(json.dumps(current), encoding="utf-8")
+            previous_path.write_text(json.dumps(previous), encoding="utf-8")
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = mutation_report.main(
+                    [
+                        str(current_path),
+                        "--previous",
+                        str(previous_path),
+                        "--max-drop",
+                        "5",
+                        "--summary",
+                        str(summary_path),
+                    ]
+                )
+
+            self.assertEqual(1, exit_code)
+            self.assertIn(
+                "large-drop gate: failed",
+                summary_path.read_text(encoding="utf-8").lower(),
+            )
+            self.assertIn("::error::", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -45,7 +45,10 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          # Stryker 4.16 targets net8.0; the test projects build with the net10 SDK.
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Restore local tools
         run: dotnet tool restore

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -57,10 +57,10 @@ jobs:
         id: previous-run
         env:
           GH_TOKEN: ${{ github.token }}
-          ARTIFACT_NAME: mutation-results-${{ matrix.campaign }}
+          ARTIFACT_NAME: mutation-baseline-${{ matrix.campaign }}
         run: |
-          # Select this campaign's latest retained main-branch artifact. A failed
-          # sibling matrix leg must not erase the passing campaign's baseline.
+          # Select this campaign's latest successful main-branch baseline. Each
+          # matrix leg uploads independently, so a failed sibling cannot erase it.
           run_id=$(gh api \
             "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100" \
             --jq '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == "main")] | sort_by(.created_at) | reverse | .[0].workflow_run.id // empty')
@@ -71,7 +71,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: mutation-results-${{ matrix.campaign }}
+          name: mutation-baseline-${{ matrix.campaign }}
           path: artifacts/previous
           github-token: ${{ github.token }}
           run-id: ${{ steps.previous-run.outputs.run_id }}
@@ -107,6 +107,15 @@ jobs:
             cat artifacts/mutation-summary.md >> "$GITHUB_STEP_SUMMARY"
           fi
           exit "$gate_exit"
+
+      - name: Upload successful mutation baseline
+        if: success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutation-baseline-${{ matrix.campaign }}
+          path: artifacts/mutation/${{ matrix.campaign }}/**/mutation-report.json
+          if-no-files-found: error
+          retention-days: 90
 
       - name: Upload mutation results
         if: always()

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -53,18 +53,17 @@ jobs:
       - name: Restore local tools
         run: dotnet tool restore
 
-      - name: Find previous successful main run
+      - name: Find previous retained campaign result
         id: previous-run
         env:
           GH_TOKEN: ${{ github.token }}
+          ARTIFACT_NAME: mutation-results-${{ matrix.campaign }}
         run: |
-          run_id=$(gh run list \
-            --workflow mutation-tests.yml \
-            --branch main \
-            --status success \
-            --limit 1 \
-            --json databaseId \
-            --jq '.[0].databaseId // empty')
+          # Select this campaign's latest retained main-branch artifact. A failed
+          # sibling matrix leg must not erase the passing campaign's baseline.
+          run_id=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100" \
+            --jq '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == "main")] | sort_by(.created_at) | reverse | .[0].workflow_run.id // empty')
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
       - name: Download previous mutation result

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -92,7 +92,9 @@ jobs:
           python3 .github/scripts/mutation_report.py "${args[@]}"
           gate_exit=$?
           set -e
-          cat artifacts/mutation-summary.md >> "$GITHUB_STEP_SUMMARY"
+          if [ -f artifacts/mutation-summary.md ]; then
+            cat artifacts/mutation-summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
           exit "$gate_exit"
 
       - name: Upload mutation results

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -1,0 +1,107 @@
+name: Mutation Tests
+
+on:
+  schedule:
+    - cron: '0 3 * * 3' # Weekly Wednesday 3 AM UTC
+  workflow_dispatch:
+    inputs:
+      max_score_drop:
+        description: 'Fail when mutation score drops by this many percentage points'
+        required: false
+        default: '5'
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: mutation-tests
+  cancel-in-progress: false
+
+env:
+  ContinuousIntegrationBuild: true
+  Deterministic: true
+
+jobs:
+  mutation-test:
+    runs-on: ubicloud-standard-8
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore local tools
+        run: dotnet tool restore
+
+      - name: Find previous successful main run
+        id: previous-run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_id=$(gh run list \
+            --workflow mutation-tests.yml \
+            --branch main \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId // empty')
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Download previous mutation result
+        if: steps.previous-run.outputs.run_id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: mutation-results
+          path: artifacts/previous
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.previous-run.outputs.run_id }}
+
+      - name: Run focused mutation tests
+        working-directory: src/Dekaf
+        run: >-
+          dotnet stryker
+          --config-file stryker-config.json
+          --output "${{ github.workspace }}/artifacts/mutation"
+
+      - name: Report trend and enforce large-drop gate
+        env:
+          MAX_SCORE_DROP: ${{ github.event.inputs.max_score_drop || '5' }}
+        run: |
+          current_report=$(find artifacts/mutation -type f -name mutation-report.json | sort | tail -n 1)
+          if [ -z "$current_report" ]; then
+            echo "::error::Stryker JSON report was not generated"
+            exit 1
+          fi
+
+          previous_report=$(find artifacts/previous -type f -name mutation-report.json 2>/dev/null | sort | tail -n 1 || true)
+          args=("$current_report" --max-drop "$MAX_SCORE_DROP" --summary artifacts/mutation-summary.md)
+          if [ -n "$previous_report" ]; then
+            args+=(--previous "$previous_report")
+          fi
+
+          set +e
+          python3 .github/scripts/mutation_report.py "${args[@]}"
+          gate_exit=$?
+          set -e
+          cat artifacts/mutation-summary.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$gate_exit"
+
+      - name: Upload mutation results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutation-results
+          path: |
+            artifacts/mutation/
+            artifacts/mutation-summary.md
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -24,8 +24,17 @@ env:
 
 jobs:
   mutation-test:
+    name: Mutation test (${{ matrix.campaign }})
     runs-on: ubicloud-standard-8
     timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - campaign: protocol
+            config: stryker-config.json
+          - campaign: producer
+            config: stryker-producer-config.json
 
     steps:
       - name: Checkout
@@ -60,7 +69,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: mutation-results
+          name: mutation-results-${{ matrix.campaign }}
           path: artifacts/previous
           github-token: ${{ github.token }}
           run-id: ${{ steps.previous-run.outputs.run_id }}
@@ -69,14 +78,14 @@ jobs:
         working-directory: src/Dekaf
         run: >-
           dotnet stryker
-          --config-file stryker-config.json
-          --output "${{ github.workspace }}/artifacts/mutation"
+          --config-file "${{ matrix.config }}"
+          --output "${{ github.workspace }}/artifacts/mutation/${{ matrix.campaign }}"
 
       - name: Report trend and enforce large-drop gate
         env:
           MAX_SCORE_DROP: ${{ github.event.inputs.max_score_drop || '5' }}
         run: |
-          current_report=$(find artifacts/mutation -type f -name mutation-report.json | sort | tail -n 1)
+          current_report=$(find "artifacts/mutation/${{ matrix.campaign }}" -type f -name mutation-report.json | sort | tail -n 1)
           if [ -z "$current_report" ]; then
             echo "::error::Stryker JSON report was not generated"
             exit 1
@@ -101,7 +110,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: mutation-results
+          name: mutation-results-${{ matrix.campaign }}
           path: |
             artifacts/mutation/
             artifacts/mutation-summary.md

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -68,7 +68,6 @@ jobs:
 
       - name: Download previous mutation result
         if: steps.previous-run.outputs.run_id != ''
-        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: mutation-baseline-${{ matrix.campaign }}

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ temptest/
 
 # Stress test logs
 stress_run.log
+
+# Stryker.NET mutation-test output
+StrykerOutput/

--- a/src/Dekaf/stryker-config.json
+++ b/src/Dekaf/stryker-config.json
@@ -1,0 +1,34 @@
+{
+  "stryker-config": {
+    "test-projects": [
+      "../../tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj"
+    ],
+    "mutate": [
+      "Protocol/KafkaProtocolReader.cs",
+      "Protocol/KafkaProtocolWriter.cs",
+      "Producer/RecordAccumulator.cs",
+      "Producer/BrokerSender.cs",
+      "Producer/KafkaProducer.cs"
+    ],
+    "test-runner": "mtp",
+    "target-framework": "net10.0",
+    "configuration": "Release",
+    "mutation-level": "Standard",
+    "coverage-analysis": "perTest",
+    "concurrency": 4,
+    "additional-timeout": 10000,
+    "break-on-initial-test-failure": true,
+    "reporters": [
+      "progress",
+      "html",
+      "json",
+      "markdown"
+    ],
+    "report-file-name": "mutation-report",
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    }
+  }
+}

--- a/src/Dekaf/stryker-config.json
+++ b/src/Dekaf/stryker-config.json
@@ -1,5 +1,6 @@
 {
   "stryker-config": {
+    "project": "Dekaf.csproj",
     "test-projects": [
       "../../tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj"
     ],

--- a/src/Dekaf/stryker-producer-config.json
+++ b/src/Dekaf/stryker-producer-config.json
@@ -2,11 +2,12 @@
   "stryker-config": {
     "project": "Dekaf.csproj",
     "test-projects": [
-      "../../tests/Dekaf.Tests.Mutation.Protocol/Dekaf.Tests.Mutation.Protocol.csproj"
+      "../../tests/Dekaf.Tests.Mutation.Producer/Dekaf.Tests.Mutation.Producer.csproj"
     ],
     "mutate": [
-      "Protocol/KafkaProtocolReader.cs",
-      "Protocol/KafkaProtocolWriter.cs"
+      "Producer/RecordAccumulator.cs",
+      "Producer/BrokerSender.cs",
+      "Producer/KafkaProducer.cs"
     ],
     "test-runner": "mtp",
     "target-framework": "net10.0",

--- a/tests/Dekaf.Tests.Mutation.Producer/Dekaf.Tests.Mutation.Producer.csproj
+++ b/tests/Dekaf.Tests.Mutation.Producer/Dekaf.Tests.Mutation.Producer.csproj
@@ -13,6 +13,7 @@
     <!-- MTP cannot yet select covering tests per mutant, so link only direct core-producer suites. -->
     <Compile Include="..\Dekaf.Tests.Unit\AssemblyInfo.cs" Link="AssemblyInfo.cs" />
     <Compile Include="..\Dekaf.Tests.Unit\TestWait.cs" Link="TestWait.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\ThreadPoolConfiguration.cs" Link="ThreadPoolConfiguration.cs" />
     <Compile Include="..\Dekaf.Tests.Unit\Producer\AdaptiveScalingTests.cs" Link="Producer\AdaptiveScalingTests.cs" />
     <Compile Include="..\Dekaf.Tests.Unit\Producer\AppendWorkerAffinityTests.cs" Link="Producer\AppendWorkerAffinityTests.cs" />
     <Compile Include="..\Dekaf.Tests.Unit\Producer\BrokerSenderMuteOrderingTests.cs" Link="Producer\BrokerSenderMuteOrderingTests.cs" />

--- a/tests/Dekaf.Tests.Mutation.Producer/Dekaf.Tests.Mutation.Producer.csproj
+++ b/tests/Dekaf.Tests.Mutation.Producer/Dekaf.Tests.Mutation.Producer.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <!-- Keep access to Dekaf internals while compiling the linked unit-test sources. -->
+    <AssemblyName>Dekaf.Tests.Unit</AssemblyName>
+    <RootNamespace>Dekaf.Tests.Unit</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- MTP cannot yet select covering tests per mutant, so link only direct core-producer suites. -->
+    <Compile Include="..\Dekaf.Tests.Unit\AssemblyInfo.cs" Link="AssemblyInfo.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\TestWait.cs" Link="TestWait.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\AdaptiveScalingTests.cs" Link="Producer\AdaptiveScalingTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\AppendWorkerAffinityTests.cs" Link="Producer\AppendWorkerAffinityTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\BrokerSenderMuteOrderingTests.cs" Link="Producer\BrokerSenderMuteOrderingTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\BrokerSenderSendLoopTests.cs" Link="Producer\BrokerSenderSendLoopTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\BrokerSenderTests.cs" Link="Producer\BrokerSenderTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\BufferMemoryTests.cs" Link="Producer\BufferMemoryTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\CoordinatedRetryTests.cs" Link="Producer\CoordinatedRetryTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\KafkaProducerBudgetTests.cs" Link="Producer\KafkaProducerBudgetTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\KafkaProducerFastPathTests.cs" Link="Producer\KafkaProducerFastPathTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\KafkaProducerMetricsTests.cs" Link="Producer\KafkaProducerMetricsTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\MaxBlockMsTests.cs" Link="Producer\MaxBlockMsTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\MemoryReleasedAtomicityTests.cs" Link="Producer\MemoryReleasedAtomicityTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\ProducerCancellationTests.cs" Link="Producer\ProducerCancellationTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\ProducerDeliveryDiagnosticsTests.cs" Link="Producer\ProducerDeliveryDiagnosticsTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\ProducerErrorTests.cs" Link="Producer\ProducerErrorTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\ProducerInitializationTests.cs" Link="Producer\ProducerInitializationTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\ProducerMessageTests.cs" Link="Producer\ProducerMessageTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\ReadyBatchIncarnationTests.cs" Link="Producer\ReadyBatchIncarnationTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\RecordAccumulatorBudgetTests.cs" Link="Producer\RecordAccumulatorBudgetTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\RecordAccumulatorReadyTests.cs" Link="Producer\RecordAccumulatorReadyTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\RecordAccumulatorTests.cs" Link="Producer\RecordAccumulatorTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\ShouldFlushTests.cs" Link="Producer\ShouldFlushTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Producer\TestKafkaConnection.cs" Link="Producer\TestKafkaConnection.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="TUnit" Version="1.58.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Dekaf.Tests.Mutation.Protocol/Dekaf.Tests.Mutation.Protocol.csproj
+++ b/tests/Dekaf.Tests.Mutation.Protocol/Dekaf.Tests.Mutation.Protocol.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <!-- Keep access to Dekaf internals while compiling the linked unit-test sources. -->
+    <AssemblyName>Dekaf.Tests.Unit</AssemblyName>
+    <RootNamespace>Dekaf.Tests.Unit</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- MTP cannot yet select covering tests per mutant, so keep this campaign protocol-only. -->
+    <Compile Include="..\Dekaf.Tests.Unit\AssemblyInfo.cs" Link="AssemblyInfo.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Protocol\ArrayEncodingTests.cs" Link="Protocol\ArrayEncodingTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Protocol\KafkaProtocolReaderTests.cs" Link="Protocol\KafkaProtocolReaderTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Protocol\KafkaProtocolWriterTests.cs" Link="Protocol\KafkaProtocolWriterTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Protocol\PrimitiveEncodingTests.cs" Link="Protocol\PrimitiveEncodingTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Protocol\SequenceTestHelpers.cs" Link="Protocol\SequenceTestHelpers.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Protocol\StringBytesEncodingTests.cs" Link="Protocol\StringBytesEncodingTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Protocol\TaggedFieldsTests.cs" Link="Protocol\TaggedFieldsTests.cs" />
+    <Compile Include="..\Dekaf.Tests.Unit\Protocol\VarIntEncodingTests.cs" Link="Protocol\VarIntEncodingTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
+    <PackageReference Include="TUnit" Version="1.58.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- pin Stryker.NET 4.16.0 and target KafkaProtocolReader/Writer plus RecordAccumulator, BrokerSender, and KafkaProducer
- run mutation testing weekly and on demand, retaining HTML, JSON, and Markdown reports for 90 days
- compare against the previous successful main run, fail only on a 5-point score drop, and rank surviving/uncovered mutants as a test backlog

## Test plan
- [x] python -m unittest discover -s .github/scripts -p 'test_*.py'
- [x] dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0
- [x] dotnet tool restore
- [x] actionlint 1.7.12 (repository custom runner label allowed)
- [ ] full mutation campaign (scheduled six-hour CI workload; local smoke reached MTP/TUnit launch but was stopped under concurrent-agent resource load)

Closes #1608
