### PR TITLE
fix(producer): enforce request size limits

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2261,8 +2261,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         continue;
                     }
 
-                    var failureException = KafkaException.FromErrorCode(partitionResponse.ErrorCode,
-                        $"Produce failed: {partitionResponse.ErrorCode}");
+                    KafkaException failureException = partitionResponse.ErrorCode == ErrorCode.MessageTooLarge
+                        ? new ProduceException(partitionResponse.ErrorCode,
+                            $"Produce failed: {partitionResponse.ErrorCode}")
+                        {
+                            Topic = expectedTopic,
+                            Partition = expectedPartition
+                        }
+                        : KafkaException.FromErrorCode(partitionResponse.ErrorCode,
+                            $"Produce failed: {partitionResponse.ErrorCode}");
                     if (_muteOnSend)
                         UnmutePartition(batch.TopicPartition);
                     try { CompleteInflightEntry(batch); }

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -861,6 +861,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var coalescedBatches = new ReadyBatch[maxCoalesce];
         var coalescedGenerations = new int[maxCoalesce];
         var coalescedCount = 0;
+        // Sum individually framed batch sizes, matching RecordAccumulator.Drain's
+        // conservative request budget across batches from separate drain passes.
+        var coalescedRequestBudgetUsed = 0L;
 
         // Pre-allocate reusable response lookup dictionary to avoid per-response allocation.
         // Single-threaded: only accessed by the send loop, cleared after each use.
@@ -1043,6 +1046,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // ── 5. Coalesce ──
                 coalescedPartitions.Clear();
                 coalescedCount = 0;
+                coalescedRequestBudgetUsed = 0;
 
                 // Drain carry-over into temp list for iteration. Per-partition FIFO order
                 // ensures oldest batch per partition is seen first (Java's Deque.pollFirst).
@@ -1054,7 +1058,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 for (var i = 0; i < drainList.Count; i++)
                 {
                     CoalesceBatch(drainList[i], coalescedBatches, coalescedGenerations, ref coalescedCount,
-                        coalescedPartitions, carryOver);
+                        ref coalescedRequestBudgetUsed, coalescedPartitions, carryOver);
                 }
 
                 // Read from the event channel lazily during coalescing (like main reads
@@ -1077,7 +1081,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             var carryBefore = carryOver.Count;
                             channelReads++;
                             CoalesceBatch(evt.GetBatchReference(), coalescedBatches, coalescedGenerations, ref coalescedCount,
-                                coalescedPartitions, carryOver);
+                                ref coalescedRequestBudgetUsed, coalescedPartitions, carryOver);
                             if (carryOver.Count > carryBefore)
                             {
                                 channelCarryOvers++;
@@ -1125,7 +1129,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         if (evt.Type == SendLoopEventType.NewBatch)
                         {
                             CoalesceBatch(evt.GetBatchReference(), coalescedBatches, coalescedGenerations, ref coalescedCount,
-                                coalescedPartitions, carryOver);
+                                ref coalescedRequestBudgetUsed, coalescedPartitions, carryOver);
                             if (coalescedCount > MicroLingerBatchThreshold)
                                 break;
                         }
@@ -1718,6 +1722,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         ReadyBatch[] coalescedBatches,
         int[] coalescedGenerations,
         ref int coalescedCount,
+        ref long coalescedRequestBudgetUsed,
         HashSet<TopicPartition> coalescedPartitions,
         PartitionCarryOver carryOver)
     {
@@ -1789,7 +1794,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // carry-over — they must retain their retry state and mute status.
             batch.RetryNotBefore = 0;
 
-            if (CarryOverIfCoalescedFull(batchRef, coalescedBatches, coalescedCount, carryOver))
+            if (CarryOverIfCoalescedLimitReached(
+                    batchRef,
+                    coalescedBatches,
+                    coalescedCount,
+                    coalescedRequestBudgetUsed,
+                    carryOver,
+                    out var batchRequestBodySize))
                 return;
 
             if (!coalescedPartitions.Add(batch.TopicPartition))
@@ -1800,7 +1811,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 return;
             }
 
-            AddCoalescedBatch(batchRef, coalescedBatches, coalescedGenerations, ref coalescedCount);
+            AddCoalescedBatch(
+                batchRef,
+                coalescedBatches,
+                coalescedGenerations,
+                ref coalescedCount,
+                ref coalescedRequestBudgetUsed,
+                batchRequestBodySize);
             return;
         }
 
@@ -1816,7 +1833,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return;
         }
 
-        if (CarryOverIfCoalescedFull(batchRef, coalescedBatches, coalescedCount, carryOver))
+        if (CarryOverIfCoalescedLimitReached(
+                batchRef,
+                coalescedBatches,
+                coalescedCount,
+                coalescedRequestBudgetUsed,
+                carryOver,
+                out var normalBatchRequestBodySize))
             return;
 
         // Ensure at most one batch per partition per coalesced request
@@ -1827,18 +1850,39 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return;
         }
 
-        AddCoalescedBatch(batchRef, coalescedBatches, coalescedGenerations, ref coalescedCount);
+        AddCoalescedBatch(
+            batchRef,
+            coalescedBatches,
+            coalescedGenerations,
+            ref coalescedCount,
+            ref coalescedRequestBudgetUsed,
+            normalBatchRequestBodySize);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool CarryOverIfCoalescedFull(
+    private bool CarryOverIfCoalescedLimitReached(
         BatchReference batchRef,
         ReadyBatch[] coalescedBatches,
         int coalescedCount,
-        PartitionCarryOver carryOver)
+        long coalescedRequestBudgetUsed,
+        PartitionCarryOver carryOver,
+        out int batchRequestBodySize)
     {
+        batchRequestBodySize = 0;
         if (coalescedCount < coalescedBatches.Length)
-            return false;
+        {
+            var candidateBatch = batchRef.Batch;
+            batchRequestBodySize = ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+                _options.TransactionalId,
+                candidateBatch.TopicPartition.Topic,
+                candidateBatch.EncodedSize);
+            var maxRequestSize = _options.MaxRequestSize > 0
+                ? _options.MaxRequestSize
+                : ProduceRequestSizeCalculator.DefaultMaxRequestSize;
+            if (coalescedCount == 0
+                || coalescedRequestBudgetUsed + batchRequestBodySize <= maxRequestSize)
+                return false;
+        }
 
         var batch = batchRef.Batch;
         batch.AppendDiag('O');
@@ -1851,13 +1895,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         BatchReference batchRef,
         ReadyBatch[] coalescedBatches,
         int[] coalescedGenerations,
-        ref int coalescedCount)
+        ref int coalescedCount,
+        ref long coalescedRequestBudgetUsed,
+        int batchRequestBodySize)
     {
         var batch = batchRef.Batch;
         batch.AppendDiag('C');
         coalescedBatches[coalescedCount] = batch;
         coalescedGenerations[coalescedCount] = batchRef.Generation;
         coalescedCount++;
+        coalescedRequestBudgetUsed += batchRequestBodySize;
     }
 
     private int CompactCurrentBatches(ReadyBatch[] batches, int[] generations, int count)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Channels;
 using Dekaf.Compression;
 using Dekaf.Errors;
@@ -3164,10 +3163,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var partIdx = 0;
             var runStart = 0;
             var requestBodySizeHint = checked(
-                CompactStringSize(_request.TransactionalId) +
+                ProduceRequestSizeCalculator.CompactStringSize(_request.TransactionalId) +
                 2 + // Acks
                 4 + // TimeoutMs
-                CompactArrayLengthSize(topicCount) +
+                ProduceRequestSizeCalculator.CompactArrayLengthSize(topicCount) +
                 1); // Request tagged fields
 
             // Single pass: populate scratch topic and partition data from contiguous runs
@@ -3184,8 +3183,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 var partitionDataStart = partIdx;
                 requestBodySizeHint = checked(
                     requestBodySizeHint +
-                    CompactStringSize(topicName) +
-                    CompactArrayLengthSize(partCount) +
+                    ProduceRequestSizeCalculator.CompactStringSize(topicName) +
+                    ProduceRequestSizeCalculator.CompactArrayLengthSize(partCount) +
                     1); // Topic tagged fields
 
                 for (var p = 0; p < partCount; p++)
@@ -3198,7 +3197,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     requestBodySizeHint = checked(
                         requestBodySizeHint +
                         4 + // Partition index
-                        CompactBytesLengthSize(batch.EncodedSize) +
+                        ProduceRequestSizeCalculator.CompactBytesLengthSize(batch.EncodedSize) +
                         batch.EncodedSize +
                         1); // Partition tagged fields
                     partIdx++;
@@ -3241,20 +3240,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _lastPartitionCount = 0;
         }
 
-        private static int CompactStringSize(string? value)
-        {
-            if (value is null)
-                return 1;
-
-            var byteCount = Encoding.UTF8.GetByteCount(value);
-            return checked(CompactBytesLengthSize(byteCount) + byteCount);
-        }
-
-        private static int CompactArrayLengthSize(int count)
-            => Record.VarUIntSize((uint)checked(count + 1));
-
-        private static int CompactBytesLengthSize(int byteCount)
-            => Record.VarUIntSize((uint)checked(byteCount + 1));
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/ProduceRequestSizeCalculator.cs
+++ b/src/Dekaf/Producer/ProduceRequestSizeCalculator.cs
@@ -33,15 +33,21 @@ internal static class ProduceRequestSizeCalculator
         if (available <= 1)
             return 0;
 
-        var encodedBatchSize = available - 1;
-        while (true)
+        // Compact-length jumps leave some budgets without an exact fit.
+        // Find the largest batch whose encoded size stays within the available bytes.
+        var lowerBound = 0;
+        var upperBound = available - 1;
+        while (lowerBound < upperBound)
         {
-            var adjustedSize = available - CompactBytesLengthSize(encodedBatchSize);
-            if (adjustedSize == encodedBatchSize)
-                return encodedBatchSize;
-
-            encodedBatchSize = adjustedSize;
+            var candidate = lowerBound + (upperBound - lowerBound + 1) / 2;
+            var encodedSizeWithLength = candidate + CompactBytesLengthSize(candidate);
+            if (encodedSizeWithLength <= available)
+                lowerBound = candidate;
+            else
+                upperBound = candidate - 1;
         }
+
+        return lowerBound;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Producer/ProduceRequestSizeCalculator.cs
+++ b/src/Dekaf/Producer/ProduceRequestSizeCalculator.cs
@@ -1,0 +1,76 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Producer;
+
+internal static class ProduceRequestSizeCalculator
+{
+    internal const int DefaultMaxRequestSize = 1_048_576;
+
+    internal static int GetSingleBatchRequestBodySize(
+        string? transactionalId,
+        string topic,
+        int encodedBatchSize)
+        => GetSingleBatchRequestBodySize(
+            GetSingleBatchFixedSize(transactionalId, topic),
+            encodedBatchSize);
+
+    internal static int GetSingleBatchRequestBodySize(
+        int singleBatchFixedSize,
+        int encodedBatchSize)
+        => checked(
+            singleBatchFixedSize +
+            CompactBytesLengthSize(encodedBatchSize) +
+            encodedBatchSize);
+
+    internal static int GetMaxEncodedBatchSize(
+        int maxRequestSize,
+        string? transactionalId,
+        string topic)
+    {
+        var available = maxRequestSize - GetSingleBatchFixedSize(transactionalId, topic);
+        if (available <= 1)
+            return 0;
+
+        var encodedBatchSize = available - 1;
+        while (true)
+        {
+            var adjustedSize = available - CompactBytesLengthSize(encodedBatchSize);
+            if (adjustedSize == encodedBatchSize)
+                return encodedBatchSize;
+
+            encodedBatchSize = adjustedSize;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int CompactArrayLengthSize(int count)
+        => Record.VarUIntSize((uint)checked(count + 1));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int CompactBytesLengthSize(int byteCount)
+        => Record.VarUIntSize((uint)checked(byteCount + 1));
+
+    internal static int CompactStringSize(string? value)
+    {
+        if (value is null)
+            return 1;
+
+        var byteCount = Encoding.UTF8.GetByteCount(value);
+        return checked(CompactBytesLengthSize(byteCount) + byteCount);
+    }
+
+    internal static int GetSingleBatchFixedSize(string? transactionalId, string topic)
+        => checked(
+            CompactStringSize(transactionalId) +
+            2 + // Acks
+            4 + // TimeoutMs
+            CompactArrayLengthSize(1) + // Topics array
+            CompactStringSize(topic) +
+            CompactArrayLengthSize(1) + // Partitions array
+            4 + // Partition index
+            1 + // Partition tagged fields
+            1 + // Topic tagged fields
+            1); // Request tagged fields
+}

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2651,10 +2651,21 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (Volatile.Read(ref _disposed) != 0)
             return false;
 
-        var recordSize = PartitionBatch.EstimateRecordSize(key.Length, value.Length, headers, headerCount);
-        ThrowIfRecordExceedsMaxRequestSize(
-            topic, partition, key.IsNull, key.Length, value.IsNull, value.Length,
-            headers, headerCount, recordSize);
+        int recordSize;
+        try
+        {
+            recordSize = PartitionBatch.EstimateRecordSize(key.Length, value.Length, headers, headerCount);
+            ThrowIfRecordExceedsMaxRequestSize(
+                topic, partition, key.IsNull, key.Length, value.IsNull, value.Length,
+                headers, headerCount, recordSize);
+        }
+        catch
+        {
+            key.Return();
+            value.Return();
+            ReturnPooledHeaders(headers);
+            throw;
+        }
 
         // Try non-blocking memory reservation. If buffer is full, return false so the
         // caller (ProduceAsync fast path) falls back to the async path.

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2253,6 +2253,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         try
         {
             recordSize = PartitionBatch.EstimateRecordSize(key.Length, value.Length, headers, headerCount);
+            ThrowIfRecordExceedsMaxRequestSize(
+                topic, partition, key.IsNull, key.Length, value.IsNull, value.Length,
+                headers, headerCount, recordSize);
         }
         catch
         {
@@ -2615,6 +2618,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             return false;
 
         var recordSize = PartitionBatch.EstimateRecordSize(key.Length, value.Length, headers, headerCount);
+        ThrowIfRecordExceedsMaxRequestSize(
+            topic, partition, key.IsNull, key.Length, value.IsNull, value.Length,
+            headers, headerCount, recordSize);
 
         // Try non-blocking memory reservation. If buffer is full, return false so the
         // caller (ProduceAsync fast path) falls back to the async path.
@@ -2649,6 +2655,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var keyLength = keyIsNull ? 0 : keyData.Length;
         var valueLength = valueIsNull ? 0 : valueData.Length;
         var recordSize = PartitionBatch.EstimateRecordSize(keyLength, valueLength, headers, headerCount);
+        ThrowIfRecordExceedsMaxRequestSize(
+            topic, partition, keyIsNull, keyLength, valueIsNull, valueLength,
+            headers, headerCount, recordSize);
 
         if (!TryReserveMemory(recordSize))
             return false;
@@ -3036,6 +3045,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         try
         {
             recordSize = PartitionBatch.EstimateRecordSize(keyLength, valueLength, headers, headerCount);
+            ThrowIfRecordExceedsMaxRequestSize(
+                topic, partition, keyIsNull, keyLength, valueIsNull, valueLength,
+                headers, headerCount, recordSize);
         }
         catch
         {
@@ -3055,6 +3067,62 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         return AppendFromSpansSlowPathPooled(topic, partition, timestamp, keyPooled, valuePooled,
             headers, headerCount, callback, recordSize, partitionCount, cancellationToken);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ThrowIfRecordExceedsMaxRequestSize(
+        string topic,
+        int partition,
+        bool keyIsNull,
+        int keyLength,
+        bool valueIsNull,
+        int valueLength,
+        Header[]? headers,
+        int headerCount,
+        int estimatedRecordSize)
+    {
+        var maxRequestSize = _options.MaxRequestSize > 0 ? _options.MaxRequestSize : 1_048_576;
+        if ((long)RecordBatch.TotalBatchHeaderSize + estimatedRecordSize <= maxRequestSize)
+            return;
+
+        ThrowIfRecordExceedsMaxRequestSizeSlow(
+            topic, partition, keyIsNull, keyLength, valueIsNull, valueLength,
+            headers, headerCount, maxRequestSize);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowIfRecordExceedsMaxRequestSizeSlow(
+        string topic,
+        int partition,
+        bool keyIsNull,
+        int keyLength,
+        bool valueIsNull,
+        int valueLength,
+        Header[]? headers,
+        int headerCount,
+        int maxRequestSize)
+    {
+        var bodySize = Record.ComputeBodySize(
+            timestampDelta: 0,
+            offsetDelta: 0,
+            keyIsNull,
+            keyLength,
+            valueIsNull,
+            valueLength,
+            headers,
+            headerCount);
+        var encodedRecordSize = checked(Record.VarIntSize(bodySize) + bodySize);
+        var encodedBatchSize = checked(RecordBatch.TotalBatchHeaderSize + encodedRecordSize);
+        if (encodedBatchSize <= maxRequestSize)
+            return;
+
+        throw new ProduceException(
+            ErrorCode.MessageTooLarge,
+            $"Encoded record batch size {encodedBatchSize} exceeds MaxRequestSize of {maxRequestSize} bytes.")
+        {
+            Topic = topic,
+            Partition = partition
+        };
     }
 
     /// <summary>
@@ -3251,10 +3319,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    // Immediate post-append sealing is limited to LingerMs == 0. Full-batch rotations that
-    // carry a pending overestimate between loop iterations require linger to keep batches open.
     private bool ShouldSealAppendedBatch(PartitionBatch batch)
-        => _options.LingerMs == 0 && batch.ShouldFlush(Stopwatch.GetTimestamp(), _options.LingerMs);
+        => batch.IsExactlyAtSizeLimit
+            || (_options.LingerMs == 0 && batch.ShouldFlush(Stopwatch.GetTimestamp(), _options.LingerMs));
 
     private ReadyBatch? CompleteDetachedBatchAndEnqueue(PartitionDeque pd, PartitionBatch batchToComplete)
     {
@@ -5179,6 +5246,12 @@ internal sealed class PartitionBatch
     public int ReservedSize => _reservedSize;
     public int OverestimatedBytes => Math.Max(0, _reservedSize - _estimatedSize);
     public int CompletionSourcesCount => _completionSourceCount;
+    public bool IsExactlyAtSizeLimit =>
+        (long)RecordBatch.TotalBatchHeaderSize + _encodedRecordsLength == EffectiveBatchSizeLimit;
+
+    private int EffectiveBatchSizeLimit => Math.Min(
+        _options.BatchSize,
+        _options.MaxRequestSize > 0 ? _options.MaxRequestSize : 1_048_576);
 
     internal readonly record struct ReservedRecordAppend(
         BatchArena Arena,
@@ -5406,9 +5479,10 @@ internal sealed class PartitionBatch
             headerCount);
         var encodedRecordSize = checked(Record.VarIntSize(bodySize) + bodySize);
 
-        // Check size limit. BatchSize is the full wire batch budget, so records must
-        // leave room for the fixed RecordBatch header.
-        var maxRecordsSize = Math.Max(0, _options.BatchSize - RecordBatch.TotalBatchHeaderSize);
+        // BatchSize and MaxRequestSize are full wire-batch budgets, so records must
+        // leave room for the fixed RecordBatch header. A first record may exceed
+        // BatchSize via the documented expanded-arena path, but never MaxRequestSize.
+        var maxRecordsSize = Math.Max(0, EffectiveBatchSizeLimit - RecordBatch.TotalBatchHeaderSize);
         if ((long)_estimatedSize + encodedRecordSize > maxRecordsSize && recordIndex > 0)
         {
             reservedAppend = default;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -874,6 +874,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     private readonly ProducerOptions _options;
     private readonly CompressionCodecRegistry? _compressionCodecs;
+    private readonly ConcurrentDictionary<string, int> _singleBatchRequestFixedSizes =
+        new(StringComparer.Ordinal);
 
     /// <summary>
     /// Per-partition deques of sealed ReadyBatches, matching Java's
@@ -1459,7 +1461,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (!_drainIndex.TryGetValue(nodeId, out var startIndex))
             startIndex = 0;
 
-        var size = 0;
+        var size = 0L;
         var count = partitions.Count;
         var now = Stopwatch.GetTimestamp();
         var lastDrainIndex = startIndex;
@@ -1493,6 +1495,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 continue;
 
             ReadyBatch? batch;
+            var batchRequestSize = 0;
             {
                 using var guard = new SpinLockGuard(ref pd.Lock);
                 batch = pd.PeekFirst();
@@ -1512,7 +1515,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     && now < batch.RetryNotBefore)
                     continue;
 
-                var batchRequestSize = batch.EncodedSize;
+                batchRequestSize = ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+                    GetSingleBatchRequestFixedSize(tp.Topic),
+                    batch.EncodedSize);
                 if (ready.Count > 0 && size + batchRequestSize > maxRequestSize)
                 {
                     // Ready() already consumed notifications for all partitions on this node.
@@ -1538,7 +1543,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             {
                 if (_options.EnableDeliveryDiagnostics)
                     batch.AppendDiag('D');
-                size += batch.EncodedSize;
+                size += batchRequestSize;
                 ready.Add(batch);
             }
         }
@@ -3081,13 +3086,23 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int headerCount,
         int estimatedRecordSize)
     {
-        var maxRequestSize = _options.MaxRequestSize > 0 ? _options.MaxRequestSize : 1_048_576;
-        if ((long)RecordBatch.TotalBatchHeaderSize + estimatedRecordSize <= maxRequestSize)
-            return;
+        var maxRequestSize = _options.MaxRequestSize > 0
+            ? _options.MaxRequestSize
+            : ProduceRequestSizeCalculator.DefaultMaxRequestSize;
+        var fixedSize = GetSingleBatchRequestFixedSize(topic);
+        var estimatedBatchSize = (long)RecordBatch.TotalBatchHeaderSize + estimatedRecordSize;
+        if (estimatedBatchSize <= int.MaxValue)
+        {
+            var estimatedRequestBodySize = fixedSize +
+                ProduceRequestSizeCalculator.CompactBytesLengthSize((int)estimatedBatchSize) +
+                estimatedBatchSize;
+            if (estimatedRequestBodySize <= maxRequestSize)
+                return;
+        }
 
         ThrowIfRecordExceedsMaxRequestSizeSlow(
             topic, partition, keyIsNull, keyLength, valueIsNull, valueLength,
-            headers, headerCount, maxRequestSize);
+            headers, headerCount, maxRequestSize, fixedSize);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -3100,7 +3115,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int valueLength,
         Header[]? headers,
         int headerCount,
-        int maxRequestSize)
+        int maxRequestSize,
+        int singleBatchFixedSize)
     {
         var bodySize = Record.ComputeBodySize(
             timestampDelta: 0,
@@ -3113,16 +3129,32 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             headerCount);
         var encodedRecordSize = checked(Record.VarIntSize(bodySize) + bodySize);
         var encodedBatchSize = checked(RecordBatch.TotalBatchHeaderSize + encodedRecordSize);
-        if (encodedBatchSize <= maxRequestSize)
+        var encodedRequestBodySize = ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            singleBatchFixedSize,
+            encodedBatchSize);
+        if (encodedRequestBodySize <= maxRequestSize)
             return;
 
         throw new ProduceException(
             ErrorCode.MessageTooLarge,
-            $"Encoded record batch size {encodedBatchSize} exceeds MaxRequestSize of {maxRequestSize} bytes.")
+            $"Encoded ProduceRequest body size {encodedRequestBodySize} bytes " +
+            $"(record batch {encodedBatchSize} bytes) exceeds MaxRequestSize of {maxRequestSize} bytes.")
         {
             Topic = topic,
             Partition = partition
         };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int GetSingleBatchRequestFixedSize(string topic)
+    {
+        if (_singleBatchRequestFixedSizes.TryGetValue(topic, out var fixedSize))
+            return fixedSize;
+
+        fixedSize = ProduceRequestSizeCalculator.GetSingleBatchFixedSize(
+            _options.TransactionalId,
+            topic);
+        return _singleBatchRequestFixedSizes.GetOrAdd(topic, fixedSize);
     }
 
     /// <summary>
@@ -5082,6 +5114,7 @@ internal sealed class PartitionBatch
     private int _encodedRecordsLength;
     private int _estimatedSize;
     private int _reservedSize;
+    private int _effectiveBatchSizeLimit;
     // Note: _offsetDelta removed - it always equals _recordCount at assignment time
     private long _createdStopwatchTimestamp;
     private int _isCompleted; // 0 = not completed, 1 = completed (Interlocked guard for idempotent Complete)
@@ -5104,6 +5137,7 @@ internal sealed class PartitionBatch
     {
         _topicPartition = topicPartition;
         _options = options;
+        _effectiveBatchSizeLimit = GetEffectiveBatchSizeLimit(topicPartition, options);
         _createdStopwatchTimestamp = Stopwatch.GetTimestamp();
 
         _initialRecordCapacity = options.InitialBatchRecordCapacity > 0
@@ -5170,6 +5204,7 @@ internal sealed class PartitionBatch
     {
         _topicPartition = topicPartition;
         _partitionCount = partitionCount;
+        _effectiveBatchSizeLimit = GetEffectiveBatchSizeLimit(topicPartition, _options);
         _createdStopwatchTimestamp = Stopwatch.GetTimestamp();
         _recordCount = 0;
         _completionSourceCount = 0;
@@ -5249,9 +5284,21 @@ internal sealed class PartitionBatch
     public bool IsExactlyAtSizeLimit =>
         (long)RecordBatch.TotalBatchHeaderSize + _encodedRecordsLength == EffectiveBatchSizeLimit;
 
-    private int EffectiveBatchSizeLimit => Math.Min(
-        _options.BatchSize,
-        _options.MaxRequestSize > 0 ? _options.MaxRequestSize : 1_048_576);
+    private int EffectiveBatchSizeLimit => _effectiveBatchSizeLimit;
+
+    private static int GetEffectiveBatchSizeLimit(
+        TopicPartition topicPartition,
+        ProducerOptions options)
+    {
+        var maxRequestSize = options.MaxRequestSize > 0
+            ? options.MaxRequestSize
+            : ProduceRequestSizeCalculator.DefaultMaxRequestSize;
+        var maxEncodedBatchSize = ProduceRequestSizeCalculator.GetMaxEncodedBatchSize(
+            maxRequestSize,
+            options.TransactionalId,
+            topicPartition.Topic ?? string.Empty);
+        return Math.Min(options.BatchSize, maxEncodedBatchSize);
+    }
 
     internal readonly record struct ReservedRecordAppend(
         BatchArena Arena,

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1496,6 +1496,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
             ReadyBatch? batch;
             var batchRequestSize = 0;
+            var oversizedBatch = false;
             {
                 using var guard = new SpinLockGuard(ref pd.Lock);
                 batch = pd.PeekFirst();
@@ -1518,7 +1519,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 batchRequestSize = ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
                     GetSingleBatchRequestFixedSize(tp.Topic),
                     batch.EncodedSize);
-                if (ready.Count > 0 && size + batchRequestSize > maxRequestSize)
+                oversizedBatch = batchRequestSize > maxRequestSize;
+                if (!oversizedBatch && ready.Count > 0 && size + batchRequestSize > maxRequestSize)
                 {
                     // Ready() already consumed notifications for all partitions on this node.
                     // Re-enqueue this and remaining partitions so they aren't orphaned.
@@ -1541,6 +1543,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
             if (batch is not null)
             {
+                if (oversizedBatch)
+                {
+                    FailOversizedBatch(batch, batchRequestSize, maxRequestSize);
+                    continue;
+                }
+
                 if (_options.EnableDeliveryDiagnostics)
                     batch.AppendDiag('D');
                 size += batchRequestSize;
@@ -1551,6 +1559,27 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         _drainIndex[nodeId] = lastDrainIndex;
         if (reenqueueLeaderChanges)
             SignalWakeup();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void FailOversizedBatch(ReadyBatch batch, int requestBodySize, int maxRequestSize)
+    {
+        var topicPartition = batch.TopicPartition;
+        var exception = new ProduceException(
+            ErrorCode.MessageTooLarge,
+            $"Encoded ProduceRequest body size {requestBodySize} bytes " +
+            $"(record batch {batch.EncodedSize} bytes) exceeds MaxRequestSize of {maxRequestSize} bytes.")
+        {
+            Topic = topicPartition.Topic,
+            Partition = topicPartition.Partition
+        };
+
+        FailBatchAndCleanup(
+            batch,
+            exception,
+            beforeFailure: null,
+            removeFromPipeline: true,
+            returnToPool: true);
     }
 
     /// <summary>
@@ -4519,7 +4548,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         foreach (var batch in readyBatches)
         {
-            FailPurgedBatch(
+            FailBatchAndCleanup(
                 batch,
                 exception,
                 onPurgingBatch,
@@ -4574,7 +4603,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             if (!OnBatchExitsPipeline(batch))
                 continue;
 
-            FailPurgedBatch(
+            FailBatchAndCleanup(
                 batch,
                 exception,
                 onPurgingBatch,
@@ -4595,14 +4624,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return pd.Contains(batch);
     }
 
-    private void FailPurgedBatch(
+    private void FailBatchAndCleanup(
         ReadyBatch batch,
         Exception exception,
-        Action<ReadyBatch>? onPurgingBatch,
+        Action<ReadyBatch>? beforeFailure,
         bool removeFromPipeline,
         bool returnToPool)
     {
-        try { onPurgingBatch?.Invoke(batch); }
+        try { beforeFailure?.Invoke(batch); }
         catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx); }
         try { batch.Fail(exception); }
         catch (Exception failEx) { LogBatchCleanupStepFailed(failEx); }

--- a/tests/Dekaf.Tests.Integration/ProducerLimitBoundaryTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerLimitBoundaryTests.cs
@@ -1,0 +1,178 @@
+using System.Diagnostics;
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Diagnostics;
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Producer")]
+public sealed class ProducerLimitBoundaryTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    private const int BoundarySize = 1_024;
+    private const int TraceparentValueLength = 55;
+    private static readonly Header[] InjectedTraceHeaders =
+        [new("traceparent", new byte[TraceparentValueLength])];
+
+    [Test]
+    public async Task MaxRequestSize_ExactBatchSucceeds_OneByteOverIsRejectedLocallyWithoutDrop()
+    {
+        using var activityListener = ListenToDekafActivities();
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var exactPayload = CreatePayloadForEncodedBatchSize(BoundarySize);
+        var oversizedPayload = new byte[exactPayload.Length + 1];
+        oversizedPayload.AsSpan().Fill(0x2A);
+        var sentinel = new byte[] { 0x7F };
+
+        await Assert.That(GetEncodedBatchSize(oversizedPayload.Length)).IsEqualTo(BoundarySize + 1);
+
+        await using var producer = await Kafka.CreateProducer<byte[], byte[]>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("request-boundary-producer")
+            .WithAcks(Acks.All)
+            .WithBatchSize(BoundarySize * 2)
+            .WithMaxRequestSize(BoundarySize)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var exactResult = await producer.ProduceAsync(topic, null, exactPayload);
+
+        var exception = await Assert.That(async () =>
+        {
+            await producer.ProduceAsync(topic, null, oversizedPayload);
+        }).Throws<ProduceException>();
+
+        var sentinelResult = await producer.ProduceAsync(topic, null, sentinel);
+
+        await Assert.That(exactResult.Offset).IsEqualTo(0);
+        await Assert.That(sentinelResult.Offset).IsEqualTo(1);
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.MessageTooLarge);
+        await Assert.That(exception.Topic).IsEqualTo(topic);
+        await Assert.That(exception.Partition).IsEqualTo(0);
+
+        await AssertOnlyExpectedRecords(topic, exactPayload, sentinel);
+    }
+
+    [Test]
+    public async Task BrokerMessageMaxBytes_ExactBatchSucceeds_OneByteOverIsRejectedWithoutDrop()
+    {
+        using var activityListener = ListenToDekafActivities();
+        var topic = $"broker-size-boundary-{Guid.NewGuid():N}";
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .Build();
+
+        await admin.CreateTopicsAsync([
+            new NewTopic
+            {
+                Name = topic,
+                NumPartitions = 1,
+                ReplicationFactor = 1,
+                Configs = new Dictionary<string, string>
+                {
+                    ["max.message.bytes"] = BoundarySize.ToString()
+                }
+            }
+        ]);
+
+        var exactPayload = CreatePayloadForEncodedBatchSize(BoundarySize);
+        var oversizedPayload = new byte[exactPayload.Length + 1];
+        oversizedPayload.AsSpan().Fill(0x3B);
+        var sentinel = new byte[] { 0x6E };
+
+        await using var producer = await Kafka.CreateProducer<byte[], byte[]>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("broker-boundary-producer")
+            .WithAcks(Acks.All)
+            .WithBatchSize(BoundarySize * 4)
+            .WithMaxRequestSize(BoundarySize * 4)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var exactResult = await producer.ProduceAsync(topic, null, exactPayload);
+
+        var exception = await Assert.That(async () =>
+        {
+            await producer.ProduceAsync(topic, null, oversizedPayload);
+        }).Throws<ProduceException>();
+
+        var sentinelResult = await producer.ProduceAsync(topic, null, sentinel);
+
+        await Assert.That(exactResult.Offset).IsEqualTo(0);
+        await Assert.That(sentinelResult.Offset).IsEqualTo(1);
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.MessageTooLarge);
+        await Assert.That(exception.Topic).IsEqualTo(topic);
+        await Assert.That(exception.Partition).IsEqualTo(0);
+
+        await AssertOnlyExpectedRecords(topic, exactPayload, sentinel);
+    }
+
+    private async Task AssertOnlyExpectedRecords(string topic, byte[] firstValue, byte[] secondValue)
+    {
+        await using var consumer = await Kafka.CreateConsumer<byte[], byte[]>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"boundary-consumer-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        var first = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30));
+        var second = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30));
+        var unexpected = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+
+        await Assert.That(first).IsNotNull();
+        await Assert.That(first!.Value.Value).IsEquivalentTo(firstValue);
+        await Assert.That(second).IsNotNull();
+        await Assert.That(second!.Value.Value).IsEquivalentTo(secondValue);
+        await Assert.That(unexpected).IsNull();
+    }
+
+    private static byte[] CreatePayloadForEncodedBatchSize(int targetSize)
+    {
+        for (var payloadLength = 0; payloadLength < targetSize; payloadLength++)
+        {
+            var encodedSize = GetEncodedBatchSize(payloadLength);
+            if (encodedSize == targetSize)
+                return new byte[payloadLength];
+            if (encodedSize > targetSize)
+                break;
+        }
+
+        throw new InvalidOperationException($"No single-record payload encodes to exactly {targetSize} bytes.");
+    }
+
+    private static int GetEncodedBatchSize(int payloadLength)
+    {
+        var bodySize = Record.ComputeBodySize(
+            timestampDelta: 0,
+            offsetDelta: 0,
+            isKeyNull: true,
+            keyLength: 0,
+            isValueNull: false,
+            valueLength: payloadLength,
+            headers: InjectedTraceHeaders,
+            headerCount: InjectedTraceHeaders.Length);
+        return RecordBatch.TotalBatchHeaderSize + Record.VarIntSize(bodySize) + bodySize;
+    }
+
+    private static ActivityListener ListenToDekafActivities()
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == DekafDiagnostics.ActivitySourceName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            SampleUsingParentId = static (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ProducerLimitBoundaryTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerLimitBoundaryTests.cs
@@ -19,16 +19,27 @@ public sealed class ProducerLimitBoundaryTests(KafkaTestContainer kafka) : Kafka
         [new("traceparent", new byte[TraceparentValueLength])];
 
     [Test]
-    public async Task MaxRequestSize_ExactBatchSucceeds_OneByteOverIsRejectedLocallyWithoutDrop()
+    public async Task MaxRequestSize_ExactRequestSucceeds_OneByteOverIsRejectedLocallyWithoutDrop()
     {
         using var activityListener = ListenToDekafActivities();
         var topic = await KafkaContainer.CreateTestTopicAsync();
-        var exactPayload = CreatePayloadForEncodedBatchSize(BoundarySize);
+        var maxEncodedBatchSize = ProduceRequestSizeCalculator.GetMaxEncodedBatchSize(
+            BoundarySize,
+            transactionalId: null,
+            topic);
+        var exactPayload = CreatePayloadForEncodedBatchSize(maxEncodedBatchSize);
         var oversizedPayload = new byte[exactPayload.Length + 1];
         oversizedPayload.AsSpan().Fill(0x2A);
         var sentinel = new byte[] { 0x7F };
 
-        await Assert.That(GetEncodedBatchSize(oversizedPayload.Length)).IsEqualTo(BoundarySize + 1);
+        await Assert.That(ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            transactionalId: null,
+            topic,
+            GetEncodedBatchSize(exactPayload.Length))).IsEqualTo(BoundarySize);
+        await Assert.That(ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            transactionalId: null,
+            topic,
+            GetEncodedBatchSize(oversizedPayload.Length))).IsEqualTo(BoundarySize + 1);
 
         await using var producer = await Kafka.CreateProducer<byte[], byte[]>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -38,7 +38,8 @@ public sealed class BrokerSenderMuteOrderingTests
 
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 0, int retryBackoffMaxMs = 0,
-        int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000) => new()
+        int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000,
+        int maxRequestSize = 1_048_576) => new()
         {
             BootstrapServers = ["localhost:9092"],
             MaxInFlightRequestsPerConnection = maxInFlight,
@@ -47,6 +48,7 @@ public sealed class BrokerSenderMuteOrderingTests
             RetryBackoffMs = retryBackoffMs,
             RetryBackoffMaxMs = retryBackoffMaxMs,
             RequestTimeoutMs = requestTimeoutMs,
+            MaxRequestSize = maxRequestSize,
             LingerMs = 0
         };
 
@@ -261,12 +263,23 @@ public sealed class BrokerSenderMuteOrderingTests
         object carryOver,
         int? capturedGeneration = null)
     {
+        var coalescedRequestBudgetUsed = 0L;
+        for (var i = 0; i < coalescedCount; i++)
+        {
+            var existingBatch = coalescedBatches[i];
+            coalescedRequestBudgetUsed += ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+                transactionalId: null,
+                existingBatch.TopicPartition.Topic,
+                existingBatch.EncodedSize);
+        }
+
         var args = new object?[]
         {
             CreateBatchReference(batch, capturedGeneration ?? batch.Generation),
             coalescedBatches,
             coalescedGenerations,
             coalescedCount,
+            coalescedRequestBudgetUsed,
             coalescedPartitions,
             carryOver
         };
@@ -326,6 +339,64 @@ public sealed class BrokerSenderMuteOrderingTests
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task CoalesceBatch_SeparateDrainPasses_RespectsMaxRequestSizeBudget()
+    {
+        const string topic = "test-topic";
+        const int encodedBatchSize = 100;
+        var maxRequestSize = ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            transactionalId: null,
+            topic,
+            encodedBatchSize);
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
+        var (pool, _) = CreateMockConnection(responseQueue);
+        var options = CreateOptions(maxRequestSize: maxRequestSize);
+        var accumulator = new RecordAccumulator(options);
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            var firstBatch = CreateMinimalBatch(topic, partition: 0);
+            var secondBatch = CreateMinimalBatch(topic, partition: 1);
+            var coalescedBatches = new ReadyBatch[4];
+            var coalescedGenerations = new int[4];
+            var coalescedCount = 0;
+            var coalescedPartitions = new HashSet<TopicPartition>();
+            var carryOver = CreateCarryOver();
+
+            // Simulate batches arriving from separate accumulator drain passes. Each batch
+            // exactly fills MaxRequestSize after ProduceRequest framing, so only one can be sent.
+            InvokeCoalesceBatch(
+                sender,
+                firstBatch,
+                coalescedBatches,
+                coalescedGenerations,
+                ref coalescedCount,
+                coalescedPartitions,
+                carryOver);
+            InvokeCoalesceBatch(
+                sender,
+                secondBatch,
+                coalescedBatches,
+                coalescedGenerations,
+                ref coalescedCount,
+                coalescedPartitions,
+                carryOver);
+
+            await Assert.That(firstBatch.EncodedSize).IsEqualTo(encodedBatchSize);
+            await Assert.That(maxRequestSize).IsGreaterThan(encodedBatchSize);
+            await Assert.That(coalescedCount).IsEqualTo(1);
+            await Assert.That(coalescedBatches[0]).IsSameReferenceAs(firstBatch);
+            await Assert.That(GetCarryOverCount(carryOver)).IsEqualTo(1);
+            await Assert.That(coalescedPartitions.Contains(secondBatch.TopicPartition)).IsFalse();
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using Dekaf.Compression;
+using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Producer;
 using Dekaf.Protocol;
@@ -1032,11 +1033,16 @@ public class RecordAccumulatorReadyTests
         accumulator.Ready(metadataManager, readyNodes);
         await Assert.That(readyNodes).Contains(1);
 
-        // Drain with a tiny maxRequestSize so only 1 partition's batch fits.
-        // This should re-enqueue notifications for the other 2 partitions.
+        // Budget exactly one framed batch so the other 2 partitions are skipped.
+        // This should re-enqueue notifications for both skipped partitions.
+        var firstBatch = PeekFirstReadyBatch(accumulator, "test-topic", partition: 0);
+        var maxRequestSize = ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            transactionalId: null,
+            "test-topic",
+            firstBatch.EncodedSize);
         var drainResult = new Dictionary<int, List<ReadyBatch>>();
         var batchListPool = new Stack<List<ReadyBatch>>();
-        accumulator.Drain(metadataManager, readyNodes, maxRequestSize: 1, drainResult, batchListPool);
+        accumulator.Drain(metadataManager, readyNodes, maxRequestSize, drainResult, batchListPool);
 
         // Verify only 1 batch was drained (maxRequestSize too small for more)
         await Assert.That(drainResult).ContainsKey(1);
@@ -1096,6 +1102,73 @@ public class RecordAccumulatorReadyTests
             batchListPool);
 
         await Assert.That(drainResult[1]).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Drain_CompressedHeadExceedsMaxRequestSize_FailsLocally()
+    {
+        const string topic = "test-topic";
+        const int maxRequestSize = 256;
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 100_000,
+            MaxRequestSize = maxRequestSize,
+            LingerMs = 0,
+            CompressionType = CompressionType.Gzip
+        };
+        var compressionCodecs = new CompressionCodecRegistry();
+        compressionCodecs.Register(new ExpandingCompressionCodec(
+            CompressionType.Gzip,
+            compressedSize: maxRequestSize));
+
+        await using var accumulator = new RecordAccumulator(options, compressionCodecs);
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        await using var metadataManager = CreateMetadataManager(topic, partitionCount: 1, nodeId: 1);
+        var completion = pool.Rent();
+        var completionTask = completion.Task;
+
+        var appended = await accumulator.AppendAsync(
+            topic,
+            partition: 0,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            PooledMemory.Null,
+            PooledMemory.Null,
+            headers: null,
+            headerCount: 0,
+            completion,
+            callback: null,
+            CancellationToken.None);
+        await Assert.That(appended).IsTrue();
+
+        var readyNodes = new HashSet<int>();
+        await TestWait.UntilAsync(
+            () =>
+            {
+                readyNodes.Clear();
+                accumulator.Ready(metadataManager, readyNodes);
+                return readyNodes.Contains(1);
+            },
+            TimeSpan.FromSeconds(5));
+
+        var drainResult = new Dictionary<int, List<ReadyBatch>>();
+        var batchListPool = new Stack<List<ReadyBatch>>();
+        accumulator.Drain(
+            metadataManager,
+            readyNodes,
+            maxRequestSize,
+            drainResult,
+            batchListPool);
+
+        await Assert.That(drainResult).DoesNotContainKey(1);
+        var exception = await Assert.ThrowsAsync<ProduceException>(async () => await completionTask);
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.MessageTooLarge);
+        await Assert.That(exception.Topic).IsEqualTo(topic);
+        await Assert.That(exception.Partition).IsEqualTo(0);
+        await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        await Assert.That(accumulator.HasPendingWork()).IsFalse();
     }
 
     [Test]
@@ -1439,6 +1512,25 @@ public class RecordAccumulatorReadyTests
             Interlocked.Increment(ref _compressCount);
             foreach (var segment in source)
                 destination.Write(segment.Span);
+        }
+
+        public void Decompress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+        {
+            foreach (var segment in source)
+                destination.Write(segment.Span);
+        }
+    }
+
+    private sealed class ExpandingCompressionCodec(CompressionType type, int compressedSize)
+        : ICompressionCodec
+    {
+        public CompressionType Type { get; } = type;
+
+        public void Compress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+        {
+            var output = destination.GetSpan(compressedSize)[..compressedSize];
+            output.Clear();
+            destination.Advance(compressedSize);
         }
 
         public void Decompress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -1050,6 +1050,55 @@ public class RecordAccumulatorReadyTests
     }
 
     [Test]
+    public async Task Drain_MaxRequestSizeBudgetIncludesProduceRequestFraming()
+    {
+        const string topic = "test-topic";
+        var options = CreateTestOptions(batchSize: 50, lingerMs: 10_000);
+        await using var accumulator = new RecordAccumulator(options);
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        await using var metadataManager = CreateMetadataManager(topic, partitionCount: 2, nodeId: 1);
+        var nullMemory = new PooledMemory(null, 0, isNull: true);
+
+        for (var partition = 0; partition < 2; partition++)
+        {
+            for (var record = 0; record < 2; record++)
+            {
+                var appended = accumulator.TryAppendWithCompletion(
+                    topic,
+                    partition,
+                    DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    nullMemory,
+                    nullMemory,
+                    headers: null,
+                    headerCount: 0,
+                    pool.Rent());
+                await Assert.That(appended).IsTrue();
+            }
+        }
+
+        var firstBatch = PeekFirstReadyBatch(accumulator, topic, partition: 0);
+        var secondBatch = PeekFirstReadyBatch(accumulator, topic, partition: 1);
+        var encodedBatchesOnlyBudget = firstBatch.EncodedSize + secondBatch.EncodedSize;
+        await Assert.That(ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            transactionalId: null,
+            topic,
+            firstBatch.EncodedSize)).IsLessThanOrEqualTo(encodedBatchesOnlyBudget);
+
+        var readyNodes = new HashSet<int>();
+        accumulator.Ready(metadataManager, readyNodes);
+        var drainResult = new Dictionary<int, List<ReadyBatch>>();
+        var batchListPool = new Stack<List<ReadyBatch>>();
+        accumulator.Drain(
+            metadataManager,
+            readyNodes,
+            encodedBatchesOnlyBudget,
+            drainResult,
+            batchListPool);
+
+        await Assert.That(drainResult[1]).Count().IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Drain_MultipleBatchesSamePartition_ReenqueuesRemaining()
     {
         // Regression test: when PollFirst drains one batch from a partition that has
@@ -1491,6 +1540,18 @@ public class RecordAccumulatorReadyTests
             BindingFlags.NonPublic | BindingFlags.Instance,
             [typeof(string), typeof(int)]);
         return method!.Invoke(accumulator, [topic, partition])!;
+    }
+
+    private static ReadyBatch PeekFirstReadyBatch(
+        RecordAccumulator accumulator,
+        string topic,
+        int partition)
+    {
+        var partitionDeque = GetPartitionDeque(accumulator, topic, partition);
+        var method = partitionDeque.GetType().GetMethod(
+            "PeekFirst",
+            BindingFlags.Public | BindingFlags.Instance);
+        return (ReadyBatch)method!.Invoke(partitionDeque, null)!;
     }
 
     private static void SetInstanceField<T>(object instance, string fieldName, T value)

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1034,19 +1034,24 @@ public class RecordAccumulatorTests
     }
 
     [Test]
-    public async Task AppendFromSpansAsync_RecordExactlyAtMaxRequestSize_SealsAndAppends()
+    public async Task AppendFromSpansAsync_RequestExactlyAtMaxRequestSize_SealsAndAppends()
     {
+        const string topic = "test-topic";
         const int valueLength = 32;
-        var maxRequestSize = RecordBatch.TotalBatchHeaderSize + EncodedRecordSize(
+        var encodedBatchSize = RecordBatch.TotalBatchHeaderSize + EncodedRecordSize(
             timestampDelta: 0,
             offsetDelta: 0,
             valueLength);
+        var maxRequestSize = ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            transactionalId: null,
+            topic,
+            encodedBatchSize);
         var options = new ProducerOptions
         {
-            BootstrapServers = new[] { "localhost:9092" },
+            BootstrapServers = ["localhost:9092"],
             ClientId = "test-producer",
             BufferMemory = ulong.MaxValue,
-            BatchSize = maxRequestSize * 2,
+            BatchSize = encodedBatchSize * 2,
             MaxRequestSize = maxRequestSize,
             LingerMs = 10_000
         };
@@ -1055,7 +1060,7 @@ public class RecordAccumulatorTests
         var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
         var appended = await accumulator.AppendFromSpansAsync(
-            "test-topic",
+            topic,
             partition: 0,
             timestamp,
             ReadOnlySpan<byte>.Empty,
@@ -1070,26 +1075,30 @@ public class RecordAccumulatorTests
 
         await Assert.That(appended).IsTrue();
         await Assert.That(accumulator.TryDrainBatch(out var readyBatch)).IsTrue();
-        await Assert.That(readyBatch!.RecordBatch.GetEncodedSize()).IsEqualTo(maxRequestSize);
+        await Assert.That(readyBatch!.RecordBatch.GetEncodedSize()).IsEqualTo(encodedBatchSize);
+        await Assert.That(ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            transactionalId: null,
+            topic,
+            readyBatch.EncodedSize)).IsEqualTo(maxRequestSize);
 
         readyBatch.CompleteSend(baseOffset: 0, DateTimeOffset.FromUnixTimeMilliseconds(timestamp));
     }
 
     [Test]
-    public async Task AppendFromSpansAsync_RecordOneByteOverMaxRequestSize_ThrowsTypedLocalRejection()
+    public async Task AppendFromSpansAsync_BatchFitsButRequestFramingExceedsMax_Throws()
     {
-        const int maxValueLength = 32;
-        var maxRequestSize = RecordBatch.TotalBatchHeaderSize + EncodedRecordSize(
+        const int valueLength = 32;
+        var encodedBatchSize = RecordBatch.TotalBatchHeaderSize + EncodedRecordSize(
             timestampDelta: 0,
             offsetDelta: 0,
-            valueLength: maxValueLength);
+            valueLength);
         var options = new ProducerOptions
         {
-            BootstrapServers = new[] { "localhost:9092" },
+            BootstrapServers = ["localhost:9092"],
             ClientId = "test-producer",
             BufferMemory = ulong.MaxValue,
-            BatchSize = maxRequestSize * 2,
-            MaxRequestSize = maxRequestSize,
+            BatchSize = encodedBatchSize * 2,
+            MaxRequestSize = encodedBatchSize,
             LingerMs = 10_000
         };
 
@@ -1098,6 +1107,82 @@ public class RecordAccumulatorTests
         {
             await accumulator.AppendFromSpansAsync(
                 "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                new byte[valueLength],
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 1);
+        }).Throws<ProduceException>();
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.MessageTooLarge);
+        await Assert.That(exception.Topic).IsEqualTo("test-topic");
+        await Assert.That(exception.Partition).IsEqualTo(0);
+        await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        await Assert.That(accumulator.HasPendingWork()).IsFalse();
+    }
+
+    [Test]
+    [Arguments(64)]
+    [Arguments(127)]
+    [Arguments(128)]
+    [Arguments(129)]
+    [Arguments(16_383)]
+    [Arguments(16_384)]
+    [Arguments(1_048_576)]
+    public async Task ProduceRequestSizeCalculator_MaxBatchExactlyFillsBudget(int maxRequestSize)
+    {
+        const string transactionalId = "transactional-id";
+        const string topic = "tøpic";
+        var maxEncodedBatchSize = ProduceRequestSizeCalculator.GetMaxEncodedBatchSize(
+            maxRequestSize,
+            transactionalId,
+            topic);
+
+        await Assert.That(ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            transactionalId,
+            topic,
+            maxEncodedBatchSize)).IsEqualTo(maxRequestSize);
+        await Assert.That(ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            transactionalId,
+            topic,
+            maxEncodedBatchSize + 1)).IsGreaterThan(maxRequestSize);
+    }
+
+    [Test]
+    public async Task AppendFromSpansAsync_RecordOneByteOverMaxRequestSize_ThrowsTypedLocalRejection()
+    {
+        const string topic = "test-topic";
+        const int maxValueLength = 32;
+        var maxEncodedBatchSize = RecordBatch.TotalBatchHeaderSize + EncodedRecordSize(
+            timestampDelta: 0,
+            offsetDelta: 0,
+            valueLength: maxValueLength);
+        var maxRequestSize = ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            transactionalId: null,
+            topic,
+            maxEncodedBatchSize);
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = maxEncodedBatchSize * 2,
+            MaxRequestSize = maxRequestSize,
+            LingerMs = 10_000
+        };
+
+        await using var accumulator = new RecordAccumulator(options);
+        var exception = await Assert.That(async () =>
+        {
+            await accumulator.AppendFromSpansAsync(
+                topic,
                 partition: 0,
                 DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                 ReadOnlySpan<byte>.Empty,
@@ -1113,7 +1198,7 @@ public class RecordAccumulatorTests
 
         await Assert.That(exception).IsNotNull();
         await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.MessageTooLarge);
-        await Assert.That(exception.Topic).IsEqualTo("test-topic");
+        await Assert.That(exception.Topic).IsEqualTo(topic);
         await Assert.That(exception.Partition).IsEqualTo(0);
         await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
         await Assert.That(accumulator.HasPendingWork()).IsFalse();

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1034,6 +1034,134 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task AppendFromSpansAsync_RecordExactlyAtMaxRequestSize_SealsAndAppends()
+    {
+        const int valueLength = 32;
+        var maxRequestSize = RecordBatch.TotalBatchHeaderSize + EncodedRecordSize(
+            timestampDelta: 0,
+            offsetDelta: 0,
+            valueLength);
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = maxRequestSize * 2,
+            MaxRequestSize = maxRequestSize,
+            LingerMs = 10_000
+        };
+
+        await using var accumulator = new RecordAccumulator(options);
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        var appended = await accumulator.AppendFromSpansAsync(
+            "test-topic",
+            partition: 0,
+            timestamp,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            new byte[valueLength],
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(appended).IsTrue();
+        await Assert.That(accumulator.TryDrainBatch(out var readyBatch)).IsTrue();
+        await Assert.That(readyBatch!.RecordBatch.GetEncodedSize()).IsEqualTo(maxRequestSize);
+
+        readyBatch.CompleteSend(baseOffset: 0, DateTimeOffset.FromUnixTimeMilliseconds(timestamp));
+    }
+
+    [Test]
+    public async Task AppendFromSpansAsync_RecordOneByteOverMaxRequestSize_ThrowsTypedLocalRejection()
+    {
+        const int maxValueLength = 32;
+        var maxRequestSize = RecordBatch.TotalBatchHeaderSize + EncodedRecordSize(
+            timestampDelta: 0,
+            offsetDelta: 0,
+            valueLength: maxValueLength);
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = maxRequestSize * 2,
+            MaxRequestSize = maxRequestSize,
+            LingerMs = 10_000
+        };
+
+        await using var accumulator = new RecordAccumulator(options);
+        var exception = await Assert.That(async () =>
+        {
+            await accumulator.AppendFromSpansAsync(
+                "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                new byte[maxValueLength + 1],
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 1);
+        }).Throws<ProduceException>();
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.MessageTooLarge);
+        await Assert.That(exception.Topic).IsEqualTo("test-topic");
+        await Assert.That(exception.Partition).IsEqualTo(0);
+        await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        await Assert.That(accumulator.HasPendingWork()).IsFalse();
+    }
+
+    [Test]
+    public async Task AppendFromSpansAsync_RecordExactlyAtBatchSize_SealsImmediately()
+    {
+        const int valueLength = 32;
+        var batchSize = RecordBatch.TotalBatchHeaderSize + EncodedRecordSize(
+            timestampDelta: 0,
+            offsetDelta: 0,
+            valueLength);
+        var options = new ProducerOptions
+        {
+            BootstrapServers = new[] { "localhost:9092" },
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = batchSize,
+            MaxRequestSize = batchSize * 2,
+            LingerMs = 10_000
+        };
+
+        await using var accumulator = new RecordAccumulator(options);
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        var appended = await accumulator.AppendFromSpansAsync(
+            "test-topic",
+            partition: 0,
+            timestamp,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            new byte[valueLength],
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(appended).IsTrue();
+        await Assert.That(accumulator.TryDrainBatch(out var readyBatch)).IsTrue();
+        await Assert.That(readyBatch!.RecordBatch.GetEncodedSize()).IsEqualTo(batchSize);
+
+        readyBatch.CompleteSend(baseOffset: 0, DateTimeOffset.FromUnixTimeMilliseconds(timestamp));
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_ArenaFullBeforeBatchSize_RotatesAndPreservesRecords()
     {
         var options = new ProducerOptions

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1156,6 +1156,36 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    [Arguments(128, 126)]
+    [Arguments(16_385, 16_382)]
+    public async Task ProduceRequestSizeCalculator_SkippedVarintBudget_ReturnsLargestFittingBatch(
+        int available,
+        int expectedBatchSize)
+    {
+        const string topic = "t";
+        var fixedSize = ProduceRequestSizeCalculator.GetSingleBatchFixedSize(
+            transactionalId: null,
+            topic);
+        var maxRequestSize = fixedSize + available;
+
+        // Keep a non-termination regression from hanging the whole test process.
+        var maxEncodedBatchSize = await Task.Run(() =>
+                ProduceRequestSizeCalculator.GetMaxEncodedBatchSize(
+                    maxRequestSize,
+                    transactionalId: null,
+                    topic))
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(maxEncodedBatchSize).IsEqualTo(expectedBatchSize);
+        await Assert.That(ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            fixedSize,
+            maxEncodedBatchSize)).IsLessThanOrEqualTo(maxRequestSize);
+        await Assert.That(ProduceRequestSizeCalculator.GetSingleBatchRequestBodySize(
+            fixedSize,
+            maxEncodedBatchSize + 1)).IsGreaterThan(maxRequestSize);
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_RecordOneByteOverMaxRequestSize_ThrowsTypedLocalRejection()
     {
         const string topic = "test-topic";

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1129,6 +1129,64 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    [NotInParallel]
+    public async Task TryAppendWithCompletion_OversizedRecord_ReturnsPooledResources()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 1_024,
+            MaxRequestSize = 64,
+            LingerMs = 10_000
+        };
+
+        await using var accumulator = new RecordAccumulator(options);
+        await using var completionPool = new ValueTaskSourcePool<RecordMetadata>();
+        var keyArray = ProducerDataPool.BytePool.Rent(16);
+        var valueArray = ProducerDataPool.BytePool.Rent(128);
+        var headers = ProducerContainerPools.Headers.Rent(1);
+        headers[0] = new Header("test", new byte[] { 1 });
+        var completion = completionPool.Rent();
+
+        await Assert.That(() => accumulator.TryAppendWithCompletion(
+                "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                new PooledMemory(keyArray, 16),
+                new PooledMemory(valueArray, 128),
+                headers,
+                headerCount: 1,
+                completion,
+                partitionCount: 1))
+            .Throws<ProduceException>();
+
+        completionPool.Return(completion);
+
+        var returnedKeyArray = ProducerDataPool.BytePool.Rent(16);
+        var returnedValueArray = ProducerDataPool.BytePool.Rent(128);
+        var returnedHeaders = ProducerContainerPools.Headers.Rent(1);
+        var keyReturned = ReferenceEquals(returnedKeyArray, keyArray);
+        var valueReturned = ReferenceEquals(returnedValueArray, valueArray);
+        var headersReturned = ReferenceEquals(returnedHeaders, headers);
+
+        ProducerDataPool.BytePool.Return(returnedKeyArray, clearArray: false);
+        ProducerDataPool.BytePool.Return(returnedValueArray, clearArray: false);
+        ProducerContainerPools.Headers.Return(returnedHeaders, clearArray: true);
+        if (!keyReturned)
+            ProducerDataPool.BytePool.Return(keyArray, clearArray: false);
+        if (!valueReturned)
+            ProducerDataPool.BytePool.Return(valueArray, clearArray: false);
+        if (!headersReturned)
+            ProducerContainerPools.Headers.Return(headers, clearArray: true);
+
+        await Assert.That(keyReturned).IsTrue();
+        await Assert.That(valueReturned).IsTrue();
+        await Assert.That(headersReturned).IsTrue();
+    }
+
+    [Test]
     [Arguments(64)]
     [Arguments(127)]
     [Arguments(128)]


### PR DESCRIPTION
## Summary
- reject records whose exact encoded batch exceeds `MaxRequestSize` before buffer reservation
- seal batches exactly at `BatchSize` or `MaxRequestSize` while preserving the oversize-record path
- surface broker `MessageTooLarge` responses as contextual `ProduceException` failures
- verify exact and one-byte-over request/broker boundaries without silent delivery

## Test plan
- [x] Release builds: unit and integration projects, net8.0 + net10.0
- [x] focused boundary unit tests: 5/5 on net8.0 and net10.0
- [x] boundary integration tests: 6/6 on net8.0
- [x] boundary + large-message integration tests: 48/48 on net10.0
- [ ] full net10.0 unit suite: 4,516/4,517; sole failure is the known unrelated ActivityListener race tracked by #1609

Closes #1625
