### PR TITLE
fix(transactions): preserve fatal fencing state

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -4088,15 +4088,9 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
             {
                 // Best-effort abort during disposal — if the broker rejects it
                 // (e.g. InvalidTxnState because no messages were produced),
-                // just clean up state and move on. A fatal broker response must remain
-                // sticky so the fenced producer cannot be reused after disposal.
-                lock (_producer._partitionsInTransactionLock)
-                {
-                    _producer._partitionsInTransaction.Clear();
-                }
-
-                if (_producer._transactionState != TransactionState.FatalError)
-                    _producer._transactionState = TransactionState.Ready;
+                // just clean up state and move on. Fatal and abortable broker responses
+                // remain sticky so an invalid producer cannot be reused after disposal.
+                _producer.FinalizeCompletedTransactionState();
             }
         }
     }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1692,16 +1692,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             throw new InvalidOperationException("Producer is not transactional. Set TransactionalId in options.");
         }
 
+        ThrowIfFatalTransactionError("Cannot begin transaction");
+
         if (_transactionState == TransactionState.Uninitialized)
         {
             throw new InvalidOperationException(
                 "Transactions not initialized. Call InitTransactionsAsync() before BeginTransaction().");
-        }
-
-        if (_transactionState == TransactionState.FatalError)
-        {
-            throw new InvalidOperationException(
-                "Producer is in a fatal error state and cannot begin new transactions.");
         }
 
         if (_transactionState == TransactionState.AbortableError)
@@ -1754,6 +1750,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         ThrowIfNotInitialized();
+        ThrowIfFatalTransactionError("Cannot initialize transactions");
         ThrowIfTwoPhaseCommitUnsupported(keepPreparedTransaction);
 
         await SemaphoreHelper.AcquireOrThrowDisposedAsync(_transactionLock, nameof(KafkaProducer<TKey, TValue>), cancellationToken).ConfigureAwait(false);
@@ -1792,6 +1789,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             throw new ArgumentException("Prepared transaction state must identify a transaction.", nameof(preparedState));
 
         ThrowIfNotInitialized();
+        ThrowIfFatalTransactionError("Cannot complete prepared transaction");
 
         if (_transactionState != TransactionState.PreparedTransaction)
         {
@@ -1856,6 +1854,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
     internal PreparedTransactionState PrepareCurrentTransaction()
     {
+        ThrowIfFatalTransactionError("Cannot prepare transaction");
+
         if (!_options.EnableTwoPhaseCommit)
         {
             throw new TransactionException(ErrorCode.InvalidTxnState,
@@ -2966,11 +2966,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         if (txnState == TransactionState.FatalError)
         {
-            throw new FatalTransactionException(_lastTransactionError,
-                "Cannot produce: the producer is in a fatal error state and must be closed.")
-            {
-                TransactionalId = _options.TransactionalId
-            };
+            ThrowFatalTransactionError("Cannot produce");
         }
 
         if (txnState == TransactionState.PreparedTransaction)
@@ -2981,6 +2977,23 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 TransactionalId = _options.TransactionalId
             };
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void ThrowIfFatalTransactionError(string operation)
+    {
+        if (_transactionState == TransactionState.FatalError)
+            ThrowFatalTransactionError(operation);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ThrowFatalTransactionError(string operation)
+    {
+        throw new FatalTransactionException(_lastTransactionError,
+            $"{operation}: the producer is in a fatal error state and must be closed.")
+        {
+            TransactionalId = _options.TransactionalId
+        };
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -3956,6 +3969,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
         CancellationToken cancellationToken = default)
     {
         ThrowIfProducerDisposed();
+        _producer.ThrowIfFatalTransactionError("Cannot produce");
 
         if (_committed || _aborted)
             throw new InvalidOperationException("Transaction is already completed");
@@ -3970,6 +3984,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
     public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
     {
         ThrowIfProducerDisposed();
+        _producer.ThrowIfFatalTransactionError("Cannot commit transaction");
 
         if (_committed || _aborted)
             throw new InvalidOperationException("Transaction is already completed");
@@ -3993,6 +4008,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
     public async ValueTask<PreparedTransactionState> PrepareAsync(CancellationToken cancellationToken = default)
     {
         ThrowIfProducerDisposed();
+        _producer.ThrowIfFatalTransactionError("Cannot prepare transaction");
 
         if (_committed || _aborted)
             throw new InvalidOperationException("Transaction is already completed");
@@ -4014,6 +4030,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
     public async ValueTask AbortAsync(CancellationToken cancellationToken = default)
     {
         ThrowIfProducerDisposed();
+        _producer.ThrowIfFatalTransactionError("Cannot abort transaction");
 
         if (_committed || _aborted)
             throw new InvalidOperationException("Transaction is already completed");
@@ -4046,6 +4063,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
         CancellationToken cancellationToken = default)
     {
         ThrowIfProducerDisposed();
+        _producer.ThrowIfFatalTransactionError("Cannot send offsets to transaction");
 
         if (_committed || _aborted)
             throw new InvalidOperationException("Transaction is already completed");

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -4088,12 +4088,15 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
             {
                 // Best-effort abort during disposal — if the broker rejects it
                 // (e.g. InvalidTxnState because no messages were produced),
-                // just clean up state and move on.
+                // just clean up state and move on. A fatal broker response must remain
+                // sticky so the fenced producer cannot be reused after disposal.
                 lock (_producer._partitionsInTransactionLock)
                 {
                     _producer._partitionsInTransaction.Clear();
                 }
-                _producer._transactionState = TransactionState.Ready;
+
+                if (_producer._transactionState != TransactionState.FatalError)
+                    _producer._transactionState = TransactionState.Ready;
             }
         }
     }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1900,7 +1900,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
     }
 
-    internal void FinalizeCompletedTransactionState()
+    internal void FinalizeCompletedTransactionState(bool preserveAbortableError = true)
     {
         lock (_partitionsInTransactionLock)
         {
@@ -1909,7 +1909,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         _preparedTransactionState = PreparedTransactionState.Empty;
 
-        if (_transactionState is not (TransactionState.AbortableError or TransactionState.FatalError))
+        var preserveError = _transactionState == TransactionState.FatalError
+            || preserveAbortableError && _transactionState == TransactionState.AbortableError;
+        if (!preserveError)
         {
             _transactionState = TransactionState.Ready;
         }
@@ -4088,9 +4090,9 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
             {
                 // Best-effort abort during disposal — if the broker rejects it
                 // (e.g. InvalidTxnState because no messages were produced),
-                // just clean up state and move on. Fatal and abortable broker responses
-                // remain sticky so an invalid producer cannot be reused after disposal.
-                _producer.FinalizeCompletedTransactionState();
+                // just clean up state and move on. Fatal responses remain sticky, while
+                // abortable responses return to Ready because this transaction is disposed.
+                _producer.FinalizeCompletedTransactionState(preserveAbortableError: false);
             }
         }
     }

--- a/tests/Dekaf.Tests.Integration/TransactionErrorHandlingTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionErrorHandlingTests.cs
@@ -1,5 +1,8 @@
+using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
 
 namespace Dekaf.Tests.Integration;
 
@@ -16,10 +19,11 @@ namespace Dekaf.Tests.Integration;
 public class TransactionErrorHandlingTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
-    public async Task Transaction_FencedByNewerProducer_ThrowsFatalAndProducerIsUnusable()
+    public async Task Transaction_FencedByNewerProducer_AllOperationsFailFatalAndWritesStayInvisible()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();
         var txnId = $"txn-fence-{Guid.NewGuid():N}";
+        var consumerGroupId = $"txn-fence-group-{Guid.NewGuid():N}";
 
         await using var producer1 = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
@@ -37,8 +41,8 @@ public class TransactionErrorHandlingTests(KafkaTestContainer kafka) : KafkaInte
         await txn1.ProduceAsync(new ProducerMessage<string, string>
         {
             Topic = topic,
-            Key = "fence-key",
-            Value = "fence-value"
+            Key = "fenced-key",
+            Value = "fenced-value"
         }, CancellationToken.None);
 
         // A second producer with the same transactional id bumps the epoch, fencing producer1.
@@ -51,12 +55,72 @@ public class TransactionErrorHandlingTests(KafkaTestContainer kafka) : KafkaInte
 
         await producer2.InitTransactionsAsync();
 
-        // producer1's commit (EndTxn) is now rejected with a fatal, fencing error.
-        var commit = () => txn1.CommitAsync().AsTask();
-        await Assert.That(commit).Throws<FatalTransactionException>();
+        // producer1's commit (EndTxn) detects the fence and transitions the producer to a
+        // permanent fatal state.
+        await AssertFencedAsync(() => txn1.CommitAsync().AsTask(), txnId);
 
-        // The producer is in a fatal state and cannot start further transactions.
-        var begin = () => producer1.BeginTransaction();
-        await Assert.That(begin).Throws<InvalidOperationException>();
+        // Every transaction operation must now fail locally with the same fatal error. None may
+        // overwrite the fatal state or attempt to resurrect the producer with a new epoch.
+        await AssertFencedAsync(() => txn1.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "post-fence-key",
+            Value = "post-fence-value"
+        }).AsTask(), txnId);
+
+        await AssertFencedAsync(() => txn1.SendOffsetsToTransactionAsync(
+            [new TopicPartitionOffset(topic, 0, 1)], consumerGroupId).AsTask(), txnId);
+
+        await AssertFencedAsync(() => txn1.PrepareAsync().AsTask(), txnId);
+        await AssertFencedAsync(() => txn1.CommitAsync().AsTask(), txnId);
+        await AssertFencedAsync(() => txn1.AbortAsync().AsTask(), txnId);
+        await AssertFencedAsync(() => producer1.InitTransactionsAsync().AsTask(), txnId);
+
+        var beginException = await Assert.That(() => producer1.BeginTransaction())
+            .Throws<FatalTransactionException>();
+
+        await Assert.That(beginException!.ErrorCode).IsEqualTo(ErrorCode.ProducerFenced);
+        await Assert.That(beginException.TransactionalId).IsEqualTo(txnId);
+
+        // The replacement producer remains healthy and can commit with the newer epoch.
+        await using (var txn2 = producer2.BeginTransaction())
+        {
+            await txn2.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = "replacement-key",
+                Value = "replacement-value"
+            });
+            await txn2.CommitAsync();
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"txn-fence-verify-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithIsolationLevel(IsolationLevel.ReadCommitted)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var visible = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(20), cts.Token);
+
+        await Assert.That(visible).IsNotNull();
+        var visibleMessage = visible!.Value;
+        await Assert.That(visibleMessage.Key).IsEqualTo("replacement-key");
+        await Assert.That(visibleMessage.Value).IsEqualTo("replacement-value");
+
+        var unexpected = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(5), cts.Token);
+        await Assert.That(unexpected).IsNull();
+    }
+
+    private static async Task AssertFencedAsync(Func<Task> action, string transactionalId)
+    {
+        var exception = await Assert.That(action).Throws<FatalTransactionException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.ProducerFenced);
+        await Assert.That(exception.TransactionalId).IsEqualTo(transactionalId);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -139,6 +139,25 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task DisposeAsync_WhenAbortIsRejected_PreservesAbortableError()
+    {
+        var preparedState = new PreparedTransactionState(42, 5);
+        await using var harness = BuildPreparedCompletionHarness(
+            preparedState,
+            currentProducerId: preparedState.ProducerId,
+            currentProducerEpoch: preparedState.ProducerEpoch,
+            endTxnError: ErrorCode.InvalidTxnState);
+
+        harness.Producer._transactionState = TransactionState.InTransaction;
+        var transaction = new Transaction<string, string>(harness.Producer);
+
+        await transaction.DisposeAsync();
+
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.AbortableError);
+        await Assert.That(harness.Producer._lastTransactionError).IsEqualTo(ErrorCode.InvalidTxnState);
+    }
+
+    [Test]
     public async Task InitTransactionsAsync_WithoutTransactionalId_Throws()
     {
         await using var producer = Kafka.CreateProducer<string, string>()

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -139,7 +139,7 @@ public sealed class TransactionTests
     }
 
     [Test]
-    public async Task DisposeAsync_WhenAbortIsRejected_PreservesAbortableError()
+    public async Task DisposeAsync_WhenAbortIsRejected_ReturnsProducerToReady()
     {
         var preparedState = new PreparedTransactionState(42, 5);
         await using var harness = BuildPreparedCompletionHarness(
@@ -153,7 +153,7 @@ public sealed class TransactionTests
 
         await transaction.DisposeAsync();
 
-        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.AbortableError);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.Ready);
         await Assert.That(harness.Producer._lastTransactionError).IsEqualTo(ErrorCode.InvalidTxnState);
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -116,6 +116,29 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task DisposeAsync_WhenAbortIsFenced_PreservesFatalError()
+    {
+        var preparedState = new PreparedTransactionState(42, 5);
+        await using var harness = BuildPreparedCompletionHarness(
+            preparedState,
+            currentProducerId: preparedState.ProducerId,
+            currentProducerEpoch: preparedState.ProducerEpoch,
+            endTxnError: ErrorCode.ProducerFenced);
+
+        harness.Producer._transactionState = TransactionState.InTransaction;
+        var transaction = new Transaction<string, string>(harness.Producer);
+
+        await transaction.DisposeAsync();
+
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.FatalError);
+        await Assert.That(harness.Producer._lastTransactionError).IsEqualTo(ErrorCode.ProducerFenced);
+
+        var exception = await Assert.That(() => harness.Producer.BeginTransaction())
+            .Throws<FatalTransactionException>();
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.ProducerFenced);
+    }
+
+    [Test]
     public async Task InitTransactionsAsync_WithoutTransactionalId_Throws()
     {
         await using var producer = Kafka.CreateProducer<string, string>()
@@ -535,7 +558,8 @@ public sealed class TransactionTests
     private static PreparedCompletionHarness BuildPreparedCompletionHarness(
         PreparedTransactionState preparedState,
         long currentProducerId,
-        short currentProducerEpoch)
+        short currentProducerEpoch,
+        ErrorCode endTxnError = ErrorCode.None)
     {
         EndTxnRequest? capturedRequest = null;
         var connection = Substitute.For<IKafkaConnection>();
@@ -548,7 +572,7 @@ public sealed class TransactionTests
                 Arg.Any<CancellationToken>())
             .Returns(_ => new ValueTask<EndTxnResponse>(new EndTxnResponse
             {
-                ErrorCode = ErrorCode.None,
+                ErrorCode = endTxnError,
                 ProducerId = preparedState.ProducerId,
                 ProducerEpoch = (short)(preparedState.ProducerEpoch + 1)
             }));

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -66,10 +66,53 @@ public sealed class TransactionTests
             .WithTransactionalId("test-txn-id")
             .Build();
 
-        ((KafkaProducer<string, string>)producer)._transactionState = TransactionState.FatalError;
+        var kafkaProducer = (KafkaProducer<string, string>)producer;
+        kafkaProducer._transactionState = TransactionState.FatalError;
+        kafkaProducer._lastTransactionError = ErrorCode.ProducerFenced;
 
         var act = () => producer.BeginTransaction();
-        await Assert.That(act).Throws<InvalidOperationException>();
+        var exception = await Assert.That(act).Throws<FatalTransactionException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.ProducerFenced);
+        await Assert.That(exception.TransactionalId).IsEqualTo("test-txn-id");
+    }
+
+    [Test]
+    public async Task FatalErrorState_AllTransactionOperationsFailFast()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTransactionalId("test-txn-id")
+            .Build();
+
+        var kafkaProducer = (KafkaProducer<string, string>)producer;
+        SetInstanceField(kafkaProducer, "_initialized", true);
+        kafkaProducer._transactionState = TransactionState.FatalError;
+        kafkaProducer._lastTransactionError = ErrorCode.ProducerFenced;
+
+        await using var transaction = new Transaction<string, string>(kafkaProducer);
+        var message = new ProducerMessage<string, string>
+        {
+            Topic = "test-topic",
+            Key = "key",
+            Value = "value"
+        };
+
+        await Assert.That(() => transaction.ProduceAsync(message).AsTask())
+            .Throws<FatalTransactionException>();
+        await Assert.That(() => transaction.SendOffsetsToTransactionAsync(
+                [new TopicPartitionOffset("test-topic", 0, 1)], "test-group").AsTask())
+            .Throws<FatalTransactionException>();
+        await Assert.That(() => transaction.PrepareAsync().AsTask())
+            .Throws<FatalTransactionException>();
+        await Assert.That(() => transaction.CommitAsync().AsTask())
+            .Throws<FatalTransactionException>();
+        await Assert.That(() => transaction.AbortAsync().AsTask())
+            .Throws<FatalTransactionException>();
+        await Assert.That(() => producer.InitTransactionsAsync().AsTask())
+            .Throws<FatalTransactionException>();
+        await Assert.That(() => producer.BeginTransaction())
+            .Throws<FatalTransactionException>();
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- preserve `ProducerFenced` as a terminal state across every transaction operation
- reject transaction re-initialization and new transactions with `FatalTransactionException`
- prove fenced records stay invisible while replacement-producer commits remain visible

## Test plan
- [x] Release build: unit + integration projects (`net8.0`, `net10.0`)
- [x] Unit `TransactionTests` (`net10.0`): 36 passed
- [x] Integration `TransactionTests` (`net10.0`, all Kafka fixtures): 15 passed
- [x] Fencing torture test (`net10.0`, all Kafka fixtures): 3 passed
- [x] Fencing torture test (`net8.0`, all Kafka fixtures): 3 passed

## Notes
- Full unit sweep passed 4509/4510; unrelated known activity-listener flake is tracked by #1609.
- Combined transaction-class stress passed 86/108; coordinator-startup saturation is tracked by #1638. Each relevant class and the new test pass when run independently.
- Child of #1597.

Closes #1619
