### PR TITLE
test: add transactional crash-recovery harness

### DIFF
--- a/tests/Dekaf.Tests.Integration/TransactionCrashRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionCrashRecoveryTests.cs
@@ -1,0 +1,77 @@
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Transaction")]
+public sealed class TransactionCrashRecoveryTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task ForceTerminatedProducer_ReplacementAbortsDanglingTransaction()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var transactionId = $"crash-recovery-{Guid.NewGuid():N}";
+        var crashedValue = $"crashed-{Guid.NewGuid():N}";
+        string[] committedValues =
+        [
+            $"committed-{Guid.NewGuid():N}",
+            $"committed-{Guid.NewGuid():N}"
+        ];
+
+        await using (var crashClient = TransactionalCrashClientProcess.Start(
+                         KafkaContainer.BootstrapServers,
+                         topic,
+                         transactionId,
+                         "crashed-key",
+                         crashedValue))
+        {
+            await crashClient.WaitUntilReadyAsync(TimeSpan.FromSeconds(45));
+            await crashClient.TerminateAsync();
+        }
+
+        await using var replacement = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId(transactionId)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await replacement.InitTransactionsAsync();
+
+        await using (var transaction = replacement.BeginTransaction())
+        {
+            for (var index = 0; index < committedValues.Length; index++)
+            {
+                await transaction.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Key = $"committed-key-{index}",
+                    Value = committedValues[index]
+                }, CancellationToken.None);
+            }
+
+            await transaction.CommitAsync();
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"crash-recovery-verify-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithIsolationLevel(IsolationLevel.ReadCommitted)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        var messages = await ConsumeMessagesAsync(consumer, committedValues.Length);
+        var unexpectedMessage = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(5));
+        var actualValues = messages.Select(message => message.Value).ToArray();
+
+        await Assert.That(actualValues).Count().IsEqualTo(committedValues.Length);
+        await Assert.That(actualValues[0]).IsEqualTo(committedValues[0]);
+        await Assert.That(actualValues[1]).IsEqualTo(committedValues[1]);
+        await Assert.That(actualValues).DoesNotContain(crashedValue);
+        await Assert.That(unexpectedMessage).IsNull();
+    }
+}

--- a/tests/Dekaf.Tests.Integration/TransactionCrashRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionCrashRecoveryTests.cs
@@ -8,6 +8,26 @@ namespace Dekaf.Tests.Integration;
 public sealed class TransactionCrashRecoveryTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
+    public async Task TerminateAsync_ProcessExitsBeforeKill_CompletesSuccessfully()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        await using var crashClient = TransactionalCrashClientProcess.Start(
+            KafkaContainer.BootstrapServers,
+            topic,
+            $"crash-exit-race-{Guid.NewGuid():N}",
+            "crashed-key",
+            "crashed-value");
+        await crashClient.WaitUntilReadyAsync(TimeSpan.FromSeconds(45));
+        crashClient.BeforeForceTerminateForTestAsync = async process =>
+        {
+            process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync();
+        };
+
+        await crashClient.TerminateAsync();
+    }
+
+    [Test]
     public async Task ForceTerminatedProducer_ReplacementAbortsDanglingTransaction()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();

--- a/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
@@ -1,0 +1,295 @@
+using System.Diagnostics;
+using System.Text;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Integration;
+
+internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
+{
+    internal const string EnabledVariable = "DEKAF_TRANSACTION_CRASH_CLIENT";
+    internal const string BootstrapServersVariable = "DEKAF_TRANSACTION_CRASH_BOOTSTRAP_SERVERS";
+    internal const string TopicVariable = "DEKAF_TRANSACTION_CRASH_TOPIC";
+    internal const string TransactionIdVariable = "DEKAF_TRANSACTION_CRASH_ID";
+    internal const string KeyVariable = "DEKAF_TRANSACTION_CRASH_KEY";
+    internal const string ValueVariable = "DEKAF_TRANSACTION_CRASH_VALUE";
+    internal const string ReadyPathVariable = "DEKAF_TRANSACTION_CRASH_READY_PATH";
+    internal const string BrokerAcknowledgedSignal = "broker-acknowledged";
+    private const int MaximumDiagnosticCharacters = 16_384;
+
+    private readonly Process _process;
+    private readonly string _readyPath;
+    private readonly BoundedProcessDiagnostics _diagnostics;
+
+    private TransactionalCrashClientProcess(
+        Process process,
+        string readyPath,
+        BoundedProcessDiagnostics diagnostics)
+    {
+        _process = process;
+        _readyPath = readyPath;
+        _diagnostics = diagnostics;
+    }
+
+    public static TransactionalCrashClientProcess Start(
+        string bootstrapServers,
+        string topic,
+        string transactionId,
+        string key,
+        string value)
+    {
+        var readyPath = Path.Combine(
+            Path.GetTempPath(),
+            $"dekaf-transaction-crash-{Guid.NewGuid():N}.ready");
+        var startInfo = CreateStartInfo(bootstrapServers, topic, transactionId, key, value, readyPath);
+        var process = new Process { StartInfo = startInfo };
+        var diagnostics = new BoundedProcessDiagnostics(MaximumDiagnosticCharacters);
+
+        process.OutputDataReceived += (_, eventArgs) => diagnostics.Append("stdout", eventArgs.Data);
+        process.ErrorDataReceived += (_, eventArgs) => diagnostics.Append("stderr", eventArgs.Data);
+
+        try
+        {
+            if (!process.Start())
+            {
+                throw new InvalidOperationException("Transactional crash client did not start.");
+            }
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            return new TransactionalCrashClientProcess(process, readyPath, diagnostics);
+        }
+        catch
+        {
+            process.Dispose();
+            DeleteSignalFiles(readyPath);
+            throw;
+        }
+    }
+
+    public async Task WaitUntilReadyAsync(TimeSpan timeout)
+    {
+        using var timeoutSource = new CancellationTokenSource(timeout);
+
+        try
+        {
+            while (!File.Exists(_readyPath))
+            {
+                ThrowIfExitedBeforeReady();
+                await Task.Delay(50, timeoutSource.Token);
+            }
+
+            var signal = await File.ReadAllTextAsync(_readyPath, timeoutSource.Token);
+            if (!string.Equals(signal, BrokerAcknowledgedSignal, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Transactional crash client wrote an invalid readiness signal: '{signal}'.");
+            }
+
+            ThrowIfExitedBeforeReady();
+        }
+        catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"Transactional crash client did not acknowledge its open transaction within {timeout}." +
+                Environment.NewLine + _diagnostics);
+        }
+    }
+
+    public async Task TerminateAsync()
+    {
+        if (_process.HasExited)
+        {
+            throw new InvalidOperationException(
+                $"Transactional crash client exited before it could be force-terminated with code {_process.ExitCode}." +
+                Environment.NewLine + _diagnostics);
+        }
+
+        await ForceTerminateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (!_process.HasExited)
+            {
+                await ForceTerminateAsync();
+            }
+        }
+        finally
+        {
+            _process.Dispose();
+            DeleteSignalFiles(_readyPath);
+        }
+    }
+
+    private async Task ForceTerminateAsync()
+    {
+        _process.Kill(entireProcessTree: true);
+
+        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        try
+        {
+            await _process.WaitForExitAsync(timeoutSource.Token);
+        }
+        catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                "Transactional crash client did not exit after force termination." +
+                Environment.NewLine + _diagnostics);
+        }
+    }
+
+    private static ProcessStartInfo CreateStartInfo(
+        string bootstrapServers,
+        string topic,
+        string transactionId,
+        string key,
+        string value,
+        string readyPath)
+    {
+        var processPath = Environment.ProcessPath
+            ?? throw new InvalidOperationException("Cannot locate the integration test executable.");
+        var startInfo = new ProcessStartInfo(processPath)
+        {
+            WorkingDirectory = AppContext.BaseDirectory,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        if (string.Equals(Path.GetFileNameWithoutExtension(processPath), "dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            startInfo.ArgumentList.Add(Environment.GetCommandLineArgs()[0]);
+        }
+
+        startInfo.ArgumentList.Add("--treenode-filter");
+        startInfo.ArgumentList.Add("/*/*/TransactionalCrashClient/*");
+        startInfo.ArgumentList.Add("--maximum-parallel-tests");
+        startInfo.ArgumentList.Add("1");
+
+        startInfo.Environment[EnabledVariable] = "1";
+        startInfo.Environment[BootstrapServersVariable] = bootstrapServers;
+        startInfo.Environment[TopicVariable] = topic;
+        startInfo.Environment[TransactionIdVariable] = transactionId;
+        startInfo.Environment[KeyVariable] = key;
+        startInfo.Environment[ValueVariable] = value;
+        startInfo.Environment[ReadyPathVariable] = readyPath;
+        return startInfo;
+    }
+
+    private void ThrowIfExitedBeforeReady()
+    {
+        if (_process.HasExited)
+        {
+            throw new InvalidOperationException(
+                $"Transactional crash client exited before signaling readiness with code {_process.ExitCode}." +
+                Environment.NewLine + _diagnostics);
+        }
+    }
+
+    private static void DeleteSignalFiles(string readyPath)
+    {
+        TryDelete(readyPath);
+        TryDelete(readyPath + ".tmp");
+
+        static void TryDelete(string path)
+        {
+            try
+            {
+                File.Delete(path);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private sealed class BoundedProcessDiagnostics(int maximumCharacters)
+    {
+        private readonly StringBuilder _buffer = new();
+
+        public void Append(string stream, string? message)
+        {
+            if (message is null)
+            {
+                return;
+            }
+
+            lock (_buffer)
+            {
+                _buffer.Append('[').Append(stream).Append("] ").AppendLine(message);
+                if (_buffer.Length > maximumCharacters)
+                {
+                    _buffer.Remove(0, _buffer.Length - maximumCharacters);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            lock (_buffer)
+            {
+                return _buffer.ToString();
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Child-process entry point used by <see cref="TransactionCrashRecoveryTests"/>.
+/// It is inert during ordinary discovery and activated only through the harness environment.
+/// </summary>
+public sealed class TransactionalCrashClient
+{
+    [Test]
+    public async Task HoldBrokerAcknowledgedTransactionOpen()
+    {
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable(TransactionalCrashClientProcess.EnabledVariable),
+                "1",
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var bootstrapServers = GetRequiredEnvironmentVariable(TransactionalCrashClientProcess.BootstrapServersVariable);
+        var topic = GetRequiredEnvironmentVariable(TransactionalCrashClientProcess.TopicVariable);
+        var transactionId = GetRequiredEnvironmentVariable(TransactionalCrashClientProcess.TransactionIdVariable);
+        var key = GetRequiredEnvironmentVariable(TransactionalCrashClientProcess.KeyVariable);
+        var value = GetRequiredEnvironmentVariable(TransactionalCrashClientProcess.ValueVariable);
+        var readyPath = GetRequiredEnvironmentVariable(TransactionalCrashClientProcess.ReadyPathVariable);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(bootstrapServers)
+            .WithTransactionalId(transactionId)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.InitTransactionsAsync();
+        await using var transaction = producer.BeginTransaction();
+        await transaction.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = key,
+            Value = value
+        }, CancellationToken.None);
+
+        var temporaryReadyPath = readyPath + ".tmp";
+        await File.WriteAllTextAsync(
+            temporaryReadyPath,
+            TransactionalCrashClientProcess.BrokerAcknowledgedSignal);
+        File.Move(temporaryReadyPath, readyPath);
+
+        await Task.Delay(Timeout.InfiniteTimeSpan);
+    }
+
+    private static string GetRequiredEnvironmentVariable(string name) =>
+        Environment.GetEnvironmentVariable(name)
+        ?? throw new InvalidOperationException($"Required environment variable '{name}' is not set.");
+}

--- a/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
@@ -20,6 +20,8 @@ internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
     private readonly string _readyPath;
     private readonly BoundedProcessDiagnostics _diagnostics;
 
+    internal Func<Process, Task>? BeforeForceTerminateForTestAsync { get; set; }
+
     private TransactionalCrashClientProcess(
         Process process,
         string readyPath,
@@ -125,6 +127,11 @@ internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
 
     private async Task ForceTerminateAsync()
     {
+        if (BeforeForceTerminateForTestAsync is not null)
+        {
+            await BeforeForceTerminateForTestAsync(_process);
+        }
+
         _process.Kill(entireProcessTree: true);
 
         using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));


### PR DESCRIPTION
## Summary
- add a child-process transactional producer that signals only after broker acknowledgment
- force-kill the client with its transaction open, then reuse the same `transactional.id`
- verify replacement commit recovery and exact `read_committed` visibility
- bound process waits, captured diagnostics, and signal-file cleanup

## Tests
- `dotnet build Dekaf.sln --configuration Release`
- `Dekaf.Tests.Unit` net10.0: 4,509 passed
- `TransactionCrashRecoveryTests` net10.0: 3 passed (Kafka 4.0/4.1/4.2)
- `TransactionCrashRecoveryTests` net8.0: 3 passed (Kafka 4.0/4.1/4.2)
- NativeAOT publish reached the platform linker; local Visual C++ linker is unavailable

Closes #1621