### PR TITLE
fix(producer): honor broker throttle delays

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -129,6 +129,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly Func<short, IReadOnlyCollection<TopicPartition>, (long ProducerId, short ProducerEpoch)>? _bumpEpoch;
     private readonly Func<short>? _getCurrentEpoch;
     private readonly ILogger _logger;
+    private readonly Action<int>? _onBrokerThrottle;
+    private readonly Func<long> _getTimestamp;
+    private readonly Func<int, CancellationToken, ValueTask> _delayForThrottle;
 
     private readonly Channel<SendLoopEvent> _eventChannel;
     private readonly Task _sendLoopTask;
@@ -518,6 +521,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // loop to undercount pending responses and enter idle wait prematurely.
     private int _totalPendingResponseCount;
 
+    // Broker quota throttling is scoped per broker, not per connection. A positive
+    // ProduceResponse.ThrottleTimeMs pauses every connection owned by this BrokerSender.
+    // Zero is the common fast path and leaves this sentinel at zero.
+    private long _brokerThrottleUntilTimestamp;
+
     // Tracks distinct partitions this broker has seen, used to skip MicroLinger when all
     // known partitions are already coalesced (e.g., single-partition topics).
     // Conservative: a brand-new partition not yet in _knownPartitions may miss one
@@ -568,7 +576,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         Action<ReadyBatch, int>? rerouteBatch,
         Action<TopicPartition, long, DateTimeOffset, int, Exception?>? onAcknowledgement,
         ILogger? logger,
-        bool canPhysicallyShrinkConnections = true)
+        bool canPhysicallyShrinkConnections = true,
+        Action<int>? onBrokerThrottle = null,
+        Func<long>? getTimestamp = null,
+        Func<int, CancellationToken, ValueTask>? delayForThrottle = null)
     {
         _brokerId = brokerId;
         _connectionPool = connectionPool;
@@ -586,6 +597,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _rerouteBatch = rerouteBatch;
         _onAcknowledgement = onAcknowledgement;
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+        _onBrokerThrottle = onBrokerThrottle;
+        _getTimestamp = getTimestamp ?? Stopwatch.GetTimestamp;
+        _delayForThrottle = delayForThrottle ?? DelayForThrottleAsync;
 
         _eventChannel = Channel.CreateUnbounded<SendLoopEvent>(new UnboundedChannelOptions
         {
@@ -641,6 +655,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             TaskCreationOptions.LongRunning,
             TaskScheduler.Default).Unwrap();
     }
+
+    private static ValueTask DelayForThrottleAsync(int delayMs, CancellationToken cancellationToken) =>
+        new(Task.Delay(delayMs, cancellationToken));
 
     /// <summary>
     /// Returns true if the send loop is still running. When false, this BrokerSender
@@ -1204,31 +1221,37 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     // epoch bump (step 4) runs before re-coalescing.
                     if (coalescedCount > 0 && Volatile.Read(ref _epochBumpRequestedForEpoch) >= 0)
                     {
-                        // Epoch bump pending — move coalesced batches back to carry-over.
-                        // Retry batches use AddFirst (they're older and must go before everything).
-                        // Normal batches use AddAfterRetries (they're newer and must go after
-                        // all retry batches to preserve per-partition ordering). Without this
-                        // distinction, AddFirst puts normal batches before retries, causing
-                        // newer data to be sent before older retry data after the partition unmutes.
-                        for (var i = 0; i < coalescedCount; i++)
+                        MoveCoalescedToCarryOver(
+                            coalescedBatches, coalescedGenerations, ref coalescedCount, carryOver);
+                        continue;
+                    }
+
+                    if (coalescedCount > 0)
+                    {
+                        var throttleDelayMs = GetRemainingBrokerThrottleMs();
+                        if (throttleDelayMs > 0)
                         {
-                            var batch = coalescedBatches[i];
-                            var generation = coalescedGenerations[i];
-                            if (!batch.IsCurrentIncarnation(generation))
+                            MoveCoalescedToCarryOver(
+                                coalescedBatches, coalescedGenerations, ref coalescedCount, carryOver);
+                            SweepExpiredCarryOver(carryOver);
+
+                            if (carryOver.Count == 0)
+                                continue;
+
+                            // Keep polling already-sent requests while new sends are throttled.
+                            // Their acknowledgements must not wait behind the broker delay.
+                            if (Volatile.Read(ref _totalPendingResponseCount) > 0)
                             {
-                                LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+                                await WaitForAnyResponseAsync(cancellationToken).ConfigureAwait(false);
                                 continue;
                             }
 
-                            if (batch.IsRetry)
-                                carryOver.AddFirst(new BatchReference(batch, generation));
-                            else
-                                carryOver.AddAfterRetries(new BatchReference(batch, generation));
+                            var nextDeadlineMs = ComputeNextWakeupMs(carryOver);
+                            var delayMs = Math.Min(throttleDelayMs, nextDeadlineMs);
+                            if (delayMs > 0)
+                                await _delayForThrottle(delayMs, cancellationToken).ConfigureAwait(false);
+                            continue;
                         }
-                        Array.Clear(coalescedBatches, 0, coalescedCount);
-                        Array.Clear(coalescedGenerations, 0, coalescedCount);
-                        coalescedCount = 0;
-                        continue;
                     }
 
                     if (coalescedCount > 0)
@@ -1921,6 +1944,73 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     /// <summary>
+    /// Requeues an unsent request without changing retry state. Retries stay ahead of
+    /// normal batches so quota waits and epoch bumps cannot reorder a partition.
+    /// </summary>
+    private void MoveCoalescedToCarryOver(
+        ReadyBatch[] batches,
+        int[] generations,
+        ref int count,
+        PartitionCarryOver carryOver)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            var batch = batches[i];
+            var generation = generations[i];
+            if (!batch.IsCurrentIncarnation(generation))
+            {
+                LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+                continue;
+            }
+
+            var batchReference = new BatchReference(batch, generation);
+            if (batch.IsRetry)
+                carryOver.AddFirst(batchReference);
+            else
+                carryOver.AddAfterRetries(batchReference);
+        }
+
+        Array.Clear(batches, 0, count);
+        Array.Clear(generations, 0, count);
+        count = 0;
+    }
+
+    private void ObserveBrokerThrottle(int throttleTimeMs)
+    {
+        _onBrokerThrottle?.Invoke(throttleTimeMs);
+
+        if (throttleTimeMs <= 0)
+            return;
+
+        var now = _getTimestamp();
+        var delayTicks = (long)Math.Ceiling(
+            throttleTimeMs * (double)Stopwatch.Frequency / 1000);
+        var throttleUntil = delayTicks >= long.MaxValue - now
+            ? long.MaxValue
+            : now + delayTicks;
+
+        if (throttleUntil > _brokerThrottleUntilTimestamp)
+            _brokerThrottleUntilTimestamp = throttleUntil;
+    }
+
+    private int GetRemainingBrokerThrottleMs()
+    {
+        if (_brokerThrottleUntilTimestamp == 0)
+            return 0;
+
+        var remainingTicks = _brokerThrottleUntilTimestamp - _getTimestamp();
+        if (remainingTicks <= 0)
+        {
+            _brokerThrottleUntilTimestamp = 0;
+            return 0;
+        }
+
+        var remainingMs = (long)Math.Ceiling(
+            remainingTicks * 1000d / Stopwatch.Frequency);
+        return (int)Math.Min(remainingMs, int.MaxValue);
+    }
+
+    /// <summary>
     /// Polls _pendingResponsesByConnection for completed response tasks and processes them inline.
     /// Equivalent to Java's Sender processing completed sends inside NetworkClient.poll().
     /// Uses compact-in-place pattern to avoid list allocation during removal.
@@ -1986,6 +2076,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
 
                 var response = task.Result;
+                ObserveBrokerThrottle(response.ThrottleTimeMs);
                 // Reuse caller-provided dictionary to avoid per-response allocation.
                 // The dictionary is cleared after use in ProcessResponseBatches.
                 var responseLookup = reusableResponseLookup;

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2444,7 +2444,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private int ComputeNextWakeupMs(PartitionCarryOver carryOver)
     {
-        var now = Stopwatch.GetTimestamp();
+        var now = _getTimestamp();
         var earliestTicks = long.MaxValue;
 
         // Use request timeout for pending responses (Java handleTimedOutRequests pattern).
@@ -3564,7 +3564,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private void SweepExpiredCarryOver(PartitionCarryOver carryOver)
     {
-        var now = Stopwatch.GetTimestamp();
+        var now = _getTimestamp();
         var deliveryTimeoutTicks = _options.DeliveryTimeoutTicks;
 
         foreach (var kvp in carryOver.Partitions)
@@ -3592,7 +3592,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                 LogDeliveryTimeoutExceeded(_brokerId, batch.TopicPartition.Topic,
                     batch.TopicPartition.Partition);
-                var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks);
+                var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks, now);
                 var configured = TimeSpan.FromMilliseconds(_options.DeliveryTimeoutMs);
                 FailAndCleanupBatch(batch, new KafkaTimeoutException(
                     TimeoutKind.Delivery,

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -93,6 +93,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private const int SendCoalescedTimeoutMs = 1500;
 
+    private const int ResponsePollIntervalMs = 100;
+
     /// <summary>
     /// Micro-linger: when coalesced batch count is at or below this threshold,
     /// briefly spin-wait for more batches before sending. Reduces per-request
@@ -1238,15 +1240,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             if (carryOver.Count == 0)
                                 continue;
 
+                            var nextDeadlineMs = ComputeNextWakeupMs(carryOver);
+
                             // Keep polling already-sent requests while new sends are throttled.
                             // Their acknowledgements must not wait behind the broker delay.
                             if (Volatile.Read(ref _totalPendingResponseCount) > 0)
                             {
-                                await WaitForAnyResponseAsync(cancellationToken).ConfigureAwait(false);
+                                var responseWaitMs = ComputeThrottledResponseWaitMs(
+                                    throttleDelayMs,
+                                    nextDeadlineMs);
+                                await WaitForAnyResponseAsync(cancellationToken, responseWaitMs)
+                                    .ConfigureAwait(false);
                                 continue;
                             }
 
-                            var nextDeadlineMs = ComputeNextWakeupMs(carryOver);
                             var delayMs = Math.Min(throttleDelayMs, nextDeadlineMs);
                             if (delayMs > 0)
                                 await _delayForThrottle(delayMs, cancellationToken).ConfigureAwait(false);
@@ -2603,21 +2610,26 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     /// <summary>
     /// Waits for any pending response to complete using an <see cref="AsyncAutoResetSignal"/>,
-    /// with a 100ms periodic wake-up to re-sweep delivery timeouts for zombie entries.
+    /// with a bounded periodic wake-up to re-sweep delivery timeouts for zombie entries.
     /// Signal may be missed if multiple responses complete between iterations;
-    /// the 100ms fallback ensures we don't wait indefinitely.
+    /// the 100ms default fallback ensures we don't wait indefinitely.
     ///
     /// Zero-allocation in steady state: the signal uses a reusable internal timer for
-    /// the 100ms timeout and a one-time shutdown token registration for cancellation.
+    /// the timeout and a one-time shutdown token registration for cancellation.
     /// </summary>
-    private async ValueTask WaitForAnyResponseAsync(CancellationToken cancellationToken)
+    private async ValueTask WaitForAnyResponseAsync(
+        CancellationToken cancellationToken,
+        int timeoutMs = ResponsePollIntervalMs)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         // WaitAsync returns true if signaled, false on timeout.
         // Throws OperationCanceledException only on shutdown (via RegisterShutdownToken).
-        await _anyResponseCompleted.WaitAsync(100).ConfigureAwait(false);
+        await _anyResponseCompleted.WaitAsync(timeoutMs).ConfigureAwait(false);
     }
+
+    internal static int ComputeThrottledResponseWaitMs(int throttleDelayMs, int batchDeadlineMs)
+        => Math.Min(ResponsePollIntervalMs, Math.Min(throttleDelayMs, batchDeadlineMs));
 
     /// <summary>
     /// Sends coalesced batches (one per partition) as a single ProduceRequest.

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1394,12 +1394,31 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             remainingBuckets -= completedSends;
 
                             // Wait for capacity on blocked connections
+                            var bucketsRequeuedForThrottle = false;
                             while (remainingBuckets > 0)
                             {
                                 ProcessCompletedResponses(carryOver, cancellationToken, responseLookup);
 
                                 // Handle timed-out requests to free zombie entries from stale connections.
                                 HandleTimedOutRequests(carryOver, cancellationToken);
+
+                                // A response processed above may start a broker-wide throttle.
+                                // Requeue every unsent bucket so the outer send gate observes it
+                                // before another connection can send during the quota pause.
+                                if (GetRemainingBrokerThrottleMs() > 0)
+                                {
+                                    for (var c = 0; c < _connectionCount; c++)
+                                    {
+                                        ref var bucket = ref connectionBuckets[c];
+                                        if (!bucket.HasBatches) continue;
+
+                                        MoveCoalescedToCarryOver(
+                                            bucket.Batches, bucket.Generations, ref bucket.Count, carryOver);
+                                    }
+
+                                    bucketsRequeuedForThrottle = true;
+                                    break;
+                                }
 
                                 // Try sending on connections that now have capacity (parallel)
                                 var sent = false;
@@ -1426,6 +1445,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                                 if (remainingBuckets > 0 && !sent)
                                     await WaitForAnyResponseAsync(cancellationToken).ConfigureAwait(false);
                             }
+
+                            if (bucketsRequeuedForThrottle)
+                                continue;
                         }
                     }
                     else

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -235,6 +235,11 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
 internal interface IProducerDiagnostics
 {
     /// <summary>
+    /// Largest throttle delay reported by a broker in a produce response while delivery diagnostics are enabled.
+    /// </summary>
+    int MaxObservedBrokerThrottleTimeMs { get; }
+
+    /// <summary>
     /// Captures batches still tracked inside the producer pipeline.
     /// </summary>
     ProducerDeliveryDiagnosticsSnapshot GetDeliveryDiagnosticsSnapshot();

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -74,6 +74,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly SemaphoreSlim _initLock = new(1, 1);
 
     private volatile int _produceApiVersion = -1;
+    private int _maxObservedBrokerThrottleTimeMs;
     private int _disposed;
 
     internal bool IsDisposed => Volatile.Read(ref _disposed) != 0;
@@ -2525,6 +2526,25 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     ProducerDeliveryDiagnosticsSnapshot IProducerDiagnostics.GetDeliveryDiagnosticsSnapshot()
         => _accumulator.GetDeliveryDiagnosticsSnapshot();
 
+    int IProducerDiagnostics.MaxObservedBrokerThrottleTimeMs =>
+        Volatile.Read(ref _maxObservedBrokerThrottleTimeMs);
+
+    private void ObserveBrokerThrottle(int throttleTimeMs)
+    {
+        var observedMaximum = Volatile.Read(ref _maxObservedBrokerThrottleTimeMs);
+        while (throttleTimeMs > observedMaximum)
+        {
+            var previous = Interlocked.CompareExchange(
+                ref _maxObservedBrokerThrottleTimeMs,
+                throttleTimeMs,
+                observedMaximum);
+            if (previous == observedMaximum)
+                return;
+
+            observedMaximum = previous;
+        }
+    }
+
     private async Task SenderLoopAsync(CancellationToken cancellationToken)
     {
         // PER-BROKER SENDER ARCHITECTURE: Each broker gets a dedicated BrokerSender with its own
@@ -2814,7 +2834,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             RerouteBatchToCurrentLeader,
             _interceptors is not null ? InvokeOnAcknowledgementForBatch : null,
             _logger,
-            canPhysicallyShrinkConnections: _ownsInfrastructure);
+            canPhysicallyShrinkConnections: _ownsInfrastructure,
+            onBrokerThrottle: _options.EnableDeliveryDiagnostics ? ObserveBrokerThrottle : null);
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Integration/QuotaAndRateLimitingTests.cs
+++ b/tests/Dekaf.Tests.Integration/QuotaAndRateLimitingTests.cs
@@ -22,6 +22,37 @@ public sealed class QuotaAndRateLimitingTests(KafkaTestContainer kafka) : KafkaI
             .Build();
     }
 
+    private static async Task WaitForProducerQuotaAsync(
+        IAdminClient admin,
+        ClientQuotaEntity quotaEntity,
+        string clientId,
+        string quotaKey,
+        double expectedValue)
+    {
+        var filter = new ClientQuotaFilter
+        {
+            Components =
+            [
+                ClientQuotaFilterComponent.Exact(ClientQuotaEntityType.ClientId, clientId)
+            ],
+            Strict = true
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (true)
+        {
+            var quotas = await admin.DescribeClientQuotasAsync(filter, cancellationToken: cts.Token);
+            if (quotas.TryGetValue(quotaEntity, out var values)
+                && values.TryGetValue(quotaKey, out var value)
+                && value == expectedValue)
+            {
+                return;
+            }
+
+            await Task.Delay(100, cts.Token);
+        }
+    }
+
     /// <summary>
     /// Helper to set a broker-level default producer byte rate quota.
     /// Uses the deprecated but widely supported <c>quota.producer.default</c> broker config.
@@ -86,6 +117,107 @@ public sealed class QuotaAndRateLimitingTests(KafkaTestContainer kafka) : KafkaI
         };
 
         await admin.IncrementalAlterConfigsAsync(alterations);
+    }
+
+    [Test]
+    public async Task ProducerThrottle_NonZeroBrokerDelay_PreservesEveryRecordExactlyOnce()
+    {
+        const string quotaKey = "producer_byte_rate";
+        const double bytesPerSecond = 16_384;
+        const int maxMessages = 24;
+        const int messagesAfterThrottle = 2;
+
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var clientId = $"test-producer-throttle-{Guid.NewGuid():N}";
+        var quotaEntity = ClientQuotaEntity.For(ClientQuotaEntityComponent.ClientId(clientId));
+        var payload = new string('x', 16_384);
+
+        await using var admin = CreateAdminClient();
+        try
+        {
+            await admin.AlterClientQuotasAsync(
+            [
+                ClientQuotaAlteration.Set(quotaEntity, quotaKey, bytesPerSecond)
+            ]);
+
+            await WaitForProducerQuotaAsync(
+                admin, quotaEntity, clientId, quotaKey, bytesPerSecond);
+
+            await using var producer = await Kafka.CreateProducer<string, string>()
+                .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                .WithClientId(clientId)
+                .WithBatchSize(32 * 1024)
+                .WithLinger(TimeSpan.Zero)
+                .WithIdempotence(true)
+                .WithDeliveryDiagnostics()
+                .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+                .BuildAsync();
+
+            var diagnostics = (IProducerDiagnostics)producer;
+            var produced = new List<RecordMetadata>();
+            var expectedKeys = new List<string>();
+            var firstThrottledMessage = -1;
+
+            for (var i = 0; i < maxMessages; i++)
+            {
+                var key = $"quota-boundary-{i}";
+                expectedKeys.Add(key);
+                produced.Add(await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Key = key,
+                    Value = payload
+                }));
+
+                if (diagnostics.MaxObservedBrokerThrottleTimeMs > 0 && firstThrottledMessage < 0)
+                    firstThrottledMessage = i;
+
+                if (firstThrottledMessage >= 0 && i >= firstThrottledMessage + messagesAfterThrottle)
+                    break;
+            }
+
+            await producer.FlushAsync();
+
+            await Assert.That(diagnostics.MaxObservedBrokerThrottleTimeMs).IsGreaterThan(0);
+            await Assert.That(firstThrottledMessage).IsGreaterThanOrEqualTo(0);
+            await Assert.That(produced.Count - firstThrottledMessage - 1)
+                .IsEqualTo(messagesAfterThrottle);
+            await Assert.That(produced.Select(result => result.Offset).Distinct().Count())
+                .IsEqualTo(produced.Count);
+
+            await using var consumer = await Kafka.CreateConsumer<string, string>()
+                .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                .WithClientId($"quota-verifier-{Guid.NewGuid():N}")
+                .WithGroupId($"quota-verifier-{Guid.NewGuid():N}")
+                .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+                .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+                .BuildAsync();
+
+            consumer.Subscribe(topic);
+            var consumed = await ConsumeMessagesAsync(consumer, expectedKeys.Count);
+
+            await Assert.That(consumed.Select(result => result.Key!).ToArray())
+                .IsEquivalentTo(expectedKeys);
+            await Assert.That(consumed.Select(result => result.Offset).Distinct().Count())
+                .IsEqualTo(expectedKeys.Count);
+
+            var duplicate = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+            await Assert.That(duplicate).IsNull();
+        }
+        finally
+        {
+            try
+            {
+                await admin.AlterClientQuotasAsync(
+                [
+                    ClientQuotaAlteration.Remove(quotaEntity, quotaKey)
+                ]);
+            }
+            catch (Errors.KafkaException)
+            {
+                // Cleanup best-effort; unique client ID prevents leakage into other tests.
+            }
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1181,6 +1181,23 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
+    [Arguments(5, 100, 5)]
+    [Arguments(20, 100, 20)]
+    [Arguments(250, 100, 100)]
+    [Arguments(20, 7, 7)]
+    public async Task ComputeThrottledResponseWaitMs_BoundsEveryDeadline(
+        int throttleDelayMs,
+        int batchDeadlineMs,
+        int expectedWaitMs)
+    {
+        var waitMs = BrokerSender.ComputeThrottledResponseWaitMs(
+            throttleDelayMs,
+            batchDeadlineMs);
+
+        await Assert.That(waitMs).IsEqualTo(expectedWaitMs);
+    }
+
+    [Test]
     [Timeout(120_000)]
     public async Task SendLoop_PositiveBrokerThrottle_DelaysNextRequestWithoutDeliveryErrors(
         CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics;
 using Dekaf.Compression;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -99,9 +100,11 @@ public sealed class BrokerSenderSendLoopTests
     /// <summary>
     /// Creates a ProduceResponse with success for the given topic/partition.
     /// </summary>
-    private static ProduceResponse CreateSuccessResponse(string topic, int partition, long baseOffset) =>
+    private static ProduceResponse CreateSuccessResponse(
+        string topic, int partition, long baseOffset, int throttleTimeMs = 0) =>
         new()
         {
+            ThrottleTimeMs = throttleTimeMs,
             TopicCount = 1,
             Responses =
             [
@@ -150,7 +153,10 @@ public sealed class BrokerSenderSendLoopTests
         IConnectionPool pool,
         ProducerOptions options,
         RecordAccumulator accumulator,
-        Action<TopicPartition, long, DateTimeOffset, int, Exception?> onAcknowledgement) =>
+        Action<TopicPartition, long, DateTimeOffset, int, Exception?> onAcknowledgement,
+        Action<int>? onBrokerThrottle = null,
+        Func<long>? getTimestamp = null,
+        Func<int, CancellationToken, ValueTask>? delayForThrottle = null) =>
         new(
             brokerId: 1, pool,
             new MetadataManager(pool, options.BootstrapServers),
@@ -165,7 +171,10 @@ public sealed class BrokerSenderSendLoopTests
             getCurrentEpoch: null,
             rerouteBatch: null,
             onAcknowledgement: onAcknowledgement,
-            logger: null);
+            logger: null,
+            onBrokerThrottle: onBrokerThrottle,
+            getTimestamp: getTimestamp,
+            delayForThrottle: delayForThrottle);
 
     private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken cancellationToken)
     {
@@ -1168,6 +1177,146 @@ public sealed class BrokerSenderSendLoopTests
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task SendLoop_PositiveBrokerThrottle_DelaysNextRequestWithoutDeliveryErrors(
+        CancellationToken cancellationToken)
+    {
+        const int throttleTimeMs = 250;
+
+        var firstResponse = new TaskCompletionSource<ProduceResponse>();
+        var secondResponse = new TaskCompletionSource<ProduceResponse>();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>([firstResponse, secondResponse]);
+        var sendSignals = new[] { new TaskCompletionSource(), new TaskCompletionSource() };
+        var sendCount = 0;
+        var (pool, _) = CreateMockConnection(responseQueue, () =>
+        {
+            var index = Interlocked.Increment(ref sendCount) - 1;
+            sendSignals[index].TrySetResult();
+        });
+
+        var options = CreateOptions(maxInFlight: 1);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var throttleWaitStarted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseThrottleWait = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observedThrottleTimes = new List<int>();
+        var timestamp = 0L;
+        var acknowledgements = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var acknowledgementCount = 0;
+
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, error) =>
+            {
+                if (error is null && Interlocked.Increment(ref acknowledgementCount) == 2)
+                    acknowledgements.TrySetResult();
+            },
+            observedThrottleTimes.Add,
+            () => Volatile.Read(ref timestamp),
+            (delayMs, token) =>
+            {
+                throttleWaitStarted.TrySetResult(delayMs);
+                return new ValueTask(releaseThrottleWait.Task.WaitAsync(token));
+            });
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
+            await sendSignals[0].Task.WaitAsync(cancellationToken);
+
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1));
+            firstResponse.SetResult(CreateSuccessResponse(
+                "test-topic", 0, baseOffset: 10, throttleTimeMs));
+
+            var requestedDelayMs = await throttleWaitStarted.Task.WaitAsync(cancellationToken);
+            await Assert.That(requestedDelayMs).IsEqualTo(throttleTimeMs);
+            await Assert.That(sendSignals[1].Task.IsCompleted).IsFalse();
+
+            Volatile.Write(ref timestamp, Stopwatch.Frequency);
+            releaseThrottleWait.SetResult();
+
+            await sendSignals[1].Task.WaitAsync(cancellationToken);
+            secondResponse.SetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 11));
+            await acknowledgements.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(observedThrottleTimes).IsEquivalentTo([throttleTimeMs, 0]);
+            await Assert.That(Volatile.Read(ref sendCount)).IsEqualTo(2);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task SendLoop_ZeroBrokerThrottle_DoesNotDelayNextRequest(
+        CancellationToken cancellationToken)
+    {
+        var firstResponse = new TaskCompletionSource<ProduceResponse>();
+        var secondResponse = new TaskCompletionSource<ProduceResponse>();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>([firstResponse, secondResponse]);
+        var sendSignals = new[] { new TaskCompletionSource(), new TaskCompletionSource() };
+        var sendCount = 0;
+        var (pool, _) = CreateMockConnection(responseQueue, () =>
+        {
+            var index = Interlocked.Increment(ref sendCount) - 1;
+            sendSignals[index].TrySetResult();
+        });
+
+        var options = CreateOptions(maxInFlight: 1);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var throttleDelayCalled = false;
+        var observedThrottleTimes = new List<int>();
+        var acknowledgements = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var acknowledgementCount = 0;
+
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, error) =>
+            {
+                if (error is null && Interlocked.Increment(ref acknowledgementCount) == 2)
+                    acknowledgements.TrySetResult();
+            },
+            observedThrottleTimes.Add,
+            delayForThrottle: (_, _) =>
+            {
+                throttleDelayCalled = true;
+                return ValueTask.CompletedTask;
+            });
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
+            await sendSignals[0].Task.WaitAsync(cancellationToken);
+
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1));
+            firstResponse.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 20));
+
+            await sendSignals[1].Task.WaitAsync(cancellationToken);
+            secondResponse.SetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 21));
+            await acknowledgements.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(throttleDelayCalled).IsFalse();
+            await Assert.That(observedThrottleTimes).IsEquivalentTo([0, 0]);
+            await Assert.That(Volatile.Read(ref sendCount)).IsEqualTo(2);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Diagnostics;
 using Dekaf.Compression;
+using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
@@ -1432,6 +1433,88 @@ public sealed class BrokerSenderSendLoopTests
             await Assert.That(throttleDelayCalled).IsFalse();
             await Assert.That(observedThrottleTimes).IsEquivalentTo([0, 0]);
             await Assert.That(Volatile.Read(ref sendCount)).IsEqualTo(2);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task SendLoop_InjectedClockControlsThrottleWakeupAndDeliveryExpiry(
+        CancellationToken cancellationToken)
+    {
+        const int deliveryTimeoutMs = 10_000;
+        const int throttleTimeMs = 20_000;
+
+        var firstResponse = new TaskCompletionSource<ProduceResponse>();
+        var secondResponse = new TaskCompletionSource<ProduceResponse>();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>([firstResponse, secondResponse]);
+        var sendSignals = new[] { new TaskCompletionSource(), new TaskCompletionSource() };
+        var sendCount = 0;
+        var (pool, _) = CreateMockConnection(responseQueue, () =>
+        {
+            var index = Interlocked.Increment(ref sendCount) - 1;
+            sendSignals[index].TrySetResult();
+        });
+
+        var options = CreateOptions(maxInFlight: 1, deliveryTimeoutMs: deliveryTimeoutMs);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var expiringBatch = CreateTestBatch(valueTaskSourcePool, "test-topic", 1);
+        var fakeTimestamp = expiringBatch.StopwatchCreatedTicks + options.DeliveryTimeoutTicks / 2;
+        var firstDelayRequested = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var unexpectedSecondDelay = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondDelayGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var deliveryFailure = new TaskCompletionSource<Exception?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var delayCount = 0;
+
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (topicPartition, _, _, _, error) =>
+            {
+                if (topicPartition.Partition == 1 && error is not null)
+                    deliveryFailure.TrySetResult(error);
+            },
+            getTimestamp: () => Volatile.Read(ref fakeTimestamp),
+            delayForThrottle: (delayMs, token) =>
+            {
+                if (Interlocked.Increment(ref delayCount) == 1)
+                {
+                    firstDelayRequested.TrySetResult(delayMs);
+                    Volatile.Write(
+                        ref fakeTimestamp,
+                        expiringBatch.StopwatchCreatedTicks + options.DeliveryTimeoutTicks);
+                    return ValueTask.CompletedTask;
+                }
+
+                unexpectedSecondDelay.TrySetResult();
+                return new ValueTask(secondDelayGate.Task.WaitAsync(token));
+            });
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
+            await sendSignals[0].Task.WaitAsync(cancellationToken);
+
+            sender.Enqueue(expiringBatch);
+            firstResponse.SetResult(CreateSuccessResponse(
+                "test-topic", 0, baseOffset: 10, throttleTimeMs));
+
+            await Assert.That(await firstDelayRequested.Task.WaitAsync(cancellationToken))
+                .IsEqualTo(deliveryTimeoutMs / 2);
+
+            var progress = await Task.WhenAny(deliveryFailure.Task, unexpectedSecondDelay.Task)
+                .WaitAsync(cancellationToken);
+            await Assert.That(progress).IsSameReferenceAs(deliveryFailure.Task);
+            await Assert.That(await deliveryFailure.Task).IsTypeOf<KafkaTimeoutException>();
+            await Assert.That(sendSignals[1].Task.IsCompleted).IsFalse();
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -26,10 +26,13 @@ public sealed class BrokerSenderSendLoopTests
 {
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 100, int retryBackoffMaxMs = 1000,
-        int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000) => new()
+        int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000,
+        int connectionsPerBroker = 1, bool enableAdaptiveConnections = true) => new()
         {
             BootstrapServers = ["localhost:9092"],
             MaxInFlightRequestsPerConnection = maxInFlight,
+            ConnectionsPerBroker = connectionsPerBroker,
+            EnableAdaptiveConnections = enableAdaptiveConnections,
             Acks = acks,
             DeliveryTimeoutMs = deliveryTimeoutMs,
             RetryBackoffMs = retryBackoffMs,
@@ -1195,6 +1198,107 @@ public sealed class BrokerSenderSendLoopTests
             batchDeadlineMs);
 
         await Assert.That(waitMs).IsEqualTo(expectedWaitMs);
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task SendLoop_ThrottleObservedDuringConnectionCapacityWait_DelaysRemainingBucket(
+        CancellationToken cancellationToken)
+    {
+        const int throttleTimeMs = 250;
+
+        var firstResponse = new TaskCompletionSource<ProduceResponse>();
+        var secondResponse = new TaskCompletionSource<ProduceResponse>();
+        var thirdResponse = new TaskCompletionSource<ProduceResponse>();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>(
+            [firstResponse, secondResponse, thirdResponse]);
+        var sendSignals = new[]
+        {
+            new TaskCompletionSource(),
+            new TaskCompletionSource(),
+            new TaskCompletionSource()
+        };
+        var sendCount = 0;
+        var connection0 = new TestKafkaConnection
+        {
+            SendProducePipelinedAfterWrite = () =>
+            {
+                var response = responseQueue.Dequeue().Task;
+                var index = Interlocked.Increment(ref sendCount) - 1;
+                sendSignals[index].TrySetResult();
+                return new ValueTask<Task<ProduceResponse>>(response);
+            }
+        };
+        var connection1 = new TestKafkaConnection();
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection0);
+        pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => new ValueTask<IKafkaConnection>(
+                (int)callInfo[1] == 0 ? connection0 : connection1));
+
+        var options = CreateOptions(
+            maxInFlight: 2,
+            connectionsPerBroker: 2,
+            enableAdaptiveConnections: false);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var throttleWaitStarted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseThrottleWait = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timestamp = 0L;
+        var acknowledgements = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var acknowledgementCount = 0;
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, error) =>
+            {
+                if (error is null && Interlocked.Increment(ref acknowledgementCount) == 3)
+                    acknowledgements.TrySetResult();
+            },
+            getTimestamp: () => Volatile.Read(ref timestamp),
+            delayForThrottle: (delayMs, token) =>
+            {
+                throttleWaitStarted.TrySetResult(delayMs);
+                return new ValueTask(releaseThrottleWait.Task.WaitAsync(token));
+            });
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
+            await sendSignals[0].Task.WaitAsync(cancellationToken);
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 2));
+            await sendSignals[1].Task.WaitAsync(cancellationToken);
+
+            var delayedBatch = CreateTestBatch(valueTaskSourcePool, "test-topic", 4);
+            delayedBatch.EnableDeliveryDiagnostics();
+            sender.Enqueue(delayedBatch);
+            await WaitUntilAsync(() => delayedBatch.DiagTrace.Contains('S'), cancellationToken);
+
+            firstResponse.SetResult(CreateSuccessResponse(
+                "test-topic", 0, baseOffset: 10, throttleTimeMs));
+            secondResponse.SetResult(CreateSuccessResponse("test-topic", 2, baseOffset: 11));
+
+            var firstProgress = await Task.WhenAny(throttleWaitStarted.Task, sendSignals[2].Task)
+                .WaitAsync(cancellationToken);
+            await Assert.That(firstProgress).IsSameReferenceAs(throttleWaitStarted.Task);
+            await Assert.That(await throttleWaitStarted.Task).IsEqualTo(throttleTimeMs);
+            await Assert.That(sendSignals[2].Task.IsCompleted).IsFalse();
+
+            Volatile.Write(ref timestamp, Stopwatch.Frequency);
+            releaseThrottleWait.SetResult();
+
+            await sendSignals[2].Task.WaitAsync(cancellationToken);
+            thirdResponse.SetResult(CreateSuccessResponse("test-topic", 4, baseOffset: 12));
+            await acknowledgements.Task.WaitAsync(cancellationToken);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- pause all produce connections for a broker when `throttle_time_ms` is positive while continuing to process in-flight responses
- retain a zero-throttle fast path and expose internal delivery diagnostics for real broker verification
- add deterministic zero/positive unit boundaries plus client-quota integration coverage for loss and duplication

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj --configuration Release --no-restore`
- [x] full unit suite: 4,511 passed
- [x] `BrokerSenderSendLoopTests`: 16 passed
- [x] `QuotaAndRateLimitingTests`: 15 passed across Kafka 4.0, 4.1, and 4.2

Closes #1626
