### PR TITLE
fix(producer): harden batch recycle races

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2754,10 +2754,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         continue;
                     }
 
-                    if (batch.TrySetMemoryReleased())
-                    {
-                        _accumulator.ReleaseMemory(batch.DataSize);
-                    }
+                    _accumulator.ReleaseBatchMemory(batch);
                 }
 
                 var pendingResponse = PendingResponse.Create(responseTask, batches, generations, count, requestStartTime);
@@ -3657,10 +3654,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Release buffer memory at batch completion (matching Java's RecordAccumulator.deallocate()).
         // This is the primary release path: memory is held throughout the entire pipeline
         // (append → drain → send → response) to provide accurate end-to-end backpressure.
-        if (batch.TrySetMemoryReleased())
-        {
-            _accumulator.ReleaseMemory(batch.DataSize);
-        }
+        _accumulator.ReleaseBatchMemory(batch);
         // Remove from tracking and decrement in-flight counter. OnBatchExitsPipeline uses
         // TryRemove as an atomic guard — if another path already removed this batch
         // (e.g., SweepExpiredInFlightBatches), it returns false but we still return

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2732,10 +2732,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         catch (Exception failEx) { LogBatchCleanupStepFailed(failEx); }
         try
         {
-            if (batch.TrySetMemoryReleased())
-            {
-                _accumulator.ReleaseMemory(batch.DataSize);
-            }
+            _accumulator.ReleaseBatchMemory(batch);
         }
         catch (Exception memEx) { LogBatchCleanupStepFailed(memEx); }
         // Remove from tracking BEFORE returning to pool. ReturnReadyBatch is idempotent

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5920,18 +5920,43 @@ internal sealed class ReadyBatch
     {
         get
         {
-            var source = Volatile.Read(ref _doneTaskSource);
-            if (source is null)
+            while (true)
             {
-                var created = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                source = Interlocked.CompareExchange(ref _doneTaskSource, created, null) ?? created;
+                var generation = Generation;
+                if (TryGetDoneTaskCompletion(generation, out var succeeded))
+                    return new ValueTask<bool>(succeeded);
+
+                var state = Volatile.Read(ref _doneTaskState);
+                if (state?.Generation != generation)
+                {
+                    var created = new DoneTaskState(generation);
+                    BeforeDoneTaskSourcePublishedForTest?.Invoke();
+
+                    // Completion and pool reuse may both happen while the source is being
+                    // allocated. Prefer the captured lifecycle's result when it is still the
+                    // most recent completion; otherwise retry against the current generation.
+                    if (TryGetDoneTaskCompletion(generation, out succeeded))
+                        return new ValueTask<bool>(succeeded);
+
+                    if (Generation != generation)
+                        continue;
+
+                    var observed = Interlocked.CompareExchange(ref _doneTaskState, created, state);
+                    if (!ReferenceEquals(observed, state))
+                        continue;
+
+                    state = created;
+                }
+
+                if (TryGetDoneTaskCompletion(generation, out succeeded))
+                    state.Source.TrySetResult(succeeded);
+
+                // A published source is safe to return while its generation is current:
+                // completion observes it before the batch can be recycled. If recycling won
+                // the race, retry unless that source was already completed.
+                if (state.Source.Task.IsCompleted || Generation == generation)
+                    return new ValueTask<bool>(state.Source.Task);
             }
-
-            var completed = Volatile.Read(ref _completed);
-            if (completed != 0)
-                source.TrySetResult(completed == CompletionSucceeded);
-
-            return new ValueTask<bool>(source.Task);
         }
     }
 
@@ -6312,7 +6337,16 @@ internal sealed class ReadyBatch
     // in-flight counter. Allocate its source lazily so the hot path remains allocation-free.
     // A Task is deliberately used instead of a resettable IValueTaskSource: ReadyBatch can be
     // returned to its pool before an asynchronous continuation consumes the prior result.
-    private TaskCompletionSource<bool>? _doneTaskSource;
+    private sealed class DoneTaskState(int generation)
+    {
+        public int Generation { get; } = generation;
+        public TaskCompletionSource<bool> Source { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    private DoneTaskState? _doneTaskState;
+    private long _lastDoneTaskCompletion;
+    internal Action? BeforeDoneTaskSourcePublishedForTest;
 
     private const int CompletionSucceeded = 1;
     private const int CompletionFailed = 2;
@@ -6432,6 +6466,9 @@ internal sealed class ReadyBatch
         // mismatch. With the old order (flags first), a holder could see _returnedToPool == 0
         // while still reading its own stale generation — passing both checks and acting on
         // a batch now owned by someone else.
+        // Clear the old lazy source before publishing the next generation. A stale getter may
+        // still race this write, but its generation tag prevents it from capturing new work.
+        Volatile.Write(ref _doneTaskState, null);
         Interlocked.Increment(ref _generation);
 
         // Reset lifecycle flags at the START of a new lifecycle (not in Reset()).
@@ -6442,7 +6479,6 @@ internal sealed class ReadyBatch
         Interlocked.Exchange(ref _cleanedUp, 0);
         Interlocked.Exchange(ref _resourcesCleanedUp, ResourceCleanupPending);
         Interlocked.Exchange(ref _activeResourcePins, 0);
-        Volatile.Write(ref _doneTaskSource, null);
         Interlocked.Exchange(ref _completed, 0);
         Interlocked.Exchange(ref _sendCompleted, 0);
         Volatile.Write(ref _terminalBookkeepingCompleted, 1);
@@ -6533,7 +6569,7 @@ internal sealed class ReadyBatch
         // previous lifecycle calling CompleteSend/Fail will hit the guard and return early.
         // These flags are reset in Initialize() when the batch starts a new lifecycle.
         // Captured DoneTask instances retain their own TaskCompletionSource after pool return.
-        Volatile.Write(ref _doneTaskSource, null);
+        Volatile.Write(ref _doneTaskState, null);
     }
 
     /// <summary>
@@ -6768,12 +6804,34 @@ internal sealed class ReadyBatch
 
     private void CompleteDoneTask(bool succeeded)
     {
+        var generation = Generation;
         var completion = succeeded ? CompletionSucceeded : CompletionFailed;
         if (Interlocked.CompareExchange(ref _completed, completion, 0) != 0)
             return;
 
-        Volatile.Read(ref _doneTaskSource)?.TrySetResult(succeeded);
+        Volatile.Write(ref _lastDoneTaskCompletion, PackDoneTaskCompletion(generation, completion));
+
+        var state = Volatile.Read(ref _doneTaskState);
+        if (state?.Generation == generation)
+            state.Source.TrySetResult(succeeded);
     }
+
+    private bool TryGetDoneTaskCompletion(int generation, out bool succeeded)
+    {
+        var packedCompletion = Volatile.Read(ref _lastDoneTaskCompletion);
+        var result = unchecked((int)packedCompletion);
+        if (result != 0 && unchecked((int)(packedCompletion >> 32)) == generation)
+        {
+            succeeded = result == CompletionSucceeded;
+            return true;
+        }
+
+        succeeded = false;
+        return false;
+    }
+
+    private static long PackDoneTaskCompletion(int generation, int completion)
+        => ((long)generation << 32) | (uint)completion;
 
     /// <summary>
     /// If CompleteSend/Fail has been called but Cleanup hasn't finished yet, spin-waits

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5920,43 +5920,15 @@ internal sealed class ReadyBatch
     {
         get
         {
-            while (true)
+            var state = RegisterDoneTaskObserver();
+            if (TryGetDoneTaskCompletion(state.Generation, out var succeeded))
             {
-                var generation = Generation;
-                if (TryGetDoneTaskCompletion(generation, out var succeeded))
-                    return new ValueTask<bool>(succeeded);
-
-                var state = Volatile.Read(ref _doneTaskState);
-                if (state?.Generation != generation)
-                {
-                    var created = new DoneTaskState(generation);
-                    BeforeDoneTaskSourcePublishedForTest?.Invoke();
-
-                    // Completion and pool reuse may both happen while the source is being
-                    // allocated. Prefer the captured lifecycle's result when it is still the
-                    // most recent completion; otherwise retry against the current generation.
-                    if (TryGetDoneTaskCompletion(generation, out succeeded))
-                        return new ValueTask<bool>(succeeded);
-
-                    if (Generation != generation)
-                        continue;
-
-                    var observed = Interlocked.CompareExchange(ref _doneTaskState, created, state);
-                    if (!ReferenceEquals(observed, state))
-                        continue;
-
-                    state = created;
-                }
-
-                if (TryGetDoneTaskCompletion(generation, out succeeded))
-                    state.Source.TrySetResult(succeeded);
-
-                // A published source is safe to return while its generation is current:
-                // completion observes it before the batch can be recycled. If recycling won
-                // the race, retry unless that source was already completed.
-                if (state.Source.Task.IsCompleted || Generation == generation)
-                    return new ValueTask<bool>(state.Source.Task);
+                RemoveDoneTaskObserver(state);
+                return new ValueTask<bool>(succeeded);
             }
+
+            AfterDoneTaskObserverRegisteredForTest?.Invoke();
+            return new ValueTask<bool>(state.Source.Task);
         }
     }
 
@@ -6344,9 +6316,11 @@ internal sealed class ReadyBatch
             new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
-    private DoneTaskState? _doneTaskState;
+    private SpinLock _doneTaskObserverLock = new(enableThreadOwnerTracking: false);
+    private List<DoneTaskState>? _doneTaskObservers;
+    private int _doneTaskObserverCount;
     private long _lastDoneTaskCompletion;
-    internal Action? BeforeDoneTaskSourcePublishedForTest;
+    internal Action? AfterDoneTaskObserverRegisteredForTest;
 
     private const int CompletionSucceeded = 1;
     private const int CompletionFailed = 2;
@@ -6466,9 +6440,6 @@ internal sealed class ReadyBatch
         // mismatch. With the old order (flags first), a holder could see _returnedToPool == 0
         // while still reading its own stale generation — passing both checks and acting on
         // a batch now owned by someone else.
-        // Clear the old lazy source before publishing the next generation. A stale getter may
-        // still race this write, but its generation tag prevents it from capturing new work.
-        Volatile.Write(ref _doneTaskState, null);
         Interlocked.Increment(ref _generation);
 
         // Reset lifecycle flags at the START of a new lifecycle (not in Reset()).
@@ -6569,7 +6540,6 @@ internal sealed class ReadyBatch
         // previous lifecycle calling CompleteSend/Fail will hit the guard and return early.
         // These flags are reset in Initialize() when the batch starts a new lifecycle.
         // Captured DoneTask instances retain their own TaskCompletionSource after pool return.
-        Volatile.Write(ref _doneTaskState, null);
     }
 
     /// <summary>
@@ -6810,10 +6780,80 @@ internal sealed class ReadyBatch
             return;
 
         Volatile.Write(ref _lastDoneTaskCompletion, PackDoneTaskCompletion(generation, completion));
+        if (Volatile.Read(ref _doneTaskObserverCount) != 0)
+            CompleteDoneTaskObservers(generation, succeeded);
+    }
 
-        var state = Volatile.Read(ref _doneTaskState);
-        if (state?.Generation == generation)
-            state.Source.TrySetResult(succeeded);
+    private DoneTaskState RegisterDoneTaskObserver()
+    {
+        // Publish registration intent before taking the lock. A racing completion either
+        // waits for this observer to be added or leaves its packed result for the immediate
+        // catch-up check in DoneTask.
+        Interlocked.Increment(ref _doneTaskObserverCount);
+        var lockTaken = false;
+        try
+        {
+            _doneTaskObserverLock.Enter(ref lockTaken);
+            var state = new DoneTaskState(Generation);
+            (_doneTaskObservers ??= new List<DoneTaskState>(1)).Add(state);
+            return state;
+        }
+        catch
+        {
+            Interlocked.Decrement(ref _doneTaskObserverCount);
+            throw;
+        }
+        finally
+        {
+            if (lockTaken)
+                _doneTaskObserverLock.Exit();
+        }
+    }
+
+    private void RemoveDoneTaskObserver(DoneTaskState state)
+    {
+        var removed = false;
+        var lockTaken = false;
+        try
+        {
+            _doneTaskObserverLock.Enter(ref lockTaken);
+            removed = _doneTaskObservers?.Remove(state) == true;
+        }
+        finally
+        {
+            if (lockTaken)
+                _doneTaskObserverLock.Exit();
+        }
+
+        if (removed)
+            Interlocked.Decrement(ref _doneTaskObserverCount);
+    }
+
+    private void CompleteDoneTaskObservers(int generation, bool succeeded)
+    {
+        var lockTaken = false;
+        try
+        {
+            _doneTaskObserverLock.Enter(ref lockTaken);
+            if (_doneTaskObservers is null)
+                return;
+
+            for (var i = _doneTaskObservers.Count - 1; i >= 0; i--)
+            {
+                var state = _doneTaskObservers[i];
+                if (state.Generation != generation)
+                    continue;
+
+                _doneTaskObservers.RemoveAt(i);
+                Interlocked.Decrement(ref _doneTaskObserverCount);
+                state.Source.TrySetResult(succeeded);
+            }
+        }
+        finally
+        {
+            if (lockTaken)
+                _doneTaskObserverLock.Exit();
+        }
     }
 
     private bool TryGetDoneTaskCompletion(int generation, out bool succeeded)

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -131,6 +131,12 @@ internal static class ProducerDebugCounters
     private static int _completionSourcesCompleted;
     private static int _completionSourcesFailed;
 
+    // ReadyBatch pool lifecycle. A return count above the rent count proves the same
+    // object entered the pool more than once and can be handed to concurrent renters.
+    private static int _readyBatchesRented;
+    private static int _readyBatchesReturned;
+    private static int _readyBatchDuplicateReturns;
+
     // Stage 5: Flush and disposal
     private static int _flushCalls;
     private static int _batchesFlushedFromDictionary;
@@ -183,6 +189,15 @@ internal static class ProducerDebugCounters
         Interlocked.Add(ref _completionSourcesFailed, count);
 
     [Conditional("DEBUG")]
+    public static void RecordReadyBatchRented() => Interlocked.Increment(ref _readyBatchesRented);
+
+    [Conditional("DEBUG")]
+    public static void RecordReadyBatchReturned() => Interlocked.Increment(ref _readyBatchesReturned);
+
+    [Conditional("DEBUG")]
+    public static void RecordReadyBatchDuplicateReturn() => Interlocked.Increment(ref _readyBatchDuplicateReturns);
+
+    [Conditional("DEBUG")]
     public static void RecordFlushCall() => Interlocked.Increment(ref _flushCalls);
 
     [Conditional("DEBUG")]
@@ -205,8 +220,35 @@ internal static class ProducerDebugCounters
         _batchesFailed = 0;
         _completionSourcesCompleted = 0;
         _completionSourcesFailed = 0;
+        _readyBatchesRented = 0;
+        _readyBatchesReturned = 0;
+        _readyBatchDuplicateReturns = 0;
         _flushCalls = 0;
         _batchesFlushedFromDictionary = 0;
+    }
+
+    public static ProducerDebugCounterSnapshot GetSnapshot()
+    {
+#if DEBUG
+        return new ProducerDebugCounterSnapshot
+        {
+            MessagesAppended = Volatile.Read(ref _messagesAppended),
+            MessagesAppendedWithCompletion = Volatile.Read(ref _messagesAppendedWithCompletion),
+            MessagesAppendedFireAndForget = Volatile.Read(ref _messagesAppendedFireAndForget),
+            CompletionSourcesStoredInBatch = Volatile.Read(ref _completionSourcesStoredInBatch),
+            BatchesCompleted = Volatile.Read(ref _batchesCompleted),
+            BatchesSentSuccessfully = Volatile.Read(ref _batchesSentSuccessfully),
+            BatchesFailed = Volatile.Read(ref _batchesFailed),
+            CompletionSourcesCompleted = Volatile.Read(ref _completionSourcesCompleted),
+            CompletionSourcesFailed = Volatile.Read(ref _completionSourcesFailed),
+            ReadyBatchesRented = Volatile.Read(ref _readyBatchesRented),
+            ReadyBatchesReturned = Volatile.Read(ref _readyBatchesReturned),
+            ReadyBatchDuplicateReturns = Volatile.Read(ref _readyBatchDuplicateReturns),
+            FlushCalls = Volatile.Read(ref _flushCalls)
+        };
+#else
+        return default;
+#endif
     }
 
     public static string GetSummary()
@@ -249,6 +291,23 @@ internal static class ProducerDebugCounters
 
     [Conditional("DEBUG")]
     public static void DumpToConsole() => Console.WriteLine(GetSummary());
+}
+
+internal readonly record struct ProducerDebugCounterSnapshot
+{
+    public int MessagesAppended { get; init; }
+    public int MessagesAppendedWithCompletion { get; init; }
+    public int MessagesAppendedFireAndForget { get; init; }
+    public int CompletionSourcesStoredInBatch { get; init; }
+    public int BatchesCompleted { get; init; }
+    public int BatchesSentSuccessfully { get; init; }
+    public int BatchesFailed { get; init; }
+    public int CompletionSourcesCompleted { get; init; }
+    public int CompletionSourcesFailed { get; init; }
+    public int ReadyBatchesRented { get; init; }
+    public int ReadyBatchesReturned { get; init; }
+    public int ReadyBatchDuplicateReturns { get; init; }
+    public int FlushCalls { get; init; }
 }
 
 /// <summary>
@@ -1873,7 +1932,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     internal void ReturnReadyBatch(ReadyBatch batch)
     {
         if (!TryClaimReadyBatchReturn(batch))
+        {
+            ProducerDebugCounters.RecordReadyBatchDuplicateReturn();
             return;
+        }
 
         CompleteClaimedReadyBatchReturn(batch);
     }
@@ -1907,6 +1969,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         batch.WaitForPreSerializationIfStarted();
         batch.WaitForResourcePins();
         batch.WaitForCleanupIfStarted();
+        batch.WaitForMemoryReleaseIfStarted();
         batch.WaitForTerminalBookkeeping();
 
         // Registration is protected by a resource pin, so release recovery only after all
@@ -2397,8 +2460,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 {
                     var disposedException = new ObjectDisposedException(nameof(RecordAccumulator));
                     batchToFail.Fail(disposedException);
-                    if (batchToFail.TrySetMemoryReleased())
-                        ReleaseMemory(batchToFail.DataSize);
+                    ReleaseBatchMemory(batchToFail);
                 }
 
                 if (!ownsRotation && sealedBatchToEnqueue is null && sealedBatchBytesToRelease > 0)
@@ -2771,8 +2833,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 {
                     var disposedException = new ObjectDisposedException(nameof(RecordAccumulator));
                     batchToFail.Fail(disposedException);
-                    if (batchToFail.TrySetMemoryReleased())
-                        ReleaseMemory(batchToFail.DataSize);
+                    ReleaseBatchMemory(batchToFail);
                 }
 
                 ReleaseDetachedBatchBytesIfSafe();
@@ -3627,6 +3688,25 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
+    /// Releases a batch's BufferMemory reservation exactly once. Pool reset waits for this
+    /// operation to finish, so the winning thread cannot observe a cleared or reused DataSize.
+    /// </summary>
+    internal void ReleaseBatchMemory(ReadyBatch batch)
+    {
+        if (!batch.TryBeginMemoryRelease(out var dataSize))
+            return;
+
+        try
+        {
+            ReleaseMemory(dataSize);
+        }
+        finally
+        {
+            batch.CompleteMemoryRelease();
+        }
+    }
+
+    /// <summary>
     /// Releases reserved buffer memory without triggering <see cref="DrainPendingAppends"/>.
     /// Used inside <see cref="DrainPendingAppends"/> when a claimed operation was already
     /// completed by timeout/cancel and the memory reservation must be returned.
@@ -4429,10 +4509,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         catch (Exception failEx) { LogBatchCleanupStepFailed(failEx); }
         try
         {
-            if (batch.TrySetMemoryReleased())
-            {
-                ReleaseMemory(batch.DataSize);
-            }
+            ReleaseBatchMemory(batch);
         }
         catch (Exception memEx) { LogBatchCleanupStepFailed(memEx); }
         if (removeFromPipeline)
@@ -4461,10 +4538,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         catch (Exception failEx) { LogBatchCleanupStepFailed(failEx); }
         try
         {
-            if (batch.TrySetMemoryReleased())
-            {
-                ReleaseMemory(batch.DataSize);
-            }
+            ReleaseBatchMemory(batch);
         }
         catch (Exception memEx) { LogBatchCleanupStepFailed(memEx); }
     }
@@ -4712,10 +4786,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                     if (readyBatch is not null)
                                     {
                                         readyBatch.Fail(disposedException);
-                                        if (readyBatch.TrySetMemoryReleased())
-                                        {
-                                            ReleaseMemory(readyBatch.DataSize);
-                                        }
+                                        ReleaseBatchMemory(readyBatch);
                                     }
                                     if (bytesToRelease > 0)
                                         ReleaseMemory(bytesToRelease);
@@ -4800,10 +4871,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             var batch = pd.PollFirst()!;
             batch.Fail(disposedException);
-            if (batch.TrySetMemoryReleased())
-            {
-                ReleaseMemory(batch.DataSize);
-            }
+            ReleaseBatchMemory(batch);
             OnBatchExitsPipeline(batch);
         }
     }
@@ -5752,6 +5820,21 @@ public readonly record struct RecordAppendResult(
 internal sealed class ReadyBatchPool(int maxPoolSize = BatchArena.DefaultPoolSize * 2)
     : ObjectPool<ReadyBatch>(maxPoolSize)
 {
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public new ReadyBatch Rent()
+    {
+        var batch = base.Rent();
+        ProducerDebugCounters.RecordReadyBatchRented();
+        return batch;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public new void Return(ReadyBatch item)
+    {
+        base.Return(item);
+        ProducerDebugCounters.RecordReadyBatchReturned();
+    }
+
     protected override ReadyBatch Create() => new();
     protected override void Reset(ReadyBatch item) => item.Reset();
 }
@@ -5795,7 +5878,7 @@ internal sealed class BatchArrayReuseQueue
 /// Returns pooled arrays to ArrayPool when complete.
 /// PooledValueTaskSource instances auto-return to their pool when GetResult() is called.
 /// </summary>
-internal sealed class ReadyBatch : IValueTaskSource<bool>
+internal sealed class ReadyBatch
 {
     private TopicPartition _topicPartition;
     private RecordBatch _recordBatch = null!;
@@ -5827,12 +5910,30 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
 
     /// <summary>
     /// Gets a ValueTask that completes when this batch is done (either sent successfully or failed).
-    /// Used by FlushAsync to wait for batch completion.
+    /// The producer's FlushAsync path uses RecordAccumulator's in-flight counter; this task is
+    /// retained for diagnostics and direct batch observers.
     /// IMPORTANT: This task never faults - it completes with true (success) or false (failure).
     /// This design eliminates UnobservedTaskException issues for fire-and-forget scenarios.
     /// Per-message exceptions are handled via the completion sources array, not this task.
     /// </summary>
-    public ValueTask<bool> DoneTask => new(this, _doneCore.Version);
+    public ValueTask<bool> DoneTask
+    {
+        get
+        {
+            var source = Volatile.Read(ref _doneTaskSource);
+            if (source is null)
+            {
+                var created = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                source = Interlocked.CompareExchange(ref _doneTaskSource, created, null) ?? created;
+            }
+
+            var completed = Volatile.Read(ref _completed);
+            if (completed != 0)
+                source.TrySetResult(completed == CompletionSucceeded);
+
+            return new ValueTask<bool>(source.Task);
+        }
+    }
 
     // Working arrays from accumulator (pooled) - mutable for pooling
     private PooledValueTaskSource<RecordMetadata>[]? _completionSourcesArray;
@@ -6093,26 +6194,62 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     }
 
     /// <summary>
-    /// Whether BufferMemory has already been released for this batch.
-    /// Set to true when ReleaseMemory is called (at TCP send time or in error paths).
+    /// Whether BufferMemory release has been claimed or completed for this batch.
     /// Prevents double-release across send and cleanup paths.
     /// Uses atomic operations because multiple threads may race to release:
     /// BrokerSender send loop, orphan sweep, and forceful disposal.
-    /// For observation/diagnostics only — use <see cref="TrySetMemoryReleased"/> as the
-    /// atomic guard when releasing memory.
+    /// For observation/diagnostics only. Production cleanup uses
+    /// <see cref="RecordAccumulator.ReleaseBatchMemory"/>.
     /// </summary>
-    internal bool MemoryReleased => Volatile.Read(ref _memoryReleased) != 0;
+    internal bool MemoryReleased => Volatile.Read(ref _memoryReleased) != MemoryReleasePending;
     private int _memoryReleased;
 
+    private const int MemoryReleasePending = 0;
+    private const int MemoryReleaseInProgress = 1;
+    private const int MemoryReleaseComplete = 2;
+
     /// <summary>
-    /// Atomically marks memory as released. Returns true if this call was the first
-    /// to set the flag (caller should release memory). Returns false if another thread
-    /// already set it (caller should skip release to avoid double-release).
+    /// Atomically marks memory as already released. Used by tests and batches whose memory
+    /// accounting is intentionally external. Production cleanup uses
+    /// <see cref="RecordAccumulator.ReleaseBatchMemory"/> so pool reset waits for release.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal bool TrySetMemoryReleased()
     {
-        return Interlocked.CompareExchange(ref _memoryReleased, 1, 0) == 0;
+        return Interlocked.CompareExchange(
+            ref _memoryReleased,
+            MemoryReleaseComplete,
+            MemoryReleasePending) == MemoryReleasePending;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryBeginMemoryRelease(out int dataSize)
+    {
+        if (Interlocked.CompareExchange(
+                ref _memoryReleased,
+                MemoryReleaseInProgress,
+                MemoryReleasePending) != MemoryReleasePending)
+        {
+            dataSize = 0;
+            return false;
+        }
+
+        dataSize = DataSize;
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void CompleteMemoryRelease()
+        => Volatile.Write(ref _memoryReleased, MemoryReleaseComplete);
+
+    internal void WaitForMemoryReleaseIfStarted()
+    {
+        if (Volatile.Read(ref _memoryReleased) != MemoryReleaseInProgress)
+            return;
+
+        var spinWait = new SpinWait();
+        while (Volatile.Read(ref _memoryReleased) == MemoryReleaseInProgress)
+            spinWait.SpinOnce();
     }
 
     /// <summary>
@@ -6171,14 +6308,23 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         IsRetry = true;
     }
 
-    // Batch-level completion tracking using resettable ManualResetValueTaskSourceCore
-    // Never faults - uses SetResult(true) for success, SetResult(false) for failure
-    private ManualResetValueTaskSourceCore<bool> _doneCore = new() { RunContinuationsAsynchronously = true };
+    // DoneTask is observed only by diagnostics/tests; producer flushing uses the accumulator's
+    // in-flight counter. Allocate its source lazily so the hot path remains allocation-free.
+    // A Task is deliberately used instead of a resettable IValueTaskSource: ReadyBatch can be
+    // returned to its pool before an asynchronous continuation consumes the prior result.
+    private TaskCompletionSource<bool>? _doneTaskSource;
+
+    private const int CompletionSucceeded = 1;
+    private const int CompletionFailed = 2;
 
     private int _cleanedUp; // 0 = not cleaned, 1 = cleaned (prevents double-cleanup in Cleanup())
-    private int _resourcesCleanedUp; // 0 = pooled resources retained, 1 = arena/RecordBatch returned
+    private const int ResourceCleanupPending = 0;
+    private const int ResourceCleanupInProgress = 1;
+    private const int ResourceCleanupComplete = 2;
+
+    private int _resourcesCleanedUp;
     private int _activeResourcePins; // readers holding RecordBatch/arena stable during serialization
-    private int _completed; // 0 = not completed, 1 = completed (prevents double-signal of _doneCore)
+    private int _completed; // 0 = pending, 1 = success, 2 = failure
     private int _sendCompleted; // 0 = not done, 1 = done (prevents concurrent CompleteSend/Fail)
     private int _terminalBookkeepingCompleted = 1; // generation-safe terminal owner finished post-Fail cleanup
     internal int _returnedToPool; // 0 = not returned, 1 = returned (prevents double pool return)
@@ -6291,11 +6437,12 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         // Reset lifecycle flags at the START of a new lifecycle (not in Reset()).
         // This ensures stale references from a previous lifecycle see _cleanedUp=1
         // and return early from CompleteSend/Fail, preventing pool corruption.
-        // _memoryReleased follows the same pattern: stale references seeing 1 (released)
+        // _memoryReleased follows the same pattern: stale references seeing a nonzero state
         // will skip the release, which is the safe/defensive behavior.
         Interlocked.Exchange(ref _cleanedUp, 0);
-        Interlocked.Exchange(ref _resourcesCleanedUp, 0);
+        Interlocked.Exchange(ref _resourcesCleanedUp, ResourceCleanupPending);
         Interlocked.Exchange(ref _activeResourcePins, 0);
+        Volatile.Write(ref _doneTaskSource, null);
         Interlocked.Exchange(ref _completed, 0);
         Interlocked.Exchange(ref _sendCompleted, 0);
         Volatile.Write(ref _terminalBookkeepingCompleted, 1);
@@ -6333,6 +6480,8 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         // has started but Cleanup hasn't finished. If we reach here, neither was ever called.
         if (Volatile.Read(ref _cleanedUp) == 0)
         {
+            ProducerDebugCounters.RecordBatchFailed();
+            var failedCount = 0;
             if (_completionSourcesCount > 0 && _completionSourcesArray is not null)
             {
                 var orphanedException = new InvalidOperationException(
@@ -6341,9 +6490,13 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
                     $"completed={Volatile.Read(ref _completed)}, trace={DiagTrace})");
                 for (var i = 0; i < _completionSourcesCount; i++)
                 {
-                    _completionSourcesArray[i]?.TrySetException(orphanedException);
+                    if (_completionSourcesArray[i]?.TrySetException(orphanedException) == true)
+                        failedCount++;
                 }
             }
+
+            ProducerDebugCounters.RecordCompletionSourceFailed(failedCount);
+            CompleteDoneTask(succeeded: false);
 
             // Cleanup() is idempotent (uses Interlocked.Exchange), so double-call is safe.
             Cleanup();
@@ -6366,7 +6519,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         InFlightPrev = null;
         InFlightNext = null;
         InFlightLinked = false;
-        // NOTE: _memoryReleased is NOT reset here — it stays armed (=1) while in pool,
+        // NOTE: _memoryReleased is NOT reset here — it stays complete while in pool,
         // so stale references calling TrySetMemoryReleased() return false (safe no-op).
         // Cleared in Initialize() at the start of the next lifecycle.
         IsRetry = false;
@@ -6376,19 +6529,12 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         _diagTraceLen = 0;
 
         // NOTE: _cleanedUp, _completed, and _sendCompleted are NOT reset here. They stay
-        // at 1 (armed) while the batch is in the pool, so that stale references from a
+        // nonzero (armed) while the batch is in the pool, so stale references from a
         // previous lifecycle calling CompleteSend/Fail will hit the guard and return early.
         // These flags are reset in Initialize() when the batch starts a new lifecycle.
-
-        // Reset the ValueTaskSourceCore for reuse
-        _doneCore.Reset();
+        // Captured DoneTask instances retain their own TaskCompletionSource after pool return.
+        Volatile.Write(ref _doneTaskSource, null);
     }
-
-    // IValueTaskSource<bool> implementation for DoneTask
-    bool IValueTaskSource<bool>.GetResult(short token) => _doneCore.GetResult(token);
-    ValueTaskSourceStatus IValueTaskSource<bool>.GetStatus(short token) => _doneCore.GetStatus(token);
-    void IValueTaskSource<bool>.OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
-        => _doneCore.OnCompleted(continuation, state, token, flags);
 
     /// <summary>
     /// Marks batch as "ready" (processed by completion loop).
@@ -6398,18 +6544,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
     /// </summary>
     public void CompleteDelivery()
     {
-        // Atomically claim completion - only one thread wins
-        if (Interlocked.CompareExchange(ref _completed, 1, 0) != 0)
-            return;
-
-        // Check _cleanedUp AFTER winning the CAS to avoid TOCTOU race.
-        // If Cleanup() ran between our CAS and this check, _doneCore may be reset.
-        // In that case, skip SetResult to avoid calling it on a reset core.
-        if (Volatile.Read(ref _cleanedUp) != 0)
-            return;
-
-        // Signal batch is done (ready for fire-and-forget semantic)
-        _doneCore.SetResult(true);
+        CompleteDoneTask(succeeded: true);
     }
 
     /// <summary>
@@ -6489,8 +6624,7 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
             }
 
             // Signal batch is done (successfully) if not already signaled by CompleteDelivery
-            if (Interlocked.CompareExchange(ref _completed, 1, 0) == 0)
-                _doneCore.SetResult(true);
+            CompleteDoneTask(succeeded: true);
         }
         finally
         {
@@ -6624,13 +6758,21 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
             // Signal batch is done (failed) - NO EXCEPTION to avoid UnobservedTaskException
             // For fire-and-forget, no one awaits this, so exception would go unobserved
             // For FlushAsync, it just needs to know "done", not success/failure details
-            if (Interlocked.CompareExchange(ref _completed, 1, 0) == 0)
-                _doneCore.SetResult(false);
+            CompleteDoneTask(succeeded: false);
         }
         finally
         {
             Cleanup();
         }
+    }
+
+    private void CompleteDoneTask(bool succeeded)
+    {
+        var completion = succeeded ? CompletionSucceeded : CompletionFailed;
+        if (Interlocked.CompareExchange(ref _completed, completion, 0) != 0)
+            return;
+
+        Volatile.Read(ref _doneTaskSource)?.TrySetResult(succeeded);
     }
 
     /// <summary>
@@ -6655,13 +6797,14 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
             while (Volatile.Read(ref _cleanedUp) == 0);
         }
 
-        if (Volatile.Read(ref _cleanedUp) != 0 && Volatile.Read(ref _resourcesCleanedUp) == 0)
+        if (Volatile.Read(ref _cleanedUp) != 0
+            && Volatile.Read(ref _resourcesCleanedUp) != ResourceCleanupComplete)
         {
             // Reset must wait for deferred resource cleanup; otherwise it can recycle fields
             // while the last serialization pin is still returning the old RecordBatch/arena.
             var sw = new SpinWait();
             do { sw.SpinOnce(); }
-            while (Volatile.Read(ref _resourcesCleanedUp) == 0);
+            while (Volatile.Read(ref _resourcesCleanedUp) != ResourceCleanupComplete);
         }
     }
 
@@ -6680,50 +6823,67 @@ internal sealed class ReadyBatch : IValueTaskSource<bool>
         if (Volatile.Read(ref _activeResourcePins) != 0)
             return;
 
-        if (Interlocked.Exchange(ref _resourcesCleanedUp, 1) != 0)
+        if (Interlocked.CompareExchange(
+                ref _resourcesCleanedUp,
+                ResourceCleanupInProgress,
+                ResourceCleanupPending) != ResourceCleanupPending)
             return;
 
-        // Return the working (container) array: either to the reuse queue for fast recycling
-        // back to PartitionBatch, or to ArrayPool as fallback.
-        // Safety: clearArray: false is intentional. Array slots past the used count may contain
-        // stale PooledValueTaskSource references, but these are never accessed because counters
-        // reset to 0 on reuse. PooledValueTaskSource instances auto-return to their pool via
-        // GetResult(), so stale references don't prevent pool recycling.
-        if (_completionSourcesArray is not null)
+        var completionSourcesArray = _completionSourcesArray;
+        var arrayReuseQueue = _arrayReuseQueue;
+        var arena = _arena;
+        var callbacks = _callbacks;
+        var recordBatch = _recordBatch;
+
+        try
         {
-            if (_arrayReuseQueue is not null)
+            // Return the working (container) array: either to the reuse queue for fast recycling
+            // back to PartitionBatch, or to ArrayPool as fallback.
+            // Safety: clearArray: false is intentional. Array slots past the used count may contain
+            // stale PooledValueTaskSource references, but these are never accessed because counters
+            // reset to 0 on reuse. PooledValueTaskSource instances auto-return to their pool via
+            // GetResult(), so stale references don't prevent pool recycling.
+            if (completionSourcesArray is not null)
             {
-                _arrayReuseQueue.EnqueueOrReturn(_completionSourcesArray);
+                if (arrayReuseQueue is not null)
+                {
+                    arrayReuseQueue.EnqueueOrReturn(completionSourcesArray);
+                }
+                else
+                {
+                    // Fallback: return to the dedicated pool (not ArrayPool<T>.Shared) to prevent
+                    // TLS accumulation from cross-thread return on BrokerSender threads
+                    ProducerContainerPools.CompletionSources.Return(completionSourcesArray, clearArray: false);
+                }
             }
-            else
+
+            // Return arena to pool for reuse (arena-based path)
+            // This avoids allocating a new BatchArena object on each batch recycle
+            if (arena is not null)
             {
-                // Fallback: return to the dedicated pool (not ArrayPool<T>.Shared) to prevent
-                // TLS accumulation from cross-thread return on BrokerSender threads
-                ProducerContainerPools.CompletionSources.Return(_completionSourcesArray, clearArray: false);
+                BatchArena.ReturnToPool(arena);
+            }
+
+            // Return callback array to dedicated pool if present
+            if (callbacks is not null)
+            {
+                ProducerContainerPools.Callbacks.Return(callbacks, clearArray: true);
+            }
+
+            // Return pre-compressed buffer and RecordBatch to pool.
+            // ReturnPreCompressedBuffer() releases the producer-pool buffer, then ReturnToPool()
+            // clears all references and returns the RecordBatch object for reuse.
+            if (recordBatch is not null)
+            {
+                recordBatch.ReturnPreCompressedBuffer();
+                recordBatch.DisposeRecordList();
+                recordBatch.ReturnToPool();
             }
         }
-
-        // Return arena to pool for reuse (arena-based path)
-        // This avoids allocating a new BatchArena object on each batch recycle
-        if (_arena is not null)
+        finally
         {
-            BatchArena.ReturnToPool(_arena);
-        }
-
-        // Return callback array to dedicated pool if present
-        if (_callbacks is not null)
-        {
-            ProducerContainerPools.Callbacks.Return(_callbacks, clearArray: true);
-        }
-
-        // Return pre-compressed buffer and RecordBatch to pool.
-        // ReturnPreCompressedBuffer() releases the producer-pool buffer, then ReturnToPool()
-        // clears all references and returns the RecordBatch object for reuse.
-        if (_recordBatch is not null)
-        {
-            _recordBatch.ReturnPreCompressedBuffer();
-            _recordBatch.DisposeRecordList();
-            _recordBatch.ReturnToPool();
+            // Reset must not clear fields until every pooled resource return above completes.
+            Volatile.Write(ref _resourcesCleanedUp, ResourceCleanupComplete);
         }
     }
 }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5920,12 +5920,9 @@ internal sealed class ReadyBatch
     {
         get
         {
-            var state = RegisterDoneTaskObserver();
-            if (TryGetDoneTaskCompletion(state.Generation, out var succeeded))
-            {
-                RemoveDoneTaskObserver(state);
+            var state = RegisterDoneTaskObserver(out var completedResult);
+            if (completedResult is { } succeeded)
                 return new ValueTask<bool>(succeeded);
-            }
 
             AfterDoneTaskObserverRegisteredForTest?.Invoke();
             return new ValueTask<bool>(state.Source.Task);
@@ -6320,6 +6317,7 @@ internal sealed class ReadyBatch
     private List<DoneTaskState>? _doneTaskObservers;
     private int _doneTaskObserverCount;
     private long _lastDoneTaskCompletion;
+    internal Action? AfterDoneTaskObserverIntentPublishedForTest;
     internal Action? AfterDoneTaskObserverRegisteredForTest;
 
     private const int CompletionSucceeded = 1;
@@ -6779,28 +6777,56 @@ internal sealed class ReadyBatch
         if (Interlocked.CompareExchange(ref _completed, completion, 0) != 0)
             return;
 
-        Volatile.Write(ref _lastDoneTaskCompletion, PackDoneTaskCompletion(generation, completion));
-        if (Volatile.Read(ref _doneTaskObserverCount) != 0)
-            CompleteDoneTaskObservers(generation, succeeded);
+        if (Volatile.Read(ref _doneTaskObserverCount) == 0)
+        {
+            Volatile.Write(ref _lastDoneTaskCompletion, PackDoneTaskCompletion(generation, completion));
+
+            // Close the race with a registration that published its intent after the first
+            // count read. It will either consume the packed result under the observer lock,
+            // or this thread will acquire that lock and deliver the result directly.
+            if (Volatile.Read(ref _doneTaskObserverCount) == 0)
+                return;
+        }
+
+        CompleteDoneTaskObservers(generation, completion, succeeded);
     }
 
-    private DoneTaskState RegisterDoneTaskObserver()
+    private DoneTaskState RegisterDoneTaskObserver(out bool? completedResult)
     {
-        // Publish registration intent before taking the lock. A racing completion either
-        // waits for this observer to be added or leaves its packed result for the immediate
-        // catch-up check in DoneTask.
-        Interlocked.Increment(ref _doneTaskObserverCount);
+        completedResult = null;
         var lockTaken = false;
+        var observerCountIncremented = false;
         try
         {
             _doneTaskObserverLock.Enter(ref lockTaken);
+
+            // Publish intent while holding the same lock used by observed completions. Once
+            // the count is visible, the current lifecycle cannot complete and recycle before
+            // its generation is captured and registered below.
+            Interlocked.Increment(ref _doneTaskObserverCount);
+            observerCountIncremented = true;
+            AfterDoneTaskObserverIntentPublishedForTest?.Invoke();
+
             var state = new DoneTaskState(Generation);
             (_doneTaskObservers ??= new List<DoneTaskState>(1)).Add(state);
+
+            // A completion that observed zero registrations publishes its result before
+            // checking the count again. Consume that hand-off before releasing the lock so a
+            // later lifecycle cannot overwrite it first.
+            if (TryGetDoneTaskCompletion(state.Generation, out var succeeded))
+            {
+                _doneTaskObservers.Remove(state);
+                Interlocked.Decrement(ref _doneTaskObserverCount);
+                observerCountIncremented = false;
+                completedResult = succeeded;
+            }
+
             return state;
         }
         catch
         {
-            Interlocked.Decrement(ref _doneTaskObserverCount);
+            if (observerCountIncremented)
+                Interlocked.Decrement(ref _doneTaskObserverCount);
             throw;
         }
         finally
@@ -6810,31 +6836,14 @@ internal sealed class ReadyBatch
         }
     }
 
-    private void RemoveDoneTaskObserver(DoneTaskState state)
-    {
-        var removed = false;
-        var lockTaken = false;
-        try
-        {
-            _doneTaskObserverLock.Enter(ref lockTaken);
-            removed = _doneTaskObservers?.Remove(state) == true;
-        }
-        finally
-        {
-            if (lockTaken)
-                _doneTaskObserverLock.Exit();
-        }
-
-        if (removed)
-            Interlocked.Decrement(ref _doneTaskObserverCount);
-    }
-
-    private void CompleteDoneTaskObservers(int generation, bool succeeded)
+    private void CompleteDoneTaskObservers(int generation, int completion, bool succeeded)
     {
         var lockTaken = false;
         try
         {
             _doneTaskObserverLock.Enter(ref lockTaken);
+            Volatile.Write(ref _lastDoneTaskCompletion, PackDoneTaskCompletion(generation, completion));
+
             if (_doneTaskObservers is null)
                 return;
 

--- a/tests/Dekaf.Tests.Unit/Concurrency/ProducerBatchLifecycleHammerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Concurrency/ProducerBatchLifecycleHammerTests.cs
@@ -1,0 +1,285 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Concurrency;
+
+/// <summary>
+/// Repeatedly races the three production cleanup owners for a batch: successful sender
+/// completion, failed sender completion, and the disposal orphan sweep. Persistent workers
+/// and a reusable barrier explore interleavings without multiplying TUnit test instances.
+/// </summary>
+[NotInParallel]
+public sealed class ProducerBatchLifecycleHammerTests
+{
+    private const int IterationCount = 10_000;
+    private const int WorkerCount = 3;
+
+    private static readonly FieldInfo InFlightBatchCountField = typeof(RecordAccumulator)
+        .GetField("_inFlightBatchCount", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private static readonly FieldInfo ReadyBatchPoolField = typeof(RecordAccumulator)
+        .GetField("_readyBatchPool", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task CompleteFailAndDisposeRace_AllAcceptedMessagesTerminateExactlyOnce(
+        CancellationToken cancellationToken)
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "batch-lifecycle-hammer",
+            BufferMemory = 16 * 1024 * 1024,
+            BatchSize = 1024,
+            LingerMs = 1_000
+        };
+
+        var accumulator = new RecordAccumulator(options);
+        var completionPool = new ValueTaskSourcePool<RecordMetadata>();
+        using var workerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var phaseBarrier = new Barrier(WorkerCount + 1);
+        var workerErrors = new ConcurrentQueue<Exception>();
+
+        ReadyBatch? currentBatch = null;
+        var currentIteration = 0;
+
+        var workers = Enumerable.Range(0, WorkerCount)
+            .Select(workerId => Task.Factory.StartNew(
+                () => RunWorker(workerId),
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default))
+            .ToArray();
+
+        ProducerDebugCounters.Reset();
+
+        try
+        {
+            for (var iteration = 0; iteration < IterationCount; iteration++)
+            {
+                var topicPartition = new TopicPartition("hammer-topic", iteration & 3);
+                var completion = completionPool.Rent();
+                var completionTask = completion.Task.AsTask();
+                var callbackInvocations = 0;
+                Exception? callbackException = null;
+                var awaitedValue = RentPayload(iteration);
+                var callbackValue = RentPayload(~iteration);
+
+                var callbackAccepted = await accumulator.AppendAsync(
+                    topicPartition.Topic,
+                    topicPartition.Partition,
+                    DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    PooledMemory.Null,
+                    callbackValue,
+                    headers: null,
+                    headerCount: 0,
+                    completionSource: null,
+                    (_, exception) =>
+                    {
+                        Volatile.Write(ref callbackException, exception);
+                        Interlocked.Increment(ref callbackInvocations);
+                    },
+                    cancellationToken);
+                var awaitedAccepted = await accumulator.AppendAsync(
+                    topicPartition.Topic,
+                    topicPartition.Partition,
+                    DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    PooledMemory.Null,
+                    awaitedValue,
+                    headers: null,
+                    headerCount: 0,
+                    completion,
+                    callback: null,
+                    cancellationToken);
+
+                await Assert.That(awaitedAccepted).IsTrue();
+                await Assert.That(callbackAccepted).IsTrue();
+
+                // FlushAsync deterministically seals both records, then remains pending on the
+                // in-flight counter while the three cleanup owners race below.
+                var flushTask = accumulator.FlushAsync(cancellationToken).AsTask();
+                await Assert.That(accumulator.TryDrainBatch(out var batch)).IsTrue();
+
+                var generation = batch!.Generation;
+                var doneTask = batch.DoneTask.AsTask();
+                await Assert.That(batch.RecordBatch.Records.Count).IsEqualTo(2);
+                await Assert.That(batch.RecordBatch.Records[0].Value.Length).IsEqualTo(64);
+                await Assert.That(batch.RecordBatch.Records[1].Value.Length).IsEqualTo(64);
+                currentBatch = batch;
+                currentIteration = iteration;
+
+                phaseBarrier.SignalAndWait(cancellationToken);
+                phaseBarrier.SignalAndWait(cancellationToken);
+                await flushTask.WaitAsync(cancellationToken);
+
+                if (!workerErrors.IsEmpty)
+                    throw new AggregateException(workerErrors);
+
+                var completed = false;
+                try
+                {
+                    _ = await completionTask.WaitAsync(cancellationToken);
+                    completed = true;
+                }
+                catch (Exception exception) when (exception is ExpectedHammerException or ObjectDisposedException)
+                {
+                    // Expected failure winner; awaiting proves completion source terminated.
+                }
+
+                var delivered = await doneTask.WaitAsync(cancellationToken);
+
+                await Assert.That(delivered).IsEqualTo(completed);
+                await Assert.That(Volatile.Read(ref callbackInvocations)).IsEqualTo(1);
+                await Assert.That(Volatile.Read(ref callbackException) is null).IsEqualTo(completed);
+                await Assert.That(batch.IsCurrentIncarnation(generation)).IsFalse();
+                await Assert.That(batch.IsReturnedToPool).IsTrue();
+                await Assert.That(accumulator.BufferedBytes).IsEqualTo(0L);
+                await Assert.That(GetInFlightBatchCount(accumulator)).IsEqualTo(0L);
+            }
+
+#if DEBUG
+            var counters = ProducerDebugCounters.GetSnapshot();
+            await Assert.That(counters.MessagesAppended).IsEqualTo(IterationCount * 2);
+            await Assert.That(counters.MessagesAppendedWithCompletion).IsEqualTo(IterationCount);
+            await Assert.That(counters.MessagesAppendedFireAndForget).IsEqualTo(IterationCount);
+            await Assert.That(counters.MessagesAppendedWithCompletion)
+                .IsEqualTo(counters.CompletionSourcesStoredInBatch);
+            await Assert.That(counters.CompletionSourcesStoredInBatch)
+                .IsEqualTo(counters.CompletionSourcesCompleted + counters.CompletionSourcesFailed);
+            await Assert.That(counters.BatchesCompleted).IsEqualTo(IterationCount);
+            await Assert.That(counters.BatchesSentSuccessfully + counters.BatchesFailed)
+                .IsEqualTo(IterationCount);
+            await Assert.That(counters.ReadyBatchesRented).IsEqualTo(IterationCount);
+            await Assert.That(counters.ReadyBatchesReturned).IsEqualTo(IterationCount);
+            await Assert.That(counters.ReadyBatchDuplicateReturns)
+                .IsGreaterThanOrEqualTo(IterationCount);
+            await Assert.That(counters.FlushCalls).IsEqualTo(IterationCount);
+#endif
+
+            await AssertConcurrentReadyBatchRentsAreUnique(accumulator, cancellationToken);
+        }
+        finally
+        {
+            workerCts.Cancel();
+            try
+            {
+                await Task.WhenAll(workers).WaitAsync(TimeSpan.FromSeconds(10), CancellationToken.None);
+            }
+            catch (OperationCanceledException) when (workerCts.IsCancellationRequested)
+            {
+                // Expected when controller leaves before all hammer phases complete.
+            }
+
+            await accumulator.DisposeAsync();
+            await completionPool.DisposeAsync();
+            ProducerDebugCounters.Reset();
+        }
+
+        void RunWorker(int workerId)
+        {
+            try
+            {
+                for (var iteration = 0; iteration < IterationCount; iteration++)
+                {
+                    phaseBarrier.SignalAndWait(workerCts.Token);
+
+                    try
+                    {
+                        PerturbSchedule(currentIteration, workerId);
+                        var batch = currentBatch!;
+                        switch ((currentIteration + workerId) % WorkerCount)
+                        {
+                            case 0:
+                                CompleteAndCleanup(batch, succeeded: true);
+                                break;
+                            case 1:
+                                CompleteAndCleanup(batch, succeeded: false);
+                                break;
+                            default:
+                                accumulator.ForceFailAllInFlightBatches();
+                                break;
+                        }
+                    }
+                    catch (Exception exception)
+                    {
+                        workerErrors.Enqueue(exception);
+                    }
+                    finally
+                    {
+                        phaseBarrier.SignalAndWait(workerCts.Token);
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (workerCts.IsCancellationRequested)
+            {
+                // Controller failed or test timed out; leave persistent worker promptly.
+            }
+        }
+
+        void CompleteAndCleanup(ReadyBatch batch, bool succeeded)
+        {
+            if (succeeded)
+                batch.CompleteSend(currentIteration, DateTimeOffset.UtcNow);
+            else
+                batch.Fail(new ExpectedHammerException());
+
+            accumulator.ReleaseBatchMemory(batch);
+
+            accumulator.OnBatchExitsPipeline(batch);
+            accumulator.ReturnReadyBatch(batch);
+        }
+    }
+
+    private static void PerturbSchedule(int iteration, int workerId)
+    {
+        Thread.SpinWait(((iteration + 1) * (workerId + 3) * 17) & 63);
+        if (((iteration << 1) + workerId) % 7 == 0)
+            Thread.Yield();
+    }
+
+    private static long GetInFlightBatchCount(RecordAccumulator accumulator)
+        => (long)InFlightBatchCountField.GetValue(accumulator)!;
+
+    private static PooledMemory RentPayload(int seed)
+    {
+        var buffer = ProducerDataPool.BytePool.Rent(64);
+        buffer.AsSpan(0, 64).Fill((byte)seed);
+        return new PooledMemory(buffer, 64);
+    }
+
+    private static async Task AssertConcurrentReadyBatchRentsAreUnique(
+        RecordAccumulator accumulator,
+        CancellationToken cancellationToken)
+    {
+        var pool = (ReadyBatchPool)ReadyBatchPoolField.GetValue(accumulator)!;
+        using var barrier = new Barrier(3);
+        var rents = Enumerable.Range(0, 2)
+            .Select(_ => Task.Factory.StartNew(
+                () =>
+                {
+                    barrier.SignalAndWait(cancellationToken);
+                    return pool.Rent();
+                },
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default))
+            .ToArray();
+
+        barrier.SignalAndWait(cancellationToken);
+        var batches = await Task.WhenAll(rents).WaitAsync(cancellationToken);
+
+        try
+        {
+            await Assert.That(ReferenceEquals(batches[0], batches[1])).IsFalse();
+        }
+        finally
+        {
+            pool.Return(batches[0]);
+            if (!ReferenceEquals(batches[0], batches[1]))
+                pool.Return(batches[1]);
+        }
+    }
+
+    private sealed class ExpectedHammerException : Exception;
+}

--- a/tests/Dekaf.Tests.Unit/Producer/MemoryReleasedAtomicityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/MemoryReleasedAtomicityTests.cs
@@ -153,18 +153,13 @@ public class MemoryReleasedAtomicityTests
             const int releaserThreads = 4;
             var tasks = new List<Task>();
 
-            foreach (var (batch, dataSize) in batches)
+            foreach (var (batch, _) in batches)
             {
                 for (var t = 0; t < releaserThreads; t++)
                 {
                     tasks.Add(Task.Run(() =>
                     {
-                        // This is the exact pattern used in production:
-                        // TrySetMemoryReleased() is the atomic guard
-                        if (batch.TrySetMemoryReleased())
-                        {
-                            accumulator.ReleaseMemory(dataSize);
-                        }
+                        accumulator.ReleaseBatchMemory(batch);
                     }));
                 }
             }

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -824,6 +824,56 @@ public class PooledValueTaskSourceTests
     }
 
     [Test]
+    public async Task ReadyBatchDoneTask_RegistrationIntentRace_CapturesStartedLifecycle()
+    {
+        var batch = new ReadyBatch();
+        InitializeBatch(batch);
+
+        using var observerIntentPublished = new ManualResetEventSlim();
+        using var continueGetter = new ManualResetEventSlim();
+        using var lifecycleStarted = new ManualResetEventSlim();
+        batch.AfterDoneTaskObserverIntentPublishedForTest = () =>
+        {
+            observerIntentPublished.Set();
+            continueGetter.Wait();
+        };
+
+        var getterTask = Task.Run(() => batch.DoneTask);
+        try
+        {
+            await Assert.That(observerIntentPublished.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+
+            var lifecycleTask = Task.Run(() =>
+            {
+                lifecycleStarted.Set();
+                batch.Fail(new InvalidOperationException("expected"));
+                batch.Reset();
+                InitializeBatch(batch);
+                batch.CompleteDelivery();
+                batch.Reset();
+                InitializeBatch(batch);
+            });
+
+            await Assert.That(lifecycleStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Task.WhenAny(lifecycleTask, Task.Delay(TimeSpan.FromSeconds(1))).ConfigureAwait(false);
+
+            continueGetter.Set();
+            await lifecycleTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            var capturedTask = await getterTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            var result = await capturedTask.AsTask().WaitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+
+            await Assert.That(result).IsFalse();
+        }
+        finally
+        {
+            batch.AfterDoneTaskObserverIntentPublishedForTest = null;
+            continueGetter.Set();
+            batch.CompleteDelivery();
+            batch.Reset();
+        }
+    }
+
+    [Test]
     public async Task ReadyBatchDoneTask_SourcePublicationRacesWithMultipleReuses_CompletesCapturedLifecycle()
     {
         var batch = new ReadyBatch();

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -824,39 +824,42 @@ public class PooledValueTaskSourceTests
     }
 
     [Test]
-    public async Task ReadyBatchDoneTask_SourcePublicationRacesWithReuse_CompletesCapturedLifecycle()
+    public async Task ReadyBatchDoneTask_SourcePublicationRacesWithMultipleReuses_CompletesCapturedLifecycle()
     {
         var batch = new ReadyBatch();
         InitializeBatch(batch);
 
-        using var sourceCreated = new ManualResetEventSlim();
-        using var continuePublication = new ManualResetEventSlim();
-        batch.BeforeDoneTaskSourcePublishedForTest = () =>
+        using var observerRegistered = new ManualResetEventSlim();
+        using var continueGetter = new ManualResetEventSlim();
+        batch.AfterDoneTaskObserverRegisteredForTest = () =>
         {
-            sourceCreated.Set();
-            continuePublication.Wait();
+            observerRegistered.Set();
+            continueGetter.Wait();
         };
 
         var getterTask = Task.Run(() => batch.DoneTask);
         try
         {
-            await Assert.That(sourceCreated.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(observerRegistered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
 
+            batch.Fail(new InvalidOperationException("expected"));
+            batch.Reset();
+            InitializeBatch(batch);
             batch.CompleteDelivery();
             batch.Reset();
             InitializeBatch(batch);
-            batch.BeforeDoneTaskSourcePublishedForTest = null;
+            batch.AfterDoneTaskObserverRegisteredForTest = null;
 
-            continuePublication.Set();
+            continueGetter.Set();
             var capturedTask = await getterTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
             var result = await capturedTask.AsTask().WaitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
 
-            await Assert.That(result).IsTrue();
+            await Assert.That(result).IsFalse();
         }
         finally
         {
-            batch.BeforeDoneTaskSourcePublishedForTest = null;
-            continuePublication.Set();
+            batch.AfterDoneTaskObserverRegisteredForTest = null;
+            continueGetter.Set();
             batch.CompleteDelivery();
             batch.Reset();
         }

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -823,6 +823,45 @@ public class PooledValueTaskSourceTests
         }
     }
 
+    [Test]
+    public async Task ReadyBatchDoneTask_SourcePublicationRacesWithReuse_CompletesCapturedLifecycle()
+    {
+        var batch = new ReadyBatch();
+        InitializeBatch(batch);
+
+        using var sourceCreated = new ManualResetEventSlim();
+        using var continuePublication = new ManualResetEventSlim();
+        batch.BeforeDoneTaskSourcePublishedForTest = () =>
+        {
+            sourceCreated.Set();
+            continuePublication.Wait();
+        };
+
+        var getterTask = Task.Run(() => batch.DoneTask);
+        try
+        {
+            await Assert.That(sourceCreated.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+
+            batch.CompleteDelivery();
+            batch.Reset();
+            InitializeBatch(batch);
+            batch.BeforeDoneTaskSourcePublishedForTest = null;
+
+            continuePublication.Set();
+            var capturedTask = await getterTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            var result = await capturedTask.AsTask().WaitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+
+            await Assert.That(result).IsTrue();
+        }
+        finally
+        {
+            batch.BeforeDoneTaskSourcePublishedForTest = null;
+            continuePublication.Set();
+            batch.CompleteDelivery();
+            batch.Reset();
+        }
+    }
+
     private static async Task<T> CompleteWithoutRunningContinuationInlineAsync<T>(
         ValueTask<T> valueTask,
         Action complete)

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -769,6 +769,60 @@ public class PooledValueTaskSourceTests
         batch.Reset();
     }
 
+    [Test]
+    public async Task ReadyBatchDoneTask_ResetBeforeContinuationConsumesResult_RemainsValid()
+    {
+        var batch = new ReadyBatch();
+        InitializeBatch(batch);
+
+        using var continuationStarted = new ManualResetEventSlim();
+        using var releaseContinuation = new ManualResetEventSlim();
+        using var continuationFinished = new ManualResetEventSlim();
+        var awaiter = batch.DoneTask.GetAwaiter();
+        Exception? continuationException = null;
+        var result = false;
+
+        awaiter.UnsafeOnCompleted(() =>
+        {
+            continuationStarted.Set();
+            releaseContinuation.Wait();
+            try
+            {
+                result = awaiter.GetResult();
+            }
+            catch (Exception exception)
+            {
+                continuationException = exception;
+            }
+            finally
+            {
+                continuationFinished.Set();
+            }
+        });
+
+        try
+        {
+            batch.CompleteDelivery();
+            await Assert.That(continuationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+
+            // Pool return resets ReadyBatch before an asynchronous DoneTask continuation
+            // necessarily consumes the result. The captured task must remain independent.
+            batch.Reset();
+            releaseContinuation.Set();
+
+            await Assert.That(continuationFinished.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            if (continuationException is not null)
+                ExceptionDispatchInfo.Capture(continuationException).Throw();
+
+            await Assert.That(result).IsTrue();
+        }
+        finally
+        {
+            releaseContinuation.Set();
+            batch.Reset();
+        }
+    }
+
     private static async Task<T> CompleteWithoutRunningContinuationInlineAsync<T>(
         ValueTask<T> valueTask,
         Action complete)

--- a/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
@@ -92,7 +92,7 @@ public sealed class ReadyBatchIncarnationTests
 
         batch.ReleaseResourcePin();
 
-        await Assert.That(GetReadyBatchInt32(batch, "_resourcesCleanedUp")).IsEqualTo(1);
+        await Assert.That(GetReadyBatchInt32(batch, "_resourcesCleanedUp")).IsEqualTo(2);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add a deterministic 10,000-round barrier hammer for batch completion, failure, force-fail disposal, FlushAsync, arena cleanup, and pool reuse
- keep captured ReadyBatch.DoneTask results valid after the batch returns to its pool
- serialize pooled-resource cleanup and BufferMemory release before Reset can clear or reuse lifecycle fields
- expose typed DEBUG counters for message completion and ReadyBatch pool-balance invariants
- complement #1602's adaptive scale-down sender coverage with systematic batch-lifecycle interleavings

## Test plan
- [x] Debug net10.0 build
- [x] 54 targeted Debug producer lifecycle/pool tests
- [x] Release net10.0 build
- [x] full Release unit suite (4,511 tests)

Closes #1599
