### PR TITLE
feat(stress): add transactional EOS scenario

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -10,6 +10,7 @@ SCENARIO_TITLES = {
     'producer-acks-all': 'Producer (Acks All)',
     'producer-async': 'Producer (Async)',
     'producer-async-idempotent': 'Producer (Async, Idempotent)',
+    'producer-transactional': 'Producer (Transactional EOS)',
     'consumer': 'Consumer',
     'consumer-batch': 'Consumer (Batch)',
     'consumer-raw': 'Consumer (Raw Bytes)',
@@ -305,6 +306,59 @@ def format_gc_table(results, title="GC Statistics"):
     return lines
 
 
+def format_transaction_verification(results):
+    """Generate committed/aborted read_committed verification rows when present."""
+    transactional = [result for result in results if result.get('transactionVerification') is not None]
+    if not transactional:
+        return []
+
+    lines = [
+        "### Transaction Verification",
+        "",
+        "| Client | Accepted | Committed | Aborted | Delivered | Duplicates | Shortfall | Aborted leaks | Unexpected | Missing sentinels | Status |",
+        "|--------|----------|-----------|---------|-----------|------------|-----------|---------------|------------|-------------------|--------|",
+    ]
+    failure_samples = []
+
+    for result in sorted(transactional, key=lambda item: item.get('client', '')):
+        verification = result['transactionVerification']
+        successful = verification.get('isSuccessful')
+        if successful is None:
+            successful = all(verification.get(field, 0) == 0 for field in (
+                'duplicateMessages',
+                'shortfallMessages',
+                'leakedAbortedMessages',
+                'unexpectedMessages',
+                'missingSentinelPartitions',
+            ))
+
+        values = [
+            result.get('client', 'Unknown'),
+            f"{verification.get('acceptedMessages', 0):,}",
+            f"{verification.get('committedMessages', 0):,}",
+            f"{verification.get('abortedMessages', 0):,}",
+            f"{verification.get('deliveredMessages', 0):,}",
+            f"{verification.get('duplicateMessages', 0):,}",
+            f"{verification.get('shortfallMessages', 0):,}",
+            f"{verification.get('leakedAbortedMessages', 0):,}",
+            f"{verification.get('unexpectedMessages', 0):,}",
+            f"{verification.get('missingSentinelPartitions', 0):,}",
+            'PASS' if successful else 'FAIL',
+        ]
+        lines.append(f"| {' | '.join(values)} |")
+        failure_samples.extend(
+            (result.get('client', 'Unknown'), sample)
+            for sample in verification.get('failureSamples', [])
+        )
+
+    lines.append("")
+    if failure_samples:
+        lines.append("**Transaction verification failure samples:**")
+        lines.extend(f"- {client}: {sample}" for client, sample in failure_samples)
+        lines.append("")
+    return lines
+
+
 def generate_scenario_tables(results, include_ratio=False, include_callout=False):
     """Generate per-scenario throughput tables for all results."""
     producer_scenarios, consumer_scenarios = group_by_scenario(results)
@@ -315,6 +369,7 @@ def generate_scenario_tables(results, include_ratio=False, include_callout=False
             title = scenario_title(scenario_key, fallback_prefix)
             scenario_results = scenarios[scenario_key]
             output.extend(format_throughput_table(scenario_results, f"{title} Throughput", include_ratio=include_ratio))
+            output.extend(format_transaction_verification(scenario_results))
             if include_callout:
                 output.extend(format_comparison_callout(scenario_results, title))
 

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -1,6 +1,6 @@
 import unittest
 
-from stress_report import format_throughput_table
+from stress_report import format_throughput_table, generate_scenario_tables
 
 
 def stress_result(client, effective_rate, median_rate=None):
@@ -58,6 +58,31 @@ class StressReportTests(unittest.TestCase):
 
         self.assertTrue(rows[0].startswith("| Dekaf"))
         self.assertIn("| 2.00x |", rows[0])
+
+    def test_transactional_scenario_reports_verification_counts(self):
+        transactional = stress_result("Dekaf", effective_rate=750)
+        transactional.update({
+            "scenario": "producer-transactional",
+            "transactionVerification": {
+                "acceptedMessages": 1000,
+                "committedMessages": 750,
+                "abortedMessages": 250,
+                "deliveredMessages": 750,
+                "duplicateMessages": 0,
+                "shortfallMessages": 0,
+                "leakedAbortedMessages": 0,
+                "unexpectedMessages": 0,
+                "missingSentinelPartitions": 0,
+                "isSuccessful": True,
+            },
+        })
+
+        lines = generate_scenario_tables([transactional])
+        report = "\n".join(lines)
+
+        self.assertIn("Producer (Transactional EOS)", report)
+        self.assertIn("Transaction Verification", report)
+        self.assertIn("| Dekaf | 1,000 | 750 | 250 | 750 | 0 | 0 | 0 | 0 | 0 | PASS |", report)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -72,6 +72,13 @@ jobs:
             artifact_suffix: ""
             timeout_minutes: 120
             name: Producer Acks All (Paired, 3 Brokers)
+          - scenario: producer-transactional
+            client: dekaf
+            brokers: 3
+            run_3conn: false
+            artifact_suffix: ""
+            timeout_minutes: 150
+            name: Dekaf Transactional EOS (3 Brokers)
           - scenario: consumer
             client: all
             brokers: 1

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -20,6 +20,11 @@
     <ProjectReference Include="..\..\src\Dekaf.Extensions.Hosting\Dekaf.Extensions.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.OpenTelemetry\Dekaf.OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Extensions.HealthChecks\Dekaf.Extensions.HealthChecks.csproj" />
+    <ProjectReference Include="..\..\tools\Dekaf.StressTests\Dekaf.StressTests.csproj" Condition="'$(TargetFramework)' == 'net10.0'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <Compile Remove="StressTests\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dekaf.Tests.Unit/StressTests/TransactionalReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/TransactionalReportingTests.cs
@@ -1,0 +1,108 @@
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class TransactionalReportingTests
+{
+    [Test]
+    public async Task CreateAllScenarios_IncludesTransactionalProducer()
+    {
+        var scenario = Dekaf.StressTests.Program.CreateAllScenarios()
+            .SingleOrDefault(item => item.Name == "producer-transactional");
+
+        await Assert.That(scenario).IsNotNull();
+        await Assert.That(scenario!.Client).IsEqualTo("Dekaf");
+    }
+
+    [Test]
+    public async Task Generate_TransactionalResult_IncludesVerificationCounts()
+    {
+        var verification = CreateVerification();
+        var result = CreateResult(verification);
+        var results = new StressTestResults
+        {
+            RunStartedAtUtc = result.StartedAtUtc,
+            RunCompletedAtUtc = result.CompletedAtUtc,
+            MachineName = "test",
+            ProcessorCount = 4,
+            Results = [result]
+        };
+
+        var markdown = MarkdownReporter.Generate(results);
+
+        await Assert.That(markdown).Contains("Transactional EOS");
+        await Assert.That(markdown).Contains("Transaction Verification");
+        await Assert.That(markdown).Contains("| Dekaf");
+        await Assert.That(markdown).Contains("| Dekaf     |      100 |");
+        await Assert.That(markdown).Contains("|        75 |      25 |        75 |");
+    }
+
+    [Test]
+    public async Task CheckForFailures_DuplicateTransactionalRecord_FailsRun()
+    {
+        var verification = CreateVerification(duplicateMessages: 1);
+
+        var failed = Dekaf.StressTests.Program.CheckForFailures([CreateResult(verification)]);
+
+        await Assert.That(failed).IsTrue();
+    }
+
+    [Test]
+    public async Task CheckForFailures_SuccessfulTransaction_DoesNotTreatAbortAsLoss()
+    {
+        var verification = CreateVerification();
+
+        var failed = Dekaf.StressTests.Program.CheckForFailures([CreateResult(verification)]);
+
+        await Assert.That(failed).IsFalse();
+    }
+
+    private static StressTestResult CreateResult(TransactionVerificationSnapshot verification)
+    {
+        var now = DateTime.UtcNow;
+        return new StressTestResult
+        {
+            Scenario = "producer-transactional",
+            Client = "Dekaf",
+            DurationMinutes = 15,
+            MessageSizeBytes = 1000,
+            StartedAtUtc = now,
+            CompletedAtUtc = now.AddMinutes(15),
+            Throughput = new ThroughputSnapshot
+            {
+                TotalMessages = verification.AcceptedMessages,
+                TotalBytes = verification.AcceptedMessages * 1000,
+                TotalErrors = 0,
+                ElapsedSeconds = 900,
+                AverageMessagesPerSecond = verification.AcceptedMessages / 900.0,
+                AverageMegabytesPerSecond = 0.001,
+                MessagesPerSecondSamples = [],
+                ErrorSamples = []
+            },
+            DeliveredMessages = verification.DeliveredMessages,
+            GcStats = new GcSnapshot
+            {
+                Gen0Collections = 0,
+                Gen1Collections = 0,
+                Gen2Collections = 0,
+                AllocatedBytes = 0
+            },
+            TransactionVerification = verification
+        };
+    }
+
+    private static TransactionVerificationSnapshot CreateVerification(long duplicateMessages = 0) => new()
+    {
+        AcceptedMessages = 100,
+        CommittedMessages = 75,
+        AbortedMessages = 25,
+        DeliveredMessages = 75,
+        DuplicateMessages = duplicateMessages,
+        ShortfallMessages = 0,
+        LeakedAbortedMessages = 0,
+        UnexpectedMessages = 0,
+        MissingSentinelPartitions = 0,
+        FailureSamples = duplicateMessages == 0 ? [] : ["Duplicate committed index 1."]
+    };
+}

--- a/tests/Dekaf.Tests.Unit/StressTests/TransactionalSequenceOracleTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/TransactionalSequenceOracleTests.cs
@@ -1,0 +1,77 @@
+using Dekaf.StressTests.Scenarios;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class TransactionalSequenceOracleTests
+{
+    [Test]
+    public async Task Observe_Failures_ReportsDuplicatesShortfallAndAbortedLeaks()
+    {
+        var oracle = new TransactionalSequenceOracle(
+            runId: "run-1",
+            committedMessages: 3,
+            abortedMessages: 2,
+            partitionCount: 2);
+
+        oracle.Observe(TransactionalSequenceOracle.CommittedKey("run-1", 0));
+        oracle.Observe(TransactionalSequenceOracle.CommittedKey("run-1", 0));
+        oracle.Observe(TransactionalSequenceOracle.CommittedKey("run-1", 2));
+        oracle.Observe(TransactionalSequenceOracle.AbortedKey("run-1", 0));
+        oracle.Observe(TransactionalSequenceOracle.SentinelKey("run-1", 0));
+        oracle.Observe(TransactionalSequenceOracle.SentinelKey("run-1", 1));
+        oracle.Observe("another-run:c:1");
+
+        var snapshot = oracle.CreateSnapshot(acceptedMessages: 5);
+
+        await Assert.That(snapshot.AcceptedMessages).IsEqualTo(5);
+        await Assert.That(snapshot.CommittedMessages).IsEqualTo(3);
+        await Assert.That(snapshot.AbortedMessages).IsEqualTo(2);
+        await Assert.That(snapshot.DeliveredMessages).IsEqualTo(2);
+        await Assert.That(snapshot.DuplicateMessages).IsEqualTo(1);
+        await Assert.That(snapshot.ShortfallMessages).IsEqualTo(1);
+        await Assert.That(snapshot.LeakedAbortedMessages).IsEqualTo(1);
+        await Assert.That(snapshot.MissingSentinelPartitions).IsEqualTo(0);
+        await Assert.That(snapshot.IsSuccessful).IsFalse();
+        await Assert.That(snapshot.FailureSamples).Contains(sample => sample.Contains("committed index 1"));
+    }
+
+    [Test]
+    public async Task Observe_CleanRun_ReportsSuccessfulVerification()
+    {
+        var oracle = new TransactionalSequenceOracle(
+            runId: "run-2",
+            committedMessages: 2,
+            abortedMessages: 1,
+            partitionCount: 2);
+
+        oracle.Observe(TransactionalSequenceOracle.CommittedKey("run-2", 0));
+        oracle.Observe(TransactionalSequenceOracle.CommittedKey("run-2", 1));
+        oracle.Observe(TransactionalSequenceOracle.SentinelKey("run-2", 0));
+        oracle.Observe(TransactionalSequenceOracle.SentinelKey("run-2", 1));
+
+        var snapshot = oracle.CreateSnapshot(acceptedMessages: 3);
+
+        await Assert.That(oracle.AllSentinelsSeen).IsTrue();
+        await Assert.That(snapshot.IsSuccessful).IsTrue();
+        await Assert.That(snapshot.DeliveredMessages).IsEqualTo(2);
+        await Assert.That(snapshot.FailureSamples).IsEmpty();
+    }
+
+    [Test]
+    public async Task CreateSnapshot_MissingSentinel_IsActionableFailure()
+    {
+        var oracle = new TransactionalSequenceOracle(
+            runId: "run-3",
+            committedMessages: 0,
+            abortedMessages: 0,
+            partitionCount: 2);
+
+        oracle.Observe(TransactionalSequenceOracle.SentinelKey("run-3", 0));
+
+        var snapshot = oracle.CreateSnapshot(acceptedMessages: 0);
+
+        await Assert.That(snapshot.MissingSentinelPartitions).IsEqualTo(1);
+        await Assert.That(snapshot.IsSuccessful).IsFalse();
+        await Assert.That(snapshot.FailureSamples).Contains(sample => sample.Contains("partition 1"));
+    }
+}

--- a/tests/Dekaf.Tests.Unit/StressTests/TransactionalSequenceOracleTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/TransactionalSequenceOracleTests.cs
@@ -58,6 +58,32 @@ public sealed class TransactionalSequenceOracleTests
     }
 
     [Test]
+    public async Task Observe_FailedCommitIntentLeak_IsReportedAsAbortedLeak()
+    {
+        var oracle = new TransactionalSequenceOracle(
+            runId: "run-failed-commit",
+            committedMessages: 2,
+            abortedMessages: 1,
+            partitionCount: 1,
+            failedCommitMessages: 2);
+
+        oracle.Observe(TransactionalSequenceOracle.CommittedKey("run-failed-commit", 0));
+        oracle.Observe(TransactionalSequenceOracle.CommittedKey("run-failed-commit", 1));
+        oracle.Observe(TransactionalSequenceOracle.CommittedKey("run-failed-commit", 2));
+        oracle.Observe(TransactionalSequenceOracle.CommittedKey("run-failed-commit", 3));
+        oracle.Observe(TransactionalSequenceOracle.SentinelKey("run-failed-commit", 0));
+
+        var snapshot = oracle.CreateSnapshot(acceptedMessages: 5);
+
+        await Assert.That(snapshot.AbortedMessages).IsEqualTo(3);
+        await Assert.That(snapshot.DeliveredMessages).IsEqualTo(2);
+        await Assert.That(snapshot.LeakedAbortedMessages).IsEqualTo(2);
+        await Assert.That(snapshot.UnexpectedMessages).IsEqualTo(0);
+        await Assert.That(snapshot.FailureSamples)
+            .Contains(sample => sample.Contains("Failed commit index 2"));
+    }
+
+    [Test]
     public async Task CreateSnapshot_MissingSentinel_IsActionableFailure()
     {
         var oracle = new TransactionalSequenceOracle(

--- a/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
+++ b/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Dekaf.Tests.Unit" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.15.0" />
     <PackageReference Include="Testcontainers" Version="4.13.0" />
     <PackageReference Include="Testcontainers.Kafka" Version="4.13.0" />

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -16,7 +16,7 @@ namespace Dekaf.StressTests;
 /// Options:
 ///   --duration &lt;minutes&gt;    Test duration in minutes (default: 15)
 ///   --message-size &lt;bytes&gt;  Message size in bytes (default: 1000)
-///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
+///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
 ///   --client &lt;name&gt;         Run specific client: dekaf, confluent, all (default: all)
 ///   --output &lt;path&gt;         Output directory for results (default: ./results)
 ///   --brokers &lt;count&gt;      Number of Kafka brokers (default: 1, use 3 for multi-broker)
@@ -104,9 +104,15 @@ public static class Program
 
         var producerTopic = $"stress-producer-{Guid.NewGuid():N}";
         var consumerTopic = $"stress-consumer-{Guid.NewGuid():N}";
+        string? transactionalTopic = null;
 
         var replicationFactor = Math.Min(options.Brokers, 3);
         await kafka.CreateTopicAsync(producerTopic, options.Partitions, replicationFactor).ConfigureAwait(false);
+        if (options.Scenario is "all" or "producer-transactional")
+        {
+            transactionalTopic = $"stress-transactional-{Guid.NewGuid():N}";
+            await kafka.CreateTopicAsync(transactionalTopic, options.Partitions, replicationFactor).ConfigureAwait(false);
+        }
         // Consumer scenarios re-read the seeded data set in a loop for the full duration.
         // Broker-level retention (tuned to bound producer-topic disk usage) must not
         // delete it mid-run, so retention is disabled at the topic level.
@@ -125,10 +131,20 @@ public static class Program
         var results = new List<StressTestResult>();
         var runStartedAt = DateTime.UtcNow;
 
+        string ResolveScenarioTopic(string scenarioName)
+        {
+            if (scenarioName.Equals("producer-transactional", StringComparison.OrdinalIgnoreCase))
+                return transactionalTopic ?? throw new InvalidOperationException("Transactional topic was not created.");
+
+            return scenarioName.StartsWith("producer", StringComparison.OrdinalIgnoreCase)
+                ? producerTopic
+                : consumerTopic;
+        }
+
         StressTestOptions BuildTestOptions(string scenarioName, int connectionsPerBroker) => new()
         {
             BootstrapServers = kafka.BootstrapServers,
-            Topic = scenarioName.StartsWith("producer", StringComparison.OrdinalIgnoreCase) ? producerTopic : consumerTopic,
+            Topic = ResolveScenarioTopic(scenarioName),
             DurationMinutes = options.DurationMinutes,
             MessageSizeBytes = options.MessageSizeBytes,
             Partitions = options.Partitions,
@@ -165,11 +181,18 @@ public static class Program
                 .ToList();
             foreach (var scenario in multiConnScenarios)
             {
+                var connectionsPerBroker = scenario.Name.Equals("producer-transactional", StringComparison.OrdinalIgnoreCase)
+                    ? 1
+                    : options.ConnectionsPerBroker;
+                var connectionLabel = connectionsPerBroker > 1 ? $" ({connectionsPerBroker}conn)" : "";
                 Console.WriteLine();
-                Console.WriteLine($"=== Running: {scenario.Client} {scenario.Name} ({options.ConnectionsPerBroker}conn) ===");
+                Console.WriteLine($"=== Running: {scenario.Client} {scenario.Name}{connectionLabel} ===");
 
-                var result = await scenario.RunAsync(BuildTestOptions(scenario.Name, options.ConnectionsPerBroker), CancellationToken.None).ConfigureAwait(false);
-                result.Client = $"Dekaf ({options.ConnectionsPerBroker}conn)";
+                var result = await scenario.RunAsync(
+                    BuildTestOptions(scenario.Name, connectionsPerBroker),
+                    CancellationToken.None).ConfigureAwait(false);
+                if (connectionsPerBroker > 1)
+                    result.Client = $"Dekaf ({connectionsPerBroker}conn)";
                 results.Add(result);
 
                 GC.Collect();
@@ -236,8 +259,8 @@ public static class Program
     /// - Any loop error (append/consume failures) or delivery error (broker-side failure of
     ///   an accepted message, observed via the producer error metric or delivery reports).
     /// - Undelivered shortfall: accepted minus broker-confirmed delivered minus delivery
-    ///   errors. The post-run drain wait already absorbs follower high-watermark lag, so
-    ///   every producer scenario treats a remaining shortfall as loss — no exemptions.
+    ///   errors for non-transactional runs; committed minus delivered for transactional
+    ///   runs, where aborted records are intentionally invisible to read-committed consumers.
     /// - Duplicate delivery in idempotent scenarios (delivered exceeding accepted), which
     ///   means broker-side deduplication of retries is broken. Non-idempotent scenarios
     ///   skip this check because retry duplicates are legitimate there.
@@ -247,7 +270,7 @@ public static class Program
     /// - Task exceptions nobody observed, surfaced after a final finalizer sweep.
     /// Results are already saved at this point; the non-zero exit only fails the CI job.
     /// </summary>
-    private static bool CheckForFailures(List<StressTestResult> results)
+    internal static bool CheckForFailures(List<StressTestResult> results)
     {
         var anyFailure = false;
 
@@ -267,6 +290,7 @@ public static class Program
             var errors = result.Throughput.TotalErrors;
             var deliveryErrors = result.Throughput.TotalDeliveryErrors;
             var accepted = result.Throughput.TotalMessages;
+            var transactionVerification = result.TransactionVerification;
             var lost = 0L;
 
             if (errors > 0)
@@ -281,10 +305,13 @@ public static class Program
 
             if (result.DeliveredMessages is { } delivered)
             {
-                lost = Math.Max(0, accepted - delivered - deliveryErrors);
+                var expectedDelivered = transactionVerification?.CommittedMessages ?? accepted;
+                lost = Math.Max(0, expectedDelivered - delivered - deliveryErrors);
                 if (lost > 0)
                 {
-                    reasons.Add($"{lost:N0} undelivered messages");
+                    reasons.Add(transactionVerification is null
+                        ? $"{lost:N0} undelivered messages"
+                        : $"{lost:N0} committed messages undelivered");
                 }
 
                 // Idempotent producers rely on broker-side retry deduplication, so any
@@ -306,6 +333,11 @@ public static class Program
             if (maxStall >= StallThresholdSamples)
             {
                 reasons.Add($"stalled for {maxStall * StressTestHelpers.SamplerIntervalSeconds:N0} consecutive seconds with zero progress");
+            }
+
+            if (transactionVerification is { IsSuccessful: false })
+            {
+                reasons.Add("transaction verification failed");
             }
 
             if (reasons.Count == 0)
@@ -333,6 +365,11 @@ public static class Program
             if (lost > 0)
             {
                 PrintProducerDeliveryDiagnostics(result.ProducerDeliveryDiagnostics);
+            }
+
+            if (transactionVerification is { IsSuccessful: false })
+            {
+                PrintTransactionVerificationFailure(transactionVerification);
             }
         }
 
@@ -372,6 +409,26 @@ public static class Program
         }
 
         return max;
+    }
+
+    private static void PrintTransactionVerificationFailure(TransactionVerificationSnapshot verification)
+    {
+        Console.WriteLine(
+            "    Transaction verification: " +
+            $"accepted={verification.AcceptedMessages:N0}, " +
+            $"committed={verification.CommittedMessages:N0}, " +
+            $"aborted={verification.AbortedMessages:N0}, " +
+            $"delivered={verification.DeliveredMessages:N0}, " +
+            $"duplicates={verification.DuplicateMessages:N0}, " +
+            $"shortfall={verification.ShortfallMessages:N0}, " +
+            $"leakedAborted={verification.LeakedAbortedMessages:N0}, " +
+            $"unexpected={verification.UnexpectedMessages:N0}, " +
+            $"missingSentinels={verification.MissingSentinelPartitions:N0}");
+
+        foreach (var sample in verification.FailureSamples)
+        {
+            Console.WriteLine($"      - {sample}");
+        }
     }
 
     private static void PrintProducerDeliveryDiagnostics(ProducerDeliveryDiagnosticsSnapshot? snapshot)
@@ -493,8 +550,16 @@ public static class Program
 
     private static List<IStressTestScenario> GetScenarios(CliOptions options)
     {
-        var allScenarios = new List<IStressTestScenario>
-        {
+        var scenarios = CreateAllScenarios()
+            .Where(s => options.Scenario == "all" || s.Name.Equals(options.Scenario, StringComparison.OrdinalIgnoreCase))
+            .Where(s => options.Client == "all" || s.Client.Equals(options.Client, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        return ApplyClientOrder(scenarios, options.Client);
+    }
+
+    internal static IReadOnlyList<IStressTestScenario> CreateAllScenarios() =>
+        [
             new ProducerStressTest(),
             new ConfluentProducerStressTest(),
             new ProducerIdempotentStressTest(),
@@ -505,20 +570,13 @@ public static class Program
             new ConfluentProducerAcksAllStressTest(),
             new ProducerAsyncIdempotentStressTest(),
             new ConfluentProducerAsyncIdempotentStressTest(),
+            new TransactionalProducerStressTest(),
             new ConsumerStressTest(),
             new ConsumerBatchStressTest(),
             new ConsumerRawStressTest(),
             new ConsumerRawBatchStressTest(),
             new ConfluentConsumerStressTest()
-        };
-
-        var scenarios = allScenarios
-            .Where(s => options.Scenario == "all" || s.Name.Equals(options.Scenario, StringComparison.OrdinalIgnoreCase))
-            .Where(s => options.Client == "all" || s.Client.Equals(options.Client, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-        return ApplyClientOrder(scenarios, options.Client);
-    }
+        ];
 
     private static List<IStressTestScenario> ApplyClientOrder(List<IStressTestScenario> scenarios, string requestedClient)
     {
@@ -674,7 +732,7 @@ public static class Program
             Options:
               --duration <minutes>    Test duration in minutes (default: 15)
               --message-size <bytes>  Message size in bytes (default: 1000)
-              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
+              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
               --client <name>         Run specific client: dekaf, confluent, all (default: all)
               --output <path>         Output directory for results (default: ./results)
               --partitions <count>    Number of topic partitions (default: 6)
@@ -696,6 +754,7 @@ public static class Program
             Examples:
               dotnet run -c Release -- --duration 15 --message-size 1000
               dotnet run -c Release -- --scenario producer --client dekaf --duration 5
+              dotnet run -c Release -- --scenario producer-transactional --client dekaf --duration 15
               dotnet run -c Release -- report --input ./results
             """);
     }

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -107,20 +107,28 @@ public static class Program
         string? transactionalTopic = null;
 
         var replicationFactor = Math.Min(options.Brokers, 3);
+        var replayTopicConfigs = new Dictionary<string, string>
+        {
+            ["retention.ms"] = "-1",
+            ["retention.bytes"] = "-1"
+        };
         await kafka.CreateTopicAsync(producerTopic, options.Partitions, replicationFactor).ConfigureAwait(false);
         if (options.Scenario is "all" or "producer-transactional")
         {
             transactionalTopic = $"stress-transactional-{Guid.NewGuid():N}";
-            await kafka.CreateTopicAsync(transactionalTopic, options.Partitions, replicationFactor).ConfigureAwait(false);
+            await kafka.CreateTopicAsync(
+                transactionalTopic,
+                options.Partitions,
+                replicationFactor,
+                replayTopicConfigs).ConfigureAwait(false);
         }
-        // Consumer scenarios re-read the seeded data set in a loop for the full duration.
-        // Broker-level retention (tuned to bound producer-topic disk usage) must not
-        // delete it mid-run, so retention is disabled at the topic level.
-        await kafka.CreateTopicAsync(consumerTopic, options.Partitions, replicationFactor, new Dictionary<string, string>
-        {
-            ["retention.ms"] = "-1",
-            ["retention.bytes"] = "-1"
-        }).ConfigureAwait(false);
+        // Transaction verification reads from earliest after the workload, while consumer
+        // scenarios replay their seeded data. Broker retention must not delete either data set.
+        await kafka.CreateTopicAsync(
+            consumerTopic,
+            options.Partitions,
+            replicationFactor,
+            replayTopicConfigs).ConfigureAwait(false);
 
         if (options.Scenario is "consumer" or "consumer-batch" or "consumer-raw" or "consumer-raw-batch" or "all")
         {

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -27,6 +27,12 @@ internal static class MarkdownReporter
 
             GenerateThroughputTable(sb, title, groupResults);
 
+            var transactionalResults = groupResults
+                .Where(r => r.TransactionVerification is not null)
+                .ToList();
+            if (transactionalResults.Count > 0)
+                GenerateTransactionVerificationTable(sb, transactionalResults, $"Transaction Verification - {label}");
+
             var resultsWithLatency = groupResults.Where(r => r.Latency is not null).ToList();
             if (resultsWithLatency.Count > 0)
                 GenerateLatencyTable(sb, resultsWithLatency, $"Latency - {label}");
@@ -178,6 +184,43 @@ internal static class MarkdownReporter
         sb.AppendLine();
     }
 
+    private static void GenerateTransactionVerificationTable(
+        StringBuilder sb,
+        List<StressTestResult> results,
+        string title)
+    {
+        var clientWidth = GetClientColumnWidth(results);
+
+        sb.AppendLine($"## {title}");
+        sb.AppendLine();
+        sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Accepted | Committed | Aborted | Delivered | Duplicates | Shortfall | Aborted leaks | Unexpected | Missing sentinels | Status |");
+        sb.AppendLine($"|{new string('-', clientWidth + 2)}|----------|-----------|---------|-----------|------------|-----------|---------------|------------|-------------------|--------|");
+
+        foreach (var result in results.OrderBy(r => r.Client))
+        {
+            var verification = result.TransactionVerification!;
+            var status = verification.IsSuccessful ? "PASS" : "FAIL";
+            sb.AppendLine(
+                $"| {result.Client.PadRight(clientWidth)} | {verification.AcceptedMessages,8:N0} | " +
+                $"{verification.CommittedMessages,9:N0} | {verification.AbortedMessages,7:N0} | " +
+                $"{verification.DeliveredMessages,9:N0} | {verification.DuplicateMessages,10:N0} | " +
+                $"{verification.ShortfallMessages,9:N0} | {verification.LeakedAbortedMessages,13:N0} | " +
+                $"{verification.UnexpectedMessages,10:N0} | {verification.MissingSentinelPartitions,17:N0} | {status} |");
+        }
+
+        sb.AppendLine();
+        var failureSamples = results
+            .SelectMany(r => r.TransactionVerification!.FailureSamples.Select(sample => (r.Client, Sample: sample)))
+            .ToList();
+        if (failureSamples.Count == 0)
+            return;
+
+        sb.AppendLine("**Transaction verification failure samples:**");
+        foreach (var (client, sample) in failureSamples)
+            sb.AppendLine($"- {client}: {sample}");
+        sb.AppendLine();
+    }
+
     private static void GenerateErrorSamplesTable(StringBuilder sb, List<StressTestResult> results, string title)
     {
         var clientWidth = GetClientColumnWidth(results);
@@ -214,6 +257,7 @@ internal static class MarkdownReporter
         "producer-acks-all" => "Producer (Acks All) Throughput",
         "producer-async" => "Producer (Async) Throughput",
         "producer-async-idempotent" => "Producer (Async, Idempotent) Throughput",
+        "producer-transactional" => "Producer (Transactional EOS) Throughput",
         "consumer" => "Consumer Throughput",
         "consumer-batch" => "Consumer (Batch) Throughput",
         "consumer-raw" => "Consumer (Raw Bytes) Throughput",
@@ -228,6 +272,7 @@ internal static class MarkdownReporter
         "producer-acks-all" => "Acks All",
         "producer-async" => "Async",
         "producer-async-idempotent" => "Async (Idempotent)",
+        "producer-transactional" => "Transactional EOS",
         "consumer" => "Consumer",
         "consumer-batch" => "Consumer (Batch)",
         "consumer-raw" => "Consumer (Raw Bytes)",

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -18,7 +18,6 @@ internal sealed class StressTestResult
     public required GcSnapshot GcStats { get; init; }
     public int BrokerCount { get; init; } = 1;
     public ProducerDeliveryDiagnosticsSnapshot? ProducerDeliveryDiagnostics { get; init; }
-
     /// <summary>
     /// Whether the scenario's producer ran with idempotence enabled. Must mirror the
     /// producer configuration a few lines above where each scenario sets it. The failure
@@ -28,15 +27,17 @@ internal sealed class StressTestResult
     /// </summary>
     public bool Idempotent { get; init; }
 
+    public TransactionVerificationSnapshot? TransactionVerification { get; init; }
+
     /// <summary>
     /// Broker-confirmed message count, measured as the end-offset (high watermark)
     /// delta across all topic partitions between test start and end. Fire-and-forget
     /// scenarios count client-side appends in <see cref="Throughput"/>; when the client
     /// buffers faster than the broker accepts (or the broker degrades mid-run), accepted
     /// and delivered diverge — this is the honest throughput number.
-    /// Every producer scenario fails the run when delivered falls short of accepted
-    /// minus recorded delivery errors: the post-run drain wait already absorbs follower
-    /// high-watermark lag, so a remaining shortfall is message loss.
+    /// Non-transactional producer scenarios fail when delivered falls short of accepted
+    /// minus recorded delivery errors. Transactional scenarios compare delivered records
+    /// with committed records because aborted records are intentionally invisible.
     /// Null when the scenario doesn't measure it (consumers).
     /// </summary>
     public long? DeliveredMessages { get; init; }
@@ -131,6 +132,27 @@ internal sealed class StressTestResult
 
     public static StressTestResult? FromJson(string json) =>
         JsonSerializer.Deserialize<StressTestResult>(json, JsonOptions);
+}
+
+internal sealed class TransactionVerificationSnapshot
+{
+    public required long AcceptedMessages { get; init; }
+    public required long CommittedMessages { get; init; }
+    public required long AbortedMessages { get; init; }
+    public required long DeliveredMessages { get; init; }
+    public required long DuplicateMessages { get; init; }
+    public required long ShortfallMessages { get; init; }
+    public required long LeakedAbortedMessages { get; init; }
+    public required long UnexpectedMessages { get; init; }
+    public required int MissingSentinelPartitions { get; init; }
+    public required List<string> FailureSamples { get; init; }
+
+    public bool IsSuccessful =>
+        DuplicateMessages == 0 &&
+        ShortfallMessages == 0 &&
+        LeakedAbortedMessages == 0 &&
+        UnexpectedMessages == 0 &&
+        MissingSentinelPartitions == 0;
 }
 
 internal sealed class StressTestResults

--- a/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
@@ -66,6 +66,7 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
         var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(runCts.Token);
         var committedMessages = 0L;
         var abortedMessages = 0L;
+        var failedCommitMessages = 0L;
         var transactionIndex = 0L;
 
         while (!runCts.IsCancellationRequested)
@@ -117,7 +118,10 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
                 try
                 {
                     await transaction.AbortAsync(CancellationToken.None).ConfigureAwait(false);
-                    abortedMessages += transactionAccepted;
+                    if (shouldCommit)
+                        failedCommitMessages += transactionAccepted;
+                    else
+                        abortedMessages += transactionAccepted;
                 }
                 catch (Exception abortException)
                 {
@@ -136,7 +140,8 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
 
         Console.WriteLine(
             $"  Workload complete: accepted={throughput.MessageCount:N0}, committed={committedMessages:N0}, " +
-            $"aborted={abortedMessages:N0}, transactions={transactionIndex:N0}");
+            $"aborted={abortedMessages + failedCommitMessages:N0}, " +
+            $"failedCommitAborts={failedCommitMessages:N0}, transactions={transactionIndex:N0}");
         StressTestHelpers.LogResourceUsage("Final");
 
         var sentinelsCommitted = await CommitPartitionSentinelsAsync(
@@ -154,6 +159,7 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
             throughput.MessageCount,
             committedMessages,
             abortedMessages,
+            failedCommitMessages,
             sentinelsCommitted,
             cancellationToken).ConfigureAwait(false);
 
@@ -252,6 +258,7 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
         long acceptedMessages,
         long committedMessages,
         long abortedMessages,
+        long failedCommitMessages,
         bool sentinelsCommitted,
         CancellationToken cancellationToken)
     {
@@ -259,7 +266,8 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
             runId,
             committedMessages,
             abortedMessages,
-            options.Partitions);
+            options.Partitions,
+            failedCommitMessages);
         if (!sentinelsCommitted)
             return oracle.CreateSnapshot(acceptedMessages);
 

--- a/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
@@ -1,0 +1,299 @@
+using Dekaf.Compression.Lz4;
+using Dekaf.Compression.Snappy;
+using Dekaf.Compression.Zstd;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
+
+namespace Dekaf.StressTests.Scenarios;
+
+internal sealed class TransactionalProducerStressTest : IStressTestScenario
+{
+    private const int RecordsPerTransaction = 100;
+    private const int AbortEveryTransactions = 4;
+
+    public string Name => "producer-transactional";
+    public string Client => "Dekaf";
+
+    public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
+    {
+        var messageValue = new string('x', options.MessageSizeBytes);
+        var runId = $"tx-{Guid.NewGuid():N}";
+        var throughput = new ThroughputTracker();
+        var startedAt = DateTime.UtcNow;
+
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(options.BootstrapServers)
+            .WithClientId("stress-producer-transactional-dekaf")
+            .WithTransactionalId($"stress-{runId}")
+            .WithAcks(Acks.All)
+            .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
+            .WithBatchSize(options.BatchSize)
+            .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes);
+
+        _ = options.Compression switch
+        {
+            "lz4" => builder.UseLz4Compression(),
+            "snappy" => builder.UseSnappyCompression(),
+            "zstd" => builder.UseZstdCompression(),
+            _ => builder
+        };
+
+        StressTestHelpers.ConfigureProducerDeliveryDiagnostics(builder, options);
+        var producer = await builder.BuildAsync(cancellationToken).ConfigureAwait(false);
+        await producer.InitTransactionsAsync(cancellationToken).ConfigureAwait(false);
+        await WarmUpAsync(producer, options.Topic, cancellationToken).ConfigureAwait(false);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var gcStats = new GcStats();
+        using var runCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        runCts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
+
+        Console.WriteLine($"  Running Dekaf transactional EOS stress test for {options.DurationMinutes} minutes...");
+        Console.WriteLine($"  Pattern: {AbortEveryTransactions - 1} committed transaction(s), then 1 aborted; " +
+            $"{RecordsPerTransaction:N0} records each");
+        Console.WriteLine($"  Run id: {runId}");
+        StressTestHelpers.LogResourceUsage("Initial");
+
+        throughput.Start();
+        var progress = new PeriodicProgressReporter(throughput);
+        var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, runCts.Token);
+        var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(runCts.Token);
+        var committedMessages = 0L;
+        var abortedMessages = 0L;
+        var transactionIndex = 0L;
+
+        while (!runCts.IsCancellationRequested)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var shouldCommit = transactionIndex % AbortEveryTransactions != AbortEveryTransactions - 1;
+            var transactionAccepted = 0L;
+            await using var transaction = producer.BeginTransaction();
+
+            try
+            {
+                for (var recordIndex = 0; recordIndex < RecordsPerTransaction; recordIndex++)
+                {
+                    var ordinal = shouldCommit
+                        ? committedMessages + transactionAccepted
+                        : abortedMessages + transactionAccepted;
+                    var key = shouldCommit
+                        ? TransactionalSequenceOracle.CommittedKey(runId, ordinal)
+                        : TransactionalSequenceOracle.AbortedKey(runId, ordinal);
+
+                    await transaction.ProduceAsync(new ProducerMessage<string, string>
+                    {
+                        Topic = options.Topic,
+                        Key = key,
+                        Value = messageValue
+                    }, cancellationToken).ConfigureAwait(false);
+
+                    transactionAccepted++;
+                    throughput.RecordMessage(options.MessageSizeBytes);
+                }
+
+                if (shouldCommit)
+                {
+                    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                    committedMessages += transactionAccepted;
+                }
+                else
+                {
+                    await transaction.AbortAsync(cancellationToken).ConfigureAwait(false);
+                    abortedMessages += transactionAccepted;
+                }
+
+                transactionIndex++;
+                progress.RecordMessage();
+            }
+            catch (Exception exception) when (exception is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+            {
+                throughput.RecordError(exception, "Transactional produce loop", throughput.MessageCount);
+                try
+                {
+                    await transaction.AbortAsync(CancellationToken.None).ConfigureAwait(false);
+                    abortedMessages += transactionAccepted;
+                }
+                catch (Exception abortException)
+                {
+                    throughput.RecordError(abortException, "Abort failed transaction", throughput.MessageCount);
+                }
+
+                break;
+            }
+        }
+
+        runCts.Cancel();
+        throughput.Stop();
+        gcStats.Capture();
+        try { await samplerTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
+        try { await resourceMonitorTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
+
+        Console.WriteLine(
+            $"  Workload complete: accepted={throughput.MessageCount:N0}, committed={committedMessages:N0}, " +
+            $"aborted={abortedMessages:N0}, transactions={transactionIndex:N0}");
+        StressTestHelpers.LogResourceUsage("Final");
+
+        var sentinelsCommitted = await CommitPartitionSentinelsAsync(
+            producer,
+            options,
+            runId,
+            throughput,
+            cancellationToken).ConfigureAwait(false);
+        var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
+        await DisposeProducerAsync(producer, throughput).ConfigureAwait(false);
+
+        var verification = await VerifyReadCommittedAsync(
+            options,
+            runId,
+            throughput.MessageCount,
+            committedMessages,
+            abortedMessages,
+            sentinelsCommitted,
+            cancellationToken).ConfigureAwait(false);
+
+        Console.WriteLine(
+            $"  Transaction verification: accepted={verification.AcceptedMessages:N0}, " +
+            $"committed={verification.CommittedMessages:N0}, aborted={verification.AbortedMessages:N0}, " +
+            $"delivered={verification.DeliveredMessages:N0}, duplicates={verification.DuplicateMessages:N0}, " +
+            $"shortfall={verification.ShortfallMessages:N0}, leakedAborted={verification.LeakedAbortedMessages:N0}, " +
+            $"unexpected={verification.UnexpectedMessages:N0}, " +
+            $"missingSentinels={verification.MissingSentinelPartitions:N0}");
+
+        return new StressTestResult
+        {
+            Scenario = Name,
+            Client = Client,
+            DurationMinutes = options.DurationMinutes,
+            BrokerCount = options.BrokerCount,
+            MessageSizeBytes = options.MessageSizeBytes,
+            StartedAtUtc = startedAt,
+            CompletedAtUtc = DateTime.UtcNow,
+            Throughput = throughput.GetSnapshot(),
+            DeliveredMessages = verification.DeliveredMessages,
+            GcStats = gcStats.ToSnapshot(),
+            CpuTimeSeconds = throughput.CpuTimeSeconds,
+            ProducerDeliveryDiagnostics = producerDiagnostics,
+            TransactionVerification = verification
+        };
+    }
+
+    private static async Task WarmUpAsync(
+        IKafkaProducer<string, string> producer,
+        string topic,
+        CancellationToken cancellationToken)
+    {
+        Console.WriteLine("  Warming up Dekaf transactional producer...");
+        await using var transaction = producer.BeginTransaction();
+        await transaction.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "transactional-warmup",
+            Value = "warmup"
+        }, cancellationToken).ConfigureAwait(false);
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<bool> CommitPartitionSentinelsAsync(
+        IKafkaProducer<string, string> producer,
+        StressTestOptions options,
+        string runId,
+        ThroughputTracker throughput,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var transaction = producer.BeginTransaction();
+            for (var partition = 0; partition < options.Partitions; partition++)
+            {
+                await transaction.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = options.Topic,
+                    Key = TransactionalSequenceOracle.SentinelKey(runId, partition),
+                    Value = "sentinel",
+                    Partition = partition
+                }, cancellationToken).ConfigureAwait(false);
+            }
+
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+        {
+            throughput.RecordError(exception, "Commit partition sentinels", throughput.MessageCount);
+            return false;
+        }
+    }
+
+    private static async Task DisposeProducerAsync(
+        IKafkaProducer<string, string> producer,
+        ThroughputTracker throughput)
+    {
+        try
+        {
+            await producer.DisposeAsync().AsTask()
+                .WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            throughput.RecordError(exception, "Dispose transactional producer", throughput.MessageCount);
+        }
+    }
+
+    private static async Task<TransactionVerificationSnapshot> VerifyReadCommittedAsync(
+        StressTestOptions options,
+        string runId,
+        long acceptedMessages,
+        long committedMessages,
+        long abortedMessages,
+        bool sentinelsCommitted,
+        CancellationToken cancellationToken)
+    {
+        var oracle = new TransactionalSequenceOracle(
+            runId,
+            committedMessages,
+            abortedMessages,
+            options.Partitions);
+        if (!sentinelsCommitted)
+            return oracle.CreateSnapshot(acceptedMessages);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(options.BootstrapServers)
+            .WithClientId("stress-transaction-verifier")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithIsolationLevel(IsolationLevel.ReadCommitted)
+            .BuildAsync(cancellationToken).ConfigureAwait(false);
+
+        var partitions = Enumerable.Range(0, options.Partitions)
+            .Select(partition => new TopicPartition(options.Topic, partition))
+            .ToArray();
+        consumer.Assign(partitions);
+
+        var verificationMinutes = Math.Clamp(options.DurationMinutes, 2, 30);
+        using var verificationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        verificationCts.CancelAfter(TimeSpan.FromMinutes(verificationMinutes));
+
+        try
+        {
+            await foreach (var record in consumer.ConsumeAsync(verificationCts.Token).ConfigureAwait(false))
+            {
+                oracle.Observe(record.Key);
+                if (oracle.AllSentinelsSeen)
+                    break;
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            Console.WriteLine(
+                $"  Warning: read_committed verification timed out after {verificationMinutes:N0} minute(s).");
+        }
+
+        return oracle.CreateSnapshot(acceptedMessages);
+    }
+}

--- a/tools/Dekaf.StressTests/Scenarios/TransactionalSequenceOracle.cs
+++ b/tools/Dekaf.StressTests/Scenarios/TransactionalSequenceOracle.cs
@@ -1,0 +1,183 @@
+using System.Collections;
+using System.Globalization;
+using Dekaf.StressTests.Reporting;
+
+namespace Dekaf.StressTests.Scenarios;
+
+/// <summary>
+/// Verifies the byte-visible outcome of the transactional stress scenario. Workload
+/// keys carry committed/aborted ordinals, while one committed sentinel per partition
+/// proves the read_committed consumer advanced past every earlier record.
+/// </summary>
+internal sealed class TransactionalSequenceOracle
+{
+    private const int MaxFailureSamples = 10;
+
+    private readonly string _keyPrefix;
+    private readonly long _committedMessages;
+    private readonly long _abortedMessages;
+    private readonly BitArray _seenCommitted;
+    private readonly BitArray _seenSentinels;
+    private readonly List<string> _failureSamples = [];
+    private long _deliveredMessages;
+    private long _duplicateMessages;
+    private long _leakedAbortedMessages;
+    private long _unexpectedMessages;
+    private int _sentinelsSeen;
+
+    internal TransactionalSequenceOracle(
+        string runId,
+        long committedMessages,
+        long abortedMessages,
+        int partitionCount)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+        ArgumentOutOfRangeException.ThrowIfNegative(committedMessages);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(committedMessages, int.MaxValue);
+        ArgumentOutOfRangeException.ThrowIfNegative(abortedMessages);
+        ArgumentOutOfRangeException.ThrowIfLessThan(partitionCount, 1);
+
+        _keyPrefix = $"{runId}:";
+        _committedMessages = committedMessages;
+        _abortedMessages = abortedMessages;
+        _seenCommitted = new BitArray((int)committedMessages);
+        _seenSentinels = new BitArray(partitionCount);
+    }
+
+    internal bool AllSentinelsSeen => _sentinelsSeen == _seenSentinels.Length;
+
+    internal static string CommittedKey(string runId, long index) =>
+        $"{runId}:c:{index.ToString(CultureInfo.InvariantCulture)}";
+
+    internal static string AbortedKey(string runId, long index) =>
+        $"{runId}:a:{index.ToString(CultureInfo.InvariantCulture)}";
+
+    internal static string SentinelKey(string runId, int partition) =>
+        $"{runId}:s:{partition.ToString(CultureInfo.InvariantCulture)}";
+
+    internal void Observe(string? key)
+    {
+        if (key is null || !key.StartsWith(_keyPrefix, StringComparison.Ordinal))
+            return;
+
+        var payload = key.AsSpan(_keyPrefix.Length);
+        if (payload.Length < 3 || payload[1] != ':')
+        {
+            RecordUnexpected(key);
+            return;
+        }
+
+        switch (payload[0])
+        {
+            case 'c':
+                ObserveCommitted(key, payload[2..]);
+                break;
+            case 'a':
+                ObserveAborted(key, payload[2..]);
+                break;
+            case 's':
+                ObserveSentinel(key, payload[2..]);
+                break;
+            default:
+                RecordUnexpected(key);
+                break;
+        }
+    }
+
+    internal TransactionVerificationSnapshot CreateSnapshot(long acceptedMessages)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(acceptedMessages);
+
+        var samples = new List<string>(_failureSamples);
+        for (var index = 0; index < _seenCommitted.Length && samples.Count < MaxFailureSamples; index++)
+        {
+            if (!_seenCommitted[index])
+                samples.Add($"Missing committed index {index:N0}.");
+        }
+
+        for (var partition = 0; partition < _seenSentinels.Length && samples.Count < MaxFailureSamples; partition++)
+        {
+            if (!_seenSentinels[partition])
+                samples.Add($"Missing terminal sentinel for partition {partition}.");
+        }
+
+        return new TransactionVerificationSnapshot
+        {
+            AcceptedMessages = acceptedMessages,
+            CommittedMessages = _committedMessages,
+            AbortedMessages = _abortedMessages,
+            DeliveredMessages = _deliveredMessages,
+            DuplicateMessages = _duplicateMessages,
+            ShortfallMessages = _committedMessages - _deliveredMessages,
+            LeakedAbortedMessages = _leakedAbortedMessages,
+            UnexpectedMessages = _unexpectedMessages,
+            MissingSentinelPartitions = _seenSentinels.Length - _sentinelsSeen,
+            FailureSamples = samples
+        };
+    }
+
+    private void ObserveCommitted(string key, ReadOnlySpan<char> indexText)
+    {
+        if (!long.TryParse(indexText, NumberStyles.None, CultureInfo.InvariantCulture, out var index) ||
+            index < 0 || index >= _committedMessages)
+        {
+            RecordUnexpected(key);
+            return;
+        }
+
+        if (_seenCommitted[(int)index])
+        {
+            _duplicateMessages++;
+            AddFailure($"Duplicate committed index {index:N0}.");
+            return;
+        }
+
+        _seenCommitted[(int)index] = true;
+        _deliveredMessages++;
+    }
+
+    private void ObserveAborted(string key, ReadOnlySpan<char> indexText)
+    {
+        if (!long.TryParse(indexText, NumberStyles.None, CultureInfo.InvariantCulture, out var index) ||
+            index < 0 || index >= _abortedMessages)
+        {
+            RecordUnexpected(key);
+            return;
+        }
+
+        _leakedAbortedMessages++;
+        AddFailure($"Aborted index {index:N0} leaked into read_committed output.");
+    }
+
+    private void ObserveSentinel(string key, ReadOnlySpan<char> partitionText)
+    {
+        if (!int.TryParse(partitionText, NumberStyles.None, CultureInfo.InvariantCulture, out var partition) ||
+            partition < 0 || partition >= _seenSentinels.Length)
+        {
+            RecordUnexpected(key);
+            return;
+        }
+
+        if (_seenSentinels[partition])
+        {
+            _duplicateMessages++;
+            AddFailure($"Duplicate terminal sentinel for partition {partition}.");
+            return;
+        }
+
+        _seenSentinels[partition] = true;
+        _sentinelsSeen++;
+    }
+
+    private void RecordUnexpected(string key)
+    {
+        _unexpectedMessages++;
+        AddFailure($"Unexpected transactional key '{key}'.");
+    }
+
+    private void AddFailure(string sample)
+    {
+        if (_failureSamples.Count < MaxFailureSamples)
+            _failureSamples.Add(sample);
+    }
+}

--- a/tools/Dekaf.StressTests/Scenarios/TransactionalSequenceOracle.cs
+++ b/tools/Dekaf.StressTests/Scenarios/TransactionalSequenceOracle.cs
@@ -16,6 +16,7 @@ internal sealed class TransactionalSequenceOracle
     private readonly string _keyPrefix;
     private readonly long _committedMessages;
     private readonly long _abortedMessages;
+    private readonly long _failedCommitMessages;
     private readonly BitArray _seenCommitted;
     private readonly BitArray _seenSentinels;
     private readonly List<string> _failureSamples = [];
@@ -29,17 +30,20 @@ internal sealed class TransactionalSequenceOracle
         string runId,
         long committedMessages,
         long abortedMessages,
-        int partitionCount)
+        int partitionCount,
+        long failedCommitMessages = 0)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(runId);
         ArgumentOutOfRangeException.ThrowIfNegative(committedMessages);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(committedMessages, int.MaxValue);
         ArgumentOutOfRangeException.ThrowIfNegative(abortedMessages);
+        ArgumentOutOfRangeException.ThrowIfNegative(failedCommitMessages);
         ArgumentOutOfRangeException.ThrowIfLessThan(partitionCount, 1);
 
         _keyPrefix = $"{runId}:";
         _committedMessages = committedMessages;
         _abortedMessages = abortedMessages;
+        _failedCommitMessages = failedCommitMessages;
         _seenCommitted = new BitArray((int)committedMessages);
         _seenSentinels = new BitArray(partitionCount);
     }
@@ -105,7 +109,7 @@ internal sealed class TransactionalSequenceOracle
         {
             AcceptedMessages = acceptedMessages,
             CommittedMessages = _committedMessages,
-            AbortedMessages = _abortedMessages,
+            AbortedMessages = _abortedMessages + _failedCommitMessages,
             DeliveredMessages = _deliveredMessages,
             DuplicateMessages = _duplicateMessages,
             ShortfallMessages = _committedMessages - _deliveredMessages,
@@ -118,9 +122,21 @@ internal sealed class TransactionalSequenceOracle
 
     private void ObserveCommitted(string key, ReadOnlySpan<char> indexText)
     {
-        if (!long.TryParse(indexText, NumberStyles.None, CultureInfo.InvariantCulture, out var index) ||
-            index < 0 || index >= _committedMessages)
+        if (!long.TryParse(indexText, NumberStyles.None, CultureInfo.InvariantCulture, out var index) || index < 0)
         {
+            RecordUnexpected(key);
+            return;
+        }
+
+        if (index >= _committedMessages)
+        {
+            // A successfully aborted failed commit retains its c: keys in this contiguous suffix.
+            if (index - _committedMessages < _failedCommitMessages)
+            {
+                RecordAbortedLeak($"Failed commit index {index:N0} leaked into read_committed output.");
+                return;
+            }
+
             RecordUnexpected(key);
             return;
         }
@@ -145,8 +161,7 @@ internal sealed class TransactionalSequenceOracle
             return;
         }
 
-        _leakedAbortedMessages++;
-        AddFailure($"Aborted index {index:N0} leaked into read_committed output.");
+        RecordAbortedLeak($"Aborted index {index:N0} leaked into read_committed output.");
     }
 
     private void ObserveSentinel(string key, ReadOnlySpan<char> partitionText)
@@ -173,6 +188,12 @@ internal sealed class TransactionalSequenceOracle
     {
         _unexpectedMessages++;
         AddFailure($"Unexpected transactional key '{key}'.");
+    }
+
+    private void RecordAbortedLeak(string sample)
+    {
+        _leakedAbortedMessages++;
+        AddFailure(sample);
     }
 
     private void AddFailure(string sample)


### PR DESCRIPTION
## Summary

- add deterministic long-running transactional producer scenario
- verify committed output with a read_committed partition-sentinel oracle
- report and fail duplicates, shortfalls, aborted leaks, unexpected records, and client errors
- run the dedicated scenario weekly against three brokers

## Test plan

- [x] net10 Release unit project build
- [x] transactional stress tests (6/6)
- [x] Python stress reporter tests (3/3)
- [x] full net10 unit suite (4,515/4,515)
- [x] one-minute Testcontainers Kafka smoke (2,200 accepted; 1,700 committed; 500 aborted; clean verification)

Closes #1623