### PR TITLE
fix(consumer): preserve offsets across rebalance

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -109,6 +109,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         return revoked;
     }
 
+    internal void RestoreRevokedPartitionsSinceLastSync(HashSet<TopicPartition> revoked)
+    {
+        foreach (var partition in revoked)
+            _revokedPartitionsSinceLastSync.Enqueue(partition);
+    }
+
     private void TrackRevokedPartitions(IReadOnlyList<TopicPartition> revoked)
     {
         foreach (var partition in revoked)

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -694,6 +694,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     {
                         if (group.ErrorCode != ErrorCode.None)
                         {
+                            HandleOffsetFetchMembershipError(group.ErrorCode);
                             throw new GroupException(group.ErrorCode,
                                 $"OffsetFetch failed for group: {group.ErrorCode}")
                             {
@@ -734,6 +735,20 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         finally
         {
             _fetchLock.Release();
+        }
+    }
+
+    private void HandleOffsetFetchMembershipError(ErrorCode errorCode)
+    {
+        switch (errorCode)
+        {
+            case ErrorCode.StaleMemberEpoch:
+                RequestRejoin();
+                break;
+
+            case ErrorCode.UnknownMemberId:
+                ResetMemberState();
+                break;
         }
     }
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Dekaf.Errors;
 using Dekaf.Metadata;
@@ -27,6 +28,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
     private readonly IRebalanceListener? _rebalanceListener;
+    // Heartbeats can revoke and reassign a partition between poll-loop snapshots.
+    // Preserve both the immediate stale-fetch signal and the revocation history needed
+    // to defeat assignment ABA (A -> B -> A with the same final set).
+    private readonly Action<IReadOnlyList<TopicPartition>>? _onPartitionsRevoked;
+    private readonly ConcurrentQueue<TopicPartition> _revokedPartitionsSinceLastSync = new();
     private IRebalanceListener? _runtimeRebalanceListener;
     private readonly ILogger _logger;
 
@@ -71,12 +77,14 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         IConnectionPool connectionPool,
         MetadataManager metadataManager,
         ILogger<ConsumerCoordinator>? logger = null,
-        Func<int>? getConnectionCount = null)
+        Func<int>? getConnectionCount = null,
+        Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoked = null)
     {
         _options = options;
         _connectionPool = connectionPool;
         _metadataManager = metadataManager;
         _rebalanceListener = options.RebalanceListener;
+        _onPartitionsRevoked = onPartitionsRevoked;
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ConsumerCoordinator>.Instance;
         _getCoordinationConnectionIndex = getConnectionCount is not null
             ? () => GetCoordinationConnectionIndex(getConnectionCount())
@@ -89,6 +97,25 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     public CoordinatorState State => _state;
     public TopicPartitionSet Assignment => _assignedPartitions;
     internal int AssignmentVersion => Volatile.Read(ref _assignmentVersion);
+
+    internal HashSet<TopicPartition>? DrainRevokedPartitionsSinceLastSync()
+    {
+        HashSet<TopicPartition>? revoked = null;
+        while (_revokedPartitionsSinceLastSync.TryDequeue(out var partition))
+        {
+            (revoked ??= []).Add(partition);
+        }
+
+        return revoked;
+    }
+
+    private void TrackRevokedPartitions(IReadOnlyList<TopicPartition> revoked)
+    {
+        foreach (var partition in revoked)
+            _revokedPartitionsSinceLastSync.Enqueue(partition);
+
+        _onPartitionsRevoked?.Invoke(revoked);
+    }
 
     internal IDisposable RegisterRuntimeRebalanceListener(IRebalanceListener listener)
     {
@@ -582,7 +609,17 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 var request = new OffsetFetchRequest
                 {
                     GroupId = _options.GroupId!,
-                    Topics = topicPartitions
+                    Topics = topicPartitions,
+                    Groups =
+                    [
+                        new OffsetFetchRequestGroup
+                        {
+                            GroupId = _options.GroupId!,
+                            MemberId = _memberId,
+                            MemberEpoch = _generationId,
+                            Topics = topicPartitions
+                        }
+                    ]
                 };
 
                 // Use negotiated API version
@@ -617,15 +654,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                         {
                             if (partition.ErrorCode != ErrorCode.None)
                             {
-                                if (partition.ErrorCode.IsRetriable())
+                                throw new GroupException(partition.ErrorCode,
+                                    $"OffsetFetch failed for {topic.Name}-{partition.PartitionIndex}: {partition.ErrorCode}")
                                 {
-                                    throw new GroupException(partition.ErrorCode,
-                                        $"OffsetFetch failed for {topic.Name}-{partition.PartitionIndex}: {partition.ErrorCode}")
-                                    {
-                                        GroupId = _options.GroupId
-                                    };
-                                }
-                                continue;
+                                    GroupId = _options.GroupId
+                                };
                             }
 
                             if (partition.CommittedOffset >= 0)
@@ -648,15 +681,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     {
                         if (group.ErrorCode != ErrorCode.None)
                         {
-                            if (group.ErrorCode.IsRetriable())
+                            throw new GroupException(group.ErrorCode,
+                                $"OffsetFetch failed for group: {group.ErrorCode}")
                             {
-                                throw new GroupException(group.ErrorCode,
-                                    $"OffsetFetch failed for group: {group.ErrorCode}")
-                                {
-                                    GroupId = _options.GroupId
-                                };
-                            }
-                            continue;
+                                GroupId = _options.GroupId
+                            };
                         }
 
                         foreach (var topic in group.Topics)
@@ -665,15 +694,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                             {
                                 if (partition.ErrorCode != ErrorCode.None)
                                 {
-                                    if (partition.ErrorCode.IsRetriable())
+                                    throw new GroupException(partition.ErrorCode,
+                                        $"OffsetFetch failed for {topic.Name}-{partition.PartitionIndex}: {partition.ErrorCode}")
                                     {
-                                        throw new GroupException(partition.ErrorCode,
-                                            $"OffsetFetch failed for {topic.Name}-{partition.PartitionIndex}: {partition.ErrorCode}")
-                                        {
-                                            GroupId = _options.GroupId
-                                        };
-                                    }
-                                    continue;
+                                        GroupId = _options.GroupId
+                                    };
                                 }
 
                                 if (partition.CommittedOffset >= 0)
@@ -711,6 +736,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private void ResetMemberState()
     {
         var hadAssignment = _assignedPartitions.Count != 0;
+        if (hadAssignment)
+        {
+            var revoked = _assignedPartitions.ToList();
+            TrackRevokedPartitions(revoked);
+        }
+
         _memberId = null;
         _generationId = -1;
         _assignedPartitions = [];
@@ -986,6 +1017,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         var changed = revoked is { Count: > 0 } || assigned is { Count: > 0 };
         if (changed)
         {
+            if (revoked is not null)
+                TrackRevokedPartitions(revoked);
+
             _assignedPartitions = newAssignment;
             Interlocked.Increment(ref _assignmentVersion);
             LogConsumerProtocolAssignmentUpdate(assigned?.Count ?? 0, revoked?.Count ?? 0);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -735,19 +735,17 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// </summary>
     private void ResetMemberState()
     {
-        var hadAssignment = _assignedPartitions.Count != 0;
-        if (hadAssignment)
-        {
-            var revoked = _assignedPartitions.ToList();
-            TrackRevokedPartitions(revoked);
-        }
+        var revoked = _assignedPartitions.Count != 0 ? _assignedPartitions.ToList() : null;
 
         _memberId = null;
         _generationId = -1;
         _assignedPartitions = [];
         _state = CoordinatorState.Unjoined;
-        if (hadAssignment)
+        if (revoked is not null)
+        {
             Interlocked.Increment(ref _assignmentVersion);
+            TrackRevokedPartitions(revoked);
+        }
     }
 
     /// <summary>
@@ -1017,11 +1015,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         var changed = revoked is { Count: > 0 } || assigned is { Count: > 0 };
         if (changed)
         {
+            _assignedPartitions = newAssignment;
+            Interlocked.Increment(ref _assignmentVersion);
+
             if (revoked is not null)
                 TrackRevokedPartitions(revoked);
 
-            _assignedPartitions = newAssignment;
-            Interlocked.Increment(ref _assignmentVersion);
             LogConsumerProtocolAssignmentUpdate(assigned?.Count ?? 0, revoked?.Count ?? 0);
         }
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -33,6 +33,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     // to defeat assignment ABA (A -> B -> A with the same final set).
     private readonly Action<IReadOnlyList<TopicPartition>>? _onPartitionsRevoked;
     private readonly ConcurrentQueue<TopicPartition> _revokedPartitionsSinceLastSync = new();
+    // Assignment publication and revocation history form one snapshot. Rebalance callbacks
+    // run only after this lock is released so user code cannot extend its critical section.
+    private readonly Lock _assignmentStateLock = new();
     private IRebalanceListener? _runtimeRebalanceListener;
     private readonly ILogger _logger;
 
@@ -98,29 +101,33 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     public TopicPartitionSet Assignment => _assignedPartitions;
     internal int AssignmentVersion => Volatile.Read(ref _assignmentVersion);
 
-    internal HashSet<TopicPartition>? DrainRevokedPartitionsSinceLastSync()
+    internal (TopicPartitionSet Assignment, int Version, HashSet<TopicPartition>? Revocations)
+        GetAssignmentSnapshotAndDrainRevocations()
     {
-        HashSet<TopicPartition>? revoked = null;
-        while (_revokedPartitionsSinceLastSync.TryDequeue(out var partition))
+        lock (_assignmentStateLock)
         {
-            (revoked ??= []).Add(partition);
-        }
+            HashSet<TopicPartition>? revoked = null;
+            while (_revokedPartitionsSinceLastSync.TryDequeue(out var partition))
+            {
+                (revoked ??= []).Add(partition);
+            }
 
-        return revoked;
+            return (_assignedPartitions, Volatile.Read(ref _assignmentVersion), revoked);
+        }
     }
 
     internal void RestoreRevokedPartitionsSinceLastSync(HashSet<TopicPartition> revoked)
     {
-        foreach (var partition in revoked)
-            _revokedPartitionsSinceLastSync.Enqueue(partition);
+        lock (_assignmentStateLock)
+        {
+            EnqueueRevokedPartitions(revoked);
+        }
     }
 
-    private void TrackRevokedPartitions(IReadOnlyList<TopicPartition> revoked)
+    private void EnqueueRevokedPartitions(IEnumerable<TopicPartition> revoked)
     {
         foreach (var partition in revoked)
             _revokedPartitionsSinceLastSync.Enqueue(partition);
-
-        _onPartitionsRevoked?.Invoke(revoked);
     }
 
     internal IDisposable RegisterRuntimeRebalanceListener(IRebalanceListener listener)
@@ -745,13 +752,19 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         _memberId = null;
         _generationId = -1;
-        _assignedPartitions = [];
         _state = CoordinatorState.Unjoined;
-        if (revoked is not null)
+        lock (_assignmentStateLock)
         {
-            Interlocked.Increment(ref _assignmentVersion);
-            TrackRevokedPartitions(revoked);
+            _assignedPartitions = [];
+            if (revoked is not null)
+            {
+                Interlocked.Increment(ref _assignmentVersion);
+                EnqueueRevokedPartitions(revoked);
+            }
         }
+
+        if (revoked is not null)
+            _onPartitionsRevoked?.Invoke(revoked);
     }
 
     /// <summary>
@@ -1021,11 +1034,17 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         var changed = revoked is { Count: > 0 } || assigned is { Count: > 0 };
         if (changed)
         {
-            _assignedPartitions = newAssignment;
-            Interlocked.Increment(ref _assignmentVersion);
+            lock (_assignmentStateLock)
+            {
+                _assignedPartitions = newAssignment;
+                Interlocked.Increment(ref _assignmentVersion);
+
+                if (revoked is not null)
+                    EnqueueRevokedPartitions(revoked);
+            }
 
             if (revoked is not null)
-                TrackRevokedPartitions(revoked);
+                _onPartitionsRevoked?.Invoke(revoked);
 
             LogConsumerProtocolAssignmentUpdate(assigned?.Count ?? 0, revoked?.Count ?? 0);
         }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3513,6 +3513,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
             }
 
+            // Invalidate broker fetches that started before the revocation immediately.
+            // Waiting for the consume loop to drain the queued clear lets an ABA reassignment
+            // make a stale response look current and advance the reinitialized fetch position.
+            Interlocked.Increment(ref _fetchBufferEpoch);
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
         }
     }
@@ -4025,6 +4029,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 if (removedPartitions is { Count: > 0 })
                     LogPartitionsRemoved(removedPartitions.Count);
 
+                // Invalidate in-flight fetches before publishing an ABA reassignment or
+                // reinitializing its position. The consume loop owns the actual buffer drain.
+                if (removedPartitions is not null)
+                    QueueCoordinatorRevokedPartitionsForFetchClear(removedPartitions);
+
                 // Update assignment from coordinator
                 _assignment.Clear();
                 foreach (var partition in coordinatorAssignment)
@@ -4041,7 +4050,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // Clean up state for removed partitions
                 if (removedPartitions is not null)
                 {
-                    QueueCoordinatorRevokedPartitionsForFetchClear(removedPartitions);
                     if (RemovePartitionState(removedPartitions))
                         PublishPausedSnapshot();
                 }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3959,6 +3959,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // _assignment HashSet causes NullReferenceException during enumeration.
         // Readers use the volatile _assignmentSnapshot instead of acquiring this lock.
         await SemaphoreHelper.AcquireOrThrowDisposedAsync(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>), cancellationToken).ConfigureAwait(false);
+        (ConsumerCoordinator Coordinator, HashSet<TopicPartition> Partitions)? unacknowledgedCoordinatorRevocations = null;
         try
         {
             coordinator = _coordinator;
@@ -3967,6 +3968,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 var coordinatorAssignmentVersion = coordinator.AssignmentVersion;
                 var coordinatorAssignment = coordinator.Assignment;
                 var coordinatorRevocations = coordinator.DrainRevokedPartitionsSinceLastSync();
+                if (coordinatorRevocations is not null)
+                {
+                    unacknowledgedCoordinatorRevocations = (coordinator, coordinatorRevocations);
+                }
 
                 // Set equality alone is insufficient: the assignment can change away and back
                 // between polls. Unseen revocations require stale-fetch cleanup and position reset.
@@ -4046,6 +4051,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 }
 
                 Volatile.Write(ref _lastCoordinatorAssignmentVersion, coordinatorAssignmentVersion);
+                unacknowledgedCoordinatorRevocations = null;
             }
             else
             {
@@ -4076,6 +4082,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
         finally
         {
+            // Position initialization and assignment-version publication acknowledge the drain.
+            // Restore on failure so the next sync repeats revocation cleanup and initialization.
+            if (unacknowledgedCoordinatorRevocations is { } revocations)
+                revocations.Coordinator.RestoreRevokedPartitionsSinceLastSync(revocations.Partitions);
+
             SemaphoreHelper.ReleaseSafely(_assignmentLock);
         }
     }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -817,6 +817,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private int _assignmentEnsureVersion;
     private int _lastManualAssignmentEnsureVersion = -1;
     private int _lastCoordinatorAssignmentVersion = -1;
+    // Deterministic test seam for assignment/revocation snapshot races.
+    internal Action? BeforeCoordinatorAssignmentSnapshotForTest { get; set; }
 
     private static readonly long s_preferredReadReplicaMaxAgeTimestampDelta =
         (long)(TimeSpan.FromMinutes(5).TotalSeconds * Stopwatch.Frequency);
@@ -3965,9 +3967,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             coordinator = _coordinator;
             if ((!_subscription.IsEmpty || topicPattern is not null) && coordinator is not null)
             {
-                var coordinatorAssignmentVersion = coordinator.AssignmentVersion;
-                var coordinatorAssignment = coordinator.Assignment;
-                var coordinatorRevocations = coordinator.DrainRevokedPartitionsSinceLastSync();
+                BeforeCoordinatorAssignmentSnapshotForTest?.Invoke();
+                var (coordinatorAssignment, coordinatorAssignmentVersion, coordinatorRevocations) =
+                    coordinator.GetAssignmentSnapshotAndDrainRevocations();
                 if (coordinatorRevocations is not null)
                 {
                     unacknowledgedCoordinatorRevocations = (coordinator, coordinatorRevocations);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3753,7 +3753,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         return await RetryHelper.WithRetryAsync(async () =>
         {
-            var connection = await GetPartitionLeaderConnectionAsync(topicPartition, cancellationToken).ConfigureAwait(false);
+            var connection = await GetPartitionLeaderControlConnectionAsync(topicPartition, cancellationToken).ConfigureAwait(false);
             if (connection is null)
                 throw new KafkaException(ErrorCode.LeaderNotAvailable, $"No leader found for partition {topicPartition}");
 
@@ -4202,7 +4202,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         return RetryHelper.WithRetryAsync(async () =>
         {
-            var connection = await GetPartitionLeaderConnectionAsync(partition, cancellationToken).ConfigureAwait(false);
+            var connection = await GetPartitionLeaderControlConnectionAsync(partition, cancellationToken).ConfigureAwait(false);
             if (connection is null)
                 return 0;
 
@@ -4265,7 +4265,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }, _metadataManager, cancellationToken);
     }
 
-    private async ValueTask<IKafkaConnection?> GetPartitionLeaderConnectionAsync(TopicPartition partition, CancellationToken cancellationToken)
+    private async ValueTask<IKafkaConnection?> GetPartitionLeaderControlConnectionAsync(
+        TopicPartition partition,
+        CancellationToken cancellationToken)
     {
         var leader = await _metadataManager.GetPartitionLeaderAsync(partition.Topic, partition.Partition, cancellationToken)
             .ConfigureAwait(false);
@@ -4273,7 +4275,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (leader is null)
             return null;
 
-        return await _connectionPool.GetConnectionByIndexAsync(leader.NodeId, 0, cancellationToken).ConfigureAwait(false);
+        // Keep offset-control requests off fetch connections. A delayed fetch response must not
+        // block assignment position initialization or watermark queries during a rebalance.
+        var connectionCount = _connectionScaler?.CurrentConnectionCount ?? _options.ConnectionsPerBroker;
+        var connectionIndex = ConsumerCoordinator.GetCoordinationConnectionIndex(connectionCount);
+        return await _connectionPool.GetConnectionByIndexAsync(leader.NodeId, connectionIndex, cancellationToken).ConfigureAwait(false);
     }
 
     private async ValueTask FetchRecordsAsync(CancellationToken cancellationToken)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1028,7 +1028,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 loggerFactory?.CreateLogger<ConsumerCoordinator>(),
                 getConnectionCount: _connectionScaler is not null
                     ? () => _connectionScaler.CurrentConnectionCount
-                    : null);
+                    : null,
+                onPartitionsRevoked: QueueCoordinatorRevokedPartitionsForFetchClear);
         }
 
         _prefetchBuffer = new MpscFetchBuffer(CalculatePrefetchBufferCapacity(options));
@@ -1959,6 +1960,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 try
                 {
                     await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+                    if (HasPendingCoordinatorRevocations())
+                    {
+                        // Only the user consume loop owns _pendingFetches. Let it discard
+                        // revoked data before prefetch can advance a reassigned position.
+                        await Task.Delay(AllPartitionsPausedDelayMs, cancellationToken).ConfigureAwait(false);
+                        continue;
+                    }
+
                     var drained = await _brokerPrefetchScheduler.DrainCompletedAsync().ConfigureAwait(false);
                     if (PrefetchLoopControl.ShouldResetConsecutiveErrors(drained))
                         consecutiveErrors = 0;
@@ -3506,23 +3515,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
-    private void CancelCoordinatorRevokedPartitionsFetchClear(IReadOnlyList<TopicPartition> partitions)
-    {
-        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
-        {
-            foreach (var partition in partitions)
-            {
-                _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
-            }
-
-            if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
-                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
-        }
-    }
-
     private bool ClearFetchBufferForPendingCoordinatorRevocations()
     {
-        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) == 0)
+        if (!HasPendingCoordinatorRevocations())
             return false;
 
         HashSet<TopicPartition>? partitionsToRemove;
@@ -3550,6 +3545,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         ClearFetchBufferForPartitions(partitionsToRemove);
         return true;
     }
+
+    private bool HasPendingCoordinatorRevocations() =>
+        Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) != 0;
 
     private bool IsCurrentlyAssigned(TopicPartition partition)
     {
@@ -3968,9 +3966,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 var coordinatorAssignmentVersion = coordinator.AssignmentVersion;
                 var coordinatorAssignment = coordinator.Assignment;
+                var coordinatorRevocations = coordinator.DrainRevokedPartitionsSinceLastSync();
 
-                // Fast path: skip all work if assignment hasn't changed (common case after stable join)
-                if (_assignment.SetEquals(coordinatorAssignment))
+                // Set equality alone is insufficient: the assignment can change away and back
+                // between polls. Unseen revocations require stale-fetch cleanup and position reset.
+                if (_assignment.SetEquals(coordinatorAssignment) && coordinatorRevocations is null)
                 {
                     Volatile.Write(ref _lastCoordinatorAssignmentVersion, coordinatorAssignmentVersion);
                     return;
@@ -3995,6 +3995,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     {
                         removedPartitions ??= new List<TopicPartition>();
                         removedPartitions.Add(partition);
+                    }
+                }
+
+                if (coordinatorRevocations is not null)
+                {
+                    foreach (var partition in coordinatorRevocations)
+                    {
+                        if (removedPartitions is null || !removedPartitions.Contains(partition))
+                            (removedPartitions ??= []).Add(partition);
+
+                        if (!coordinatorAssignment.Contains(partition))
+                            continue;
+
+                        if (newPartitions is null || !newPartitions.Contains(partition))
+                            (newPartitions ??= []).Add(partition);
                     }
                 }
 
@@ -4027,7 +4042,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // Initialize positions for new partitions
                 if (newPartitions is { Count: > 0 })
                 {
-                    CancelCoordinatorRevokedPartitionsFetchClear(newPartitions);
                     await InitializePositionsAsync(newPartitions, cancellationToken).ConfigureAwait(false);
                 }
 

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
@@ -1,0 +1,653 @@
+using System.Globalization;
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+
+namespace Dekaf.Tests.Integration;
+
+/// <summary>
+/// Exercises KIP-848 group churn while a finite, sequenced backlog remains available.
+/// Consumption permits make every churn phase deterministic without timing sleeps.
+/// </summary>
+[Category("ConsumerGroup")]
+[SupportsKafka(400)]
+public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    private const int PartitionCount = 4;
+    private const int MessagesPerPartition = 32;
+    private const int CommitInterval = 4;
+    private const int ChurnCycles = 2;
+    private const int JointPhaseMessagesPerMember = 3;
+    private const int RecoveryPhaseMessages = 3;
+
+    [Test]
+    [Timeout(600_000)]
+    public async Task DynamicMembers_ChurnUnderLoad_PreservesSequencesAndCommittedProgress(
+        CancellationToken cancellationToken)
+    {
+        foreach (var assignor in new[] { "uniform", "range" })
+        {
+            await RunChurnScenarioAsync(assignor, cancellationToken);
+        }
+    }
+
+    private async Task RunChurnScenarioAsync(string assignor, CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: PartitionCount);
+        var groupId = $"rebalance-chaos-{assignor}-{Guid.NewGuid():N}";
+        var oracle = new SequenceOracle(topic, PartitionCount, MessagesPerPartition, CommitInterval);
+
+        await using var admin = KafkaContainer.CreateAdminClient();
+        await admin.IncrementalAlterConfigsAsync(
+            new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+            {
+                [ConfigResource.Topic(topic)] = [ConfigAlter.Set("retention.ms", "600000")]
+            },
+            cancellationToken: cancellationToken);
+        await ProduceSequencedBacklogAsync(topic, cancellationToken);
+
+        await using var anchor = await CreateMemberAsync(
+            topic,
+            groupId,
+            $"{assignor}-anchor",
+            assignor,
+            oracle,
+            cancellationToken);
+
+        anchor.Allow(1);
+        await anchor.WaitForAssignmentCountAsync(PartitionCount, cancellationToken);
+        await anchor.WaitForObservedCountAsync(1, cancellationToken);
+
+        for (var cycle = 0; cycle < ChurnCycles; cycle++)
+        {
+            await using var transient = await CreateMemberAsync(
+                topic,
+                groupId,
+                $"{assignor}-transient-{cycle}",
+                assignor,
+                oracle,
+                cancellationToken);
+
+            transient.Allow(1);
+            await transient.WaitForAnyAssignmentAsync(cancellationToken);
+            await transient.WaitForObservedCountAsync(1, cancellationToken);
+
+            var anchorTarget = anchor.ObservedCount + JointPhaseMessagesPerMember;
+            var transientTarget = transient.ObservedCount + JointPhaseMessagesPerMember;
+            anchor.Allow(JointPhaseMessagesPerMember);
+            transient.Allow(JointPhaseMessagesPerMember);
+
+            await Task.WhenAll(
+                anchor.WaitForObservedCountAsync(anchorTarget, cancellationToken),
+                transient.WaitForObservedCountAsync(transientTarget, cancellationToken));
+
+            await transient.StopAsync();
+
+            await AssertCommittedOffsetsAsync(admin, groupId, oracle, cancellationToken);
+            await anchor.WaitForAssignmentCountAsync(PartitionCount, cancellationToken);
+            var recoveryTarget = anchor.ObservedCount + RecoveryPhaseMessages;
+            anchor.Allow(RecoveryPhaseMessages);
+            await anchor.WaitForObservedCountAsync(recoveryTarget, cancellationToken);
+        }
+
+        anchor.Allow(PartitionCount * MessagesPerPartition * 2);
+        await oracle.WaitForAllSequencesAsync(cancellationToken);
+        await oracle.WaitForFinalCommitsAsync(cancellationToken);
+        await anchor.StopAsync();
+
+        await Assert.That(oracle.UniqueCount).IsEqualTo(PartitionCount * MessagesPerPartition);
+        var violations = oracle.Violations;
+        await Assert.That(violations).IsEmpty()
+            .Because(string.Join(Environment.NewLine, violations));
+
+        for (var partition = 0; partition < PartitionCount; partition++)
+        {
+            await Assert.That(oracle.GetSeenOffsets(partition))
+                .IsEquivalentTo(Enumerable.Range(0, MessagesPerPartition).Select(static value => (long)value));
+        }
+
+        await AssertCommittedOffsetsAsync(admin, groupId, oracle, cancellationToken);
+    }
+
+    private async Task ProduceSequencedBacklogAsync(string topic, CancellationToken cancellationToken)
+    {
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("rebalance-chaos-seeder")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+
+        for (var sequence = 0; sequence < MessagesPerPartition; sequence++)
+        {
+            for (var partition = 0; partition < PartitionCount; partition++)
+            {
+                await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Partition = partition,
+                    Key = partition.ToString(CultureInfo.InvariantCulture),
+                    Value = sequence.ToString(CultureInfo.InvariantCulture)
+                }, cancellationToken);
+            }
+        }
+    }
+
+    private async Task<ConsumerMember> CreateMemberAsync(
+        string topic,
+        string groupId,
+        string clientId,
+        string assignor,
+        SequenceOracle oracle,
+        CancellationToken cancellationToken)
+    {
+        var assignments = new AssignmentTracker();
+        var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId(clientId)
+            .WithGroupId(groupId)
+            .WithGroupRemoteAssignor(assignor)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithMaxPollRecords(1)
+            .WithQueuedMinMessages(1)
+            .WithRebalanceListener(assignments)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+
+        consumer.Subscribe(topic);
+        return new ConsumerMember(clientId, consumer, assignments, oracle, cancellationToken);
+    }
+
+    private static async Task AssertCommittedOffsetsAsync(
+        IAdminClient admin,
+        string groupId,
+        SequenceOracle oracle,
+        CancellationToken cancellationToken)
+    {
+        var committedOffsets = await admin.ListConsumerGroupOffsetsAsync(groupId, cancellationToken);
+
+        for (var partition = 0; partition < PartitionCount; partition++)
+        {
+            var expected = oracle.GetCommittedOffset(partition);
+            if (expected == 0)
+                continue;
+
+            await Assert.That(committedOffsets.TryGetValue(
+                    new TopicPartition(oracle.Topic, partition),
+                    out var committed))
+                .IsTrue();
+            await Assert.That(committed).IsEqualTo(expected);
+        }
+    }
+
+    private sealed class ConsumerMember : IAsyncDisposable
+    {
+        private readonly IKafkaConsumer<string, string> _consumer;
+        private readonly string _clientId;
+        private readonly AssignmentTracker _assignments;
+        private readonly SequenceOracle _oracle;
+        private readonly CancellationTokenSource _stopping;
+        private readonly SemaphoreSlim _permits = new(0, int.MaxValue);
+        private readonly AsyncCounter _observed = new();
+        private readonly Task _runTask;
+        private int _stopped;
+
+        public ConsumerMember(
+            string clientId,
+            IKafkaConsumer<string, string> consumer,
+            AssignmentTracker assignments,
+            SequenceOracle oracle,
+            CancellationToken cancellationToken)
+        {
+            _clientId = clientId;
+            _consumer = consumer;
+            _assignments = assignments;
+            _oracle = oracle;
+            _stopping = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _runTask = Task.Run(RunAsync, CancellationToken.None);
+        }
+
+        public int ObservedCount => _observed.Value;
+
+        public void Allow(int count) => _permits.Release(count);
+
+        public Task WaitForAnyAssignmentAsync(CancellationToken cancellationToken) =>
+            WaitForSignalOrCompletionAsync(
+                _assignments.WaitForAnyAsync(cancellationToken),
+                "Consumer completed before receiving an assignment",
+                cancellationToken);
+
+        public Task WaitForAssignmentCountAsync(int count, CancellationToken cancellationToken) =>
+            WaitForSignalOrCompletionAsync(
+                _assignments.WaitForCountAsync(count, cancellationToken),
+                $"Consumer completed before receiving {count} partitions",
+                cancellationToken);
+
+        public Task WaitForObservedCountAsync(int count, CancellationToken cancellationToken) =>
+            WaitForSignalOrCompletionAsync(
+                _observed.WaitForAsync(count, cancellationToken),
+                $"Consumer completed before observing {count} records",
+                cancellationToken);
+
+        public async Task StopAsync()
+        {
+            if (Interlocked.Exchange(ref _stopped, 1) != 0)
+                return;
+
+            try
+            {
+                await _stopping.CancelAsync();
+                await _runTask;
+            }
+            finally
+            {
+                try
+                {
+                    await _consumer.DisposeAsync();
+                }
+                finally
+                {
+                    _permits.Dispose();
+                    _stopping.Dispose();
+                }
+            }
+        }
+
+        public async ValueTask DisposeAsync() => await StopAsync();
+
+        private async Task RunAsync()
+        {
+            try
+            {
+                await using var enumerator = _consumer
+                    .ConsumeAsync(_stopping.Token)
+                    .GetAsyncEnumerator(_stopping.Token);
+
+                while (!_oracle.IsComplete)
+                {
+                    await _permits.WaitAsync(_stopping.Token);
+                    if (!await enumerator.MoveNextAsync())
+                    {
+                        _stopping.Token.ThrowIfCancellationRequested();
+                        throw new InvalidOperationException("Consumer stream completed before the sequence oracle");
+                    }
+
+                    var result = enumerator.Current;
+                    _oracle.Record(_clientId, result);
+                    _observed.Increment();
+                    await _oracle.CommitIfNeededAsync(_consumer, result, _stopping.Token);
+                }
+            }
+            catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
+            {
+            }
+        }
+
+        private async Task WaitForSignalOrCompletionAsync(
+            Task signal,
+            string completionMessage,
+            CancellationToken cancellationToken)
+        {
+            var completed = await Task.WhenAny(signal, _runTask).WaitAsync(cancellationToken);
+            if (ReferenceEquals(completed, _runTask))
+            {
+                await _runTask;
+                if (!signal.IsCompleted)
+                    throw new InvalidOperationException(completionMessage);
+            }
+
+            await signal.WaitAsync(cancellationToken);
+        }
+    }
+
+    private sealed class SequenceOracle
+    {
+        private readonly string _topic;
+        private readonly int _messagesPerPartition;
+        private readonly int _commitInterval;
+        private readonly PartitionState[] _partitions;
+        private readonly SemaphoreSlim[] _commitLocks;
+        private readonly AsyncCounter _unique = new();
+        private readonly AsyncCounter _finalCommits = new();
+        private readonly object _violationsGate = new();
+        private readonly List<string> _violations = [];
+
+        public SequenceOracle(
+            string topic,
+            int partitionCount,
+            int messagesPerPartition,
+            int commitInterval)
+        {
+            _topic = topic;
+            _messagesPerPartition = messagesPerPartition;
+            _commitInterval = commitInterval;
+            _partitions = Enumerable.Range(0, partitionCount)
+                .Select(static _ => new PartitionState())
+                .ToArray();
+            _commitLocks = Enumerable.Range(0, partitionCount)
+                .Select(static _ => new SemaphoreSlim(1, 1))
+                .ToArray();
+        }
+
+        public int UniqueCount => _unique.Value;
+
+        public string Topic => _topic;
+
+        public bool IsComplete => UniqueCount == _partitions.Length * _messagesPerPartition;
+
+        public string[] Violations
+        {
+            get
+            {
+                lock (_violationsGate)
+                    return [.. _violations];
+            }
+        }
+
+        public void Record(string clientId, ConsumeResult<string, string> result)
+        {
+            if (!string.Equals(result.Topic, _topic, StringComparison.Ordinal))
+            {
+                AddViolation($"Unexpected topic {result.Topic}; expected {_topic}");
+                return;
+            }
+
+            if (result.Partition < 0 || result.Partition >= _partitions.Length)
+            {
+                AddViolation($"Unexpected partition {result.Partition}");
+                return;
+            }
+
+            if (!long.TryParse(result.Value, NumberStyles.None, CultureInfo.InvariantCulture, out var sequence))
+            {
+                AddViolation($"Partition {result.Partition}: invalid sequence payload '{result.Value}'");
+                return;
+            }
+
+            if (sequence != result.Offset)
+                AddViolation($"Partition {result.Partition}: payload {sequence} does not match offset {result.Offset}");
+
+            if (result.Offset < 0 || result.Offset >= _messagesPerPartition)
+            {
+                AddViolation($"Partition {result.Partition}: offset {result.Offset} is outside seeded range");
+                return;
+            }
+
+            var state = _partitions[result.Partition];
+            var unique = false;
+            lock (state.Gate)
+            {
+                if (state.Seen.Add(result.Offset))
+                {
+                    unique = true;
+                    if (result.Offset != state.NextExpected)
+                    {
+                        AddViolation(
+                            $"Partition {result.Partition}: observed new offset {result.Offset} before {state.NextExpected}");
+                    }
+
+                    while (state.Seen.Contains(state.NextExpected))
+                        state.NextExpected++;
+                }
+                else if (result.Offset < state.CommittedExclusive)
+                {
+                    AddViolation(
+                        $"{clientId}, partition {result.Partition}: replayed offset {result.Offset} below committed offset {state.CommittedExclusive}");
+                }
+            }
+
+            if (unique)
+                _unique.Increment();
+        }
+
+        public async Task CommitIfNeededAsync(
+            IKafkaConsumer<string, string> consumer,
+            ConsumeResult<string, string> result,
+            CancellationToken cancellationToken)
+        {
+            var partition = result.Partition;
+            var commitLock = _commitLocks[partition];
+            await commitLock.WaitAsync(cancellationToken);
+            try
+            {
+                var state = _partitions[partition];
+                long candidate;
+                lock (state.Gate)
+                {
+                    candidate = Math.Min(state.NextExpected, result.Offset + 1);
+                    if (candidate <= state.CommittedExclusive)
+                        return;
+
+                    if (candidate < _messagesPerPartition &&
+                        candidate - state.CommittedExclusive < _commitInterval)
+                    {
+                        return;
+                    }
+                }
+
+                try
+                {
+                    await consumer.CommitAsync(
+                        [new TopicPartitionOffset(_topic, partition, candidate)],
+                        cancellationToken);
+                }
+                catch (GroupException exception) when (IsExpectedRebalanceCommitFailure(exception.ErrorCode))
+                {
+                    return;
+                }
+
+                var finalCommit = false;
+                lock (state.Gate)
+                {
+                    if (candidate < state.CommittedExclusive)
+                    {
+                        AddViolation(
+                            $"Partition {partition}: commit rewound from {state.CommittedExclusive} to {candidate}");
+                    }
+                    else if (candidate > state.NextExpected)
+                    {
+                        AddViolation(
+                            $"Partition {partition}: commit {candidate} jumped past processed offset {state.NextExpected}");
+                    }
+                    else
+                    {
+                        finalCommit = state.CommittedExclusive < _messagesPerPartition &&
+                                      candidate == _messagesPerPartition;
+                        state.CommittedExclusive = candidate;
+                    }
+                }
+
+                if (finalCommit)
+                    _finalCommits.Increment();
+            }
+            finally
+            {
+                commitLock.Release();
+            }
+        }
+
+        public Task WaitForAllSequencesAsync(CancellationToken cancellationToken) =>
+            _unique.WaitForAsync(_partitions.Length * _messagesPerPartition, cancellationToken);
+
+        public Task WaitForFinalCommitsAsync(CancellationToken cancellationToken) =>
+            _finalCommits.WaitForAsync(_partitions.Length, cancellationToken);
+
+        public long[] GetSeenOffsets(int partition)
+        {
+            var state = _partitions[partition];
+            lock (state.Gate)
+                return [.. state.Seen.Order()];
+        }
+
+        public long GetCommittedOffset(int partition)
+        {
+            var state = _partitions[partition];
+            lock (state.Gate)
+                return state.CommittedExclusive;
+        }
+
+        private static bool IsExpectedRebalanceCommitFailure(ErrorCode? errorCode) => errorCode is
+            ErrorCode.IllegalGeneration or
+            ErrorCode.UnknownMemberId or
+            ErrorCode.RebalanceInProgress or
+            ErrorCode.FencedMemberEpoch or
+            ErrorCode.StaleMemberEpoch;
+
+        private void AddViolation(string violation)
+        {
+            lock (_violationsGate)
+                _violations.Add(violation);
+        }
+
+        private sealed class PartitionState
+        {
+            public object Gate { get; } = new();
+            public HashSet<long> Seen { get; } = [];
+            public long NextExpected { get; set; }
+            public long CommittedExclusive { get; set; }
+        }
+    }
+
+    private sealed class AssignmentTracker : IRebalanceListener
+    {
+        private readonly object _gate = new();
+        private readonly HashSet<TopicPartition> _assigned = [];
+        private readonly List<AssignmentWaiter> _waiters = [];
+
+        public ValueTask OnPartitionsAssignedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            Update(partitions, assigned: true);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnPartitionsRevokedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            Update(partitions, assigned: false);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnPartitionsLostAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            Update(partitions, assigned: false);
+            return ValueTask.CompletedTask;
+        }
+
+        public Task WaitForAnyAsync(CancellationToken cancellationToken) =>
+            WaitForAsync(static count => count > 0, cancellationToken);
+
+        public Task WaitForCountAsync(int count, CancellationToken cancellationToken) =>
+            WaitForAsync(current => current == count, cancellationToken);
+
+        private Task WaitForAsync(Func<int, bool> predicate, CancellationToken cancellationToken)
+        {
+            Task signal;
+            lock (_gate)
+            {
+                if (predicate(_assigned.Count))
+                    return Task.CompletedTask;
+
+                var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _waiters.Add(new AssignmentWaiter(predicate, completion));
+                signal = completion.Task;
+            }
+
+            return signal.WaitAsync(cancellationToken);
+        }
+
+        private void Update(IEnumerable<TopicPartition> partitions, bool assigned)
+        {
+            List<TaskCompletionSource>? completed = null;
+            lock (_gate)
+            {
+                foreach (var partition in partitions)
+                {
+                    if (assigned)
+                        _assigned.Add(partition);
+                    else
+                        _assigned.Remove(partition);
+                }
+
+                for (var index = _waiters.Count - 1; index >= 0; index--)
+                {
+                    var waiter = _waiters[index];
+                    if (!waiter.Predicate(_assigned.Count))
+                        continue;
+
+                    completed ??= [];
+                    completed.Add(waiter.Completion);
+                    _waiters.RemoveAt(index);
+                }
+            }
+
+            if (completed is null)
+                return;
+
+            foreach (var completion in completed)
+                completion.TrySetResult();
+        }
+
+        private sealed record AssignmentWaiter(
+            Func<int, bool> Predicate,
+            TaskCompletionSource Completion);
+    }
+
+    private sealed class AsyncCounter
+    {
+        private readonly object _gate = new();
+        private readonly List<CounterWaiter> _waiters = [];
+        private int _value;
+
+        public int Value => Volatile.Read(ref _value);
+
+        public void Increment()
+        {
+            List<TaskCompletionSource>? completed = null;
+            lock (_gate)
+            {
+                _value++;
+                for (var index = _waiters.Count - 1; index >= 0; index--)
+                {
+                    var waiter = _waiters[index];
+                    if (_value < waiter.Target)
+                        continue;
+
+                    completed ??= [];
+                    completed.Add(waiter.Completion);
+                    _waiters.RemoveAt(index);
+                }
+            }
+
+            if (completed is null)
+                return;
+
+            foreach (var completion in completed)
+                completion.TrySetResult();
+        }
+
+        public Task WaitForAsync(int target, CancellationToken cancellationToken)
+        {
+            Task signal;
+            lock (_gate)
+            {
+                if (_value >= target)
+                    return Task.CompletedTask;
+
+                var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _waiters.Add(new CounterWaiter(target, completion));
+                signal = completion.Task;
+            }
+
+            return signal.WaitAsync(cancellationToken);
+        }
+
+        private sealed record CounterWaiter(int Target, TaskCompletionSource Completion);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -255,6 +255,39 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task EnsureAssignmentAsync_AssignmentChangesBeforeRevocationDrain_UsesMatchingSnapshot()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupConsumerGroupHeartbeat(connection, CreateAssignment(0));
+        SetupOffsetFetch(connection);
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var coordinator = GetCoordinator(consumer);
+        var revokedPartition = new TopicPartition("test-topic", 0);
+        var assignedPartition = new TopicPartition("test-topic", 1);
+        InvalidateCoordinatorAssignmentSnapshot(consumer);
+        consumer.BeforeCoordinatorAssignmentSnapshotForTest = () =>
+        {
+            consumer.BeforeCoordinatorAssignmentSnapshotForTest = null;
+            ProcessCoordinatorAssignment(coordinator, CreateAssignment(1));
+        };
+
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        await Assert.That(consumer.Assignment).DoesNotContain(revokedPartition);
+        await Assert.That(consumer.Assignment).Contains(assignedPartition);
+        await Assert.That(GetFetchPositions(consumer)[assignedPartition]).IsEqualTo(20L);
+    }
+
+    [Test]
     public async Task CoordinatorRevocationFetchClear_ConcurrentQueueAndDrain_KeepsPendingFlagConsistent()
     {
         await using var consumer = CreateConsumer();
@@ -747,6 +780,28 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("_coordinator field not found.");
 
         return (ConsumerCoordinator)field.GetValue(consumer)!;
+    }
+
+    private static void InvalidateCoordinatorAssignmentSnapshot(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_lastCoordinatorAssignmentVersion",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_lastCoordinatorAssignmentVersion field not found.");
+
+        field.SetValue(consumer, -1);
+    }
+
+    private static void ProcessCoordinatorAssignment(
+        ConsumerCoordinator coordinator,
+        ConsumerGroupHeartbeatAssignment assignment)
+    {
+        var method = typeof(ConsumerCoordinator).GetMethod(
+            "ProcessConsumerGroupAssignment",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ProcessConsumerGroupAssignment method not found.");
+
+        method.Invoke(coordinator, [assignment]);
     }
 
     private static PendingFetchData CreateFetch(int partition, long baseOffset, string value)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text;
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
@@ -216,6 +217,41 @@ public sealed class ConsumerAssignmentFastPathTests
 
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
         await Assert.That(GetPendingFetches(consumer)).IsEmpty();
+    }
+
+    [Test]
+    public async Task EnsureAssignmentAsync_AbaInitializationFailure_RetriesRevocationRecovery()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupAssignmentAbaConsumerGroupHeartbeat(connection);
+        SetupOffsetFetchFailureAfterInitialAssignment(connection);
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var reassignedPartition = new TopicPartition("test-topic", 1);
+        var coordinator = GetCoordinator(consumer);
+        coordinator.RequestRejoin();
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        coordinator.RequestRejoin();
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        var exception = await Assert.That(async () =>
+                await consumer.EnsureAssignmentAsync(CancellationToken.None))
+            .Throws<GroupException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.StaleMemberEpoch);
+        await Assert.That(GetFetchPositions(consumer).ContainsKey(reassignedPartition)).IsFalse();
+
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        await Assert.That(GetFetchPositions(consumer)[reassignedPartition]).IsEqualTo(20L);
     }
 
     [Test]
@@ -483,33 +519,58 @@ public sealed class ConsumerAssignmentFastPathTests
                 Arg.Any<OffsetFetchRequest>(),
                 Arg.Any<short>(),
                 Arg.Any<CancellationToken>())
-            .Returns(ValueTask.FromResult(new OffsetFetchResponse
+            .Returns(ValueTask.FromResult(CreateSuccessfulOffsetFetchResponse()));
+    }
+
+    private static void SetupOffsetFetchFailureAfterInitialAssignment(IKafkaConnection connection)
+    {
+        var callCount = 0;
+        connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
+                Arg.Any<OffsetFetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => Interlocked.Increment(ref callCount) == 2
+                ? ValueTask.FromResult(new OffsetFetchResponse
+                {
+                    Groups =
+                    [
+                        new OffsetFetchResponseGroup
+                        {
+                            GroupId = "group-a",
+                            Topics = [],
+                            ErrorCode = ErrorCode.StaleMemberEpoch
+                        }
+                    ]
+                })
+                : ValueTask.FromResult(CreateSuccessfulOffsetFetchResponse()));
+    }
+
+    private static OffsetFetchResponse CreateSuccessfulOffsetFetchResponse() => new()
+    {
+        ErrorCode = ErrorCode.None,
+        Topics =
+        [
+            new OffsetFetchResponseTopic
             {
-                ErrorCode = ErrorCode.None,
-                Topics =
+                Name = "test-topic",
+                Partitions =
                 [
-                    new OffsetFetchResponseTopic
+                    new OffsetFetchResponsePartition
                     {
-                        Name = "test-topic",
-                        Partitions =
-                        [
-                            new OffsetFetchResponsePartition
-                            {
-                                PartitionIndex = 0,
-                                CommittedOffset = 10,
-                                ErrorCode = ErrorCode.None
-                            },
-                            new OffsetFetchResponsePartition
-                            {
-                                PartitionIndex = 1,
-                                CommittedOffset = 20,
-                                ErrorCode = ErrorCode.None
-                            }
-                        ]
+                        PartitionIndex = 0,
+                        CommittedOffset = 10,
+                        ErrorCode = ErrorCode.None
+                    },
+                    new OffsetFetchResponsePartition
+                    {
+                        PartitionIndex = 1,
+                        CommittedOffset = 20,
+                        ErrorCode = ErrorCode.None
                     }
                 ]
-            }));
-    }
+            }
+        ]
+    };
 
     private static ConsumerGroupHeartbeatAssignment CreateAssignment(params int[] partitions)
     {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -178,6 +178,47 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task EnsureAssignmentAsync_RevokeAndReassignBetweenPolls_ReinitializesCommittedPosition()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupAssignmentAbaConsumerGroupHeartbeat(connection);
+        SetupOffsetFetch(connection);
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var reassignedPartition = new TopicPartition("test-topic", 1);
+        var staleFetch = CreateFetch(partition: 1, baseOffset: 0, value: "stale");
+        GetPendingFetches(consumer).Enqueue(staleFetch);
+        GetFetchPositions(consumer)[reassignedPartition] = 0;
+
+        var coordinator = GetCoordinator(consumer);
+        coordinator.RequestRejoin();
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer))
+            .ContainsKey(reassignedPartition);
+
+        coordinator.RequestRejoin();
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        await Assert.That(consumer.Assignment).Contains(reassignedPartition);
+        await Assert.That(GetFetchPositions(consumer)[reassignedPartition]).IsEqualTo(20L);
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer))
+            .ContainsKey(reassignedPartition);
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(GetPendingFetches(consumer)).IsEmpty();
+    }
+
+    [Test]
     public async Task CoordinatorRevocationFetchClear_ConcurrentQueueAndDrain_KeepsPendingFlagConsistent()
     {
         await using var consumer = CreateConsumer();
@@ -202,28 +243,6 @@ public sealed class ConsumerAssignmentFastPathTests
         }
 
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).IsEmpty();
-        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
-    }
-
-    [Test]
-    public async Task CancelCoordinatorRevokedPartitionsFetchClear_ReassignedPartitionRemovesPendingClear()
-    {
-        await using var consumer = CreateConsumer();
-        var reassignedPartition = new TopicPartition("test-topic", 0);
-        var stillRevokedPartition = new TopicPartition("test-topic", 1);
-
-        QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [reassignedPartition, stillRevokedPartition]);
-
-        CancelCoordinatorRevokedPartitionsFetchClear(consumer, [reassignedPartition]);
-
-        var pendingRevocations = GetCoordinatorRevokedPartitionsPendingFetchClear(consumer);
-        await Assert.That(pendingRevocations.ContainsKey(reassignedPartition)).IsFalse();
-        await Assert.That(pendingRevocations.ContainsKey(stillRevokedPartition)).IsTrue();
-        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(1);
-
-        CancelCoordinatorRevokedPartitionsFetchClear(consumer, [stillRevokedPartition]);
-
-        await Assert.That(pendingRevocations).IsEmpty();
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
     }
 
@@ -437,6 +456,27 @@ public sealed class ConsumerAssignmentFastPathTests
             });
     }
 
+    private static void SetupAssignmentAbaConsumerGroupHeartbeat(IKafkaConnection connection)
+    {
+        var callCount = 0;
+        connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = count,
+                    HeartbeatIntervalMs = 60000,
+                    Assignment = count == 2 ? CreateAssignment(0) : CreateAssignment(0, 1)
+                });
+            });
+    }
+
     private static void SetupOffsetFetch(IKafkaConnection connection)
     {
         connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
@@ -578,18 +618,6 @@ public sealed class ConsumerAssignmentFastPathTests
             "QueueCoordinatorRevokedPartitionsForFetchClear",
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("QueueCoordinatorRevokedPartitionsForFetchClear method not found.");
-
-        method.Invoke(consumer, [partitions]);
-    }
-
-    private static void CancelCoordinatorRevokedPartitionsFetchClear(
-        KafkaConsumer<string, string> consumer,
-        TopicPartition[] partitions)
-    {
-        var method = typeof(KafkaConsumer<string, string>).GetMethod(
-            "CancelCoordinatorRevokedPartitionsFetchClear",
-            BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("CancelCoordinatorRevokedPartitionsFetchClear method not found.");
 
         method.Invoke(consumer, [partitions]);
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -179,7 +179,7 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
-    public async Task EnsureAssignmentAsync_RevokeAndReassignBetweenPolls_ReinitializesCommittedPosition()
+    public async Task EnsureAssignmentAsync_RevokeAndReassignBetweenPolls_InvalidatesPrefetchAndReinitializesPosition()
     {
         var connectionPool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
@@ -195,8 +195,10 @@ public sealed class ConsumerAssignmentFastPathTests
         await consumer.EnsureAssignmentAsync(CancellationToken.None);
 
         var reassignedPartition = new TopicPartition("test-topic", 1);
-        var staleFetch = CreateFetch(partition: 1, baseOffset: 0, value: "stale");
-        GetPendingFetches(consumer).Enqueue(staleFetch);
+        var stalePendingFetch = CreateFetch(partition: 1, baseOffset: 0, value: "stale-pending");
+        var stalePrefetch = CreateFetch(partition: 1, baseOffset: 1_999_999, value: "stale-prefetch");
+        var staleFetchBufferEpoch = GetFetchBufferEpoch(consumer);
+        GetPendingFetches(consumer).Enqueue(stalePendingFetch);
         GetFetchPositions(consumer)[reassignedPartition] = 0;
 
         var coordinator = GetCoordinator(consumer);
@@ -209,9 +211,12 @@ public sealed class ConsumerAssignmentFastPathTests
         await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
 
         await consumer.EnsureAssignmentAsync(CancellationToken.None);
+        await WritePrefetchedItemsAsync(consumer, [stalePrefetch], staleFetchBufferEpoch);
 
         await Assert.That(consumer.Assignment).Contains(reassignedPartition);
         await Assert.That(GetFetchPositions(consumer)[reassignedPartition]).IsEqualTo(20L);
+        await Assert.That(GetPrefetchBuffer(consumer).TryRead(out _)).IsFalse();
+        await Assert.That(GetPrefetchedBytes(consumer)).IsEqualTo(0L);
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer))
             .ContainsKey(reassignedPartition);
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -329,6 +329,64 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_RevocationCallback_ObservesPublishedAssignment()
+    {
+        SetupFindCoordinator();
+
+        var callCount = 0;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = count,
+                    HeartbeatIntervalMs = 60000,
+                    Assignment = count == 1
+                        ? CreateAssignment(TestTopicId, 0, 1)
+                        : CreateAssignment(TestTopicId, 1)
+                });
+            });
+
+        ConsumerCoordinator? coordinator = null;
+        HashSet<TopicPartition>? assignmentObservedByCallback = null;
+        var versionObservedByCallback = -1;
+
+        void OnPartitionsRevoked(IReadOnlyList<TopicPartition> _)
+        {
+            assignmentObservedByCallback = coordinator!.Assignment.ToHashSet();
+            versionObservedByCallback = coordinator.AssignmentVersion;
+        }
+
+        var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 60000);
+        coordinator = new ConsumerCoordinator(
+            options,
+            _connectionPool,
+            _metadataManager,
+            onPartitionsRevoked: OnPartitionsRevoked);
+        await using var coordinatorLifetime = coordinator;
+        var topics = new HashSet<string> { "test-topic" };
+
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        var versionAfterInitialAssignment = coordinator.AssignmentVersion;
+
+        coordinator.RequestRejoin();
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+
+        await Assert.That(assignmentObservedByCallback).IsNotNull();
+        await Assert.That(assignmentObservedByCallback!).Contains(new TopicPartition("test-topic", 1));
+        await Assert.That(assignmentObservedByCallback).DoesNotContain(new TopicPartition("test-topic", 0));
+        await Assert.That(versionObservedByCallback).IsEqualTo(versionAfterInitialAssignment + 1);
+    }
+
+    [Test]
     public async Task ConsumerProtocol_AssignmentVersion_IncrementsWhenResetClearsAssignment()
     {
         SetupFindCoordinator();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -811,7 +811,9 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
-    public async Task FetchOffsetsAsync_GroupError_ThrowsInsteadOfResettingPosition()
+    [Arguments(ErrorCode.StaleMemberEpoch)]
+    [Arguments(ErrorCode.UnknownMemberId)]
+    public async Task FetchOffsetsAsync_MembershipGroupError_ThrowsAndRequestsRejoin(ErrorCode errorCode)
     {
         _metadataManager.SetApiVersion(ApiKey.OffsetFetch, 9, 9);
         SetupSuccessfulConsumerProtocolJoin();
@@ -828,20 +830,31 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
                     {
                         GroupId = "test-group",
                         Topics = [],
-                        ErrorCode = ErrorCode.StaleMemberEpoch
+                        ErrorCode = errorCode
                     }
                 ]
             }));
 
         var options = CreateConsumerProtocolOptions();
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
-        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        var topics = new HashSet<string> { "test-topic" };
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
 
         var exception = await Assert.That(async () =>
                 await coordinator.FetchOffsetsAsync([new TopicPartition("test-topic", 0)], CancellationToken.None))
             .Throws<GroupException>();
 
-        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.StaleMemberEpoch);
+        await Assert.That(exception!.ErrorCode).IsEqualTo(errorCode);
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+        await Assert.That(coordinator.MemberId).IsEqualTo(
+            errorCode == ErrorCode.UnknownMemberId ? null : "member-1");
+
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+
+        await _connection.Received(2).SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Any<ConsumerGroupHeartbeatRequest>(),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -711,6 +711,81 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await Assert.That(topicSnapshots[1][0].PartitionCount).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task FetchOffsetsAsync_Kip848Member_SendsMemberIdentity()
+    {
+        _metadataManager.SetApiVersion(ApiKey.OffsetFetch, 9, 9);
+        SetupSuccessfulConsumerProtocolJoin(memberId: "member-42", memberEpoch: 7);
+
+        OffsetFetchRequest? capturedRequest = null;
+        _connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
+                Arg.Any<OffsetFetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedRequest = callInfo.Arg<OffsetFetchRequest>();
+                return ValueTask.FromResult(new OffsetFetchResponse
+                {
+                    Groups =
+                    [
+                        new OffsetFetchResponseGroup
+                        {
+                            GroupId = "test-group",
+                            Topics = [],
+                            ErrorCode = ErrorCode.None
+                        }
+                    ]
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await coordinator.FetchOffsetsAsync([new TopicPartition("test-topic", 0)], CancellationToken.None);
+
+        await Assert.That(capturedRequest).IsNotNull();
+        await Assert.That(capturedRequest!.Groups).IsNotNull();
+        await Assert.That(capturedRequest.Groups!).Count().IsEqualTo(1);
+        await Assert.That(capturedRequest.Groups![0].MemberId).IsEqualTo("member-42");
+        await Assert.That(capturedRequest.Groups[0].MemberEpoch).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task FetchOffsetsAsync_GroupError_ThrowsInsteadOfResettingPosition()
+    {
+        _metadataManager.SetApiVersion(ApiKey.OffsetFetch, 9, 9);
+        SetupSuccessfulConsumerProtocolJoin();
+
+        _connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
+                Arg.Any<OffsetFetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new OffsetFetchResponse
+            {
+                Groups =
+                [
+                    new OffsetFetchResponseGroup
+                    {
+                        GroupId = "test-group",
+                        Topics = [],
+                        ErrorCode = ErrorCode.StaleMemberEpoch
+                    }
+                ]
+            }));
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        var exception = await Assert.That(async () =>
+                await coordinator.FetchOffsetsAsync([new TopicPartition("test-topic", 0)], CancellationToken.None))
+            .Throws<GroupException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.StaleMemberEpoch);
+    }
+
     #endregion
 
     #region Error Handling Tests

--- a/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsRetryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsRetryTests.cs
@@ -24,7 +24,7 @@ public sealed class QueryWatermarkOffsetsRetryTests
 
         pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IKafkaConnection>(connection));
-        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+        pool.GetConnectionByIndexAsync(1, 1, Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IKafkaConnection>(connection));
 
         connection.SendAsync<MetadataRequest, MetadataResponse>(

--- a/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsTests.cs
@@ -18,11 +18,11 @@ public sealed class QueryWatermarkOffsetsTests
     private const long LatestOffsetTimestamp = -1;
 
     [Test]
-    public async Task QueryWatermarkOffsetsAsync_StartsEarliestAndLatestRequestsBeforeAwaitingResponses()
+    public async Task QueryWatermarkOffsetsAsync_UsesCoordinationConnectionAndStartsRequestsConcurrently()
     {
         var connectionPool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
-        connectionPool.GetConnectionByIndexAsync(0, 0, Arg.Any<CancellationToken>())
+        connectionPool.GetConnectionByIndexAsync(0, 1, Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult(connection));
 
         var metadataManager = new MetadataManager(connectionPool, ["localhost:9092"]);
@@ -87,6 +87,10 @@ public sealed class QueryWatermarkOffsetsTests
 
         await Assert.That(watermarks.Low).IsEqualTo(10);
         await Assert.That(watermarks.High).IsEqualTo(42);
+        _ = connectionPool.Received(1).GetConnectionByIndexAsync(
+            0,
+            1,
+            Arg.Any<CancellationToken>());
     }
 
     private static async Task<ListOffsetsResponse> CreateListOffsetsResponseAsync(long timestamp, Task release)


### PR DESCRIPTION
## Summary
- add deterministic KIP-848 rebalance-chaos coverage for uniform/range assignors
- preserve heartbeat revocations across poll gaps so assignment ABA cannot reuse stale fetches
- send KIP-848 identity on OffsetFetch v9 and fail closed on offset-fetch errors

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- [x] net10 unit suite (4511 passed)
- [x] focused chaos integration test on Kafka 4.0, 4.1, and 4.2

Closes #1614
