### PR TITLE
Harden Testcontainers startup races

### DIFF
--- a/tests/Dekaf.Tests.Integration/ContainerStartupRetry.cs
+++ b/tests/Dekaf.Tests.Integration/ContainerStartupRetry.cs
@@ -1,0 +1,73 @@
+using Docker.DotNet;
+using DotNet.Testcontainers.Containers;
+
+namespace Dekaf.Tests.Integration;
+
+internal static class ContainerStartupRetry
+{
+    private const int MaxAttempts = 3;
+
+    internal static async Task RunAsync(
+        Func<Task> startAttemptAsync,
+        Func<ValueTask> cleanupAttemptAsync,
+        Func<Exception, bool> isTransient)
+    {
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            try
+            {
+                await startAttemptAsync().ConfigureAwait(false);
+                return;
+            }
+            catch (Exception exception)
+            {
+                await TryCleanupAsync(cleanupAttemptAsync).ConfigureAwait(false);
+
+                if (attempt == MaxAttempts || !isTransient(exception))
+                    throw;
+
+                Console.WriteLine(
+                    $"[ContainerStartupRetry] Transient container startup failure on attempt {attempt}; retrying with fresh resources: {exception.Message}");
+            }
+        }
+    }
+
+    internal static bool IsPortBindingCollision(Exception exception) =>
+        Contains(exception, static candidate =>
+            candidate is DockerApiException &&
+            candidate.Message.Contains("port is already allocated", StringComparison.OrdinalIgnoreCase));
+
+    internal static bool IsKafkaStartupScriptBusy(Exception exception) =>
+        Contains(exception, static candidate =>
+            candidate is ContainerNotRunningException &&
+            candidate.Message.Contains(
+                "/testcontainers.sh: Text file busy",
+                StringComparison.Ordinal));
+
+    private static bool Contains(Exception exception, Func<Exception, bool> predicate)
+    {
+        if (predicate(exception))
+            return true;
+
+        return exception switch
+        {
+            AggregateException aggregateException =>
+                aggregateException.InnerExceptions.Any(inner => Contains(inner, predicate)),
+            { InnerException: not null } => Contains(exception.InnerException, predicate),
+            _ => false
+        };
+    }
+
+    private static async ValueTask TryCleanupAsync(Func<ValueTask> cleanupAttemptAsync)
+    {
+        try
+        {
+            await cleanupAttemptAsync().ConfigureAwait(false);
+        }
+        catch (Exception cleanupException)
+        {
+            Console.Error.WriteLine(
+                $"[ContainerStartupRetry] Failed to clean up a rejected startup attempt: {cleanupException}");
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ContainerStartupRetryTests.cs
+++ b/tests/Dekaf.Tests.Integration/ContainerStartupRetryTests.cs
@@ -4,8 +4,7 @@ using DotNet.Testcontainers.Containers;
 
 namespace Dekaf.Tests.Integration;
 
-[Category("Consumer")]
-[Category("MessagingOrdering")]
+[Category("Retry")]
 public sealed class ContainerStartupRetryTests
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/ContainerStartupRetryTests.cs
+++ b/tests/Dekaf.Tests.Integration/ContainerStartupRetryTests.cs
@@ -110,8 +110,13 @@ public sealed class ContainerStartupRetryTests
     }
 
     [Test]
-    public async Task KafkaStartupCommand_WaitsForStableCopy_ThenUsesShell()
+    public async Task KafkaStartupCommand_OverwritesTestcontainersDefault()
     {
+        var effectiveCommand = KafkaTestContainer.StartupCommandOverride
+            .Compose(["while [ ! -f /testcontainers.sh ]; do sleep 0.1; done; /testcontainers.sh"])
+            .ToArray();
+
+        await Assert.That(effectiveCommand).IsEquivalentTo([KafkaTestContainer.StartupCommand]);
         await Assert.That(KafkaTestContainer.StartupCommand).Contains("wc -c");
         await Assert.That(KafkaTestContainer.StartupCommand).Contains("exec /bin/sh /testcontainers.sh");
     }

--- a/tests/Dekaf.Tests.Integration/ContainerStartupRetryTests.cs
+++ b/tests/Dekaf.Tests.Integration/ContainerStartupRetryTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using Docker.DotNet;
+using DotNet.Testcontainers.Containers;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Consumer")]
+[Category("MessagingOrdering")]
+public sealed class ContainerStartupRetryTests
+{
+    [Test]
+    public async Task RunAsync_PortBindingCollision_UsesFreshAttempt()
+    {
+        var attempts = 0;
+        var cleanups = 0;
+
+        await ContainerStartupRetry.RunAsync(
+            () => ++attempts == 1
+                ? Task.FromException(new DockerApiException(
+                    HttpStatusCode.InternalServerError,
+                    "Bind for 0.0.0.0:32769 failed: port is already allocated"))
+                : Task.CompletedTask,
+            () =>
+            {
+                cleanups++;
+                return ValueTask.CompletedTask;
+            },
+            ContainerStartupRetry.IsPortBindingCollision);
+
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(cleanups).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task RunAsync_KafkaStartupScriptBusy_UsesFreshAttempt()
+    {
+        var attempts = 0;
+        var cleanups = 0;
+
+        await ContainerStartupRetry.RunAsync(
+            () => ++attempts == 1
+                ? Task.FromException(new ContainerNotRunningException(
+                    "container-id",
+                    string.Empty,
+                    "/bin/sh: /testcontainers.sh: Text file busy",
+                    126,
+                    new InvalidOperationException("container exited")))
+                : Task.CompletedTask,
+            () =>
+            {
+                cleanups++;
+                return ValueTask.CompletedTask;
+            },
+            ContainerStartupRetry.IsKafkaStartupScriptBusy);
+
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(cleanups).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task RunAsync_NonTransientDockerFailure_DoesNotRetry()
+    {
+        var attempts = 0;
+        var cleanups = 0;
+
+        var action = async () => await ContainerStartupRetry.RunAsync(
+            () =>
+            {
+                attempts++;
+                return Task.FromException(new DockerApiException(
+                    HttpStatusCode.InternalServerError,
+                    "broker configuration is invalid"));
+            },
+            () =>
+            {
+                cleanups++;
+                return ValueTask.CompletedTask;
+            },
+            ContainerStartupRetry.IsPortBindingCollision);
+
+        await Assert.That(action).Throws<DockerApiException>();
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(cleanups).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task RunAsync_RepeatedTransientFailure_StopsAfterThreeAttempts()
+    {
+        var attempts = 0;
+        var cleanups = 0;
+
+        var action = async () => await ContainerStartupRetry.RunAsync(
+            () =>
+            {
+                attempts++;
+                return Task.FromException(new DockerApiException(
+                    HttpStatusCode.InternalServerError,
+                    "Bind failed: port is already allocated"));
+            },
+            () =>
+            {
+                cleanups++;
+                return ValueTask.CompletedTask;
+            },
+            ContainerStartupRetry.IsPortBindingCollision);
+
+        await Assert.That(action).Throws<DockerApiException>();
+        await Assert.That(attempts).IsEqualTo(3);
+        await Assert.That(cleanups).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task KafkaStartupCommand_WaitsForStableCopy_ThenUsesShell()
+    {
+        await Assert.That(KafkaTestContainer.StartupCommand).Contains("wc -c");
+        await Assert.That(KafkaTestContainer.StartupCommand).Contains("exec /bin/sh /testcontainers.sh");
+    }
+}

--- a/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
@@ -15,16 +15,32 @@ namespace Dekaf.Tests.Integration;
 /// </summary>
 public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
 {
+    // Testcontainers.Kafka starts the container before its startup callback copies this script.
+    // Wait until the copy size stabilizes, then read it through sh instead of directly executing
+    // a file that Docker may still hold open for writing (which fails with ETXTBSY on Linux).
+    internal const string StartupCommand =
+        "while [ ! -s /testcontainers.sh ]; do sleep 0.1; done; " +
+        "size=$(wc -c < /testcontainers.sh); sleep 0.1; " +
+        "while [ \"$(wc -c < /testcontainers.sh)\" != \"$size\" ]; do " +
+        "size=$(wc -c < /testcontainers.sh); sleep 0.1; done; " +
+        "exec /bin/sh /testcontainers.sh";
+
     private KafkaContainer? _container;
     protected KafkaContainer? ContainerInstance => _container;
-    private KafkaContainer Container => _container ??= ConfigureBuilder(
-        new KafkaBuilder(ContainerName)
+
+    private KafkaContainer CreateContainer()
+    {
+        var builder = ConfigureBuilder(new KafkaBuilder(ContainerName)
             .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")     // Limit JVM heap for CI runners
             .WithEnvironment("KAFKA_LOG_RETENTION_MS", "30000")           // Delete segments after 30s
             .WithEnvironment("KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS", "10000") // Check every 10s
             .WithEnvironment("KAFKA_LOG_SEGMENT_BYTES", "1048576")        // 1MB segments for faster rotation
-            .WithEnvironment("KAFKA_LOG_CLEANUP_POLICY", "delete"))
-        .Build();
+            .WithEnvironment("KAFKA_LOG_CLEANUP_POLICY", "delete"));
+
+        return builder
+            .WithCommand(StartupCommand)
+            .Build();
+    }
 
     private string _bootstrapServers = string.Empty;
     private readonly ConcurrentDictionary<string, byte> _createdTopics = new();
@@ -66,9 +82,16 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
     {
         Console.WriteLine("[KafkaTestContainer] Starting Kafka container via Testcontainers...");
 
-        await Container.StartAsync().ConfigureAwait(false);
+        await ContainerStartupRetry.RunAsync(
+            async () =>
+            {
+                _container = CreateContainer();
+                await _container.StartAsync().ConfigureAwait(false);
+            },
+            ResetContainerAsync,
+            ContainerStartupRetry.IsKafkaStartupScriptBusy).ConfigureAwait(false);
 
-        var rawAddress = Container.GetBootstrapAddress();
+        var rawAddress = _container!.GetBootstrapAddress();
         // GetBootstrapAddress() may return "plaintext://host:port/" - extract just host:port
         _bootstrapServers = ExtractHostPort(rawAddress);
 
@@ -300,11 +323,17 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
 
     public virtual async ValueTask DisposeAsync()
     {
-        if (_container is not null)
-        {
-            await _container.DisposeAsync().ConfigureAwait(false);
-        }
+        await ResetContainerAsync().ConfigureAwait(false);
 
         GC.SuppressFinalize(this);
+    }
+
+    private async ValueTask ResetContainerAsync()
+    {
+        var container = _container;
+        _container = null;
+
+        if (container is not null)
+            await container.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Net.Sockets;
 using Dekaf.Admin;
+using DotNet.Testcontainers.Configurations;
 using Testcontainers.Kafka;
 using TUnit.Core.Interfaces;
 
@@ -25,6 +26,9 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
         "size=$(wc -c < /testcontainers.sh); sleep 0.1; done; " +
         "exec /bin/sh /testcontainers.sh";
 
+    internal static ComposableEnumerable<string> StartupCommandOverride { get; } =
+        new OverwriteEnumerable<string>([StartupCommand]);
+
     private KafkaContainer? _container;
     protected KafkaContainer? ContainerInstance => _container;
 
@@ -38,7 +42,7 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
             .WithEnvironment("KAFKA_LOG_CLEANUP_POLICY", "delete"));
 
         return builder
-            .WithCommand(StartupCommand)
+            .WithCommand(StartupCommandOverride)
             .Build();
     }
 

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -15,15 +15,26 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
     private const int ControllerPort = 9093;
     private const int ExternalBrokerPort = 19092;
 
-    private readonly string _resourceSuffix = Guid.NewGuid().ToString("N")[..12];
-    private readonly int[] _hostPorts = GetFreeTcpPorts(3);
-    private readonly IContainer[] _brokers = new IContainer[3];
+    private string _resourceSuffix = string.Empty;
+    private int[] _hostPorts = [];
+    private IContainer[] _brokers = [];
     private INetwork? _network;
 
     public string BootstrapServers => string.Join(",", _hostPorts.Select(port => $"127.0.0.1:{port}"));
 
     public async Task InitializeAsync()
     {
+        await ContainerStartupRetry.RunAsync(
+            StartClusterAttemptAsync,
+            DisposeClusterAttemptAsync,
+            ContainerStartupRetry.IsPortBindingCollision).ConfigureAwait(false);
+    }
+
+    private async Task StartClusterAttemptAsync()
+    {
+        _resourceSuffix = Guid.NewGuid().ToString("N")[..12];
+        _hostPorts = GetFreeTcpPorts(3);
+        _brokers = new IContainer[3];
         _network = new NetworkBuilder()
             .WithName($"dekaf-rack-{_resourceSuffix}")
             .Build();
@@ -40,14 +51,43 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
 
     public async ValueTask DisposeAsync()
     {
-        foreach (var broker in _brokers.AsEnumerable().Reverse())
+        await DisposeClusterAttemptAsync().ConfigureAwait(false);
+    }
+
+    private async ValueTask DisposeClusterAttemptAsync()
+    {
+        var brokers = _brokers;
+        var network = _network;
+        _brokers = [];
+        _network = null;
+        _hostPorts = [];
+
+        Exception? firstError = null;
+        foreach (var broker in brokers.AsEnumerable().Reverse())
         {
-            if (broker is not null)
-                await broker.DisposeAsync().ConfigureAwait(false);
+            try
+            {
+                if (broker is not null)
+                    await broker.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                firstError ??= exception;
+            }
         }
 
-        if (_network is not null)
-            await _network.DisposeAsync().ConfigureAwait(false);
+        try
+        {
+            if (network is not null)
+                await network.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            firstError ??= exception;
+        }
+
+        if (firstError is not null)
+            throw firstError;
     }
 
     public IAdminClient CreateAdminClient()


### PR DESCRIPTION
## Summary
- wait for Testcontainers.Kafka's generated startup script copy to stabilize, then read it through `/bin/sh` so Docker cannot hit `ETXTBSY`
- retry only the proven Kafka script-busy and Docker host-port collision failures, bounded to three attempts
- dispose rejected attempts and rebuild Kafka containers or rack-aware broker/network/port resources before retrying
- add deterministic coverage for retry success, exact error scoping, bounded exhaustion, and startup-command safety

## Test plan
- [x] TDD: new tests failed before implementation because retry/command safeguards did not exist
- [x] `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj -c Release -f net10.0 --no-restore`
- [x] `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj -c Release -f net8.0 --no-restore`
- [x] startup retry tests: 5/5 on net10.0 and net8.0
- [x] startup retry tests repeated 10x: 50/50
- [x] three-version Kafka startup repeated 5x: 15/15
- [x] rack-aware three-broker test repeated 3x: 3/3
- [x] full MessagingOrdering category: 41/41 on net10.0 and net8.0
- [x] post-rebase MessagingOrdering category: 41/41 on net10.0

Closes #1677
