### PR TITLE
Test transaction abort under coordinator fault

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -2942,10 +2942,21 @@ public sealed partial class KafkaConnection :
     [LoggerMessage(Level = LogLevel.Debug, Message = "Connected to {Host}:{Port}")]
     private partial void LogConnected(string host, int port);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Sending {ApiKey} request (correlation {CorrelationId}, version {Version}) to {Host}:{Port}")]
+    internal const int SendingRequestEventId = 1001;
+    internal const int RequestSentWaitingForResponseEventId = 1002;
+
+    [LoggerMessage(
+        EventId = SendingRequestEventId,
+        EventName = "SendingRequest",
+        Level = LogLevel.Debug,
+        Message = "Sending {ApiKey} request (correlation {CorrelationId}, version {Version}) to {Host}:{Port}")]
     private partial void LogSendingRequest(ApiKey apiKey, int correlationId, short version, string host, int port);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Request sent, waiting for response (correlation {CorrelationId})")]
+    [LoggerMessage(
+        EventId = RequestSentWaitingForResponseEventId,
+        EventName = "RequestSentWaitingForResponse",
+        Level = LogLevel.Debug,
+        Message = "Request sent, waiting for response (correlation {CorrelationId})")]
     private partial void LogRequestSentWaitingForResponse(int correlationId);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Sending fire-and-forget {ApiKey} request (correlation {CorrelationId}, version {Version}) to {Host}:{Port}")]

--- a/tests/Dekaf.Tests.Integration/CapturingLoggerProvider.cs
+++ b/tests/Dekaf.Tests.Integration/CapturingLoggerProvider.cs
@@ -1,0 +1,74 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.Tests.Integration;
+
+internal sealed class CapturingLoggerProvider(Action<CapturedLogEntry>? entryCaptured = null) : ILoggerProvider
+{
+    private readonly ConcurrentQueue<CapturedLogEntry> _entries = new();
+
+    public IReadOnlyCollection<CapturedLogEntry> Entries => _entries;
+
+    public ILogger CreateLogger(string categoryName) =>
+        new CapturingLogger(categoryName, _entries, entryCaptured);
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class CapturingLogger(
+        string categoryName,
+        ConcurrentQueue<CapturedLogEntry> entries,
+        Action<CapturedLogEntry>? onEntry) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var properties = state is IEnumerable<KeyValuePair<string, object?>> structuredState
+                ? structuredState.ToArray()
+                : [];
+            var entry = new CapturedLogEntry(
+                categoryName,
+                logLevel,
+                eventId,
+                properties,
+                formatter(state, exception));
+
+            entries.Enqueue(entry);
+            onEntry?.Invoke(entry);
+        }
+    }
+}
+
+internal sealed record CapturedLogEntry(
+    string CategoryName,
+    LogLevel LogLevel,
+    EventId EventId,
+    IReadOnlyList<KeyValuePair<string, object?>> Properties,
+    string Message)
+{
+    public bool TryGetProperty<T>(string name, out T? value)
+    {
+        foreach (var property in Properties)
+        {
+            if (property.Key == name && property.Value is T typedValue)
+            {
+                value = typedValue;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/tests/Dekaf.Tests.Integration/CleanupFailureCollector.cs
+++ b/tests/Dekaf.Tests.Integration/CleanupFailureCollector.cs
@@ -1,0 +1,61 @@
+namespace Dekaf.Tests.Integration;
+
+internal sealed class CleanupFailureCollector
+{
+    private readonly List<Exception> _failures = [];
+
+    public async Task CaptureTaskAsync(string operation, Func<Task> cleanup)
+    {
+        try
+        {
+            await cleanup().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            AddFailure(operation, ex);
+        }
+    }
+
+    public async ValueTask CaptureValueTaskAsync(string operation, Func<ValueTask> cleanup)
+    {
+        try
+        {
+            await cleanup().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            AddFailure(operation, ex);
+        }
+    }
+
+    public void Capture(string operation, Action cleanup)
+    {
+        try
+        {
+            cleanup();
+        }
+        catch (Exception ex)
+        {
+            AddFailure(operation, ex);
+        }
+    }
+
+    public void WriteFailuresToConsole()
+    {
+        foreach (var failure in _failures)
+        {
+            Console.WriteLine($"[Cleanup] {failure}");
+        }
+    }
+
+    public void ThrowIfAny()
+    {
+        if (_failures.Count > 0)
+        {
+            throw new AggregateException("One or more cleanup operations failed.", _failures);
+        }
+    }
+
+    private void AddFailure(string operation, Exception exception) =>
+        _failures.Add(new InvalidOperationException($"{operation} failed.", exception));
+}

--- a/tests/Dekaf.Tests.Integration/ConsumerRackAwarenessIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerRackAwarenessIntegrationTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Microsoft.Extensions.Logging;
@@ -75,8 +74,8 @@ public sealed class ConsumerRackAwarenessIntegrationTests(RackAwareKafkaContaine
     {
         for (var attempt = 0; attempt < 50; attempt++)
         {
-            if (logs.Messages.Any(message =>
-                message.Contains($"Fetching {topic}-0 from preferred read replica 2 instead of leader 1",
+            if (logs.Entries.Any(entry =>
+                entry.Message.Contains($"Fetching {topic}-0 from preferred read replica 2 instead of leader 1",
                     StringComparison.Ordinal)))
             {
                 return;
@@ -86,40 +85,5 @@ public sealed class ConsumerRackAwarenessIntegrationTests(RackAwareKafkaContaine
         }
 
         throw new InvalidOperationException("Consumer did not fetch from preferred read replica 2.");
-    }
-
-    private sealed class CapturingLoggerProvider : ILoggerProvider
-    {
-        private readonly ConcurrentQueue<string> _messages = new();
-
-        public IReadOnlyCollection<string> Messages => _messages;
-
-        public ILogger CreateLogger(string categoryName) => new CapturingLogger(_messages);
-
-        public void Dispose()
-        {
-        }
-    }
-
-    private sealed class CapturingLogger(ConcurrentQueue<string> messages) : ILogger
-    {
-        public IDisposable? BeginScope<TState>(TState state)
-            where TState : notnull
-            => null;
-
-        public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
-
-        public void Log<TState>(
-            LogLevel logLevel,
-            EventId eventId,
-            TState state,
-            Exception? exception,
-            Func<TState, Exception?, string> formatter)
-        {
-            if (!IsEnabled(logLevel))
-                return;
-
-            messages.Enqueue(formatter(state, exception));
-        }
     }
 }

--- a/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
+++ b/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="TUnit" Version="1.58.0" />
     <PackageReference Include="TUnit.Logging.Microsoft" Version="1.58.0" />
     <PackageReference Include="Testcontainers.Kafka" Version="4.13.0" />
+    <PackageReference Include="Testcontainers.Toxiproxy" Version="4.13.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.1" />
   </ItemGroup>
 

--- a/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Net.Sockets;
 using Dekaf.Admin;
 using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
 using Testcontainers.Kafka;
 using TUnit.Core.Interfaces;
 
@@ -46,7 +47,6 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
             .Build();
     }
 
-    private string _bootstrapServers = string.Empty;
     private readonly ConcurrentDictionary<string, byte> _createdTopics = new();
 
     public abstract string ContainerName { get; }
@@ -55,7 +55,7 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
     /// <summary>
     /// The Kafka bootstrap servers connection string.
     /// </summary>
-    public string BootstrapServers => _bootstrapServers;
+    public string BootstrapServers { get; protected set; } = string.Empty;
 
     /// <summary>
     /// Hook to customize the <see cref="KafkaBuilder"/> before the container is built.
@@ -82,7 +82,7 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
             .Build();
     }
 
-    public async Task InitializeAsync()
+    public virtual async Task InitializeAsync()
     {
         Console.WriteLine("[KafkaTestContainer] Starting Kafka container via Testcontainers...");
 
@@ -97,9 +97,9 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
 
         var rawAddress = _container!.GetBootstrapAddress();
         // GetBootstrapAddress() may return "plaintext://host:port/" - extract just host:port
-        _bootstrapServers = ExtractHostPort(rawAddress);
+        BootstrapServers = ExtractHostPort(rawAddress);
 
-        Console.WriteLine($"[KafkaTestContainer] Kafka started at {_bootstrapServers}");
+        Console.WriteLine($"[KafkaTestContainer] Kafka started at {BootstrapServers}");
 
         await WaitForKafkaAsync().ConfigureAwait(false);
         await OnAfterInitializeAsync().ConfigureAwait(false);
@@ -122,9 +122,9 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
         const int maxAttempts = 30;
 
         // Parse host and port from host:port format
-        var colonIndex = _bootstrapServers.LastIndexOf(':');
-        var host = _bootstrapServers[..colonIndex];
-        var port = int.Parse(_bootstrapServers[(colonIndex + 1)..]);
+        var colonIndex = BootstrapServers.LastIndexOf(':');
+        var host = BootstrapServers[..colonIndex];
+        var port = int.Parse(BootstrapServers[(colonIndex + 1)..]);
 
         for (var attempt = 0; attempt < maxAttempts; attempt++)
         {
@@ -304,16 +304,18 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
         return builder.Build();
     }
 
-    private async Task<string> TryGetBrokerLogTailAsync()
+    protected virtual async Task<string> TryGetBrokerLogTailAsync()
     {
-        if (_container is null)
-        {
-            return string.Empty;
-        }
+        return _container is null
+            ? string.Empty
+            : await TryGetContainerLogTailAsync(_container).ConfigureAwait(false);
+    }
 
+    protected static async Task<string> TryGetContainerLogTailAsync(IContainer container)
+    {
         try
         {
-            var (stdout, stderr) = await _container.GetLogsAsync().ConfigureAwait(false);
+            var (stdout, stderr) = await container.GetLogsAsync().ConfigureAwait(false);
             return $"\nBroker stdout tail:\n{Tail(stdout, 4000)}\nBroker stderr tail:\n{Tail(stderr, 2000)}";
         }
         catch

--- a/tests/Dekaf.Tests.Integration/TestInfrastructureTests.cs
+++ b/tests/Dekaf.Tests.Integration/TestInfrastructureTests.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.Tests.Integration;
+
+public sealed partial class TestInfrastructureTests
+{
+    [Test]
+    public async Task CapturingLoggerProvider_CapturesStructuredEntryAndNotifiesObserver()
+    {
+        CapturedLogEntry? observed = null;
+        using var provider = new CapturingLoggerProvider(entry => observed = entry);
+        using var factory = LoggerFactory.Create(builder => builder.AddProvider(provider));
+        var logger = factory.CreateLogger<TestInfrastructureTests>();
+
+        LogCapturedValue(logger, 17);
+
+        var entry = provider.Entries.Single();
+        await Assert.That(entry.EventId.Id).IsEqualTo(42);
+        await Assert.That(entry.EventId.Name).IsEqualTo("StructuredEvent");
+        await Assert.That(entry.Message).IsEqualTo("Captured value 17");
+        await Assert.That(entry.TryGetProperty<int>("Value", out var value)).IsTrue();
+        await Assert.That(value).IsEqualTo(17);
+        await Assert.That(observed).IsEqualTo(entry);
+    }
+
+    [Test]
+    public async Task CleanupFailureCollector_ContinuesAndReportsLabeledFailures()
+    {
+        var collector = new CleanupFailureCollector();
+        var secondCleanupRan = false;
+
+        await collector.CaptureTaskAsync(
+            "first cleanup",
+            () => Task.FromException(new InvalidOperationException("failure")));
+        await collector.CaptureTaskAsync(
+            "second cleanup",
+            () =>
+            {
+                secondCleanupRan = true;
+                return Task.CompletedTask;
+            });
+
+        await Assert.That(secondCleanupRan).IsTrue();
+        var exception = await Assert.That(collector.ThrowIfAny).Throws<AggregateException>();
+        await Assert.That(exception!.InnerExceptions).Count().IsEqualTo(1);
+        await Assert.That(exception.InnerExceptions[0].Message).IsEqualTo("first cleanup failed.");
+        await Assert.That(exception.InnerExceptions[0].InnerException!.Message).IsEqualTo("failure");
+    }
+
+    [LoggerMessage(
+        EventId = 42,
+        EventName = "StructuredEvent",
+        Level = LogLevel.Information,
+        Message = "Captured value {Value}")]
+    private static partial void LogCapturedValue(ILogger logger, int value);
+}

--- a/tests/Dekaf.Tests.Integration/TransactionCoordinatorFaultTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionCoordinatorFaultTests.cs
@@ -1,0 +1,193 @@
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
+using Microsoft.Extensions.Logging;
+using TUnit.Logging.Microsoft;
+
+namespace Dekaf.Tests.Integration;
+
+[ClassDataSource<TransactionFaultKafkaContainer>(Shared = SharedType.PerTestSession)]
+[Category("Transaction")]
+public sealed class TransactionCoordinatorFaultTests(TransactionFaultKafkaContainer kafka)
+{
+    [Test]
+    public async Task Abort_CoordinatorResponseDelayed_RecoversWithoutVisibility()
+    {
+        using var testTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = testTimeout.Token;
+        var topic = await kafka.CreateTestTopicAsync();
+
+        await using (var seedProducer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.ProducerBootstrapServers)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken))
+        {
+            _ = await seedProducer.ProduceAsync(topic, "seed-key", "seed-value", cancellationToken);
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.ConsumerBootstrapServers)
+            .WithGroupId($"transaction-fault-consumer-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithIsolationLevel(IsolationLevel.ReadCommitted)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+        consumer.Subscribe(topic);
+
+        var seed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cancellationToken);
+        await Assert.That(seed).IsNotNull();
+        await Assert.That(seed!.Value.Value).IsEqualTo("seed-value");
+
+        using var endTxnObserver = new EndTxnRequestObserver();
+        using var producerLoggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Debug);
+            builder.AddTUnit(TestContext.Current!);
+            builder.AddProvider(endTxnObserver);
+        });
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.ProducerBootstrapServers)
+            .WithTransactionalId($"transaction-fault-{Guid.NewGuid():N}")
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(producerLoggerFactory)
+            .BuildAsync(cancellationToken);
+        await producer.InitTransactionsAsync(cancellationToken);
+
+        var transaction = producer.BeginTransaction();
+        try
+        {
+            _ = await transaction.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = "aborted-key",
+                Value = "aborted-value",
+            }, cancellationToken);
+
+            var visibilityTask = consumer
+                .ConsumeOneAsync(TimeSpan.FromSeconds(30), cancellationToken)
+                .AsTask();
+
+            await kafka.AddCoordinatorLatencyAsync(cancellationToken);
+            var abortTask = transaction.AbortAsync(cancellationToken).AsTask();
+
+            var endTxnEndpoint = await endTxnObserver.WaitForEndTxnAsync(cancellationToken);
+            await Assert.That(endTxnEndpoint).IsEqualTo(kafka.ProducerBootstrapServers);
+
+            await Assert.That(abortTask.IsCompleted).IsFalse();
+            await Assert.That(visibilityTask.IsCompleted).IsFalse();
+
+            await kafka.HealCoordinatorAsync(cancellationToken);
+            await abortTask.WaitAsync(cancellationToken);
+
+            await using (var recoveryTransaction = producer.BeginTransaction())
+            {
+                _ = await recoveryTransaction.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Key = "recovery-key",
+                    Value = "recovery-value",
+                }, cancellationToken);
+                await recoveryTransaction.CommitAsync(cancellationToken);
+            }
+
+            var visible = await visibilityTask.WaitAsync(cancellationToken);
+            await Assert.That(visible).IsNotNull();
+            await Assert.That(visible!.Value.Key).IsEqualTo("recovery-key");
+            await Assert.That(visible.Value.Value).IsEqualTo("recovery-value");
+        }
+        finally
+        {
+            await kafka.HealCoordinatorAsync();
+            await transaction.DisposeAsync();
+        }
+    }
+
+    private sealed class EndTxnRequestObserver : ILoggerProvider
+    {
+        private readonly TaskCompletionSource<string> _endTxnSeen =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly object _sync = new();
+        private int? _endTxnCorrelationId;
+        private string? _endTxnEndpoint;
+
+        public ILogger CreateLogger(string categoryName) => new ObserverLogger(this);
+
+        public Task<string> WaitForEndTxnAsync(CancellationToken cancellationToken) =>
+            _endTxnSeen.Task.WaitAsync(cancellationToken);
+
+        public void Dispose()
+        {
+        }
+
+        private void Observe<TState>(
+            LogLevel logLevel,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel != LogLevel.Debug
+                || state is not IEnumerable<KeyValuePair<string, object?>> properties)
+            {
+                return;
+            }
+
+            int? correlationId = null;
+            string? apiKey = null;
+            string? host = null;
+            int? port = null;
+            foreach (var property in properties)
+            {
+                switch (property.Key)
+                {
+                    case "ApiKey":
+                        apiKey = property.Value?.ToString();
+                        break;
+                    case "CorrelationId" when property.Value is int correlationValue:
+                        correlationId = correlationValue;
+                        break;
+                    case "Host":
+                        host = property.Value as string;
+                        break;
+                    case "Port" when property.Value is int portValue:
+                        port = portValue;
+                        break;
+                }
+            }
+
+            lock (_sync)
+            {
+                if (apiKey == "EndTxn" && correlationId.HasValue && host is not null && port.HasValue)
+                {
+                    _endTxnCorrelationId = correlationId;
+                    _endTxnEndpoint = $"{host}:{port}";
+                    return;
+                }
+
+                if (_endTxnCorrelationId == correlationId && _endTxnEndpoint is not null
+                    && formatter(state, exception).StartsWith("Request sent, waiting for response", StringComparison.Ordinal))
+                {
+                    _endTxnSeen.TrySetResult(_endTxnEndpoint);
+                }
+            }
+        }
+
+        private sealed class ObserverLogger(EndTxnRequestObserver observer) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                observer.Observe(logLevel, state, exception, formatter);
+            }
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/TransactionCoordinatorFaultTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionCoordinatorFaultTests.cs
@@ -1,5 +1,8 @@
+using System.Runtime.ExceptionServices;
 using Dekaf.Consumer;
+using Dekaf.Networking;
 using Dekaf.Producer;
+using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Microsoft.Extensions.Logging;
 using TUnit.Logging.Microsoft;
@@ -8,12 +11,15 @@ namespace Dekaf.Tests.Integration;
 
 [ClassDataSource<TransactionFaultKafkaContainer>(Shared = SharedType.PerTestSession)]
 [Category("Transaction")]
+[NotInParallel("TransactionFaultKafkaContainer")]
 public sealed class TransactionCoordinatorFaultTests(TransactionFaultKafkaContainer kafka)
 {
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(2);
+
     [Test]
     public async Task Abort_CoordinatorResponseDelayed_RecoversWithoutVisibility()
     {
-        using var testTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var testTimeout = new CancellationTokenSource(TestTimeout);
         var cancellationToken = testTimeout.Token;
         var topic = await kafka.CreateTestTopicAsync();
 
@@ -39,12 +45,13 @@ public sealed class TransactionCoordinatorFaultTests(TransactionFaultKafkaContai
         await Assert.That(seed).IsNotNull();
         await Assert.That(seed!.Value.Value).IsEqualTo("seed-value");
 
-        using var endTxnObserver = new EndTxnRequestObserver();
+        var endTxnObserver = new EndTxnRequestObserver();
+        using var capturedLogs = new CapturingLoggerProvider(endTxnObserver.Observe);
         using var producerLoggerFactory = LoggerFactory.Create(builder =>
         {
             builder.SetMinimumLevel(LogLevel.Debug);
             builder.AddTUnit(TestContext.Current!);
-            builder.AddProvider(endTxnObserver);
+            builder.AddProvider(capturedLogs);
         });
 
         await using var producer = await Kafka.CreateProducer<string, string>()
@@ -56,6 +63,10 @@ public sealed class TransactionCoordinatorFaultTests(TransactionFaultKafkaContai
         await producer.InitTransactionsAsync(cancellationToken);
 
         var transaction = producer.BeginTransaction();
+        using var backgroundCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        Task<ConsumeResult<string, string>?>? visibilityTask = null;
+        Task? abortTask = null;
+        Exception? testFailure = null;
         try
         {
             _ = await transaction.ProduceAsync(new ProducerMessage<string, string>
@@ -65,12 +76,12 @@ public sealed class TransactionCoordinatorFaultTests(TransactionFaultKafkaContai
                 Value = "aborted-value",
             }, cancellationToken);
 
-            var visibilityTask = consumer
-                .ConsumeOneAsync(TimeSpan.FromSeconds(30), cancellationToken)
+            visibilityTask = consumer
+                .ConsumeOneAsync(TimeSpan.FromSeconds(30), backgroundCancellation.Token)
                 .AsTask();
 
             await kafka.AddCoordinatorLatencyAsync(cancellationToken);
-            var abortTask = transaction.AbortAsync(cancellationToken).AsTask();
+            abortTask = transaction.AbortAsync(backgroundCancellation.Token).AsTask();
 
             var endTxnEndpoint = await endTxnObserver.WaitForEndTxnAsync(cancellationToken);
             await Assert.That(endTxnEndpoint).IsEqualTo(kafka.ProducerBootstrapServers);
@@ -97,14 +108,53 @@ public sealed class TransactionCoordinatorFaultTests(TransactionFaultKafkaContai
             await Assert.That(visible!.Value.Key).IsEqualTo("recovery-key");
             await Assert.That(visible.Value.Value).IsEqualTo("recovery-value");
         }
-        finally
+        catch (Exception ex)
         {
-            await kafka.HealCoordinatorAsync();
-            await transaction.DisposeAsync();
+            testFailure = ex;
+        }
+
+        var cleanup = new CleanupFailureCollector();
+        await cleanup.CaptureTaskAsync("coordinator healing", () => kafka.HealCoordinatorAsync());
+        cleanup.Capture("background task cancellation", backgroundCancellation.Cancel);
+
+        if (abortTask is not null)
+        {
+            await cleanup.CaptureTaskAsync(
+                "abort task observation",
+                () => ObserveBackgroundTaskAsync(abortTask, backgroundCancellation.Token));
+        }
+
+        if (visibilityTask is not null)
+        {
+            await cleanup.CaptureTaskAsync(
+                "visibility task observation",
+                () => ObserveBackgroundTaskAsync(visibilityTask, backgroundCancellation.Token));
+        }
+
+        await cleanup.CaptureValueTaskAsync("transaction disposal", transaction.DisposeAsync);
+
+        if (testFailure is not null)
+        {
+            cleanup.WriteFailuresToConsole();
+            ExceptionDispatchInfo.Capture(testFailure).Throw();
+        }
+
+        cleanup.ThrowIfAny();
+    }
+
+    private static async Task ObserveBackgroundTaskAsync(Task task, CancellationToken cleanupCancellation)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cleanupCancellation.IsCancellationRequested)
+        {
+            // Expected when cleanup cancels an incomplete background operation.
         }
     }
 
-    private sealed class EndTxnRequestObserver : ILoggerProvider
+    private sealed class EndTxnRequestObserver
     {
         private readonly TaskCompletionSource<string> _endTxnSeen =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -112,53 +162,26 @@ public sealed class TransactionCoordinatorFaultTests(TransactionFaultKafkaContai
         private int? _endTxnCorrelationId;
         private string? _endTxnEndpoint;
 
-        public ILogger CreateLogger(string categoryName) => new ObserverLogger(this);
-
         public Task<string> WaitForEndTxnAsync(CancellationToken cancellationToken) =>
             _endTxnSeen.Task.WaitAsync(cancellationToken);
 
-        public void Dispose()
+        public void Observe(CapturedLogEntry entry)
         {
-        }
-
-        private void Observe<TState>(
-            LogLevel logLevel,
-            TState state,
-            Exception? exception,
-            Func<TState, Exception?, string> formatter)
-        {
-            if (logLevel != LogLevel.Debug
-                || state is not IEnumerable<KeyValuePair<string, object?>> properties)
+            if (entry.CategoryName != typeof(KafkaConnection).FullName
+                || entry.LogLevel != LogLevel.Debug
+                || !entry.TryGetProperty<int>("CorrelationId", out var correlationId))
             {
                 return;
             }
 
-            int? correlationId = null;
-            string? apiKey = null;
-            string? host = null;
-            int? port = null;
-            foreach (var property in properties)
-            {
-                switch (property.Key)
-                {
-                    case "ApiKey":
-                        apiKey = property.Value?.ToString();
-                        break;
-                    case "CorrelationId" when property.Value is int correlationValue:
-                        correlationId = correlationValue;
-                        break;
-                    case "Host":
-                        host = property.Value as string;
-                        break;
-                    case "Port" when property.Value is int portValue:
-                        port = portValue;
-                        break;
-                }
-            }
-
             lock (_sync)
             {
-                if (apiKey == "EndTxn" && correlationId.HasValue && host is not null && port.HasValue)
+                if (entry.EventId.Id == KafkaConnection.SendingRequestEventId
+                    && entry.TryGetProperty<ApiKey>("ApiKey", out var apiKey)
+                    && apiKey == ApiKey.EndTxn
+                    && entry.TryGetProperty<string>("Host", out var host)
+                    && host is not null
+                    && entry.TryGetProperty<int>("Port", out var port))
                 {
                     _endTxnCorrelationId = correlationId;
                     _endTxnEndpoint = $"{host}:{port}";
@@ -166,27 +189,10 @@ public sealed class TransactionCoordinatorFaultTests(TransactionFaultKafkaContai
                 }
 
                 if (_endTxnCorrelationId == correlationId && _endTxnEndpoint is not null
-                    && formatter(state, exception).StartsWith("Request sent, waiting for response", StringComparison.Ordinal))
+                    && entry.EventId.Id == KafkaConnection.RequestSentWaitingForResponseEventId)
                 {
                     _endTxnSeen.TrySetResult(_endTxnEndpoint);
                 }
-            }
-        }
-
-        private sealed class ObserverLogger(EndTxnRequestObserver observer) : ILogger
-        {
-            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-
-            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
-
-            public void Log<TState>(
-                LogLevel logLevel,
-                EventId eventId,
-                TState state,
-                Exception? exception,
-                Func<TState, Exception?, string> formatter)
-            {
-                observer.Observe(logLevel, state, exception, formatter);
             }
         }
     }

--- a/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
@@ -208,11 +208,11 @@ public sealed class TransactionFaultKafkaContainer : IAsyncInitializer, IAsyncDi
     private async Task WaitForKafkaAsync()
     {
         Exception? lastError = null;
+        await using var admin = CreateAdminClient();
         for (var attempt = 0; attempt < 30; attempt++)
         {
             try
             {
-                await using var admin = CreateAdminClient();
                 _ = await admin.ListTopicsAsync().ConfigureAwait(false);
                 return;
             }

--- a/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
@@ -6,7 +6,6 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Testcontainers.Toxiproxy;
-using TUnit.Core.Interfaces;
 
 namespace Dekaf.Tests.Integration;
 
@@ -15,7 +14,7 @@ namespace Dekaf.Tests.Integration;
 /// Producer and consumer traffic use separate proxy listeners so coordinator faults do not
 /// disrupt the read-committed verification lane or any shared integration-test container.
 /// </summary>
-public sealed class TransactionFaultKafkaContainer : IAsyncInitializer, IAsyncDisposable
+public sealed class TransactionFaultKafkaContainer : KafkaTestContainer
 {
     private const string KafkaNetworkAlias = "transaction-fault-kafka";
     private const string ProducerProxyName = "transaction-producer";
@@ -28,6 +27,10 @@ public sealed class TransactionFaultKafkaContainer : IAsyncInitializer, IAsyncDi
     private const ushort KafkaConsumerPort = 19_093;
     private const ushort KafkaBrokerPort = 19_094;
     private const ushort KafkaControllerPort = 19_095;
+
+    public override string ContainerName => "apache/kafka:4.0.1";
+
+    public override int Version => 401;
 
     private readonly INetwork _network = new NetworkBuilder().Build();
     private readonly ToxiproxyContainer _toxiproxy;
@@ -49,7 +52,7 @@ public sealed class TransactionFaultKafkaContainer : IAsyncInitializer, IAsyncDi
 
     public string ConsumerBootstrapServers { get; private set; } = string.Empty;
 
-    public async Task InitializeAsync()
+    public override async Task InitializeAsync()
     {
         await _network.CreateAsync().ConfigureAwait(false);
         await _toxiproxy.StartAsync().ConfigureAwait(false);
@@ -59,6 +62,7 @@ public sealed class TransactionFaultKafkaContainer : IAsyncInitializer, IAsyncDi
         var consumerPublicPort = _toxiproxy.GetMappedPublicPort(ConsumerProxyPort);
         ProducerBootstrapServers = $"{toxiproxyHost}:{producerPublicPort}";
         ConsumerBootstrapServers = $"{toxiproxyHost}:{consumerPublicPort}";
+        BootstrapServers = ProducerBootstrapServers;
 
         _toxiproxyClient.BaseAddress = new Uri(
             $"http://{toxiproxyHost}:{_toxiproxy.GetMappedPublicPort(ToxiproxyBuilder.ToxiproxyControlPort)}/");
@@ -74,23 +78,7 @@ public sealed class TransactionFaultKafkaContainer : IAsyncInitializer, IAsyncDi
 
         _kafka = CreateKafkaContainer(toxiproxyHost, producerPublicPort, consumerPublicPort);
         await _kafka.StartAsync().ConfigureAwait(false);
-        await WaitForKafkaAsync().ConfigureAwait(false);
-    }
-
-    public async Task<string> CreateTestTopicAsync()
-    {
-        var topic = $"transaction-fault-{Guid.NewGuid():N}";
-        await using var admin = CreateAdminClient();
-        await admin.CreateTopicsAsync(
-        [
-            new NewTopic
-            {
-                Name = topic,
-                NumPartitions = 1,
-                ReplicationFactor = 1,
-            },
-        ]).ConfigureAwait(false);
-        return topic;
+        await WaitForAdminReadyAsync("transaction fault proxy").ConfigureAwait(false);
     }
 
     public async Task AddCoordinatorLatencyAsync(CancellationToken cancellationToken)
@@ -124,27 +112,25 @@ public sealed class TransactionFaultKafkaContainer : IAsyncInitializer, IAsyncDi
         _faultActive = false;
     }
 
-    public async ValueTask DisposeAsync()
+    public override async ValueTask DisposeAsync()
     {
-        try
-        {
-            await HealCoordinatorAsync().ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"[TransactionFaultKafkaContainer] Fault cleanup failed: {ex.Message}");
-        }
-
-        _toxiproxyClient.Dispose();
+        var cleanup = new CleanupFailureCollector();
+        await cleanup.CaptureTaskAsync("coordinator fault cleanup", () => HealCoordinatorAsync())
+            .ConfigureAwait(false);
+        cleanup.Capture("Toxiproxy HTTP client disposal", _toxiproxyClient.Dispose);
 
         if (_kafka is not null)
         {
-            await _kafka.DisposeAsync().ConfigureAwait(false);
+            await cleanup.CaptureValueTaskAsync("Kafka container disposal", _kafka.DisposeAsync)
+                .ConfigureAwait(false);
         }
 
-        await _toxiproxy.DisposeAsync().ConfigureAwait(false);
-        await _network.DisposeAsync().ConfigureAwait(false);
-        GC.SuppressFinalize(this);
+        await cleanup.CaptureValueTaskAsync("Toxiproxy container disposal", _toxiproxy.DisposeAsync)
+            .ConfigureAwait(false);
+        await cleanup.CaptureValueTaskAsync("transaction network disposal", _network.DisposeAsync)
+            .ConfigureAwait(false);
+        await base.DisposeAsync().ConfigureAwait(false);
+        cleanup.ThrowIfAny();
     }
 
     private IContainer CreateKafkaContainer(
@@ -186,10 +172,17 @@ public sealed class TransactionFaultKafkaContainer : IAsyncInitializer, IAsyncDi
             .Build();
     }
 
-    private IAdminClient CreateAdminClient() => Kafka.CreateAdminClient()
+    public override IAdminClient CreateAdminClient() => Kafka.CreateAdminClient()
         .WithBootstrapServers(ProducerBootstrapServers)
         .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
         .Build();
+
+    protected override async Task<string> TryGetBrokerLogTailAsync()
+    {
+        return _kafka is null
+            ? string.Empty
+            : await TryGetContainerLogTailAsync(_kafka).ConfigureAwait(false);
+    }
 
     private async Task AddProxyAsync(string name, ushort listenPort, ushort upstreamPort)
     {
@@ -205,27 +198,6 @@ public sealed class TransactionFaultKafkaContainer : IAsyncInitializer, IAsyncDi
         response.EnsureSuccessStatusCode();
     }
 
-    private async Task WaitForKafkaAsync()
-    {
-        Exception? lastError = null;
-        await using var admin = CreateAdminClient();
-        for (var attempt = 0; attempt < 30; attempt++)
-        {
-            try
-            {
-                _ = await admin.ListTopicsAsync().ConfigureAwait(false);
-                return;
-            }
-            catch (Exception ex)
-            {
-                lastError = ex;
-            }
-
-            await Task.Delay(250).ConfigureAwait(false);
-        }
-
-        throw new InvalidOperationException("Kafka did not become ready through Toxiproxy.", lastError);
-    }
 }
 
 internal sealed record ToxiproxyProxyConfiguration(

--- a/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
@@ -1,0 +1,248 @@
+using Dekaf.Admin;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Testcontainers.Toxiproxy;
+using TUnit.Core.Interfaces;
+
+namespace Dekaf.Tests.Integration;
+
+/// <summary>
+/// Owns an isolated Kafka/Toxiproxy topology for transaction coordinator fault tests.
+/// Producer and consumer traffic use separate proxy listeners so coordinator faults do not
+/// disrupt the read-committed verification lane or any shared integration-test container.
+/// </summary>
+public sealed class TransactionFaultKafkaContainer : IAsyncInitializer, IAsyncDisposable
+{
+    private const string KafkaNetworkAlias = "transaction-fault-kafka";
+    private const string ProducerProxyName = "transaction-producer";
+    private const string ConsumerProxyName = "transaction-consumer";
+    private const string CoordinatorFaultName = "coordinator-latency";
+
+    private const ushort ProducerProxyPort = ToxiproxyBuilder.FirstProxiedPort;
+    private const ushort ConsumerProxyPort = ToxiproxyBuilder.FirstProxiedPort + 1;
+    private const ushort KafkaProducerPort = 19_092;
+    private const ushort KafkaConsumerPort = 19_093;
+    private const ushort KafkaBrokerPort = 19_094;
+    private const ushort KafkaControllerPort = 19_095;
+
+    private readonly INetwork _network = new NetworkBuilder().Build();
+    private readonly ToxiproxyContainer _toxiproxy;
+    private readonly HttpClient _toxiproxyClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(10),
+    };
+    private IContainer? _kafka;
+    private bool _faultActive;
+
+    public TransactionFaultKafkaContainer()
+    {
+        _toxiproxy = new ToxiproxyBuilder("ghcr.io/shopify/toxiproxy:2.12.0")
+            .WithNetwork(_network)
+            .Build();
+    }
+
+    public string ProducerBootstrapServers { get; private set; } = string.Empty;
+
+    public string ConsumerBootstrapServers { get; private set; } = string.Empty;
+
+    public async Task InitializeAsync()
+    {
+        await _toxiproxy.StartAsync().ConfigureAwait(false);
+
+        var toxiproxyHost = _toxiproxy.Hostname;
+        var producerPublicPort = _toxiproxy.GetMappedPublicPort(ProducerProxyPort);
+        var consumerPublicPort = _toxiproxy.GetMappedPublicPort(ConsumerProxyPort);
+        ProducerBootstrapServers = $"{toxiproxyHost}:{producerPublicPort}";
+        ConsumerBootstrapServers = $"{toxiproxyHost}:{consumerPublicPort}";
+
+        _toxiproxyClient.BaseAddress = new Uri(
+            $"http://{toxiproxyHost}:{_toxiproxy.GetMappedPublicPort(ToxiproxyBuilder.ToxiproxyControlPort)}/");
+
+        await AddProxyAsync(
+            ProducerProxyName,
+            ProducerProxyPort,
+            KafkaProducerPort).ConfigureAwait(false);
+        await AddProxyAsync(
+            ConsumerProxyName,
+            ConsumerProxyPort,
+            KafkaConsumerPort).ConfigureAwait(false);
+
+        _kafka = CreateKafkaContainer(toxiproxyHost, producerPublicPort, consumerPublicPort);
+        await _kafka.StartAsync().ConfigureAwait(false);
+        await WaitForKafkaAsync().ConfigureAwait(false);
+    }
+
+    public async Task<string> CreateTestTopicAsync()
+    {
+        var topic = $"transaction-fault-{Guid.NewGuid():N}";
+        await using var admin = CreateAdminClient();
+        await admin.CreateTopicsAsync(
+        [
+            new NewTopic
+            {
+                Name = topic,
+                NumPartitions = 1,
+                ReplicationFactor = 1,
+            },
+        ]).ConfigureAwait(false);
+        return topic;
+    }
+
+    public async Task AddCoordinatorLatencyAsync(CancellationToken cancellationToken)
+    {
+        var toxic = new ToxiproxyLatencyConfiguration(
+            CoordinatorFaultName,
+            "latency",
+            "downstream",
+            1,
+            new ToxiproxyLatencyAttributes(5_000, 0));
+        using var response = await _toxiproxyClient.PostAsJsonAsync(
+            $"proxies/{ProducerProxyName}/toxics",
+            toxic,
+            ToxiproxyJsonContext.Default.ToxiproxyLatencyConfiguration,
+            cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        _faultActive = true;
+    }
+
+    public async Task HealCoordinatorAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_faultActive)
+        {
+            return;
+        }
+
+        using var response = await _toxiproxyClient.DeleteAsync(
+            $"proxies/{ProducerProxyName}/toxics/{CoordinatorFaultName}",
+            cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        _faultActive = false;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await HealCoordinatorAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[TransactionFaultKafkaContainer] Fault cleanup failed: {ex.Message}");
+        }
+
+        _toxiproxyClient.Dispose();
+
+        if (_kafka is not null)
+        {
+            await _kafka.DisposeAsync().ConfigureAwait(false);
+        }
+
+        await _toxiproxy.DisposeAsync().ConfigureAwait(false);
+        await _network.DisposeAsync().ConfigureAwait(false);
+        GC.SuppressFinalize(this);
+    }
+
+    private IContainer CreateKafkaContainer(
+        string toxiproxyHost,
+        ushort producerPublicPort,
+        ushort consumerPublicPort)
+    {
+        return new ContainerBuilder("apache/kafka:4.0.1")
+            .WithNetwork(_network)
+            .WithNetworkAliases(KafkaNetworkAlias)
+            .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")
+            .WithEnvironment("KAFKA_NODE_ID", "1")
+            .WithEnvironment("KAFKA_PROCESS_ROLES", "broker,controller")
+            .WithEnvironment(
+                "KAFKA_LISTENERS",
+                $"PRODUCER://0.0.0.0:{KafkaProducerPort}," +
+                $"CONSUMER://0.0.0.0:{KafkaConsumerPort}," +
+                $"BROKER://0.0.0.0:{KafkaBrokerPort}," +
+                $"CONTROLLER://0.0.0.0:{KafkaControllerPort}")
+            .WithEnvironment(
+                "KAFKA_ADVERTISED_LISTENERS",
+                $"PRODUCER://{toxiproxyHost}:{producerPublicPort}," +
+                $"CONSUMER://{toxiproxyHost}:{consumerPublicPort}," +
+                $"BROKER://{KafkaNetworkAlias}:{KafkaBrokerPort}")
+            .WithEnvironment(
+                "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+                "PRODUCER:PLAINTEXT,CONSUMER:PLAINTEXT,BROKER:PLAINTEXT,CONTROLLER:PLAINTEXT")
+            .WithEnvironment("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER")
+            .WithEnvironment("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER")
+            .WithEnvironment("KAFKA_CONTROLLER_QUORUM_VOTERS", $"1@localhost:{KafkaControllerPort}")
+            .WithEnvironment("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1")
+            .WithEnvironment("KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS", "1")
+            .WithEnvironment("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")
+            .WithEnvironment("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
+            .WithEnvironment("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
+            .WithEnvironment("CLUSTER_ID", "4L6g3nShT-eMCtK--X86sw")
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilMessageIsLogged(".*Transitioning from RECOVERY to RUNNING.*"))
+            .Build();
+    }
+
+    private IAdminClient CreateAdminClient() => Kafka.CreateAdminClient()
+        .WithBootstrapServers(ProducerBootstrapServers)
+        .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+        .Build();
+
+    private async Task AddProxyAsync(string name, ushort listenPort, ushort upstreamPort)
+    {
+        var proxy = new ToxiproxyProxyConfiguration(
+            name,
+            $"0.0.0.0:{listenPort}",
+            $"{KafkaNetworkAlias}:{upstreamPort}",
+            true);
+        using var response = await _toxiproxyClient.PostAsJsonAsync(
+            "proxies",
+            proxy,
+            ToxiproxyJsonContext.Default.ToxiproxyProxyConfiguration).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task WaitForKafkaAsync()
+    {
+        Exception? lastError = null;
+        for (var attempt = 0; attempt < 30; attempt++)
+        {
+            try
+            {
+                await using var admin = CreateAdminClient();
+                _ = await admin.ListTopicsAsync().ConfigureAwait(false);
+                return;
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+            }
+
+            await Task.Delay(250).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException("Kafka did not become ready through Toxiproxy.", lastError);
+    }
+}
+
+internal sealed record ToxiproxyProxyConfiguration(
+    string Name,
+    string Listen,
+    string Upstream,
+    bool Enabled);
+
+internal sealed record ToxiproxyLatencyConfiguration(
+    string Name,
+    string Type,
+    string Stream,
+    double Toxicity,
+    ToxiproxyLatencyAttributes Attributes);
+
+internal sealed record ToxiproxyLatencyAttributes(int Latency, int Jitter);
+
+[JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
+[JsonSerializable(typeof(ToxiproxyProxyConfiguration))]
+[JsonSerializable(typeof(ToxiproxyLatencyConfiguration))]
+internal sealed partial class ToxiproxyJsonContext : JsonSerializerContext;

--- a/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
@@ -51,6 +51,7 @@ public sealed class TransactionFaultKafkaContainer : IAsyncInitializer, IAsyncDi
 
     public async Task InitializeAsync()
     {
+        await _network.CreateAsync().ConfigureAwait(false);
         await _toxiproxy.StartAsync().ConfigureAwait(false);
 
         var toxiproxyHost = _toxiproxy.Hostname;


### PR DESCRIPTION
## Summary
- add an isolated Kafka/Toxiproxy fixture with separate coordinator and read-committed lanes
- delay the `EndTxn` response during abort, heal the fault, and verify transactional recovery
- prove the read-committed consumer never exposes the aborted record before or after the fault
- use condition-based request observation and bounded cancellation
- use source-generated JSON for NativeAOT-safe Toxiproxy control calls

## Test plan
- `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj --configuration Release --no-restore`
- focused coordinator-fault test on net8.0 (1 passed)
- focused coordinator-fault test on net10.0 (1 passed)
- net10.0 transaction regression selection (16 passed)
- NativeAOT analysis produced no new trim/AOT warnings; local final link unavailable because the VS C++ workload is not installed

Closes #1620