### PR TITLE
test: bound transaction coordinator concurrency

### DIFF
--- a/tests/Dekaf.Tests.Integration/AdminTransactionRemediationTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminTransactionRemediationTests.cs
@@ -8,7 +8,7 @@ using Dekaf.Protocol.Messages;
 namespace Dekaf.Tests.Integration;
 
 [Category("Transaction")]
-public sealed class AdminTransactionRemediationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+public sealed class AdminTransactionRemediationTests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
 {
     [Test]
     public async Task FenceProducersAsync_FencesActiveTransactionalProducer()

--- a/tests/Dekaf.Tests.Integration/ExactlyOnceSemanticsTests.cs
+++ b/tests/Dekaf.Tests.Integration/ExactlyOnceSemanticsTests.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Tests.Integration;
 /// multi-producer isolation, epoch bumping/fencing, and consume-transform-produce patterns.
 /// </summary>
 [Category("Transaction")]
-public sealed class ExactlyOnceSemanticsTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+public sealed class ExactlyOnceSemanticsTests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
 {
     [Test]
     public async Task TransactionOffsetCommit_Atomicity_OffsetsAndMessagesCommittedTogether()

--- a/tests/Dekaf.Tests.Integration/RealWorld/ExactlyOnceProcessingTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/ExactlyOnceProcessingTests.cs
@@ -8,7 +8,7 @@ namespace Dekaf.Tests.Integration.RealWorld;
 /// Tests for exactly-once processing semantics using consume-transform-produce with transactions.
 /// </summary>
 [Category("Transaction")]
-public sealed class ExactlyOnceProcessingTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+public sealed class ExactlyOnceProcessingTests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
 {
     [Test]
     public async Task ConsumeTransformProduce_WithTransactionalOffsetCommit_ExactlyOnceSemantics()

--- a/tests/Dekaf.Tests.Integration/RealWorld/TransactionEdgeCaseTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/TransactionEdgeCaseTests.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Tests.Integration.RealWorld;
 /// sequential transaction ordering, and consume-transform-produce failure scenarios.
 /// </summary>
 [Category("Transaction")]
-public sealed class TransactionEdgeCaseTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+public sealed class TransactionEdgeCaseTests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
 {
     [Test]
     public async Task MultiPartition_Commit_AllPartitionsVisible()

--- a/tests/Dekaf.Tests.Integration/TransactionCoordinatorTestGateTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionCoordinatorTestGateTests.cs
@@ -1,0 +1,27 @@
+namespace Dekaf.Tests.Integration;
+
+[Category("Transaction")]
+public sealed class TransactionCoordinatorTestGateTests
+{
+    [Test]
+    public async Task Gate_IsLimitedAndScopedPerKafkaFixture()
+    {
+        await using var firstFixture = new StubKafkaTestContainer("first");
+        await using var secondFixture = new StubKafkaTestContainer("second");
+
+        var firstGate = TransactionCoordinatorTestGate.Get(firstFixture);
+        var sameFixtureGate = TransactionCoordinatorTestGate.Get(firstFixture);
+        var secondFixtureGate = TransactionCoordinatorTestGate.Get(secondFixture);
+
+        await Assert.That(firstGate.CurrentCount)
+            .IsEqualTo(TransactionCoordinatorTestGate.MaximumConcurrencyPerFixture);
+        await Assert.That(ReferenceEquals(firstGate, sameFixtureGate)).IsTrue();
+        await Assert.That(ReferenceEquals(firstGate, secondFixtureGate)).IsFalse();
+    }
+
+    private sealed class StubKafkaTestContainer(string name) : KafkaTestContainer
+    {
+        public override string ContainerName => name;
+        public override int Version => 0;
+    }
+}

--- a/tests/Dekaf.Tests.Integration/TransactionErrorHandlingTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionErrorHandlingTests.cs
@@ -13,7 +13,7 @@ namespace Dekaf.Tests.Integration;
 /// there is no reliable, non-flaky way to force a broker into returning an abortable error here.
 /// </remarks>
 [Category("Transaction")]
-public class TransactionErrorHandlingTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+public class TransactionErrorHandlingTests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
 {
     [Test]
     public async Task Transaction_FencedByNewerProducer_ThrowsFatalAndProducerIsUnusable()

--- a/tests/Dekaf.Tests.Integration/TransactionIsolationLevelTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionIsolationLevelTests.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Tests.Integration;
 /// concurrent commit/abort, abort markers, and last stable offset blocking.
 /// </summary>
 [Category("Transaction")]
-public sealed class TransactionIsolationLevelTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+public sealed class TransactionIsolationLevelTests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
 {
     [Test]
     public async Task ReadUncommitted_SeesMessages_FromOpenTransactions()

--- a/tests/Dekaf.Tests.Integration/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionTests.cs
@@ -7,7 +7,7 @@ namespace Dekaf.Tests.Integration;
 /// Integration tests for producer transactions.
 /// </summary>
 [Category("Transaction")]
-public class TransactionTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+public class TransactionTests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
 {
     [Test]
     public async Task InitTransactions_SetsProducerIdAndEpoch()

--- a/tests/Dekaf.Tests.Integration/TransactionTimeoutTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionTimeoutTests.cs
@@ -9,7 +9,7 @@ namespace Dekaf.Tests.Integration;
 /// multi-topic transactions, isolation level behavior, and failure recovery scenarios.
 /// </summary>
 [Category("Transaction")]
-public sealed class TransactionTimeoutTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+public sealed class TransactionTimeoutTests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
 {
     [Test]
     public async Task Transaction_MultipleTopicsAndPartitions_CommitsAtomically()

--- a/tests/Dekaf.Tests.Integration/TransactionV2Tests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionV2Tests.cs
@@ -9,7 +9,7 @@ namespace Dekaf.Tests.Integration;
 /// are automatically active when connected to Kafka 4.0+ brokers that support transaction.version >= 2.
 /// </summary>
 [Category("Transaction")]
-public class TransactionV2Tests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+public class TransactionV2Tests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
 {
     [Test]
     public async Task Transaction_Commit_ThenNewTransaction_Succeeds()

--- a/tests/Dekaf.Tests.Integration/TransactionalKafkaIntegrationTest.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionalKafkaIntegrationTest.cs
@@ -1,0 +1,43 @@
+using System.Runtime.CompilerServices;
+
+namespace Dekaf.Tests.Integration;
+
+internal static class TransactionCoordinatorTestGate
+{
+    internal const int MaximumConcurrencyPerFixture = 4;
+
+    private static readonly ConditionalWeakTable<KafkaTestContainer, SemaphoreSlim> Gates = new();
+
+    internal static SemaphoreSlim Get(KafkaTestContainer kafka) =>
+        Gates.GetValue(kafka, static _ =>
+            new SemaphoreSlim(MaximumConcurrencyPerFixture, MaximumConcurrencyPerFixture));
+}
+
+/// <summary>
+/// Limits transaction-test concurrency per shared Kafka fixture so each broker's transaction
+/// coordinator remains responsive while independent Kafka versions still run in parallel.
+/// </summary>
+public abstract class TransactionalKafkaIntegrationTest(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    private readonly SemaphoreSlim _coordinatorGate = TransactionCoordinatorTestGate.Get(kafka);
+    private bool _gateEntered;
+
+    [Before(Test)]
+    public async Task EnterTransactionCoordinatorGate(CancellationToken cancellationToken)
+    {
+        await _coordinatorGate.WaitAsync(cancellationToken);
+        _gateEntered = true;
+    }
+
+    [After(Test)]
+    public void ExitTransactionCoordinatorGate()
+    {
+        if (!_gateEntered)
+        {
+            return;
+        }
+
+        _gateEntered = false;
+        _coordinatorGate.Release();
+    }
+}


### PR DESCRIPTION
## Summary
- cap transaction integration concurrency at four tests per shared Kafka fixture
- keep Kafka 4.0, 4.1, and 4.2 fixtures parallel while protecting each broker coordinator
- route all nine transaction suites through inherited TUnit lifecycle hooks
- cover gate limit reuse and per-fixture isolation

## Tests
- `dotnet build Dekaf.sln --configuration Release`
- `Dekaf.Tests.Unit` net10.0: 4,509 passed
- combined transaction classes net10.0: 108 passed (two consecutive runs)
- combined transaction classes net8.0: 108 passed
- coordinator gate focused test: passed

Closes #1638