### PR TITLE
test(consumer): stabilize compacted lag

### DIFF
--- a/tests/Dekaf.Tests.Integration/ConsumerLagCompactionTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerLagCompactionTests.cs
@@ -156,20 +156,23 @@ public sealed class ConsumerLagCompactionTests(KafkaTestContainer kafka) : Kafka
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        // Produce messages with duplicate keys
-        for (var round = 0; round < duplicatesPerKey; round++)
+        async Task ProduceRangeAsync(int startOffset, int endOffset)
         {
-            for (var key = 0; key < uniqueKeys; key++)
+            for (var producedOffset = startOffset; producedOffset < endOffset; producedOffset++)
             {
-                var producedOffset = round * uniqueKeys + key;
                 await producer.ProduceAsync(new ProducerMessage<string, string>
                 {
                     Topic = topic,
-                    Key = producedOffset == lagBoundaryOffset ? lagBoundaryKey : $"key-{key}",
-                    Value = $"value-round-{round}"
+                    Key = producedOffset == lagBoundaryOffset
+                        ? lagBoundaryKey
+                        : $"key-{producedOffset % uniqueKeys}",
+                    Value = $"value-round-{producedOffset / uniqueKeys}"
                 }, CancellationToken.None);
             }
         }
+
+        // Stop production at the marker so the consumer cannot prefetch beyond it.
+        await ProduceRangeAsync(0, (int)lagBoundaryOffset + 1);
 
         await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
@@ -194,9 +197,17 @@ public sealed class ConsumerLagCompactionTests(KafkaTestContainer kafka) : Kafka
 
         await Assert.That(processedOffset).IsEqualTo(lagBoundaryOffset);
 
-        // Derive application progress from the yielded marker instead of consumer fetch state.
+        // The unique marker gives the exact consumed offset regardless of compacted gaps.
         var processedPosition = processedOffset!.Value + 1;
+
+        // Produce the tail only after the marker enumerator has stopped. Background prefetch
+        // can fetch these records, but it must not advance the reported consumed position.
+        await ProduceRangeAsync((int)processedPosition, totalProduced);
+
+        var reportedPosition = consumer.GetPosition(tp);
         var watermarks = await consumer.QueryWatermarkOffsetsAsync(tp);
+
+        await Assert.That(reportedPosition).IsEqualTo(processedPosition);
 
         // High watermark always reflects total produced, regardless of compaction
         await Assert.That(watermarks.High).IsEqualTo(totalProduced);
@@ -205,7 +216,7 @@ public sealed class ConsumerLagCompactionTests(KafkaTestContainer kafka) : Kafka
         // Even with compaction, offset-based lag reflects the offset distance,
         // not the number of physically remaining messages.
         var expectedLag = totalProduced - processedPosition;
-        var lag = watermarks.High - processedPosition;
+        var lag = watermarks.High - reportedPosition!.Value;
         await Assert.That(lag).IsEqualTo(expectedLag);
 
         // Give the log cleaner time to run. Correctness does not depend on whether it finishes.
@@ -216,8 +227,10 @@ public sealed class ConsumerLagCompactionTests(KafkaTestContainer kafka) : Kafka
         // High watermark must remain the same after compaction
         await Assert.That(watermarksAfterCompaction.High).IsEqualTo(totalProduced);
 
-        // Processed boundary is application-owned and unaffected by background prefetch.
-        var lagAfterCompaction = watermarksAfterCompaction.High - processedPosition;
+        var reportedPositionAfterCompaction = consumer.GetPosition(tp);
+        await Assert.That(reportedPositionAfterCompaction).IsEqualTo(processedPosition);
+
+        var lagAfterCompaction = watermarksAfterCompaction.High - reportedPositionAfterCompaction!.Value;
         await Assert.That(lagAfterCompaction).IsEqualTo(expectedLag);
     }
 

--- a/tests/Dekaf.Tests.Integration/ConsumerLagCompactionTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerLagCompactionTests.cs
@@ -150,6 +150,7 @@ public sealed class ConsumerLagCompactionTests(KafkaTestContainer kafka) : Kafka
         const int totalProduced = uniqueKeys * duplicatesPerKey;
         const string lagBoundaryKey = "lag-boundary";
         const long lagBoundaryOffset = totalProduced / 2;
+        const int markerTimeoutSeconds = 30;
 
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
@@ -185,17 +186,25 @@ public sealed class ConsumerLagCompactionTests(KafkaTestContainer kafka) : Kafka
         // Consume through a stable offset boundary. Counting physical records is invalid for
         // compacted topics because earlier duplicate-key records may already be gone.
         long? processedOffset = null;
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(markerTimeoutSeconds));
 
-        await foreach (var msg in consumer.ConsumeAsync(cts.Token))
+        try
         {
-            if (msg.Key != lagBoundaryKey) continue;
+            await foreach (var msg in consumer.ConsumeAsync(cts.Token))
+            {
+                if (msg.Key != lagBoundaryKey) continue;
 
-            processedOffset = msg.Offset;
-            break;
+                processedOffset = msg.Offset;
+                break;
+            }
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            // Let the assertion below report which deterministic boundary was missed.
         }
 
-        await Assert.That(processedOffset).IsEqualTo(lagBoundaryOffset);
+        await Assert.That(processedOffset).IsEqualTo(lagBoundaryOffset)
+            .Because($"Consumer should reach marker '{lagBoundaryKey}' before the {markerTimeoutSeconds}-second timeout");
 
         // The unique marker gives the exact consumed offset regardless of compacted gaps.
         var processedPosition = processedOffset!.Value + 1;

--- a/tests/Dekaf.Tests.Integration/ConsumerLagCompactionTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerLagCompactionTests.cs
@@ -142,12 +142,14 @@ public sealed class ConsumerLagCompactionTests(KafkaTestContainer kafka) : Kafka
     }
 
     [Test]
-    public async Task CompactedTopic_ConsumerLag_ReflectsActualMessages()
+    public async Task CompactedTopic_ConsumerLag_UsesProcessedOffsetBoundary()
     {
         var topic = await CreateCompactedTopicAsync();
         const int uniqueKeys = 10;
         const int duplicatesPerKey = 5;
-        var totalProduced = uniqueKeys * duplicatesPerKey;
+        const int totalProduced = uniqueKeys * duplicatesPerKey;
+        const string lagBoundaryKey = "lag-boundary";
+        const long lagBoundaryOffset = totalProduced / 2;
 
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
@@ -159,10 +161,11 @@ public sealed class ConsumerLagCompactionTests(KafkaTestContainer kafka) : Kafka
         {
             for (var key = 0; key < uniqueKeys; key++)
             {
+                var producedOffset = round * uniqueKeys + key;
                 await producer.ProduceAsync(new ProducerMessage<string, string>
                 {
                     Topic = topic,
-                    Key = $"key-{key}",
+                    Key = producedOffset == lagBoundaryOffset ? lagBoundaryKey : $"key-{key}",
                     Value = $"value-round-{round}"
                 }, CancellationToken.None);
             }
@@ -176,25 +179,24 @@ public sealed class ConsumerLagCompactionTests(KafkaTestContainer kafka) : Kafka
         var tp = new TopicPartition(topic, 0);
         consumer.Assign(tp);
 
-        // Consume half the messages
-        var consumeCount = totalProduced / 2;
-        var consumed = new List<ConsumeResult<string, string>>();
+        // Consume through a stable offset boundary. Counting physical records is invalid for
+        // compacted topics because earlier duplicate-key records may already be gone.
+        long? processedOffset = null;
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
         await foreach (var msg in consumer.ConsumeAsync(cts.Token))
         {
-            consumed.Add(msg);
-            if (consumed.Count >= consumeCount) break;
+            if (msg.Key != lagBoundaryKey) continue;
+
+            processedOffset = msg.Offset;
+            break;
         }
 
-        await Assert.That(consumed).Count().IsEqualTo(consumeCount);
+        await Assert.That(processedOffset).IsEqualTo(lagBoundaryOffset);
 
-        // Check consumer position and watermarks
-        var position = consumer.GetPosition(tp);
+        // Derive application progress from the yielded marker instead of consumer fetch state.
+        var processedPosition = processedOffset!.Value + 1;
         var watermarks = await consumer.QueryWatermarkOffsetsAsync(tp);
-
-        await Assert.That(position).IsNotNull();
-        await Assert.That(position!.Value).IsEqualTo(consumeCount);
 
         // High watermark always reflects total produced, regardless of compaction
         await Assert.That(watermarks.High).IsEqualTo(totalProduced);
@@ -202,10 +204,11 @@ public sealed class ConsumerLagCompactionTests(KafkaTestContainer kafka) : Kafka
         // Lag is calculated as high watermark minus position.
         // Even with compaction, offset-based lag reflects the offset distance,
         // not the number of physically remaining messages.
-        var lag = watermarks.High - position.Value;
-        await Assert.That(lag).IsEqualTo(totalProduced - consumeCount);
+        var expectedLag = totalProduced - processedPosition;
+        var lag = watermarks.High - processedPosition;
+        await Assert.That(lag).IsEqualTo(expectedLag);
 
-        // Wait for compaction and re-check: lag calculation should still be consistent
+        // Give the log cleaner time to run. Correctness does not depend on whether it finishes.
         await Task.Delay(10_000);
 
         var watermarksAfterCompaction = await consumer.QueryWatermarkOffsetsAsync(tp);
@@ -213,13 +216,9 @@ public sealed class ConsumerLagCompactionTests(KafkaTestContainer kafka) : Kafka
         // High watermark must remain the same after compaction
         await Assert.That(watermarksAfterCompaction.High).IsEqualTo(totalProduced);
 
-        // Position hasn't changed (we stopped consuming)
-        var positionAfterCompaction = consumer.GetPosition(tp);
-        await Assert.That(positionAfterCompaction).IsEqualTo(consumeCount);
-
-        // Lag calculation remains consistent
-        var lagAfterCompaction = watermarksAfterCompaction.High - positionAfterCompaction!.Value;
-        await Assert.That(lagAfterCompaction).IsEqualTo(totalProduced - consumeCount);
+        // Processed boundary is application-owned and unaffected by background prefetch.
+        var lagAfterCompaction = watermarksAfterCompaction.High - processedPosition;
+        await Assert.That(lagAfterCompaction).IsEqualTo(expectedLag);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- produce a unique midpoint marker that survives log compaction
- derive application lag from the last yielded marker offset instead of physical record counts
- keep post-cleaner assertions independent of fetch prefetch timing

## Tests
- `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
- focused lag boundary test: 3 passed (Kafka 4.0, 4.1, 4.2)
- `ConsumerLagCompactionTests`: 12 passed
- broad consumer/fetch filter: 304 passed, 20 expected skips, 0 failed

Closes #1650