### PR TITLE
Fix consumer log-truncation recovery after failover

### DIFF
--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -206,6 +206,18 @@ foreach (var (tp, offset) in offsets)
 }
 ```
 
+### Log Truncation Recovery
+
+After broker failover, leader-epoch validation can report that a new leader's log ends before
+records already prefetched from the previous leader. Dekaf clears stale buffered records for the
+affected partition and resumes from the broker's corrected offset without rewinding records already
+yielded to the application.
+
+This recovery is internal. Dekaf logs a warning instead of surfacing a terminal
+`ConsumeException(OffsetOutOfRange)`. Applications that used that exception to detect log
+truncation should monitor warning logs instead. Other `OffsetOutOfRange` handling continues to
+follow the configured auto-offset-reset policy.
+
 ## Delivery Semantics
 
 | Mode | Semantics | Risk |

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -151,6 +151,12 @@ namespace Dekaf.Consumer
                     keyDeserializer: _batch._keyDeserializer,
                     valueDeserializer: _batch._valueDeserializer);
 
+                if (_batch._isPartitionStillAssigned is not null
+                    && !_batch._isPartitionStillAssigned(pending.TopicPartition))
+                {
+                    return false;
+                }
+
                 pending.TrackConsumed(offset, messageBytes);
                 _recordsYielded++;
                 _batch._count++;

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -162,6 +162,12 @@ namespace Dekaf.Consumer
                     isKeyNull: record.IsKeyNull,
                     isValueNull: record.IsValueNull);
 
+                if (_batch._isPartitionStillAssigned is not null
+                    && !_batch._isPartitionStillAssigned(pending.TopicPartition))
+                {
+                    return false;
+                }
+
                 pending.TrackConsumed(offset, messageBytes);
                 _recordsYielded++;
                 _batch._count++;

--- a/src/Dekaf/Consumer/FetchSessionHandler.cs
+++ b/src/Dekaf/Consumer/FetchSessionHandler.cs
@@ -235,13 +235,15 @@ internal sealed class FetchSessionHandler
         long FetchOffset,
         long LogStartOffset,
         int PartitionMaxBytes,
-        int CurrentLeaderEpoch)
+        int CurrentLeaderEpoch,
+        int LastFetchedEpoch)
     {
         public static CachedPartitionData From(FetchRequestPartition partition) => new(
             partition.FetchOffset,
             partition.LogStartOffset,
             partition.PartitionMaxBytes,
-            partition.CurrentLeaderEpoch);
+            partition.CurrentLeaderEpoch,
+            partition.LastFetchedEpoch);
     }
 }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -701,7 +701,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     // Pending fetch responses for lazy record iteration
     private readonly Queue<PendingFetchData> _pendingFetches = new();
-    private readonly ConcurrentQueue<Exception> _pendingFetchExceptions = new();
     // Auto-commit reads this snapshot from its background task instead of touching _pendingFetches.
     private string? _activeConsumedTopic;
     private int _activeConsumedPartition;
@@ -1362,8 +1361,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            ThrowPendingFetchException();
-
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
 
@@ -1427,8 +1424,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Direct fetch (no prefetching)
                     await FetchRecordsAsync(cancellationToken).ConfigureAwait(false);
                 }
-
-                ThrowPendingFetchException();
             }
 
             // Yield records lazily from pending fetches
@@ -1668,8 +1663,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            ThrowPendingFetchException();
-
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
 
@@ -1728,8 +1721,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Direct fetch (no prefetching)
                     await FetchRecordsAsync(cancellationToken).ConfigureAwait(false);
                 }
-
-                ThrowPendingFetchException();
             }
 
             // Yield batches from pending fetches
@@ -1808,8 +1799,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            ThrowPendingFetchException();
-
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
 
@@ -1868,8 +1857,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Direct fetch (no prefetching)
                     await FetchRecordsAsync(cancellationToken).ConfigureAwait(false);
                 }
-
-                ThrowPendingFetchException();
             }
 
             // Yield raw batches from pending fetches
@@ -3007,8 +2994,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            ThrowPendingFetchException();
-
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
 
@@ -3025,8 +3010,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 {
                     return null;
                 }
-
-                ThrowPendingFetchException();
             }
 
             if (TryConsumeOneFromPendingFetches(out var result))
@@ -5296,17 +5279,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private int GetStoredOffsetLeaderEpoch(TopicPartition partition) =>
         _storedOffsetLeaderEpochs.GetValueOrDefault(partition, -1);
-
-    private void ThrowPendingFetchException()
-    {
-        if (_pendingFetchExceptions.TryDequeue(out var exception))
-            throw exception;
-    }
-
-    private void QueueFetchException(Exception exception)
-    {
-        _pendingFetchExceptions.Enqueue(exception);
-    }
 
     private bool ResetToDivergingEpoch(
         string topic,

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3632,9 +3632,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (!_pendingDivergingEpochResets.TryRemove(partition, out var reset))
                 continue;
 
-            var resumeOffset = Math.Max(
-                reset.EndOffset,
-                _positions.GetValueOrDefault(partition, reset.EndOffset));
+            // Refetch unread common-prefix records that were buffered before the divergence
+            // response. Only offsets already yielded to the application are safe to skip.
+            var resumeOffset = _positions.GetValueOrDefault(partition, reset.EndOffset);
 
             foreach (var pending in _pendingFetches)
             {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1330,7 +1330,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         // Clear any pending fetch data for the removed partitions
-        ClearFetchBufferForPartitions(partitions, invalidateAllFetches: true);
+        ClearFetchBufferForPartitions(partitions, invalidateAllFetches: clearAll);
 
         if (hadPaused)
             PublishPausedSnapshot();
@@ -3564,6 +3564,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             foreach (var partition in partitions)
             {
+                // Coordinator revocation supersedes any correction from the old assignment.
+                // Keep the revocation marker so the consume loop still drains stale buffers.
+                _pendingDivergingEpochResets.TryRemove(partition, out _);
                 _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
             }
 
@@ -3607,29 +3610,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
     }
 
-    private void CancelCoordinatorRevokedPartitionsFetchClear(IReadOnlyList<TopicPartition> partitions)
-    {
-        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
-        {
-            var cancelledDivergingEpochReset = false;
-            foreach (var partition in partitions)
-            {
-                cancelledDivergingEpochReset |= _pendingDivergingEpochResets.TryRemove(partition, out _);
-                _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
-            }
-
-            // Reject fetches started after the correction but before reassignment.
-            if (cancelledDivergingEpochReset)
-                InvalidateFetchesForPartitionsLocked(partitions);
-
-            if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
-            {
-                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 0);
-                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
-            }
-        }
-    }
-
     private bool ClearFetchBufferForPendingCoordinatorRevocations()
     {
         if (!HasPendingCoordinatorRevocations())
@@ -3645,20 +3625,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
 
             var partitionsToRemove = _coordinatorRevokedPartitionsPendingFetchClear.Keys.ToHashSet();
-            var invalidatesAssignment = false;
-            foreach (var partition in partitionsToRemove)
-            {
-                if (!_pendingDivergingEpochResets.ContainsKey(partition))
-                {
-                    invalidatesAssignment = true;
-                    break;
-                }
-            }
 
             // Keep partitions marked while clearing. Background prefetches use this
             // marker to avoid advancing positions for data that will be discarded.
             ApplyPendingDivergingEpochResets(partitionsToRemove);
-            ClearFetchBufferForPartitions(partitionsToRemove, invalidateAllFetches: invalidatesAssignment);
+            ClearFetchBufferForPartitions(partitionsToRemove);
 
             foreach (var partition in partitionsToRemove)
                 _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3674,6 +3674,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             _fetchPositions[partition] = resumeOffset;
             SetPosition(partition, resumeOffset, dirty: false);
+            // Clearing the pending fetch bypasses its normal position flush. Discard the
+            // matching auto-commit snapshot so a later commit/position read cannot restore
+            // the pre-divergence leader epoch after the reset below clears it.
+            ClearActiveConsumedPosition(partition, resumeOffset);
             // The diverging epoch is the last common epoch, not the new leader epoch.
             // Reusing it would make every subsequent fetch report the same divergence.
             ClearLastConsumedLeaderEpoch(partition);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1533,14 +1533,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             if (HasPendingFetchClear(pending.TopicPartition))
                                 break;
 
-                            TrackConsumedPosition(pending, offset, messageBytes);
-                            // Position dictionaries are flushed once per fetch; auto-commit reads
-                            // the published active snapshot without touching the pending queue.
-
                             // Apply OnConsume interceptors before yielding to user
                             // Uses hoisted hasInterceptors to skip method call when no interceptors
                             if (hasInterceptors)
+                            {
                                 nextResult = ApplyOnConsumeInterceptors(nextResult);
+
+                                // An interceptor can run long enough for background prefetch to
+                                // publish a divergence reset. Do not mark that stale record consumed.
+                                if (HasPendingFetchClear(pending.TopicPartition))
+                                    break;
+                            }
+
+                            TrackConsumedPosition(pending, offset, messageBytes);
+                            // Position dictionaries are flushed once per fetch; auto-commit reads
+                            // the published active snapshot without touching the pending queue.
 
                             // Store raw byte references for DLQ lazy capture (zero-copy — just memory slices)
                             if (rawTrackingEnabled)
@@ -3151,10 +3158,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         if (HasPendingFetchClear(pending.TopicPartition))
                             break;
 
-                        TrackConsumedPosition(pending, offset, messageBytes);
-
                         if (hasInterceptors)
+                        {
                             result = ApplyOnConsumeInterceptors(result);
+
+                            if (HasPendingFetchClear(pending.TopicPartition))
+                                break;
+                        }
+
+                        TrackConsumedPosition(pending, offset, messageBytes);
 
                         if (rawTrackingEnabled)
                         {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3157,6 +3157,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             keyDeserializer: _keyDeserializer,
                             valueDeserializer: _valueDeserializer);
 
+                        if (HasPublishedPendingFetchClear(pending.TopicPartition))
+                            break;
+
                         TrackConsumedPosition(pending, offset, messageBytes);
 
                         if (hasInterceptors)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -720,8 +720,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private int _fetchBufferEpoch;
     private int _minimumFetchBufferEpoch;
     private readonly ConcurrentDictionary<TopicPartition, int> _minimumFetchBufferEpochsByPartition = new();
-    // The marker flag stops record iteration as soon as a clear is staged. The pending flag
-    // publishes a fully staged batch to the poll loop without adding dictionary work normally.
+    // Coordinator revocations and diverging-epoch corrections share this partition set because
+    // both must stop record iteration before the poll loop clears stale fetch data. The marker
+    // flag stops iteration as soon as a clear is staged; the pending flag publishes a fully
+    // staged batch without adding dictionary work to the normal path.
     private readonly object _coordinatorRevokedPartitionsPendingFetchClearLock = new();
     private readonly ConcurrentDictionary<TopicPartition, byte> _coordinatorRevokedPartitionsPendingFetchClear = new();
     private readonly ConcurrentDictionary<TopicPartition, (long EndOffset, int Epoch)> _pendingDivergingEpochResets = new();

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3438,6 +3438,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _positions.TryRemove(partition, out _);
             ClearStoredOffset(partition);
             _fetchPositions.TryRemove(partition, out _);
+            _minimumFetchBufferEpochsByPartition.TryRemove(partition, out _);
             _lastConsumedLeaderEpochs.TryRemove(partition, out _);
             _committed.TryRemove(partition, out _);
             _highWatermarks.TryRemove(partition, out _);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1526,6 +1526,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 keyDeserializer: _keyDeserializer,
                                 valueDeserializer: _valueDeserializer);
 
+                            if (HasPublishedPendingFetchClear(pending.TopicPartition))
+                                break;
+
                             TrackConsumedPosition(pending, offset, messageBytes);
                             // Position dictionaries are flushed once per fetch; auto-commit reads
                             // the published active snapshot without touching the pending queue.
@@ -3711,6 +3714,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         return _assignmentSnapshot.Contains(partition);
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool HasPublishedPendingFetchClear(TopicPartition partition) =>
+        Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) != 0
+        && _coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition);
 
     private bool CanContinueBatchIteration(TopicPartition partition) =>
         !_coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1743,7 +1743,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         pending,
                         _keyDeserializer,
                         _valueDeserializer,
-                        IsCurrentlyAssigned,
+                        CanContinueBatchIteration,
                         _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
@@ -1879,7 +1879,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     pending.EagerParseAll();
 
                     // Yield the raw batch to the caller for synchronous iteration
-                    ConsumeRawBatch batch = new(pending, IsCurrentlyAssigned, _options.MaxPollRecords);
+                    ConsumeRawBatch batch = new(pending, CanContinueBatchIteration, _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
                 }
@@ -3711,6 +3711,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         return _assignmentSnapshot.Contains(partition);
     }
+
+    private bool CanContinueBatchIteration(TopicPartition partition) =>
+        !_coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition)
+        && IsCurrentlyAssigned(partition);
 
     private bool IsFetchBufferEpochStale(int fetchBufferEpoch) =>
         Volatile.Read(ref _fetchBufferEpoch) != fetchBufferEpoch;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -716,13 +716,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // Coarse-grained by design: unrelated partition clears may restart the current
     // iteration, avoiding per-partition tracking on the per-message hot path.
     private int _pendingFetchesVersion;
-    // Invalidates in-flight prefetch completions after Seek/Assign clears buffered data.
-    // Otherwise stale fetches can arrive after a rewind and advance _fetchPositions again.
+    // Generates fetch epochs. Full clears advance the global minimum; partition clears advance
+    // only that partition's minimum so an unrelated broker response can still be consumed.
     private int _fetchBufferEpoch;
-    // Keeps the pending flag and dictionary in sync while preserving the volatile hot-path check.
+    private int _minimumFetchBufferEpoch;
+    private readonly ConcurrentDictionary<TopicPartition, int> _minimumFetchBufferEpochsByPartition = new();
+    // The marker flag stops record iteration as soon as a clear is staged. The pending flag
+    // publishes a fully staged batch to the poll loop without adding dictionary work normally.
     private readonly object _coordinatorRevokedPartitionsPendingFetchClearLock = new();
     private readonly ConcurrentDictionary<TopicPartition, byte> _coordinatorRevokedPartitionsPendingFetchClear = new();
     private readonly ConcurrentDictionary<TopicPartition, (long EndOffset, int Epoch)> _pendingDivergingEpochResets = new();
+    private int _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent;
     private int _coordinatorRevokedPartitionsPendingFetchClearPending;
 
     // Background prefetch support
@@ -1326,7 +1330,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         // Clear any pending fetch data for the removed partitions
-        ClearFetchBufferForPartitions(partitions);
+        ClearFetchBufferForPartitions(partitions, invalidateAllFetches: true);
 
         if (hadPaused)
             PublishPausedSnapshot();
@@ -1526,7 +1530,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 keyDeserializer: _keyDeserializer,
                                 valueDeserializer: _valueDeserializer);
 
-                            if (HasPublishedPendingFetchClear(pending.TopicPartition))
+                            if (HasPendingFetchClear(pending.TopicPartition))
                                 break;
 
                             TrackConsumedPosition(pending, offset, messageBytes);
@@ -2146,7 +2150,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private Dictionary<int, List<TopicPartition>> ExcludePartitionsPendingFetchClear(
         Dictionary<int, List<TopicPartition>> partitionsByBroker)
     {
-        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) == 0)
+        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) == 0)
             return partitionsByBroker;
 
         var filtered = new Dictionary<int, List<TopicPartition>>(partitionsByBroker.Count);
@@ -2407,14 +2411,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             var memoryOwner = response.PooledMemoryOwner;
             response.PooledMemoryOwner = null; // Clear to prevent double-dispose
 
-            if (IsFetchBufferEpochStale(fetchBufferEpoch))
-            {
-                fetchSessionHandler?.HandleResponse(response);
-                response.ReturnToPool();
-                memoryOwner?.Dispose();
-                return;
-            }
-
             if (response.ErrorCode != ErrorCode.None)
             {
                 fetchSessionHandler?.HandleResponse(response);
@@ -2462,11 +2458,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 fetchBufferEpoch);
                             continue;
                         }
-
-                        // A correction invalidates this response, but keep scanning it so every
-                        // partition with the same correction is queued before the epoch changes.
-                        if (queuedDivergingEpochReset)
-                            continue;
 
                         if (partitionResponse.ErrorCode != ErrorCode.None)
                         {
@@ -2527,7 +2518,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             finally
             {
                 if (queuedDivergingEpochReset)
-                    CompleteDivergingEpochResets(fetchBufferEpoch);
+                    CompleteDivergingEpochResets();
 
                 // Return the response and its nested objects to their pools.
                 // Data has been transferred to PendingFetchData; the response wrappers are no longer needed.
@@ -3157,7 +3148,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             keyDeserializer: _keyDeserializer,
                             valueDeserializer: _valueDeserializer);
 
-                        if (HasPublishedPendingFetchClear(pending.TopicPartition))
+                        if (HasPendingFetchClear(pending.TopicPartition))
                             break;
 
                         TrackConsumedPosition(pending, offset, messageBytes);
@@ -3474,7 +3465,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            Interlocked.Increment(ref _fetchBufferEpoch);
+            InvalidateAllFetchesLocked();
             _pendingDivergingEpochResets.Clear();
         }
 
@@ -3494,7 +3485,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _pendingEofEvents.Clear();
     }
 
-    private void ClearFetchBufferForPartitions(IEnumerable<TopicPartition> partitionsToRemove)
+    private void ClearFetchBufferForPartitions(
+        IEnumerable<TopicPartition> partitionsToRemove,
+        bool invalidateAllFetches = false)
     {
         // Create a set for efficient lookup
         var removeSet = partitionsToRemove is HashSet<TopicPartition> set
@@ -3506,7 +3499,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            Interlocked.Increment(ref _fetchBufferEpoch);
+            if (invalidateAllFetches)
+                InvalidateAllFetchesLocked();
+            else
+                InvalidateFetchesForPartitionsLocked(removeSet);
+
             foreach (var partition in removeSet)
                 _pendingDivergingEpochResets.TryRemove(partition, out _);
         }
@@ -3572,23 +3569,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             // Invalidate broker fetches that started before the revocation immediately.
             // Waiting for the consume loop to drain the queued clear lets an ABA reassignment
             // make a stale response look current and advance the reinitialized fetch position.
-            Interlocked.Increment(ref _fetchBufferEpoch);
-            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
-        }
-    }
-
-    private void QueueDivergingEpochReset(
-        TopicPartition partition,
-        long endOffset,
-        int epoch,
-        int fetchBufferEpoch)
-    {
-        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
-        {
-            if (!TryQueueDivergingEpochResetLocked(partition, endOffset, epoch, fetchBufferEpoch))
-                return;
-
-            Interlocked.Increment(ref _fetchBufferEpoch);
+            InvalidateFetchesForPartitionsLocked(partitions);
+            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
         }
     }
@@ -3614,18 +3596,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         _pendingDivergingEpochResets[partition] = (endOffset, epoch);
         _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
+        Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
         return true;
     }
 
-    private void CompleteDivergingEpochResets(int fetchBufferEpoch)
+    private void CompleteDivergingEpochResets()
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
-        {
-            if (!IsFetchBufferEpochStale(fetchBufferEpoch))
-                Interlocked.Increment(ref _fetchBufferEpoch);
-
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
-        }
     }
 
     private void CancelCoordinatorRevokedPartitionsFetchClear(IReadOnlyList<TopicPartition> partitions)
@@ -3641,10 +3619,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             // Reject fetches started after the correction but before reassignment.
             if (cancelledDivergingEpochReset)
-                Interlocked.Increment(ref _fetchBufferEpoch);
+                InvalidateFetchesForPartitionsLocked(partitions);
 
             if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
+            {
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 0);
                 Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
+            }
         }
     }
 
@@ -3657,20 +3638,31 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
             {
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 0);
                 Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
                 return false;
             }
 
             var partitionsToRemove = _coordinatorRevokedPartitionsPendingFetchClear.Keys.ToHashSet();
+            var invalidatesAssignment = false;
+            foreach (var partition in partitionsToRemove)
+            {
+                if (!_pendingDivergingEpochResets.ContainsKey(partition))
+                {
+                    invalidatesAssignment = true;
+                    break;
+                }
+            }
 
             // Keep partitions marked while clearing. Background prefetches use this
             // marker to avoid advancing positions for data that will be discarded.
             ApplyPendingDivergingEpochResets(partitionsToRemove);
-            ClearFetchBufferForPartitions(partitionsToRemove);
+            ClearFetchBufferForPartitions(partitionsToRemove, invalidateAllFetches: invalidatesAssignment);
 
             foreach (var partition in partitionsToRemove)
                 _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
 
+            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 0);
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
             return true;
         }
@@ -3719,21 +3711,37 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool HasPublishedPendingFetchClear(TopicPartition partition) =>
-        Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) != 0
+    private bool HasPendingFetchClear(TopicPartition partition) =>
+        Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0
         && _coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition);
 
     private bool CanContinueBatchIteration(TopicPartition partition) =>
-        !_coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition)
+        !HasPendingFetchClear(partition)
         && IsCurrentlyAssigned(partition);
 
-    private bool IsFetchBufferEpochStale(int fetchBufferEpoch) =>
-        Volatile.Read(ref _fetchBufferEpoch) != fetchBufferEpoch;
+    private bool IsFetchBufferEpochStale(TopicPartition partition, int fetchBufferEpoch) =>
+        fetchBufferEpoch < Volatile.Read(ref _minimumFetchBufferEpoch)
+        || (_minimumFetchBufferEpochsByPartition.TryGetValue(partition, out var minimumEpoch)
+            && fetchBufferEpoch < minimumEpoch);
 
     private bool ShouldDropStaleFetchPartition(TopicPartition partition, int fetchBufferEpoch) =>
-        IsFetchBufferEpochStale(fetchBufferEpoch)
+        IsFetchBufferEpochStale(partition, fetchBufferEpoch)
         || _coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition)
         || !IsCurrentlyAssigned(partition);
+
+    private void InvalidateAllFetchesLocked()
+    {
+        var minimumEpoch = Interlocked.Increment(ref _fetchBufferEpoch);
+        Volatile.Write(ref _minimumFetchBufferEpoch, minimumEpoch);
+        _minimumFetchBufferEpochsByPartition.Clear();
+    }
+
+    private void InvalidateFetchesForPartitionsLocked(IEnumerable<TopicPartition> partitions)
+    {
+        var minimumEpoch = Interlocked.Increment(ref _fetchBufferEpoch);
+        foreach (var partition in partitions)
+            _minimumFetchBufferEpochsByPartition[partition] = minimumEpoch;
+    }
 
     private async ValueTask WritePrefetchedItemsAsync(
         IReadOnlyList<PendingFetchData> pendingItems,
@@ -4548,18 +4556,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     {
                         try
                         {
-                            if (IsFetchBufferEpochStale(fetchBufferEpoch))
-                            {
-                                foreach (var pending in pendingItems)
-                                {
-                                    pending.Dispose();
-                                }
-
-                                continue;
-                            }
-
                             foreach (var pending in pendingItems)
                             {
+                                if (ShouldDropStaleFetchPartition(pending.TopicPartition, fetchBufferEpoch))
+                                {
+                                    pending.Dispose();
+                                    continue;
+                                }
+
                                 _pendingFetches.Enqueue(pending);
                             }
                         }
@@ -5035,14 +5039,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var memoryOwner = response.PooledMemoryOwner;
         response.PooledMemoryOwner = null; // Clear to prevent double-dispose
 
-        if (IsFetchBufferEpochStale(fetchBufferEpoch))
-        {
-            fetchSessionHandler?.HandleResponse(response);
-            response.ReturnToPool();
-            memoryOwner?.Dispose();
-            return null;
-        }
-
         if (response.ErrorCode != ErrorCode.None)
         {
             fetchSessionHandler?.HandleResponse(response);
@@ -5085,11 +5081,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             fetchBufferEpoch);
                         continue;
                     }
-
-                    // A correction invalidates this response, but keep scanning it so every
-                    // partition with the same correction is queued before the epoch changes.
-                    if (queuedDivergingEpochReset)
-                        continue;
 
                     if (partitionResponse.ErrorCode != ErrorCode.None)
                     {
@@ -5149,7 +5140,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         finally
         {
             if (queuedDivergingEpochReset)
-                CompleteDivergingEpochResets(fetchBufferEpoch);
+                CompleteDivergingEpochResets();
 
             // Return the response and its nested objects to their pools.
             // Data has been transferred to PendingFetchData; the response wrappers are no longer needed.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2431,6 +2431,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             // concurrently for different brokers AND different connections to the same broker
             var pendingItems = _prefetchPendingItemsByBroker.GetOrAdd((brokerId, connectionIndex), static _ => []);
             pendingItems.Clear();
+            var queuedDivergingEpochReset = false;
 
             // Write to prefetch channel
             try
@@ -2452,9 +2453,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (partitionResponse.DivergingEpoch is not null)
                         {
-                            ResetToDivergingEpoch(topic, partitionResponse, fetchBufferEpoch);
+                            queuedDivergingEpochReset |= ResetToDivergingEpoch(
+                                topic,
+                                partitionResponse,
+                                fetchBufferEpoch);
                             continue;
                         }
+
+                        // A correction invalidates this response, but keep scanning it so every
+                        // partition with the same correction is queued before the epoch changes.
+                        if (queuedDivergingEpochReset)
+                            continue;
 
                         if (partitionResponse.ErrorCode != ErrorCode.None)
                         {
@@ -2514,6 +2523,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
             finally
             {
+                if (queuedDivergingEpochReset)
+                    CompleteDivergingEpochResets(fetchBufferEpoch);
+
                 // Return the response and its nested objects to their pools.
                 // Data has been transferred to PendingFetchData; the response wrappers are no longer needed.
                 response.ReturnToPool();
@@ -3567,12 +3579,45 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            if (ShouldDropStaleFetchPartition(partition, fetchBufferEpoch))
+            if (!TryQueueDivergingEpochResetLocked(partition, endOffset, epoch, fetchBufferEpoch))
                 return;
 
-            _pendingDivergingEpochResets[partition] = (endOffset, epoch);
-            _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
             Interlocked.Increment(ref _fetchBufferEpoch);
+            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+        }
+    }
+
+    private bool StageDivergingEpochReset(
+        TopicPartition partition,
+        long endOffset,
+        int epoch,
+        int fetchBufferEpoch)
+    {
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+            return TryQueueDivergingEpochResetLocked(partition, endOffset, epoch, fetchBufferEpoch);
+    }
+
+    private bool TryQueueDivergingEpochResetLocked(
+        TopicPartition partition,
+        long endOffset,
+        int epoch,
+        int fetchBufferEpoch)
+    {
+        if (ShouldDropStaleFetchPartition(partition, fetchBufferEpoch))
+            return false;
+
+        _pendingDivergingEpochResets[partition] = (endOffset, epoch);
+        _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
+        return true;
+    }
+
+    private void CompleteDivergingEpochResets(int fetchBufferEpoch)
+    {
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            if (!IsFetchBufferEpochStale(fetchBufferEpoch))
+                Interlocked.Increment(ref _fetchBufferEpoch);
+
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
         }
     }
@@ -4997,6 +5042,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         // Collect pending fetch data items - we need to assign memory owner to the last one
         List<PendingFetchData>? pendingItems = null;
+        var queuedDivergingEpochReset = false;
 
         // Queue pending fetch data for lazy iteration - don't parse records yet!
         try
@@ -5018,9 +5064,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                     if (partitionResponse.DivergingEpoch is not null)
                     {
-                        ResetToDivergingEpoch(topic, partitionResponse, fetchBufferEpoch);
+                        queuedDivergingEpochReset |= ResetToDivergingEpoch(
+                            topic,
+                            partitionResponse,
+                            fetchBufferEpoch);
                         continue;
                     }
+
+                    // A correction invalidates this response, but keep scanning it so every
+                    // partition with the same correction is queued before the epoch changes.
+                    if (queuedDivergingEpochReset)
+                        continue;
 
                     if (partitionResponse.ErrorCode != ErrorCode.None)
                     {
@@ -5079,6 +5133,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
         finally
         {
+            if (queuedDivergingEpochReset)
+                CompleteDivergingEpochResets(fetchBufferEpoch);
+
             // Return the response and its nested objects to their pools.
             // Data has been transferred to PendingFetchData; the response wrappers are no longer needed.
             response.ReturnToPool();
@@ -5257,19 +5314,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _pendingFetchExceptions.Enqueue(exception);
     }
 
-    private void ResetToDivergingEpoch(
+    private bool ResetToDivergingEpoch(
         string topic,
         FetchResponsePartition partitionResponse,
         int fetchBufferEpoch)
     {
         if (partitionResponse.DivergingEpoch is not { } divergingEpoch)
-            return;
+            return false;
 
         var partition = new TopicPartition(topic, partitionResponse.PartitionIndex);
         if (ShouldDropStaleFetchPartition(partition, fetchBufferEpoch))
-            return;
+            return false;
 
-        QueueDivergingEpochReset(
+        return StageDivergingEpochReset(
             partition,
             divergingEpoch.EndOffset,
             divergingEpoch.Epoch,

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3581,11 +3581,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
+            var cancelledDivergingEpochReset = false;
             foreach (var partition in partitions)
             {
-                if (!_pendingDivergingEpochResets.ContainsKey(partition))
-                    _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
+                cancelledDivergingEpochReset |= _pendingDivergingEpochResets.TryRemove(partition, out _);
+                _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
             }
+
+            // Reject fetches started after the correction but before reassignment.
+            if (cancelledDivergingEpochReset)
+                Interlocked.Increment(ref _fetchBufferEpoch);
 
             if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
                 Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3454,7 +3454,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void ClearFetchBuffer()
     {
-        Interlocked.Increment(ref _fetchBufferEpoch);
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            Interlocked.Increment(ref _fetchBufferEpoch);
+            _pendingDivergingEpochResets.Clear();
+        }
 
         // Dispose and clear pending fetches to release pooled memory
         while (_pendingFetches.TryDequeue(out var pending))
@@ -3482,7 +3486,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (removeSet.Count == 0)
             return;
 
-        Interlocked.Increment(ref _fetchBufferEpoch);
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            Interlocked.Increment(ref _fetchBufferEpoch);
+            foreach (var partition in removeSet)
+                _pendingDivergingEpochResets.TryRemove(partition, out _);
+        }
 
         // Filter in-place without allocating a temporary queue
         // Dequeue all items and re-enqueue only those we want to keep
@@ -3550,10 +3559,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
-    private void QueueDivergingEpochReset(TopicPartition partition, long endOffset, int epoch)
+    private void QueueDivergingEpochReset(
+        TopicPartition partition,
+        long endOffset,
+        int epoch,
+        int fetchBufferEpoch)
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
+            if (ShouldDropStaleFetchPartition(partition, fetchBufferEpoch))
+                return;
+
             _pendingDivergingEpochResets[partition] = (endOffset, epoch);
             _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
             Interlocked.Increment(ref _fetchBufferEpoch);
@@ -5248,7 +5264,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (ShouldDropStaleFetchPartition(partition, fetchBufferEpoch))
             return;
 
-        QueueDivergingEpochReset(partition, divergingEpoch.EndOffset, divergingEpoch.Epoch);
+        QueueDivergingEpochReset(
+            partition,
+            divergingEpoch.EndOffset,
+            divergingEpoch.Epoch,
+            fetchBufferEpoch);
     }
 
     private async ValueTask ResetOffsetOutOfRangeAsync(

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -722,6 +722,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // Keeps the pending flag and dictionary in sync while preserving the volatile hot-path check.
     private readonly object _coordinatorRevokedPartitionsPendingFetchClearLock = new();
     private readonly ConcurrentDictionary<TopicPartition, byte> _coordinatorRevokedPartitionsPendingFetchClear = new();
+    private readonly ConcurrentDictionary<TopicPartition, (long EndOffset, int Epoch)> _pendingDivergingEpochResets = new();
     private int _coordinatorRevokedPartitionsPendingFetchClearPending;
 
     // Background prefetch support
@@ -2056,6 +2057,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private async ValueTask<(int Started, int TargetCount)> DispatchReadyBrokerPrefetchesAsync(CancellationToken cancellationToken)
     {
         var partitionsByBroker = await GroupPartitionsByBrokerAsync(cancellationToken).ConfigureAwait(false);
+        partitionsByBroker = ExcludePartitionsPendingFetchClear(partitionsByBroker);
         var fetchSessionSnapshot = ShouldUseFetchSessions && !_fetchSessions.IsEmpty
             ? _fetchSessions.ToArray()
             : Array.Empty<KeyValuePair<(int BrokerId, int ConnectionIndex), FetchSessionHandler>>();
@@ -2136,6 +2138,29 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         return (started, targetCount);
+    }
+
+    private Dictionary<int, List<TopicPartition>> ExcludePartitionsPendingFetchClear(
+        Dictionary<int, List<TopicPartition>> partitionsByBroker)
+    {
+        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) == 0)
+            return partitionsByBroker;
+
+        var filtered = new Dictionary<int, List<TopicPartition>>(partitionsByBroker.Count);
+        foreach (var (brokerId, partitions) in partitionsByBroker)
+        {
+            List<TopicPartition>? retained = null;
+            foreach (var partition in partitions)
+            {
+                if (!_coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition))
+                    (retained ??= []).Add(partition);
+            }
+
+            if (retained is { Count: > 0 })
+                filtered[brokerId] = retained;
+        }
+
+        return filtered;
     }
 
     private bool TryStartBrokerPrefetch(
@@ -2796,7 +2821,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         ClearDirtyStoredOffsetIfCommitted(partition, committedOffset);
     }
 
-    private void UpdateFetchPositionsFromPrefetch(PendingFetchData pending)
+    private void UpdateFetchPositionsFromPrefetch(PendingFetchData pending, int fetchBufferEpoch)
     {
         // Calculate the last offset in the prefetched data
         // We need to update fetch positions so next prefetch gets new data
@@ -2813,11 +2838,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // concurrent seek-forward with a stale prefetch offset.
         // Uses the factoryArgument overload with static lambdas to avoid closure allocation.
         var nextOffset = lastOffset + 1;
+        var update = (Consumer: this, FetchBufferEpoch: fetchBufferEpoch, NextOffset: nextOffset);
         _fetchPositions.AddOrUpdate(
             tp,
-            static (_, nextOffset) => nextOffset,
-            static (_, currentPos, nextOffset) => Math.Max(currentPos, nextOffset),
-            nextOffset);
+            static (_, update) => update.NextOffset,
+            static (partition, currentPos, update) =>
+                update.Consumer.ShouldDropStaleFetchPartition(partition, update.FetchBufferEpoch)
+                    ? currentPos
+                    : Math.Max(currentPos, update.NextOffset),
+            update);
     }
 
     /// <summary>
@@ -3521,12 +3550,37 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
+    private void QueueDivergingEpochReset(TopicPartition partition, long endOffset, int epoch)
+    {
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            _pendingDivergingEpochResets[partition] = (endOffset, epoch);
+            _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
+            Interlocked.Increment(ref _fetchBufferEpoch);
+            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+        }
+    }
+
+    private void CancelCoordinatorRevokedPartitionsFetchClear(IReadOnlyList<TopicPartition> partitions)
+    {
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            foreach (var partition in partitions)
+            {
+                if (!_pendingDivergingEpochResets.ContainsKey(partition))
+                    _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
+            }
+
+            if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
+        }
+    }
+
     private bool ClearFetchBufferForPendingCoordinatorRevocations()
     {
         if (!HasPendingCoordinatorRevocations())
             return false;
 
-        HashSet<TopicPartition>? partitionsToRemove;
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
             if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
@@ -3535,21 +3589,53 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 return false;
             }
 
-            partitionsToRemove = [];
-            foreach (var partition in _coordinatorRevokedPartitionsPendingFetchClear.Keys)
-            {
-                if (_coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _))
-                    partitionsToRemove.Add(partition);
-            }
+            var partitionsToRemove = _coordinatorRevokedPartitionsPendingFetchClear.Keys.ToHashSet();
+
+            // Keep partitions marked while clearing. Background prefetches use this
+            // marker to avoid advancing positions for data that will be discarded.
+            ApplyPendingDivergingEpochResets(partitionsToRemove);
+            ClearFetchBufferForPartitions(partitionsToRemove);
+
+            foreach (var partition in partitionsToRemove)
+                _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
 
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
+            return true;
         }
+    }
 
-        if (partitionsToRemove.Count == 0)
-            return false;
+    private void ApplyPendingDivergingEpochResets(IReadOnlyCollection<TopicPartition> partitions)
+    {
+        foreach (var partition in partitions)
+        {
+            if (!_pendingDivergingEpochResets.TryRemove(partition, out var reset))
+                continue;
 
-        ClearFetchBufferForPartitions(partitionsToRemove);
-        return true;
+            var resumeOffset = Math.Max(
+                reset.EndOffset,
+                _positions.GetValueOrDefault(partition, reset.EndOffset));
+
+            foreach (var pending in _pendingFetches)
+            {
+                if (TryGetConsumedPosition(pending, out var pendingPartition, out var nextOffset, out _)
+                    && pendingPartition.Equals(partition))
+                {
+                    resumeOffset = Math.Max(resumeOffset, nextOffset);
+                }
+            }
+
+            _fetchPositions[partition] = resumeOffset;
+            SetPosition(partition, resumeOffset, dirty: false);
+            // The diverging epoch is the last common epoch, not the new leader epoch.
+            // Reusing it would make every subsequent fetch report the same divergence.
+            ClearLastConsumedLeaderEpoch(partition);
+            LogDivergingEpochReset(
+                partition.Topic,
+                partition.Partition,
+                resumeOffset,
+                reset.EndOffset,
+                reset.Epoch);
+        }
     }
 
     private bool HasPendingCoordinatorRevocations() =>
@@ -3564,7 +3650,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         Volatile.Read(ref _fetchBufferEpoch) != fetchBufferEpoch;
 
     private bool ShouldDropStaleFetchPartition(TopicPartition partition, int fetchBufferEpoch) =>
-        IsFetchBufferEpochStale(fetchBufferEpoch) || !IsCurrentlyAssigned(partition);
+        IsFetchBufferEpochStale(fetchBufferEpoch)
+        || _coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition)
+        || !IsCurrentlyAssigned(partition);
 
     private async ValueTask WritePrefetchedItemsAsync(
         IReadOnlyList<PendingFetchData> pendingItems,
@@ -3583,7 +3671,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             // Track memory and advance fetch positions only after confirming
             // this pipelined response still belongs to the current assignment.
             TrackPrefetchedBytes(pending, release: false);
-            UpdateFetchPositionsFromPrefetch(pending);
+            UpdateFetchPositionsFromPrefetch(pending, fetchBufferEpoch);
 
             while (!_prefetchBuffer.TryWrite(pending))
             {
@@ -5160,13 +5248,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (ShouldDropStaleFetchPartition(partition, fetchBufferEpoch))
             return;
 
-        _fetchPositions[partition] = divergingEpoch.EndOffset;
-        SetPosition(partition, divergingEpoch.EndOffset, dirty: false);
-        SetLastConsumedLeaderEpoch(partition, divergingEpoch.Epoch);
-        QueueFetchException(new Errors.ConsumeException(
-            ErrorCode.OffsetOutOfRange,
-            $"Log truncation detected for {topic}-{partitionResponse.PartitionIndex}; reset fetch position to offset {divergingEpoch.EndOffset} at leader epoch {divergingEpoch.Epoch}.",
-            isRetriable: true));
+        QueueDivergingEpochReset(partition, divergingEpoch.EndOffset, divergingEpoch.Epoch);
     }
 
     private async ValueTask ResetOffsetOutOfRangeAsync(
@@ -6230,6 +6312,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "{Error} for {Topic}-{Partition}, refreshing leader metadata")]
     private partial void LogLeaderEpochRefresh(string topic, int partition, ErrorCode error);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Log truncation detected for {Topic}-{Partition}; reset fetch position to offset {ResumeOffset} from broker correction {EndOffset} at leader epoch {LeaderEpoch}")]
+    private partial void LogDivergingEpochReset(
+        string topic,
+        int partition,
+        long resumeOffset,
+        long endOffset,
+        int leaderEpoch);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Preferred read replica {ReplicaId} selected for {Topic}-{Partition}")]
     private partial void LogPreferredReadReplicaSelected(string topic, int partition, int replicaId);

--- a/tests/Dekaf.Tests.Integration/ConsumerLeaderFailoverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerLeaderFailoverIntegrationTests.cs
@@ -1,0 +1,210 @@
+using Dekaf.Consumer;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Consumer")]
+[Category("Resilience")]
+[NotInParallel("RackAwareKafkaContainer")]
+[ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ConsumerLeaderFailoverIntegrationTests(RackAwareKafkaContainer kafka)
+{
+    private const int MessageCount = 200;
+
+    [Test]
+    [Timeout(180_000)]
+    public async Task Consumer_PartitionLeaderHandoff_ContinuesWithoutSkippedOrDuplicateRecords(
+        CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateReplicatedTopicAsync().ConfigureAwait(false);
+        int? stoppedBrokerId = null;
+        using var scenarioCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        await using var consumer = await CreateConsumerAsync(scenarioCancellation.Token).ConfigureAwait(false);
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        var firstConsumed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var consumeTask = ConsumeSequenceAsync(consumer, firstConsumed, scenarioCancellation.Token);
+
+        try
+        {
+            await ProduceRangeAsync(topic, start: 0, count: 25, scenarioCancellation.Token).ConfigureAwait(false);
+            await firstConsumed.Task.WaitAsync(scenarioCancellation.Token).ConfigureAwait(false);
+
+            stoppedBrokerId = await kafka.GetPartitionLeaderIdAsync(topic, scenarioCancellation.Token)
+                .ConfigureAwait(false);
+            await kafka.StopBrokerAsync(stoppedBrokerId.Value, scenarioCancellation.Token).ConfigureAwait(false);
+            _ = await kafka.WaitForPartitionLeaderChangeAsync(
+                    topic,
+                    stoppedBrokerId.Value,
+                    scenarioCancellation.Token)
+                .ConfigureAwait(false);
+
+            // A fresh producer isolates this consumer-recovery test from the separate
+            // stale-producer-metadata path while still producing under the broker fault.
+            await ProduceRangeAsync(topic, start: 25, count: 75, scenarioCancellation.Token).ConfigureAwait(false);
+
+            await kafka.StartBrokerAsync(stoppedBrokerId.Value, scenarioCancellation.Token).ConfigureAwait(false);
+            await kafka.WaitForInSyncReplicasAsync(topic, 3, scenarioCancellation.Token).ConfigureAwait(false);
+            stoppedBrokerId = null;
+
+            await ProduceRangeAsync(topic, start: 100, count: 100, scenarioCancellation.Token).ConfigureAwait(false);
+            var consumed = await consumeTask.ConfigureAwait(false);
+            AssertCompleteSequence(consumed);
+        }
+        finally
+        {
+            scenarioCancellation.Cancel();
+            if (stoppedBrokerId is { } brokerId)
+                await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    [Test]
+    [Timeout(240_000)]
+    public async Task Consumer_ThreeBrokerRollingRestart_ContinuesWithoutSkippedOrDuplicateRecords(
+        CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateReplicatedTopicAsync().ConfigureAwait(false);
+        int? stoppedBrokerId = null;
+        using var scenarioCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        await using var consumer = await CreateConsumerAsync(scenarioCancellation.Token).ConfigureAwait(false);
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        var firstConsumed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var consumeTask = ConsumeSequenceAsync(consumer, firstConsumed, scenarioCancellation.Token);
+
+        try
+        {
+            await ProduceRangeAsync(topic, start: 0, count: 25, scenarioCancellation.Token).ConfigureAwait(false);
+            await firstConsumed.Task.WaitAsync(scenarioCancellation.Token).ConfigureAwait(false);
+
+            var nextValue = 25;
+            for (var nodeId = 1; nodeId <= 3; nodeId++)
+            {
+                stoppedBrokerId = nodeId;
+                var leaderId = await kafka.GetPartitionLeaderIdAsync(topic, scenarioCancellation.Token)
+                    .ConfigureAwait(false);
+                await kafka.StopBrokerAsync(nodeId, scenarioCancellation.Token).ConfigureAwait(false);
+                if (leaderId == nodeId)
+                {
+                    _ = await kafka.WaitForPartitionLeaderChangeAsync(topic, leaderId, scenarioCancellation.Token)
+                        .ConfigureAwait(false);
+                }
+
+                // Every phase acknowledges 50 records with one broker down while the
+                // same consumer continues polling through metadata/epoch changes.
+                await ProduceRangeAsync(topic, nextValue, count: 50, scenarioCancellation.Token)
+                    .ConfigureAwait(false);
+                nextValue += 50;
+
+                await kafka.StartBrokerAsync(nodeId, scenarioCancellation.Token).ConfigureAwait(false);
+                await kafka.WaitForInSyncReplicasAsync(topic, 3, scenarioCancellation.Token).ConfigureAwait(false);
+                stoppedBrokerId = null;
+            }
+
+            await ProduceRangeAsync(
+                    topic,
+                    nextValue,
+                    MessageCount - nextValue,
+                    scenarioCancellation.Token)
+                .ConfigureAwait(false);
+
+            var consumed = await consumeTask.ConfigureAwait(false);
+            AssertCompleteSequence(consumed);
+        }
+        finally
+        {
+            scenarioCancellation.Cancel();
+            if (stoppedBrokerId is { } brokerId)
+                await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<IKafkaConsumer<string, string>> CreateConsumerAsync(CancellationToken cancellationToken)
+    {
+        return await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"leader-failover-consumer-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task ProduceRangeAsync(
+        string topic,
+        int start,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"leader-failover-producer-{Guid.NewGuid():N}")
+            .WithAcks(Acks.All)
+            .WithIdempotence(true)
+            .WithRequestTimeout(TimeSpan.FromSeconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(45))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        for (var value = start; value < start + count; value++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = value.ToString(),
+                Value = value.ToString()
+            }, cancellationToken).ConfigureAwait(false);
+        }
+
+        await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<IReadOnlyList<ConsumeResult<string, string>>> ConsumeSequenceAsync(
+        IKafkaConsumer<string, string> consumer,
+        TaskCompletionSource firstConsumed,
+        CancellationToken cancellationToken)
+    {
+        var results = new List<ConsumeResult<string, string>>(MessageCount);
+        while (results.Count < MessageCount)
+        {
+            var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(5), cancellationToken)
+                .ConfigureAwait(false);
+            if (result is null)
+                continue;
+
+            results.Add(result.Value);
+            firstConsumed.TrySetResult();
+        }
+
+        return results;
+    }
+
+    private static void AssertCompleteSequence(IReadOnlyList<ConsumeResult<string, string>> consumed)
+    {
+        if (consumed.Count != MessageCount)
+            throw new InvalidOperationException($"Expected {MessageCount} records, actual {consumed.Count}.");
+
+        for (var index = 0; index < MessageCount; index++)
+        {
+            var result = consumed[index];
+            if (result.Offset != index)
+            {
+                throw new InvalidOperationException(
+                    $"Offset mismatch at index {index}: expected {index}, actual {result.Offset}. " +
+                    $"Actual offsets: [{string.Join(", ", consumed.Select(static item => item.Offset))}]");
+            }
+
+            var expectedValue = index.ToString();
+            if (result.Value != expectedValue)
+            {
+                throw new InvalidOperationException(
+                    $"Value mismatch at index {index}: expected {expectedValue}, actual {result.Value}.");
+            }
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -200,6 +200,13 @@ public sealed class ConsumerAssignmentFastPathTests
         var staleFetchBufferEpoch = GetFetchBufferEpoch(consumer);
         GetPendingFetches(consumer).Enqueue(stalePendingFetch);
         GetFetchPositions(consumer)[reassignedPartition] = 0;
+        StageDivergingEpochReset(
+            consumer,
+            reassignedPartition,
+            endOffset: 42,
+            epoch: 7,
+            staleFetchBufferEpoch);
+        CompleteDivergingEpochResets(consumer);
 
         var coordinator = GetCoordinator(consumer);
         coordinator.RequestRejoin();
@@ -222,6 +229,40 @@ public sealed class ConsumerAssignmentFastPathTests
 
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
         await Assert.That(GetPendingFetches(consumer)).IsEmpty();
+        await Assert.That(GetLastConsumedLeaderEpoch(consumer, reassignedPartition)).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task EnsureAssignmentAsync_RevocationDiscardsPendingDivergenceReset()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupRevokingConsumerGroupHeartbeat(connection);
+        SetupOffsetFetch(connection);
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var revokedPartition = new TopicPartition("test-topic", 0);
+        StageDivergingEpochReset(
+            consumer,
+            revokedPartition,
+            endOffset: 42,
+            epoch: 7,
+            GetFetchBufferEpoch(consumer));
+        CompleteDivergingEpochResets(consumer);
+
+        GetCoordinator(consumer).RequestRejoin();
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.Assignment).DoesNotContain(revokedPartition);
+        await Assert.That(GetFetchPositions(consumer).ContainsKey(revokedPartition)).IsFalse();
     }
 
     [Test]
@@ -321,44 +362,56 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
-    public async Task CancelCoordinatorRevokedPartitionsFetchClear_ReassignedPartitionRemovesPendingClear()
+    public async Task IncrementalUnassign_InvalidatesOnlyRemovedPartitionFetches()
     {
         await using var consumer = CreateConsumer();
-        var reassignedPartition = new TopicPartition("test-topic", 0);
-        var stillRevokedPartition = new TopicPartition("test-topic", 1);
+        var removedPartition = new TopicPartition("test-topic", 0);
+        var retainedPartition = new TopicPartition("test-topic", 1);
+        consumer.IncrementalAssign(
+        [
+            new TopicPartitionOffset(removedPartition.Topic, removedPartition.Partition, 0),
+            new TopicPartitionOffset(retainedPartition.Topic, retainedPartition.Partition, 0)
+        ]);
+        var globalMinimumEpoch = GetMinimumFetchBufferEpoch(consumer);
 
-        QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [reassignedPartition, stillRevokedPartition]);
+        consumer.IncrementalUnassign([removedPartition]);
 
-        CancelCoordinatorRevokedPartitionsFetchClear(consumer, [reassignedPartition]);
-
-        var pendingRevocations = GetCoordinatorRevokedPartitionsPendingFetchClear(consumer);
-        await Assert.That(pendingRevocations.ContainsKey(reassignedPartition)).IsFalse();
-        await Assert.That(pendingRevocations.ContainsKey(stillRevokedPartition)).IsTrue();
-        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(1);
-
-        CancelCoordinatorRevokedPartitionsFetchClear(consumer, [stillRevokedPartition]);
-
-        await Assert.That(pendingRevocations).IsEmpty();
-        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+        var partitionMinimumEpochs = GetMinimumFetchBufferEpochsByPartition(consumer);
+        await Assert.That(GetMinimumFetchBufferEpoch(consumer)).IsEqualTo(globalMinimumEpoch);
+        await Assert.That(partitionMinimumEpochs.ContainsKey(removedPartition)).IsTrue();
+        await Assert.That(partitionMinimumEpochs.ContainsKey(retainedPartition)).IsFalse();
     }
 
     [Test]
-    public async Task CancelCoordinatorRevokedPartitionsFetchClear_ReassignmentCancelsDivergenceReset()
+    public async Task PendingRevocationDrain_InvalidatesOnlyAffectedPartitionFetches()
     {
         await using var consumer = CreateConsumer();
-        var partition = new TopicPartition("test-topic", 0);
-        consumer.IncrementalAssign([new TopicPartitionOffset("test-topic", 0, 0)]);
-
-        StageDivergingEpochReset(consumer, partition, endOffset: 42, epoch: 7, GetFetchBufferEpoch(consumer));
+        var divergingPartition = new TopicPartition("test-topic", 0);
+        var revokedPartition = new TopicPartition("test-topic", 1);
+        var retainedPartition = new TopicPartition("test-topic", 2);
+        consumer.IncrementalAssign(
+        [
+            new TopicPartitionOffset(divergingPartition.Topic, divergingPartition.Partition, 0),
+            new TopicPartitionOffset(revokedPartition.Topic, revokedPartition.Partition, 0),
+            new TopicPartitionOffset(retainedPartition.Topic, retainedPartition.Partition, 0)
+        ]);
+        StageDivergingEpochReset(
+            consumer,
+            divergingPartition,
+            endOffset: 42,
+            epoch: 7,
+            GetFetchBufferEpoch(consumer));
         CompleteDivergingEpochResets(consumer);
-        var staleFetchEpoch = GetFetchBufferEpoch(consumer);
+        QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [revokedPartition]);
+        var globalMinimumEpoch = GetMinimumFetchBufferEpoch(consumer);
 
-        CancelCoordinatorRevokedPartitionsFetchClear(consumer, [partition]);
-        StageDivergingEpochReset(consumer, partition, endOffset: 43, epoch: 8, staleFetchEpoch);
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
 
-        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsFalse();
-        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(0L);
-        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+        var partitionMinimumEpochs = GetMinimumFetchBufferEpochsByPartition(consumer);
+        await Assert.That(GetMinimumFetchBufferEpoch(consumer)).IsEqualTo(globalMinimumEpoch);
+        await Assert.That(partitionMinimumEpochs.ContainsKey(divergingPartition)).IsTrue();
+        await Assert.That(partitionMinimumEpochs.ContainsKey(revokedPartition)).IsTrue();
+        await Assert.That(partitionMinimumEpochs.ContainsKey(retainedPartition)).IsFalse();
     }
 
     [Test]
@@ -654,12 +707,14 @@ public sealed class ConsumerAssignmentFastPathTests
                     {
                         PartitionIndex = 0,
                         CommittedOffset = 10,
+                        CommittedLeaderEpoch = 4,
                         ErrorCode = ErrorCode.None
                     },
                     new OffsetFetchResponsePartition
                     {
                         PartitionIndex = 1,
                         CommittedOffset = 20,
+                        CommittedLeaderEpoch = 5,
                         ErrorCode = ErrorCode.None
                     }
                 ]
@@ -733,6 +788,16 @@ public sealed class ConsumerAssignmentFastPathTests
         return (int)field.GetValue(consumer)!;
     }
 
+    private static int GetMinimumFetchBufferEpoch(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_minimumFetchBufferEpoch",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_minimumFetchBufferEpoch field not found.");
+
+        return (int)field.GetValue(consumer)!;
+    }
+
     private static ConcurrentDictionary<TopicPartition, int> GetMinimumFetchBufferEpochsByPartition(
         KafkaConsumer<string, string> consumer)
     {
@@ -775,6 +840,18 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("_fetchPositions field not found.");
 
         return (ConcurrentDictionary<TopicPartition, long>)field.GetValue(consumer)!;
+    }
+
+    private static int GetLastConsumedLeaderEpoch(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition partition)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "GetLastConsumedLeaderEpoch",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("GetLastConsumedLeaderEpoch method not found.");
+
+        return (int)method.Invoke(consumer, [partition])!;
     }
 
     private static void QueueCoordinatorRevokedPartitionsForFetchClear(
@@ -824,18 +901,6 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("CompleteDivergingEpochResets method not found.");
 
         method.Invoke(consumer, []);
-    }
-
-    private static void CancelCoordinatorRevokedPartitionsFetchClear(
-        KafkaConsumer<string, string> consumer,
-        TopicPartition[] partitions)
-    {
-        var method = typeof(KafkaConsumer<string, string>).GetMethod(
-            "CancelCoordinatorRevokedPartitionsFetchClear",
-            BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("CancelCoordinatorRevokedPartitionsFetchClear method not found.");
-
-        method.Invoke(consumer, [partitions]);
     }
 
     private static bool ClearFetchBufferForPendingCoordinatorRevocations(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -321,6 +321,46 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task CancelCoordinatorRevokedPartitionsFetchClear_ReassignedPartitionRemovesPendingClear()
+    {
+        await using var consumer = CreateConsumer();
+        var reassignedPartition = new TopicPartition("test-topic", 0);
+        var stillRevokedPartition = new TopicPartition("test-topic", 1);
+
+        QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [reassignedPartition, stillRevokedPartition]);
+
+        CancelCoordinatorRevokedPartitionsFetchClear(consumer, [reassignedPartition]);
+
+        var pendingRevocations = GetCoordinatorRevokedPartitionsPendingFetchClear(consumer);
+        await Assert.That(pendingRevocations.ContainsKey(reassignedPartition)).IsFalse();
+        await Assert.That(pendingRevocations.ContainsKey(stillRevokedPartition)).IsTrue();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(1);
+
+        CancelCoordinatorRevokedPartitionsFetchClear(consumer, [stillRevokedPartition]);
+
+        await Assert.That(pendingRevocations).IsEmpty();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CancelCoordinatorRevokedPartitionsFetchClear_ReassignmentCancelsDivergenceReset()
+    {
+        await using var consumer = CreateConsumer();
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset("test-topic", 0, 0)]);
+
+        QueueDivergingEpochReset(consumer, partition, endOffset: 42, epoch: 7, GetFetchBufferEpoch(consumer));
+        var staleFetchEpoch = GetFetchBufferEpoch(consumer);
+
+        CancelCoordinatorRevokedPartitionsFetchClear(consumer, [partition]);
+        QueueDivergingEpochReset(consumer, partition, endOffset: 43, epoch: 8, staleFetchEpoch);
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsFalse();
+        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(0L);
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task WritePrefetchedItemsAsync_DropsUnassignedPartitionsBeforeAdvancingFetchPosition()
     {
         await using var consumer = CreateConsumer();
@@ -717,6 +757,33 @@ public sealed class ConsumerAssignmentFastPathTests
             "QueueCoordinatorRevokedPartitionsForFetchClear",
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("QueueCoordinatorRevokedPartitionsForFetchClear method not found.");
+
+        method.Invoke(consumer, [partitions]);
+    }
+
+    private static void QueueDivergingEpochReset(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition partition,
+        long endOffset,
+        int epoch,
+        int fetchBufferEpoch)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "QueueDivergingEpochReset",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("QueueDivergingEpochReset method not found.");
+
+        method.Invoke(consumer, [partition, endOffset, epoch, fetchBufferEpoch]);
+    }
+
+    private static void CancelCoordinatorRevokedPartitionsFetchClear(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition[] partitions)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "CancelCoordinatorRevokedPartitionsFetchClear",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("CancelCoordinatorRevokedPartitionsFetchClear method not found.");
 
         method.Invoke(consumer, [partitions]);
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -362,6 +362,22 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task RemovePartitionState_RemovesPartitionFetchEpochMinimum()
+    {
+        await using var consumer = CreateConsumer();
+        var removedPartition = new TopicPartition("test-topic", 0);
+        var retainedPartition = new TopicPartition("test-topic", 1);
+        var minimumEpochs = GetMinimumFetchBufferEpochsByPartition(consumer);
+        minimumEpochs[removedPartition] = 2;
+        minimumEpochs[retainedPartition] = 3;
+
+        RemovePartitionState(consumer, [removedPartition]);
+
+        await Assert.That(minimumEpochs.ContainsKey(removedPartition)).IsFalse();
+        await Assert.That(minimumEpochs[retainedPartition]).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task WritePrefetchedItemsAsync_DropsUnassignedPartitionsBeforeAdvancingFetchPosition()
     {
         await using var consumer = CreateConsumer();
@@ -717,6 +733,17 @@ public sealed class ConsumerAssignmentFastPathTests
         return (int)field.GetValue(consumer)!;
     }
 
+    private static ConcurrentDictionary<TopicPartition, int> GetMinimumFetchBufferEpochsByPartition(
+        KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_minimumFetchBufferEpochsByPartition",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_minimumFetchBufferEpochsByPartition field not found.");
+
+        return (ConcurrentDictionary<TopicPartition, int>)field.GetValue(consumer)!;
+    }
+
     private static ConcurrentDictionary<TopicPartition, byte> GetCoordinatorRevokedPartitionsPendingFetchClear(
         KafkaConsumer<string, string> consumer)
     {
@@ -758,6 +785,18 @@ public sealed class ConsumerAssignmentFastPathTests
             "QueueCoordinatorRevokedPartitionsForFetchClear",
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("QueueCoordinatorRevokedPartitionsForFetchClear method not found.");
+
+        method.Invoke(consumer, [partitions]);
+    }
+
+    private static void RemovePartitionState(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition[] partitions)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "RemovePartitionState",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("RemovePartitionState method not found.");
 
         method.Invoke(consumer, [partitions]);
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -349,11 +349,12 @@ public sealed class ConsumerAssignmentFastPathTests
         var partition = new TopicPartition("test-topic", 0);
         consumer.IncrementalAssign([new TopicPartitionOffset("test-topic", 0, 0)]);
 
-        QueueDivergingEpochReset(consumer, partition, endOffset: 42, epoch: 7, GetFetchBufferEpoch(consumer));
+        StageDivergingEpochReset(consumer, partition, endOffset: 42, epoch: 7, GetFetchBufferEpoch(consumer));
+        CompleteDivergingEpochResets(consumer);
         var staleFetchEpoch = GetFetchBufferEpoch(consumer);
 
         CancelCoordinatorRevokedPartitionsFetchClear(consumer, [partition]);
-        QueueDivergingEpochReset(consumer, partition, endOffset: 43, epoch: 8, staleFetchEpoch);
+        StageDivergingEpochReset(consumer, partition, endOffset: 43, epoch: 8, staleFetchEpoch);
 
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsFalse();
         await Assert.That(consumer.GetPosition(partition)).IsEqualTo(0L);
@@ -761,7 +762,7 @@ public sealed class ConsumerAssignmentFastPathTests
         method.Invoke(consumer, [partitions]);
     }
 
-    private static void QueueDivergingEpochReset(
+    private static void StageDivergingEpochReset(
         KafkaConsumer<string, string> consumer,
         TopicPartition partition,
         long endOffset,
@@ -769,11 +770,21 @@ public sealed class ConsumerAssignmentFastPathTests
         int fetchBufferEpoch)
     {
         var method = typeof(KafkaConsumer<string, string>).GetMethod(
-            "QueueDivergingEpochReset",
+            "StageDivergingEpochReset",
             BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("QueueDivergingEpochReset method not found.");
+            ?? throw new InvalidOperationException("StageDivergingEpochReset method not found.");
 
         method.Invoke(consumer, [partition, endOffset, epoch, fetchBufferEpoch]);
+    }
+
+    private static void CompleteDivergingEpochResets(KafkaConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "CompleteDivergingEpochResets",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("CompleteDivergingEpochResets method not found.");
+
+        method.Invoke(consumer, []);
     }
 
     private static void CancelCoordinatorRevokedPartitionsFetchClear(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -465,6 +465,69 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
+    public async Task ResetToDivergingEpoch_StopsConsumeAsyncWhenInterceptorPublishesReset()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var interceptor = new CallbackConsumerInterceptor();
+        using var cancellationSource = new CancellationTokenSource();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager, interceptor: interceptor);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+        SetInitialized(consumer);
+
+        interceptor.Callback = () =>
+        {
+            InvokeResetToDivergingEpoch(
+                consumer,
+                CreateDivergingEpochResponse(),
+                GetFetchBufferEpoch(consumer));
+            cancellationSource.Cancel();
+        };
+
+        GetPendingFetches(consumer).Enqueue(CreatePendingFetchData());
+        await using var enumerator = consumer
+            .ConsumeAsync(cancellationSource.Token)
+            .GetAsyncEnumerator();
+
+        await Assert.That(await enumerator.MoveNextAsync()).IsFalse();
+        InvokeCompleteDivergingEpochResets(consumer);
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ResetToDivergingEpoch_StopsConsumeOneAsyncWhenInterceptorPublishesReset()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var interceptor = new CallbackConsumerInterceptor();
+        using var cancellationSource = new CancellationTokenSource();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager, interceptor: interceptor);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+        SetInitialized(consumer);
+
+        interceptor.Callback = () =>
+        {
+            InvokeResetToDivergingEpoch(
+                consumer,
+                CreateDivergingEpochResponse(),
+                GetFetchBufferEpoch(consumer));
+            cancellationSource.Cancel();
+        };
+
+        GetPendingFetches(consumer).Enqueue(CreatePendingFetchData());
+
+        var result = await consumer.ConsumeOneAsync(
+            TimeSpan.FromSeconds(1),
+            cancellationSource.Token);
+
+        await Assert.That(result).IsNull();
+        InvokeCompleteDivergingEpochResets(consumer);
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ResetToDivergingEpoch_StopsRawBatchAtLastDeliveredRecord()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -657,12 +720,14 @@ public sealed class ConsumerLeaderDiscoveryTests
     private static KafkaConsumer<string, string> CreateConsumer(
         IConnectionPool pool,
         MetadataManager metadataManager,
-        IDeserializer<string>? keyDeserializer = null)
+        IDeserializer<string>? keyDeserializer = null,
+        IConsumerInterceptor<string, string>? interceptor = null)
         => new(
             new ConsumerOptions
             {
                 BootstrapServers = ["localhost:9092"],
-                ClientId = "test-consumer"
+                ClientId = "test-consumer",
+                Interceptors = interceptor is null ? null : [interceptor]
             },
             keyDeserializer ?? Serializers.String,
             Serializers.String,
@@ -922,5 +987,18 @@ public sealed class ConsumerLeaderDiscoveryTests
                 "ClearFetchBufferForPendingCoordinatorRevocations method not found");
 
         return (bool)method.Invoke(consumer, [])!;
+    }
+
+    private sealed class CallbackConsumerInterceptor : IConsumerInterceptor<string, string>
+    {
+        public Action? Callback { get; set; }
+
+        public ConsumeResult<string, string> OnConsume(ConsumeResult<string, string> result)
+        {
+            Callback?.Invoke();
+            return result;
+        }
+
+        public void OnCommit(IReadOnlyList<TopicPartitionOffset> offsets) { }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -187,7 +187,7 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
-    public async Task QueueDivergingEpochResets_QueuesEveryPartitionBeforeInvalidatingEpoch()
+    public async Task QueueDivergingEpochResets_StagesEveryPartitionBeforePublishingClear()
     {
         var pool = Substitute.For<IConnectionPool>();
         await using var metadataManager = CreateMetadataManager(pool);
@@ -209,11 +209,112 @@ public sealed class ConsumerLeaderDiscoveryTests
             fetchBufferEpoch);
 
         await Assert.That(GetFetchBufferEpoch(consumer)).IsEqualTo(fetchBufferEpoch);
-        InvokeCompleteDivergingEpochResets(consumer, fetchBufferEpoch);
+        InvokeCompleteDivergingEpochResets(consumer);
 
-        await Assert.That(GetFetchBufferEpoch(consumer)).IsEqualTo(fetchBufferEpoch + 1);
+        await Assert.That(GetFetchBufferEpoch(consumer)).IsEqualTo(fetchBufferEpoch);
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(GetFetchBufferEpoch(consumer)).IsEqualTo(fetchBufferEpoch + 1);
         await Assert.That(GetLastConsumedLeaderEpoch(consumer, partition: 0)).IsEqualTo(-1);
+        await Assert.That(GetLastConsumedLeaderEpoch(consumer, partition: 1)).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task FetchResponse_WithDivergence_StillReturnsNormalPartitions()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FetchResponse
+            {
+                Responses =
+                [
+                    new FetchResponseTopic
+                    {
+                        Topic = Topic,
+                        Partitions =
+                        [
+                            CreateDivergingEpochResponse(partition: 0),
+                            new FetchResponsePartition
+                            {
+                                PartitionIndex = 1,
+                                Records =
+                                [
+                                    new RecordBatch
+                                    {
+                                        BaseOffset = 10,
+                                        Records = [new Record { OffsetDelta = 0, Value = "normal"u8.ToArray() }]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }));
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        await using var metadataManager = CreateMetadataManager(pool);
+        metadataManager.SetApiVersion(ApiKey.Fetch, FetchRequest.LowestSupportedVersion, FetchRequest.HighestSupportedVersion);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.IncrementalAssign(
+        [
+            new TopicPartitionOffset(Topic, 0, 0),
+            new TopicPartitionOffset(Topic, 1, 10)
+        ]);
+
+        var pendingItems = await InvokeFetchFromBrokerAsync(
+            consumer,
+            brokerId: 1,
+            [new TopicPartition(Topic, 0), new TopicPartition(Topic, 1)],
+            GetFetchBufferEpoch(consumer));
+
+        try
+        {
+            await Assert.That(pendingItems).IsNotNull();
+            await Assert.That(pendingItems!).Count().IsEqualTo(1);
+            await Assert.That(pendingItems[0].TopicPartition).IsEqualTo(new TopicPartition(Topic, 1));
+        }
+        finally
+        {
+            DisposeAndReturn(pendingItems);
+        }
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+    }
+
+    [Test]
+    public async Task DivergingEpochReset_InvalidatesOnlyCorrectedPartition()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.IncrementalAssign(
+        [
+            new TopicPartitionOffset(Topic, 0, 0, leaderEpoch: 3),
+            new TopicPartitionOffset(Topic, 1, 0, leaderEpoch: 4)
+        ]);
+        var fetchBufferEpoch = GetFetchBufferEpoch(consumer);
+
+        await Assert.That(InvokeResetToDivergingEpoch(
+            consumer,
+            CreateDivergingEpochResponse(partition: 0),
+            fetchBufferEpoch)).IsTrue();
+        InvokeCompleteDivergingEpochResets(consumer);
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+
+        await Assert.That(InvokeResetToDivergingEpoch(
+            consumer,
+            CreateDivergingEpochResponse(partition: 0),
+            fetchBufferEpoch)).IsFalse();
+        await Assert.That(InvokeResetToDivergingEpoch(
+            consumer,
+            CreateDivergingEpochResponse(partition: 1),
+            fetchBufferEpoch)).IsTrue();
+        InvokeCompleteDivergingEpochResets(consumer);
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
         await Assert.That(GetLastConsumedLeaderEpoch(consumer, partition: 1)).IsEqualTo(-1);
     }
 
@@ -308,7 +409,10 @@ public sealed class ConsumerLeaderDiscoveryTests
                 Arg.Any<SerializationContext>())
             .Returns(callInfo =>
             {
-                InvokeResetToDivergingEpoch(consumer, CreateDivergingEpochResponse());
+                InvokeResetToDivergingEpoch(
+                    consumer,
+                    CreateDivergingEpochResponse(),
+                    GetFetchBufferEpoch(consumer));
                 cancellationSource.Cancel();
                 return Encoding.UTF8.GetString(callInfo.ArgAt<ReadOnlyMemory<byte>>(0).Span);
             });
@@ -319,6 +423,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             .GetAsyncEnumerator();
 
         await Assert.That(await enumerator.MoveNextAsync()).IsFalse();
+        InvokeCompleteDivergingEpochResets(consumer);
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
         await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(0);
     }
@@ -339,7 +444,10 @@ public sealed class ConsumerLeaderDiscoveryTests
                 Arg.Any<SerializationContext>())
             .Returns(callInfo =>
             {
-                InvokeResetToDivergingEpoch(consumer, CreateDivergingEpochResponse());
+                InvokeResetToDivergingEpoch(
+                    consumer,
+                    CreateDivergingEpochResponse(),
+                    GetFetchBufferEpoch(consumer));
                 cancellationSource.Cancel();
                 return Encoding.UTF8.GetString(callInfo.ArgAt<ReadOnlyMemory<byte>>(0).Span);
             });
@@ -351,6 +459,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             cancellationSource.Token);
 
         await Assert.That(result).IsNull();
+        InvokeCompleteDivergingEpochResets(consumer);
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
         await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(0);
     }
@@ -666,7 +775,7 @@ public sealed class ConsumerLeaderDiscoveryTests
         await valueTask.ConfigureAwait(false);
     }
 
-    private static void InvokeResetToDivergingEpoch(
+    private static bool InvokeResetToDivergingEpoch(
         KafkaConsumer<string, string> consumer,
         FetchResponsePartition partitionResponse,
         int? fetchBufferEpoch = null)
@@ -676,21 +785,54 @@ public sealed class ConsumerLeaderDiscoveryTests
             ?? throw new InvalidOperationException("ResetToDivergingEpoch method not found");
 
         var epoch = fetchBufferEpoch ?? GetFetchBufferEpoch(consumer);
-        method.Invoke(consumer, [Topic, partitionResponse, epoch]);
+        var staged = (bool)method.Invoke(consumer, [Topic, partitionResponse, epoch])!;
 
-        if (fetchBufferEpoch is null)
-            InvokeCompleteDivergingEpochResets(consumer, epoch);
+        if (fetchBufferEpoch is null && staged)
+            InvokeCompleteDivergingEpochResets(consumer);
+
+        return staged;
     }
 
-    private static void InvokeCompleteDivergingEpochResets(
+    private static async ValueTask<List<PendingFetchData>?> InvokeFetchFromBrokerAsync(
         KafkaConsumer<string, string> consumer,
+        int brokerId,
+        List<TopicPartition> partitions,
         int fetchBufferEpoch)
+    {
+        var method = typeof(KafkaConsumer<string, string>)
+            .GetMethod("FetchFromBrokerAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("FetchFromBrokerAsync method not found");
+
+        var result = method.Invoke(consumer, [brokerId, partitions, fetchBufferEpoch, CancellationToken.None]);
+        if (result is not ValueTask<List<PendingFetchData>?> valueTask)
+            throw new InvalidOperationException("FetchFromBrokerAsync returned unexpected type");
+
+        return await valueTask.ConfigureAwait(false);
+    }
+
+    private static void DisposeAndReturn(List<PendingFetchData>? pendingItems)
+    {
+        if (pendingItems is null)
+            return;
+
+        try
+        {
+            foreach (var pending in pendingItems)
+                pending.Dispose();
+        }
+        finally
+        {
+            ConsumerFetchPools.ReturnPendingFetchDataList(pendingItems);
+        }
+    }
+
+    private static void InvokeCompleteDivergingEpochResets(KafkaConsumer<string, string> consumer)
     {
         var method = typeof(KafkaConsumer<string, string>)
             .GetMethod("CompleteDivergingEpochResets", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("CompleteDivergingEpochResets method not found");
 
-        method.Invoke(consumer, [fetchBufferEpoch]);
+        method.Invoke(consumer, []);
     }
 
     private static int GetFetchBufferEpoch(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -337,6 +337,29 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
+    public async Task ResetToDivergingEpoch_ClearsActiveConsumedLeaderEpoch()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        var partition = new TopicPartition(Topic, 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+        SetInitialized(consumer);
+        GetPendingFetches(consumer).Enqueue(CreatePendingFetchData(leaderEpoch: 9));
+
+        await using var enumerator = consumer
+            .ConsumeAsync(CancellationToken.None)
+            .GetAsyncEnumerator();
+
+        await Assert.That(await enumerator.MoveNextAsync()).IsTrue();
+        InvokeResetToDivergingEpoch(consumer, CreateDivergingEpochResponse());
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(1);
+        await Assert.That(GetLastConsumedLeaderEpoch(consumer)).IsEqualTo(-1);
+    }
+
+    [Test]
     public async Task ResetToDivergingEpoch_StopsDecodedBatchAtLastDeliveredRecord()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -810,7 +833,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             }
         };
 
-    private static PendingFetchData CreatePendingFetchData()
+    private static PendingFetchData CreatePendingFetchData(int leaderEpoch = -1)
     {
         var records = new Record[3];
         for (var i = 0; i < records.Length; i++)
@@ -826,7 +849,7 @@ public sealed class ConsumerLeaderDiscoveryTests
         var pending = PendingFetchData.Create(
             Topic,
             partitionIndex: 0,
-            [new RecordBatch { BaseOffset = 0, Records = records }]);
+            [new RecordBatch { BaseOffset = 0, PartitionLeaderEpoch = leaderEpoch, Records = records }]);
         pending.EagerParseAll();
         return pending;
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -261,6 +261,37 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
+    public async Task ResetToDivergingEpoch_StopsConsumeAsyncBeforeUndeliveredRecord()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var keyDeserializer = Substitute.For<IDeserializer<string>>();
+        using var cancellationSource = new CancellationTokenSource();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager, keyDeserializer);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+        SetInitialized(consumer);
+
+        keyDeserializer.Deserialize(
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<SerializationContext>())
+            .Returns(callInfo =>
+            {
+                InvokeResetToDivergingEpoch(consumer, CreateDivergingEpochResponse());
+                cancellationSource.Cancel();
+                return Encoding.UTF8.GetString(callInfo.ArgAt<ReadOnlyMemory<byte>>(0).Span);
+            });
+
+        GetPendingFetches(consumer).Enqueue(CreatePendingFetchData());
+        await using var enumerator = consumer
+            .ConsumeAsync(cancellationSource.Token)
+            .GetAsyncEnumerator();
+
+        await Assert.That(await enumerator.MoveNextAsync()).IsFalse();
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ResetToDivergingEpoch_StopsRawBatchAtLastDeliveredRecord()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -434,14 +465,15 @@ public sealed class ConsumerLeaderDiscoveryTests
 
     private static KafkaConsumer<string, string> CreateConsumer(
         IConnectionPool pool,
-        MetadataManager metadataManager)
+        MetadataManager metadataManager,
+        IDeserializer<string>? keyDeserializer = null)
         => new(
             new ConsumerOptions
             {
                 BootstrapServers = ["localhost:9092"],
                 ClientId = "test-consumer"
             },
-            Serializers.String,
+            keyDeserializer ?? Serializers.String,
             Serializers.String,
             pool,
             metadataManager);
@@ -605,6 +637,16 @@ public sealed class ConsumerLeaderDiscoveryTests
             ?? throw new InvalidOperationException("_fetchBufferEpoch field not found.");
 
         return (int)field.GetValue(consumer)!;
+    }
+
+    private static void SetInitialized(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_initialized",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_initialized field not found.");
+
+        field.SetValue(consumer, true);
     }
 
     private static Queue<PendingFetchData> GetPendingFetches(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -292,6 +292,38 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
+    public async Task ResetToDivergingEpoch_StopsConsumeOneAsyncBeforeUndeliveredRecord()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var keyDeserializer = Substitute.For<IDeserializer<string>>();
+        using var cancellationSource = new CancellationTokenSource();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager, keyDeserializer);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+        SetInitialized(consumer);
+
+        keyDeserializer.Deserialize(
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<SerializationContext>())
+            .Returns(callInfo =>
+            {
+                InvokeResetToDivergingEpoch(consumer, CreateDivergingEpochResponse());
+                cancellationSource.Cancel();
+                return Encoding.UTF8.GetString(callInfo.ArgAt<ReadOnlyMemory<byte>>(0).Span);
+            });
+
+        GetPendingFetches(consumer).Enqueue(CreatePendingFetchData());
+
+        var result = await consumer.ConsumeOneAsync(
+            TimeSpan.FromSeconds(1),
+            cancellationSource.Token);
+
+        await Assert.That(result).IsNull();
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ResetToDivergingEpoch_StopsRawBatchAtLastDeliveredRecord()
     {
         var pool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -167,7 +167,7 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
-    public async Task ResetToDivergingEpoch_RepositionsAndSchedulesStaleFetchClearWithoutException()
+    public async Task ResetToDivergingEpoch_RefetchesFromCurrentPosition()
     {
         var pool = Substitute.For<IConnectionPool>();
         await using var metadataManager = CreateMetadataManager(pool);
@@ -179,9 +179,27 @@ public sealed class ConsumerLeaderDiscoveryTests
         InvokeResetToDivergingEpoch(consumer, partitionResponse);
 
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
-        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(42);
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(0);
         await Assert.That(GetLastConsumedLeaderEpoch(consumer)).IsEqualTo(-1);
         await Assert.That(DrainPendingFetchException(consumer)).IsNull();
+    }
+
+    [Test]
+    public async Task ResetToDivergingEpoch_ResumesAfterLastYieldedBufferedRecord()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+
+        var pending = PendingFetchData.Create(Topic, 0, []);
+        pending.TrackConsumed(9, messageBytes: 0);
+        GetPendingFetches(consumer).Enqueue(pending);
+
+        InvokeResetToDivergingEpoch(consumer, CreateDivergingEpochResponse());
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(10);
     }
 
     [Test]
@@ -457,6 +475,16 @@ public sealed class ConsumerLeaderDiscoveryTests
             ?? throw new InvalidOperationException("_fetchBufferEpoch field not found.");
 
         return (int)field.GetValue(consumer)!;
+    }
+
+    private static Queue<PendingFetchData> GetPendingFetches(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_pendingFetches",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_pendingFetches field not found.");
+
+        return (Queue<PendingFetchData>)field.GetValue(consumer)!;
     }
 
     private static int GetLastConsumedLeaderEpoch(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -1,10 +1,12 @@
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 using NSubstitute;
 
@@ -231,6 +233,52 @@ public sealed class ConsumerLeaderDiscoveryTests
 
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
         await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task ResetToDivergingEpoch_StopsDecodedBatchAtLastDeliveredRecord()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+
+        var pending = CreatePendingFetchData();
+        GetPendingFetches(consumer).Enqueue(pending);
+        var batch = new ConsumeBatch<string, string>(
+            pending,
+            Serializers.String,
+            Serializers.String,
+            GetCanContinueBatchIteration(consumer));
+        using var enumerator = batch.GetEnumerator();
+
+        await Assert.That(enumerator.MoveNext()).IsTrue();
+        InvokeResetToDivergingEpoch(consumer, CreateDivergingEpochResponse());
+
+        await Assert.That(enumerator.MoveNext()).IsFalse();
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ResetToDivergingEpoch_StopsRawBatchAtLastDeliveredRecord()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+
+        var pending = CreatePendingFetchData();
+        GetPendingFetches(consumer).Enqueue(pending);
+        var batch = new ConsumeRawBatch(pending, GetCanContinueBatchIteration(consumer));
+        using var enumerator = batch.GetEnumerator();
+
+        await Assert.That(enumerator.MoveNext()).IsTrue();
+        InvokeResetToDivergingEpoch(consumer, CreateDivergingEpochResponse());
+
+        await Assert.That(enumerator.MoveNext()).IsFalse();
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(1);
     }
 
     [Test]
@@ -473,6 +521,38 @@ public sealed class ConsumerLeaderDiscoveryTests
                 EndOffset = endOffset
             }
         };
+
+    private static PendingFetchData CreatePendingFetchData()
+    {
+        var records = new Record[3];
+        for (var i = 0; i < records.Length; i++)
+        {
+            records[i] = new Record
+            {
+                OffsetDelta = i,
+                Key = Encoding.UTF8.GetBytes($"key-{i}"),
+                Value = Encoding.UTF8.GetBytes($"value-{i}")
+            };
+        }
+
+        var pending = PendingFetchData.Create(
+            Topic,
+            partitionIndex: 0,
+            [new RecordBatch { BaseOffset = 0, Records = records }]);
+        pending.EagerParseAll();
+        return pending;
+    }
+
+    private static Func<TopicPartition, bool> GetCanContinueBatchIteration(
+        KafkaConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "CanContinueBatchIteration",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("CanContinueBatchIteration method not found");
+
+        return method.CreateDelegate<Func<TopicPartition, bool>>(consumer);
+    }
 
     private static async ValueTask InvokeHandleLeaderEpochRefreshAsync(
         KafkaConsumer<string, string> consumer,

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -486,6 +486,24 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
+    public async Task RawBatch_RechecksAssignmentBeforeTrackingRecord()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        var pending = CreatePendingFetchData();
+        GetPendingFetches(consumer).Enqueue(pending);
+        var assignmentChecks = 0;
+        var batch = new ConsumeRawBatch(
+            pending,
+            _ => Interlocked.Increment(ref assignmentChecks) == 1);
+        using var enumerator = batch.GetEnumerator();
+
+        await Assert.That(enumerator.MoveNext()).IsFalse();
+        await Assert.That(assignmentChecks).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task ResetToDivergingEpoch_DoesNotRewindDeliveredPosition()
     {
         var pool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -261,6 +261,38 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
+    public async Task ResetToDivergingEpoch_StopsDecodedBatchBeforeUndeliveredRecord()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var keyDeserializer = Substitute.For<IDeserializer<string>>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager, keyDeserializer);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+
+        keyDeserializer.Deserialize(
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<SerializationContext>())
+            .Returns(callInfo =>
+            {
+                InvokeResetToDivergingEpoch(consumer, CreateDivergingEpochResponse());
+                return Encoding.UTF8.GetString(callInfo.ArgAt<ReadOnlyMemory<byte>>(0).Span);
+            });
+
+        var pending = CreatePendingFetchData();
+        GetPendingFetches(consumer).Enqueue(pending);
+        var batch = new ConsumeBatch<string, string>(
+            pending,
+            keyDeserializer,
+            Serializers.String,
+            GetCanContinueBatchIteration(consumer));
+        using var enumerator = batch.GetEnumerator();
+
+        await Assert.That(enumerator.MoveNext()).IsFalse();
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ResetToDivergingEpoch_StopsConsumeAsyncBeforeUndeliveredRecord()
     {
         var pool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -185,6 +185,37 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
+    public async Task QueueDivergingEpochResets_QueuesEveryPartitionBeforeInvalidatingEpoch()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.IncrementalAssign(
+        [
+            new TopicPartitionOffset(Topic, 0, 10, leaderEpoch: 3),
+            new TopicPartitionOffset(Topic, 1, 20, leaderEpoch: 4)
+        ]);
+        var fetchBufferEpoch = GetFetchBufferEpoch(consumer);
+
+        InvokeResetToDivergingEpoch(
+            consumer,
+            CreateDivergingEpochResponse(partition: 0, epoch: 7, endOffset: 8),
+            fetchBufferEpoch);
+        InvokeResetToDivergingEpoch(
+            consumer,
+            CreateDivergingEpochResponse(partition: 1, epoch: 8, endOffset: 18),
+            fetchBufferEpoch);
+
+        await Assert.That(GetFetchBufferEpoch(consumer)).IsEqualTo(fetchBufferEpoch);
+        InvokeCompleteDivergingEpochResets(consumer, fetchBufferEpoch);
+
+        await Assert.That(GetFetchBufferEpoch(consumer)).IsEqualTo(fetchBufferEpoch + 1);
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(GetLastConsumedLeaderEpoch(consumer, partition: 0)).IsEqualTo(-1);
+        await Assert.That(GetLastConsumedLeaderEpoch(consumer, partition: 1)).IsEqualTo(-1);
+    }
+
+    [Test]
     public async Task ResetToDivergingEpoch_ResumesAfterLastYieldedBufferedRecord()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -429,14 +460,17 @@ public sealed class ConsumerLeaderDiscoveryTests
         }
     }
 
-    private static FetchResponsePartition CreateDivergingEpochResponse() =>
+    private static FetchResponsePartition CreateDivergingEpochResponse(
+        int partition = 0,
+        int epoch = 7,
+        long endOffset = 42) =>
         new()
         {
-            PartitionIndex = 0,
+            PartitionIndex = partition,
             DivergingEpoch = new EpochEndOffset
             {
-                Epoch = 7,
-                EndOffset = 42
+                Epoch = epoch,
+                EndOffset = endOffset
             }
         };
 
@@ -458,13 +492,29 @@ public sealed class ConsumerLeaderDiscoveryTests
 
     private static void InvokeResetToDivergingEpoch(
         KafkaConsumer<string, string> consumer,
-        FetchResponsePartition partitionResponse)
+        FetchResponsePartition partitionResponse,
+        int? fetchBufferEpoch = null)
     {
         var method = typeof(KafkaConsumer<string, string>)
             .GetMethod("ResetToDivergingEpoch", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("ResetToDivergingEpoch method not found");
 
-        method.Invoke(consumer, [Topic, partitionResponse, GetFetchBufferEpoch(consumer)]);
+        var epoch = fetchBufferEpoch ?? GetFetchBufferEpoch(consumer);
+        method.Invoke(consumer, [Topic, partitionResponse, epoch]);
+
+        if (fetchBufferEpoch is null)
+            InvokeCompleteDivergingEpochResets(consumer, epoch);
+    }
+
+    private static void InvokeCompleteDivergingEpochResets(
+        KafkaConsumer<string, string> consumer,
+        int fetchBufferEpoch)
+    {
+        var method = typeof(KafkaConsumer<string, string>)
+            .GetMethod("CompleteDivergingEpochResets", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("CompleteDivergingEpochResets method not found");
+
+        method.Invoke(consumer, [fetchBufferEpoch]);
     }
 
     private static int GetFetchBufferEpoch(KafkaConsumer<string, string> consumer)
@@ -487,14 +537,16 @@ public sealed class ConsumerLeaderDiscoveryTests
         return (Queue<PendingFetchData>)field.GetValue(consumer)!;
     }
 
-    private static int GetLastConsumedLeaderEpoch(KafkaConsumer<string, string> consumer)
+    private static int GetLastConsumedLeaderEpoch(
+        KafkaConsumer<string, string> consumer,
+        int partition = 0)
     {
         var method = typeof(KafkaConsumer<string, string>).GetMethod(
             "GetLastConsumedLeaderEpoch",
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("GetLastConsumedLeaderEpoch method not found");
 
-        return (int)method.Invoke(consumer, [new TopicPartition(Topic, 0)])!;
+        return (int)method.Invoke(consumer, [new TopicPartition(Topic, partition)])!;
     }
 
     private static Exception? DrainPendingFetchException(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -174,15 +174,7 @@ public sealed class ConsumerLeaderDiscoveryTests
         await using var consumer = CreateConsumer(pool, metadataManager);
         consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
 
-        var partitionResponse = new FetchResponsePartition
-        {
-            PartitionIndex = 0,
-            DivergingEpoch = new EpochEndOffset
-            {
-                Epoch = 7,
-                EndOffset = 42
-            }
-        };
+        var partitionResponse = CreateDivergingEpochResponse();
 
         InvokeResetToDivergingEpoch(consumer, partitionResponse);
 
@@ -200,15 +192,7 @@ public sealed class ConsumerLeaderDiscoveryTests
         await using var consumer = CreateConsumer(pool, metadataManager);
         consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 43)]);
 
-        var partitionResponse = new FetchResponsePartition
-        {
-            PartitionIndex = 0,
-            DivergingEpoch = new EpochEndOffset
-            {
-                Epoch = 7,
-                EndOffset = 42
-            }
-        };
+        var partitionResponse = CreateDivergingEpochResponse();
 
         InvokeResetToDivergingEpoch(consumer, partitionResponse);
 
@@ -216,6 +200,61 @@ public sealed class ConsumerLeaderDiscoveryTests
         await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(43);
         await Assert.That(GetLastConsumedLeaderEpoch(consumer)).IsEqualTo(-1);
         await Assert.That(DrainPendingFetchException(consumer)).IsNull();
+    }
+
+    [Test]
+    public async Task ResetToDivergingEpoch_ExplicitSeekSupersedesPendingReset()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        var partition = new TopicPartition(Topic, 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+
+        var partitionResponse = CreateDivergingEpochResponse();
+
+        InvokeResetToDivergingEpoch(consumer, partitionResponse);
+        consumer.Seek(new TopicPartitionOffset(Topic, 0, 5));
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task ResetToDivergingEpoch_ReassignmentSupersedesPendingReset()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        var partition = new TopicPartition(Topic, 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+
+        var partitionResponse = CreateDivergingEpochResponse();
+
+        InvokeResetToDivergingEpoch(consumer, partitionResponse);
+        consumer.IncrementalUnassign([partition]);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 5)]);
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task ResetToDivergingEpoch_ManualAssignSupersedesPendingReset()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        var partition = new TopicPartition(Topic, 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+
+        var partitionResponse = CreateDivergingEpochResponse();
+
+        InvokeResetToDivergingEpoch(consumer, partitionResponse);
+        consumer.Assign(partition);
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(0);
     }
 
     [Test]
@@ -371,6 +410,17 @@ public sealed class ConsumerLeaderDiscoveryTests
             await task.ConfigureAwait(false);
         }
     }
+
+    private static FetchResponsePartition CreateDivergingEpochResponse() =>
+        new()
+        {
+            PartitionIndex = 0,
+            DivergingEpoch = new EpochEndOffset
+            {
+                Epoch = 7,
+                EndOffset = 42
+            }
+        };
 
     private static async ValueTask InvokeHandleLeaderEpochRefreshAsync(
         KafkaConsumer<string, string> consumer,

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -183,7 +183,6 @@ public sealed class ConsumerLeaderDiscoveryTests
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
         await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(0);
         await Assert.That(GetLastConsumedLeaderEpoch(consumer)).IsEqualTo(-1);
-        await Assert.That(DrainPendingFetchException(consumer)).IsNull();
     }
 
     [Test]
@@ -337,11 +336,14 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
-    public async Task ResetToDivergingEpoch_ClearsActiveConsumedLeaderEpoch()
+    public async Task ResetToDivergingEpoch_ClearsActiveAutoCommitSnapshot()
     {
         var pool = Substitute.For<IConnectionPool>();
         await using var metadataManager = CreateMetadataManager(pool);
-        await using var consumer = CreateConsumer(pool, metadataManager);
+        await using var consumer = CreateConsumer(
+            pool,
+            metadataManager,
+            offsetCommitMode: OffsetCommitMode.Auto);
         var partition = new TopicPartition(Topic, 0);
         consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
         SetInitialized(consumer);
@@ -352,9 +354,16 @@ public sealed class ConsumerLeaderDiscoveryTests
             .GetAsyncEnumerator();
 
         await Assert.That(await enumerator.MoveNextAsync()).IsTrue();
+        var activePosition = GetActiveConsumedPosition(consumer, partition);
+        await Assert.That(activePosition.HasValue).IsTrue();
+        var activePositionValue = activePosition.GetValueOrDefault();
+        await Assert.That(activePositionValue.Position).IsEqualTo(1);
+        await Assert.That(activePositionValue.LeaderEpoch).IsEqualTo(9);
+
         InvokeResetToDivergingEpoch(consumer, CreateDivergingEpochResponse());
 
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(GetActiveConsumedPosition(consumer, partition).HasValue).IsFalse();
         await Assert.That(consumer.GetPosition(partition)).IsEqualTo(1);
         await Assert.That(GetLastConsumedLeaderEpoch(consumer)).IsEqualTo(-1);
     }
@@ -604,7 +613,6 @@ public sealed class ConsumerLeaderDiscoveryTests
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
         await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(43);
         await Assert.That(GetLastConsumedLeaderEpoch(consumer)).IsEqualTo(-1);
-        await Assert.That(DrainPendingFetchException(consumer)).IsNull();
     }
 
     [Test]
@@ -744,13 +752,15 @@ public sealed class ConsumerLeaderDiscoveryTests
         IConnectionPool pool,
         MetadataManager metadataManager,
         IDeserializer<string>? keyDeserializer = null,
-        IConsumerInterceptor<string, string>? interceptor = null)
+        IConsumerInterceptor<string, string>? interceptor = null,
+        OffsetCommitMode offsetCommitMode = OffsetCommitMode.Auto)
         => new(
             new ConsumerOptions
             {
                 BootstrapServers = ["localhost:9092"],
                 ClientId = "test-consumer",
-                Interceptors = interceptor is null ? null : [interceptor]
+                Interceptors = interceptor is null ? null : [interceptor],
+                OffsetCommitMode = offsetCommitMode
             },
             keyDeserializer ?? Serializers.String,
             Serializers.String,
@@ -983,21 +993,19 @@ public sealed class ConsumerLeaderDiscoveryTests
         return (int)method.Invoke(consumer, [new TopicPartition(Topic, partition)])!;
     }
 
-    private static Exception? DrainPendingFetchException(KafkaConsumer<string, string> consumer)
+    private static (long Position, int LeaderEpoch)? GetActiveConsumedPosition(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition partition)
     {
         var method = typeof(KafkaConsumer<string, string>)
-            .GetMethod("ThrowPendingFetchException", BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("ThrowPendingFetchException method not found");
+            .GetMethod("TryGetActiveConsumedPosition", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("TryGetActiveConsumedPosition method not found");
 
-        try
-        {
-            method.Invoke(consumer, []);
+        object?[] arguments = [partition, 0L, -1];
+        if (!(bool)method.Invoke(consumer, arguments)!)
             return null;
-        }
-        catch (TargetInvocationException ex)
-        {
-            return ex.InnerException;
-        }
+
+        return ((long)arguments[1]!, (int)arguments[2]!);
     }
 
     private static bool ClearFetchBufferForPendingCoordinatorRevocations(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using Dekaf.Consumer;
-using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
@@ -168,7 +167,7 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
-    public async Task ResetToDivergingEpoch_RepositionsAndQueuesConsumeException()
+    public async Task ResetToDivergingEpoch_RepositionsAndSchedulesStaleFetchClearWithoutException()
     {
         var pool = Substitute.For<IConnectionPool>();
         await using var metadataManager = CreateMetadataManager(pool);
@@ -187,12 +186,36 @@ public sealed class ConsumerLeaderDiscoveryTests
 
         InvokeResetToDivergingEpoch(consumer, partitionResponse);
 
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
         await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(42);
-        var exception = DrainPendingFetchException(consumer);
-        await Assert.That(exception).IsTypeOf<ConsumeException>();
-        var consumeException = (ConsumeException)exception!;
-        await Assert.That(consumeException.ErrorCode).IsEqualTo(ErrorCode.OffsetOutOfRange);
-        await Assert.That(consumeException.IsRetriable).IsTrue();
+        await Assert.That(GetLastConsumedLeaderEpoch(consumer)).IsEqualTo(-1);
+        await Assert.That(DrainPendingFetchException(consumer)).IsNull();
+    }
+
+    [Test]
+    public async Task ResetToDivergingEpoch_DoesNotRewindDeliveredPosition()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 43)]);
+
+        var partitionResponse = new FetchResponsePartition
+        {
+            PartitionIndex = 0,
+            DivergingEpoch = new EpochEndOffset
+            {
+                Epoch = 7,
+                EndOffset = 42
+            }
+        };
+
+        InvokeResetToDivergingEpoch(consumer, partitionResponse);
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(43);
+        await Assert.That(GetLastConsumedLeaderEpoch(consumer)).IsEqualTo(-1);
+        await Assert.That(DrainPendingFetchException(consumer)).IsNull();
     }
 
     [Test]
@@ -386,6 +409,16 @@ public sealed class ConsumerLeaderDiscoveryTests
         return (int)field.GetValue(consumer)!;
     }
 
+    private static int GetLastConsumedLeaderEpoch(KafkaConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "GetLastConsumedLeaderEpoch",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("GetLastConsumedLeaderEpoch method not found");
+
+        return (int)method.Invoke(consumer, [new TopicPartition(Topic, 0)])!;
+    }
+
     private static Exception? DrainPendingFetchException(KafkaConsumer<string, string> consumer)
     {
         var method = typeof(KafkaConsumer<string, string>)
@@ -401,5 +434,17 @@ public sealed class ConsumerLeaderDiscoveryTests
         {
             return ex.InnerException;
         }
+    }
+
+    private static bool ClearFetchBufferForPendingCoordinatorRevocations(
+        KafkaConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "ClearFetchBufferForPendingCoordinatorRevocations",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "ClearFetchBufferForPendingCoordinatorRevocations method not found");
+
+        return (bool)method.Invoke(consumer, [])!;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/FetchSessionHandlerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/FetchSessionHandlerTests.cs
@@ -45,6 +45,22 @@ public sealed class FetchSessionHandlerTests
     }
 
     [Test]
+    public async Task Build_LastFetchedEpochChanged_SendsPartitionUpdate()
+    {
+        var handler = new FetchSessionHandler();
+        var initial = TopicsWithEpoch(lastFetchedEpoch: 7);
+
+        handler.Build(initial, clusterMetadata: null);
+        handler.HandleResponse(Response(sessionId: 42));
+
+        var changed = handler.Build(TopicsWithEpoch(lastFetchedEpoch: -1), clusterMetadata: null);
+
+        await Assert.That(changed.Topics).Count().IsEqualTo(1);
+        await Assert.That(changed.Topics[0].Partitions).Count().IsEqualTo(1);
+        await Assert.That(changed.Topics[0].Partitions[0].LastFetchedEpoch).IsEqualTo(-1);
+    }
+
+    [Test]
     public async Task Build_IncrementalDetectsForgottenPartitions()
     {
         var topicId = Guid.NewGuid();
@@ -150,6 +166,25 @@ public sealed class FetchSessionHandlerTests
 
         return result;
     }
+
+    private static List<FetchRequestTopic> TopicsWithEpoch(int lastFetchedEpoch) =>
+    [
+        new FetchRequestTopic
+        {
+            Topic = "topic-a",
+            Partitions =
+            [
+                new FetchRequestPartition
+                {
+                    Partition = 0,
+                    FetchOffset = 100,
+                    PartitionMaxBytes = 1024,
+                    CurrentLeaderEpoch = 8,
+                    LastFetchedEpoch = lastFetchedEpoch
+                }
+            ]
+        }
+    ];
 
     private static ClusterMetadata Metadata(string topic, Guid topicId)
     {


### PR DESCRIPTION
## Summary

- apply broker divergence corrections on the consumer thread instead of surfacing a terminal `ConsumeException`
- invalidate and pause stale prefetch work while buffered records are cleared
- resume from the broker correction without rewinding records already yielded to the application
- add exact-sequence coverage for partition leader handoff and a three-broker rolling restart
- extend the shared rack-aware fixture with replicated-topic and broker lifecycle helpers

The integration fixture also exposed a separate same-producer metadata recovery regression, tracked in #1670. These tests use a fresh producer per fault phase to keep the consumer behavior isolated.

## Validation

- `dotnet build src/Dekaf/Dekaf.csproj -c Release --no-restore`
- `ConsumerLeaderDiscoveryTests`: 7 passed
- `ConsumerAssignmentFastPathTests`: 9 passed
- leader handoff + rolling restart integration tests: 2 passed
- `dotnet format Dekaf.sln --verify-no-changes --no-restore --include ...`

Closes #1639