### PR TITLE
test(consumer): isolate parallel fetch load case

### DIFF
--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -1069,7 +1069,9 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
         await Assert.That(r.Value).IsEqualTo("value-7");
     }
 
-    [Test]
+    // This validates parallel client fetches, not shared-broker saturation. Run alone because
+    // hundreds of concurrent consumer cases can starve the per-session Kafka container.
+    [Test, NotInParallel]
     public async Task Consumer_ParallelFetchFromMultiplePartitions_ConsumesAllMessages()
     {
         // This test verifies that parallel fetches work correctly across multiple partitions


### PR DESCRIPTION
## Summary

- run the six-partition parallel-fetch regression alone so hundreds of concurrent consumer cases cannot starve its shared Kafka container
- preserve behavioral coverage for all 600 records across all six partitions on Kafka 4.0, 4.1, and 4.2
- identify suite-load resource coupling rather than a prefetch-path defect; focused and broad baseline runs both completed the target successfully

## Test plan

- [x] `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj --configuration Release`
- [x] net10 focused test after rebase (3/3)
- [x] net8 focused test (3/3)
- [x] broad consumer/fetch-buffer filter: target passed; unrelated `Consumer_SeekToEnd_SkipsExistingMessages` failure tracked in #1664

The scheduling failure is contention-dependent, so no deterministic red-first unit test exists; the existing three-fixture integration test is the behavioral check.

Closes #1651