### PR TITLE
ci: test Kafka floor and current releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,8 @@ jobs:
           retention-days: 7
 
   integration-tests:
-    name: Integration Tests (${{ matrix.category }}, ${{ matrix.framework }}, Kafka ${{ matrix.kafka }})
+    # Preserve the current-lane names required by the default-branch ruleset.
+    name: "Integration Tests (${{ matrix.category }}, ${{ matrix.framework }}${{ matrix.kafka != 'current' && format(', Kafka {0}', matrix.kafka) || '' }})"
     needs: build-and-unit-test
     runs-on: ubuntu-latest
     strategy:
@@ -284,7 +285,8 @@ jobs:
           retention-days: 7
 
   integration-tests-aot:
-    name: Integration Tests AOT (${{ matrix.category }}, Kafka ${{ matrix.kafka }})
+    # Preserve the current-lane names required by the default-branch ruleset.
+    name: "Integration Tests AOT (${{ matrix.category }}${{ matrix.kafka != 'current' && format(', Kafka {0}', matrix.kafka) || '' }})"
     needs: native-aot-integration-publish
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,12 +212,13 @@ jobs:
           retention-days: 7
 
   integration-tests:
-    name: Integration Tests (${{ matrix.category }}, ${{ matrix.framework }})
+    name: Integration Tests (${{ matrix.category }}, ${{ matrix.framework }}, Kafka ${{ matrix.kafka }})
     needs: build-and-unit-test
     runs-on: ubuntu-latest
     strategy:
       matrix:
         framework: [net8.0, net10.0]
+        kafka: [floor, current]
         category: [Producer, MultiInFlightProducer, Backpressure, Consumer, ConsumerLag, ConsumerGroup, Transaction, Admin, Authentication, Authorization, Tls, Serialization, Resilience, Messaging, MessagingPatterns, MessagingOrdering, Compression, Interop, Offsets, NetworkPartition, Retry, ShareConsumer, ShareConsumerAdmin, Telemetry]
       fail-fast: true
 
@@ -257,6 +258,7 @@ jobs:
       - name: Run Pipeline
         env:
           NET_VERSION: ${{ matrix.framework }}
+          DEKAF_TEST_KAFKA_LANE: ${{ matrix.kafka }}
           INTEGRATION_TEST_CATEGORY: ${{ matrix.category }}
           SKIP_UNIT_TESTS: 'true'
         run: dotnet run --project tools/Dekaf.Pipeline
@@ -265,7 +267,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-results-integration-${{ matrix.category }}-${{ matrix.framework }}
+          name: test-results-integration-${{ matrix.category }}-${{ matrix.framework }}-kafka-${{ matrix.kafka }}
           path: |
             **/TestResults/**
             **/test-results/**
@@ -275,18 +277,19 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: hangdump-artifacts-${{ matrix.category }}-${{ matrix.framework }}
+          name: hangdump-artifacts-${{ matrix.category }}-${{ matrix.framework }}-kafka-${{ matrix.kafka }}
           path: |
             **/*.dmp
           if-no-files-found: ignore
           retention-days: 7
 
   integration-tests-aot:
-    name: Integration Tests AOT (${{ matrix.category }})
+    name: Integration Tests AOT (${{ matrix.category }}, Kafka ${{ matrix.kafka }})
     needs: native-aot-integration-publish
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        kafka: [floor, current]
         category: [Producer, MultiInFlightProducer, Backpressure, Consumer, ConsumerLag, ConsumerGroup, Transaction, Admin, Authentication, Authorization, Tls, Serialization, Resilience, Messaging, MessagingPatterns, MessagingOrdering, Compression, Offsets, NetworkPartition, Retry, ShareConsumer, ShareConsumerAdmin, Telemetry]
       fail-fast: true
 
@@ -321,6 +324,7 @@ jobs:
         timeout-minutes: 25
         env:
           NET_VERSION: net10.0
+          DEKAF_TEST_KAFKA_LANE: ${{ matrix.kafka }}
           DOTNET_GCConserveMemory: '9'
         run: |
           chmod +x ./artifacts/aot/integration/Dekaf.Tests.Integration
@@ -344,7 +348,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-results-integration-aot-${{ matrix.category }}
+          name: test-results-integration-aot-${{ matrix.category }}-kafka-${{ matrix.kafka }}
           path: |
             **/TestResults/**
             **/test-results/**
@@ -354,7 +358,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: hangdump-artifacts-integration-aot-${{ matrix.category }}
+          name: hangdump-artifacts-integration-aot-${{ matrix.category }}-kafka-${{ matrix.kafka }}
           path: |
             **/*.dmp
           if-no-files-found: ignore

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,32 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^tests\\/Dekaf.Tests.Integration\\/KafkaTestImages\\.cs$/"
+      ],
+      "matchStrings": [
+        "renovate: datasource=(?<datasource>\\S+) packageName=(?<packageName>\\S+) depName=(?<depName>\\S+)\\s+public const string \\w+Image = \\\"[^:\\\"]+:(?<currentValue>[^\\\"@]+)@(?<currentDigest>sha256:[a-f0-9]+)\\\";"
+      ],
+      "versioningTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Keep the compatibility lane on Kafka 4.0.x",
+      "matchDepNames": [
+        "apache-kafka-floor"
+      ],
+      "allowedVersions": "/^4\\.0\\./",
+      "pinDigests": true
+    },
+    {
+      "description": "Keep the current-stable Kafka lane digest-pinned",
+      "matchDepNames": [
+        "apache-kafka-current"
+      ],
+      "pinDigests": true
+    }
+  ]
 }

--- a/tests/Dekaf.Tests.Integration/AdminClientTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminClientTests.cs
@@ -965,7 +965,7 @@ public class AdminClientTests(KafkaTestContainer kafka) : KafkaIntegrationTest(k
     }
 
     [Test]
-    [SupportsKafka(370)]
+    [SupportsKafka("3.7.0")]
     public async Task DescribeTopicPartitionsAsync_WithPagination_ReturnsAllPartitions()
     {
         // Arrange

--- a/tests/Dekaf.Tests.Integration/ClientTelemetryIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ClientTelemetryIntegrationTests.cs
@@ -5,7 +5,7 @@ using Dekaf.Telemetry;
 namespace Dekaf.Tests.Integration;
 
 [Category("Telemetry")]
-[SupportsKafka(420)]
+[SupportsKafka("4.2.0")]
 public sealed class ClientTelemetryIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     private static readonly FieldInfo ProducerTelemetryManagerField = typeof(KafkaProducer<string, string>)

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
@@ -16,7 +16,7 @@ namespace Dekaf.Tests.Integration;
 /// Consumption permits make every churn phase deterministic without timing sleeps.
 /// </summary>
 [Category("ConsumerGroup")]
-[SupportsKafka(400)]
+[SupportsKafka("4.0.0")]
 public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     private const int PartitionCount = 4;

--- a/tests/Dekaf.Tests.Integration/KafkaContainer40.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainer40.cs
@@ -1,7 +1,0 @@
-namespace Dekaf.Tests.Integration;
-
-public class KafkaContainer40 : KafkaTestContainer
-{
-    public override string ContainerName => "apache/kafka:4.0.1";
-    public override int Version => 401; // major*100 + minor*10 + patch
-}

--- a/tests/Dekaf.Tests.Integration/KafkaContainer41.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainer41.cs
@@ -1,7 +1,0 @@
-namespace Dekaf.Tests.Integration;
-
-public class KafkaContainer41 : KafkaTestContainer
-{
-    public override string ContainerName => "apache/kafka:4.1.1";
-    public override int Version => 411; // major*100 + minor*10 + patch
-}

--- a/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
@@ -7,9 +7,7 @@ namespace Dekaf.Tests.Integration;
 /// The <see cref="KafkaTestContainer"/> instance is shared across all tests in the session via TUnit's ClassDataSource.
 /// Derived classes receive the container through their own primary constructor parameter.
 /// </summary>
-[ClassDataSource<KafkaContainer40>(Shared = SharedType.PerTestSession)]
-[ClassDataSource<KafkaContainer41>(Shared = SharedType.PerTestSession)]
-[ClassDataSource<KafkaContainer42>(Shared = SharedType.PerTestSession)]
+[ClassDataSource<KafkaVersionMatrixContainer>(Shared = SharedType.PerTestSession)]
 public abstract class KafkaIntegrationTest(KafkaTestContainer kafkaTestContainer)
 {
     public KafkaTestContainer KafkaContainer { get; } = kafkaTestContainer;

--- a/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
@@ -37,7 +37,7 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
     private readonly ConcurrentDictionary<string, byte> _createdTopics = new();
 
     public virtual string ContainerName => s_selectedImage.Image;
-    public virtual int Version => s_selectedImage.VersionNumber;
+    public virtual Version Version => s_selectedImage.Version;
 
     private KafkaContainer CreateContainer()
     {

--- a/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
@@ -30,31 +30,34 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
     internal static ComposableEnumerable<string> StartupCommandOverride { get; } =
         new OverwriteEnumerable<string>([StartupCommand]);
 
+    private static readonly KafkaTestImage s_selectedImage = KafkaTestImages.Selected;
     private KafkaContainer? _container;
     protected KafkaContainer? ContainerInstance => _container;
+
+    private readonly ConcurrentDictionary<string, byte> _createdTopics = new();
+
+    public virtual string ContainerName => s_selectedImage.Image;
+    public virtual int Version => s_selectedImage.VersionNumber;
 
     private KafkaContainer CreateContainer()
     {
         // Keep broker defaults, but allow individual KIP-848 groups to opt into
         // shorter test-only liveness intervals through group configuration.
-        var builder = ConfigureBuilder(new KafkaBuilder(ContainerName)
+        var builder = new KafkaBuilder(ContainerName)
             .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")     // Limit JVM heap for CI runners
             .WithEnvironment("KAFKA_LOG_RETENTION_MS", "30000")           // Delete segments after 30s
             .WithEnvironment("KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS", "10000") // Check every 10s
             .WithEnvironment("KAFKA_LOG_SEGMENT_BYTES", "1048576")        // 1MB segments for faster rotation
             .WithEnvironment("KAFKA_LOG_CLEANUP_POLICY", "delete")
             .WithEnvironment("KAFKA_GROUP_CONSUMER_MIN_SESSION_TIMEOUT_MS", "6000")
-            .WithEnvironment("KAFKA_GROUP_CONSUMER_MIN_HEARTBEAT_INTERVAL_MS", "1000"));
+            .WithEnvironment("KAFKA_GROUP_CONSUMER_MIN_HEARTBEAT_INTERVAL_MS", "1000");
 
+        builder = ConfigureBuilder(builder);
+        builder = KafkaTestImages.ConfigureBuilderForVersion(builder, Version);
         return builder
             .WithCommand(StartupCommandOverride)
             .Build();
     }
-
-    private readonly ConcurrentDictionary<string, byte> _createdTopics = new();
-
-    public abstract string ContainerName { get; }
-    public abstract int Version { get; }
 
     /// <summary>
     /// The Kafka bootstrap servers connection string.

--- a/tests/Dekaf.Tests.Integration/KafkaTestImages.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImages.cs
@@ -65,7 +65,7 @@ internal static class KafkaTestImages
             UnixFileModes.OtherRead | UnixFileModes.OtherExecute);
     }
 
-    private static KafkaTestImage Parse(string image)
+    internal static KafkaTestImage Parse(string image)
     {
         var digestSeparator = image.IndexOf('@');
         var tagSeparator = digestSeparator > 0 ? image.LastIndexOf(':', digestSeparator) : -1;
@@ -80,6 +80,12 @@ internal static class KafkaTestImages
             !int.TryParse(components[2], out var patch))
         {
             throw new InvalidOperationException($"Kafka image '{image}' must use a major.minor.patch tag.");
+        }
+
+        if (major < 0 || minor is < 0 or > 9 || patch is < 0 or > 9)
+        {
+            throw new InvalidOperationException(
+                $"Kafka image '{image}' must use a non-negative major and single-digit minor and patch components.");
         }
 
         var versionNumber = checked(major * 100 + minor * 10 + patch);

--- a/tests/Dekaf.Tests.Integration/KafkaTestImages.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImages.cs
@@ -1,0 +1,54 @@
+namespace Dekaf.Tests.Integration;
+
+internal static class KafkaTestImages
+{
+    public const string LaneEnvironmentVariable = "DEKAF_TEST_KAFKA_LANE";
+    public const string FloorLane = "floor";
+    public const string CurrentLane = "current";
+
+    // renovate: datasource=docker packageName=apache/kafka depName=apache-kafka-floor
+    public const string FloorImage = "apache/kafka:4.0.2@sha256:836cafdad9f4825880d7cf1d5a21202915ae2527bd0ef1c3600c526ed7814d1f";
+
+    // renovate: datasource=docker packageName=apache/kafka depName=apache-kafka-current
+    public const string CurrentImage = "apache/kafka:4.3.1@sha256:77e3df9054047a88b520d0cc46e16696d3b22022e1d580aeccd2632df6532837";
+
+    private static readonly KafkaTestImage s_floor = Parse(FloorImage);
+    private static readonly KafkaTestImage s_current = Parse(CurrentImage);
+
+    public static int FloorVersionNumber => s_floor.VersionNumber;
+    public static int CurrentVersionNumber => s_current.VersionNumber;
+
+    public static KafkaTestImage Resolve(string? requestedLane)
+    {
+        return requestedLane switch
+        {
+            null or "" or CurrentLane => s_current,
+            FloorLane => s_floor,
+            _ => throw new InvalidOperationException(
+                $"Unsupported Kafka test lane '{requestedLane}'. Supported lanes: {FloorLane}, {CurrentLane}.")
+        };
+    }
+
+    private static KafkaTestImage Parse(string image)
+    {
+        var digestSeparator = image.IndexOf('@');
+        var tagSeparator = digestSeparator > 0 ? image.LastIndexOf(':', digestSeparator) : -1;
+        if (tagSeparator < 0 || digestSeparator <= tagSeparator + 1)
+            throw new InvalidOperationException($"Kafka image '{image}' must contain a version tag and digest.");
+
+        var release = image[(tagSeparator + 1)..digestSeparator];
+        var components = release.Split('.');
+        if (components.Length != 3 ||
+            !int.TryParse(components[0], out var major) ||
+            !int.TryParse(components[1], out var minor) ||
+            !int.TryParse(components[2], out var patch))
+        {
+            throw new InvalidOperationException($"Kafka image '{image}' must use a major.minor.patch tag.");
+        }
+
+        var versionNumber = checked(major * 100 + minor * 10 + patch);
+        return new KafkaTestImage(image, release, versionNumber);
+    }
+}
+
+internal readonly record struct KafkaTestImage(string Image, string Release, int VersionNumber);

--- a/tests/Dekaf.Tests.Integration/KafkaTestImages.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImages.cs
@@ -1,7 +1,13 @@
+using System.Text;
+using DotNet.Testcontainers.Configurations;
+using Testcontainers.Kafka;
+
 namespace Dekaf.Tests.Integration;
 
 internal static class KafkaTestImages
 {
+    private const int RunWrapperMinimumVersion = 420;
+
     public const string LaneEnvironmentVariable = "DEKAF_TEST_KAFKA_LANE";
     public const string FloorLane = "floor";
     public const string CurrentLane = "current";
@@ -14,9 +20,16 @@ internal static class KafkaTestImages
 
     private static readonly KafkaTestImage s_floor = Parse(FloorImage);
     private static readonly KafkaTestImage s_current = Parse(CurrentImage);
+    private static readonly byte[] s_runWrapperScript = Encoding.UTF8.GetBytes(
+        "#!/bin/bash\n" +
+        "export KAFKA_ADVERTISED_LISTENERS=$(echo \"$KAFKA_ADVERTISED_LISTENERS\" | sed 's/,$//')\n" +
+        "/etc/kafka/docker/configure\n" +
+        "exec /etc/kafka/docker/launch\n");
 
     public static int FloorVersionNumber => s_floor.VersionNumber;
     public static int CurrentVersionNumber => s_current.VersionNumber;
+    public static KafkaTestImage Selected => Resolve(
+        Environment.GetEnvironmentVariable(LaneEnvironmentVariable));
 
     public static KafkaTestImage Resolve(string? requestedLane)
     {
@@ -27,6 +40,29 @@ internal static class KafkaTestImages
             _ => throw new InvalidOperationException(
                 $"Unsupported Kafka test lane '{requestedLane}'. Supported lanes: {FloorLane}, {CurrentLane}.")
         };
+    }
+
+    public static KafkaBuilder CreateBuilderForSelectedLane()
+    {
+        var selected = Selected;
+        return ConfigureBuilderForVersion(new KafkaBuilder(selected.Image), selected.VersionNumber);
+    }
+
+    public static KafkaBuilder ConfigureBuilderForVersion(KafkaBuilder builder, int versionNumber)
+    {
+        if (versionNumber < RunWrapperMinimumVersion)
+            return builder;
+
+        // Testcontainers.Kafka emits a trailing comma in KAFKA_ADVERTISED_LISTENERS
+        // when no extra listener is configured. Kafka 4.2+ rejects that empty entry.
+        return builder.WithResourceMapping(
+            s_runWrapperScript,
+            "/etc/kafka/docker/run",
+            0,
+            0,
+            UnixFileModes.UserRead | UnixFileModes.UserWrite | UnixFileModes.UserExecute |
+            UnixFileModes.GroupRead | UnixFileModes.GroupExecute |
+            UnixFileModes.OtherRead | UnixFileModes.OtherExecute);
     }
 
     private static KafkaTestImage Parse(string image)

--- a/tests/Dekaf.Tests.Integration/KafkaTestImages.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImages.cs
@@ -7,6 +7,7 @@ namespace Dekaf.Tests.Integration;
 internal static class KafkaTestImages
 {
     private static readonly Version s_runWrapperMinimumVersion = new(4, 2, 0);
+    private static readonly Version s_shareGroupsMinimumVersion = new(4, 2, 0);
 
     public const string LaneEnvironmentVariable = "DEKAF_TEST_KAFKA_LANE";
     public const string FloorLane = "floor";
@@ -26,10 +27,10 @@ internal static class KafkaTestImages
         "/etc/kafka/docker/configure\n" +
         "exec /etc/kafka/docker/launch\n");
 
-    public static Version FloorVersion => s_floor.Version;
-    public static Version CurrentVersion => s_current.Version;
     public static KafkaTestImage Selected => Resolve(
         Environment.GetEnvironmentVariable(LaneEnvironmentVariable));
+
+    public static bool SupportsShareGroups(Version version) => version >= s_shareGroupsMinimumVersion;
 
     public static KafkaTestImage Resolve(string? requestedLane)
     {

--- a/tests/Dekaf.Tests.Integration/KafkaTestImages.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImages.cs
@@ -6,7 +6,7 @@ namespace Dekaf.Tests.Integration;
 
 internal static class KafkaTestImages
 {
-    private const int RunWrapperMinimumVersion = 420;
+    private static readonly Version s_runWrapperMinimumVersion = new(4, 2, 0);
 
     public const string LaneEnvironmentVariable = "DEKAF_TEST_KAFKA_LANE";
     public const string FloorLane = "floor";
@@ -26,8 +26,8 @@ internal static class KafkaTestImages
         "/etc/kafka/docker/configure\n" +
         "exec /etc/kafka/docker/launch\n");
 
-    public static int FloorVersionNumber => s_floor.VersionNumber;
-    public static int CurrentVersionNumber => s_current.VersionNumber;
+    public static Version FloorVersion => s_floor.Version;
+    public static Version CurrentVersion => s_current.Version;
     public static KafkaTestImage Selected => Resolve(
         Environment.GetEnvironmentVariable(LaneEnvironmentVariable));
 
@@ -45,12 +45,12 @@ internal static class KafkaTestImages
     public static KafkaBuilder CreateBuilderForSelectedLane()
     {
         var selected = Selected;
-        return ConfigureBuilderForVersion(new KafkaBuilder(selected.Image), selected.VersionNumber);
+        return ConfigureBuilderForVersion(new KafkaBuilder(selected.Image), selected.Version);
     }
 
-    public static KafkaBuilder ConfigureBuilderForVersion(KafkaBuilder builder, int versionNumber)
+    public static KafkaBuilder ConfigureBuilderForVersion(KafkaBuilder builder, Version version)
     {
-        if (versionNumber < RunWrapperMinimumVersion)
+        if (version < s_runWrapperMinimumVersion)
             return builder;
 
         // Testcontainers.Kafka emits a trailing comma in KAFKA_ADVERTISED_LISTENERS
@@ -82,15 +82,14 @@ internal static class KafkaTestImages
             throw new InvalidOperationException($"Kafka image '{image}' must use a major.minor.patch tag.");
         }
 
-        if (major < 0 || minor is < 0 or > 9 || patch is < 0 or > 9)
+        if (major < 0 || minor < 0 || patch < 0)
         {
             throw new InvalidOperationException(
-                $"Kafka image '{image}' must use a non-negative major and single-digit minor and patch components.");
+                $"Kafka image '{image}' must use non-negative version components.");
         }
 
-        var versionNumber = checked(major * 100 + minor * 10 + patch);
-        return new KafkaTestImage(image, release, versionNumber);
+        return new KafkaTestImage(image, release, new Version(major, minor, patch));
     }
 }
 
-internal readonly record struct KafkaTestImage(string Image, string Release, int VersionNumber);
+internal readonly record struct KafkaTestImage(string Image, string Release, Version Version);

--- a/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
@@ -51,6 +51,17 @@ public sealed class KafkaTestImagesTests
     }
 
     [Test]
+    [Arguments("4.1.9", false)]
+    [Arguments("4.2.0", true)]
+    [Arguments("5.0.0", true)]
+    public async Task SupportsShareGroups_UsesKafkaFeatureVersion(string release, bool expected)
+    {
+        var supported = KafkaTestImages.SupportsShareGroups(Version.Parse(release));
+
+        await Assert.That(supported).IsEqualTo(expected);
+    }
+
+    [Test]
     public async Task TransactionFaultContainer_UsesSelectedKafkaLane()
     {
         var selected = KafkaTestImages.Selected;

--- a/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
@@ -1,5 +1,6 @@
 namespace Dekaf.Tests.Integration;
 
+[Category("Admin")]
 public sealed class KafkaTestImagesTests
 {
     [Test]
@@ -8,7 +9,7 @@ public sealed class KafkaTestImagesTests
         var resolved = KafkaTestImages.Resolve(null);
 
         await Assert.That(resolved.Release).IsEqualTo("4.3.1");
-        await Assert.That(resolved.VersionNumber).IsEqualTo(431);
+        await Assert.That(resolved.Version).IsEqualTo(new Version(4, 3, 1));
         await Assert.That(resolved.Image).IsEqualTo(KafkaTestImages.CurrentImage);
     }
 
@@ -18,7 +19,7 @@ public sealed class KafkaTestImagesTests
         var resolved = KafkaTestImages.Resolve(KafkaTestImages.FloorLane);
 
         await Assert.That(resolved.Release).IsEqualTo("4.0.2");
-        await Assert.That(resolved.VersionNumber).IsEqualTo(402);
+        await Assert.That(resolved.Version).IsEqualTo(new Version(4, 0, 2));
         await Assert.That(resolved.Image).IsEqualTo(KafkaTestImages.FloorImage);
     }
 
@@ -33,13 +34,13 @@ public sealed class KafkaTestImagesTests
     [Test]
     [Arguments("4.0.10")]
     [Arguments("4.10.0")]
-    public async Task Parse_MultiDigitCompactVersionComponent_Throws(string release)
+    public async Task Parse_MultiDigitVersionComponent_IsAccepted(string release)
     {
         var image = $"apache/kafka:{release}@sha256:test";
+        var parsed = KafkaTestImages.Parse(image);
 
-        await Assert.That(() => KafkaTestImages.Parse(image))
-            .Throws<InvalidOperationException>()
-            .WithMessageContaining("single-digit minor and patch");
+        await Assert.That(parsed.Release).IsEqualTo(release);
+        await Assert.That(parsed.Version).IsEqualTo(Version.Parse(release));
     }
 
     [Test]
@@ -48,7 +49,7 @@ public sealed class KafkaTestImagesTests
         var resolved = KafkaTestImages.Resolve(KafkaTestImages.CurrentLane);
 
         await Assert.That(resolved.Release).IsEqualTo("4.3.1");
-        await Assert.That(resolved.VersionNumber).IsEqualTo(431);
+        await Assert.That(resolved.Version).IsEqualTo(new Version(4, 3, 1));
         await Assert.That(resolved.Image).IsEqualTo(KafkaTestImages.CurrentImage);
     }
 
@@ -59,6 +60,6 @@ public sealed class KafkaTestImagesTests
         await using var container = new TransactionFaultKafkaContainer();
 
         await Assert.That(container.ContainerName).IsEqualTo(selected.Image);
-        await Assert.That(container.Version).IsEqualTo(selected.VersionNumber);
+        await Assert.That(container.Version).IsEqualTo(selected.Version);
     }
 }

--- a/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
@@ -31,6 +31,18 @@ public sealed class KafkaTestImagesTests
     }
 
     [Test]
+    [Arguments("4.0.10")]
+    [Arguments("4.10.0")]
+    public async Task Parse_MultiDigitCompactVersionComponent_Throws(string release)
+    {
+        var image = $"apache/kafka:{release}@sha256:test";
+
+        await Assert.That(() => KafkaTestImages.Parse(image))
+            .Throws<InvalidOperationException>()
+            .WithMessageContaining("single-digit minor and patch");
+    }
+
+    [Test]
     [NotInParallel("KafkaTestLaneEnvironment")]
     public async Task Selected_UsesConfiguredLane()
     {

--- a/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
@@ -1,0 +1,32 @@
+namespace Dekaf.Tests.Integration;
+
+public sealed class KafkaTestImagesTests
+{
+    [Test]
+    public async Task Resolve_WithoutRequestedVersion_UsesCurrentStableImage()
+    {
+        var resolved = KafkaTestImages.Resolve(null);
+
+        await Assert.That(resolved.Release).IsEqualTo("4.3.1");
+        await Assert.That(resolved.VersionNumber).IsEqualTo(431);
+        await Assert.That(resolved.Image).IsEqualTo(KafkaTestImages.CurrentImage);
+    }
+
+    [Test]
+    public async Task Resolve_FloorLane_UsesPinnedFloorImage()
+    {
+        var resolved = KafkaTestImages.Resolve(KafkaTestImages.FloorLane);
+
+        await Assert.That(resolved.Release).IsEqualTo("4.0.2");
+        await Assert.That(resolved.VersionNumber).IsEqualTo(402);
+        await Assert.That(resolved.Image).IsEqualTo(KafkaTestImages.FloorImage);
+    }
+
+    [Test]
+    public async Task Resolve_UnknownVersion_Throws()
+    {
+        await Assert.That(() => KafkaTestImages.Resolve("3.9.0"))
+            .Throws<InvalidOperationException>()
+            .WithMessageContaining("Supported lanes");
+    }
+}

--- a/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
@@ -43,26 +43,12 @@ public sealed class KafkaTestImagesTests
     }
 
     [Test]
-    [NotInParallel("KafkaTestLaneEnvironment")]
-    public async Task Selected_UsesConfiguredLane()
+    public async Task Resolve_CurrentLane_UsesCurrentStableImage()
     {
-        var originalLane = Environment.GetEnvironmentVariable(KafkaTestImages.LaneEnvironmentVariable);
+        var resolved = KafkaTestImages.Resolve(KafkaTestImages.CurrentLane);
 
-        try
-        {
-            Environment.SetEnvironmentVariable(
-                KafkaTestImages.LaneEnvironmentVariable,
-                KafkaTestImages.FloorLane);
-            await Assert.That(KafkaTestImages.Selected.Image).IsEqualTo(KafkaTestImages.FloorImage);
-
-            Environment.SetEnvironmentVariable(
-                KafkaTestImages.LaneEnvironmentVariable,
-                KafkaTestImages.CurrentLane);
-            await Assert.That(KafkaTestImages.Selected.Image).IsEqualTo(KafkaTestImages.CurrentImage);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(KafkaTestImages.LaneEnvironmentVariable, originalLane);
-        }
+        await Assert.That(resolved.Release).IsEqualTo("4.3.1");
+        await Assert.That(resolved.VersionNumber).IsEqualTo(431);
+        await Assert.That(resolved.Image).IsEqualTo(KafkaTestImages.CurrentImage);
     }
 }

--- a/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
@@ -7,20 +7,18 @@ public sealed class KafkaTestImagesTests
     public async Task Resolve_WithoutRequestedVersion_UsesCurrentStableImage()
     {
         var resolved = KafkaTestImages.Resolve(null);
+        var expected = KafkaTestImages.Parse(KafkaTestImages.CurrentImage);
 
-        await Assert.That(resolved.Release).IsEqualTo("4.3.1");
-        await Assert.That(resolved.Version).IsEqualTo(new Version(4, 3, 1));
-        await Assert.That(resolved.Image).IsEqualTo(KafkaTestImages.CurrentImage);
+        await Assert.That(resolved).IsEqualTo(expected);
     }
 
     [Test]
     public async Task Resolve_FloorLane_UsesPinnedFloorImage()
     {
         var resolved = KafkaTestImages.Resolve(KafkaTestImages.FloorLane);
+        var expected = KafkaTestImages.Parse(KafkaTestImages.FloorImage);
 
-        await Assert.That(resolved.Release).IsEqualTo("4.0.2");
-        await Assert.That(resolved.Version).IsEqualTo(new Version(4, 0, 2));
-        await Assert.That(resolved.Image).IsEqualTo(KafkaTestImages.FloorImage);
+        await Assert.That(resolved).IsEqualTo(expected);
     }
 
     [Test]
@@ -47,10 +45,9 @@ public sealed class KafkaTestImagesTests
     public async Task Resolve_CurrentLane_UsesCurrentStableImage()
     {
         var resolved = KafkaTestImages.Resolve(KafkaTestImages.CurrentLane);
+        var expected = KafkaTestImages.Parse(KafkaTestImages.CurrentImage);
 
-        await Assert.That(resolved.Release).IsEqualTo("4.3.1");
-        await Assert.That(resolved.Version).IsEqualTo(new Version(4, 3, 1));
-        await Assert.That(resolved.Image).IsEqualTo(KafkaTestImages.CurrentImage);
+        await Assert.That(resolved).IsEqualTo(expected);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
@@ -29,4 +29,28 @@ public sealed class KafkaTestImagesTests
             .Throws<InvalidOperationException>()
             .WithMessageContaining("Supported lanes");
     }
+
+    [Test]
+    [NotInParallel("KafkaTestLaneEnvironment")]
+    public async Task Selected_UsesConfiguredLane()
+    {
+        var originalLane = Environment.GetEnvironmentVariable(KafkaTestImages.LaneEnvironmentVariable);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(
+                KafkaTestImages.LaneEnvironmentVariable,
+                KafkaTestImages.FloorLane);
+            await Assert.That(KafkaTestImages.Selected.Image).IsEqualTo(KafkaTestImages.FloorImage);
+
+            Environment.SetEnvironmentVariable(
+                KafkaTestImages.LaneEnvironmentVariable,
+                KafkaTestImages.CurrentLane);
+            await Assert.That(KafkaTestImages.Selected.Image).IsEqualTo(KafkaTestImages.CurrentImage);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(KafkaTestImages.LaneEnvironmentVariable, originalLane);
+        }
+    }
 }

--- a/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestImagesTests.cs
@@ -51,4 +51,14 @@ public sealed class KafkaTestImagesTests
         await Assert.That(resolved.VersionNumber).IsEqualTo(431);
         await Assert.That(resolved.Image).IsEqualTo(KafkaTestImages.CurrentImage);
     }
+
+    [Test]
+    public async Task TransactionFaultContainer_UsesSelectedKafkaLane()
+    {
+        var selected = KafkaTestImages.Selected;
+        await using var container = new TransactionFaultKafkaContainer();
+
+        await Assert.That(container.ContainerName).IsEqualTo(selected.Image);
+        await Assert.That(container.Version).IsEqualTo(selected.VersionNumber);
+    }
 }

--- a/tests/Dekaf.Tests.Integration/KafkaVersionMatrixContainer.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaVersionMatrixContainer.cs
@@ -6,7 +6,7 @@ public sealed class KafkaVersionMatrixContainer : KafkaTestContainer
 {
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder)
     {
-        if (Version < KafkaTestImages.CurrentVersion)
+        if (!KafkaTestImages.SupportsShareGroups(Version))
             return builder;
 
         // Enable share groups (KIP-932). The coordinator needs both the feature gate

--- a/tests/Dekaf.Tests.Integration/KafkaVersionMatrixContainer.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaVersionMatrixContainer.cs
@@ -1,50 +1,23 @@
-using System.Text;
-using DotNet.Testcontainers.Configurations;
 using Testcontainers.Kafka;
 
 namespace Dekaf.Tests.Integration;
 
 public sealed class KafkaVersionMatrixContainer : KafkaTestContainer
 {
-    private static readonly KafkaTestImage s_selectedImage = KafkaTestImages.Resolve(
-        Environment.GetEnvironmentVariable(KafkaTestImages.LaneEnvironmentVariable));
-
-    public override string ContainerName => s_selectedImage.Image;
-    public override int Version => s_selectedImage.VersionNumber;
-
-    // Testcontainers.Kafka generates a startup script that sets
-    // KAFKA_ADVERTISED_LISTENERS with a trailing comma when no extra
-    // listeners are configured. Kafka 4.2+ (KIP-1161) rejects empty
-    // values in LIST-type configs, so the trailing comma causes a
-    // ConfigException. This wrapper strips the trailing comma before
-    // running the normal Kafka startup sequence.
-    private static readonly byte[] RunWrapperScript = Encoding.UTF8.GetBytes(
-        "#!/bin/bash\n" +
-        "export KAFKA_ADVERTISED_LISTENERS=$(echo \"$KAFKA_ADVERTISED_LISTENERS\" | sed 's/,$//')\n" +
-        "/etc/kafka/docker/configure\n" +
-        "exec /etc/kafka/docker/launch\n");
-
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder)
     {
         if (Version < KafkaTestImages.CurrentVersionNumber)
             return builder;
 
+        // Enable share groups (KIP-932). The coordinator needs both the feature gate
+        // and the share rebalance protocol. Single-broker state topics also need
+        // replication settings compatible with one node.
         return builder
-            .WithResourceMapping(RunWrapperScript, "/etc/kafka/docker/run", 0, 0,
-                UnixFileModes.UserRead | UnixFileModes.UserWrite | UnixFileModes.UserExecute |
-                UnixFileModes.GroupRead | UnixFileModes.GroupExecute |
-                UnixFileModes.OtherRead | UnixFileModes.OtherExecute)
-            // Enable share groups (KIP-932). Requires two pieces:
-            // 1. group.share.enable — gates the share group client protocol
-            // 2. group.coordinator.rebalance.protocols must include "share"
-            //    for the coordinator to handle share group state
             .WithEnvironment("KAFKA_GROUP_SHARE_ENABLE", "true")
             .WithEnvironment("KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS", "classic,consumer,share")
             .WithEnvironment("KAFKA_GROUP_SHARE_RECORD_LOCK_DURATION_MS", "15000")
             .WithEnvironment("KAFKA_GROUP_SHARE_MIN_RECORD_LOCK_DURATION_MS", "5000")
             .WithEnvironment("KAFKA_GROUP_SHARE_MAX_RECORD_LOCK_DURATION_MS", "60000")
-            // Single-broker: the internal __share_group_state topic requires settings
-            // compatible with a single-node cluster.
             .WithEnvironment("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR", "1")
             .WithEnvironment("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR", "1")
             .WithEnvironment("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_NUM_PARTITIONS", "3");

--- a/tests/Dekaf.Tests.Integration/KafkaVersionMatrixContainer.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaVersionMatrixContainer.cs
@@ -4,10 +4,13 @@ using Testcontainers.Kafka;
 
 namespace Dekaf.Tests.Integration;
 
-public class KafkaContainer42 : KafkaTestContainer
+public sealed class KafkaVersionMatrixContainer : KafkaTestContainer
 {
-    public override string ContainerName => "apache/kafka:4.2.0";
-    public override int Version => 420;
+    private static readonly KafkaTestImage s_selectedImage = KafkaTestImages.Resolve(
+        Environment.GetEnvironmentVariable(KafkaTestImages.LaneEnvironmentVariable));
+
+    public override string ContainerName => s_selectedImage.Image;
+    public override int Version => s_selectedImage.VersionNumber;
 
     // Testcontainers.Kafka generates a startup script that sets
     // KAFKA_ADVERTISED_LISTENERS with a trailing comma when no extra
@@ -23,6 +26,9 @@ public class KafkaContainer42 : KafkaTestContainer
 
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder)
     {
+        if (Version < KafkaTestImages.CurrentVersionNumber)
+            return builder;
+
         return builder
             .WithResourceMapping(RunWrapperScript, "/etc/kafka/docker/run", 0, 0,
                 UnixFileModes.UserRead | UnixFileModes.UserWrite | UnixFileModes.UserExecute |

--- a/tests/Dekaf.Tests.Integration/KafkaVersionMatrixContainer.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaVersionMatrixContainer.cs
@@ -6,7 +6,7 @@ public sealed class KafkaVersionMatrixContainer : KafkaTestContainer
 {
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder)
     {
-        if (Version < KafkaTestImages.CurrentVersionNumber)
+        if (Version < KafkaTestImages.CurrentVersion)
             return builder;
 
         // Enable share groups (KIP-932). The coordinator needs both the feature gate

--- a/tests/Dekaf.Tests.Integration/NetworkPartition/NetworkPartitionKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/NetworkPartition/NetworkPartitionKafkaContainer.cs
@@ -13,9 +13,6 @@ public class NetworkPartitionKafkaContainer : KafkaTestContainer
 {
     private DockerClient? _dockerClient;
 
-    public override string ContainerName => KafkaTestImages.FloorImage;
-    public override int Version => KafkaTestImages.FloorVersionNumber;
-
     /// <summary>
     /// Pauses the Kafka container, simulating a network partition.
     /// All processes in the container are frozen; TCP connections go silent.

--- a/tests/Dekaf.Tests.Integration/NetworkPartition/NetworkPartitionKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/NetworkPartition/NetworkPartitionKafkaContainer.cs
@@ -7,14 +7,14 @@ namespace Dekaf.Tests.Integration.NetworkPartition;
 /// Uses Docker's pause/unpause to freeze container processes, simulating a network partition
 /// where TCP connections go silent (no RST, no FIN).
 /// Shared once per test session for network partition tests. Do not reuse the general
-/// KafkaContainer40 session instance because pause/unpause would affect unrelated tests.
+/// <see cref="KafkaVersionMatrixContainer"/> session instance because pause/unpause would affect unrelated tests.
 /// </summary>
 public class NetworkPartitionKafkaContainer : KafkaTestContainer
 {
     private DockerClient? _dockerClient;
 
-    public override string ContainerName => "apache/kafka:4.0.1";
-    public override int Version => 401;
+    public override string ContainerName => KafkaTestImages.FloorImage;
+    public override int Version => KafkaTestImages.FloorVersionNumber;
 
     /// <summary>
     /// Pauses the Kafka container, simulating a network partition.

--- a/tests/Dekaf.Tests.Integration/NewConsumerProtocolTests.cs
+++ b/tests/Dekaf.Tests.Integration/NewConsumerProtocolTests.cs
@@ -11,7 +11,7 @@ namespace Dekaf.Tests.Integration;
 /// Requires Kafka 4.0+.
 /// </summary>
 [Category("Consumer")]
-[SupportsKafka(400)]
+[SupportsKafka("4.0.0")]
 public class NewConsumerProtocolTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/ProtocolVersionTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProtocolVersionTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Consumer;
+using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Producer;
 using Dekaf.Protocol;
@@ -62,6 +63,42 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         {
             await pool.DisposeAsync();
         }
+    }
+
+    [Test]
+    public async Task Metadata_NegotiatesDownToBrokerMaximum()
+    {
+        await using var pool = new ConnectionPool(
+            "version-negotiation-test",
+            new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(30) },
+            null);
+        await using var metadataManager = new MetadataManager(
+            pool,
+            [KafkaContainer.BootstrapServers]);
+
+        await metadataManager.InitializeAsync(CancellationToken.None);
+
+        var parts = KafkaContainer.BootstrapServers.Split(':');
+        var connection = await pool.GetConnectionAsync(
+            parts[0],
+            int.Parse(parts[1]),
+            CancellationToken.None);
+        var apiVersions = await SendApiVersionsAsync(connection);
+        var brokerMetadataVersion = apiVersions.ApiKeys.Single(version => version.ApiKey == ApiKey.Metadata);
+        var simulatedClientMaximum = checked((short)(brokerMetadataVersion.MaxVersion + 1));
+
+        var negotiatedVersion = metadataManager.GetNegotiatedApiVersion(
+            ApiKey.Metadata,
+            MetadataRequest.LowestSupportedVersion,
+            simulatedClientMaximum);
+        var metadata = await connection.SendAsync<MetadataRequest, MetadataResponse>(
+            MetadataRequest.ForAllTopics(),
+            negotiatedVersion,
+            CancellationToken.None);
+
+        await Assert.That(negotiatedVersion).IsEqualTo(brokerMetadataVersion.MaxVersion);
+        await Assert.That(negotiatedVersion).IsLessThan(simulatedClientMaximum);
+        await Assert.That(metadata.Brokers).IsNotEmpty();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Tests.Integration;
 
 public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposable
 {
-    private const string Image = "apache/kafka:4.2.0";
+    private const string Image = KafkaTestImages.CurrentImage;
     private const int InternalBrokerPort = 9092;
     private const int ControllerPort = 9093;
     private const int ExternalBrokerPort = 19092;

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Tests.Integration;
 
 public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposable
 {
-    private const string Image = KafkaTestImages.CurrentImage;
+    private static readonly string Image = KafkaTestImages.Selected.Image;
     private const int InternalBrokerPort = 9092;
     private const int ControllerPort = 9093;
     private const int ExternalBrokerPort = 19092;

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
@@ -71,7 +71,7 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
         Console.WriteLine("[KafkaWithSchemaRegistry] Starting Kafka container...");
 
         // Start Kafka with network alias
-        _kafkaContainer = new KafkaBuilder(KafkaTestImages.FloorImage)
+        _kafkaContainer = KafkaTestImages.CreateBuilderForSelectedLane()
             .WithNetwork(_network)
             .WithNetworkAliases("kafka")
             .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
@@ -71,7 +71,7 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
         Console.WriteLine("[KafkaWithSchemaRegistry] Starting Kafka container...");
 
         // Start Kafka with network alias
-        _kafkaContainer = new KafkaBuilder("apache/kafka:4.0.1")
+        _kafkaContainer = new KafkaBuilder(KafkaTestImages.FloorImage)
             .WithNetwork(_network)
             .WithNetworkAliases("kafka")
             .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")

--- a/tests/Dekaf.Tests.Integration/Security/AclKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/AclKafkaContainer.cs
@@ -46,8 +46,8 @@ public class AclKafkaContainer : KafkaTestContainer
     /// </summary>
     public const string TestPrincipal = $"User:{TestUsername}";
 
-    public override string ContainerName => "apache/kafka:4.0.1";
-    public override int Version => 401;
+    public override string ContainerName => KafkaTestImages.FloorImage;
+    public override int Version => KafkaTestImages.FloorVersionNumber;
 
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) =>
         builder

--- a/tests/Dekaf.Tests.Integration/Security/AclKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/AclKafkaContainer.cs
@@ -46,9 +46,6 @@ public class AclKafkaContainer : KafkaTestContainer
     /// </summary>
     public const string TestPrincipal = $"User:{TestUsername}";
 
-    public override string ContainerName => KafkaTestImages.FloorImage;
-    public override int Version => KafkaTestImages.FloorVersionNumber;
-
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) =>
         builder
             // Enable StandardAuthorizer for KRaft mode

--- a/tests/Dekaf.Tests.Integration/Security/OAuthBearerKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/OAuthBearerKafkaContainer.cs
@@ -36,8 +36,8 @@ public class OAuthBearerKafkaContainer : KafkaTestContainer
     private const string UnsecuredValidatorCallbackHandler =
         "org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredValidatorCallbackHandler";
 
-    public override string ContainerName => "apache/kafka:4.0.1";
-    public override int Version => 401;
+    public override string ContainerName => KafkaTestImages.FloorImage;
+    public override int Version => KafkaTestImages.FloorVersionNumber;
 
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) => builder
         // External (PLAINTEXT-named) listener uses SASL_PLAINTEXT; inter-broker stays PLAINTEXT.

--- a/tests/Dekaf.Tests.Integration/Security/OAuthBearerKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/OAuthBearerKafkaContainer.cs
@@ -36,9 +36,6 @@ public class OAuthBearerKafkaContainer : KafkaTestContainer
     private const string UnsecuredValidatorCallbackHandler =
         "org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredValidatorCallbackHandler";
 
-    public override string ContainerName => KafkaTestImages.FloorImage;
-    public override int Version => KafkaTestImages.FloorVersionNumber;
-
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) => builder
         // External (PLAINTEXT-named) listener uses SASL_PLAINTEXT; inter-broker stays PLAINTEXT.
         .WithEnvironment("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "PLAINTEXT:SASL_PLAINTEXT,BROKER:PLAINTEXT,CONTROLLER:PLAINTEXT")

--- a/tests/Dekaf.Tests.Integration/Security/SaslKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslKafkaContainer.cs
@@ -34,9 +34,6 @@ public class SaslKafkaContainer : KafkaTestContainer
         $"password=\"{SaslPassword}\" " +
         $"user_{SaslUsername}=\"{SaslPassword}\";";
 
-    public override string ContainerName => KafkaTestImages.FloorImage;
-    public override int Version => KafkaTestImages.FloorVersionNumber;
-
     /// <summary>
     /// Adds SASL-specific environment variables to the Kafka container builder.
     /// </summary>

--- a/tests/Dekaf.Tests.Integration/Security/SaslKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslKafkaContainer.cs
@@ -34,8 +34,8 @@ public class SaslKafkaContainer : KafkaTestContainer
         $"password=\"{SaslPassword}\" " +
         $"user_{SaslUsername}=\"{SaslPassword}\";";
 
-    public override string ContainerName => "apache/kafka:4.0.1";
-    public override int Version => 401;
+    public override string ContainerName => KafkaTestImages.FloorImage;
+    public override int Version => KafkaTestImages.FloorVersionNumber;
 
     /// <summary>
     /// Adds SASL-specific environment variables to the Kafka container builder.

--- a/tests/Dekaf.Tests.Integration/Security/SaslSslKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslSslKafkaContainer.cs
@@ -40,9 +40,6 @@ public class SaslSslKafkaContainer : KafkaTestContainer
     private const string KeystoreContainerPath = $"{ContainerSecretsDir}/server.p12";
     private const string TruststoreContainerPath = $"{ContainerSecretsDir}/truststore.p12";
 
-    public override string ContainerName => KafkaTestImages.FloorImage;
-    public override int Version => KafkaTestImages.FloorVersionNumber;
-
     /// <summary>
     /// TLS configuration that validates the broker certificate against the test CA.
     /// </summary>

--- a/tests/Dekaf.Tests.Integration/Security/SaslSslKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslSslKafkaContainer.cs
@@ -40,8 +40,8 @@ public class SaslSslKafkaContainer : KafkaTestContainer
     private const string KeystoreContainerPath = $"{ContainerSecretsDir}/server.p12";
     private const string TruststoreContainerPath = $"{ContainerSecretsDir}/truststore.p12";
 
-    public override string ContainerName => "apache/kafka:4.0.1";
-    public override int Version => 401;
+    public override string ContainerName => KafkaTestImages.FloorImage;
+    public override int Version => KafkaTestImages.FloorVersionNumber;
 
     /// <summary>
     /// TLS configuration that validates the broker certificate against the test CA.

--- a/tests/Dekaf.Tests.Integration/Security/TlsKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/TlsKafkaContainer.cs
@@ -83,7 +83,7 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
         TestCertificateGenerator.ExportCertificateToPemFile(_certGenerator.ServerCertificate, serverCertPemPath);
         TestCertificateGenerator.ExportPrivateKeyToPemFile(_certGenerator.ServerCertificate, serverKeyPemPath);
 
-        _container = new KafkaBuilder(KafkaTestImages.FloorImage)
+        _container = KafkaTestImages.CreateBuilderForSelectedLane()
             .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")
             // SSL listener configuration
             // The Testcontainers KafkaBuilder manages KAFKA_LISTENERS and KAFKA_LISTENER_SECURITY_PROTOCOL_MAP

--- a/tests/Dekaf.Tests.Integration/Security/TlsKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/TlsKafkaContainer.cs
@@ -83,7 +83,7 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
         TestCertificateGenerator.ExportCertificateToPemFile(_certGenerator.ServerCertificate, serverCertPemPath);
         TestCertificateGenerator.ExportPrivateKeyToPemFile(_certGenerator.ServerCertificate, serverKeyPemPath);
 
-        _container = new KafkaBuilder("apache/kafka:4.0.1")
+        _container = new KafkaBuilder(KafkaTestImages.FloorImage)
             .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")
             // SSL listener configuration
             // The Testcontainers KafkaBuilder manages KAFKA_LISTENERS and KAFKA_LISTENER_SECURITY_PROTOCOL_MAP

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -14,7 +14,7 @@ namespace Dekaf.Tests.Integration;
 /// them to be within the acquisition window.
 /// </summary>
 [Category("ShareConsumer")]
-[SupportsKafka(420)]
+[SupportsKafka("4.2.0")]
 [NotInParallel("ShareConsumerKafkaCurrent")]
 public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
@@ -272,7 +272,7 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
 /// Requires Kafka 4.2+ with group.share.enable=true.
 /// </summary>
 [Category("ShareConsumerAdmin")]
-[SupportsKafka(420)]
+[SupportsKafka("4.2.0")]
 [NotInParallel("ShareConsumerKafkaCurrent")]
 public class ShareConsumerAdminTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -15,7 +15,7 @@ namespace Dekaf.Tests.Integration;
 /// </summary>
 [Category("ShareConsumer")]
 [SupportsKafka(420)]
-[NotInParallel("ShareConsumerKafka42")]
+[NotInParallel("ShareConsumerKafkaCurrent")]
 public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
@@ -273,7 +273,7 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
 /// </summary>
 [Category("ShareConsumerAdmin")]
 [SupportsKafka(420)]
-[NotInParallel("ShareConsumerKafka42")]
+[NotInParallel("ShareConsumerKafkaCurrent")]
 public class ShareConsumerAdminTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/SupportsKafkaAttribute.cs
+++ b/tests/Dekaf.Tests.Integration/SupportsKafkaAttribute.cs
@@ -1,22 +1,24 @@
 namespace Dekaf.Tests.Integration;
 
-public class SupportsKafkaAttribute(int supportedKafkaVersion) : SkipAttribute(string.Empty)
+public class SupportsKafkaAttribute(string supportedKafkaVersion) : SkipAttribute(string.Empty)
 {
+    private readonly Version _supportedKafkaVersion = Version.Parse(supportedKafkaVersion);
+
     public override Task<bool> ShouldSkip(TestRegisteredContext context)
     {
         var kafkaVersionUsedInTest = GetKafkaVersionUsedInTest(context);
 
-        return Task.FromResult(kafkaVersionUsedInTest < supportedKafkaVersion);
+        return Task.FromResult(kafkaVersionUsedInTest < _supportedKafkaVersion);
     }
 
     protected override string GetSkipReason(TestRegisteredContext context)
     {
         var kafkaVersionUsedInTest = GetKafkaVersionUsedInTest(context);
 
-        return $"The test requires Kafka {supportedKafkaVersion} or above, but this test is testing {kafkaVersionUsedInTest}";
+        return $"The test requires Kafka {_supportedKafkaVersion} or above, but this test is testing {kafkaVersionUsedInTest}";
     }
 
-    private static int GetKafkaVersionUsedInTest(TestRegisteredContext context)
+    private static Version GetKafkaVersionUsedInTest(TestRegisteredContext context)
     {
         return context.TestContext
             .Metadata

--- a/tests/Dekaf.Tests.Integration/TransactionCoordinatorTestGateTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionCoordinatorTestGateTests.cs
@@ -21,7 +21,9 @@ public sealed class TransactionCoordinatorTestGateTests
 
     private sealed class StubKafkaTestContainer(string name) : KafkaTestContainer
     {
+        private static readonly Version s_version = new(0, 0, 0);
+
         public override string ContainerName => name;
-        public override int Version => 0;
+        public override Version Version => s_version;
     }
 }

--- a/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
@@ -16,8 +16,6 @@ namespace Dekaf.Tests.Integration;
 /// </summary>
 public sealed class TransactionFaultKafkaContainer : KafkaTestContainer
 {
-    private static readonly KafkaTestImage s_selectedImage = KafkaTestImages.Selected;
-
     private const string KafkaNetworkAlias = "transaction-fault-kafka";
     private const string ProducerProxyName = "transaction-producer";
     private const string ConsumerProxyName = "transaction-consumer";
@@ -29,10 +27,6 @@ public sealed class TransactionFaultKafkaContainer : KafkaTestContainer
     private const ushort KafkaConsumerPort = 19_093;
     private const ushort KafkaBrokerPort = 19_094;
     private const ushort KafkaControllerPort = 19_095;
-
-    public override string ContainerName => s_selectedImage.Image;
-
-    public override Version Version => s_selectedImage.Version;
 
     private readonly INetwork _network = new NetworkBuilder().Build();
     private readonly ToxiproxyContainer _toxiproxy;

--- a/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
@@ -16,6 +16,8 @@ namespace Dekaf.Tests.Integration;
 /// </summary>
 public sealed class TransactionFaultKafkaContainer : KafkaTestContainer
 {
+    private static readonly KafkaTestImage s_selectedImage = KafkaTestImages.Selected;
+
     private const string KafkaNetworkAlias = "transaction-fault-kafka";
     private const string ProducerProxyName = "transaction-producer";
     private const string ConsumerProxyName = "transaction-consumer";
@@ -28,9 +30,9 @@ public sealed class TransactionFaultKafkaContainer : KafkaTestContainer
     private const ushort KafkaBrokerPort = 19_094;
     private const ushort KafkaControllerPort = 19_095;
 
-    public override string ContainerName => "apache/kafka:4.0.1";
+    public override string ContainerName => s_selectedImage.Image;
 
-    public override int Version => 401;
+    public override int Version => s_selectedImage.VersionNumber;
 
     private readonly INetwork _network = new NetworkBuilder().Build();
     private readonly ToxiproxyContainer _toxiproxy;
@@ -138,7 +140,7 @@ public sealed class TransactionFaultKafkaContainer : KafkaTestContainer
         ushort producerPublicPort,
         ushort consumerPublicPort)
     {
-        return new ContainerBuilder("apache/kafka:4.0.1")
+        return new ContainerBuilder(ContainerName)
             .WithNetwork(_network)
             .WithNetworkAliases(KafkaNetworkAlias)
             .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")

--- a/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
@@ -32,7 +32,7 @@ public sealed class TransactionFaultKafkaContainer : KafkaTestContainer
 
     public override string ContainerName => s_selectedImage.Image;
 
-    public override int Version => s_selectedImage.VersionNumber;
+    public override Version Version => s_selectedImage.Version;
 
     private readonly INetwork _network = new NetworkBuilder().Build();
     private readonly ToxiproxyContainer _toxiproxy;


### PR DESCRIPTION
## Summary
- run managed and NativeAOT integration jobs against separate Kafka floor and current-stable lanes
- centralize integration-test Kafka images on digest-pinned 4.0.2 and 4.3.1 releases maintained by Renovate
- verify live API-version downgrade behavior against both broker lanes

## Test plan
- [x] dotnet build Dekaf.sln --configuration Release
- [x] ProtocolVersionTests on Kafka floor/current (
et10.0)
- [x] image resolver and negotiation tests on Kafka floor/current (
et8.0)
- [x] ShareConsumer smoke test on current Kafka (
et10.0)
- [x] ctionlint .github/workflows/ci.yml
- [x] enovate-config-validator renovate.json
- [x] dotnet format --verify-no-changes for changed C# files

Closes #1604
