### PR TITLE
feat(stress): add resource-trend soak

### DIFF
--- a/.github/workflows/soak-tests.yml
+++ b/.github/workflows/soak-tests.yml
@@ -1,0 +1,103 @@
+name: 24h Soak Tests
+
+on:
+  schedule:
+    - cron: '0 2 * * 2'  # Weekly Tuesday 02:00 UTC
+  workflow_dispatch:
+    inputs:
+      duration_minutes:
+        description: 'Manual-run duration in minutes (scheduled segments use 288)'
+        required: false
+        default: '60'
+      messages_per_second:
+        description: 'Target mixed-load message rate'
+        required: false
+        default: '1000'
+      warmup_minutes:
+        description: 'Minutes excluded from trend analysis'
+        required: false
+        default: '15'
+      minimum_samples:
+        description: 'Minimum post-warmup samples (one sample per minute)'
+        required: false
+        default: '30'
+
+concurrency:
+  group: soak-tests
+  cancel-in-progress: false
+
+env:
+  ContinuousIntegrationBuild: true
+  Deterministic: true
+  STRESS_BROKER_TMPFS: 2g
+  STRESS_BROKER_HEAP: -Xmx768m -Xms768m
+
+jobs:
+  soak-test:
+    name: Mixed Soak (${{ matrix.brokers }} broker${{ matrix.brokers == 1 && '' || 's' }}, segment ${{ matrix.segment }})
+    # Public repository GitHub-hosted runners avoid third-party runner charges.
+    runs-on: ubuntu-latest
+    # GitHub-hosted jobs stop at six hours. Each scheduled segment measures 4h48m,
+    # leaving over an hour for setup, broker drain, and artifact upload.
+    timeout-minutes: 355
+    strategy:
+      fail-fast: false
+      matrix:
+        brokers: [1, 3]
+        # Five independent 288-minute processes provide 24 cumulative soak hours per
+        # broker topology while respecting the public runner's six-hour hard limit.
+        segment: ${{ fromJSON(github.event_name == 'schedule' && '[1,2,3,4,5]' || '[1]') }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build Soak Runner
+        run: dotnet build tools/Dekaf.StressTests --configuration Release
+
+      - name: Run Mixed Soak
+        env:
+          SOAK_DURATION_MINUTES: ${{ github.event_name == 'schedule' && '288' || inputs.duration_minutes }}
+          SOAK_MESSAGES_PER_SECOND: ${{ inputs.messages_per_second || '1000' }}
+          SOAK_WARMUP_MINUTES: ${{ github.event_name == 'schedule' && '30' || inputs.warmup_minutes }}
+          SOAK_MINIMUM_SAMPLES: ${{ inputs.minimum_samples || '30' }}
+        run: |
+          mkdir -p tools/Dekaf.StressTests/results
+          echo "Duration: ${SOAK_DURATION_MINUTES} minutes"
+          echo "Target rate: ${SOAK_MESSAGES_PER_SECOND} msg/s"
+          echo "Brokers: ${{ matrix.brokers }}"
+
+          dotnet run \
+            --project tools/Dekaf.StressTests \
+            --configuration Release \
+            --no-build -- \
+            --duration "${SOAK_DURATION_MINUTES}" \
+            --message-size 1000 \
+            --scenario soak \
+            --client dekaf \
+            --brokers ${{ matrix.brokers }} \
+            --connections-per-broker 1 \
+            --soak-messages-per-second "${SOAK_MESSAGES_PER_SECOND}" \
+            --resource-sample-seconds 60 \
+            --soak-warmup-minutes "${SOAK_WARMUP_MINUTES}" \
+            --soak-minimum-samples "${SOAK_MINIMUM_SAMPLES}" \
+            --max-working-set-slope-mib-per-hour 8 \
+            --max-gc-heap-slope-mib-per-hour 4 \
+            --max-loh-slope-mib-per-hour 4 \
+            --max-throughput-decay-percent-per-hour 5 \
+            --producer-delivery-diagnostics \
+            --output tools/Dekaf.StressTests/results/segment-${{ matrix.segment }}
+
+      - name: Upload Soak Results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: soak-results-${{ matrix.brokers }}brokers-segment-${{ matrix.segment }}
+          path: tools/Dekaf.StressTests/results/
+          if-no-files-found: warn
+          retention-days: 90

--- a/docs/docs/soak-tests.md
+++ b/docs/docs/soak-tests.md
@@ -15,6 +15,7 @@ The segments intentionally restart the process. A single continuous 24-hour proc
 Strict message checks remain active for the entire run:
 
 - producer errors or consumer errors fail the run;
+- client-accepted throughput must reach at least 95% of the requested pacing rate;
 - broker end-offset growth must equal client-accepted messages;
 - the consumer must catch up to every broker-delivered message after the producer drains.
 

--- a/docs/docs/soak-tests.md
+++ b/docs/docs/soak-tests.md
@@ -18,7 +18,7 @@ Strict message checks remain active for the entire run:
 - broker end-offset growth must equal client-accepted messages;
 - the consumer must catch up to every broker-delivered message after the producer drains.
 
-After a 60-minute warmup, linear regression is calculated over every one-minute sample. The run fails when any slope crosses its limit:
+After a 30-minute warmup, linear regression is calculated over every one-minute sample. The run fails when any slope crosses its limit:
 
 | Metric | Limit |
 |---|---:|

--- a/docs/docs/soak-tests.md
+++ b/docs/docs/soak-tests.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 15
+---
+
+# 24-hour soak tests
+
+The mixed soak runs a paced, idempotent `Acks.All` producer and a live consumer in the same process. CI targets 1,000 1 KB messages per second, enough to exercise producer, consumer, networking, batching, offset, and sequence bookkeeping without turning a shared public runner into a throughput benchmark.
+
+GitHub Actions runs the scenario every Tuesday at 02:00 UTC against both one-broker and three-broker clusters. Public `ubuntu-latest` jobs have a six-hour hard limit, so each topology runs five independent 288-minute segments: 24 cumulative hours of weekly load and five separate post-warmup leak-slope gates. Each segment uploads its JSON, Markdown, and per-minute samples for 90 days.
+
+The segments intentionally restart the process. A single continuous 24-hour process would require a paid or self-hosted runner; this layout keeps the repository on free public GitHub runners.
+
+## Failure gates
+
+Strict message checks remain active for the entire run:
+
+- producer errors or consumer errors fail the run;
+- broker end-offset growth must equal client-accepted messages;
+- the consumer must catch up to every broker-delivered message after the producer drains.
+
+After a 60-minute warmup, linear regression is calculated over every one-minute sample. The run fails when any slope crosses its limit:
+
+| Metric | Limit |
+|---|---:|
+| Working set | +8 MiB/hour |
+| Managed GC heap | +4 MiB/hour |
+| Large object heap (LOH) | +4 MiB/hour |
+| Produced throughput | -5%/hour |
+| Consumed throughput | -5%/hour |
+
+Each sample also records cumulative Gen2 collections and process thread count. LOH has no independent collection counter in .NET; LOH collections occur with Gen2, so the result records Gen2 cadence and LOH size separately.
+
+At least 30 post-warmup samples are required. Missing samples fail closed instead of turning a broken monitor into a green soak.
+
+## Run locally
+
+Docker must be running. Full one-broker soak:
+
+```powershell
+dotnet run --project tools/Dekaf.StressTests --configuration Release -- `
+  --scenario soak --client dekaf --brokers 1 --duration 1440 `
+  --soak-messages-per-second 5000 --resource-sample-seconds 60 `
+  --soak-warmup-minutes 60 --soak-minimum-samples 30 `
+  --producer-delivery-diagnostics --output ./soak-results
+```
+
+Functional two-minute smoke (trend limits deliberately permissive; this verifies orchestration and result generation, not leak detection):
+
+```powershell
+dotnet run --project tools/Dekaf.StressTests --configuration Release -- `
+  --scenario soak --client dekaf --brokers 1 --duration 2 `
+  --soak-messages-per-second 100 --resource-sample-seconds 10 `
+  --soak-warmup-minutes 0 --soak-minimum-samples 2 `
+  --max-working-set-slope-mib-per-hour 100000 `
+  --max-gc-heap-slope-mib-per-hour 100000 `
+  --max-loh-slope-mib-per-hour 100000 `
+  --max-throughput-decay-percent-per-hour 100000 `
+  --output ./soak-smoke-results
+```

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -27,10 +27,6 @@
     <Compile Remove="StressTests\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <ProjectReference Include="..\..\tools\Dekaf.StressTests\Dekaf.StressTests.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.35.1" />
     <PackageReference Include="OpenTelemetry" Version="1.16.0" />

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -27,6 +27,10 @@
     <Compile Remove="StressTests\**\*.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <ProjectReference Include="..\..\tools\Dekaf.StressTests\Dekaf.StressTests.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.35.1" />
     <PackageReference Include="OpenTelemetry" Version="1.16.0" />

--- a/tests/Dekaf.Tests.Unit/StressTests/ResourceTrendAnalyzerTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ResourceTrendAnalyzerTests.cs
@@ -1,0 +1,127 @@
+#if NET10_0
+using Dekaf.StressTests.Metrics;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class ResourceTrendAnalyzerTests
+{
+    private const long Mib = 1024 * 1024;
+
+    [Test]
+    public async Task Analyze_StablePostWarmupSamples_Passes()
+    {
+        var samples = CreateSamples(90, static _ => 0);
+
+        var analysis = ResourceTrendAnalyzer.Analyze(samples, CreateThresholds());
+
+        await Assert.That(analysis.Failures).IsEmpty();
+        await Assert.That(analysis.SampleCount).IsEqualTo(60);
+        await Assert.That(analysis.WorkingSetSlopeMibPerHour).IsBetween(-0.001, 0.001);
+        await Assert.That(analysis.GcHeapSlopeMibPerHour).IsBetween(-0.001, 0.001);
+        await Assert.That(analysis.LohSlopeMibPerHour).IsBetween(-0.001, 0.001);
+    }
+
+    [Test]
+    public async Task Analyze_GrowthBeforeWarmupOnly_Passes()
+    {
+        var samples = CreateSamples(90, minute => minute < 30 ? minute * Mib : 30 * Mib);
+
+        var analysis = ResourceTrendAnalyzer.Analyze(samples, CreateThresholds());
+
+        await Assert.That(analysis.Failures).IsEmpty();
+        await Assert.That(analysis.WorkingSetSlopeMibPerHour).IsBetween(-0.001, 0.001);
+    }
+
+    [Test]
+    public async Task Analyze_SustainedWorkingSetGrowth_Fails()
+    {
+        var samples = CreateSamples(90, minute => minute * Mib / 4);
+
+        var analysis = ResourceTrendAnalyzer.Analyze(samples, CreateThresholds());
+
+        await Assert.That(analysis.WorkingSetSlopeMibPerHour).IsBetween(14.99, 15.01);
+        await Assert.That(analysis.Failures).Contains(x => x.Contains("working set", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public async Task Analyze_SustainedGcHeapAndLohGrowth_FailsBoth()
+    {
+        var samples = CreateSamples(
+            90,
+            workingSetGrowth: static _ => 0,
+            gcHeapGrowth: minute => minute * Mib / 8,
+            lohGrowth: minute => minute * Mib / 10);
+
+        var analysis = ResourceTrendAnalyzer.Analyze(samples, CreateThresholds());
+
+        await Assert.That(analysis.Failures).Contains(x => x.Contains("GC heap", StringComparison.OrdinalIgnoreCase));
+        await Assert.That(analysis.Failures).Contains(x => x.Contains("LOH", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public async Task Analyze_SustainedThroughputDecay_Fails()
+    {
+        var samples = CreateSamples(
+            90,
+            workingSetGrowth: static _ => 0,
+            producedRate: minute => 1_000 - (minute * 2),
+            consumedRate: minute => 1_000 - (minute * 2));
+
+        var analysis = ResourceTrendAnalyzer.Analyze(samples, CreateThresholds());
+
+        await Assert.That(analysis.ProducedThroughputSlopePercentPerHour).IsLessThan(-10);
+        await Assert.That(analysis.ConsumedThroughputSlopePercentPerHour).IsLessThan(-10);
+        await Assert.That(analysis.Failures).Contains(x => x.Contains("produced throughput", StringComparison.OrdinalIgnoreCase));
+        await Assert.That(analysis.Failures).Contains(x => x.Contains("consumed throughput", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public async Task Analyze_TooFewPostWarmupSamples_FailsClosed()
+    {
+        var thresholds = CreateThresholds() with { MinimumSampleCount = 60 };
+        var samples = CreateSamples(50, static _ => 0);
+
+        var analysis = ResourceTrendAnalyzer.Analyze(samples, thresholds);
+
+        await Assert.That(analysis.Failures).Contains(x => x.Contains("at least 60", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static ResourceTrendThresholds CreateThresholds() => new()
+    {
+        WarmupMinutes = 30,
+        MinimumSampleCount = 30,
+        MaxWorkingSetSlopeMibPerHour = 8,
+        MaxGcHeapSlopeMibPerHour = 4,
+        MaxLohSlopeMibPerHour = 2,
+        MaxThroughputDecayPercentPerHour = 5
+    };
+
+    private static List<ResourceSample> CreateSamples(
+        int count,
+        Func<int, long> workingSetGrowth,
+        Func<int, long>? gcHeapGrowth = null,
+        Func<int, long>? lohGrowth = null,
+        Func<int, double>? producedRate = null,
+        Func<int, double>? consumedRate = null)
+    {
+        gcHeapGrowth ??= static _ => 0;
+        lohGrowth ??= static _ => 0;
+        producedRate ??= static _ => 1_000;
+        consumedRate ??= static _ => 1_000;
+
+        return Enumerable.Range(0, count)
+            .Select(minute => new ResourceSample
+            {
+                ElapsedMinutes = minute,
+                WorkingSetBytes = (256 * Mib) + workingSetGrowth(minute),
+                GcHeapBytes = (128 * Mib) + gcHeapGrowth(minute),
+                LohSizeBytes = (32 * Mib) + lohGrowth(minute),
+                Gen2Collections = minute / 10,
+                ThreadCount = 16,
+                ProducedMessagesPerSecond = producedRate(minute),
+                ConsumedMessagesPerSecond = consumedRate(minute)
+            })
+            .ToList();
+    }
+}
+#endif

--- a/tests/Dekaf.Tests.Unit/StressTests/ResourceTrendMonitorTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ResourceTrendMonitorTests.cs
@@ -1,0 +1,25 @@
+#if NET10_0
+using Dekaf.StressTests.Metrics;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class ResourceTrendMonitorTests
+{
+    [Test]
+    [Arguments(0.01, 60, false)]
+    [Arguments(29.99, 60, false)]
+    [Arguments(30, 60, true)]
+    [Arguments(60, 60, true)]
+    public async Task ShouldCaptureFinalSample_RequiresMeaningfulPartialInterval(
+        double elapsedSeconds,
+        double sampleIntervalSeconds,
+        bool expected)
+    {
+        var result = ResourceTrendMonitor.ShouldCaptureFinalSample(
+            TimeSpan.FromSeconds(elapsedSeconds),
+            TimeSpan.FromSeconds(sampleIntervalSeconds));
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+}
+#endif

--- a/tests/Dekaf.Tests.Unit/StressTests/SoakStressTestTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/SoakStressTestTests.cs
@@ -1,10 +1,76 @@
 #if NET10_0
+using Dekaf.Producer;
+using Dekaf.StressTests.Diagnostics;
+using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Scenarios;
+using NSubstitute;
 
 namespace Dekaf.Tests.Unit.StressTests;
 
 public sealed class SoakStressTestTests
 {
+    [Test]
+    public async Task TrackMeasurementProgress_StallCapturesSoakProducerDiagnostics()
+    {
+        var outputDirectory = Path.Combine(Path.GetTempPath(), $"dekaf-soak-watchdog-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(outputDirectory);
+
+        try
+        {
+            var exited = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var throughput = new ThroughputTracker();
+            throughput.Start();
+
+            using var watchdog = new ProgressWatchdog(
+                outputDirectory,
+                captureAfter: TimeSpan.FromMilliseconds(20),
+                exitAfter: TimeSpan.FromMilliseconds(60),
+                pollInterval: TimeSpan.FromMilliseconds(10),
+                exitProcess: code => exited.TrySetResult(code),
+                captureManagedStackReport: () => "fake managed stack");
+            using var registration = new SoakStressTest().TrackMeasurementProgress(
+                watchdog,
+                throughput,
+                () => new ProducerDeliveryDiagnosticsSnapshot
+                {
+                    DiagnosticsEnabled = true,
+                    CapturedAtUtc = DateTimeOffset.UtcNow
+                });
+
+            await exited.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var producerArtifact = Directory.GetFiles(
+                Path.Combine(outputDirectory, ProgressWatchdog.ArtifactsDirectoryName),
+                "*-fatal-producer.json").Single();
+            var contents = await File.ReadAllTextAsync(producerArtifact);
+            await Assert.That(contents).Contains("\"scenario\": \"soak\"");
+            await Assert.That(contents).Contains("\"diagnosticsEnabled\": true");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task DisposeWithTimeoutAsync_WhenProducerHangs_RecordsError()
+    {
+        var producer = Substitute.For<IKafkaProducer<string, string>>();
+        var disposeCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        producer.DisposeAsync().Returns(new ValueTask(disposeCompletion.Task));
+        var throughput = new ThroughputTracker();
+
+        await StressTestHelpers.DisposeWithTimeoutAsync(
+            producer,
+            throughput,
+            TimeSpan.FromMilliseconds(20));
+        disposeCompletion.TrySetResult();
+
+        var snapshot = throughput.GetSnapshot();
+        await Assert.That(snapshot.TotalErrors).IsEqualTo(1);
+        await Assert.That(snapshot.ErrorSamples.Single().ExceptionType).IsEqualTo("DisposeTimeout");
+    }
+
     [Test]
     [Arguments(1_000L, 1_000L, true)]
     [Arguments(1_000L, 999L, false)]

--- a/tests/Dekaf.Tests.Unit/StressTests/SoakStressTestTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/SoakStressTestTests.cs
@@ -1,0 +1,39 @@
+#if NET10_0
+using Dekaf.StressTests.Scenarios;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class SoakStressTestTests
+{
+    [Test]
+    [Arguments(1_000L, 1_000L, true)]
+    [Arguments(1_000L, 999L, false)]
+    [Arguments(1_000L, 1_001L, false)]
+    public async Task IsBrokerDeliveryExact_RequiresAcceptedCount(
+        long acceptedMessages,
+        long deliveredMessages,
+        bool expected)
+    {
+        var result = SoakStressTest.IsBrokerDeliveryExact(acceptedMessages, deliveredMessages);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments(95, 100, true)]
+    [Arguments(94.9, 100, false)]
+    [Arguments(100, 100, true)]
+    [Arguments(0, 100, false)]
+    public async Task MeetsMinimumPacingRate_RequiresNinetyFivePercentOfTarget(
+        double acceptedRate,
+        int targetMessagesPerSecond,
+        bool expected)
+    {
+        var result = SoakStressTest.MeetsMinimumPacingRate(
+            acceptedRate,
+            targetMessagesPerSecond);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+}
+#endif

--- a/tools/Dekaf.StressTests/Metrics/ResourceTrendAnalyzer.cs
+++ b/tools/Dekaf.StressTests/Metrics/ResourceTrendAnalyzer.cs
@@ -1,0 +1,197 @@
+namespace Dekaf.StressTests.Metrics;
+
+internal sealed record ResourceSample
+{
+    public required double ElapsedMinutes { get; init; }
+    public required long WorkingSetBytes { get; init; }
+    public required long GcHeapBytes { get; init; }
+    public required long LohSizeBytes { get; init; }
+    public required int Gen2Collections { get; init; }
+    public required int ThreadCount { get; init; }
+    public required double ProducedMessagesPerSecond { get; init; }
+    public required double ConsumedMessagesPerSecond { get; init; }
+}
+
+internal sealed record ResourceTrendThresholds
+{
+    public required double WarmupMinutes { get; init; }
+    public required int MinimumSampleCount { get; init; }
+    public required double MaxWorkingSetSlopeMibPerHour { get; init; }
+    public required double MaxGcHeapSlopeMibPerHour { get; init; }
+    public required double MaxLohSlopeMibPerHour { get; init; }
+    public required double MaxThroughputDecayPercentPerHour { get; init; }
+}
+
+internal sealed class ResourceTrendAnalysis
+{
+    public required int SampleCount { get; init; }
+    public required double WorkingSetSlopeMibPerHour { get; init; }
+    public required double GcHeapSlopeMibPerHour { get; init; }
+    public required double LohSlopeMibPerHour { get; init; }
+    public required double ProducedThroughputSlopePercentPerHour { get; init; }
+    public required double ConsumedThroughputSlopePercentPerHour { get; init; }
+    public required List<string> Failures { get; init; }
+
+    public bool Passed => Failures.Count == 0;
+}
+
+internal static class ResourceTrendAnalyzer
+{
+    private const double BytesPerMib = 1024 * 1024;
+
+    internal static ResourceTrendAnalysis Analyze(
+        IReadOnlyCollection<ResourceSample> samples,
+        ResourceTrendThresholds thresholds)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        ArgumentNullException.ThrowIfNull(thresholds);
+        ValidateThresholds(thresholds);
+
+        var postWarmup = samples
+            .Where(sample => sample.ElapsedMinutes >= thresholds.WarmupMinutes)
+            .OrderBy(sample => sample.ElapsedMinutes)
+            .ToArray();
+
+        var failures = new List<string>();
+        if (postWarmup.Length < thresholds.MinimumSampleCount)
+        {
+            failures.Add(
+                $"Resource trend requires at least {thresholds.MinimumSampleCount} post-warmup samples; " +
+                $"captured {postWarmup.Length}.");
+        }
+
+        var workingSetSlope = CalculateSlopePerHour(postWarmup, static sample => sample.WorkingSetBytes) / BytesPerMib;
+        var gcHeapSlope = CalculateSlopePerHour(postWarmup, static sample => sample.GcHeapBytes) / BytesPerMib;
+        var lohSlope = CalculateSlopePerHour(postWarmup, static sample => sample.LohSizeBytes) / BytesPerMib;
+        var producedThroughputSlope = CalculatePercentSlopePerHour(
+            postWarmup,
+            static sample => sample.ProducedMessagesPerSecond,
+            "produced throughput",
+            failures);
+        var consumedThroughputSlope = CalculatePercentSlopePerHour(
+            postWarmup,
+            static sample => sample.ConsumedMessagesPerSecond,
+            "consumed throughput",
+            failures);
+
+        AddGrowthFailure(
+            failures,
+            "working set",
+            workingSetSlope,
+            thresholds.MaxWorkingSetSlopeMibPerHour);
+        AddGrowthFailure(
+            failures,
+            "GC heap",
+            gcHeapSlope,
+            thresholds.MaxGcHeapSlopeMibPerHour);
+        AddGrowthFailure(
+            failures,
+            "LOH",
+            lohSlope,
+            thresholds.MaxLohSlopeMibPerHour);
+        AddDecayFailure(
+            failures,
+            "produced throughput",
+            producedThroughputSlope,
+            thresholds.MaxThroughputDecayPercentPerHour);
+        AddDecayFailure(
+            failures,
+            "consumed throughput",
+            consumedThroughputSlope,
+            thresholds.MaxThroughputDecayPercentPerHour);
+
+        return new ResourceTrendAnalysis
+        {
+            SampleCount = postWarmup.Length,
+            WorkingSetSlopeMibPerHour = workingSetSlope,
+            GcHeapSlopeMibPerHour = gcHeapSlope,
+            LohSlopeMibPerHour = lohSlope,
+            ProducedThroughputSlopePercentPerHour = producedThroughputSlope,
+            ConsumedThroughputSlopePercentPerHour = consumedThroughputSlope,
+            Failures = failures
+        };
+    }
+
+    private static void ValidateThresholds(ResourceTrendThresholds thresholds)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(thresholds.WarmupMinutes);
+        ArgumentOutOfRangeException.ThrowIfLessThan(thresholds.MinimumSampleCount, 2);
+        ArgumentOutOfRangeException.ThrowIfNegative(thresholds.MaxWorkingSetSlopeMibPerHour);
+        ArgumentOutOfRangeException.ThrowIfNegative(thresholds.MaxGcHeapSlopeMibPerHour);
+        ArgumentOutOfRangeException.ThrowIfNegative(thresholds.MaxLohSlopeMibPerHour);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(thresholds.MaxThroughputDecayPercentPerHour);
+    }
+
+    private static double CalculateSlopePerHour(
+        IReadOnlyList<ResourceSample> samples,
+        Func<ResourceSample, double> selector)
+    {
+        if (samples.Count < 2)
+        {
+            return 0;
+        }
+
+        var meanHours = samples.Average(static sample => sample.ElapsedMinutes / 60);
+        var meanValue = samples.Average(selector);
+        var numerator = 0.0;
+        var denominator = 0.0;
+
+        foreach (var sample in samples)
+        {
+            var hoursDelta = (sample.ElapsedMinutes / 60) - meanHours;
+            numerator += hoursDelta * (selector(sample) - meanValue);
+            denominator += hoursDelta * hoursDelta;
+        }
+
+        return denominator == 0 ? 0 : numerator / denominator;
+    }
+
+    private static double CalculatePercentSlopePerHour(
+        IReadOnlyList<ResourceSample> samples,
+        Func<ResourceSample, double> selector,
+        string metric,
+        List<string> failures)
+    {
+        if (samples.Count < 2)
+        {
+            return 0;
+        }
+
+        var mean = samples.Average(selector);
+        if (mean <= 0 || !double.IsFinite(mean))
+        {
+            failures.Add($"Post-warmup {metric} mean is not positive and finite ({mean:N2} msg/s).");
+            return 0;
+        }
+
+        return CalculateSlopePerHour(samples, selector) / mean * 100;
+    }
+
+    private static void AddGrowthFailure(
+        List<string> failures,
+        string metric,
+        double slopeMibPerHour,
+        double maximumMibPerHour)
+    {
+        if (slopeMibPerHour > maximumMibPerHour)
+        {
+            failures.Add(
+                $"Post-warmup {metric} slope {slopeMibPerHour:N2} MiB/hour exceeds " +
+                $"{maximumMibPerHour:N2} MiB/hour.");
+        }
+    }
+
+    private static void AddDecayFailure(
+        List<string> failures,
+        string metric,
+        double slopePercentPerHour,
+        double maximumDecayPercentPerHour)
+    {
+        if (slopePercentPerHour < -maximumDecayPercentPerHour)
+        {
+            failures.Add(
+                $"Post-warmup {metric} slope {slopePercentPerHour:N2}%/hour exceeds " +
+                $"the allowed {maximumDecayPercentPerHour:N2}%/hour decay.");
+        }
+    }
+}

--- a/tools/Dekaf.StressTests/Metrics/ResourceTrendMonitor.cs
+++ b/tools/Dekaf.StressTests/Metrics/ResourceTrendMonitor.cs
@@ -34,10 +34,20 @@ internal sealed class ResourceTrendMonitor(
         }
         finally
         {
-            CaptureSample();
+            var elapsedSinceLastSample = TimeSpan.FromSeconds(
+                _elapsed.Elapsed.TotalSeconds - _lastSampleElapsedSeconds);
+            if (ShouldCaptureFinalSample(elapsedSinceLastSample, sampleInterval))
+            {
+                CaptureSample();
+            }
             _elapsed.Stop();
         }
     }
+
+    // Cancellation can race an exact timer tick. Treat a shorter tail as the same interval so it
+    // cannot add a near-zero-rate point, while retaining a substantial partial interval.
+    internal static bool ShouldCaptureFinalSample(TimeSpan elapsedSinceLastSample, TimeSpan sampleInterval)
+        => elapsedSinceLastSample >= TimeSpan.FromTicks(sampleInterval.Ticks / 2);
 
     internal ResourceTrendSnapshot GetSnapshot(ResourceTrendThresholds thresholds)
     {

--- a/tools/Dekaf.StressTests/Metrics/ResourceTrendMonitor.cs
+++ b/tools/Dekaf.StressTests/Metrics/ResourceTrendMonitor.cs
@@ -1,0 +1,114 @@
+using System.Diagnostics;
+
+namespace Dekaf.StressTests.Metrics;
+
+internal sealed class ResourceTrendMonitor(
+    Func<long> producedCount,
+    Func<long> consumedCount,
+    TimeSpan sampleInterval)
+{
+    private readonly Stopwatch _elapsed = new();
+    private readonly List<ResourceSample> _samples = [];
+    private long _lastProducedCount;
+    private long _lastConsumedCount;
+    private double _lastSampleElapsedSeconds;
+
+    internal async Task RunAsync(CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(sampleInterval, TimeSpan.Zero);
+
+        _elapsed.Start();
+        CaptureSample();
+
+        using var timer = new PeriodicTimer(sampleInterval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+            {
+                CaptureSample();
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Expected when the soak measurement window ends.
+        }
+        finally
+        {
+            CaptureSample();
+            _elapsed.Stop();
+        }
+    }
+
+    internal ResourceTrendSnapshot GetSnapshot(ResourceTrendThresholds thresholds)
+    {
+        var samples = _samples.ToList();
+        return new ResourceTrendSnapshot
+        {
+            SampleIntervalSeconds = sampleInterval.TotalSeconds,
+            WarmupMinutes = thresholds.WarmupMinutes,
+            Samples = samples,
+            Analysis = ResourceTrendAnalyzer.Analyze(samples, thresholds)
+        };
+    }
+
+    private void CaptureSample()
+    {
+        var elapsedSeconds = _elapsed.Elapsed.TotalSeconds;
+        if (_samples.Count > 0 && elapsedSeconds <= _lastSampleElapsedSeconds)
+        {
+            return;
+        }
+
+        var currentProducedCount = producedCount();
+        var currentConsumedCount = consumedCount();
+        var intervalSeconds = elapsedSeconds - _lastSampleElapsedSeconds;
+        var producedRate = intervalSeconds > 0
+            ? (currentProducedCount - _lastProducedCount) / intervalSeconds
+            : 0;
+        var consumedRate = intervalSeconds > 0
+            ? (currentConsumedCount - _lastConsumedCount) / intervalSeconds
+            : 0;
+
+        using var process = Process.GetCurrentProcess();
+        process.Refresh();
+
+        var gcMemoryInfo = GC.GetGCMemoryInfo();
+        var generationInfo = gcMemoryInfo.GenerationInfo;
+        var lohSize = generationInfo.Length > 3 ? generationInfo[3].SizeAfterBytes : 0;
+        var sample = new ResourceSample
+        {
+            ElapsedMinutes = elapsedSeconds / 60,
+            WorkingSetBytes = process.WorkingSet64,
+            GcHeapBytes = GC.GetTotalMemory(forceFullCollection: false),
+            LohSizeBytes = lohSize,
+            Gen2Collections = GC.CollectionCount(2),
+            ThreadCount = process.Threads.Count,
+            ProducedMessagesPerSecond = producedRate,
+            ConsumedMessagesPerSecond = consumedRate
+        };
+
+        _samples.Add(sample);
+        _lastProducedCount = currentProducedCount;
+        _lastConsumedCount = currentConsumedCount;
+        _lastSampleElapsedSeconds = elapsedSeconds;
+
+        Console.WriteLine(
+            $"  [{DateTime.UtcNow:HH:mm:ss}] Soak resources: " +
+            $"WorkingSet={ToMib(sample.WorkingSetBytes):N1}MiB, " +
+            $"GCHeap={ToMib(sample.GcHeapBytes):N1}MiB, " +
+            $"LOH={ToMib(sample.LohSizeBytes):N1}MiB, " +
+            $"Gen2={sample.Gen2Collections:N0}, Threads={sample.ThreadCount:N0}, " +
+            $"Produced={sample.ProducedMessagesPerSecond:N0}msg/s, " +
+            $"Consumed={sample.ConsumedMessagesPerSecond:N0}msg/s");
+    }
+
+    private static double ToMib(long bytes) => bytes / (1024.0 * 1024);
+}
+
+internal sealed class ResourceTrendSnapshot
+{
+    public required double SampleIntervalSeconds { get; init; }
+    public required double WarmupMinutes { get; init; }
+    public required List<ResourceSample> Samples { get; init; }
+    public required ResourceTrendAnalysis Analysis { get; init; }
+}

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 using Dekaf.Producer;
 using Dekaf.StressTests.Diagnostics;
 using Dekaf.StressTests.FaultInjection;
@@ -118,6 +119,11 @@ public static class Program
 
         Console.WriteLine($"Compression: {options.Compression}");
         Console.WriteLine($"Brokers: {options.Brokers}");
+        if (options.Scenario.Equals("soak", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine($"Soak target rate: {options.SoakMessagesPerSecond:N0} msg/s");
+            Console.WriteLine($"Resource sample interval: {options.ResourceSampleIntervalSeconds:N0} seconds");
+        }
         Console.WriteLine($"Producer delivery diagnostics: {(options.EnableProducerDeliveryDiagnostics ? "enabled" : "disabled")}");
         Console.WriteLine($"Progress watchdog: stacks at {ProgressWatchdog.DefaultCaptureAfter.TotalSeconds:F0}s; " +
             $"fail at {ProgressWatchdog.DefaultExitAfter.TotalMinutes:F0} minutes");
@@ -172,7 +178,7 @@ public static class Program
             if (scenarioName.Equals("producer-transactional", StringComparison.OrdinalIgnoreCase))
                 return transactionalTopic ?? throw new InvalidOperationException("Transactional topic was not created.");
 
-            return scenarioName.StartsWith("producer", StringComparison.OrdinalIgnoreCase)
+            return UsesProducerTopic(scenarioName)
                 ? producerTopic
                 : consumerTopic;
         }
@@ -190,7 +196,18 @@ public static class Program
             BrokerCount = options.Brokers,
             ConnectionsPerBroker = connectionsPerBroker,
             EnableProducerDeliveryDiagnostics = options.EnableProducerDeliveryDiagnostics,
-            ProgressWatchdog = progressWatchdog
+            ProgressWatchdog = progressWatchdog,
+            SoakMessagesPerSecond = options.SoakMessagesPerSecond,
+            ResourceSampleIntervalSeconds = options.ResourceSampleIntervalSeconds,
+            ResourceTrendThresholds = new ResourceTrendThresholds
+            {
+                WarmupMinutes = options.SoakWarmupMinutes,
+                MinimumSampleCount = options.SoakMinimumSamples,
+                MaxWorkingSetSlopeMibPerHour = options.MaxWorkingSetSlopeMibPerHour,
+                MaxGcHeapSlopeMibPerHour = options.MaxGcHeapSlopeMibPerHour,
+                MaxLohSlopeMibPerHour = options.MaxLohSlopeMibPerHour,
+                MaxThroughputDecayPercentPerHour = options.MaxThroughputDecayPercentPerHour
+            }
         };
 
         if (options.ConnectionsPerBroker == 1)
@@ -214,7 +231,7 @@ public static class Program
             // Multi-connection pass: Dekaf-only producer scenarios with explicit
             // ConnectionsPerBroker to measure parallel TCP connection throughput.
             var multiConnScenarios = scenarios
-                .Where(s => s.Client == "Dekaf" && s.Name.StartsWith("producer", StringComparison.OrdinalIgnoreCase))
+                .Where(s => s.Client == "Dekaf" && UsesProducerTopic(s.Name))
                 .ToList();
             foreach (var scenario in multiConnScenarios)
             {
@@ -273,8 +290,39 @@ public static class Program
         Console.WriteLine();
         Console.WriteLine(MarkdownReporter.Generate(allResults));
 
-        return CheckForFailures(results) ? 1 : 0;
+        var failed = CheckForFailures(results);
+        failed |= CheckForResourceTrendFailures(results);
+        return failed ? 1 : 0;
     }
+
+    private static bool CheckForResourceTrendFailures(List<StressTestResult> results)
+    {
+        var failures = results
+            .Where(result => result.ResourceTrend?.Analysis.Passed == false)
+            .ToList();
+
+        if (failures.Count == 0)
+        {
+            return false;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("RESOURCE TREND REGRESSION DETECTED - failing the run:");
+        foreach (var result in failures)
+        {
+            Console.WriteLine($"  {result.Client} {result.Scenario} ({result.BrokerCount} broker(s)):");
+            foreach (var failure in result.ResourceTrend!.Analysis.Failures)
+            {
+                Console.WriteLine($"    - {failure}");
+            }
+        }
+
+        return true;
+    }
+
+    private static bool UsesProducerTopic(string scenarioName) =>
+        scenarioName.StartsWith("producer", StringComparison.OrdinalIgnoreCase) ||
+        scenarioName.Equals("soak", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Maximum consecutive seconds with zero client progress before the run is failed as
@@ -594,9 +642,17 @@ public static class Program
     private static List<IStressTestScenario> GetScenarios(CliOptions options)
     {
         var scenarios = CreateAllScenarios()
-            .Where(s => options.Scenario == "all" || s.Name.Equals(options.Scenario, StringComparison.OrdinalIgnoreCase))
+            .Where(s => options.Scenario == "all"
+                ? !s.Name.Equals("soak", StringComparison.OrdinalIgnoreCase)
+                : s.Name.Equals(options.Scenario, StringComparison.OrdinalIgnoreCase))
             .Where(s => options.Client == "all" || s.Client.Equals(options.Client, StringComparison.OrdinalIgnoreCase))
             .ToList();
+
+        if (scenarios.Count == 0)
+        {
+            throw new ArgumentException(
+                $"No stress scenario matched --scenario {options.Scenario} --client {options.Client}.");
+        }
 
         return ApplyClientOrder(scenarios, options.Client);
     }
@@ -618,7 +674,8 @@ public static class Program
             new ConsumerBatchStressTest(),
             new ConsumerRawStressTest(),
             new ConsumerRawBatchStressTest(),
-            new ConfluentConsumerStressTest()
+            new ConfluentConsumerStressTest(),
+            new SoakStressTest()
         ];
 
     private static List<IStressTestScenario> ApplyClientOrder(List<IStressTestScenario> scenarios, string requestedClient)
@@ -778,6 +835,34 @@ public static class Program
                 case "--messages-after-fault":
                     options.MessagesAfterFault = ParsePositiveInt(args[++i], "--messages-after-fault");
                     break;
+                case "--soak-messages-per-second":
+                    options.SoakMessagesPerSecond = ParsePositiveInt(args[++i], arg);
+                    break;
+                case "--resource-sample-seconds":
+                    options.ResourceSampleIntervalSeconds = ParsePositiveDouble(args[++i], arg);
+                    break;
+                case "--soak-warmup-minutes":
+                    options.SoakWarmupMinutes = ParseNonNegativeDouble(args[++i], arg);
+                    break;
+                case "--soak-minimum-samples":
+                    options.SoakMinimumSamples = ParsePositiveInt(args[++i], arg);
+                    if (options.SoakMinimumSamples < 2)
+                    {
+                        throw new ArgumentException("--soak-minimum-samples must be at least 2");
+                    }
+                    break;
+                case "--max-working-set-slope-mib-per-hour":
+                    options.MaxWorkingSetSlopeMibPerHour = ParseNonNegativeDouble(args[++i], arg);
+                    break;
+                case "--max-gc-heap-slope-mib-per-hour":
+                    options.MaxGcHeapSlopeMibPerHour = ParseNonNegativeDouble(args[++i], arg);
+                    break;
+                case "--max-loh-slope-mib-per-hour":
+                    options.MaxLohSlopeMibPerHour = ParseNonNegativeDouble(args[++i], arg);
+                    break;
+                case "--max-throughput-decay-percent-per-hour":
+                    options.MaxThroughputDecayPercentPerHour = ParsePositiveDouble(args[++i], arg);
+                    break;
                 case "--help":
                 case "-h":
                     PrintHelp();
@@ -791,13 +876,29 @@ public static class Program
 
     private static int ParsePositiveInt(string value, string optionName)
     {
-        var parsed = int.Parse(value);
+        var parsed = int.Parse(value, CultureInfo.InvariantCulture);
         if (parsed < 1)
         {
             throw new ArgumentException($"{optionName} must be at least 1");
         }
 
         return parsed;
+    }
+
+    private static double ParsePositiveDouble(string value, string option)
+    {
+        var parsed = double.Parse(value, CultureInfo.InvariantCulture);
+        return parsed > 0 && double.IsFinite(parsed)
+            ? parsed
+            : throw new ArgumentException($"{option} must be finite and greater than zero");
+    }
+
+    private static double ParseNonNegativeDouble(string value, string option)
+    {
+        var parsed = double.Parse(value, CultureInfo.InvariantCulture);
+        return parsed >= 0 && double.IsFinite(parsed)
+            ? parsed
+            : throw new ArgumentException($"{option} must be finite and non-negative");
     }
 
     private static void PrintHelp()
@@ -811,7 +912,7 @@ public static class Program
             Options:
               --duration <minutes>    Test duration in minutes (default: 15)
               --message-size <bytes>  Message size in bytes (default: 1000)
-              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
+              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, consumer, consumer-batch, consumer-raw, consumer-raw-batch, soak, all (default: all; all excludes soak)
               --client <name>         Run specific client: dekaf, confluent, all (default: all)
               --output <path>         Output directory for results (default: ./results)
               --partitions <count>    Number of topic partitions (default: 6)
@@ -822,6 +923,14 @@ public static class Program
               --connections-per-broker <n>  TCP connections per broker (default: 1, pass 3 for multi-connection comparison)
               --seed-messages <count> Messages pre-seeded into the consumer topic (default: 2000000)
               --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message loss and watchdog stalls
+              --soak-messages-per-second <n>   Mixed soak target rate (default: 5000)
+              --resource-sample-seconds <n>    Soak resource sample interval (default: 60)
+              --soak-warmup-minutes <n>        Samples excluded before trend analysis (default: 60)
+              --soak-minimum-samples <n>       Minimum post-warmup trend samples (default: 30)
+              --max-working-set-slope-mib-per-hour <n>  Working-set growth limit (default: 8)
+              --max-gc-heap-slope-mib-per-hour <n>      GC-heap growth limit (default: 4)
+              --max-loh-slope-mib-per-hour <n>          LOH growth limit (default: 4)
+              --max-throughput-decay-percent-per-hour <n> Throughput decay limit (default: 5)
               report --input <path>   Generate report from existing results
 
             Fault injection:
@@ -844,6 +953,7 @@ public static class Program
               dotnet run -c Release -- --duration 15 --message-size 1000
               dotnet run -c Release -- --scenario producer --client dekaf --duration 5
               dotnet run -c Release -- --scenario producer-transactional --client dekaf --duration 15
+              dotnet run -c Release -- --scenario soak --client dekaf --duration 1440 --brokers 1
               dotnet run -c Release -- report --input ./results
               dotnet run -c Release -- fault --fault-profile broker --brokers 3
             """);
@@ -873,5 +983,13 @@ public static class Program
         public int MaxMessagesDuringFault { get; set; } = 20_000;
         public int MessagesAfterFault { get; set; } = 2_000;
         public HashSet<string> AllowedFailureWindows { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public int SoakMessagesPerSecond { get; set; } = 5_000;
+        public double ResourceSampleIntervalSeconds { get; set; } = 60;
+        public double SoakWarmupMinutes { get; set; } = 60;
+        public int SoakMinimumSamples { get; set; } = 30;
+        public double MaxWorkingSetSlopeMibPerHour { get; set; } = 8;
+        public double MaxGcHeapSlopeMibPerHour { get; set; } = 4;
+        public double MaxLohSlopeMibPerHour { get; set; } = 4;
+        public double MaxThroughputDecayPercentPerHour { get; set; } = 5;
     }
 }

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -39,6 +39,10 @@ internal static class MarkdownReporter
 
             GenerateGcTable(sb, groupResults, $"GC Statistics - {label}");
 
+            var resultsWithResourceTrends = groupResults.Where(r => r.ResourceTrend is not null).ToList();
+            if (resultsWithResourceTrends.Count > 0)
+                GenerateResourceTrendTable(sb, resultsWithResourceTrends, $"Resource Trends - {label}");
+
             var resultsWithErrorSamples = groupResults
                 .Where(r => r.Throughput.ErrorSamples.Count > 0)
                 .ToList();
@@ -250,6 +254,37 @@ internal static class MarkdownReporter
         sb.AppendLine();
     }
 
+    private static void GenerateResourceTrendTable(StringBuilder sb, List<StressTestResult> results, string title)
+    {
+        var clientWidth = GetClientColumnWidth(results);
+
+        sb.AppendLine($"## {title}");
+        sb.AppendLine();
+        sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Samples | Working Set MiB/h | GC Heap MiB/h | LOH MiB/h | Produced %/h | Consumed %/h | Consumed | Status |");
+        sb.AppendLine($"|{new string('-', clientWidth + 2)}|---------|-------------------|---------------|-----------|---------------|---------------|----------|--------|");
+
+        foreach (var result in results.OrderBy(r => r.Client))
+        {
+            var trend = result.ResourceTrend!.Analysis;
+            var consumed = result.ConsumedMessages is { } count ? count.ToString("N0") : "-";
+            var status = trend.Passed ? "PASS" : "FAIL";
+            sb.AppendLine(
+                $"| {result.Client.PadRight(clientWidth)} | {trend.SampleCount,7:N0} | " +
+                $"{trend.WorkingSetSlopeMibPerHour,17:N2} | {trend.GcHeapSlopeMibPerHour,13:N2} | " +
+                $"{trend.LohSlopeMibPerHour,9:N2} | {trend.ProducedThroughputSlopePercentPerHour,13:N2} | " +
+                $"{trend.ConsumedThroughputSlopePercentPerHour,13:N2} | {consumed,8} | {status} |");
+
+            foreach (var failure in trend.Failures)
+            {
+                sb.AppendLine($"| {new string(' ', clientWidth)} |  |  |  |  |  |  |  | {EscapeTableCell(failure)} |");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("*Memory slopes use post-warmup linear regression. LOH is sampled separately; LOH collections occur with Gen2 collections.*");
+        sb.AppendLine();
+    }
+
     private static string FormatScenarioTitle(string scenario) => scenario switch
     {
         "producer" => "Producer (Fire-and-Forget) Throughput",
@@ -262,6 +297,7 @@ internal static class MarkdownReporter
         "consumer-batch" => "Consumer (Batch) Throughput",
         "consumer-raw" => "Consumer (Raw Bytes) Throughput",
         "consumer-raw-batch" => "Consumer (Raw Batch) Throughput",
+        "soak" => "Mixed Produce/Consume Soak",
         _ => $"{scenario} Throughput"
     };
 
@@ -277,6 +313,7 @@ internal static class MarkdownReporter
         "consumer-batch" => "Consumer (Batch)",
         "consumer-raw" => "Consumer (Raw Bytes)",
         "consumer-raw-batch" => "Consumer (Raw Batch)",
+        "soak" => "Mixed Soak",
         _ => scenario
     };
 

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -26,6 +26,8 @@ internal sealed class StressTestResult
     /// retry deduplication broken); non-idempotent runs tolerate retry duplicates.
     /// </summary>
     public bool Idempotent { get; init; }
+    public ResourceTrendSnapshot? ResourceTrend { get; init; }
+    public long? ConsumedMessages { get; init; }
 
     public TransactionVerificationSnapshot? TransactionVerification { get; init; }
 

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -1,4 +1,5 @@
 using Dekaf.StressTests.Diagnostics;
+using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 
 namespace Dekaf.StressTests.Scenarios;
@@ -24,4 +25,15 @@ internal sealed class StressTestOptions
     public int ConnectionsPerBroker { get; init; } = 1;
     public bool EnableProducerDeliveryDiagnostics { get; init; }
     public required ProgressWatchdog ProgressWatchdog { get; init; }
+    public int SoakMessagesPerSecond { get; init; } = 5_000;
+    public double ResourceSampleIntervalSeconds { get; init; } = 60;
+    public ResourceTrendThresholds ResourceTrendThresholds { get; init; } = new()
+    {
+        WarmupMinutes = 60,
+        MinimumSampleCount = 30,
+        MaxWorkingSetSlopeMibPerHour = 8,
+        MaxGcHeapSlopeMibPerHour = 4,
+        MaxLohSlopeMibPerHour = 4,
+        MaxThroughputDecayPercentPerHour = 5
+    };
 }

--- a/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
@@ -1,0 +1,311 @@
+using System.Diagnostics;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
+
+namespace Dekaf.StressTests.Scenarios;
+
+internal sealed class SoakStressTest : IStressTestScenario
+{
+    private const string WarmupKey = "__dekaf_soak_warmup__";
+    private static readonly TimeSpan WarmupTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan FlushTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan ConsumerCatchUpTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan ProducerPacingInterval = TimeSpan.FromMilliseconds(100);
+
+    public string Name => "soak";
+    public string Client => "Dekaf";
+
+    public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
+    {
+        var messageValue = new string('x', options.MessageSizeBytes);
+        var throughput = new ThroughputTracker();
+        var warmupSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var measurementActive = 0;
+        var consumedMessages = 0L;
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(options.BootstrapServers)
+            .WithClientId("soak-consumer-dekaf")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithCachedStringValues()
+            .BuildAsync(cancellationToken);
+        consumer.Assign(
+            Enumerable.Range(0, options.Partitions)
+                .Select(partition => new TopicPartition(options.Topic, partition))
+                .ToArray());
+
+        using var consumerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var consumerTask = ConsumeAsync(
+            consumer,
+            throughput,
+            warmupSeen,
+            () => Volatile.Read(ref measurementActive) != 0,
+            () => Interlocked.Increment(ref consumedMessages),
+            consumerCts.Token);
+
+        var producerBuilder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(options.BootstrapServers)
+            .WithClientId("soak-producer-dekaf")
+            .WithIdempotence(true)
+            .WithAcks(Acks.All)
+            .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
+            .WithBatchSize(options.BatchSize)
+            .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
+        StressTestHelpers.ConfigureProducerDeliveryDiagnostics(producerBuilder, options);
+        var producer = await producerBuilder.BuildAsync(cancellationToken);
+        var producerDisposed = false;
+
+        try
+        {
+            await producer.ProduceAsync(options.Topic, WarmupKey, messageValue, cancellationToken).ConfigureAwait(false);
+            await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
+            await warmupSeen.Task.WaitAsync(WarmupTimeout, cancellationToken).ConfigureAwait(false);
+
+            var startOffset = await StressTestHelpers.QueryTotalEndOffsetAsync(
+                options.BootstrapServers,
+                options.Topic,
+                options.Partitions).ConfigureAwait(false);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            var gcStats = new GcStats();
+            using var measurementCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            measurementCts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
+            var monitor = new ResourceTrendMonitor(
+                () => throughput.MessageCount,
+                () => Interlocked.Read(ref consumedMessages),
+                TimeSpan.FromSeconds(options.ResourceSampleIntervalSeconds));
+
+            var startedAt = DateTime.UtcNow;
+            Console.WriteLine(
+                $"  Running mixed Dekaf soak for {options.DurationMinutes:N0} minutes at " +
+                $"{options.SoakMessagesPerSecond:N0} msg/s...");
+            Console.WriteLine(
+                $"  Resource samples every {options.ResourceSampleIntervalSeconds:N0}s; " +
+                $"trend warmup {options.ResourceTrendThresholds.WarmupMinutes:N0}m");
+
+            throughput.Start();
+            Volatile.Write(ref measurementActive, 1);
+            var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, measurementCts.Token);
+            var monitorTask = monitor.RunAsync(measurementCts.Token);
+
+            await RunPacedProducerAsync(
+                producer,
+                options,
+                messageValue,
+                throughput,
+                measurementCts.Token).ConfigureAwait(false);
+
+            try
+            {
+                await producer.FlushAsync(CancellationToken.None)
+                    .AsTask()
+                    .WaitAsync(FlushTimeout, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            catch (TimeoutException ex)
+            {
+                throughput.RecordError(ex, "Final producer flush");
+            }
+
+            throughput.Stop();
+            gcStats.Capture();
+
+            await samplerTask.ConfigureAwait(false);
+            await monitorTask.ConfigureAwait(false);
+
+            var completedAt = DateTime.UtcNow;
+            var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
+            await producer.DisposeAsync().ConfigureAwait(false);
+            producerDisposed = true;
+
+            var endOffset = await StressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync(
+                options.BootstrapServers,
+                options.Topic,
+                options.Partitions,
+                startOffset,
+                throughput.MessageCount).ConfigureAwait(false);
+            var deliveredMessages = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
+
+            await WaitForConsumerCatchUpAsync(
+                () => Interlocked.Read(ref consumedMessages),
+                deliveredMessages,
+                consumerTask,
+                cancellationToken).ConfigureAwait(false);
+
+            var finalConsumedMessages = Interlocked.Read(ref consumedMessages);
+            if (finalConsumedMessages != deliveredMessages)
+            {
+                throughput.RecordError(
+                    "ConsumerCountMismatch",
+                    $"Mixed soak consumed {finalConsumedMessages:N0} of {deliveredMessages:N0} broker-delivered messages.",
+                    "Consumer catch-up");
+            }
+
+            consumerCts.Cancel();
+            await consumerTask.ConfigureAwait(false);
+
+            var resourceTrend = monitor.GetSnapshot(options.ResourceTrendThresholds);
+            PrintTrendAnalysis(resourceTrend.Analysis);
+
+            return new StressTestResult
+            {
+                Scenario = Name,
+                Client = Client,
+                DurationMinutes = options.DurationMinutes,
+                BrokerCount = options.BrokerCount,
+                MessageSizeBytes = options.MessageSizeBytes,
+                StartedAtUtc = startedAt,
+                CompletedAtUtc = completedAt,
+                Throughput = throughput.GetSnapshot(),
+                DeliveredMessages = deliveredMessages,
+                ConsumedMessages = finalConsumedMessages,
+                FailOnDeliveredShortfall = true,
+                Latency = null,
+                GcStats = gcStats.ToSnapshot(),
+                CpuTimeSeconds = throughput.CpuTimeSeconds,
+                ProducerDeliveryDiagnostics = producerDiagnostics,
+                ResourceTrend = resourceTrend
+            };
+        }
+        finally
+        {
+            Volatile.Write(ref measurementActive, 0);
+            consumerCts.Cancel();
+            await consumerTask.ConfigureAwait(false);
+
+            if (!producerDisposed)
+            {
+                await producer.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task ConsumeAsync(
+        IKafkaConsumer<string, string> consumer,
+        ThroughputTracker throughput,
+        TaskCompletionSource warmupSeen,
+        Func<bool> measurementActive,
+        Action recordConsumed,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await foreach (var record in consumer.ConsumeAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (string.Equals(record.Key, WarmupKey, StringComparison.Ordinal))
+                {
+                    warmupSeen.TrySetResult();
+                    continue;
+                }
+
+                if (measurementActive())
+                {
+                    recordConsumed();
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Expected when measurement and catch-up complete.
+        }
+        catch (Exception ex)
+        {
+            warmupSeen.TrySetException(ex);
+            throughput.RecordError(ex, "Mixed soak consume loop");
+        }
+    }
+
+    private static async Task RunPacedProducerAsync(
+        IKafkaProducer<string, string> producer,
+        StressTestOptions options,
+        string value,
+        ThroughputTracker throughput,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var attemptedMessages = 0L;
+        var nextPacingTick = ProducerPacingInterval;
+        var maximumBurst = Math.Max(1, options.SoakMessagesPerSecond / 2);
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var delay = nextPacingTick - stopwatch.Elapsed;
+                if (delay > TimeSpan.Zero)
+                {
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+
+                var expectedMessages = (long)(stopwatch.Elapsed.TotalSeconds * options.SoakMessagesPerSecond);
+                var messagesThisTick = Math.Min(expectedMessages - attemptedMessages, maximumBurst);
+                for (var i = 0L; i < messagesThisTick; i++)
+                {
+                    var messageIndex = attemptedMessages++;
+                    try
+                    {
+                        await producer.FireAsync(
+                            options.Topic,
+                            StressTestHelpers.GetKey(messageIndex),
+                            value).ConfigureAwait(false);
+                        throughput.RecordMessage(options.MessageSizeBytes);
+                    }
+                    catch (Exception ex)
+                    {
+                        throughput.RecordError(ex, "Mixed soak produce loop", messageIndex);
+                    }
+                }
+
+                nextPacingTick += ProducerPacingInterval;
+                if (nextPacingTick < stopwatch.Elapsed - ProducerPacingInterval)
+                {
+                    nextPacingTick = stopwatch.Elapsed + ProducerPacingInterval;
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Expected when duration expires.
+        }
+    }
+
+    private static async Task WaitForConsumerCatchUpAsync(
+        Func<long> consumedCount,
+        long deliveredMessages,
+        Task consumerTask,
+        CancellationToken cancellationToken)
+    {
+        var timeout = Stopwatch.StartNew();
+        while (consumedCount() < deliveredMessages && timeout.Elapsed < ConsumerCatchUpTimeout)
+        {
+            if (consumerTask.IsCompleted)
+            {
+                break;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static void PrintTrendAnalysis(ResourceTrendAnalysis analysis)
+    {
+        Console.WriteLine(
+            $"  Post-warmup slopes ({analysis.SampleCount:N0} samples): " +
+            $"WorkingSet={analysis.WorkingSetSlopeMibPerHour:N2}MiB/h, " +
+            $"GCHeap={analysis.GcHeapSlopeMibPerHour:N2}MiB/h, " +
+            $"LOH={analysis.LohSlopeMibPerHour:N2}MiB/h, " +
+            $"Produced={analysis.ProducedThroughputSlopePercentPerHour:N2}%/h, " +
+            $"Consumed={analysis.ConsumedThroughputSlopePercentPerHour:N2}%/h");
+
+        foreach (var failure in analysis.Failures)
+        {
+            Console.WriteLine($"  TREND FAILURE: {failure}");
+        }
+    }
+}

--- a/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
@@ -4,6 +4,7 @@ using Dekaf.Compression.Snappy;
 using Dekaf.Compression.Zstd;
 using Dekaf.Consumer;
 using Dekaf.Producer;
+using Dekaf.StressTests.Diagnostics;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
 
@@ -69,7 +70,7 @@ internal sealed class SoakStressTest : IStressTestScenario
 
         StressTestHelpers.ConfigureProducerDeliveryDiagnostics(producerBuilder, options);
         var producer = await producerBuilder.BuildAsync(cancellationToken);
-        var producerDisposed = false;
+        var producerDisposeAttempted = false;
 
         try
         {
@@ -107,12 +108,18 @@ internal sealed class SoakStressTest : IStressTestScenario
             var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, measurementCts.Token);
             var monitorTask = monitor.RunAsync(measurementCts.Token);
 
-            await RunPacedProducerAsync(
-                producer,
-                options,
-                messageValue,
-                throughput,
-                measurementCts.Token).ConfigureAwait(false);
+            using (var measurementWatchdog = TrackMeasurementProgress(
+                       options.ProgressWatchdog,
+                       throughput,
+                       () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options)))
+            {
+                await RunPacedProducerAsync(
+                    producer,
+                    options,
+                    messageValue,
+                    throughput,
+                    measurementCts.Token).ConfigureAwait(false);
+            }
 
             try
             {
@@ -145,8 +152,8 @@ internal sealed class SoakStressTest : IStressTestScenario
 
             var completedAt = DateTime.UtcNow;
             var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
-            await producer.DisposeAsync().ConfigureAwait(false);
-            producerDisposed = true;
+            producerDisposeAttempted = true;
+            await StressTestHelpers.DisposeWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
 
             var endOffset = await StressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync(
                 options.BootstrapServers,
@@ -213,12 +220,18 @@ internal sealed class SoakStressTest : IStressTestScenario
             consumerCts.Cancel();
             await consumerTask.ConfigureAwait(false);
 
-            if (!producerDisposed)
+            if (!producerDisposeAttempted)
             {
-                await producer.DisposeAsync().ConfigureAwait(false);
+                await StressTestHelpers.DisposeWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
             }
         }
     }
+
+    internal IDisposable TrackMeasurementProgress(
+        ProgressWatchdog watchdog,
+        ThroughputTracker throughput,
+        Func<ProducerDeliveryDiagnosticsSnapshot?> captureProducerDiagnostics) =>
+        watchdog.Track(throughput, Client, Name, captureProducerDiagnostics);
 
     internal static bool IsBrokerDeliveryExact(long acceptedMessages, long deliveredMessages) =>
         acceptedMessages == deliveredMessages;

--- a/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
@@ -1,4 +1,7 @@
 using System.Diagnostics;
+using Dekaf.Compression.Lz4;
+using Dekaf.Compression.Snappy;
+using Dekaf.Compression.Zstd;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.StressTests.Metrics;
@@ -55,6 +58,15 @@ internal sealed class SoakStressTest : IStressTestScenario
             .WithBatchSize(options.BatchSize)
             .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
             .WithConnectionsPerBroker(options.ConnectionsPerBroker);
+
+        _ = options.Compression switch
+        {
+            "lz4" => producerBuilder.UseLz4Compression(),
+            "snappy" => producerBuilder.UseSnappyCompression(),
+            "zstd" => producerBuilder.UseZstdCompression(),
+            _ => producerBuilder
+        };
+
         StressTestHelpers.ConfigureProducerDeliveryDiagnostics(producerBuilder, options);
         var producer = await producerBuilder.BuildAsync(cancellationToken);
         var producerDisposed = false;

--- a/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
@@ -13,6 +13,7 @@ internal sealed class SoakStressTest : IStressTestScenario
     private static readonly TimeSpan FlushTimeout = TimeSpan.FromMinutes(2);
     private static readonly TimeSpan ConsumerCatchUpTimeout = TimeSpan.FromMinutes(2);
     private static readonly TimeSpan ProducerPacingInterval = TimeSpan.FromMilliseconds(100);
+    private const double MinimumPacingRateRatio = 0.95;
 
     public string Name => "soak";
     public string Client => "Dekaf";
@@ -116,6 +117,17 @@ internal sealed class SoakStressTest : IStressTestScenario
             throughput.Stop();
             gcStats.Capture();
 
+            var acceptedMessages = throughput.MessageCount;
+            var acceptedRate = throughput.GetAverageMessagesPerSecond();
+            if (!MeetsMinimumPacingRate(acceptedRate, options.SoakMessagesPerSecond))
+            {
+                var minimumRate = options.SoakMessagesPerSecond * MinimumPacingRateRatio;
+                throughput.RecordError(
+                    "SoakTargetRateMiss",
+                    $"Accepted rate {acceptedRate:N0} msg/s was below the required {minimumRate:N0} msg/s.",
+                    "Producer pacing");
+            }
+
             await samplerTask.ConfigureAwait(false);
             await monitorTask.ConfigureAwait(false);
 
@@ -129,8 +141,18 @@ internal sealed class SoakStressTest : IStressTestScenario
                 options.Topic,
                 options.Partitions,
                 startOffset,
-                throughput.MessageCount).ConfigureAwait(false);
+                acceptedMessages,
+                throughput,
+                "Post-run drain").ConfigureAwait(false);
             var deliveredMessages = StressTestHelpers.ComputeDelivered(startOffset, endOffset, throughput);
+
+            if (!IsBrokerDeliveryExact(acceptedMessages, deliveredMessages))
+            {
+                throughput.RecordError(
+                    "BrokerDeliveryCountMismatch",
+                    $"Mixed soak accepted {acceptedMessages:N0} messages but broker end offsets advanced by {deliveredMessages:N0}.",
+                    "Broker delivery verification");
+            }
 
             await WaitForConsumerCatchUpAsync(
                 () => Interlocked.Read(ref consumedMessages),
@@ -165,7 +187,7 @@ internal sealed class SoakStressTest : IStressTestScenario
                 Throughput = throughput.GetSnapshot(),
                 DeliveredMessages = deliveredMessages,
                 ConsumedMessages = finalConsumedMessages,
-                FailOnDeliveredShortfall = true,
+                Idempotent = true,
                 Latency = null,
                 GcStats = gcStats.ToSnapshot(),
                 CpuTimeSeconds = throughput.CpuTimeSeconds,
@@ -185,6 +207,12 @@ internal sealed class SoakStressTest : IStressTestScenario
             }
         }
     }
+
+    internal static bool IsBrokerDeliveryExact(long acceptedMessages, long deliveredMessages) =>
+        acceptedMessages == deliveredMessages;
+
+    internal static bool MeetsMinimumPacingRate(double acceptedRate, int targetMessagesPerSecond) =>
+        acceptedRate >= targetMessagesPerSecond * MinimumPacingRateRatio;
 
     private static async Task ConsumeAsync(
         IKafkaConsumer<string, string> consumer,

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -272,19 +272,25 @@ internal static class StressTestHelpers
     /// Disposes the producer, recording a timeout as an error — a hung dispose is a
     /// shutdown bug even when every message was already delivered.
     /// </summary>
+    internal static Task DisposeWithTimeoutAsync(
+        IKafkaProducer<string, string> producer,
+        ThroughputTracker throughput) =>
+        DisposeWithTimeoutAsync(producer, throughput, OperationTimeout);
+
     internal static async Task DisposeWithTimeoutAsync(
         IKafkaProducer<string, string> producer,
-        ThroughputTracker throughput)
+        ThroughputTracker throughput,
+        TimeSpan timeout)
     {
         try
         {
             await producer.DisposeAsync().AsTask()
-                .WaitAsync(OperationTimeout, CancellationToken.None).ConfigureAwait(false);
+                .WaitAsync(timeout, CancellationToken.None).ConfigureAwait(false);
             Console.WriteLine($"  Producer disposed successfully");
         }
         catch (TimeoutException)
         {
-            var message = $"Dispose did not complete within {OperationTimeout.TotalSeconds:N0} seconds";
+            var message = $"Dispose did not complete within {timeout.TotalSeconds:N0} seconds";
             Console.WriteLine($"  Error: {message}");
             throughput.RecordError("DisposeTimeout", message, "DisposeAsync");
         }


### PR DESCRIPTION
## Summary
- add a paced idempotent `Acks.All` producer plus live consumer soak scenario with strict broker-delivery and consumer catch-up checks
- sample working set, managed heap, LOH, Gen2 collections, thread count, and produce/consume throughput; fail on post-warmup regression slopes
- schedule five 288-minute `ubuntu-latest` segments for both one- and three-broker topologies, giving 24 cumulative public-runner hours per topology without paid runners
- serialize trend samples/results and document CI gates plus local commands

## Test plan
- [x] net10 unit suite: 4,515 passed
- [x] net8 unit suite: 4,503 passed
- [x] focused `ResourceTrendAnalyzerTests`: 6 passed
- [x] real Kafka smoke: 5,990 accepted, 5,990 broker-delivered, 5,990 consumed, zero errors
- [x] stress runner Release build
- [x] Docusaurus production build
- [x] `actionlint .github/workflows/soak-tests.yml`

Closes #1598
