### PR TITLE
Fix producer stale-leader recovery after handoff

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -915,6 +915,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             ? new ValueTask[connectionCapacity]
             : Array.Empty<ValueTask>();
 
+        // Shared by all connection buckets dispatched in one send-loop iteration. Send
+        // failures can complete concurrently, so PrepareDeferredNetworkRetry protects it.
+        HashSet<string>? retryMetadataRefreshTopics = null;
+
         // Per-connection timeout CTS for multi-connection mode, reused with TryReset()
         // to avoid per-send CTS allocation (same pattern as sendTimeoutCts for single-connection).
         // Entries beyond the current connection count are created lazily on scale-up.
@@ -1359,6 +1363,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         {
                             // === Multi-connection path ===
 
+                            var metadataRefreshTopics = retryMetadataRefreshTopics ??=
+                                new HashSet<string>(StringComparer.Ordinal);
+                            metadataRefreshTopics.Clear();
+
                             // Distribute coalesced batches into per-connection buckets.
                             // Partition affinity (partition % N) keeps each partition's batches
                             // on the same connection for CPU cache locality. This also preserves
@@ -1396,7 +1404,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                                 ResetBucketTimeout(ref bucketTimeoutCts[c], cancellationToken);
                                 parallelSends[pendingSendCount++] = SendConnectionBucketAsync(c, connectionBuckets,
-                                    scratches[c], bucketTimeoutCts[c].Token);
+                                    scratches[c], metadataRefreshTopics, bucketTimeoutCts[c].Token);
                             }
 
                             var completedSends = await AwaitParallelSendsAsync(parallelSends, pendingSendCount)
@@ -1441,7 +1449,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                                     ResetBucketTimeout(ref bucketTimeoutCts[c], cancellationToken);
                                     parallelSends[pendingSendCount++] = SendConnectionBucketAsync(c, connectionBuckets,
-                                        scratches[c], bucketTimeoutCts[c].Token);
+                                        scratches[c], metadataRefreshTopics, bucketTimeoutCts[c].Token);
                                 }
 
                                 var waitCompletedSends = await AwaitParallelSendsAsync(parallelSends, pendingSendCount)
@@ -2676,7 +2684,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         int count,
         ProduceRequestScratch scratch,
         int connectionIndex,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        HashSet<string>? metadataRefreshTopics = null)
     {
         // Snapshot batch generations before the first await, while this send still has
         // exclusive ownership handed over by the send loop's coalesce step. If the request
@@ -2997,7 +3006,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // Aligned with Java Kafka's Sender: transient failures cause reenqueue for retry.
             _pinnedConnections[connectionIndex] = null; // Invalidate only the broken connection
             LogResponseFailed(ex, _brokerId);
-            HashSet<string>? metadataRefreshTopics = null;
 
             for (var i = 0; i < count; i++)
             {
@@ -3073,7 +3081,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             batch.TopicPartition.Partition, _options.RetryBackoffMs);
         batch.RetryNotBefore = Stopwatch.GetTimestamp() + _options.RetryBackoffTicks;
 
-        if (metadataRefreshTopics.Add(batch.TopicPartition.Topic))
+        bool refreshMetadata;
+        lock (metadataRefreshTopics)
+        {
+            refreshMetadata = metadataRefreshTopics.Add(batch.TopicPartition.Topic);
+        }
+
+        if (refreshMetadata)
         {
             // The send token may already be cancelled when a write times out. Use the sender
             // lifetime token so recovery can still refresh metadata.
@@ -3319,7 +3333,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private async ValueTask SendConnectionBucketAsync(
         int connIdx, ConnectionBucket[] connectionBuckets,
-        ProduceRequestScratch scratch, CancellationToken cancellationToken)
+        ProduceRequestScratch scratch,
+        HashSet<string> metadataRefreshTopics,
+        CancellationToken cancellationToken)
     {
         ref var bucket = ref connectionBuckets[connIdx];
         var batchesToSend = ArrayPool<ReadyBatch>.Shared.Rent(bucket.Count);
@@ -3340,7 +3356,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return;
         }
 
-        await SendCoalescedAsync(batchesToSend, countToSend, scratch, connIdx, cancellationToken)
+        await SendCoalescedAsync(
+                batchesToSend,
+                countToSend,
+                scratch,
+                connIdx,
+                cancellationToken,
+                metadataRefreshTopics)
             .ConfigureAwait(false);
     }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -971,7 +971,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             retry.Generation,
                             ErrorCode.NetworkException,
                             carryOver,
-                            cancellationToken);
+                            cancellationToken,
+                            networkRetryPrepared: true);
                     }
                     else
                         LogStaleRetryBatchSkipped(_instanceId, _brokerId);
@@ -2505,8 +2506,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// Called inline from ProcessCompletedResponses in the single-threaded send loop.
     /// </summary>
     private void HandleRetriableBatch(ReadyBatch batch, int generation, ErrorCode errorCode,
-        PartitionCarryOver carryOver, CancellationToken cancellationToken)
-        => HandleRetriableBatch(batch, generation, errorCode, null, [], carryOver, cancellationToken);
+        PartitionCarryOver carryOver, CancellationToken cancellationToken,
+        bool networkRetryPrepared = false)
+        => HandleRetriableBatch(batch, generation, errorCode, null, [], carryOver, cancellationToken,
+            networkRetryPrepared);
 
     private void HandleRetriableBatch(
         ReadyBatch batch,
@@ -2515,7 +2518,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         LeaderIdAndEpoch? currentLeader,
         IReadOnlyList<NodeEndpoint> nodeEndpoints,
         PartitionCarryOver carryOver,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool networkRetryPrepared = false)
     {
         if (!batch.IsCurrentIncarnation(generation))
         {
@@ -2585,7 +2589,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
             batch.InflightEntry = null;
         }
-        else
+        else if (!networkRetryPrepared)
         {
             if (TryApplyInlineLeader(batch.TopicPartition, errorCode, currentLeader, nodeEndpoints))
             {
@@ -3029,10 +3033,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     }
                     else
                     {
-                        // Parallel connection buckets may still be sending, so mute before
-                        // deferring to prevent newer batches from being drained in the gap.
-                        _mutedPartitions.TryAdd(batch.TopicPartition, 0);
-                        _accumulator.MutePartition(batch.TopicPartition);
+                        PrepareDeferredNetworkRetry(batch);
                         _sendFailedRetries.Enqueue((batch, generations[i]));
                     }
                 }
@@ -3058,6 +3059,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (!pendingResponseAdded)
                 ArrayPool<int>.Shared.Return(generations);
         }
+    }
+
+    private void PrepareDeferredNetworkRetry(ReadyBatch batch)
+    {
+        // Parallel connection buckets may still be sending. Begin recovery here so a blocked
+        // sibling write cannot postpone metadata refresh or the start of retry backoff.
+        _mutedPartitions.TryAdd(batch.TopicPartition, 0);
+        _accumulator.MutePartition(batch.TopicPartition);
+        LogRetriableErrorWithBackoff(ErrorCode.NetworkException, batch.TopicPartition.Topic,
+            batch.TopicPartition.Partition, _options.RetryBackoffMs);
+        // The send token may already be cancelled when a write times out. Use the sender lifetime
+        // token so timeout recovery can still refresh metadata.
+        _ = ObserveMetadataRefreshAsync(batch.TopicPartition.Topic, _cts.Token);
+        batch.RetryNotBefore = Stopwatch.GetTimestamp() + _options.RetryBackoffTicks;
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3065,8 +3065,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     {
         // Parallel connection buckets may still be sending. Begin recovery here so a blocked
         // sibling write cannot postpone metadata refresh or the start of retry backoff.
-        _mutedPartitions.TryAdd(batch.TopicPartition, 0);
-        _accumulator.MutePartition(batch.TopicPartition);
+        if (!batch.IsLoopExitRedelivery)
+            MutePartition(batch.TopicPartition);
         LogRetriableErrorWithBackoff(ErrorCode.NetworkException, batch.TopicPartition.Topic,
             batch.TopicPartition.Partition, _options.RetryBackoffMs);
         // The send token may already be cancelled when a write times out. Use the sender lifetime

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -388,6 +388,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // FIFO ordering (matching the old List iteration order) and is optimized for the
     // cross-thread producer-consumer pattern used here.
     //
+    // The send loop drains this queue through HandleRetriableBatch so connection failures
+    // trigger the same metadata refresh and ordering logic as broker error responses.
+    //
     // Each entry carries the batch's generation captured at send start. ReadyBatch objects
     // are pooled, so a reference sitting in this queue can be completed and recycled by
     // another owner before the send loop dequeues it. IsReturnedToPool alone cannot detect
@@ -956,13 +959,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 ProcessCompletedResponses(carryOver, cancellationToken, responseLookup);
 
                 // ── 2. Pick up send-failed retries ──
-                // FIFO dequeue + AddFirst reverses the enqueue order, but this is intentional:
-                // each retry batch goes before all existing carry-over for its partition,
-                // matching Java's Deque.addFirst semantics for retry priority.
+                // Process these through the common retriable-error path. In particular, a
+                // stopped leader often fails before returning a ProduceResponse, so this is
+                // the only point that can request fresh metadata before the stale route retries.
                 while (_sendFailedRetries.TryDequeue(out var retry))
                 {
                     if (retry.Batch.IsCurrentIncarnation(retry.Generation))
-                        carryOver.AddFirst(new BatchReference(retry.Batch, retry.Generation));
+                    {
+                        HandleRetriableBatch(
+                            retry.Batch,
+                            retry.Generation,
+                            ErrorCode.NetworkException,
+                            carryOver,
+                            cancellationToken);
+                    }
                     else
                         LogStaleRetryBatchSkipped(_instanceId, _brokerId);
                 }
@@ -3019,12 +3029,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     }
                     else
                     {
-                        // Mute partition (ordering guarantee) and queue for retry.
-                        if (!batch.IsLoopExitRedelivery)
-                            MutePartition(batch.TopicPartition);
-                        batch.IsRetry = true;
-                        batch.RetryNotBefore = Stopwatch.GetTimestamp() +
-                            _options.RetryBackoffTicks;
+                        // Queue for the single-threaded send loop to apply the common
+                        // retriable-error path, including metadata refresh and partition muting.
                         _sendFailedRetries.Enqueue((batch, generations[i]));
                     }
                 }

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2550,7 +2550,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Mute partition so no newer batches overtake the retry (ordering guarantee).
         // Also mute in accumulator so Ready/Drain skips this partition — prevents the
         // sender loop from draining newer batches that would jump the retry queue.
-        if (!batch.IsLoopExitRedelivery)
+        if (!networkRetryPrepared && !batch.IsLoopExitRedelivery)
             MutePartition(batch.TopicPartition);
 
         var isEpochBumpError = errorCode is ErrorCode.OutOfOrderSequenceNumber
@@ -2997,6 +2997,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // Aligned with Java Kafka's Sender: transient failures cause reenqueue for retry.
             _pinnedConnections[connectionIndex] = null; // Invalidate only the broken connection
             LogResponseFailed(ex, _brokerId);
+            HashSet<string>? metadataRefreshTopics = null;
 
             for (var i = 0; i < count; i++)
             {
@@ -3033,7 +3034,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     }
                     else
                     {
-                        PrepareDeferredNetworkRetry(batch);
+                        metadataRefreshTopics ??= new HashSet<string>(StringComparer.Ordinal);
+                        PrepareDeferredNetworkRetry(batch, metadataRefreshTopics);
                         _sendFailedRetries.Enqueue((batch, generations[i]));
                     }
                 }
@@ -3061,7 +3063,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
     }
 
-    private void PrepareDeferredNetworkRetry(ReadyBatch batch)
+    private void PrepareDeferredNetworkRetry(ReadyBatch batch, HashSet<string> metadataRefreshTopics)
     {
         // Parallel connection buckets may still be sending. Begin recovery here so a blocked
         // sibling write cannot postpone metadata refresh or the start of retry backoff.
@@ -3069,10 +3071,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             MutePartition(batch.TopicPartition);
         LogRetriableErrorWithBackoff(ErrorCode.NetworkException, batch.TopicPartition.Topic,
             batch.TopicPartition.Partition, _options.RetryBackoffMs);
-        // The send token may already be cancelled when a write times out. Use the sender lifetime
-        // token so timeout recovery can still refresh metadata.
-        _ = ObserveMetadataRefreshAsync(batch.TopicPartition.Topic, _cts.Token);
         batch.RetryNotBefore = Stopwatch.GetTimestamp() + _options.RetryBackoffTicks;
+
+        if (metadataRefreshTopics.Add(batch.TopicPartition.Topic))
+        {
+            // The send token may already be cancelled when a write times out. Use the sender
+            // lifetime token so recovery can still refresh metadata.
+            _ = ObserveMetadataRefreshAsync(batch.TopicPartition.Topic, _cts.Token);
+        }
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -401,9 +401,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly ConcurrentQueue<(ReadyBatch Batch, int Generation)> _sendFailedRetries = new();
 
     // Batches recovered from an unexpectedly exited sender. These must run before both
-    // send-failure retries and normal channel backlog on the replacement sender. They use
-    // a separate queue because _sendFailedRetries is drained with AddFirst (which reverses
-    // FIFO order when multiple same-partition entries arrive together).
+    // send-failure retries and normal channel backlog on the replacement sender. Their
+    // separate queue preserves LoopExitRedeliveryOrder while carry-over insertion keeps
+    // every crash recovery ahead of ordinary retries and new work.
     private readonly ConcurrentQueue<(ReadyBatch Batch, int Generation)> _loopExitRedeliveries = new();
 
     // Partitions accepted while this sender is alive. Guarded with _loopExited so an

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3029,8 +3029,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     }
                     else
                     {
-                        // Queue for the single-threaded send loop to apply the common
-                        // retriable-error path, including metadata refresh and partition muting.
+                        // Parallel connection buckets may still be sending, so mute before
+                        // deferring to prevent newer batches from being drained in the gap.
+                        _mutedPartitions.TryAdd(batch.TopicPartition, 0);
+                        _accumulator.MutePartition(batch.TopicPartition);
                         _sendFailedRetries.Enqueue((batch, generations[i]));
                     }
                 }

--- a/tests/Dekaf.Tests.Integration/ConsumerRackAwarenessIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerRackAwarenessIntegrationTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 namespace Dekaf.Tests.Integration;
 
 [Category("Consumer")]
+[NotInParallel("RackAwareKafkaContainer")]
 [ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
 public sealed class ConsumerRackAwarenessIntegrationTests(RackAwareKafkaContainer kafka)
 {

--- a/tests/Dekaf.Tests.Integration/ProducerLeaderFailoverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerLeaderFailoverIntegrationTests.cs
@@ -1,0 +1,159 @@
+using Dekaf.Consumer;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Producer")]
+[Category("Resilience")]
+[NotInParallel("RackAwareKafkaContainer")]
+[ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContainer kafka)
+{
+    private const int InitialMessageCount = 25;
+    private const int FailoverMessageCount = 75;
+    private const int MessageCount = 200;
+
+    [Test]
+    [Timeout(180_000)]
+    public async Task Producer_PartitionLeaderHandoff_ReroutesRetriesWithoutDuplicates(
+        CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateReplicatedTopicAsync().ConfigureAwait(false);
+        int? stoppedBrokerId = null;
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"leader-failover-producer-{Guid.NewGuid():N}")
+            .WithAcks(Acks.All)
+            .WithIdempotence(true)
+            .WithRequestTimeout(TimeSpan.FromSeconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(45))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        try
+        {
+            var acknowledgements = new List<RecordMetadata>(MessageCount);
+            await ProduceRangeAsync(
+                    producer,
+                    topic,
+                    start: 0,
+                    InitialMessageCount,
+                    acknowledgements,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            stoppedBrokerId = await kafka.GetPartitionLeaderIdAsync(topic, cancellationToken)
+                .ConfigureAwait(false);
+            await kafka.StopBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+            _ = await kafka.WaitForPartitionLeaderChangeAsync(topic, stoppedBrokerId.Value, cancellationToken)
+                .ConfigureAwait(false);
+
+            await ProduceRangeAsync(
+                    producer,
+                    topic,
+                    InitialMessageCount,
+                    FailoverMessageCount,
+                    acknowledgements,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            await kafka.StartBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+            await kafka.WaitForInSyncReplicasAsync(topic, 3, cancellationToken).ConfigureAwait(false);
+            stoppedBrokerId = null;
+
+            await ProduceRangeAsync(
+                    producer,
+                    topic,
+                    InitialMessageCount + FailoverMessageCount,
+                    MessageCount - InitialMessageCount - FailoverMessageCount,
+                    acknowledgements,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+            AssertAcknowledgementOrder(acknowledgements);
+            await AssertBrokerRecordsAsync(topic, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (stoppedBrokerId is { } brokerId)
+                await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task ProduceRangeAsync(
+        IKafkaProducer<string, string> producer,
+        string topic,
+        int start,
+        int count,
+        List<RecordMetadata> acknowledgements,
+        CancellationToken cancellationToken)
+    {
+        for (var value = start; value < start + count; value++)
+        {
+            var metadata = await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = value.ToString(),
+                Value = value.ToString()
+            }, cancellationToken).ConfigureAwait(false);
+            acknowledgements.Add(metadata);
+        }
+    }
+
+    private static void AssertAcknowledgementOrder(IReadOnlyList<RecordMetadata> acknowledgements)
+    {
+        if (acknowledgements.Count != MessageCount)
+            throw new InvalidOperationException(
+                $"Expected {MessageCount} acknowledgements, actual {acknowledgements.Count}.");
+
+        for (var index = 0; index < acknowledgements.Count; index++)
+        {
+            var acknowledgement = acknowledgements[index];
+            if (acknowledgement.Offset != index)
+            {
+                throw new InvalidOperationException(
+                    $"Acknowledgement offset mismatch at index {index}: expected {index}, " +
+                    $"actual {acknowledgement.Offset}.");
+            }
+        }
+    }
+
+    private async Task AssertBrokerRecordsAsync(string topic, CancellationToken cancellationToken)
+    {
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"leader-failover-oracle-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        for (var index = 0; index < MessageCount; index++)
+        {
+            var consumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), cancellationToken)
+                .ConfigureAwait(false);
+            if (consumed is null)
+                throw new InvalidOperationException($"Timed out after consuming {index} of {MessageCount} records.");
+
+            var result = consumed.Value;
+            var expected = index.ToString();
+            if (result.Offset != index || result.Key != expected || result.Value != expected)
+            {
+                throw new InvalidOperationException(
+                    $"Record mismatch at index {index}: offset={result.Offset}, key={result.Key}, value={result.Value}.");
+            }
+        }
+
+        var extra = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(2), cancellationToken)
+            .ConfigureAwait(false);
+        if (extra is not null)
+        {
+            throw new InvalidOperationException(
+                $"Unexpected duplicate record at offset {extra.Value.Offset}: {extra.Value.Value}.");
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -176,27 +176,13 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
         int previousLeaderId,
         CancellationToken cancellationToken = default)
     {
-        Exception? lastError = null;
-        for (var attempt = 0; attempt < 90; attempt++)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            try
-            {
-                var leaderId = await GetPartitionLeaderIdAsync(topic, cancellationToken).ConfigureAwait(false);
-                if (leaderId >= 0 && leaderId != previousLeaderId)
-                    return leaderId;
-            }
-            catch (Exception ex)
-            {
-                lastError = ex;
-            }
-
-            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
-        }
-
-        throw new InvalidOperationException(
-            $"Topic '{topic}' did not elect a new leader after broker {previousLeaderId} stopped. " +
-            $"Last error: {lastError?.Message}");
+        return await PollUntilAsync(
+            token => GetPartitionLeaderIdAsync(topic, token),
+            leaderId => leaderId >= 0 && leaderId != previousLeaderId,
+            maxAttempts: 90,
+            delay: TimeSpan.FromMilliseconds(500),
+            timeoutMessage: $"Topic '{topic}' did not elect a new leader after broker {previousLeaderId} stopped.",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     public async Task WaitForInSyncReplicasAsync(
@@ -204,28 +190,18 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
         int expectedCount,
         CancellationToken cancellationToken = default)
     {
-        Exception? lastError = null;
-        for (var attempt = 0; attempt < 120; attempt++)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            try
+        _ = await PollUntilAsync(
+            async token =>
             {
                 await using var admin = CreateAdminClient();
-                var descriptions = await admin.DescribeTopicsAsync([topic], cancellationToken).ConfigureAwait(false);
-                if (descriptions[topic].Partitions.Single().IsrNodes.Count == expectedCount)
-                    return;
-            }
-            catch (Exception ex)
-            {
-                lastError = ex;
-            }
-
-            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
-        }
-
-        throw new InvalidOperationException(
-            $"Topic '{topic}' did not restore {expectedCount} in-sync replicas. " +
-            $"Last error: {lastError?.Message}");
+                var descriptions = await admin.DescribeTopicsAsync([topic], token).ConfigureAwait(false);
+                return descriptions[topic].Partitions.Single().IsrNodes.Count;
+            },
+            isComplete: count => count == expectedCount,
+            maxAttempts: 120,
+            delay: TimeSpan.FromMilliseconds(500),
+            timeoutMessage: $"Topic '{topic}' did not restore {expectedCount} in-sync replicas.",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     private IContainer CreateBroker(int nodeId, string rack, int externalPort)
@@ -277,55 +253,80 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
 
     private async Task WaitForClusterAsync(CancellationToken cancellationToken = default)
     {
-        Exception? lastError = null;
-        for (var attempt = 0; attempt < 90; attempt++)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            try
+        _ = await PollUntilAsync(
+            async token =>
             {
                 await using var admin = CreateAdminClient();
-                var cluster = await admin.DescribeClusterAsync(cancellationToken).ConfigureAwait(false);
-                if (cluster.Nodes.Count == 3)
-                    return;
-            }
-            catch (Exception ex)
-            {
-                lastError = ex;
-            }
-
-            await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
-        }
-
-        throw new InvalidOperationException(
-            $"Rack-aware Kafka cluster was not ready after 90s. Last error: {lastError?.Message}");
-    }
-
-    private static async Task WaitForTopicAssignmentAsync(IAdminClient admin, string topic)
-    {
-        await WaitForTopicAssignmentAsync(admin, topic, [1, 2]).ConfigureAwait(false);
+                var cluster = await admin.DescribeClusterAsync(token).ConfigureAwait(false);
+                return cluster.Nodes.Count;
+            },
+            isComplete: nodeCount => nodeCount == 3,
+            maxAttempts: 90,
+            delay: TimeSpan.FromSeconds(1),
+            timeoutMessage: "Rack-aware Kafka cluster was not ready after 90s.",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task WaitForTopicAssignmentAsync(
         IAdminClient admin,
         string topic,
-        IReadOnlyList<int> expectedReplicas)
+        CancellationToken cancellationToken = default)
     {
-        for (var attempt = 0; attempt < 60; attempt++)
-        {
-            var descriptions = await admin.DescribeTopicsAsync([topic]).ConfigureAwait(false);
-            var partition = descriptions[topic].Partitions.Single();
+        await WaitForTopicAssignmentAsync(admin, topic, [1, 2], cancellationToken).ConfigureAwait(false);
+    }
 
-            if (partition.LeaderId == 1
-                && partition.ReplicaNodes.SequenceEqual(expectedReplicas)
-                && expectedReplicas.All(partition.IsrNodes.Contains))
+    private static async Task WaitForTopicAssignmentAsync(
+        IAdminClient admin,
+        string topic,
+        IReadOnlyList<int> expectedReplicas,
+        CancellationToken cancellationToken = default)
+    {
+        _ = await PollUntilAsync(
+            async token =>
             {
-                return;
+                var descriptions = await admin.DescribeTopicsAsync([topic], token).ConfigureAwait(false);
+                var partition = descriptions[topic].Partitions.Single();
+                return partition.LeaderId == 1
+                    && partition.ReplicaNodes.SequenceEqual(expectedReplicas)
+                    && expectedReplicas.All(partition.IsrNodes.Contains);
+            },
+            isComplete: static assigned => assigned,
+            maxAttempts: 60,
+            delay: TimeSpan.FromMilliseconds(500),
+            timeoutMessage: $"Topic '{topic}' did not get expected rack-aware assignment.",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<T> PollUntilAsync<T>(
+        Func<CancellationToken, Task<T>> probeAsync,
+        Func<T, bool> isComplete,
+        int maxAttempts,
+        TimeSpan delay,
+        string timeoutMessage,
+        CancellationToken cancellationToken = default)
+    {
+        Exception? lastError = null;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var result = await probeAsync(cancellationToken).ConfigureAwait(false);
+                if (isComplete(result))
+                    return result;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+            {
+                lastError = ex;
             }
 
-            await Task.Delay(500).ConfigureAwait(false);
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
         }
 
-        throw new InvalidOperationException($"Topic '{topic}' did not get expected rack-aware assignment.");
+        if (lastError is null)
+            throw new InvalidOperationException(timeoutMessage);
+
+        throw new InvalidOperationException($"{timeoutMessage} Last error: {lastError.Message}", lastError);
     }
 
     private IContainer GetBroker(int nodeId)

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -124,6 +124,110 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
         return topic;
     }
 
+    public async Task<string> CreateReplicatedTopicAsync()
+    {
+        var topic = $"replicated-{Guid.NewGuid():N}";
+        await using var admin = CreateAdminClient();
+
+        await admin.CreateTopicsAsync([
+            new NewTopic
+            {
+                Name = topic,
+                NumPartitions = -1,
+                ReplicationFactor = -1,
+                ReplicaAssignments = new Dictionary<int, IReadOnlyList<int>>
+                {
+                    [0] = [1, 2, 3]
+                },
+                Configs = new Dictionary<string, string>
+                {
+                    ["min.insync.replicas"] = "2"
+                }
+            }
+        ]).ConfigureAwait(false);
+
+        await WaitForTopicAssignmentAsync(admin, topic, [1, 2, 3]).ConfigureAwait(false);
+        return topic;
+    }
+
+    public async Task<int> GetPartitionLeaderIdAsync(
+        string topic,
+        CancellationToken cancellationToken = default)
+    {
+        await using var admin = CreateAdminClient();
+        var descriptions = await admin.DescribeTopicsAsync([topic], cancellationToken).ConfigureAwait(false);
+        return descriptions[topic].Partitions.Single().LeaderId;
+    }
+
+    public Task StopBrokerAsync(int nodeId, CancellationToken cancellationToken = default) =>
+        GetBroker(nodeId).StopAsync(cancellationToken);
+
+    public async Task StartBrokerAsync(int nodeId, CancellationToken cancellationToken = default)
+    {
+        var broker = GetBroker(nodeId);
+        if (broker.State != TestcontainersStates.Running)
+            await broker.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        await WaitForClusterAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<int> WaitForPartitionLeaderChangeAsync(
+        string topic,
+        int previousLeaderId,
+        CancellationToken cancellationToken = default)
+    {
+        Exception? lastError = null;
+        for (var attempt = 0; attempt < 90; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var leaderId = await GetPartitionLeaderIdAsync(topic, cancellationToken).ConfigureAwait(false);
+                if (leaderId >= 0 && leaderId != previousLeaderId)
+                    return leaderId;
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+            }
+
+            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException(
+            $"Topic '{topic}' did not elect a new leader after broker {previousLeaderId} stopped. " +
+            $"Last error: {lastError?.Message}");
+    }
+
+    public async Task WaitForInSyncReplicasAsync(
+        string topic,
+        int expectedCount,
+        CancellationToken cancellationToken = default)
+    {
+        Exception? lastError = null;
+        for (var attempt = 0; attempt < 120; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                await using var admin = CreateAdminClient();
+                var descriptions = await admin.DescribeTopicsAsync([topic], cancellationToken).ConfigureAwait(false);
+                if (descriptions[topic].Partitions.Single().IsrNodes.Count == expectedCount)
+                    return;
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+            }
+
+            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException(
+            $"Topic '{topic}' did not restore {expectedCount} in-sync replicas. " +
+            $"Last error: {lastError?.Message}");
+    }
+
     private IContainer CreateBroker(int nodeId, string rack, int externalPort)
     {
         var brokerAlias = BrokerAlias(nodeId);
@@ -171,15 +275,16 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
         };
     }
 
-    private async Task WaitForClusterAsync()
+    private async Task WaitForClusterAsync(CancellationToken cancellationToken = default)
     {
         Exception? lastError = null;
         for (var attempt = 0; attempt < 90; attempt++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             try
             {
                 await using var admin = CreateAdminClient();
-                var cluster = await admin.DescribeClusterAsync().ConfigureAwait(false);
+                var cluster = await admin.DescribeClusterAsync(cancellationToken).ConfigureAwait(false);
                 if (cluster.Nodes.Count == 3)
                     return;
             }
@@ -188,7 +293,7 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
                 lastError = ex;
             }
 
-            await Task.Delay(1000).ConfigureAwait(false);
+            await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
         }
 
         throw new InvalidOperationException(
@@ -197,14 +302,22 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
 
     private static async Task WaitForTopicAssignmentAsync(IAdminClient admin, string topic)
     {
+        await WaitForTopicAssignmentAsync(admin, topic, [1, 2]).ConfigureAwait(false);
+    }
+
+    private static async Task WaitForTopicAssignmentAsync(
+        IAdminClient admin,
+        string topic,
+        IReadOnlyList<int> expectedReplicas)
+    {
         for (var attempt = 0; attempt < 60; attempt++)
         {
             var descriptions = await admin.DescribeTopicsAsync([topic]).ConfigureAwait(false);
             var partition = descriptions[topic].Partitions.Single();
 
             if (partition.LeaderId == 1
-                && partition.ReplicaNodes.SequenceEqual([1, 2])
-                && partition.IsrNodes.Contains(2))
+                && partition.ReplicaNodes.SequenceEqual(expectedReplicas)
+                && expectedReplicas.All(partition.IsrNodes.Contains))
             {
                 return;
             }
@@ -213,6 +326,15 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
         }
 
         throw new InvalidOperationException($"Topic '{topic}' did not get expected rack-aware assignment.");
+    }
+
+    private IContainer GetBroker(int nodeId)
+    {
+        if (nodeId < 1 || nodeId > _brokers.Length)
+            throw new ArgumentOutOfRangeException(nameof(nodeId), nodeId, "Broker node ID must be between 1 and 3.");
+
+        return _brokers[nodeId - 1]
+            ?? throw new InvalidOperationException($"Broker {nodeId} has not been initialized.");
     }
 
     private static int[] GetFreeTcpPorts(int count)

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -777,11 +777,51 @@ public sealed class BrokerSenderSendLoopTests
             .Returns(new ValueTask<IKafkaConnection>(failedConnection));
         pool.GetConnectionByIndexAsync(1, 1, Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IKafkaConnection>(siblingConnection));
+        var metadataConnection = Substitute.For<IKafkaConnection>();
+        var metadataRefreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(metadataConnection));
+        metadataConnection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<ApiVersionsResponse>(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                ]
+            }));
+        metadataConnection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                metadataRefreshStarted.TrySetResult();
+                return new ValueTask<MetadataResponse>(CreateLeaderMetadataResponse(
+                    topic, leaderId: 2, leaderEpoch: 2));
+            });
 
-        var options = CreateOptions(maxInFlight: 2, connectionsPerBroker: 2);
+        var options = CreateOptions(
+            maxInFlight: 2,
+            retryBackoffMs: 10_000,
+            retryBackoffMaxMs: 10_000,
+            connectionsPerBroker: 2);
         var accumulator = new RecordAccumulator(options);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.Metadata.Update(CreateLeaderMetadataResponse(topic, leaderId: 1, leaderEpoch: 1));
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
-        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, _) => { },
+            metadataManager);
 
         try
         {
@@ -790,8 +830,10 @@ public sealed class BrokerSenderSendLoopTests
             sender.EnqueueBulk([failedBatch, siblingBatch]);
 
             await siblingWriteStarted.Task.WaitAsync(cancellationToken);
+            await metadataRefreshStarted.Task.WaitAsync(cancellationToken);
 
             await Assert.That(accumulator.IsMuted(failedBatch.TopicPartition)).IsTrue();
+            await Assert.That(failedBatch.RetryNotBefore).IsGreaterThan(0);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -150,6 +150,39 @@ public sealed class BrokerSenderSendLoopTests
             ]
         };
 
+    private static MetadataResponse CreateLeaderMetadataResponse(
+        string topic,
+        int leaderId,
+        int leaderEpoch) =>
+        new()
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9093 },
+                new BrokerMetadata { NodeId = 2, Host = "broker-2", Port = 9094 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = topic,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = leaderId,
+                            LeaderEpoch = leaderEpoch,
+                            ReplicaNodes = [1, 2],
+                            IsrNodes = [1, 2]
+                        }
+                    ]
+                }
+            ]
+        };
+
     /// <summary>
     /// Creates a BrokerSender with standard test defaults, reducing constructor boilerplate.
     /// </summary>
@@ -158,12 +191,14 @@ public sealed class BrokerSenderSendLoopTests
         ProducerOptions options,
         RecordAccumulator accumulator,
         Action<TopicPartition, long, DateTimeOffset, int, Exception?> onAcknowledgement,
+        MetadataManager? metadataManager = null,
+        Action<ReadyBatch>? rerouteBatch = null,
         Action<int>? onBrokerThrottle = null,
         Func<long>? getTimestamp = null,
         Func<int, CancellationToken, ValueTask>? delayForThrottle = null) =>
         new(
             brokerId: 1, pool,
-            new MetadataManager(pool, options.BootstrapServers),
+            metadataManager ?? new MetadataManager(pool, options.BootstrapServers),
             accumulator, options,
             new CompressionCodecRegistry(),
             inflightTracker: new PartitionInflightTracker(),
@@ -173,7 +208,7 @@ public sealed class BrokerSenderSendLoopTests
             ensurePartitionInTransaction: null,
             bumpEpoch: null,
             getCurrentEpoch: null,
-            rerouteBatch: null,
+            rerouteBatch,
             onAcknowledgement: onAcknowledgement,
             logger: null,
             onBrokerThrottle: onBrokerThrottle,
@@ -631,6 +666,81 @@ public sealed class BrokerSenderSendLoopTests
             // Batch should eventually be acknowledged
             var offset = await acknowledged.Task.WaitAsync(cancellationToken);
             await Assert.That(offset).IsEqualTo(99);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task SendLoop_SendFailure_RefreshesMetadataAndReroutes(CancellationToken cancellationToken)
+    {
+        const string topic = "test-topic";
+        var staleConnection = new TestKafkaConnection
+        {
+            SendProducePipelinedAfterWrite = () =>
+                ValueTask.FromException<Task<ProduceResponse>>(new IOException("Leader connection closed"))
+        };
+        var metadataConnection = Substitute.For<IKafkaConnection>();
+        var metadataRequests = 0;
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(1, Arg.Any<CancellationToken>())
+            .Returns(staleConnection);
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(metadataConnection));
+        metadataConnection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<ApiVersionsResponse>(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                ]
+            }));
+        metadataConnection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref metadataRequests);
+                return new ValueTask<MetadataResponse>(CreateLeaderMetadataResponse(topic, leaderId: 2, leaderEpoch: 2));
+            });
+
+        var options = CreateOptions(retryBackoffMs: 10, retryBackoffMaxMs: 10);
+        var accumulator = new RecordAccumulator(options);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.Metadata.Update(CreateLeaderMetadataResponse(topic, leaderId: 1, leaderEpoch: 1));
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var rerouted = new TaskCompletionSource<ReadyBatch>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: (_, _, _, _, _) => { },
+            metadataManager,
+            rerouteBatch: batch => rerouted.TrySetResult(batch));
+
+        try
+        {
+            var batch = CreateTestBatch(vtPool, topic, partition: 0);
+            sender.Enqueue(batch);
+
+            var reroutedBatch = await rerouted.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(reroutedBatch).IsSameReferenceAs(batch);
+            await Assert.That(Volatile.Read(ref metadataRequests)).IsEqualTo(1);
+            await Assert.That(metadataManager.Metadata.GetPartitionLeader(topic, 0)!.NodeId).IsEqualTo(2);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1543,9 +1543,9 @@ public sealed class BrokerSenderSendLoopTests
                 if (error is null && Interlocked.Increment(ref acknowledgementCount) == 2)
                     acknowledgements.TrySetResult();
             },
-            observedThrottleTimes.Add,
-            () => Volatile.Read(ref timestamp),
-            (delayMs, token) =>
+            onBrokerThrottle: observedThrottleTimes.Add,
+            getTimestamp: () => Volatile.Read(ref timestamp),
+            delayForThrottle: (delayMs, token) =>
             {
                 throttleWaitStarted.TrySetResult(delayMs);
                 return new ValueTask(releaseThrottleWait.Task.WaitAsync(token));
@@ -1615,7 +1615,7 @@ public sealed class BrokerSenderSendLoopTests
                 if (error is null && Interlocked.Increment(ref acknowledgementCount) == 2)
                     acknowledgements.TrySetResult();
             },
-            observedThrottleTimes.Add,
+            onBrokerThrottle: observedThrottleTimes.Add,
             delayForThrottle: (_, _) =>
             {
                 throttleDelayCalled = true;

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -153,7 +153,8 @@ public sealed class BrokerSenderSendLoopTests
     private static MetadataResponse CreateLeaderMetadataResponse(
         string topic,
         int leaderId,
-        int leaderEpoch) =>
+        int leaderEpoch,
+        int partitionCount = 1) =>
         new()
         {
             Brokers =
@@ -167,18 +168,16 @@ public sealed class BrokerSenderSendLoopTests
                 {
                     ErrorCode = ErrorCode.None,
                     Name = topic,
-                    Partitions =
-                    [
-                        new PartitionMetadata
+                    Partitions = Enumerable.Range(0, partitionCount)
+                        .Select(partition => new PartitionMetadata
                         {
                             ErrorCode = ErrorCode.None,
-                            PartitionIndex = 0,
+                            PartitionIndex = partition,
                             LeaderId = leaderId,
                             LeaderEpoch = leaderEpoch,
                             ReplicaNodes = [1, 2],
                             IsrNodes = [1, 2]
-                        }
-                    ]
+                        }).ToArray()
                 }
             ]
         };
@@ -747,6 +746,94 @@ public sealed class BrokerSenderSendLoopTests
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task SendLoop_CoalescedSendFailure_RefreshesMetadataOncePerTopic(
+        CancellationToken cancellationToken)
+    {
+        const string topic = "test-topic";
+        var staleConnection = new TestKafkaConnection
+        {
+            SendProducePipelinedAfterWrite = () =>
+                ValueTask.FromException<Task<ProduceResponse>>(new IOException("Leader connection closed"))
+        };
+        var metadataConnection = Substitute.For<IKafkaConnection>();
+        var metadataRequests = 0;
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(1, Arg.Any<CancellationToken>())
+            .Returns(staleConnection);
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(metadataConnection));
+        metadataConnection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<ApiVersionsResponse>(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                ]
+            }));
+        metadataConnection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref metadataRequests);
+                return new ValueTask<MetadataResponse>(CreateLeaderMetadataResponse(
+                    topic, leaderId: 2, leaderEpoch: 2, partitionCount: 2));
+            });
+
+        var options = CreateOptions(retryBackoffMs: 10, retryBackoffMaxMs: 10);
+        var accumulator = new RecordAccumulator(options);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.Metadata.Update(CreateLeaderMetadataResponse(
+            topic, leaderId: 1, leaderEpoch: 1, partitionCount: 2));
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var rerouted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reroutedCount = 0;
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: (_, _, _, _, _) => { },
+            metadataManager,
+            rerouteBatch: (_, _) =>
+            {
+                if (Interlocked.Increment(ref reroutedCount) == 2)
+                    rerouted.TrySetResult();
+            });
+
+        try
+        {
+            var firstBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 0);
+            var secondBatch = CreateTestBatch(valueTaskSourcePool, topic, partition: 1);
+            sender.EnqueueBulk(
+            [
+                firstBatch,
+                secondBatch
+            ]);
+
+            await rerouted.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(Volatile.Read(ref metadataRequests)).IsEqualTo(1);
+            await Assert.That(accumulator.IsMuted(firstBatch.TopicPartition)).IsFalse();
+            await Assert.That(accumulator.IsMuted(secondBatch.TopicPartition)).IsFalse();
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -751,6 +751,58 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
+    [Timeout(30_000)]
+    public async Task SendLoop_ParallelSendFailure_MutesPartitionBeforeSiblingWriteCompletes(
+        CancellationToken cancellationToken)
+    {
+        const string topic = "test-topic";
+        var failedConnection = new TestKafkaConnection
+        {
+            SendProducePipelinedAfterWrite = () =>
+                ValueTask.FromException<Task<ProduceResponse>>(new IOException("Leader connection closed"))
+        };
+        var siblingWriteStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSiblingWrite = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var siblingConnection = new TestKafkaConnection
+        {
+            SendProducePipelinedAfterWrite = async () =>
+            {
+                siblingWriteStarted.TrySetResult();
+                await releaseSiblingWrite.Task;
+                return Task.FromResult(CreateSuccessResponse(topic, partition: 1, baseOffset: 0));
+            }
+        };
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(failedConnection));
+        pool.GetConnectionByIndexAsync(1, 1, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(siblingConnection));
+
+        var options = CreateOptions(maxInFlight: 2, connectionsPerBroker: 2);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            var failedBatch = CreateTestBatch(vtPool, topic, partition: 0);
+            var siblingBatch = CreateTestBatch(vtPool, topic, partition: 1);
+            sender.EnqueueBulk([failedBatch, siblingBatch]);
+
+            await siblingWriteStarted.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(accumulator.IsMuted(failedBatch.TopicPartition)).IsTrue();
+        }
+        finally
+        {
+            releaseSiblingWrite.TrySetResult();
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
     [Timeout(120_000)]
     public async Task SendLoop_MultipleInFlight_AllResponsesProcessed(CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -839,6 +839,108 @@ public sealed class BrokerSenderSendLoopTests
 
     [Test]
     [Timeout(30_000)]
+    public async Task SendLoop_ParallelSendFailures_RefreshMetadataOncePerTopic(
+        CancellationToken cancellationToken)
+    {
+        const string topic = "test-topic";
+        var firstFailedConnection = new TestKafkaConnection
+        {
+            SendProducePipelinedAfterWrite = () =>
+                ValueTask.FromException<Task<ProduceResponse>>(new IOException("First leader connection closed"))
+        };
+        var secondFailedConnection = new TestKafkaConnection
+        {
+            SendProducePipelinedAfterWrite = () =>
+                ValueTask.FromException<Task<ProduceResponse>>(new IOException("Second leader connection closed"))
+        };
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(firstFailedConnection));
+        pool.GetConnectionByIndexAsync(1, 1, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(secondFailedConnection));
+
+        var metadataConnection = Substitute.For<IKafkaConnection>();
+        var metadataRequests = 0;
+        var duplicateMetadataRequest = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection>(metadataConnection));
+        metadataConnection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<ApiVersionsResponse>(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                ]
+            }));
+        metadataConnection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref metadataRequests) > 1)
+                    duplicateMetadataRequest.TrySetResult();
+
+                return new ValueTask<MetadataResponse>(CreateLeaderMetadataResponse(
+                    topic, leaderId: 2, leaderEpoch: 2, partitionCount: 2));
+            });
+
+        var options = CreateOptions(
+            maxInFlight: 2,
+            retryBackoffMs: 500,
+            retryBackoffMaxMs: 500,
+            connectionsPerBroker: 2);
+        var accumulator = new RecordAccumulator(options);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.Metadata.Update(CreateLeaderMetadataResponse(
+            topic, leaderId: 1, leaderEpoch: 1, partitionCount: 2));
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var allRerouted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reroutedCount = 0;
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: (_, _, _, _, _) => { },
+            metadataManager,
+            rerouteBatch: (_, _) =>
+            {
+                if (Interlocked.Increment(ref reroutedCount) == 2)
+                    allRerouted.TrySetResult();
+            });
+
+        try
+        {
+            sender.EnqueueBulk(
+            [
+                CreateTestBatch(valueTaskSourcePool, topic, partition: 0),
+                CreateTestBatch(valueTaskSourcePool, topic, partition: 1)
+            ]);
+
+            var firstResult = await Task.WhenAny(allRerouted.Task, duplicateMetadataRequest.Task)
+                .WaitAsync(cancellationToken);
+
+            await Assert.That(firstResult).IsSameReferenceAs(allRerouted.Task);
+            await Assert.That(Volatile.Read(ref metadataRequests)).IsEqualTo(1);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
     public async Task SendLoop_ParallelSendFailure_MutesPartitionBeforeSiblingWriteCompletes(
         CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -192,7 +192,7 @@ public sealed class BrokerSenderSendLoopTests
         RecordAccumulator accumulator,
         Action<TopicPartition, long, DateTimeOffset, int, Exception?> onAcknowledgement,
         MetadataManager? metadataManager = null,
-        Action<ReadyBatch>? rerouteBatch = null,
+        Action<ReadyBatch, int>? rerouteBatch = null,
         Action<int>? onBrokerThrottle = null,
         Func<long>? getTimestamp = null,
         Func<int, CancellationToken, ValueTask>? delayForThrottle = null) =>
@@ -729,7 +729,7 @@ public sealed class BrokerSenderSendLoopTests
             accumulator,
             onAcknowledgement: (_, _, _, _, _) => { },
             metadataManager,
-            rerouteBatch: batch => rerouted.TrySetResult(batch));
+            rerouteBatch: (batch, _) => rerouted.TrySetResult(batch));
 
         try
         {


### PR DESCRIPTION
## Summary
- route socket-level produce failures through the common retriable path so they trigger metadata refresh
- reroute the retained idempotent batch to the elected leader while preserving partition muting and ordering
- add deterministic unit coverage and a three-broker same-producer leader-handoff regression test

## Test plan
- [x] BrokerSenderSendLoopTests — net10.0 (15/15)
- [x] BrokerSenderSendLoopTests — net8.0 (15/15)
- [x] full unit suite — net10.0 (4515/4515)
- [x] full unit suite — net8.0 (4509/4509)
- [x] ProducerLeaderFailoverIntegrationTests — net10.0
- [x] ProducerLeaderFailoverIntegrationTests — net8.0
- [x] ConsumerRackAwarenessIntegrationTests — net10.0

Closes #1670
