### PR TITLE
test(records): cover null and empty boundaries

### DIFF
--- a/tests/Dekaf.Tests.Integration/RecordBoundaryRoundTripTests.cs
+++ b/tests/Dekaf.Tests.Integration/RecordBoundaryRoundTripTests.cs
@@ -11,11 +11,13 @@ public sealed class RecordBoundaryRoundTripTests(KafkaTestContainer kafka) : Kaf
     public async Task ProduceConsume_PreservesNullEmptyAndHeaderBoundaries()
     {
         const int highHeaderCount = 1024;
+        // Reuse one key so this count boundary does not fill the process-global header-key cache.
+        const string repeatedHeaderKey = "boundary-high";
         var topic = await KafkaContainer.CreateTestTopicAsync();
         var highHeaders = new Headers(highHeaderCount);
         for (var i = 0; i < highHeaderCount; i++)
         {
-            highHeaders.Add($"boundary-high-{i:D4}", [(byte)(i % 251)]);
+            highHeaders.Add(repeatedHeaderKey, [(byte)(i % 251)]);
         }
 
         var messages = new ProducerMessage<string?, string?>[]
@@ -110,12 +112,9 @@ public sealed class RecordBoundaryRoundTripTests(KafkaTestContainer kafka) : Kaf
         await Assert.That(duplicateHeaders[2].GetValueAsString()).IsEqualTo("present");
 
         var actualHighHeaders = consumed[3].Headers
-            .Where(header => header.Key.StartsWith("boundary-high-", StringComparison.Ordinal))
+            .Where(header => header.Key == repeatedHeaderKey)
             .ToArray();
         await Assert.That(actualHighHeaders.Length).IsEqualTo(highHeaderCount);
-        var actualKeys = actualHighHeaders.Select(header => header.Key);
-        var expectedKeys = Enumerable.Range(0, highHeaderCount).Select(i => $"boundary-high-{i:D4}");
-        await Assert.That(actualKeys.SequenceEqual(expectedKeys)).IsTrue();
         var actualValues = actualHighHeaders.Select(header => header.Value.Span[0]);
         var expectedValues = Enumerable.Range(0, highHeaderCount).Select(i => (byte)(i % 251));
         await Assert.That(actualValues.SequenceEqual(expectedValues)).IsTrue();

--- a/tests/Dekaf.Tests.Integration/RecordBoundaryRoundTripTests.cs
+++ b/tests/Dekaf.Tests.Integration/RecordBoundaryRoundTripTests.cs
@@ -8,56 +8,81 @@ namespace Dekaf.Tests.Integration;
 public sealed class RecordBoundaryRoundTripTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
-    public async Task ProduceConsume_PreservesNullEmptyAndHeaderBoundaries()
+    public async Task ProduceConsume_NullKeyValueAndZeroHeaders_PreservesBoundaries()
+    {
+        var consumed = await RoundTripAsync(null, null, new Headers());
+
+        await Assert.That(consumed.Key).IsNull();
+        await Assert.That(consumed.Value).IsNull();
+        await Assert.That(UserHeaders(consumed.Headers).Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ProduceConsume_EmptyKeyValueAndHeaderValue_PreservesBoundaries()
+    {
+        var consumed = await RoundTripAsync(
+            string.Empty,
+            string.Empty,
+            new Headers().Add("boundary-single", Array.Empty<byte>()));
+
+        await Assert.That(consumed.Key).IsEqualTo(string.Empty);
+        await Assert.That(consumed.Value).IsEqualTo(string.Empty);
+        var header = UserHeaders(consumed.Headers).Single();
+        await Assert.That(header.Key).IsEqualTo("boundary-single");
+        await Assert.That(header.IsValueNull).IsFalse();
+        await Assert.That(header.Value.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ProduceConsume_DuplicateHeaderKeys_PreservesValues()
+    {
+        var consumed = await RoundTripAsync(
+            "duplicates",
+            "duplicates",
+            new Headers()
+                .Add("boundary-duplicate", (byte[]?)null)
+                .Add("boundary-duplicate", Array.Empty<byte>())
+                .Add("boundary-duplicate", "present"));
+
+        var headers = consumed.Headers
+            .Where(header => header.Key == "boundary-duplicate")
+            .ToArray();
+        await Assert.That(headers.Length).IsEqualTo(3);
+        await Assert.That(headers[0].IsValueNull).IsTrue();
+        await Assert.That(headers[1].IsValueNull).IsFalse();
+        await Assert.That(headers[1].Value.Length).IsEqualTo(0);
+        await Assert.That(headers[2].GetValueAsString()).IsEqualTo("present");
+    }
+
+    [Test]
+    public async Task ProduceConsume_HighHeaderCount_PreservesOrder()
     {
         const int highHeaderCount = 1024;
         // Reuse one key so this count boundary does not fill the process-global header-key cache.
         const string repeatedHeaderKey = "boundary-high";
-        var topic = await KafkaContainer.CreateTestTopicAsync();
-        var highHeaders = new Headers(highHeaderCount);
+        var headers = new Headers(highHeaderCount);
         for (var i = 0; i < highHeaderCount; i++)
         {
-            highHeaders.Add(repeatedHeaderKey, [(byte)(i % 251)]);
+            headers.Add(repeatedHeaderKey, [(byte)(i % 251)]);
         }
 
-        var messages = new ProducerMessage<string?, string?>[]
-        {
-            new()
-            {
-                Topic = topic,
-                Partition = 0,
-                Key = null,
-                Value = null,
-                Headers = new Headers()
-            },
-            new()
-            {
-                Topic = topic,
-                Partition = 0,
-                Key = string.Empty,
-                Value = string.Empty,
-                Headers = new Headers().Add("boundary-single", Array.Empty<byte>())
-            },
-            new()
-            {
-                Topic = topic,
-                Partition = 0,
-                Key = "duplicates",
-                Value = "duplicates",
-                Headers = new Headers()
-                    .Add("boundary-duplicate", (byte[]?)null)
-                    .Add("boundary-duplicate", Array.Empty<byte>())
-                    .Add("boundary-duplicate", "present")
-            },
-            new()
-            {
-                Topic = topic,
-                Partition = 0,
-                Key = "many",
-                Value = "headers",
-                Headers = highHeaders
-            }
-        };
+        var consumed = await RoundTripAsync("many", "headers", headers);
+
+        var actualHeaders = consumed.Headers
+            .Where(header => header.Key == repeatedHeaderKey)
+            .ToArray();
+        await Assert.That(actualHeaders.Length).IsEqualTo(highHeaderCount);
+        var actualValues = actualHeaders.Select(header => header.Value.Span[0]);
+        var expectedValues = Enumerable.Range(0, highHeaderCount).Select(i => (byte)(i % 251));
+        await Assert.That(actualValues.SequenceEqual(expectedValues)).IsTrue();
+    }
+
+    private async Task<(string? Key, string? Value, Header[] Headers)> RoundTripAsync(
+        string? key,
+        string? value,
+        Headers headers)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
 
         await using var producer = await Kafka.CreateProducer<string?, string?>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
@@ -66,10 +91,14 @@ public sealed class RecordBoundaryRoundTripTests(KafkaTestContainer kafka) : Kaf
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        foreach (var message in messages)
+        await producer.ProduceAsync(new ProducerMessage<string?, string?>
         {
-            await producer.ProduceAsync(message, CancellationToken.None);
-        }
+            Topic = topic,
+            Partition = 0,
+            Key = key,
+            Value = value,
+            Headers = headers
+        }, CancellationToken.None);
 
         await using var consumer = await Kafka.CreateConsumer<string?, string?>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
@@ -81,43 +110,17 @@ public sealed class RecordBoundaryRoundTripTests(KafkaTestContainer kafka) : Kaf
 
         consumer.Assign(new TopicPartition(topic, 0));
 
-        var consumed = new List<(string? Key, string? Value, Header[] Headers)>();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        for (var i = 0; i < messages.Length; i++)
-        {
-            var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
-            await Assert.That(result).IsNotNull();
-            var record = result!.Value;
-            consumed.Add((record.Key, record.Value, record.Headers?.ToArray() ?? []));
-        }
-
-        await Assert.That(consumed[0].Key).IsNull();
-        await Assert.That(consumed[0].Value).IsNull();
-        await Assert.That(UserHeaders(consumed[0].Headers).Count).IsEqualTo(0);
-
-        await Assert.That(consumed[1].Key).IsEqualTo(string.Empty);
-        await Assert.That(consumed[1].Value).IsEqualTo(string.Empty);
-        var singleHeader = UserHeaders(consumed[1].Headers).Single();
-        await Assert.That(singleHeader.Key).IsEqualTo("boundary-single");
-        await Assert.That(singleHeader.IsValueNull).IsFalse();
-        await Assert.That(singleHeader.Value.Length).IsEqualTo(0);
-
-        var duplicateHeaders = consumed[2].Headers
-            .Where(header => header.Key == "boundary-duplicate")
-            .ToArray();
-        await Assert.That(duplicateHeaders.Length).IsEqualTo(3);
-        await Assert.That(duplicateHeaders[0].IsValueNull).IsTrue();
-        await Assert.That(duplicateHeaders[1].IsValueNull).IsFalse();
-        await Assert.That(duplicateHeaders[1].Value.Length).IsEqualTo(0);
-        await Assert.That(duplicateHeaders[2].GetValueAsString()).IsEqualTo("present");
-
-        var actualHighHeaders = consumed[3].Headers
-            .Where(header => header.Key == repeatedHeaderKey)
-            .ToArray();
-        await Assert.That(actualHighHeaders.Length).IsEqualTo(highHeaderCount);
-        var actualValues = actualHighHeaders.Select(header => header.Value.Span[0]);
-        var expectedValues = Enumerable.Range(0, highHeaderCount).Select(i => (byte)(i % 251));
-        await Assert.That(actualValues.SequenceEqual(expectedValues)).IsTrue();
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+        await Assert.That(result).IsNotNull();
+        var record = result!.Value;
+        // Header values reference pooled fetch memory; copy before disposing the consumer.
+        var copiedHeaders = record.Headers?
+            .Select(header => new Header(
+                header.Key,
+                header.IsValueNull ? null : header.Value.ToArray()))
+            .ToArray() ?? [];
+        return (record.Key, record.Value, copiedHeaders);
     }
 
     private static IReadOnlyList<Header> UserHeaders(IEnumerable<Header> headers) =>

--- a/tests/Dekaf.Tests.Integration/RecordBoundaryRoundTripTests.cs
+++ b/tests/Dekaf.Tests.Integration/RecordBoundaryRoundTripTests.cs
@@ -1,0 +1,126 @@
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Serialization")]
+public sealed class RecordBoundaryRoundTripTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task ProduceConsume_PreservesNullEmptyAndHeaderBoundaries()
+    {
+        const int highHeaderCount = 1024;
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var highHeaders = new Headers(highHeaderCount);
+        for (var i = 0; i < highHeaderCount; i++)
+        {
+            highHeaders.Add($"boundary-high-{i:D4}", [(byte)(i % 251)]);
+        }
+
+        var messages = new ProducerMessage<string?, string?>[]
+        {
+            new()
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = null,
+                Value = null,
+                Headers = new Headers()
+            },
+            new()
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = string.Empty,
+                Value = string.Empty,
+                Headers = new Headers().Add("boundary-single", Array.Empty<byte>())
+            },
+            new()
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = "duplicates",
+                Value = "duplicates",
+                Headers = new Headers()
+                    .Add("boundary-duplicate", (byte[]?)null)
+                    .Add("boundary-duplicate", Array.Empty<byte>())
+                    .Add("boundary-duplicate", "present")
+            },
+            new()
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = "many",
+                Value = "headers",
+                Headers = highHeaders
+            }
+        };
+
+        await using var producer = await Kafka.CreateProducer<string?, string?>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithKeySerializer(Serializers.NullableString)
+            .WithValueSerializer(Serializers.NullableString)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        foreach (var message in messages)
+        {
+            await producer.ProduceAsync(message, CancellationToken.None);
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string?, string?>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithKeyDeserializer(Serializers.NullableString)
+            .WithValueDeserializer(Serializers.NullableString)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        var consumed = new List<(string? Key, string? Value, Header[] Headers)>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        for (var i = 0; i < messages.Length; i++)
+        {
+            var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+            await Assert.That(result).IsNotNull();
+            var record = result!.Value;
+            consumed.Add((record.Key, record.Value, record.Headers?.ToArray() ?? []));
+        }
+
+        await Assert.That(consumed[0].Key).IsNull();
+        await Assert.That(consumed[0].Value).IsNull();
+        await Assert.That(UserHeaders(consumed[0].Headers).Count).IsEqualTo(0);
+
+        await Assert.That(consumed[1].Key).IsEqualTo(string.Empty);
+        await Assert.That(consumed[1].Value).IsEqualTo(string.Empty);
+        var singleHeader = UserHeaders(consumed[1].Headers).Single();
+        await Assert.That(singleHeader.Key).IsEqualTo("boundary-single");
+        await Assert.That(singleHeader.IsValueNull).IsFalse();
+        await Assert.That(singleHeader.Value.Length).IsEqualTo(0);
+
+        var duplicateHeaders = consumed[2].Headers
+            .Where(header => header.Key == "boundary-duplicate")
+            .ToArray();
+        await Assert.That(duplicateHeaders.Length).IsEqualTo(3);
+        await Assert.That(duplicateHeaders[0].IsValueNull).IsTrue();
+        await Assert.That(duplicateHeaders[1].IsValueNull).IsFalse();
+        await Assert.That(duplicateHeaders[1].Value.Length).IsEqualTo(0);
+        await Assert.That(duplicateHeaders[2].GetValueAsString()).IsEqualTo("present");
+
+        var actualHighHeaders = consumed[3].Headers
+            .Where(header => header.Key.StartsWith("boundary-high-", StringComparison.Ordinal))
+            .ToArray();
+        await Assert.That(actualHighHeaders.Length).IsEqualTo(highHeaderCount);
+        var actualKeys = actualHighHeaders.Select(header => header.Key);
+        var expectedKeys = Enumerable.Range(0, highHeaderCount).Select(i => $"boundary-high-{i:D4}");
+        await Assert.That(actualKeys.SequenceEqual(expectedKeys)).IsTrue();
+        var actualValues = actualHighHeaders.Select(header => header.Value.Span[0]);
+        var expectedValues = Enumerable.Range(0, highHeaderCount).Select(i => (byte)(i % 251));
+        await Assert.That(actualValues.SequenceEqual(expectedValues)).IsTrue();
+    }
+
+    private static IReadOnlyList<Header> UserHeaders(IEnumerable<Header> headers) =>
+        headers.Where(header => header.Key.StartsWith("boundary-", StringComparison.Ordinal)).ToArray();
+}

--- a/tests/Dekaf.Tests.Unit/Internal/Utf8StringInternCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/Utf8StringInternCacheTests.cs
@@ -1,0 +1,24 @@
+using Dekaf.Internal;
+
+namespace Dekaf.Tests.Unit.Internal;
+
+public sealed class Utf8StringInternCacheTests
+{
+    [Test]
+    public async Task Intern_EntryLimitExceeded_DecodesWithoutCaching()
+    {
+        var cache = new Utf8StringInternCache(maxCachedEntries: 1, maxCachedBytes: 64);
+        var cachedBytes = "cached"u8.ToArray();
+        var overflowBytes = "overflow"u8.ToArray();
+
+        var cached = cache.Intern(cachedBytes);
+        var cachedAgain = cache.Intern(cachedBytes);
+        var overflow = cache.Intern(overflowBytes);
+        var overflowAgain = cache.Intern(overflowBytes);
+
+        await Assert.That(cachedAgain).IsSameReferenceAs(cached);
+        await Assert.That(overflow).IsEqualTo("overflow");
+        await Assert.That(overflowAgain).IsEqualTo("overflow");
+        await Assert.That(overflowAgain).IsNotSameReferenceAs(overflow);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -239,8 +239,10 @@ public class RecordBatchTests
     public async Task RecordBatch_RoundTrip_PreservesNullEmptyAndHeaderBoundaries()
     {
         const int highHeaderCount = 1024;
+        // Reuse one key so this count boundary does not fill the process-global header-key cache.
+        const string repeatedHeaderKey = "high";
         var highHeaders = Enumerable.Range(0, highHeaderCount)
-            .Select(i => new Header($"high-{i:D4}", [(byte)(i % 251)]))
+            .Select(i => new Header(repeatedHeaderKey, [(byte)(i % 251)]))
             .ToArray();
         var buffer = new ArrayBufferWriter<byte>();
         var originalBatch = new RecordBatch
@@ -322,11 +324,9 @@ public class RecordBatchTests
 
         await Assert.That(highHeaderRecord.HeaderCount).IsEqualTo(highHeaderCount);
         var roundTrippedHighHeaders = highHeaderRecord.Headers!;
-        var actualKeys = roundTrippedHighHeaders
+        await Assert.That(roundTrippedHighHeaders
             .Take(highHeaderRecord.HeaderCount)
-            .Select(header => header.Key);
-        var expectedKeys = Enumerable.Range(0, highHeaderCount).Select(i => $"high-{i:D4}");
-        await Assert.That(actualKeys.SequenceEqual(expectedKeys)).IsTrue();
+            .All(header => header.Key == repeatedHeaderKey)).IsTrue();
         var actualValues = roundTrippedHighHeaders
             .Take(highHeaderRecord.HeaderCount)
             .Select(header => header.Value.Span[0]);

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -235,6 +235,105 @@ public class RecordBatchTests
         await Assert.That(parsedBatch.Records[0].Value.ToArray()).IsEquivalentTo("value"u8.ToArray());
     }
 
+    [Test]
+    public async Task RecordBatch_RoundTrip_PreservesNullEmptyAndHeaderBoundaries()
+    {
+        const int highHeaderCount = 1024;
+        var highHeaders = Enumerable.Range(0, highHeaderCount)
+            .Select(i => new Header($"high-{i:D4}", [(byte)(i % 251)]))
+            .ToArray();
+        var buffer = new ArrayBufferWriter<byte>();
+        var originalBatch = new RecordBatch
+        {
+            BaseOffset = 0,
+            BaseTimestamp = 0,
+            MaxTimestamp = 3,
+            LastOffsetDelta = 3,
+            Records =
+            [
+                new Record
+                {
+                    OffsetDelta = 0,
+                    TimestampDelta = 0,
+                    IsKeyNull = true,
+                    IsValueNull = true
+                },
+                new Record
+                {
+                    OffsetDelta = 1,
+                    TimestampDelta = 1,
+                    Headers = [new Header("single", Array.Empty<byte>())],
+                    HeaderCount = 1
+                },
+                new Record
+                {
+                    OffsetDelta = 2,
+                    TimestampDelta = 2,
+                    Key = "key"u8.ToArray(),
+                    Value = "value"u8.ToArray(),
+                    Headers =
+                    [
+                        new Header("duplicate", (byte[]?)null),
+                        new Header("duplicate", Array.Empty<byte>()),
+                        new Header("duplicate", "present"u8.ToArray())
+                    ],
+                    HeaderCount = 3
+                },
+                new Record
+                {
+                    OffsetDelta = 3,
+                    TimestampDelta = 3,
+                    Key = "many"u8.ToArray(),
+                    Value = "headers"u8.ToArray(),
+                    Headers = highHeaders,
+                    HeaderCount = highHeaderCount
+                }
+            ]
+        };
+
+        originalBatch.Write(buffer);
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        using var parsedBatch = RecordBatch.Read(ref reader);
+        var nullRecord = parsedBatch.Records[0];
+        var emptyRecord = parsedBatch.Records[1];
+        var duplicateHeaderRecord = parsedBatch.Records[2];
+        var highHeaderRecord = parsedBatch.Records[3];
+
+        await Assert.That(nullRecord.IsKeyNull).IsTrue();
+        await Assert.That(nullRecord.IsValueNull).IsTrue();
+        await Assert.That(nullRecord.HeaderCount).IsEqualTo(0);
+
+        await Assert.That(emptyRecord.IsKeyNull).IsFalse();
+        await Assert.That(emptyRecord.Key.Length).IsEqualTo(0);
+        await Assert.That(emptyRecord.IsValueNull).IsFalse();
+        await Assert.That(emptyRecord.Value.Length).IsEqualTo(0);
+        await Assert.That(emptyRecord.HeaderCount).IsEqualTo(1);
+        await Assert.That(emptyRecord.Headers![0].IsValueNull).IsFalse();
+        await Assert.That(emptyRecord.Headers[0].Value.Length).IsEqualTo(0);
+
+        await Assert.That(duplicateHeaderRecord.HeaderCount).IsEqualTo(3);
+        await Assert.That(duplicateHeaderRecord.Headers![0].Key).IsEqualTo("duplicate");
+        await Assert.That(duplicateHeaderRecord.Headers[0].IsValueNull).IsTrue();
+        await Assert.That(duplicateHeaderRecord.Headers[1].Key).IsEqualTo("duplicate");
+        await Assert.That(duplicateHeaderRecord.Headers[1].IsValueNull).IsFalse();
+        await Assert.That(duplicateHeaderRecord.Headers[1].Value.Length).IsEqualTo(0);
+        await Assert.That(duplicateHeaderRecord.Headers[2].GetValueAsString()).IsEqualTo("present");
+
+        await Assert.That(highHeaderRecord.HeaderCount).IsEqualTo(highHeaderCount);
+        var roundTrippedHighHeaders = highHeaderRecord.Headers!;
+        var actualKeys = roundTrippedHighHeaders
+            .Take(highHeaderRecord.HeaderCount)
+            .Select(header => header.Key);
+        var expectedKeys = Enumerable.Range(0, highHeaderCount).Select(i => $"high-{i:D4}");
+        await Assert.That(actualKeys.SequenceEqual(expectedKeys)).IsTrue();
+        var actualValues = roundTrippedHighHeaders
+            .Take(highHeaderRecord.HeaderCount)
+            .Select(header => header.Value.Span[0]);
+        var expectedValues = Enumerable.Range(0, highHeaderCount).Select(i => (byte)(i % 251));
+        await Assert.That(actualValues.SequenceEqual(expectedValues)).IsTrue();
+    }
+
     #endregion
 
     #region Attributes Tests


### PR DESCRIPTION
## Summary
- pin null versus zero-length key and value wire behavior
- cover null/empty header values plus zero, one, duplicate, and 1,024-header boundaries
- verify header order and values through a broker-backed produce/consume path

## Tests
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- `Dekaf.Tests.Unit --treenode-filter '/*/*/RecordBatchTests/*'` (38 passed)
- `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
- focused `RecordBoundaryRoundTripTests` (passed)
- `HeaderRoundTripTests` (15 passed)
- `TombstoneAndNullValueTests` (18 passed)

Closes #1627