### PR TITLE
test(stress): add fault-injection suite

### DIFF
--- a/.github/workflows/fault-injection.yml
+++ b/.github/workflows/fault-injection.yml
@@ -42,9 +42,6 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    # Keep collecting three-broker reports while #1639 is open without making
-    # its known consumer-recovery failure a permanent red scheduled run.
-    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:
@@ -52,15 +49,17 @@ jobs:
           - name: TCP Faults (1 Broker)
             profile: network
             brokers: 1
-            allow_failure: false
+            allowed_failure_windows: ''
           - name: Broker Kill and Restart (1 Broker)
             profile: broker
             brokers: 1
-            allow_failure: false
+            allowed_failure_windows: ''
           - name: Cluster Failover and Rolling Restart (3 Brokers)
             profile: broker
             brokers: 3
-            allow_failure: true
+            # #1639 covers only these two live-consumer recovery windows.
+            # Setup failures and broker-kill-restart remain hard failures.
+            allowed_failure_windows: 'leader-election,rolling-restart'
 
     steps:
       - name: Checkout
@@ -79,6 +78,7 @@ jobs:
           dotnet run --project tools/Dekaf.StressTests --configuration Release --no-build --
           fault
           --fault-profile ${{ matrix.profile }}
+          --allowed-failure-windows "${{ matrix.allowed_failure_windows }}"
           --brokers ${{ matrix.brokers }}
           --partitions 6
           --message-size 1000

--- a/.github/workflows/fault-injection.yml
+++ b/.github/workflows/fault-injection.yml
@@ -42,6 +42,9 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # Keep collecting three-broker reports while #1639 is open without making
+    # its known consumer-recovery failure a permanent red scheduled run.
+    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:
@@ -49,12 +52,15 @@ jobs:
           - name: TCP Faults (1 Broker)
             profile: network
             brokers: 1
+            allow_failure: false
           - name: Broker Kill and Restart (1 Broker)
             profile: broker
             brokers: 1
+            allow_failure: false
           - name: Cluster Failover and Rolling Restart (3 Brokers)
             profile: broker
             brokers: 3
+            allow_failure: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/fault-injection.yml
+++ b/.github/workflows/fault-injection.yml
@@ -1,0 +1,92 @@
+name: Fault Injection Stress
+
+on:
+  schedule:
+    - cron: '0 3 * * 3'  # Weekly Wednesday 3 AM UTC
+  workflow_dispatch:
+    inputs:
+      fault_duration_seconds:
+        description: 'Duration of each active fault window'
+        required: false
+        default: '5'
+      messages_before_fault:
+        description: 'Messages produced before each fault'
+        required: false
+        default: '2000'
+      max_messages_during_fault:
+        description: 'Maximum messages buffered during each fault'
+        required: false
+        default: '20000'
+      messages_after_fault:
+        description: 'Messages proving recovery after each fault'
+        required: false
+        default: '2000'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fault-injection-stress
+  cancel-in-progress: false
+
+env:
+  ContinuousIntegrationBuild: true
+  Deterministic: true
+  FAULT_DURATION_SECONDS: ${{ inputs.fault_duration_seconds || '5' }}
+  MESSAGES_BEFORE_FAULT: ${{ inputs.messages_before_fault || '2000' }}
+  MAX_MESSAGES_DURING_FAULT: ${{ inputs.max_messages_during_fault || '20000' }}
+  MESSAGES_AFTER_FAULT: ${{ inputs.messages_after_fault || '2000' }}
+
+jobs:
+  fault-injection:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: TCP Faults (1 Broker)
+            profile: network
+            brokers: 1
+          - name: Broker Kill and Restart (1 Broker)
+            profile: broker
+            brokers: 1
+          - name: Cluster Failover and Rolling Restart (3 Brokers)
+            profile: broker
+            brokers: 3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build Fault Injection Suite
+        run: dotnet build tools/Dekaf.StressTests --configuration Release
+
+      - name: Run ${{ matrix.name }}
+        run: >-
+          dotnet run --project tools/Dekaf.StressTests --configuration Release --no-build --
+          fault
+          --fault-profile ${{ matrix.profile }}
+          --brokers ${{ matrix.brokers }}
+          --partitions 6
+          --message-size 1000
+          --fault-duration-seconds "$FAULT_DURATION_SECONDS"
+          --messages-before-fault "$MESSAGES_BEFORE_FAULT"
+          --max-messages-during-fault "$MAX_MESSAGES_DURING_FAULT"
+          --messages-after-fault "$MESSAGES_AFTER_FAULT"
+          --output ./results
+
+      - name: Upload Fault Report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fault-injection-${{ matrix.profile }}-${{ matrix.brokers }}brokers
+          path: results/fault-injection-*.json
+          if-no-files-found: warn
+          retention-days: 90

--- a/Dekaf.sln
+++ b/Dekaf.sln
@@ -50,7 +50,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Testing", "src\Dekaf.Testing\Dekaf.Testing.csproj", "{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Tests.Aot", "tests\Dekaf.Tests.Aot\Dekaf.Tests.Aot.csproj", "{297DF785-1A36-4A2A-9335-B71EED7D1D26}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Tests.Aot.DependencyInjection", "tests\Dekaf.Tests.Aot.DependencyInjection\Dekaf.Tests.Aot.DependencyInjection.csproj", "{439DB660-B5F9-4C6B-BB4B-9EB15AE144E8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.StressTests.Tests", "tools\Dekaf.StressTests.Tests\Dekaf.StressTests.Tests.csproj", "{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -314,6 +317,18 @@ Global
 		{439DB660-B5F9-4C6B-BB4B-9EB15AE144E8}.Release|x64.Build.0 = Release|Any CPU
 		{439DB660-B5F9-4C6B-BB4B-9EB15AE144E8}.Release|x86.ActiveCfg = Release|Any CPU
 		{439DB660-B5F9-4C6B-BB4B-9EB15AE144E8}.Release|x86.Build.0 = Release|Any CPU
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Debug|x64.Build.0 = Debug|Any CPU
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Debug|x86.Build.0 = Debug|Any CPU
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Release|x64.ActiveCfg = Release|Any CPU
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Release|x64.Build.0 = Release|Any CPU
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Release|x86.ActiveCfg = Release|Any CPU
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -340,5 +355,6 @@ Global
 		{63412BB7-06F4-4BA8-96C2-4ACC4FE8D57B} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{297DF785-1A36-4A2A-9335-B71EED7D1D26} = {B2C3D4E5-F6A7-8901-BCDE-F12345678901}
 		{439DB660-B5F9-4C6B-BB4B-9EB15AE144E8} = {B2C3D4E5-F6A7-8901-BCDE-F12345678901}
+		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 	EndGlobalSection
 EndGlobal

--- a/tools/Dekaf.Pipeline/Modules/PackModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/PackModule.cs
@@ -11,6 +11,7 @@ namespace Dekaf.Pipeline.Modules;
 public record PackedProject(string Name, string Version);
 
 [DependsOn<BuildModule>]
+[DependsOn<RunStressTestsUnitTestsModule>]
 [DependsOn<RunUnitTestsModule>]
 [DependsOn<GenerateVersionModule>]
 public class PackModule : Module<List<PackedProject>>

--- a/tools/Dekaf.Pipeline/Modules/RunStressTestsUnitTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunStressTestsUnitTestsModule.cs
@@ -1,0 +1,16 @@
+namespace Dekaf.Pipeline.Modules;
+
+public class RunStressTestsUnitTestsModule : TestBaseModule
+{
+    protected override IEnumerable<string> TestableFrameworks
+    {
+        get
+        {
+            // The stress harness targets net10 only, but the unit-test pipeline also has a net8 lane.
+            if (string.Equals(GetTargetFramework(), "net10.0", StringComparison.OrdinalIgnoreCase))
+                yield return "net10.0";
+        }
+    }
+
+    protected override string ProjectFileName => "Dekaf.StressTests.Tests.csproj";
+}

--- a/tools/Dekaf.Pipeline/Program.cs
+++ b/tools/Dekaf.Pipeline/Program.cs
@@ -30,6 +30,7 @@ builder.Services.AddModule<BuildModule>();
 if (!skipUnitTests)
 {
     builder.Services.AddModule<RunUnitTestsModule>();
+    builder.Services.AddModule<RunStressTestsUnitTestsModule>();
     if (!skipAotSmokeTests)
     {
         builder.Services.AddModule<RunAotSmokeTestsModule>();

--- a/tools/Dekaf.StressTests.Tests/Dekaf.StressTests.Tests.csproj
+++ b/tools/Dekaf.StressTests.Tests/Dekaf.StressTests.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <NoWarn>$(NoWarn);CA1707</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dekaf.StressTests\Dekaf.StressTests.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.1" />
+    <PackageReference Include="TUnit" Version="1.58.0" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
+++ b/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
@@ -91,4 +91,50 @@ public class FaultWindowVerifierTests
 
         await Assert.That(plan).Count().IsEqualTo(expectedCount);
     }
+
+    [Test]
+    public async Task DetermineExitCode_AllowsOnlyNamedWindowFailures()
+    {
+        FaultWindowRunResult[] results =
+        [
+            new()
+            {
+                Name = "broker-kill-restart",
+                StartedAtUtc = DateTime.UnixEpoch,
+                Succeeded = false
+            },
+            new()
+            {
+                Name = "leader-election",
+                StartedAtUtc = DateTime.UnixEpoch,
+                Succeeded = false
+            }
+        ];
+
+        var allowedFailures = new HashSet<string>(["leader-election"], StringComparer.OrdinalIgnoreCase);
+
+        var exitCode = FaultInjectionRunner.DetermineExitCode(results, allowedFailures);
+
+        await Assert.That(exitCode).IsEqualTo(1);
+
+        allowedFailures.Add("broker-kill-restart");
+        exitCode = FaultInjectionRunner.DetermineExitCode(results, allowedFailures);
+
+        await Assert.That(exitCode).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Validate_RejectsAllowedFailureOutsideSelectedPlan()
+    {
+        var options = new FaultInjectionOptions
+        {
+            Profile = "broker",
+            BrokerCount = 1,
+            AllowedFailureWindows = new HashSet<string>(["leader-election"], StringComparer.OrdinalIgnoreCase)
+        };
+
+        await Assert.That(options.Validate)
+            .Throws<ArgumentException>()
+            .WithMessageContaining("leader-election");
+    }
 }

--- a/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
+++ b/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
@@ -159,9 +159,33 @@ public class FaultWindowVerifierTests
     {
         var failure = FaultInjectionRunner.ClassifyLiveConsumerFailure(
             recoveryFailure: null,
-            shutdownFailure: new TimeoutException("consumer did not stop"));
+            shutdownFailure: new TimeoutException("consumer did not stop"),
+            consumerExitedBeforeCancellation: false);
 
         await Assert.That(failure).IsEqualTo(LiveConsumerFailureKind.Shutdown);
+    }
+
+    [Test]
+    public async Task ClassifyLiveConsumerFailure_RecoveryTimeoutAndShutdownHang_RemainsHardFailure()
+    {
+        var failure = FaultInjectionRunner.ClassifyLiveConsumerFailure(
+            recoveryFailure: new TimeoutException("consumer did not recover"),
+            shutdownFailure: new TimeoutException("consumer did not stop"),
+            consumerExitedBeforeCancellation: false);
+
+        await Assert.That(failure).IsEqualTo(LiveConsumerFailureKind.Shutdown);
+    }
+
+    [Test]
+    public async Task ClassifyLiveConsumerFailure_ConsumerFaultDuringRecovery_IsRecoveryFailure()
+    {
+        var consumerFailure = new InvalidOperationException("consumer failed");
+        var failure = FaultInjectionRunner.ClassifyLiveConsumerFailure(
+            recoveryFailure: consumerFailure,
+            shutdownFailure: consumerFailure,
+            consumerExitedBeforeCancellation: true);
+
+        await Assert.That(failure).IsEqualTo(LiveConsumerFailureKind.Recovery);
     }
 
     [Test]

--- a/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
+++ b/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
@@ -155,6 +155,47 @@ public class FaultWindowVerifierTests
     }
 
     [Test]
+    public async Task ClassifyLiveConsumerFailure_ShutdownAfterRecovery_RemainsHardFailure()
+    {
+        var failure = FaultInjectionRunner.ClassifyLiveConsumerFailure(
+            recoveryFailure: null,
+            shutdownFailure: new TimeoutException("consumer did not stop"));
+
+        await Assert.That(failure).IsEqualTo(LiveConsumerFailureKind.Shutdown);
+    }
+
+    [Test]
+    public async Task DetermineExitCode_KeepsShutdownFailureHardInAllowedWindow()
+    {
+        FaultWindowRunResult[] results =
+        [
+            new()
+            {
+                Name = "leader-election",
+                StartedAtUtc = DateTime.UnixEpoch,
+                Succeeded = false,
+                LiveConsumerShutdownFailed = true
+            }
+        ];
+
+        var allowedFailures = new HashSet<string>(["leader-election"], StringComparer.OrdinalIgnoreCase);
+
+        var exitCode = FaultInjectionRunner.DetermineExitCode(results, allowedFailures);
+
+        await Assert.That(exitCode).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task GetExpectedBrokerDeliveryCount_SubtractsDeliveryErrors()
+    {
+        var expected = FaultInjectionRunner.GetExpectedBrokerDeliveryCount(
+            acceptedMessages: 10,
+            deliveryErrorCount: 2);
+
+        await Assert.That(expected).IsEqualTo(8);
+    }
+
+    [Test]
     public async Task Validate_RejectsAllowedFailureOutsideSelectedPlan()
     {
         var options = new FaultInjectionOptions

--- a/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
+++ b/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
@@ -1,0 +1,94 @@
+using Dekaf.StressTests.FaultInjection;
+
+namespace Dekaf.StressTests.Tests.FaultInjection;
+
+public class FaultWindowVerifierTests
+{
+    [Test]
+    public async Task Verify_ExactIdempotentDelivery_Passes()
+    {
+        var result = FaultWindowVerifier.Verify(
+            acceptedMessageCount: 4,
+            brokerDeliveredCount: 4,
+            deliveryErrorIds: [],
+            consumedIds: [0, 1, 2, 3],
+            requireZeroDuplicates: true);
+
+        await Assert.That(result.Succeeded).IsTrue();
+        await Assert.That(result.UnexplainedLossCount).IsEqualTo(0);
+        await Assert.That(result.DuplicateCount).IsEqualTo(0);
+        await Assert.That(result.MissingIds).IsEmpty();
+        await Assert.That(result.UnexpectedIds).IsEmpty();
+    }
+
+    [Test]
+    public async Task Verify_RecordedDeliveryError_DoesNotCountAsUnexplainedLoss()
+    {
+        var result = FaultWindowVerifier.Verify(
+            acceptedMessageCount: 4,
+            brokerDeliveredCount: 3,
+            deliveryErrorIds: [2],
+            consumedIds: [0, 1, 3],
+            requireZeroDuplicates: true);
+
+        await Assert.That(result.Succeeded).IsTrue();
+        await Assert.That(result.UnexplainedLossCount).IsEqualTo(0);
+        await Assert.That(result.MissingIds).IsEmpty();
+    }
+
+    [Test]
+    public async Task Verify_UnexplainedMissingMessage_Fails()
+    {
+        var result = FaultWindowVerifier.Verify(
+            acceptedMessageCount: 4,
+            brokerDeliveredCount: 3,
+            deliveryErrorIds: [],
+            consumedIds: [0, 1, 3],
+            requireZeroDuplicates: true);
+
+        await Assert.That(result.Succeeded).IsFalse();
+        await Assert.That(result.UnexplainedLossCount).IsEqualTo(1);
+        await Assert.That(result.MissingIds).IsEquivalentTo([2L]);
+    }
+
+    [Test]
+    public async Task Verify_DuplicateIdempotentRecord_Fails()
+    {
+        var result = FaultWindowVerifier.Verify(
+            acceptedMessageCount: 4,
+            brokerDeliveredCount: 5,
+            deliveryErrorIds: [],
+            consumedIds: [0, 1, 2, 2, 3],
+            requireZeroDuplicates: true);
+
+        await Assert.That(result.Succeeded).IsFalse();
+        await Assert.That(result.DuplicateCount).IsEqualTo(1);
+        await Assert.That(result.DuplicateIds).IsEquivalentTo([2L]);
+    }
+
+    [Test]
+    public async Task Verify_UnexpectedMessageId_Fails()
+    {
+        var result = FaultWindowVerifier.Verify(
+            acceptedMessageCount: 4,
+            brokerDeliveredCount: 5,
+            deliveryErrorIds: [],
+            consumedIds: [0, 1, 2, 3, 99],
+            requireZeroDuplicates: true);
+
+        await Assert.That(result.Succeeded).IsFalse();
+        await Assert.That(result.UnexpectedIds).IsEquivalentTo([99L]);
+    }
+
+    [Test]
+    [Arguments("network", 1, 4)]
+    [Arguments("broker", 1, 1)]
+    [Arguments("broker", 3, 3)]
+    [Arguments("all", 3, 7)]
+    public async Task BuildPlan_SelectsRequiredFaultWindows(string profile, int brokerCount, int expectedCount)
+    {
+        var plan = FaultInjectionPlan.Build(profile, brokerCount);
+
+        await Assert.That(plan).Count().IsEqualTo(expectedCount);
+    }
+}

--- a/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
+++ b/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
@@ -234,6 +234,27 @@ public class FaultWindowVerifierTests
     }
 
     [Test]
+    public async Task CompletePreFaultPhaseAsync_DrainsBeforeSignalingFault()
+    {
+        var flush = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var readyForFault = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var completion = FaultInjectionRunner.CompletePreFaultPhaseAsync(
+            new ValueTask(flush.Task),
+            acceptedMessages: 37,
+            readyForFault,
+            CancellationToken.None);
+
+        await Assert.That(readyForFault.Task.IsCompleted).IsFalse();
+
+        flush.SetResult();
+        var firstFaultMessageId = await completion;
+
+        await Assert.That(firstFaultMessageId).IsEqualTo(37);
+        await Assert.That(readyForFault.Task.IsCompletedSuccessfully).IsTrue();
+    }
+
+    [Test]
     [Arguments(1, false)]
     [Arguments(2, true)]
     [Arguments(4, true)]

--- a/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
+++ b/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
@@ -93,16 +93,31 @@ public class FaultWindowVerifierTests
     }
 
     [Test]
-    public async Task DetermineExitCode_AllowsOnlyNamedWindowFailures()
+    public async Task DetermineExitCode_AllowsNamedLiveConsumerRecoveryFailure()
     {
         FaultWindowRunResult[] results =
         [
             new()
             {
-                Name = "broker-kill-restart",
+                Name = "leader-election",
                 StartedAtUtc = DateTime.UnixEpoch,
-                Succeeded = false
-            },
+                Succeeded = false,
+                LiveConsumerRecoveryFailed = true
+            }
+        ];
+
+        var allowedFailures = new HashSet<string>(["leader-election"], StringComparer.OrdinalIgnoreCase);
+
+        var exitCode = FaultInjectionRunner.DetermineExitCode(results, allowedFailures);
+
+        await Assert.That(exitCode).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DetermineExitCode_KeepsOtherFailuresHardInAllowedWindow()
+    {
+        FaultWindowRunResult[] results =
+        [
             new()
             {
                 Name = "leader-election",
@@ -116,11 +131,27 @@ public class FaultWindowVerifierTests
         var exitCode = FaultInjectionRunner.DetermineExitCode(results, allowedFailures);
 
         await Assert.That(exitCode).IsEqualTo(1);
+    }
 
-        allowedFailures.Add("broker-kill-restart");
-        exitCode = FaultInjectionRunner.DetermineExitCode(results, allowedFailures);
+    [Test]
+    public async Task DetermineExitCode_KeepsLiveConsumerRecoveryFailureHardOutsideAllowedWindow()
+    {
+        FaultWindowRunResult[] results =
+        [
+            new()
+            {
+                Name = "broker-kill-restart",
+                StartedAtUtc = DateTime.UnixEpoch,
+                Succeeded = false,
+                LiveConsumerRecoveryFailed = true
+            }
+        ];
 
-        await Assert.That(exitCode).IsEqualTo(0);
+        var allowedFailures = new HashSet<string>(["leader-election"], StringComparer.OrdinalIgnoreCase);
+
+        var exitCode = FaultInjectionRunner.DetermineExitCode(results, allowedFailures);
+
+        await Assert.That(exitCode).IsEqualTo(1);
     }
 
     [Test]

--- a/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
+++ b/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
@@ -220,6 +220,21 @@ public class FaultWindowVerifierTests
     }
 
     [Test]
+    [Arguments(1, false)]
+    [Arguments(2, true)]
+    [Arguments(4, true)]
+    [Arguments(5, false)]
+    public async Task IsFaultWindowDeliveryError_OnlyMatchesActiveRange(long messageId, bool expected)
+    {
+        var actual = FaultInjectionRunner.IsFaultWindowDeliveryError(
+            messageId,
+            firstFaultMessageId: 2,
+            firstPostHealMessageId: 5);
+
+        await Assert.That(actual).IsEqualTo(expected);
+    }
+
+    [Test]
     public async Task Validate_RejectsAllowedFailureOutsideSelectedPlan()
     {
         var options = new FaultInjectionOptions

--- a/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
+++ b/tools/Dekaf.StressTests.Tests/FaultInjection/FaultWindowVerifierTests.cs
@@ -220,6 +220,20 @@ public class FaultWindowVerifierTests
     }
 
     [Test]
+    public async Task AwaitProducerDisposalAsync_IncompleteDispose_ThrowsTimeout()
+    {
+        var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var action = () => FaultInjectionRunner.AwaitProducerDisposalAsync(
+            new ValueTask(pending.Task),
+            TimeSpan.Zero);
+
+        await Assert.That(action)
+            .Throws<TimeoutException>()
+            .WithMessageContaining("Producer disposal did not complete");
+    }
+
+    [Test]
     [Arguments(1, false)]
     [Arguments(2, true)]
     [Arguments(4, true)]

--- a/tools/Dekaf.StressTests.Tests/ProgramTests.cs
+++ b/tools/Dekaf.StressTests.Tests/ProgramTests.cs
@@ -1,0 +1,22 @@
+namespace Dekaf.StressTests.Tests;
+
+public class ProgramTests
+{
+    [Test]
+    public async Task EscalateUnobservedTaskExceptions_SuccessfulRunFails()
+    {
+        Exception[] exceptions = [new InvalidOperationException("escaped background failure")];
+
+        var exitCode = Program.EscalateUnobservedTaskExceptions(0, exceptions);
+
+        await Assert.That(exitCode).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task EscalateUnobservedTaskExceptions_NoExceptionsPreservesExitCode()
+    {
+        var exitCode = Program.EscalateUnobservedTaskExceptions(7, []);
+
+        await Assert.That(exitCode).IsEqualTo(7);
+    }
+}

--- a/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
+++ b/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Dekaf.Tests.Unit" />
+    <InternalsVisibleTo Include="Dekaf.StressTests.Tests" />
   </ItemGroup>
 
   <ItemGroup>
@@ -26,6 +27,8 @@
     <PackageReference Include="Confluent.Kafka" Version="2.15.0" />
     <PackageReference Include="Testcontainers" Version="4.13.0" />
     <PackageReference Include="Testcontainers.Kafka" Version="4.13.0" />
+    <PackageReference Include="Testcontainers.Toxiproxy" Version="4.13.0" />
+    <PackageReference Include="ToxiproxyNetCore" Version="1.0.50" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
@@ -1,0 +1,588 @@
+using Confluent.Kafka;
+using Dekaf.Admin;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using Testcontainers.Toxiproxy;
+using Toxiproxy.Net;
+using Toxiproxy.Net.Toxics;
+using ConfluentAdminClientBuilder = Confluent.Kafka.AdminClientBuilder;
+using ConfluentAdminClient = Confluent.Kafka.IAdminClient;
+using ConfluentKafkaException = Confluent.Kafka.KafkaException;
+
+namespace Dekaf.StressTests.FaultInjection;
+
+internal sealed class FaultInjectionKafkaEnvironment : IAsyncDisposable
+{
+    private const ushort InternalBrokerPort = 9092;
+    private const ushort ControllerPort = 9093;
+    private const ushort ExternalBrokerPort = 29092;
+    private const string KafkaImage = "apache/kafka:4.1.0";
+    private const string ToxiproxyImage = "ghcr.io/shopify/toxiproxy:2.12.0";
+    private const string ClusterId = "MkU3OEVBNTcwNTJENDM2Qg";
+
+    private readonly INetwork _network;
+    private readonly ToxiproxyContainer _toxiproxyContainer;
+    private readonly Connection _toxiproxyConnection;
+    private readonly Client _toxiproxyClient;
+    private readonly IReadOnlyList<Proxy> _proxies;
+    private readonly IReadOnlyList<IContainer> _brokers;
+    private readonly DockerClient _dockerClient;
+    private bool _disposed;
+
+    private FaultInjectionKafkaEnvironment(
+        int brokerCount,
+        string bootstrapServers,
+        INetwork network,
+        ToxiproxyContainer toxiproxyContainer,
+        Connection toxiproxyConnection,
+        Client toxiproxyClient,
+        IReadOnlyList<Proxy> proxies,
+        IReadOnlyList<IContainer> brokers,
+        DockerClient dockerClient)
+    {
+        BrokerCount = brokerCount;
+        BootstrapServers = bootstrapServers;
+        _network = network;
+        _toxiproxyContainer = toxiproxyContainer;
+        _toxiproxyConnection = toxiproxyConnection;
+        _toxiproxyClient = toxiproxyClient;
+        _proxies = proxies;
+        _brokers = brokers;
+        _dockerClient = dockerClient;
+    }
+
+    internal int BrokerCount { get; }
+
+    internal string BootstrapServers { get; }
+
+    internal static async Task<FaultInjectionKafkaEnvironment> CreateAsync(
+        int brokerCount,
+        CancellationToken cancellationToken)
+    {
+        if (brokerCount is not 1 and not 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(brokerCount), brokerCount,
+                "Fault injection supports one or three brokers.");
+        }
+
+        var network = new NetworkBuilder()
+            .WithName($"kafka-fault-{Guid.NewGuid():N}")
+            .Build();
+        await network.CreateAsync(cancellationToken).ConfigureAwait(false);
+
+        ToxiproxyContainer? toxiproxyContainer = null;
+        Connection? toxiproxyConnection = null;
+        DockerClient? dockerClient = null;
+        var brokers = new List<IContainer>(brokerCount);
+
+        try
+        {
+            toxiproxyContainer = new ToxiproxyBuilder(ToxiproxyImage)
+                .WithNetwork(network)
+                .Build();
+            await toxiproxyContainer.StartAsync(cancellationToken).ConfigureAwait(false);
+
+            toxiproxyConnection = new Connection(
+                toxiproxyContainer.Hostname,
+                toxiproxyContainer.GetMappedPublicPort(ToxiproxyBuilder.ToxiproxyControlPort));
+            var toxiproxyClient = toxiproxyConnection.Client();
+            var proxies = new List<Proxy>(brokerCount);
+            var bootstrapEndpoints = new List<string>(brokerCount);
+
+            for (var nodeId = 1; nodeId <= brokerCount; nodeId++)
+            {
+                var proxyPort = checked((ushort)(ToxiproxyBuilder.FirstProxiedPort + nodeId - 1));
+                var proxy = await toxiproxyClient.AddAsync(new Proxy
+                {
+                    Name = $"kafka-{nodeId}",
+                    Enabled = true,
+                    Listen = $"0.0.0.0:{proxyPort}",
+                    Upstream = $"kafka-{nodeId}:{ExternalBrokerPort}"
+                }).WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                proxies.Add(proxy);
+                bootstrapEndpoints.Add(
+                    $"{toxiproxyContainer.Hostname}:{toxiproxyContainer.GetMappedPublicPort(proxyPort)}");
+            }
+
+            var advertisedHost = toxiproxyContainer.Hostname;
+            var quorumVoters = string.Join(",",
+                Enumerable.Range(1, brokerCount).Select(nodeId => $"{nodeId}@kafka-{nodeId}:{ControllerPort}"));
+            var replicationFactor = Math.Min(3, brokerCount);
+            var minInSyncReplicas = brokerCount == 1 ? 1 : 2;
+
+            for (var nodeId = 1; nodeId <= brokerCount; nodeId++)
+            {
+                var hostname = $"kafka-{nodeId}";
+                var proxyPort = checked((ushort)(ToxiproxyBuilder.FirstProxiedPort + nodeId - 1));
+                var mappedProxyPort = toxiproxyContainer.GetMappedPublicPort(proxyPort);
+
+                var broker = new ContainerBuilder(KafkaImage)
+                    .WithName($"{hostname}-fault-{Guid.NewGuid():N}")
+                    .WithHostname(hostname)
+                    .WithNetwork(network)
+                    .WithNetworkAliases(hostname)
+                    .WithEnvironment("KAFKA_NODE_ID", nodeId.ToString())
+                    .WithEnvironment("KAFKA_PROCESS_ROLES", "broker,controller")
+                    .WithEnvironment("KAFKA_CONTROLLER_QUORUM_VOTERS", quorumVoters)
+                    .WithEnvironment("CLUSTER_ID", ClusterId)
+                    .WithEnvironment("KAFKA_LISTENERS",
+                        $"INTERNAL://0.0.0.0:{InternalBrokerPort},CONTROLLER://0.0.0.0:{ControllerPort},EXTERNAL://0.0.0.0:{ExternalBrokerPort}")
+                    .WithEnvironment("KAFKA_ADVERTISED_LISTENERS",
+                        $"INTERNAL://{hostname}:{InternalBrokerPort},EXTERNAL://{advertisedHost}:{mappedProxyPort}")
+                    .WithEnvironment("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+                        "INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT")
+                    .WithEnvironment("KAFKA_INTER_BROKER_LISTENER_NAME", "INTERNAL")
+                    .WithEnvironment("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER")
+                    .WithEnvironment("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", replicationFactor.ToString())
+                    .WithEnvironment("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", replicationFactor.ToString())
+                    .WithEnvironment("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", minInSyncReplicas.ToString())
+                    .WithEnvironment("KAFKA_DEFAULT_REPLICATION_FACTOR", replicationFactor.ToString())
+                    .WithEnvironment("KAFKA_MIN_INSYNC_REPLICAS", minInSyncReplicas.ToString())
+                    .WithEnvironment("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
+                    .WithEnvironment("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
+                    .Build();
+
+                brokers.Add(broker);
+            }
+
+            await Task.WhenAll(brokers.Select(broker => broker.StartAsync(cancellationToken)))
+                .ConfigureAwait(false);
+
+            var bootstrapServers = string.Join(",", bootstrapEndpoints);
+            await WaitForClusterAsync(bootstrapServers, brokerCount, TimeSpan.FromMinutes(2), cancellationToken)
+                .ConfigureAwait(false);
+
+            dockerClient = new DockerClientBuilder().Build();
+            Console.WriteLine($"Fault-injection Kafka cluster ready: {bootstrapServers}");
+            return new FaultInjectionKafkaEnvironment(
+                brokerCount,
+                bootstrapServers,
+                network,
+                toxiproxyContainer,
+                toxiproxyConnection,
+                toxiproxyClient,
+                proxies,
+                brokers,
+                dockerClient);
+        }
+        catch
+        {
+            dockerClient?.Dispose();
+            toxiproxyConnection?.Dispose();
+            foreach (var broker in brokers)
+            {
+                try { await broker.DisposeAsync().ConfigureAwait(false); } catch { }
+            }
+
+            if (toxiproxyContainer is not null)
+            {
+                try { await toxiproxyContainer.DisposeAsync().ConfigureAwait(false); } catch { }
+            }
+
+            await network.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    internal async Task CreateTopicAsync(string topic, int partitionCount, CancellationToken cancellationToken)
+    {
+        var replicationFactor = (short)Math.Min(3, BrokerCount);
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(BootstrapServers)
+            .WithClientId("fault-injection-admin")
+            .Build();
+
+        await admin.CreateTopicsAsync(
+        [
+            new NewTopic
+            {
+                Name = topic,
+                NumPartitions = partitionCount,
+                ReplicationFactor = replicationFactor,
+                Configs = new Dictionary<string, string>
+                {
+                    ["min.insync.replicas"] = BrokerCount == 1 ? "1" : "2",
+                    ["retention.ms"] = "-1",
+                    ["retention.bytes"] = "-1"
+                }
+            }
+        ], cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await WaitForTopicHealthyAsync(topic, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal async Task ExecuteNetworkFaultAsync(
+        FaultWindowKind kind,
+        TimeSpan duration,
+        Action faultActivated,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(faultActivated);
+        try
+        {
+            switch (kind)
+            {
+                case FaultWindowKind.ConnectionReset:
+                    await AddToEveryProxyAsync(static () => new ResetPeerToxic
+                    {
+                        Name = "reset-upstream",
+                        Stream = ToxicDirection.UpStream,
+                        Toxicity = 1,
+                        Attributes = { Timeout = 0 }
+                    }, cancellationToken).ConfigureAwait(false);
+                    await AddToEveryProxyAsync(static () => new ResetPeerToxic
+                    {
+                        Name = "reset-downstream",
+                        Stream = ToxicDirection.DownStream,
+                        Toxicity = 1,
+                        Attributes = { Timeout = 0 }
+                    }, cancellationToken).ConfigureAwait(false);
+                    faultActivated();
+                    await Task.Delay(duration, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case FaultWindowKind.HalfOpen:
+                    await AddToEveryProxyAsync(static () => new TimeoutToxic
+                    {
+                        Name = "half-open-upstream",
+                        Stream = ToxicDirection.UpStream,
+                        Toxicity = 1,
+                        Attributes = { Timeout = 0 }
+                    }, cancellationToken).ConfigureAwait(false);
+                    faultActivated();
+                    await Task.Delay(duration, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case FaultWindowKind.SlowClose:
+                    await AddToEveryProxyAsync(() => new SlowCloseToxic
+                    {
+                        Name = "slow-close-downstream",
+                        Stream = ToxicDirection.DownStream,
+                        Toxicity = 1,
+                        Attributes = { Delay = checked((int)duration.TotalMilliseconds) }
+                    }, cancellationToken).ConfigureAwait(false);
+                    await SetAllProxiesEnabledAsync(false, cancellationToken).ConfigureAwait(false);
+                    faultActivated();
+                    await Task.Delay(duration, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case FaultWindowKind.LatencyAndBandwidth:
+                    foreach (var direction in new[] { ToxicDirection.UpStream, ToxicDirection.DownStream })
+                    {
+                        var suffix = direction == ToxicDirection.UpStream ? "upstream" : "downstream";
+                        await AddToEveryProxyAsync(() => new LatencyToxic
+                        {
+                            Name = $"latency-{suffix}",
+                            Stream = direction,
+                            Toxicity = 1,
+                            Attributes = { Latency = 300, Jitter = 100 }
+                        }, cancellationToken).ConfigureAwait(false);
+                        await AddToEveryProxyAsync(() => new BandwidthToxic
+                        {
+                            Name = $"bandwidth-{suffix}",
+                            Stream = direction,
+                            Toxicity = 1,
+                            Attributes = { Rate = 128 }
+                        }, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    faultActivated();
+                    await Task.Delay(duration, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(kind), kind, "Not a network fault.");
+            }
+        }
+        finally
+        {
+            await ResetProxiesAsync().ConfigureAwait(false);
+        }
+    }
+
+    internal async Task KillAndRestartBrokerAsync(
+        int nodeId,
+        string topic,
+        TimeSpan downtime,
+        Action faultActivated,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(faultActivated);
+        var broker = GetBroker(nodeId);
+        Console.WriteLine($"  SIGKILL broker {nodeId}");
+        await _dockerClient.Containers.KillContainerAsync(
+            broker.Id,
+            new ContainerKillParameters { Signal = "SIGKILL" },
+            cancellationToken).ConfigureAwait(false);
+        faultActivated();
+        try
+        {
+            await Task.Delay(downtime, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            Console.WriteLine($"  Restart broker {nodeId}");
+            await RestoreBrokerAsync(broker, topic).ConfigureAwait(false);
+        }
+    }
+
+    internal async Task ForceLeaderElectionAsync(
+        string topic,
+        TimeSpan downtime,
+        Action faultActivated,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(faultActivated);
+        if (BrokerCount < 3)
+        {
+            throw new InvalidOperationException("Leader-election fault requires three brokers.");
+        }
+
+        var previousLeader = GetLeaderNodeId(topic, partition: 0);
+        var broker = GetBroker(previousLeader);
+        Console.WriteLine($"  Controlled stop of partition-0 leader broker {previousLeader}");
+        await broker.StopAsync(cancellationToken).ConfigureAwait(false);
+        faultActivated();
+        try
+        {
+            await WaitForLeaderChangeAsync(topic, previousLeader, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(downtime, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            Console.WriteLine($"  Restart former leader broker {previousLeader}");
+            await RestoreBrokerAsync(broker, topic).ConfigureAwait(false);
+        }
+    }
+
+    internal async Task RollingRestartAsync(
+        string topic,
+        TimeSpan downtime,
+        Action faultActivated,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(faultActivated);
+        if (BrokerCount < 3)
+        {
+            throw new InvalidOperationException("Rolling restart requires three brokers.");
+        }
+
+        var activated = false;
+        for (var nodeId = 1; nodeId <= BrokerCount; nodeId++)
+        {
+            var broker = GetBroker(nodeId);
+            Console.WriteLine($"  Rolling stop broker {nodeId}");
+            await broker.StopAsync(cancellationToken).ConfigureAwait(false);
+            if (!activated)
+            {
+                activated = true;
+                faultActivated();
+            }
+
+            try
+            {
+                await Task.Delay(downtime, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                Console.WriteLine($"  Rolling start broker {nodeId}");
+                await RestoreBrokerAsync(broker, topic).ConfigureAwait(false);
+            }
+        }
+    }
+
+    internal async Task WaitForTopicHealthyAsync(string topic, CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(2);
+        Exception? lastError = null;
+        using var admin = CreateMetadataClient(BootstrapServers);
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var metadata = admin.GetMetadata(topic, TimeSpan.FromSeconds(5));
+                var topicMetadata = metadata.Topics.SingleOrDefault(candidate => candidate.Topic == topic);
+                if (topicMetadata is not null
+                    && !topicMetadata.Error.IsError
+                    && topicMetadata.Partitions.Count > 0
+                    && topicMetadata.Partitions.All(partition =>
+                        !partition.Error.IsError
+                        && partition.Leader > 0
+                        && partition.InSyncReplicas.Length == Math.Min(3, BrokerCount)))
+                {
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+            }
+
+            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException($"Topic {topic} did not become fully in-sync.", lastError);
+    }
+
+    private async Task AddToEveryProxyAsync<T>(Func<T> toxicFactory, CancellationToken cancellationToken)
+        where T : ToxicBase
+    {
+        foreach (var proxy in _proxies)
+        {
+            await proxy.AddAsync(toxicFactory()).WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task SetAllProxiesEnabledAsync(bool enabled, CancellationToken cancellationToken)
+    {
+        foreach (var proxy in _proxies)
+        {
+            proxy.Enabled = enabled;
+            await proxy.UpdateAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ResetProxiesAsync()
+    {
+        await _toxiproxyClient.ResetAsync().ConfigureAwait(false);
+        foreach (var proxy in _proxies)
+        {
+            proxy.Enabled = true;
+        }
+    }
+
+    private async Task RestoreBrokerAsync(IContainer broker, string topic)
+    {
+        await broker.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        await WaitForTopicHealthyAsync(topic, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private IContainer GetBroker(int nodeId)
+    {
+        if (nodeId < 1 || nodeId > _brokers.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(nodeId), nodeId, "Unknown broker node ID.");
+        }
+
+        return _brokers[nodeId - 1];
+    }
+
+    private int GetLeaderNodeId(string topic, int partition)
+    {
+        using var admin = CreateMetadataClient(BootstrapServers);
+        return GetLeaderNodeId(admin, topic, partition);
+    }
+
+    private static int GetLeaderNodeId(ConfluentAdminClient admin, string topic, int partition)
+    {
+        var metadata = admin.GetMetadata(topic, TimeSpan.FromSeconds(10));
+        var topicMetadata = metadata.Topics.Single(candidate => candidate.Topic == topic);
+        return topicMetadata.Partitions.Single(candidate => candidate.PartitionId == partition).Leader;
+    }
+
+    private async Task WaitForLeaderChangeAsync(
+        string topic,
+        int previousLeader,
+        CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(1);
+        using var admin = CreateMetadataClient(BootstrapServers);
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var leader = GetLeaderNodeId(admin, topic, partition: 0);
+                if (leader > 0 && leader != previousLeader)
+                {
+                    Console.WriteLine($"  Partition-0 leader moved {previousLeader} -> {leader}");
+                    return;
+                }
+            }
+            catch (ConfluentKafkaException)
+            {
+            }
+
+            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException($"Partition-0 leader did not move away from broker {previousLeader}.");
+    }
+
+    private static async Task WaitForClusterAsync(
+        string bootstrapServers,
+        int expectedBrokerCount,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        Exception? lastError = null;
+        using var admin = CreateMetadataClient(bootstrapServers);
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var metadata = admin.GetMetadata(TimeSpan.FromSeconds(5));
+                if (metadata.Brokers.Count >= expectedBrokerCount)
+                {
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+            }
+
+            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException(
+            $"Kafka cluster did not expose {expectedBrokerCount} brokers through Toxiproxy.",
+            lastError);
+    }
+
+    private static ConfluentAdminClient CreateMetadataClient(string bootstrapServers) =>
+        new ConfluentAdminClientBuilder(new AdminClientConfig
+        {
+            BootstrapServers = bootstrapServers,
+            SocketTimeoutMs = 5_000
+        }).Build();
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        var errors = new List<Exception>();
+        try { await ResetProxiesAsync().ConfigureAwait(false); }
+        catch (Exception ex) { errors.Add(ex); }
+        foreach (var broker in _brokers)
+        {
+            try { await broker.DisposeAsync().ConfigureAwait(false); }
+            catch (Exception ex) { errors.Add(ex); }
+        }
+
+        try { _dockerClient.Dispose(); }
+        catch (Exception ex) { errors.Add(ex); }
+        try { _toxiproxyConnection.Dispose(); }
+        catch (Exception ex) { errors.Add(ex); }
+        try { await _toxiproxyContainer.DisposeAsync().ConfigureAwait(false); }
+        catch (Exception ex) { errors.Add(ex); }
+        try { await _network.DisposeAsync().ConfigureAwait(false); }
+        catch (Exception ex) { errors.Add(ex); }
+
+        if (errors.Count > 0)
+        {
+            throw new AggregateException("Fault-injection environment cleanup failed.", errors);
+        }
+    }
+}

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionOptions.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionOptions.cs
@@ -1,0 +1,26 @@
+namespace Dekaf.StressTests.FaultInjection;
+
+internal sealed class FaultInjectionOptions
+{
+    internal string Profile { get; init; } = "all";
+    internal int BrokerCount { get; init; } = 1;
+    internal int PartitionCount { get; init; } = 6;
+    internal int MessageSizeBytes { get; init; } = 1_000;
+    internal TimeSpan FaultDuration { get; init; } = TimeSpan.FromSeconds(5);
+    internal int MessagesBeforeFault { get; init; } = 2_000;
+    internal int MaxMessagesDuringFault { get; init; } = 20_000;
+    internal int MessagesAfterFault { get; init; } = 2_000;
+    internal string OutputPath { get; init; } = "./results";
+
+    internal void Validate()
+    {
+        _ = FaultInjectionPlan.Build(Profile, BrokerCount);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(PartitionCount);
+        ArgumentOutOfRangeException.ThrowIfLessThan(MessageSizeBytes, 32);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(FaultDuration, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(MessagesBeforeFault);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(MaxMessagesDuringFault);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(MessagesAfterFault);
+        ArgumentException.ThrowIfNullOrWhiteSpace(OutputPath);
+    }
+}

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionOptions.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionOptions.cs
@@ -11,10 +11,12 @@ internal sealed class FaultInjectionOptions
     internal int MaxMessagesDuringFault { get; init; } = 20_000;
     internal int MessagesAfterFault { get; init; } = 2_000;
     internal string OutputPath { get; init; } = "./results";
+    internal IReadOnlySet<string> AllowedFailureWindows { get; init; } =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     internal void Validate()
     {
-        _ = FaultInjectionPlan.Build(Profile, BrokerCount);
+        var plan = FaultInjectionPlan.Build(Profile, BrokerCount);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(PartitionCount);
         ArgumentOutOfRangeException.ThrowIfLessThan(MessageSizeBytes, 32);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(FaultDuration, TimeSpan.Zero);
@@ -22,5 +24,15 @@ internal sealed class FaultInjectionOptions
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(MaxMessagesDuringFault);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(MessagesAfterFault);
         ArgumentException.ThrowIfNullOrWhiteSpace(OutputPath);
+
+        foreach (var allowedFailure in AllowedFailureWindows)
+        {
+            if (!plan.Any(window => window.Name.Equals(allowedFailure, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new ArgumentException(
+                    $"Allowed failure window '{allowedFailure}' is not part of the selected fault plan.",
+                    nameof(AllowedFailureWindows));
+            }
+        }
     }
 }

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionPlan.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionPlan.cs
@@ -1,0 +1,62 @@
+namespace Dekaf.StressTests.FaultInjection;
+
+internal enum FaultWindowKind
+{
+    ConnectionReset,
+    HalfOpen,
+    SlowClose,
+    LatencyAndBandwidth,
+    BrokerKillAndRestart,
+    LeaderElection,
+    RollingRestart
+}
+
+internal sealed record FaultWindowDefinition(string Name, FaultWindowKind Kind);
+
+internal static class FaultInjectionPlan
+{
+    private static readonly FaultWindowDefinition[] NetworkFaults =
+    [
+        new("connection-reset", FaultWindowKind.ConnectionReset),
+        new("half-open", FaultWindowKind.HalfOpen),
+        new("slow-close", FaultWindowKind.SlowClose),
+        new("latency-bandwidth", FaultWindowKind.LatencyAndBandwidth)
+    ];
+
+    internal static IReadOnlyList<FaultWindowDefinition> Build(string profile, int brokerCount)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(profile);
+        if (brokerCount is not 1 and not 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(brokerCount), brokerCount,
+                "Fault injection supports one or three brokers.");
+        }
+
+        var includeNetwork = profile.Equals("network", StringComparison.OrdinalIgnoreCase)
+            || profile.Equals("all", StringComparison.OrdinalIgnoreCase);
+        var includeBroker = profile.Equals("broker", StringComparison.OrdinalIgnoreCase)
+            || profile.Equals("all", StringComparison.OrdinalIgnoreCase);
+        if (!includeNetwork && !includeBroker)
+        {
+            throw new ArgumentException("Fault profile must be network, broker, or all.", nameof(profile));
+        }
+
+        var plan = new List<FaultWindowDefinition>(7);
+        if (includeNetwork)
+        {
+            plan.AddRange(NetworkFaults);
+        }
+
+        if (includeBroker)
+        {
+            plan.Add(new FaultWindowDefinition("broker-kill-restart", FaultWindowKind.BrokerKillAndRestart));
+            if (brokerCount == 3)
+            {
+                plan.Add(new FaultWindowDefinition("leader-election", FaultWindowKind.LeaderElection));
+                plan.Add(new FaultWindowDefinition("rolling-restart", FaultWindowKind.RollingRestart));
+            }
+        }
+
+        return plan;
+    }
+}

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionReport.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionReport.cs
@@ -45,6 +45,7 @@ internal sealed class FaultWindowRunResult
     public long BrokerDeliveredMessages { get; set; }
     public long OracleConsumedMessages { get; set; }
     public long LiveConsumerMessages { get; set; }
+    public bool LiveConsumerRecoveryFailed { get; set; }
     public long UnexplainedLoss { get; set; }
     public long Duplicates { get; set; }
     public long OracleCountMismatch { get; set; }

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionReport.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionReport.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+
+namespace Dekaf.StressTests.FaultInjection;
+
+internal sealed class FaultInjectionReport
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    public required DateTime StartedAtUtc { get; init; }
+    public DateTime CompletedAtUtc { get; set; }
+    public required string MachineName { get; init; }
+    public required string Profile { get; init; }
+    public required int BrokerCount { get; init; }
+    public required int PartitionCount { get; init; }
+    public required int MessageSizeBytes { get; init; }
+    public required int FaultDurationSeconds { get; init; }
+    public List<FaultWindowRunResult> Windows { get; } = [];
+
+    internal async Task SaveAsync(string path, CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, this, SerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}
+
+internal sealed class FaultWindowRunResult
+{
+    public required string Name { get; init; }
+    public required DateTime StartedAtUtc { get; init; }
+    public DateTime CompletedAtUtc { get; set; }
+    public bool Succeeded { get; set; }
+    public long AcceptedMessages { get; set; }
+    public long DeliveryErrors { get; set; }
+    public long DeliveryCallbacks { get; set; }
+    public long BrokerDeliveredMessages { get; set; }
+    public long OracleConsumedMessages { get; set; }
+    public long LiveConsumerMessages { get; set; }
+    public long UnexplainedLoss { get; set; }
+    public long Duplicates { get; set; }
+    public long OracleCountMismatch { get; set; }
+    public IReadOnlyList<long> MissingIds { get; set; } = [];
+    public IReadOnlyList<long> DuplicateIds { get; set; } = [];
+    public IReadOnlyList<long> UnexpectedIds { get; set; } = [];
+    public IReadOnlyList<DeliveryErrorSample> DeliveryErrorSamples { get; set; } = [];
+    public string? Failure { get; set; }
+}
+
+internal sealed record DeliveryErrorSample(long MessageId, string Error);

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionReport.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionReport.cs
@@ -46,6 +46,7 @@ internal sealed class FaultWindowRunResult
     public long OracleConsumedMessages { get; set; }
     public long LiveConsumerMessages { get; set; }
     public bool LiveConsumerRecoveryFailed { get; set; }
+    public bool LiveConsumerShutdownFailed { get; set; }
     public long UnexplainedLoss { get; set; }
     public long Duplicates { get; set; }
     public long OracleCountMismatch { get; set; }
@@ -57,3 +58,10 @@ internal sealed class FaultWindowRunResult
 }
 
 internal sealed record DeliveryErrorSample(long MessageId, string Error);
+
+internal enum LiveConsumerFailureKind
+{
+    None,
+    Recovery,
+    Shutdown
+}

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
@@ -1,0 +1,570 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.StressTests.Scenarios;
+using ConfluentConsumerConfig = Confluent.Kafka.ConsumerConfig;
+
+namespace Dekaf.StressTests.FaultInjection;
+
+internal static class FaultInjectionRunner
+{
+    private static readonly TimeSpan OperationTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan RecoveryTimeout = TimeSpan.FromMinutes(1);
+
+    internal static async Task<int> RunAsync(
+        FaultInjectionOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        options.Validate();
+
+        var plan = FaultInjectionPlan.Build(options.Profile, options.BrokerCount);
+        var startedAt = DateTime.UtcNow;
+        var report = new FaultInjectionReport
+        {
+            StartedAtUtc = startedAt,
+            MachineName = Environment.MachineName,
+            Profile = options.Profile,
+            BrokerCount = options.BrokerCount,
+            PartitionCount = options.PartitionCount,
+            MessageSizeBytes = options.MessageSizeBytes,
+            FaultDurationSeconds = checked((int)options.FaultDuration.TotalSeconds)
+        };
+        var reportPath = Path.Combine(
+            options.OutputPath,
+            $"fault-injection-{options.Profile}-{options.BrokerCount}brokers-{startedAt:yyyyMMdd-HHmmss}.json");
+
+        Console.WriteLine("Dekaf fault-injection stress suite");
+        Console.WriteLine($"Profile: {options.Profile}; brokers: {options.BrokerCount}; windows: {plan.Count}");
+        Console.WriteLine($"Fault duration: {options.FaultDuration.TotalSeconds:N0}s");
+        Console.WriteLine($"Messages: {options.MessagesBeforeFault:N0} before, up to " +
+            $"{options.MaxMessagesDuringFault:N0} during, {options.MessagesAfterFault:N0} after");
+
+        await using var environment = await FaultInjectionKafkaEnvironment
+            .CreateAsync(options.BrokerCount, cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (var definition in plan)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Console.WriteLine();
+            Console.WriteLine($"=== Fault window: {definition.Name} ===");
+            var result = new FaultWindowRunResult
+            {
+                Name = definition.Name,
+                StartedAtUtc = DateTime.UtcNow
+            };
+
+            try
+            {
+                await RunWindowAsync(environment, definition, options, result, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                result.Succeeded = false;
+                result.Failure = ex.ToString();
+                Console.WriteLine($"  FAILED: {ex}");
+            }
+            finally
+            {
+                result.CompletedAtUtc = DateTime.UtcNow;
+                report.Windows.Add(result);
+                report.CompletedAtUtc = result.CompletedAtUtc;
+                await report.SaveAsync(reportPath, CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+
+        report.CompletedAtUtc = DateTime.UtcNow;
+        await report.SaveAsync(reportPath, CancellationToken.None).ConfigureAwait(false);
+        var failed = report.Windows.Where(window => !window.Succeeded).ToArray();
+        Console.WriteLine();
+        Console.WriteLine($"Fault report: {reportPath}");
+        Console.WriteLine($"Windows: {report.Windows.Count - failed.Length} passed, {failed.Length} failed");
+        foreach (var window in failed)
+        {
+            Console.WriteLine($"  - {window.Name}: {FirstLine(window.Failure)}");
+        }
+
+        return failed.Length == 0 ? 0 : 1;
+    }
+
+    private static async Task RunWindowAsync(
+        FaultInjectionKafkaEnvironment environment,
+        FaultWindowDefinition definition,
+        FaultInjectionOptions options,
+        FaultWindowRunResult result,
+        CancellationToken cancellationToken)
+    {
+        var topic = $"fault-{definition.Name}-{Guid.NewGuid():N}";
+        await environment.CreateTopicAsync(topic, options.PartitionCount, cancellationToken)
+            .ConfigureAwait(false);
+
+        using var windowCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        windowCts.CancelAfter(OperationTimeout);
+        using var liveConsumerCts = CancellationTokenSource.CreateLinkedTokenSource(windowCts.Token);
+        var liveState = new LiveConsumerState();
+        var liveConsumerTask = RunLiveConsumerAsync(
+            environment.BootstrapServers,
+            topic,
+            liveState,
+            liveConsumerCts.Token);
+
+        IKafkaProducer<string, string>? producer = null;
+        try
+        {
+            producer = await Kafka.CreateProducer<string, string>()
+                .WithBootstrapServers(environment.BootstrapServers)
+                .WithClientId($"fault-producer-{definition.Name}")
+                .WithIdempotence(true)
+                .WithAcks(Dekaf.Producer.Acks.All)
+                .WithLinger(TimeSpan.FromMilliseconds(20))
+                .WithBatchSize(1024 * 1024)
+                .WithBufferMemory(64UL * 1024 * 1024)
+                .WithMaxBlock(TimeSpan.FromMinutes(2))
+                .WithRequestTimeout(TimeSpan.FromSeconds(10))
+                .WithDeliveryTimeout(TimeSpan.FromMinutes(2))
+                .BuildAsync(windowCts.Token)
+                .ConfigureAwait(false);
+
+            var readyForFault = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var faultActive = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var faultHealed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var deliveryErrors = new ConcurrentDictionary<long, string>();
+            var callbackCount = 0L;
+
+            var produceTask = RunProducerLoadAsync(
+                producer,
+                topic,
+                options,
+                readyForFault,
+                faultActive,
+                faultHealed,
+                deliveryErrors,
+                () => Interlocked.Increment(ref callbackCount),
+                windowCts.Token);
+            var faultTask = RunFaultAsync(
+                environment,
+                definition,
+                topic,
+                options.FaultDuration,
+                readyForFault,
+                faultActive,
+                faultHealed,
+                windowCts.Token);
+
+            ProducerOutcome producerOutcome;
+            try
+            {
+                await Task.WhenAll(produceTask, faultTask).ConfigureAwait(false);
+                producerOutcome = await produceTask.ConfigureAwait(false);
+            }
+            catch
+            {
+                windowCts.Cancel();
+                throw;
+            }
+
+            await producer.DisposeAsync().ConfigureAwait(false);
+            producer = null;
+
+            result.AcceptedMessages = producerOutcome.AcceptedMessages;
+            result.DeliveryErrors = deliveryErrors.Count;
+            result.DeliveryCallbacks = callbackCount;
+            result.LiveConsumerMessages = Volatile.Read(ref liveState.MessageCount);
+            result.DeliveryErrorSamples = deliveryErrors
+                .OrderBy(pair => pair.Key)
+                .Take(20)
+                .Select(pair => new DeliveryErrorSample(pair.Key, pair.Value))
+                .ToArray();
+
+            if (callbackCount != producerOutcome.AcceptedMessages)
+            {
+                throw new InvalidOperationException(
+                    $"Only {callbackCount:N0} of {producerOutcome.AcceptedMessages:N0} delivery callbacks completed.");
+            }
+
+            await environment.WaitForTopicHealthyAsync(topic, windowCts.Token).ConfigureAwait(false);
+            var liveConsumerFailure = await WaitForLiveConsumerRecoveryAsync(
+                liveConsumerTask,
+                liveState,
+                producerOutcome.FirstPostHealMessageId,
+                windowCts.Token).ConfigureAwait(false);
+
+            liveConsumerCts.Cancel();
+            liveConsumerFailure ??= await AwaitLiveConsumerShutdownAsync(liveConsumerTask).ConfigureAwait(false);
+            result.LiveConsumerMessages = Volatile.Read(ref liveState.MessageCount);
+
+            var brokerDelivered = await StressTestHelpers.QueryTotalEndOffsetAsync(
+                environment.BootstrapServers,
+                topic,
+                options.PartitionCount).ConfigureAwait(false)
+                ?? throw new InvalidOperationException("Broker end-offset query failed after fault recovery.");
+            var consumedIds = await ReadBrokerLogWithConfluentAsync(
+                environment.BootstrapServers,
+                topic,
+                options.PartitionCount,
+                windowCts.Token).ConfigureAwait(false);
+            var verification = FaultWindowVerifier.Verify(
+                producerOutcome.AcceptedMessages,
+                brokerDelivered,
+                deliveryErrors.Keys,
+                consumedIds,
+                requireZeroDuplicates: true);
+
+            result.BrokerDeliveredMessages = brokerDelivered;
+            result.OracleConsumedMessages = consumedIds.Count;
+            result.UnexplainedLoss = verification.UnexplainedLossCount;
+            result.Duplicates = verification.DuplicateCount;
+            result.OracleCountMismatch = verification.OracleCountMismatch;
+            result.MissingIds = verification.MissingIds.Take(100).ToArray();
+            result.DuplicateIds = verification.DuplicateIds.Take(100).ToArray();
+            result.UnexpectedIds = verification.UnexpectedIds.Take(100).ToArray();
+            result.Succeeded = verification.Succeeded && liveConsumerFailure is null;
+
+            Console.WriteLine(
+                $"  accepted={result.AcceptedMessages:N0} errors={result.DeliveryErrors:N0} " +
+                $"broker={result.BrokerDeliveredMessages:N0} oracle={result.OracleConsumedMessages:N0} " +
+                $"live-consumed={result.LiveConsumerMessages:N0}");
+            Console.WriteLine(
+                $"  unexplained-loss={result.UnexplainedLoss:N0} duplicates={result.Duplicates:N0} " +
+                $"oracle-mismatch={result.OracleCountMismatch:N0}");
+
+            if (!verification.Succeeded)
+            {
+                throw new InvalidOperationException(
+                    $"Strict fault-window verification failed: unexplained loss={verification.UnexplainedLossCount}, " +
+                    $"duplicates={verification.DuplicateCount}, oracle mismatch={verification.OracleCountMismatch}, " +
+                    $"missing IDs={verification.MissingIds.Count}, " +
+                    $"unexpected IDs={verification.UnexpectedIds.Count}.");
+            }
+
+            if (liveConsumerFailure is not null)
+            {
+                throw new InvalidOperationException(
+                    "Live Dekaf consumer failed instead of recovering after the fault window.",
+                    liveConsumerFailure);
+            }
+        }
+        finally
+        {
+            liveConsumerCts.Cancel();
+            _ = await AwaitLiveConsumerShutdownAsync(liveConsumerTask).ConfigureAwait(false);
+            if (producer is not null)
+            {
+                try { await producer.DisposeAsync().ConfigureAwait(false); }
+                catch (Exception ex) { Console.WriteLine($"  Producer cleanup failed: {ex.Message}"); }
+            }
+        }
+    }
+
+    private static async Task<ProducerOutcome> RunProducerLoadAsync(
+        IKafkaProducer<string, string> producer,
+        string topic,
+        FaultInjectionOptions options,
+        TaskCompletionSource readyForFault,
+        TaskCompletionSource faultActive,
+        TaskCompletionSource faultHealed,
+        ConcurrentDictionary<long, string> deliveryErrors,
+        Action callbackCompleted,
+        CancellationToken cancellationToken)
+    {
+        var accepted = 0L;
+        var payload = new string('x', options.MessageSizeBytes - 21);
+        try
+        {
+            for (var i = 0; i < options.MessagesBeforeFault; i++)
+            {
+                await ProduceOneAsync().ConfigureAwait(false);
+            }
+
+            readyForFault.TrySetResult();
+            await faultActive.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            var duringFault = 0;
+            while (!faultHealed.Task.IsCompleted && duringFault < options.MaxMessagesDuringFault)
+            {
+                await ProduceOneAsync().ConfigureAwait(false);
+                duringFault++;
+                if ((duringFault & 255) == 0)
+                {
+                    await Task.Yield();
+                }
+            }
+
+            await faultHealed.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            var firstPostHealMessageId = accepted;
+            for (var i = 0; i < options.MessagesAfterFault; i++)
+            {
+                await ProduceOneAsync().ConfigureAwait(false);
+            }
+
+            Console.WriteLine($"  Flushing {accepted:N0} accepted messages...");
+            await producer.FlushAsync(CancellationToken.None)
+                .AsTask()
+                .WaitAsync(TimeSpan.FromMinutes(2), CancellationToken.None)
+                .ConfigureAwait(false);
+            return new ProducerOutcome(accepted, firstPostHealMessageId);
+        }
+        catch (Exception ex)
+        {
+            readyForFault.TrySetException(ex);
+            throw;
+        }
+
+        async ValueTask ProduceOneAsync()
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var messageId = accepted;
+            var key = messageId.ToString(CultureInfo.InvariantCulture);
+            var value = $"{messageId:D20}|{payload}";
+            await producer.FireAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = key,
+                Value = value
+            }, (_, exception) =>
+            {
+                if (exception is not null)
+                {
+                    deliveryErrors.TryAdd(messageId, $"{exception.GetType().Name}: {exception.Message}");
+                }
+
+                callbackCompleted();
+            }).ConfigureAwait(false);
+            accepted++;
+        }
+    }
+
+    private static async Task RunFaultAsync(
+        FaultInjectionKafkaEnvironment environment,
+        FaultWindowDefinition definition,
+        string topic,
+        TimeSpan duration,
+        TaskCompletionSource readyForFault,
+        TaskCompletionSource faultActive,
+        TaskCompletionSource faultHealed,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await readyForFault.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            Action activated = () => faultActive.TrySetResult();
+            switch (definition.Kind)
+            {
+                case FaultWindowKind.ConnectionReset:
+                case FaultWindowKind.HalfOpen:
+                case FaultWindowKind.SlowClose:
+                case FaultWindowKind.LatencyAndBandwidth:
+                    await environment.ExecuteNetworkFaultAsync(
+                        definition.Kind,
+                        duration,
+                        activated,
+                        cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case FaultWindowKind.BrokerKillAndRestart:
+                    await environment.KillAndRestartBrokerAsync(
+                        nodeId: 1,
+                        topic,
+                        duration,
+                        activated,
+                        cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case FaultWindowKind.LeaderElection:
+                    await environment.ForceLeaderElectionAsync(
+                        topic,
+                        duration,
+                        activated,
+                        cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case FaultWindowKind.RollingRestart:
+                    await environment.RollingRestartAsync(
+                        topic,
+                        duration,
+                        activated,
+                        cancellationToken).ConfigureAwait(false);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(definition), definition.Kind, "Unknown fault kind.");
+            }
+        }
+        finally
+        {
+            faultActive.TrySetResult();
+            faultHealed.TrySetResult();
+        }
+    }
+
+    private static async Task RunLiveConsumerAsync(
+        string bootstrapServers,
+        string topic,
+        LiveConsumerState state,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var consumer = await Kafka.CreateConsumer<string, string>()
+                .WithBootstrapServers(bootstrapServers)
+                .WithClientId($"fault-live-consumer-{Guid.NewGuid():N}")
+                .WithGroupId($"fault-live-{Guid.NewGuid():N}")
+                .WithAutoOffsetReset(Dekaf.Consumer.AutoOffsetReset.Earliest)
+                .BuildAsync(cancellationToken)
+                .ConfigureAwait(false);
+            consumer.Subscribe(topic);
+
+            await foreach (var record in consumer.ConsumeAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (!long.TryParse(record.Key, NumberStyles.None, CultureInfo.InvariantCulture, out var messageId))
+                {
+                    throw new InvalidDataException($"Live consumer received invalid message ID '{record.Key}'.");
+                }
+
+                Interlocked.Increment(ref state.MessageCount);
+                if (messageId > Volatile.Read(ref state.MaxMessageId))
+                {
+                    Volatile.Write(ref state.MaxMessageId, messageId);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private static async Task<Exception?> WaitForLiveConsumerRecoveryAsync(
+        Task liveConsumerTask,
+        LiveConsumerState state,
+        long firstPostHealMessageId,
+        CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow + RecoveryTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (liveConsumerTask.IsCompleted)
+            {
+                var failure = await AwaitLiveConsumerShutdownAsync(liveConsumerTask).ConfigureAwait(false);
+                return failure ?? new InvalidOperationException(
+                    "Live Dekaf consumer stopped before observing a post-heal message.");
+            }
+
+            if (Volatile.Read(ref state.MaxMessageId) >= firstPostHealMessageId)
+            {
+                Console.WriteLine($"  Live consumer recovered through message " +
+                    $"{Volatile.Read(ref state.MaxMessageId):N0}");
+                return null;
+            }
+
+            await Task.Delay(200, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException(
+            $"Live Dekaf consumer did not observe post-heal message {firstPostHealMessageId:N0}.");
+    }
+
+    private static async Task<Exception?> AwaitLiveConsumerShutdownAsync(Task liveConsumerTask)
+    {
+        try
+        {
+            await liveConsumerTask.WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None)
+                .ConfigureAwait(false);
+            return null;
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+        catch (TimeoutException)
+        {
+            Console.WriteLine("  Warning: live consumer did not stop within 30 seconds.");
+            return new TimeoutException("Live Dekaf consumer did not stop within 30 seconds.");
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+    }
+
+    private static Task<IReadOnlyList<long>> ReadBrokerLogWithConfluentAsync(
+        string bootstrapServers,
+        string topic,
+        int partitionCount,
+        CancellationToken cancellationToken) =>
+        Task.Run<IReadOnlyList<long>>(() =>
+        {
+            var config = new ConfluentConsumerConfig
+            {
+                BootstrapServers = bootstrapServers,
+                GroupId = $"fault-oracle-{Guid.NewGuid():N}",
+                EnableAutoCommit = false,
+                EnablePartitionEof = true,
+                AutoOffsetReset = Confluent.Kafka.AutoOffsetReset.Earliest,
+                SocketTimeoutMs = 10_000
+            };
+            using var consumer = new Confluent.Kafka.ConsumerBuilder<string, string>(config).Build();
+            var assignments = new List<Confluent.Kafka.TopicPartitionOffset>(partitionCount);
+            var expectedCount = 0L;
+            for (var partition = 0; partition < partitionCount; partition++)
+            {
+                var topicPartition = new Confluent.Kafka.TopicPartition(topic, partition);
+                var watermarks = consumer.QueryWatermarkOffsets(topicPartition, TimeSpan.FromSeconds(10));
+                assignments.Add(new Confluent.Kafka.TopicPartitionOffset(topicPartition, watermarks.Low));
+                expectedCount += watermarks.High.Value - watermarks.Low.Value;
+            }
+
+            consumer.Assign(assignments);
+            var ids = new List<long>(checked((int)Math.Min(expectedCount, int.MaxValue)));
+            var stopwatch = Stopwatch.StartNew();
+            while (ids.Count < expectedCount && stopwatch.Elapsed < OperationTimeout)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var record = consumer.Consume(TimeSpan.FromSeconds(1));
+                if (record is null || record.IsPartitionEOF)
+                {
+                    continue;
+                }
+
+                if (!long.TryParse(record.Message.Key, NumberStyles.None, CultureInfo.InvariantCulture, out var messageId))
+                {
+                    throw new InvalidDataException(
+                        $"Confluent oracle received invalid message ID '{record.Message.Key}'.");
+                }
+
+                ids.Add(messageId);
+            }
+
+            if (ids.Count != expectedCount)
+            {
+                throw new TimeoutException(
+                    $"Confluent oracle read {ids.Count:N0} of {expectedCount:N0} broker records.");
+            }
+
+            consumer.Close();
+            return ids;
+        }, cancellationToken);
+
+    private static string FirstLine(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return "strict verification failed";
+        }
+
+        var newline = text.IndexOfAny(['\r', '\n']);
+        return newline < 0 ? text : text[..newline];
+    }
+
+    private sealed record ProducerOutcome(long AcceptedMessages, long FirstPostHealMessageId);
+
+    private sealed class LiveConsumerState
+    {
+        internal long MessageCount;
+        internal long MaxMessageId = -1;
+    }
+}

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
@@ -85,7 +85,9 @@ internal static class FaultInjectionRunner
         Console.WriteLine($"Windows: {report.Windows.Count - failed.Length} passed, {failed.Length} failed");
         foreach (var window in failed)
         {
-            var allowedSuffix = options.AllowedFailureWindows.Contains(window.Name) ? " (allowed)" : string.Empty;
+            var allowedSuffix = IsAllowedFailure(window, options.AllowedFailureWindows)
+                ? " (allowed)"
+                : string.Empty;
             Console.WriteLine($"  - {window.Name}{allowedSuffix}: {FirstLine(window.Failure)}");
         }
 
@@ -100,7 +102,7 @@ internal static class FaultInjectionRunner
         ArgumentNullException.ThrowIfNull(allowedFailureWindows);
 
         return windows.Any(window =>
-            !window.Succeeded && !allowedFailureWindows.Contains(window.Name)) ? 1 : 0;
+            !window.Succeeded && !IsAllowedFailure(window, allowedFailureWindows)) ? 1 : 0;
     }
 
     private static async Task RunWindowAsync(
@@ -255,6 +257,7 @@ internal static class FaultInjectionRunner
 
             if (liveConsumerFailure is not null)
             {
+                result.LiveConsumerRecoveryFailed = true;
                 throw new InvalidOperationException(
                     "Live Dekaf consumer failed instead of recovering after the fault window.",
                     liveConsumerFailure);
@@ -476,7 +479,7 @@ internal static class FaultInjectionRunner
             await Task.Delay(200, cancellationToken).ConfigureAwait(false);
         }
 
-        throw new TimeoutException(
+        return new TimeoutException(
             $"Live Dekaf consumer did not observe post-heal message {firstPostHealMessageId:N0}.");
     }
 
@@ -571,6 +574,11 @@ internal static class FaultInjectionRunner
         var newline = text.IndexOfAny(['\r', '\n']);
         return newline < 0 ? text : text[..newline];
     }
+
+    private static bool IsAllowedFailure(
+        FaultWindowRunResult window,
+        IReadOnlySet<string> allowedFailureWindows) =>
+        window.LiveConsumerRecoveryFailed && allowedFailureWindows.Contains(window.Name);
 
     private sealed record ProducerOutcome(long AcceptedMessages, long FirstPostHealMessageId);
 

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
@@ -107,12 +107,19 @@ internal static class FaultInjectionRunner
 
     internal static LiveConsumerFailureKind ClassifyLiveConsumerFailure(
         Exception? recoveryFailure,
-        Exception? shutdownFailure) =>
-        recoveryFailure is not null
+        Exception? shutdownFailure,
+        bool consumerExitedBeforeCancellation)
+    {
+        if (shutdownFailure is not null
+            && (recoveryFailure is null || !consumerExitedBeforeCancellation))
+        {
+            return LiveConsumerFailureKind.Shutdown;
+        }
+
+        return recoveryFailure is not null
             ? LiveConsumerFailureKind.Recovery
-            : shutdownFailure is not null
-                ? LiveConsumerFailureKind.Shutdown
-                : LiveConsumerFailureKind.None;
+            : LiveConsumerFailureKind.None;
+    }
 
     internal static long GetExpectedBrokerDeliveryCount(long acceptedMessages, long deliveryErrorCount)
     {
@@ -230,12 +237,14 @@ internal static class FaultInjectionRunner
                 producerOutcome.FirstPostHealMessageId,
                 windowCts.Token).ConfigureAwait(false);
 
+            var consumerExitedBeforeCancellation = liveConsumerTask.IsCompleted;
             liveConsumerCts.Cancel();
             var liveConsumerShutdownFailure = await AwaitLiveConsumerShutdownAsync(liveConsumerTask)
                 .ConfigureAwait(false);
             var liveConsumerFailureKind = ClassifyLiveConsumerFailure(
                 liveConsumerRecoveryFailure,
-                liveConsumerShutdownFailure);
+                liveConsumerShutdownFailure,
+                consumerExitedBeforeCancellation);
             result.LiveConsumerMessages = Volatile.Read(ref liveState.MessageCount);
 
             var expectedBrokerDeliveryCount = GetExpectedBrokerDeliveryCount(

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
@@ -85,10 +85,22 @@ internal static class FaultInjectionRunner
         Console.WriteLine($"Windows: {report.Windows.Count - failed.Length} passed, {failed.Length} failed");
         foreach (var window in failed)
         {
-            Console.WriteLine($"  - {window.Name}: {FirstLine(window.Failure)}");
+            var allowedSuffix = options.AllowedFailureWindows.Contains(window.Name) ? " (allowed)" : string.Empty;
+            Console.WriteLine($"  - {window.Name}{allowedSuffix}: {FirstLine(window.Failure)}");
         }
 
-        return failed.Length == 0 ? 0 : 1;
+        return DetermineExitCode(report.Windows, options.AllowedFailureWindows);
+    }
+
+    internal static int DetermineExitCode(
+        IEnumerable<FaultWindowRunResult> windows,
+        IReadOnlySet<string> allowedFailureWindows)
+    {
+        ArgumentNullException.ThrowIfNull(windows);
+        ArgumentNullException.ThrowIfNull(allowedFailureWindows);
+
+        return windows.Any(window =>
+            !window.Succeeded && !allowedFailureWindows.Contains(window.Name)) ? 1 : 0;
     }
 
     private static async Task RunWindowAsync(

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
@@ -12,6 +12,7 @@ namespace Dekaf.StressTests.FaultInjection;
 internal static class FaultInjectionRunner
 {
     private static readonly TimeSpan OperationTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan ProducerFlushTimeout = TimeSpan.FromMinutes(2);
     private static readonly TimeSpan RecoveryTimeout = TimeSpan.FromMinutes(1);
 
     internal static async Task<int> RunAsync(
@@ -383,6 +384,18 @@ internal static class FaultInjectionRunner
         }
     }
 
+    internal static async Task<long> CompletePreFaultPhaseAsync(
+        ValueTask producerFlush,
+        long acceptedMessages,
+        TaskCompletionSource readyForFault,
+        CancellationToken cancellationToken)
+    {
+        await producerFlush.AsTask()
+            .WaitAsync(ProducerFlushTimeout, cancellationToken).ConfigureAwait(false);
+        readyForFault.TrySetResult();
+        return acceptedMessages;
+    }
+
     private static async Task<ProducerOutcome> RunProducerLoadAsync(
         IKafkaProducer<string, string> producer,
         string topic,
@@ -403,8 +416,12 @@ internal static class FaultInjectionRunner
                 await ProduceOneAsync().ConfigureAwait(false);
             }
 
-            var firstFaultMessageId = accepted;
-            readyForFault.TrySetResult();
+            Console.WriteLine($"  Flushing {accepted:N0} pre-fault messages...");
+            var firstFaultMessageId = await CompletePreFaultPhaseAsync(
+                producer.FlushAsync(CancellationToken.None),
+                accepted,
+                readyForFault,
+                cancellationToken).ConfigureAwait(false);
             await faultActive.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             var duringFault = 0;
@@ -428,7 +445,7 @@ internal static class FaultInjectionRunner
             Console.WriteLine($"  Flushing {accepted:N0} accepted messages...");
             await producer.FlushAsync(CancellationToken.None)
                 .AsTask()
-                .WaitAsync(TimeSpan.FromMinutes(2), CancellationToken.None)
+                .WaitAsync(ProducerFlushTimeout, CancellationToken.None)
                 .ConfigureAwait(false);
             return new ProducerOutcome(accepted, firstFaultMessageId, firstPostHealMessageId);
         }

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Globalization;
 using Dekaf.Consumer;
 using Dekaf.Producer;
+using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Scenarios;
 using ConfluentConsumerConfig = Confluent.Kafka.ConsumerConfig;
 
@@ -250,12 +251,15 @@ internal static class FaultInjectionRunner
             var expectedBrokerDeliveryCount = GetExpectedBrokerDeliveryCount(
                 producerOutcome.AcceptedMessages,
                 deliveryErrors.Count);
+            var brokerDrain = new ThroughputTracker();
             var brokerDelivered = await StressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync(
                 environment.BootstrapServers,
                 topic,
                 options.PartitionCount,
                 startOffset: 0,
-                acceptedMessages: expectedBrokerDeliveryCount).ConfigureAwait(false)
+                acceptedMessages: expectedBrokerDeliveryCount,
+                throughput: brokerDrain,
+                operation: "Fault recovery drain").ConfigureAwait(false)
                 ?? throw new InvalidOperationException("Broker end-offset query failed after fault recovery.");
             var consumedIds = await ReadBrokerLogWithConfluentAsync(
                 environment.BootstrapServers,
@@ -286,6 +290,12 @@ internal static class FaultInjectionRunner
             Console.WriteLine(
                 $"  unexplained-loss={result.UnexplainedLoss:N0} duplicates={result.Duplicates:N0} " +
                 $"oracle-mismatch={result.OracleCountMismatch:N0}");
+
+            if (brokerDrain.ErrorCount > 0)
+            {
+                throw new InvalidOperationException(
+                    "Broker end offsets did not catch up after fault recovery.");
+            }
 
             if (!verification.Succeeded)
             {

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
@@ -218,8 +218,11 @@ internal static class FaultInjectionRunner
                 throw;
             }
 
-            await producer.DisposeAsync().ConfigureAwait(false);
+            var producerToDispose = producer;
             producer = null;
+            await AwaitProducerDisposalAsync(
+                producerToDispose.DisposeAsync(),
+                StressTestHelpers.OperationTimeout).ConfigureAwait(false);
 
             result.AcceptedMessages = producerOutcome.AcceptedMessages;
             result.DeliveryErrors = deliveryErrors.Count;
@@ -354,9 +357,29 @@ internal static class FaultInjectionRunner
             _ = await AwaitLiveConsumerShutdownAsync(liveConsumerTask).ConfigureAwait(false);
             if (producer is not null)
             {
-                try { await producer.DisposeAsync().ConfigureAwait(false); }
+                try
+                {
+                    await AwaitProducerDisposalAsync(
+                        producer.DisposeAsync(),
+                        StressTestHelpers.OperationTimeout).ConfigureAwait(false);
+                }
                 catch (Exception ex) { Console.WriteLine($"  Producer cleanup failed: {ex.Message}"); }
             }
+        }
+    }
+
+    internal static async Task AwaitProducerDisposalAsync(ValueTask disposal, TimeSpan timeout)
+    {
+        try
+        {
+            await disposal.AsTask()
+                .WaitAsync(timeout, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new TimeoutException(
+                $"Producer disposal did not complete within {timeout.TotalSeconds:N0} seconds.",
+                ex);
         }
     }
 

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
@@ -136,6 +136,12 @@ internal static class FaultInjectionRunner
         return acceptedMessages - deliveryErrorCount;
     }
 
+    internal static bool IsFaultWindowDeliveryError(
+        long messageId,
+        long firstFaultMessageId,
+        long firstPostHealMessageId) =>
+        messageId >= firstFaultMessageId && messageId < firstPostHealMessageId;
+
     private static async Task RunWindowAsync(
         FaultInjectionKafkaEnvironment environment,
         FaultWindowDefinition definition,
@@ -231,6 +237,26 @@ internal static class FaultInjectionRunner
                     $"Only {callbackCount:N0} of {producerOutcome.AcceptedMessages:N0} delivery callbacks completed.");
             }
 
+            var faultWindowDeliveryErrorIds = deliveryErrors.Keys
+                .Where(messageId => IsFaultWindowDeliveryError(
+                    messageId,
+                    producerOutcome.FirstFaultMessageId,
+                    producerOutcome.FirstPostHealMessageId))
+                .ToArray();
+            var healthyPhaseDeliveryErrorIds = deliveryErrors.Keys
+                .Where(messageId => !IsFaultWindowDeliveryError(
+                    messageId,
+                    producerOutcome.FirstFaultMessageId,
+                    producerOutcome.FirstPostHealMessageId))
+                .Order()
+                .ToArray();
+            if (healthyPhaseDeliveryErrorIds.Length > 0)
+            {
+                throw new InvalidOperationException(
+                    $"{healthyPhaseDeliveryErrorIds.Length:N0} delivery errors occurred outside the active " +
+                    $"fault window (message IDs: {string.Join(", ", healthyPhaseDeliveryErrorIds.Take(20))}).");
+            }
+
             await environment.WaitForTopicHealthyAsync(topic, windowCts.Token).ConfigureAwait(false);
             var liveConsumerRecoveryFailure = await WaitForLiveConsumerRecoveryAsync(
                 liveConsumerTask,
@@ -250,7 +276,7 @@ internal static class FaultInjectionRunner
 
             var expectedBrokerDeliveryCount = GetExpectedBrokerDeliveryCount(
                 producerOutcome.AcceptedMessages,
-                deliveryErrors.Count);
+                faultWindowDeliveryErrorIds.Length);
             var brokerDrain = new ThroughputTracker();
             var brokerDelivered = await StressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync(
                 environment.BootstrapServers,
@@ -269,7 +295,7 @@ internal static class FaultInjectionRunner
             var verification = FaultWindowVerifier.Verify(
                 producerOutcome.AcceptedMessages,
                 brokerDelivered,
-                deliveryErrors.Keys,
+                faultWindowDeliveryErrorIds,
                 consumedIds,
                 requireZeroDuplicates: true);
 
@@ -354,6 +380,7 @@ internal static class FaultInjectionRunner
                 await ProduceOneAsync().ConfigureAwait(false);
             }
 
+            var firstFaultMessageId = accepted;
             readyForFault.TrySetResult();
             await faultActive.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
 
@@ -380,7 +407,7 @@ internal static class FaultInjectionRunner
                 .AsTask()
                 .WaitAsync(TimeSpan.FromMinutes(2), CancellationToken.None)
                 .ConfigureAwait(false);
-            return new ProducerOutcome(accepted, firstPostHealMessageId);
+            return new ProducerOutcome(accepted, firstFaultMessageId, firstPostHealMessageId);
         }
         catch (Exception ex)
         {
@@ -639,7 +666,10 @@ internal static class FaultInjectionRunner
         IReadOnlySet<string> allowedFailureWindows) =>
         window.LiveConsumerRecoveryFailed && allowedFailureWindows.Contains(window.Name);
 
-    private sealed record ProducerOutcome(long AcceptedMessages, long FirstPostHealMessageId);
+    private sealed record ProducerOutcome(
+        long AcceptedMessages,
+        long FirstFaultMessageId,
+        long FirstPostHealMessageId);
 
     private sealed class LiveConsumerState
     {

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
@@ -105,6 +105,29 @@ internal static class FaultInjectionRunner
             !window.Succeeded && !IsAllowedFailure(window, allowedFailureWindows)) ? 1 : 0;
     }
 
+    internal static LiveConsumerFailureKind ClassifyLiveConsumerFailure(
+        Exception? recoveryFailure,
+        Exception? shutdownFailure) =>
+        recoveryFailure is not null
+            ? LiveConsumerFailureKind.Recovery
+            : shutdownFailure is not null
+                ? LiveConsumerFailureKind.Shutdown
+                : LiveConsumerFailureKind.None;
+
+    internal static long GetExpectedBrokerDeliveryCount(long acceptedMessages, long deliveryErrorCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(acceptedMessages);
+        ArgumentOutOfRangeException.ThrowIfNegative(deliveryErrorCount);
+        if (deliveryErrorCount > acceptedMessages)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(deliveryErrorCount),
+                "Delivery errors cannot exceed accepted messages.");
+        }
+
+        return acceptedMessages - deliveryErrorCount;
+    }
+
     private static async Task RunWindowAsync(
         FaultInjectionKafkaEnvironment environment,
         FaultWindowDefinition definition,
@@ -201,20 +224,29 @@ internal static class FaultInjectionRunner
             }
 
             await environment.WaitForTopicHealthyAsync(topic, windowCts.Token).ConfigureAwait(false);
-            var liveConsumerFailure = await WaitForLiveConsumerRecoveryAsync(
+            var liveConsumerRecoveryFailure = await WaitForLiveConsumerRecoveryAsync(
                 liveConsumerTask,
                 liveState,
                 producerOutcome.FirstPostHealMessageId,
                 windowCts.Token).ConfigureAwait(false);
 
             liveConsumerCts.Cancel();
-            liveConsumerFailure ??= await AwaitLiveConsumerShutdownAsync(liveConsumerTask).ConfigureAwait(false);
+            var liveConsumerShutdownFailure = await AwaitLiveConsumerShutdownAsync(liveConsumerTask)
+                .ConfigureAwait(false);
+            var liveConsumerFailureKind = ClassifyLiveConsumerFailure(
+                liveConsumerRecoveryFailure,
+                liveConsumerShutdownFailure);
             result.LiveConsumerMessages = Volatile.Read(ref liveState.MessageCount);
 
-            var brokerDelivered = await StressTestHelpers.QueryTotalEndOffsetAsync(
+            var expectedBrokerDeliveryCount = GetExpectedBrokerDeliveryCount(
+                producerOutcome.AcceptedMessages,
+                deliveryErrors.Count);
+            var brokerDelivered = await StressTestHelpers.QueryTotalEndOffsetAfterProducerDrainAsync(
                 environment.BootstrapServers,
                 topic,
-                options.PartitionCount).ConfigureAwait(false)
+                options.PartitionCount,
+                startOffset: 0,
+                acceptedMessages: expectedBrokerDeliveryCount).ConfigureAwait(false)
                 ?? throw new InvalidOperationException("Broker end-offset query failed after fault recovery.");
             var consumedIds = await ReadBrokerLogWithConfluentAsync(
                 environment.BootstrapServers,
@@ -236,7 +268,7 @@ internal static class FaultInjectionRunner
             result.MissingIds = verification.MissingIds.Take(100).ToArray();
             result.DuplicateIds = verification.DuplicateIds.Take(100).ToArray();
             result.UnexpectedIds = verification.UnexpectedIds.Take(100).ToArray();
-            result.Succeeded = verification.Succeeded && liveConsumerFailure is null;
+            result.Succeeded = verification.Succeeded && liveConsumerFailureKind == LiveConsumerFailureKind.None;
 
             Console.WriteLine(
                 $"  accepted={result.AcceptedMessages:N0} errors={result.DeliveryErrors:N0} " +
@@ -255,12 +287,20 @@ internal static class FaultInjectionRunner
                     $"unexpected IDs={verification.UnexpectedIds.Count}.");
             }
 
-            if (liveConsumerFailure is not null)
+            if (liveConsumerFailureKind == LiveConsumerFailureKind.Recovery)
             {
                 result.LiveConsumerRecoveryFailed = true;
                 throw new InvalidOperationException(
                     "Live Dekaf consumer failed instead of recovering after the fault window.",
-                    liveConsumerFailure);
+                    liveConsumerRecoveryFailure);
+            }
+
+            if (liveConsumerFailureKind == LiveConsumerFailureKind.Shutdown)
+            {
+                result.LiveConsumerShutdownFailed = true;
+                throw new InvalidOperationException(
+                    "Live Dekaf consumer recovered but failed to stop after the fault window.",
+                    liveConsumerShutdownFailure);
             }
         }
         finally

--- a/tools/Dekaf.StressTests/FaultInjection/FaultWindowVerifier.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultWindowVerifier.cs
@@ -1,0 +1,78 @@
+namespace Dekaf.StressTests.FaultInjection;
+
+internal sealed record FaultWindowVerification(
+    bool Succeeded,
+    long UnexplainedLossCount,
+    long DuplicateCount,
+    long OracleCountMismatch,
+    IReadOnlyList<long> MissingIds,
+    IReadOnlyList<long> DuplicateIds,
+    IReadOnlyList<long> UnexpectedIds);
+
+internal static class FaultWindowVerifier
+{
+    internal static FaultWindowVerification Verify(
+        long acceptedMessageCount,
+        long brokerDeliveredCount,
+        IEnumerable<long> deliveryErrorIds,
+        IEnumerable<long> consumedIds,
+        bool requireZeroDuplicates)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(acceptedMessageCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(brokerDeliveredCount);
+        ArgumentNullException.ThrowIfNull(deliveryErrorIds);
+        ArgumentNullException.ThrowIfNull(consumedIds);
+
+        var errors = deliveryErrorIds.ToHashSet();
+        if (errors.Any(id => id < 0 || id >= acceptedMessageCount))
+        {
+            throw new ArgumentOutOfRangeException(nameof(deliveryErrorIds),
+                "Delivery-error IDs must identify accepted messages.");
+        }
+
+        var seen = new HashSet<long>();
+        var duplicateIds = new HashSet<long>();
+        long consumedCount = 0;
+        foreach (var id in consumedIds)
+        {
+            consumedCount++;
+            if (!seen.Add(id))
+            {
+                duplicateIds.Add(id);
+            }
+        }
+
+        var missingIds = new List<long>();
+        for (var id = 0L; id < acceptedMessageCount; id++)
+        {
+            if (!errors.Contains(id) && !seen.Contains(id))
+            {
+                missingIds.Add(id);
+            }
+        }
+
+        var unexpectedIds = seen
+            .Where(id => id < 0 || id >= acceptedMessageCount)
+            .Order()
+            .ToArray();
+
+        var expectedMinimum = acceptedMessageCount - errors.Count;
+        var unexplainedLoss = Math.Max(0, expectedMinimum - brokerDeliveredCount);
+        var duplicateCount = consumedCount - seen.Count;
+        var oracleCountMismatch = Math.Abs(brokerDeliveredCount - consumedCount);
+        var succeeded = unexplainedLoss == 0
+            && missingIds.Count == 0
+            && unexpectedIds.Length == 0
+            && oracleCountMismatch == 0
+            && (!requireZeroDuplicates || duplicateCount == 0);
+
+        return new FaultWindowVerification(
+            succeeded,
+            unexplainedLoss,
+            duplicateCount,
+            oracleCountMismatch,
+            missingIds,
+            duplicateIds.Order().ToArray(),
+            unexpectedIds);
+    }
+}

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Dekaf.Producer;
 using Dekaf.StressTests.Diagnostics;
+using Dekaf.StressTests.FaultInjection;
 using Dekaf.StressTests.Infrastructure;
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
@@ -23,6 +24,7 @@ namespace Dekaf.StressTests;
 ///   --brokers &lt;count&gt;      Number of Kafka brokers (default: 1, use 3 for multi-broker)
 ///   --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message loss and watchdog stalls
 ///   report --input &lt;path&gt;   Generate report from existing results
+///   fault [options]          Run fault-injection correctness suite
 ///
 /// Environment Variables:
 ///   KAFKA_BOOTSTRAP_SERVERS - Use external Kafka instead of Testcontainers
@@ -30,6 +32,7 @@ namespace Dekaf.StressTests;
 /// Examples:
 ///   dotnet run -c Release -- --duration 15 --message-size 1000
 ///   dotnet run -c Release -- --scenario producer --client dekaf --duration 5
+///   dotnet run -c Release -- fault --fault-profile network --brokers 1
 ///   dotnet run -c Release -- report --input ./results
 /// </summary>
 public static class Program
@@ -65,6 +68,22 @@ public static class Program
             if (options.IsReport)
             {
                 return await RunReportAsync(options).ConfigureAwait(false);
+            }
+
+            if (options.IsFaultInjection)
+            {
+                return await FaultInjectionRunner.RunAsync(new FaultInjectionOptions
+                {
+                    Profile = options.FaultProfile,
+                    BrokerCount = options.Brokers,
+                    PartitionCount = options.Partitions,
+                    MessageSizeBytes = options.MessageSizeBytes,
+                    FaultDuration = TimeSpan.FromSeconds(options.FaultDurationSeconds),
+                    MessagesBeforeFault = options.MessagesBeforeFault,
+                    MaxMessagesDuringFault = options.MaxMessagesDuringFault,
+                    MessagesAfterFault = options.MessagesAfterFault,
+                    OutputPath = options.OutputPath
+                }).ConfigureAwait(false);
             }
 
             return await RunStressTestsAsync(options).ConfigureAwait(false);
@@ -601,6 +620,9 @@ public static class Program
                 case "report":
                     options.IsReport = true;
                     break;
+                case "fault":
+                    options.IsFaultInjection = true;
+                    break;
                 case "--duration":
                     options.DurationMinutes = int.Parse(args[++i]);
                     break;
@@ -655,6 +677,21 @@ public static class Program
                 case "--producer-delivery-diagnostics":
                     options.EnableProducerDeliveryDiagnostics = true;
                     break;
+                case "--fault-profile":
+                    options.FaultProfile = args[++i].ToLowerInvariant();
+                    break;
+                case "--fault-duration-seconds":
+                    options.FaultDurationSeconds = ParsePositiveInt(args[++i], "--fault-duration-seconds");
+                    break;
+                case "--messages-before-fault":
+                    options.MessagesBeforeFault = ParsePositiveInt(args[++i], "--messages-before-fault");
+                    break;
+                case "--max-messages-during-fault":
+                    options.MaxMessagesDuringFault = ParsePositiveInt(args[++i], "--max-messages-during-fault");
+                    break;
+                case "--messages-after-fault":
+                    options.MessagesAfterFault = ParsePositiveInt(args[++i], "--messages-after-fault");
+                    break;
                 case "--help":
                 case "-h":
                     PrintHelp();
@@ -664,6 +701,17 @@ public static class Program
         }
 
         return options;
+    }
+
+    private static int ParsePositiveInt(string value, string optionName)
+    {
+        var parsed = int.Parse(value);
+        if (parsed < 1)
+        {
+            throw new ArgumentException($"{optionName} must be at least 1");
+        }
+
+        return parsed;
     }
 
     private static void PrintHelp()
@@ -690,6 +738,15 @@ public static class Program
               --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message loss and watchdog stalls
               report --input <path>   Generate report from existing results
 
+            Fault injection:
+              fault                    Run fault-injection correctness suite
+              --fault-profile <name>   network, broker, or all (default: all)
+              --fault-duration-seconds <n>  Active duration of each fault (default: 5)
+              --messages-before-fault <n>   Messages produced before activation (default: 2000)
+              --max-messages-during-fault <n>  Maximum buffered during active fault (default: 20000)
+              --messages-after-fault <n>    Messages proving post-heal recovery (default: 2000)
+              --brokers <count>        Fault mode accepts 1 or 3 brokers
+
             Environment Variables:
               KAFKA_BOOTSTRAP_SERVERS - Use external Kafka instead of Testcontainers
               STRESS_CLIENT_ORDER      - For --client all, run paired clients as dekaf-first or confluent-first
@@ -700,12 +757,14 @@ public static class Program
               dotnet run -c Release -- --duration 15 --message-size 1000
               dotnet run -c Release -- --scenario producer --client dekaf --duration 5
               dotnet run -c Release -- report --input ./results
+              dotnet run -c Release -- fault --fault-profile broker --brokers 3
             """);
     }
 
     private sealed class CliOptions
     {
         public bool IsReport { get; set; }
+        public bool IsFaultInjection { get; set; }
         public int DurationMinutes { get; set; } = 15;
         public int MessageSizeBytes { get; set; } = 1000;
         public string Scenario { get; set; } = "all";
@@ -720,5 +779,10 @@ public static class Program
         public int ConnectionsPerBroker { get; set; } = 1;
         public int SeedMessages { get; set; } = 2_000_000;
         public bool EnableProducerDeliveryDiagnostics { get; set; }
+        public string FaultProfile { get; set; } = "all";
+        public int FaultDurationSeconds { get; set; } = 5;
+        public int MessagesBeforeFault { get; set; } = 2_000;
+        public int MaxMessagesDuringFault { get; set; } = 20_000;
+        public int MessagesAfterFault { get; set; } = 2_000;
     }
 }

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -72,7 +72,7 @@ public static class Program
 
             if (options.IsFaultInjection)
             {
-                return await FaultInjectionRunner.RunAsync(new FaultInjectionOptions
+                var exitCode = await FaultInjectionRunner.RunAsync(new FaultInjectionOptions
                 {
                     Profile = options.FaultProfile,
                     BrokerCount = options.Brokers,
@@ -85,6 +85,8 @@ public static class Program
                     OutputPath = options.OutputPath,
                     AllowedFailureWindows = options.AllowedFailureWindows
                 }).ConfigureAwait(false);
+
+                return CompleteRun(exitCode);
             }
 
             return await RunStressTestsAsync(options).ConfigureAwait(false);
@@ -359,29 +361,39 @@ public static class Program
             }
         }
 
+        return CompleteRun(anyFailure ? 1 : 0) != 0;
+    }
+
+    private static int CompleteRun(int exitCode)
+    {
         // Drain finalizers so exceptions from abandoned tasks surface before the verdict.
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        if (!UnobservedTaskExceptions.IsEmpty)
-        {
-            MarkFailure();
+        return EscalateUnobservedTaskExceptions(exitCode, UnobservedTaskExceptions);
+    }
 
-            Console.WriteLine($"  {UnobservedTaskExceptions.Count:N0} unobserved task exception(s):");
-            var printed = 0;
-            foreach (var exception in UnobservedTaskExceptions)
+    internal static int EscalateUnobservedTaskExceptions(
+        int exitCode,
+        IReadOnlyCollection<Exception> exceptions)
+    {
+        if (exceptions.Count == 0)
+            return exitCode;
+
+        Console.WriteLine($"  {exceptions.Count:N0} unobserved task exception(s):");
+        var printed = 0;
+        foreach (var exception in exceptions)
+        {
+            Console.WriteLine($"    - {exception}");
+            if (++printed >= 5)
             {
-                Console.WriteLine($"    - {exception}");
-                if (++printed >= 5)
-                {
-                    Console.WriteLine("    (further exceptions omitted)");
-                    break;
-                }
+                Console.WriteLine("    (further exceptions omitted)");
+                break;
             }
         }
 
-        return anyFailure;
+        return 1;
     }
 
     private static int MaxConsecutiveZeroSamples(List<double> samples)

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -82,7 +82,8 @@ public static class Program
                     MessagesBeforeFault = options.MessagesBeforeFault,
                     MaxMessagesDuringFault = options.MaxMessagesDuringFault,
                     MessagesAfterFault = options.MessagesAfterFault,
-                    OutputPath = options.OutputPath
+                    OutputPath = options.OutputPath,
+                    AllowedFailureWindows = options.AllowedFailureWindows
                 }).ConfigureAwait(false);
             }
 
@@ -680,6 +681,13 @@ public static class Program
                 case "--fault-profile":
                     options.FaultProfile = args[++i].ToLowerInvariant();
                     break;
+                case "--allowed-failure-windows":
+                    foreach (var window in args[++i].Split(
+                                 ',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    {
+                        options.AllowedFailureWindows.Add(window);
+                    }
+                    break;
                 case "--fault-duration-seconds":
                     options.FaultDurationSeconds = ParsePositiveInt(args[++i], "--fault-duration-seconds");
                     break;
@@ -741,6 +749,7 @@ public static class Program
             Fault injection:
               fault                    Run fault-injection correctness suite
               --fault-profile <name>   network, broker, or all (default: all)
+              --allowed-failure-windows <names>  Comma-separated window names that may fail
               --fault-duration-seconds <n>  Active duration of each fault (default: 5)
               --messages-before-fault <n>   Messages produced before activation (default: 2000)
               --max-messages-during-fault <n>  Maximum buffered during active fault (default: 20000)
@@ -784,5 +793,6 @@ public static class Program
         public int MessagesBeforeFault { get; set; } = 2_000;
         public int MaxMessagesDuringFault { get; set; } = 20_000;
         public int MessagesAfterFault { get; set; } = 2_000;
+        public HashSet<string> AllowedFailureWindows { get; } = new(StringComparer.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Summary
- add a Toxiproxy-backed one/three-broker KRaft environment with reset, half-open, slow-close, latency, bandwidth, SIGKILL, leader-election, and rolling-restart faults
- run idempotent Dekaf producer and live Dekaf consumer load through every window
- verify accepted-minus-delivery-errors against broker offsets and scan every broker record with an independent Confluent oracle for loss, duplicate, and unexpected IDs
- schedule weekly network, single-broker restart, and three-broker failover jobs with JSON reports

## Test plan
- [x] `dotnet build Dekaf.sln --configuration Release`
- [x] `Dekaf.StressTests.Tests.exe` (9 passed)
- [x] reduced one-broker TCP fault smoke (4/4 windows passed; zero loss/duplicates)
- [x] reduced one-broker SIGKILL/restart smoke (passed; zero loss/duplicates)
- [x] reduced three-broker smoke completed broker/oracle verification for every window; leader-election and rolling-restart live-consumer failures are tracked by #1639

Closes #1594
