### PR TITLE
test(consumer): remove flaky timing ceiling

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Reflection;
 using System.Text;
@@ -258,11 +257,8 @@ public sealed class ConsumeOneFastPathTests
 
         using var cts = new CancellationTokenSource();
 
-        var stopwatch = Stopwatch.StartNew();
         var consumeTask = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
-        stopwatch.Stop();
 
-        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(100));
         await Assert.That(consumeTask.IsCompleted).IsFalse();
 
         cts.Cancel();


### PR DESCRIPTION
## Summary
- remove the scheduler-dependent 100 ms wall-clock ceiling from the empty-prefetch test
- retain the deterministic `ValueTask.IsCompleted == false` assertion proving `ConsumeOneAsync` returned without synchronously waiting
- retain cancellation verification for the outstanding operation

The failure is load-dependent, so a deterministic red test is not possible; issue #1631 contains the captured 108 ms reproduction.

## Test plan
- [x] focused test passes on net8.0 and net10.0
- [x] net10.0 full parallel unit suite: 4,509 passed
- [x] net8.0 full parallel unit suite: target passed; 4,502 passed and only known pre-existing #1609 activity-listener race failed
- [x] Release build for net8.0 and net10.0

Closes #1631
