### PR TITLE
fix(agent-locks): isolate linked worktree markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Test Agent Lock Worktree Isolation
+        if: matrix.framework == 'net10.0'
+        shell: pwsh
+        run: ./scripts/Test-AgentLocks.ps1
+
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v4
         with:

--- a/scripts/AgentLocks.ps1
+++ b/scripts/AgentLocks.ps1
@@ -41,7 +41,8 @@
 #
 # Lock-name resolution (renew/release/status): -LockName is OPTIONAL there. When
 # omitted it is resolved from, in order: (1) a marker persisted in the current
-# worktree's git config (`agent.lockName`), which `acquire`/`renew -Worktree` writes;
+# worktree's per-worktree git config (`agent.lockName`), which
+# `acquire`/`renew -Worktree` writes after enabling `extensions.worktreeConfig`;
 # then (2) an `issue-<N>-*` branch name -> `issue-<N>`. `acquire` still REQUIRES an
 # explicit name (or an `issue-<N>-*` branch): it runs before the worktree exists, and
 # a PR lock's number (`pr-<N>`) is not derivable from the branch (`issue-<M>-...`).
@@ -76,11 +77,31 @@ $stateDir = Join-Path ([System.IO.Path]::GetTempPath()) 'dekaf-agent-locks'
 
 function Die([int]$code, [string]$msg) { if ($msg) { [Console]::Error.WriteLine($msg) }; exit $code }
 
+function Get-WorktreeLockMarker {
+    # `git config --worktree` aliases shared local config until this extension is
+    # enabled. Skip legacy shared markers entirely so they cannot shadow issue branch
+    # derivation; every marker written by this version enables the extension first.
+    $enabled = (git config --local --bool --get extensions.worktreeConfig 2>$null)
+    if ($LASTEXITCODE -ne 0 -or -not $enabled -or $enabled.Trim() -ne 'true') { return $null }
+
+    $marker = (git config --worktree --get agent.lockName 2>$null)
+    if ($LASTEXITCODE -eq 0 -and $marker) { return $marker.Trim() }
+    return $null
+}
+
+function Set-WorktreeLockMarker([string]$Path) {
+    # Linked worktrees share --local config. Enable the extension in that common
+    # config, then persist the marker in the target worktree's config.worktree file.
+    git -C $Path config --local extensions.worktreeConfig true 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) { return }
+    git -C $Path config --worktree agent.lockName $LockName 2>$null | Out-Null
+}
+
 function Resolve-LockName([string]$Explicit) {
     if ($Explicit) { return $Explicit }
     # 1. marker persisted in the current worktree by a prior `acquire`/`renew -Worktree`.
-    $cfg = (git config --local --get agent.lockName 2>$null)
-    if ($LASTEXITCODE -eq 0 -and $cfg) { return $cfg.Trim() }
+    $marker = Get-WorktreeLockMarker
+    if ($marker) { return $marker }
     # 2. derive issue-<N> from an issue-<N>-<desc> branch (never yields pr-<N>).
     $branch = (git rev-parse --abbrev-ref HEAD 2>$null)
     if ($LASTEXITCODE -eq 0 -and $branch -match '^issue-(\d+)-') { return "issue-$($Matches[1])" }
@@ -149,7 +170,7 @@ switch ($Verb) {
         New-Item -ItemType Directory -Force $stateDir | Out-Null
         Set-Content -LiteralPath $tokenFile -Value $token -NoNewline
         # If the worktree already exists at acquire time, write the auto-derive marker.
-        if ($Worktree) { git -C $Worktree config --local agent.lockName $LockName 2>$null | Out-Null }
+        if ($Worktree) { Set-WorktreeLockMarker $Worktree }
         Write-Output $token
         exit 0
     }
@@ -164,7 +185,7 @@ switch ($Verb) {
         if ((Redis EVAL $script 2 $lockKey $metaKey $token $lockTtlSeconds (New-Meta $token)) -ne '1') {
             Die 4 'LOST'
         }
-        if ($Worktree) { git -C $Worktree config --local agent.lockName $LockName 2>$null | Out-Null }
+        if ($Worktree) { Set-WorktreeLockMarker $Worktree }
         exit 0
     }
 

--- a/scripts/Test-AgentLocks.ps1
+++ b/scripts/Test-AgentLocks.ps1
@@ -1,0 +1,153 @@
+# Regression tests for per-worktree AgentLocks markers.
+
+$ErrorActionPreference = 'Stop'
+
+$agentLocks = Join-Path $PSScriptRoot 'AgentLocks.ps1'
+$suffix = [Guid]::NewGuid().ToString('N')
+$issueNumber = Get-Random -Minimum 100000 -Maximum 999999
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dekaf-agent-lock-tests-$suffix"
+$repo = Join-Path $testRoot 'repo'
+$issueWorktree = Join-Path $testRoot 'issue'
+$worktreeA = Join-Path $testRoot 'marker-a'
+$worktreeB = Join-Path $testRoot 'marker-b'
+
+$issueLock = "issue-$issueNumber"
+$lockA = "pr-agentlocks-a-$suffix"
+$lockB = "pr-agentlocks-b-$suffix"
+$explicitLock = "pr-agentlocks-explicit-$suffix"
+$staleLock = "pr-agentlocks-stale-$suffix"
+$allLocks = @($issueLock, $lockA, $lockB, $explicitLock)
+
+function Invoke-AgentLocks {
+    param(
+        [Parameter(Mandatory)]
+        [string]$WorkingDirectory,
+
+        [Parameter(Mandatory)]
+        [string[]]$Arguments
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        $output = @(& pwsh -NoProfile -File $agentLocks @Arguments 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+
+    [pscustomobject]@{
+        ExitCode = $exitCode
+        Output = (($output | ForEach-Object { $_.ToString() }) -join "`n").Trim()
+    }
+}
+
+function Assert-ExitZero {
+    param(
+        [Parameter(Mandatory)]
+        $Result,
+
+        [Parameter(Mandatory)]
+        [string]$Operation
+    )
+
+    if ($Result.ExitCode -ne 0) {
+        throw "$Operation failed with exit $($Result.ExitCode): $($Result.Output)"
+    }
+}
+
+function Assert-Status {
+    param(
+        [Parameter(Mandatory)]
+        [string]$WorkingDirectory,
+
+        [Parameter(Mandatory)]
+        [string[]]$Arguments,
+
+        [Parameter(Mandatory)]
+        [string]$Expected,
+
+        [Parameter(Mandatory)]
+        [string]$Operation
+    )
+
+    $result = Invoke-AgentLocks -WorkingDirectory $WorkingDirectory -Arguments $Arguments
+    Assert-ExitZero -Result $result -Operation $Operation
+    if ($result.Output -ne $Expected) {
+        throw "$Operation returned '$($result.Output)', expected '$Expected'"
+    }
+}
+
+function Invoke-Git {
+    param([Parameter(ValueFromRemainingArguments)] [string[]]$Arguments)
+
+    & git @Arguments 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "git command failed: git $($Arguments -join ' ')"
+    }
+}
+
+try {
+    New-Item -ItemType Directory -Force $repo | Out-Null
+    Invoke-Git init --initial-branch=main $repo
+    Invoke-Git -C $repo config user.email 'agent-lock-tests@example.invalid'
+    Invoke-Git -C $repo config user.name 'Agent Lock Tests'
+    Set-Content -LiteralPath (Join-Path $repo 'fixture.txt') -Value 'fixture'
+    Invoke-Git -C $repo add fixture.txt
+    Invoke-Git -C $repo commit -m 'test fixture'
+    Invoke-Git -C $repo worktree add -b "issue-$issueNumber-marker-test" $issueWorktree HEAD
+    Invoke-Git -C $repo worktree add -b marker-a $worktreeA HEAD
+    Invoke-Git -C $repo worktree add -b marker-b $worktreeB HEAD
+
+    # Simulate marker left by the pre-fix implementation in shared local config.
+    Invoke-Git -C $repo config --local agent.lockName $staleLock
+
+    Assert-ExitZero -Result (Invoke-AgentLocks $repo @('acquire', '-LockName', $issueLock)) -Operation 'acquire issue lock'
+    Assert-ExitZero -Result (Invoke-AgentLocks $repo @('acquire', '-LockName', $lockA, '-Worktree', $worktreeA)) -Operation 'acquire marker A'
+    Assert-ExitZero -Result (Invoke-AgentLocks $repo @('acquire', '-LockName', $lockB)) -Operation 'acquire marker B'
+    Assert-ExitZero -Result (Invoke-AgentLocks $repo @('renew', '-LockName', $lockB, '-Worktree', $worktreeB)) -Operation 'write marker B during renew'
+
+    # Leave B's marker behind while making its lock FREE. An issue worktree must
+    # derive its issue lock instead of reading B's marker from shared config.
+    Assert-ExitZero -Result (Invoke-AgentLocks $repo @('release', '-LockName', $lockB)) -Operation 'release marker B explicitly'
+    Assert-Status $issueWorktree @('status') 'HELD-BY-ME' 'implicit issue status'
+    Assert-ExitZero -Result (Invoke-AgentLocks $repo @('acquire', '-LockName', $lockB)) -Operation 'reacquire marker B'
+    Assert-ExitZero -Result (Invoke-AgentLocks $repo @('renew', '-LockName', $lockB, '-Worktree', $worktreeB)) -Operation 'rewrite marker B during renew'
+    Assert-ExitZero -Result (Invoke-AgentLocks $issueWorktree @('release')) -Operation 'implicit issue release'
+    Assert-Status $repo @('status', '-LockName', $issueLock) 'FREE' 'explicit issue status after implicit release'
+    Assert-Status $repo @('status', '-LockName', $lockB) 'HELD-BY-ME' 'marker B remains held'
+
+    # Markers in linked worktrees must resolve independently for implicit verbs.
+    Assert-Status $worktreeA @('status') 'HELD-BY-ME' 'implicit marker A status'
+    Assert-Status $worktreeB @('status') 'HELD-BY-ME' 'implicit marker B status'
+    Assert-ExitZero -Result (Invoke-AgentLocks $worktreeA @('release')) -Operation 'implicit marker A release'
+    Assert-Status $repo @('status', '-LockName', $lockA) 'FREE' 'marker A released'
+    Assert-Status $repo @('status', '-LockName', $lockB) 'HELD-BY-ME' 'marker B isolated from marker A release'
+    Assert-ExitZero -Result (Invoke-AgentLocks $worktreeB @('release')) -Operation 'implicit marker B release'
+
+    # Explicit names always override any marker in the current worktree.
+    Assert-ExitZero -Result (Invoke-AgentLocks $repo @('acquire', '-LockName', $explicitLock)) -Operation 'acquire explicit lock'
+    Assert-Status $worktreeA @('status', '-LockName', $explicitLock) 'HELD-BY-ME' 'explicit status override'
+    Assert-ExitZero -Result (Invoke-AgentLocks $worktreeB @('release', '-LockName', $explicitLock)) -Operation 'explicit release override'
+    Assert-Status $repo @('status', '-LockName', $explicitLock) 'FREE' 'explicit lock released'
+
+    Write-Host 'OK AgentLocks worktree marker tests passed.'
+}
+finally {
+    if (Test-Path -LiteralPath $repo) {
+        foreach ($lockName in $allLocks) {
+            $status = Invoke-AgentLocks $repo @('status', '-LockName', $lockName)
+            if ($status.ExitCode -eq 0 -and $status.Output -eq 'HELD-BY-ME') {
+                Invoke-AgentLocks $repo @('release', '-LockName', $lockName) | Out-Null
+            }
+        }
+    }
+
+    $tempRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+    $resolvedTestRoot = [System.IO.Path]::GetFullPath($testRoot)
+    if (-not $resolvedTestRoot.StartsWith($tempRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to remove test directory outside temp: $resolvedTestRoot"
+    }
+
+    Remove-Item -LiteralPath $resolvedTestRoot -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary
- store `agent.lockName` in each linked worktree's `config.worktree`
- ignore legacy shared markers so issue branches fall back to branch-derived lock names
- cover independent implicit status/release plus explicit `-LockName` behavior
- run lock isolation regression in CI

## Test plan
- [x] `pwsh -NoProfile -File scripts/Test-AgentLocks.ps1`
- [x] implicit and explicit `issue-1642` status smoke
- [x] PowerShell parser validation for all 9 scripts
- [x] `pwsh -NoProfile -File scripts/Test-AssertPrGreenReviewHeuristics.ps1`
- [x] CI workflow YAML parse

Closes #1642
