### PR TITLE
Add cross-client interop oracle tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        category: [Producer, MultiInFlightProducer, Backpressure, Consumer, ConsumerLag, ConsumerGroup, Transaction, Admin, Authentication, Authorization, Tls, Serialization, Resilience, Messaging, MessagingPatterns, MessagingOrdering, Compression, Interop, Offsets, NetworkPartition, Retry, ShareConsumer, ShareConsumerAdmin, Telemetry]
+        category: [Producer, MultiInFlightProducer, Backpressure, Consumer, ConsumerLag, ConsumerGroup, Transaction, Admin, Authentication, Authorization, Tls, Serialization, Resilience, Messaging, MessagingPatterns, MessagingOrdering, Compression, Offsets, NetworkPartition, Retry, ShareConsumer, ShareConsumerAdmin, Telemetry]
       fail-fast: true
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
     strategy:
       matrix:
         framework: [net8.0, net10.0]
-        category: [Producer, MultiInFlightProducer, Backpressure, Consumer, ConsumerLag, ConsumerGroup, Transaction, Admin, Authentication, Authorization, Tls, Serialization, Resilience, Messaging, MessagingPatterns, MessagingOrdering, Compression, Offsets, NetworkPartition, Retry, ShareConsumer, ShareConsumerAdmin, Telemetry]
+        category: [Producer, MultiInFlightProducer, Backpressure, Consumer, ConsumerLag, ConsumerGroup, Transaction, Admin, Authentication, Authorization, Tls, Serialization, Resilience, Messaging, MessagingPatterns, MessagingOrdering, Compression, Interop, Offsets, NetworkPartition, Retry, ShareConsumer, ShareConsumerAdmin, Telemetry]
       fail-fast: true
 
     steps:
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        category: [Producer, MultiInFlightProducer, Backpressure, Consumer, ConsumerLag, ConsumerGroup, Transaction, Admin, Authentication, Authorization, Tls, Serialization, Resilience, Messaging, MessagingPatterns, MessagingOrdering, Compression, Offsets, NetworkPartition, Retry, ShareConsumer, ShareConsumerAdmin, Telemetry]
+        category: [Producer, MultiInFlightProducer, Backpressure, Consumer, ConsumerLag, ConsumerGroup, Transaction, Admin, Authentication, Authorization, Tls, Serialization, Resilience, Messaging, MessagingPatterns, MessagingOrdering, Compression, Interop, Offsets, NetworkPartition, Retry, ShareConsumer, ShareConsumerAdmin, Telemetry]
       fail-fast: true
 
     steps:

--- a/src/Dekaf.Compression.Snappy/SnappyCompressionCodec.cs
+++ b/src/Dekaf.Compression.Snappy/SnappyCompressionCodec.cs
@@ -104,13 +104,7 @@ public sealed class SnappyCompressionCodec : ICompressionCodec
         if (source.Length < HeaderSize)
             throw new InvalidDataException("Snappy data too short for xerial header.");
 
-        // Verify and skip xerial header (magic + version + compat version)
-        Span<byte> headerBuffer = stackalloc byte[HeaderSize];
-        source.Slice(0, HeaderSize).CopyTo(headerBuffer);
-
-        if (!headerBuffer.Slice(0, XerialMagic.Length).SequenceEqual(XerialMagic))
-            throw new InvalidDataException("Invalid xerial-snappy magic header.");
-
+        // Skip xerial header (magic + version + compat version).
         var position = source.GetPosition(HeaderSize);
         var remaining = source.Length - HeaderSize;
 

--- a/src/Dekaf.Compression.Snappy/SnappyCompressionCodec.cs
+++ b/src/Dekaf.Compression.Snappy/SnappyCompressionCodec.cs
@@ -6,8 +6,9 @@ using Dekaf.Protocol.Records;
 namespace Dekaf.Compression.Snappy;
 
 /// <summary>
-/// Snappy compression codec with xerial-snappy framing.
-/// Kafka uses xerial-snappy format which wraps raw snappy blocks with:
+/// Snappy compression codec with xerial-snappy framing for writes and support for both
+/// xerial-framed and raw Snappy payloads when reading. Kafka clients may emit either format.
+/// Xerial-snappy wraps raw Snappy blocks with:
 /// - Magic header (8 bytes): 0x82 SNAPPY 0x00
 /// - Version (4 bytes BE): 1
 /// - Min compatible version (4 bytes BE): 1
@@ -94,6 +95,12 @@ public sealed class SnappyCompressionCodec : ICompressionCodec
     /// <inheritdoc />
     public void Decompress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
     {
+        if (!HasXerialMagic(source))
+        {
+            Snappier.Snappy.Decompress(source, destination);
+            return;
+        }
+
         if (source.Length < HeaderSize)
             throw new InvalidDataException("Snappy data too short for xerial header.");
 
@@ -134,6 +141,16 @@ public sealed class SnappyCompressionCodec : ICompressionCodec
 
         if (remaining != 0)
             throw new InvalidDataException("Trailing data after last xerial-snappy block.");
+    }
+
+    private static bool HasXerialMagic(ReadOnlySequence<byte> source)
+    {
+        if (source.Length < XerialMagic.Length)
+            return false;
+
+        Span<byte> magic = stackalloc byte[XerialMagic.Length];
+        source.Slice(0, XerialMagic.Length).CopyTo(magic);
+        return magic.SequenceEqual(XerialMagic);
     }
 
 }

--- a/src/Dekaf/Serialization/BuiltInSerializers.cs
+++ b/src/Dekaf/Serialization/BuiltInSerializers.cs
@@ -121,7 +121,7 @@ internal sealed class ByteArraySerde : ISerde<byte[]>
 
     public byte[] Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
     {
-        return data.ToArray();
+        return context.IsNull ? null! : data.ToArray();
     }
 }
 

--- a/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
+++ b/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Apache.Avro" Version="1.12.1" />
+    <PackageReference Include="Confluent.Kafka" Version="2.15.0" />
     <PackageReference Include="Google.Protobuf" Version="3.35.1" />
     <PackageReference Include="Grpc.Tools" Version="2.82.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />

--- a/tests/Dekaf.Tests.Integration/RealWorld/CrossClientInteropTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/CrossClientInteropTests.cs
@@ -1,0 +1,521 @@
+using System.Text;
+using ConfluentKafka = Confluent.Kafka;
+using Dekaf.Compression.Lz4;
+using Dekaf.Compression.Snappy;
+using Dekaf.Compression.Zstd;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Integration.RealWorld;
+
+/// <summary>
+/// Uses Confluent.Kafka as an independent wire-format oracle for Dekaf producers and consumers.
+/// </summary>
+[Category("Interop")]
+public sealed class CrossClientInteropTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    private const int ExpectedPartition = 2;
+    private const int LargeMessageSize = 950_000;
+    private const int LargeFetchSize = 2 * 1024 * 1024;
+
+    private static readonly CodecCase[] CompressionCodecs =
+    [
+        new("none", ConfluentKafka.CompressionType.None),
+        new("gzip", ConfluentKafka.CompressionType.Gzip),
+        new("lz4", ConfluentKafka.CompressionType.Lz4),
+        new("snappy", ConfluentKafka.CompressionType.Snappy),
+        new("zstd", ConfluentKafka.CompressionType.Zstd)
+    ];
+
+    [Test]
+    public async Task DekafProduce_ConfluentConsume_PreservesWireDataExactly()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 3);
+        var expectedRecords = CreateEdgeCaseRecords();
+
+        await using var producer = await Kafka.CreateProducer<byte[]?, byte[]?>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        foreach (var expected in expectedRecords)
+        {
+            var metadata = await producer.ProduceAsync(new ProducerMessage<byte[]?, byte[]?>
+            {
+                Topic = topic,
+                Partition = ExpectedPartition,
+                Key = expected.Key,
+                Value = expected.Value,
+                Headers = CreateDekafHeaders(expected.Headers),
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(expected.TimestampMs)
+            }, CancellationToken.None);
+
+            await Assert.That(metadata.Partition).IsEqualTo(ExpectedPartition);
+        }
+
+        using var consumer = CreateConfluentConsumer();
+        consumer.Assign(new ConfluentKafka.TopicPartitionOffset(
+            topic,
+            ExpectedPartition,
+            ConfluentKafka.Offset.Beginning));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        foreach (var expected in expectedRecords)
+        {
+            var actual = consumer.Consume(cts.Token);
+            await AssertConfluentRecordAsync(actual, expected);
+        }
+    }
+
+    [Test]
+    public async Task ConfluentProduce_DekafConsume_PreservesWireDataExactly()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 3);
+        var expectedRecords = CreateEdgeCaseRecords();
+
+        using (var producer = CreateConfluentProducer())
+        {
+            foreach (var expected in expectedRecords)
+            {
+                var delivery = await producer.ProduceAsync(
+                    new ConfluentKafka.TopicPartition(topic, ExpectedPartition),
+                    new ConfluentKafka.Message<byte[]?, byte[]?>
+                    {
+                        Key = expected.Key,
+                        Value = expected.Value,
+                        Headers = CreateConfluentHeaders(expected.Headers),
+                        Timestamp = new ConfluentKafka.Timestamp(
+                            expected.TimestampMs,
+                            ConfluentKafka.TimestampType.CreateTime)
+                    });
+
+                await Assert.That(delivery.Partition.Value).IsEqualTo(ExpectedPartition);
+            }
+        }
+
+        await using var consumer = await CreateDekafConsumerAsync();
+        consumer.Assign(new TopicPartition(topic, ExpectedPartition));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        foreach (var expected in expectedRecords)
+        {
+            var actual = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+            await Assert.That(actual).IsNotNull();
+            await AssertDekafRecordAsync(actual!.Value, expected);
+        }
+    }
+
+    [Test]
+    public async Task AllKafkaCompressionCodecs_InteroperateInBothDirections()
+    {
+        foreach (var codec in CompressionCodecs)
+        {
+            var topic = await KafkaContainer.CreateTestTopicAsync();
+            var dekafKey = Encoding.UTF8.GetBytes($"dekaf-{codec.Name}");
+            var dekafValue = CreatePayload(64 * 1024, codec.Name.Length);
+
+            var dekafBuilder = ConfigureDekafCompression(
+                Kafka.CreateProducer<byte[]?, byte[]?>()
+                    .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                    .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()),
+                codec.Name);
+
+            await using (var producer = await dekafBuilder.BuildAsync())
+            {
+                await producer.ProduceAsync(new ProducerMessage<byte[]?, byte[]?>
+                {
+                    Topic = topic,
+                    Partition = 0,
+                    Key = dekafKey,
+                    Value = dekafValue
+                }, CancellationToken.None);
+            }
+
+            using (var consumer = CreateConfluentConsumer())
+            {
+                consumer.Assign(new ConfluentKafka.TopicPartitionOffset(
+                    topic,
+                    0,
+                    ConfluentKafka.Offset.Beginning));
+                var actual = consumer.Consume(TimeSpan.FromSeconds(30));
+
+                await Assert.That(actual).IsNotNull();
+                await AssertBytesAsync(actual!.Message.Key, dekafKey);
+                await AssertBytesAsync(actual.Message.Value, dekafValue);
+            }
+
+            var confluentKey = Encoding.UTF8.GetBytes($"confluent-{codec.Name}");
+            var confluentValue = CreatePayload(64 * 1024, codec.Name.Length + 17);
+            using (var producer = CreateConfluentProducer(codec.ConfluentCompression))
+            {
+                await producer.ProduceAsync(
+                    new ConfluentKafka.TopicPartition(topic, 0),
+                    new ConfluentKafka.Message<byte[]?, byte[]?>
+                    {
+                        Key = confluentKey,
+                        Value = confluentValue
+                    });
+            }
+
+            await using var dekafConsumer = await CreateDekafConsumerAsync();
+            dekafConsumer.Assign(new TopicPartition(topic, 0));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+            var first = await dekafConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+            var second = await dekafConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+
+            await Assert.That(first).IsNotNull();
+            await Assert.That(second).IsNotNull();
+            await AssertBytesAsync(second!.Value.Key, confluentKey);
+            await AssertBytesAsync(second.Value.Value, confluentValue);
+        }
+    }
+
+    [Test]
+    public async Task NearBrokerLimitMessages_InteroperateInBothDirections()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var dekafValue = CreatePayload(LargeMessageSize, 31);
+
+        await using (var producer = await Kafka.CreateProducer<byte[]?, byte[]?>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync())
+        {
+            await producer.ProduceAsync(new ProducerMessage<byte[]?, byte[]?>
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = [0xD, 0xE, 0xC, 0xA, 0xF],
+                Value = dekafValue
+            }, CancellationToken.None);
+        }
+
+        using (var consumer = CreateConfluentConsumer(maxFetchBytes: LargeFetchSize))
+        {
+            consumer.Assign(new ConfluentKafka.TopicPartitionOffset(
+                topic,
+                0,
+                ConfluentKafka.Offset.Beginning));
+            var actual = consumer.Consume(TimeSpan.FromSeconds(30));
+
+            await Assert.That(actual).IsNotNull();
+            await AssertBytesAsync(actual!.Message.Value, dekafValue);
+        }
+
+        var confluentValue = CreatePayload(LargeMessageSize, 47);
+        using (var producer = CreateConfluentProducer(messageMaxBytes: LargeFetchSize))
+        {
+            await producer.ProduceAsync(
+                new ConfluentKafka.TopicPartition(topic, 0),
+                new ConfluentKafka.Message<byte[]?, byte[]?>
+                {
+                    Key = [0xC, 0x0, 0xF, 0xF, 0xE, 0xE],
+                    Value = confluentValue
+                });
+        }
+
+        await using var dekafConsumer = await CreateDekafConsumerAsync(maxFetchBytes: LargeFetchSize);
+        dekafConsumer.Assign(new TopicPartition(topic, 0));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var first = await dekafConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+        var second = await dekafConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+
+        await Assert.That(first).IsNotNull();
+        await Assert.That(second).IsNotNull();
+        await AssertBytesAsync(second!.Value.Value, confluentValue);
+    }
+
+    [Test]
+    public async Task TransactionMarkers_HaveReadCommittedVisibilityAcrossClients()
+    {
+        var dekafTopic = await KafkaContainer.CreateTestTopicAsync();
+        await ProduceDekafTransactionsAsync(dekafTopic);
+
+        using (var consumer = CreateConfluentConsumer(readCommitted: true))
+        {
+            consumer.Assign(new ConfluentKafka.TopicPartitionOffset(
+                dekafTopic,
+                0,
+                ConfluentKafka.Offset.Beginning));
+
+            var committed = consumer.Consume(TimeSpan.FromSeconds(30));
+            await Assert.That(committed).IsNotNull();
+            await AssertBytesAsync(committed!.Message.Value, "dekaf-committed"u8.ToArray());
+
+            var extra = consumer.Consume(TimeSpan.FromSeconds(2));
+            await Assert.That(extra).IsNull();
+        }
+
+        var confluentTopic = await KafkaContainer.CreateTestTopicAsync();
+        await ProduceConfluentTransactionsAsync(confluentTopic);
+
+        await using var dekafConsumer = await CreateDekafConsumerAsync(readCommitted: true);
+        dekafConsumer.Assign(new TopicPartition(confluentTopic, 0));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var committedRecord = await dekafConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+        await Assert.That(committedRecord).IsNotNull();
+        await AssertBytesAsync(committedRecord!.Value.Value, "confluent-committed"u8.ToArray());
+
+        var extraRecord = await dekafConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(2), cts.Token);
+        await Assert.That(extraRecord).IsNull();
+    }
+
+    private async Task ProduceDekafTransactionsAsync(string topic)
+    {
+        await using var producer = await Kafka.CreateProducer<byte[]?, byte[]?>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId($"interop-dekaf-{Guid.NewGuid():N}")
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.InitTransactionsAsync();
+
+        await using (var transaction = producer.BeginTransaction())
+        {
+            await transaction.ProduceAsync(new ProducerMessage<byte[]?, byte[]?>
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = "aborted"u8.ToArray(),
+                Value = "dekaf-aborted"u8.ToArray()
+            }, CancellationToken.None);
+            await transaction.AbortAsync();
+        }
+
+        await using (var transaction = producer.BeginTransaction())
+        {
+            await transaction.ProduceAsync(new ProducerMessage<byte[]?, byte[]?>
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = "committed"u8.ToArray(),
+                Value = "dekaf-committed"u8.ToArray()
+            }, CancellationToken.None);
+            await transaction.CommitAsync();
+        }
+    }
+
+    private async Task ProduceConfluentTransactionsAsync(string topic)
+    {
+        using var producer = CreateConfluentProducer(
+            transactionalId: $"interop-confluent-{Guid.NewGuid():N}");
+        producer.InitTransactions(TimeSpan.FromSeconds(30));
+
+        producer.BeginTransaction();
+        await producer.ProduceAsync(
+            new ConfluentKafka.TopicPartition(topic, 0),
+            new ConfluentKafka.Message<byte[]?, byte[]?>
+            {
+                Key = "aborted"u8.ToArray(),
+                Value = "confluent-aborted"u8.ToArray()
+            });
+        producer.AbortTransaction(TimeSpan.FromSeconds(30));
+
+        producer.BeginTransaction();
+        await producer.ProduceAsync(
+            new ConfluentKafka.TopicPartition(topic, 0),
+            new ConfluentKafka.Message<byte[]?, byte[]?>
+            {
+                Key = "committed"u8.ToArray(),
+                Value = "confluent-committed"u8.ToArray()
+            });
+        producer.CommitTransaction(TimeSpan.FromSeconds(30));
+    }
+
+    private ConfluentKafka.IProducer<byte[]?, byte[]?> CreateConfluentProducer(
+        ConfluentKafka.CompressionType compression = ConfluentKafka.CompressionType.None,
+        int messageMaxBytes = 1_000_000,
+        string? transactionalId = null)
+    {
+        return new ConfluentKafka.ProducerBuilder<byte[]?, byte[]?>(new ConfluentKafka.ProducerConfig
+        {
+            BootstrapServers = KafkaContainer.BootstrapServers,
+            Acks = ConfluentKafka.Acks.All,
+            CompressionType = compression,
+            MessageMaxBytes = messageMaxBytes,
+            TransactionalId = transactionalId
+        }).Build();
+    }
+
+    private ConfluentKafka.IConsumer<byte[]?, byte[]?> CreateConfluentConsumer(
+        bool readCommitted = false,
+        int maxFetchBytes = 1_000_000)
+    {
+        return new ConfluentKafka.ConsumerBuilder<byte[]?, byte[]?>(new ConfluentKafka.ConsumerConfig
+        {
+            BootstrapServers = KafkaContainer.BootstrapServers,
+            GroupId = $"interop-confluent-{Guid.NewGuid():N}",
+            AutoOffsetReset = ConfluentKafka.AutoOffsetReset.Earliest,
+            EnableAutoCommit = false,
+            IsolationLevel = readCommitted
+                ? ConfluentKafka.IsolationLevel.ReadCommitted
+                : ConfluentKafka.IsolationLevel.ReadUncommitted,
+            FetchMaxBytes = maxFetchBytes,
+            MaxPartitionFetchBytes = maxFetchBytes
+        }).Build();
+    }
+
+    private async ValueTask<IKafkaConsumer<byte[]?, byte[]?>> CreateDekafConsumerAsync(
+        bool readCommitted = false,
+        int maxFetchBytes = 1_000_000)
+    {
+        var builder = Kafka.CreateConsumer<byte[]?, byte[]?>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithFetchMaxBytes(maxFetchBytes)
+            .WithMaxPartitionFetchBytes(maxFetchBytes)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory());
+
+        if (readCommitted)
+        {
+            builder.WithIsolationLevel(Dekaf.Protocol.Messages.IsolationLevel.ReadCommitted);
+        }
+
+        return await builder.BuildAsync();
+    }
+
+    private static ProducerBuilder<byte[]?, byte[]?> ConfigureDekafCompression(
+        ProducerBuilder<byte[]?, byte[]?> builder,
+        string codec)
+    {
+        return codec switch
+        {
+            "none" => builder,
+            "gzip" => builder.UseGzipCompression(),
+            "lz4" => builder.UseLz4Compression(),
+            "snappy" => builder.UseSnappyCompression(),
+            "zstd" => builder.UseZstdCompression(),
+            _ => throw new ArgumentOutOfRangeException(nameof(codec), codec, "Unsupported compression codec")
+        };
+    }
+
+    private static WireRecord[] CreateEdgeCaseRecords()
+    {
+        var timestampMs = DateTimeOffset.UtcNow.AddMinutes(-1).ToUnixTimeMilliseconds();
+        return
+        [
+            new WireRecord(
+                [0x00, 0x7F, 0x80, 0xFF],
+                [0xFF, 0x00, 0xFE, 0x01],
+                timestampMs,
+                [
+                    new ExpectedHeader("duplicate", [0x01, 0x02]),
+                    new ExpectedHeader("duplicate", [0x03, 0x04]),
+                    new ExpectedHeader("empty", []),
+                    new ExpectedHeader("null", null)
+                ]),
+            new WireRecord(null, [], timestampMs + 1, []),
+            new WireRecord([], null, timestampMs + 2, [])
+        ];
+    }
+
+    private static Headers? CreateDekafHeaders(IReadOnlyList<ExpectedHeader> expected)
+    {
+        if (expected.Count == 0)
+        {
+            return null;
+        }
+
+        var headers = new Headers(expected.Count);
+        foreach (var header in expected)
+        {
+            headers.Add(header.Key, header.Value);
+        }
+
+        return headers;
+    }
+
+    private static ConfluentKafka.Headers? CreateConfluentHeaders(IReadOnlyList<ExpectedHeader> expected)
+    {
+        if (expected.Count == 0)
+        {
+            return null;
+        }
+
+        var headers = new ConfluentKafka.Headers();
+        foreach (var header in expected)
+        {
+            headers.Add(header.Key, header.Value!);
+        }
+
+        return headers;
+    }
+
+    private static async Task AssertConfluentRecordAsync(
+        ConfluentKafka.ConsumeResult<byte[]?, byte[]?> actual,
+        WireRecord expected)
+    {
+        await Assert.That(actual).IsNotNull();
+        await Assert.That(actual.Partition.Value).IsEqualTo(ExpectedPartition);
+        await Assert.That(actual.Message.Timestamp.UnixTimestampMs).IsEqualTo(expected.TimestampMs);
+        await Assert.That(actual.Message.Timestamp.Type).IsEqualTo(ConfluentKafka.TimestampType.CreateTime);
+        await AssertBytesAsync(actual.Message.Key, expected.Key);
+        await AssertBytesAsync(actual.Message.Value, expected.Value);
+
+        // TUnit installs an ActivityListener, so Dekaf correctly appends W3C propagation headers.
+        // Compare the caller-supplied headers byte-for-byte after excluding those known transport headers.
+        var applicationHeaders = actual.Message.Headers
+            .Where(static header => header.Key is not "traceparent" and not "tracestate")
+            .ToArray();
+        await Assert.That(applicationHeaders.Length).IsEqualTo(expected.Headers.Count);
+        for (var i = 0; i < expected.Headers.Count; i++)
+        {
+            await Assert.That(applicationHeaders[i].Key).IsEqualTo(expected.Headers[i].Key);
+            await AssertBytesAsync(applicationHeaders[i].GetValueBytes(), expected.Headers[i].Value);
+        }
+    }
+
+    private static async Task AssertDekafRecordAsync(ConsumeResult<byte[]?, byte[]?> actual, WireRecord expected)
+    {
+        await Assert.That(actual.Partition).IsEqualTo(ExpectedPartition);
+        await Assert.That(actual.TimestampMs).IsEqualTo(expected.TimestampMs);
+        await Assert.That(actual.TimestampType).IsEqualTo(TimestampType.CreateTime);
+        await AssertBytesAsync(actual.Key, expected.Key);
+        await AssertBytesAsync(actual.Value, expected.Value);
+
+        var actualHeaders = actual.Headers;
+        await Assert.That(actualHeaders?.Count ?? 0).IsEqualTo(expected.Headers.Count);
+        for (var i = 0; i < expected.Headers.Count; i++)
+        {
+            await Assert.That(actualHeaders![i].Key).IsEqualTo(expected.Headers[i].Key);
+            await AssertBytesAsync(actualHeaders[i].GetValueAsArray(), expected.Headers[i].Value);
+        }
+    }
+
+    private static async Task AssertBytesAsync(byte[]? actual, byte[]? expected)
+    {
+        if (expected is null)
+        {
+            await Assert.That(actual).IsNull();
+            return;
+        }
+
+        await Assert.That(actual).IsNotNull();
+        var equal = actual is not null && actual.AsSpan().SequenceEqual(expected);
+        await Assert.That(equal).IsTrue();
+    }
+
+    private static byte[] CreatePayload(int size, int salt)
+    {
+        var payload = GC.AllocateUninitializedArray<byte>(size);
+        for (var i = 0; i < payload.Length; i++)
+        {
+            payload[i] = unchecked((byte)((i * 31) + (i / 251) + salt));
+        }
+
+        return payload;
+    }
+
+    private sealed record CodecCase(string Name, ConfluentKafka.CompressionType ConfluentCompression);
+    private sealed record ExpectedHeader(string Key, byte[]? Value);
+    private sealed record WireRecord(
+        byte[]? Key,
+        byte[]? Value,
+        long TimestampMs,
+        IReadOnlyList<ExpectedHeader> Headers);
+}

--- a/tests/Dekaf.Tests.Unit/Compression/SnappyCompressionCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Compression/SnappyCompressionCodecTests.cs
@@ -93,10 +93,10 @@ public class SnappyCompressionCodecTests
     }
 
     [Test]
-    public async Task Decompress_InvalidMagicHeader_Throws()
+    public async Task Decompress_MalformedRawPayload_Throws()
     {
         var codec = new SnappyCompressionCodec();
-        var invalidData = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        var invalidData = new byte[] { 0x80 }; // Truncated raw Snappy uncompressed-length varint.
         var decompressedBuffer = new ArrayBufferWriter<byte>();
 
         await Assert.That(() => codec.Decompress(new ReadOnlySequence<byte>(invalidData), decompressedBuffer))
@@ -142,6 +142,22 @@ public class SnappyCompressionCodecTests
 
         codec.Compress(new ReadOnlySequence<byte>(original), compressedBuffer);
         codec.Decompress(new ReadOnlySequence<byte>(compressedBuffer.WrittenMemory), decompressedBuffer);
+
+        await Assert.That(decompressedBuffer.WrittenSpan.ToArray()).IsEquivalentTo(original);
+    }
+
+    [Test]
+    public async Task Decompress_RawSnappyPayload_PreservesData()
+    {
+        var codec = new SnappyCompressionCodec();
+        var original = Encoding.UTF8.GetBytes(new string('R', 10_000));
+        var compressed = new byte[Snappier.Snappy.GetMaxCompressedLength(original.Length)];
+        var compressedLength = Snappier.Snappy.Compress(original, compressed);
+        var decompressedBuffer = new ArrayBufferWriter<byte>();
+
+        codec.Decompress(
+            new ReadOnlySequence<byte>(compressed.AsMemory(0, compressedLength)),
+            decompressedBuffer);
 
         await Assert.That(decompressedBuffer.WrittenSpan.ToArray()).IsEquivalentTo(original);
     }

--- a/tests/Dekaf.Tests.Unit/Compression/SnappyCompressionCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Compression/SnappyCompressionCodecTests.cs
@@ -104,14 +104,16 @@ public class SnappyCompressionCodecTests
     }
 
     [Test]
-    public async Task Decompress_TruncatedHeader_Throws()
+    public async Task Decompress_TruncatedXerialHeader_Throws()
     {
         var codec = new SnappyCompressionCodec();
-        var truncatedData = new byte[] { 0x82, 0x53, 0x4e, 0x41 }; // Only 4 bytes
+        // Complete xerial magic, but no version or minimum-compatible-version fields.
+        var truncatedData = new byte[] { 0x82, 0x53, 0x4e, 0x41, 0x50, 0x50, 0x59, 0x00 };
         var decompressedBuffer = new ArrayBufferWriter<byte>();
 
         await Assert.That(() => codec.Decompress(new ReadOnlySequence<byte>(truncatedData), decompressedBuffer))
-            .Throws<InvalidDataException>();
+            .Throws<InvalidDataException>()
+            .WithMessage("Snappy data too short for xerial header.");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Serialization/SerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/SerializerTests.cs
@@ -111,6 +111,22 @@ public class SerializerTests
     }
 
     [Test]
+    public async Task ByteArraySerializer_NullRecord_ReturnsNull()
+    {
+        var serializer = Serializers.ByteArray;
+        var context = new SerializationContext
+        {
+            Topic = "test",
+            Component = SerializationComponent.Value,
+            IsNull = true
+        };
+
+        var result = serializer.Deserialize(ReadOnlyMemory<byte>.Empty, context);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
     public async Task DoubleSerializer_SerializesAndDeserializes()
     {
         var serializer = Serializers.Double;

--- a/tools/Dekaf.Pipeline/Modules/RunInteropIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunInteropIntegrationTestsModule.cs
@@ -1,0 +1,6 @@
+namespace Dekaf.Pipeline.Modules;
+
+public class RunInteropIntegrationTestsModule : RunIntegrationTestsModule
+{
+    protected override string Category => "Interop";
+}

--- a/tools/Dekaf.Pipeline/Program.cs
+++ b/tools/Dekaf.Pipeline/Program.cs
@@ -53,6 +53,7 @@ if (!skipIntegrationTests)
         ["Consumer"] = () => builder.Services.AddModule<RunConsumerIntegrationTestsModule>(),
         ["ConsumerGroup"] = () => builder.Services.AddModule<RunConsumerGroupIntegrationTestsModule>(),
         ["ConsumerLag"] = () => builder.Services.AddModule<RunConsumerLagIntegrationTestsModule>(),
+        ["Interop"] = () => builder.Services.AddModule<RunInteropIntegrationTestsModule>(),
         ["Messaging"] = () => builder.Services.AddModule<RunMessagingIntegrationTestsModule>(),
         ["MessagingPatterns"] = () => builder.Services.AddModule<RunMessagingPatternsIntegrationTestsModule>(),
         ["MessagingOrdering"] = () => builder.Services.AddModule<RunMessagingOrderingIntegrationTestsModule>(),


### PR DESCRIPTION
## Summary
- add Confluent.Kafka oracle tests for byte-exact records in both directions
- cover null/empty payloads, duplicate/empty/null headers, timestamps, partitions, all Kafka codecs, 950 KB messages, and read_committed transactions
- preserve byte-array tombstones and accept raw Snappy payloads emitted by foreign clients

## Tests
- net10 interop: 15/15 across Kafka 4.0, 4.1, 4.2
- net8 interop: 15/15 across Kafka 4.0, 4.1, 4.2
- net10 unit: 4511/4511
- net8 unit: 4505/4505

Closes #1595