### PR TITLE
fix(internal): close stack publication race

### DIFF
--- a/src/Dekaf/Internal/LockFreeStack.cs
+++ b/src/Dekaf/Internal/LockFreeStack.cs
@@ -4,9 +4,9 @@ using System.Runtime.CompilerServices;
 namespace Dekaf.Internal;
 
 /// <summary>
-/// Thread-safe bounded LIFO stack using pre-allocated striped arrays with CAS-guarded indices.
+/// Thread-safe bounded LIFO stack using pre-allocated striped node arrays with stamped CAS heads.
 /// Zero allocation in steady state: TryPush/TryPop only perform Interlocked operations
-/// on stripe pointers and array slots — no linked list nodes or wrapper objects.
+/// on stripe heads and pre-allocated nodes — no linked list nodes or wrapper objects are allocated.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -18,12 +18,17 @@ namespace Dekaf.Internal;
 /// The previous ConcurrentStack/ConcurrentQueue implementations allocated a Node object
 /// (~32 bytes) per Push/Enqueue call. At high throughput these short-lived allocations
 /// promoted to Gen2 and caused a GC feedback loop. This array-based CAS stack eliminates
-/// all per-operation allocations — only the fixed-size array is allocated at construction time.
+/// all per-operation allocations — only fixed-size arrays are allocated at construction time.
 /// </para>
 /// <para>
 /// Large pools are striped by processor so hot rent/return paths do not all contend on
 /// one cache line. A pop starts at the current processor's stripe and steals from other
 /// stripes on miss; this keeps the pool bounded while spreading CAS traffic.
+/// </para>
+/// <para>
+/// Each node is either on a stripe's free list, on its available-item stack, or exclusively
+/// owned by one operation. Push writes the item before publishing the node. Version-stamped
+/// heads prevent ABA when nodes are rapidly recycled between the two lists.
 /// </para>
 /// </remarks>
 /// <typeparam name="T">The pooled item type. Must be a reference type for Interlocked.Exchange.</typeparam>
@@ -32,24 +37,55 @@ internal sealed class LockFreeStack<T> where T : class
     private const int MinCapacityForStriping = 64;
     private const int MaxStripeCount = 32;
     private const int MinSlotsPerStripe = 16;
+    private const int EmptyIndex = -1;
 
     private readonly Stripe[] _stripes;
     private readonly int _capacity;
+    private readonly Action? _beforePublish;
 
-    private sealed class Stripe(int capacity)
+    private struct Node
     {
-        public readonly T?[] Slots = new T?[capacity];
-        public int Top;
+        public T? Item;
+        public int Next;
+    }
+
+    private sealed class Stripe
+    {
+        public readonly Node[] Nodes;
+        public long AvailableHead;
+        public long FreeHead;
+        public int Count;
+
+        public Stripe(int capacity)
+        {
+            Nodes = new Node[capacity];
+            Reset();
+        }
+
+        public void Reset()
+        {
+            for (var i = 0; i < Nodes.Length; i++)
+            {
+                Nodes[i].Item = null;
+                Nodes[i].Next = i + 1 < Nodes.Length ? i + 1 : EmptyIndex;
+            }
+
+            Volatile.Write(ref AvailableHead, PackHead(0, EmptyIndex));
+            Volatile.Write(ref FreeHead, PackHead(0, 0));
+            Volatile.Write(ref Count, 0);
+        }
     }
 
     /// <summary>
     /// Creates a new stack with the specified capacity.
     /// </summary>
     /// <param name="capacity">Maximum number of items the stack can hold.</param>
-    public LockFreeStack(int capacity)
+    /// <param name="beforePublish">Optional test hook invoked after storing an item but before publishing it.</param>
+    public LockFreeStack(int capacity, Action? beforePublish = null)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
         _capacity = capacity;
+        _beforePublish = beforePublish;
 
         var stripeCount = ComputeStripeCount(capacity);
         _stripes = new Stripe[stripeCount];
@@ -78,22 +114,16 @@ internal sealed class LockFreeStack<T> where T : class
         return false;
     }
 
-    private static bool TryPush(Stripe stripe, T item)
+    private bool TryPush(Stripe stripe, T item)
     {
-        var slots = stripe.Slots;
-        while (true)
-        {
-            var top = Volatile.Read(ref stripe.Top);
-            if (top >= slots.Length)
-                return false; // Stack full
+        if (!TryTakeNode(ref stripe.FreeHead, stripe.Nodes, out var nodeIndex))
+            return false;
 
-            if (Interlocked.CompareExchange(ref stripe.Top, top + 1, top) == top)
-            {
-                Volatile.Write(ref slots[top], item);
-                return true;
-            }
-            // CAS failed — retry.
-        }
+        Volatile.Write(ref stripe.Nodes[nodeIndex].Item, item);
+        _beforePublish?.Invoke();
+        Interlocked.Increment(ref stripe.Count);
+        PublishNode(ref stripe.AvailableHead, stripe.Nodes, nodeIndex);
+        return true;
     }
 
     /// <summary>
@@ -117,35 +147,16 @@ internal sealed class LockFreeStack<T> where T : class
 
     private static bool TryPop(Stripe stripe, [NotNullWhen(true)] out T? item)
     {
-        var slots = stripe.Slots;
-        while (true)
+        if (!TryTakeNode(ref stripe.AvailableHead, stripe.Nodes, out var nodeIndex))
         {
-            var top = Volatile.Read(ref stripe.Top);
-            if (top <= 0)
-            {
-                item = null;
-                return false;
-            }
-
-            if (Interlocked.CompareExchange(ref stripe.Top, top - 1, top) == top)
-            {
-                // We own slot [top - 1]. Exchange it to null atomically to prevent
-                // another concurrent pop from seeing the same item.
-                item = Interlocked.Exchange(ref slots[top - 1], null);
-                if (item is not null)
-                    return true;
-
-                // Slot was null — a concurrent TryPush advanced this stripe's top
-                // but had not written the item yet. That late write can strand one
-                // pooled item until a later TryPush overwrites the same slot; pool
-                // misses recreate on demand.
-                //
-                // Note: if TryPush writes BEFORE our Exchange, Exchange returns the item
-                // (non-null) and we return true at line 86 — that path never reaches here.
-                return false;
-            }
-            // CAS failed — retry.
+            item = null;
+            return false;
         }
+
+        item = Interlocked.Exchange(ref stripe.Nodes[nodeIndex].Item, null);
+        Interlocked.Decrement(ref stripe.Count);
+        PublishNode(ref stripe.FreeHead, stripe.Nodes, nodeIndex);
+        return item is not null;
     }
 
     /// <summary>
@@ -157,7 +168,7 @@ internal sealed class LockFreeStack<T> where T : class
         {
             var count = 0;
             foreach (var stripe in _stripes)
-                count += Volatile.Read(ref stripe.Top);
+                count += Volatile.Read(ref stripe.Count);
             return count;
         }
     }
@@ -174,11 +185,45 @@ internal sealed class LockFreeStack<T> where T : class
     public void Clear()
     {
         foreach (var stripe in _stripes)
+            stripe.Reset();
+    }
+
+    private static bool TryTakeNode(ref long head, Node[] nodes, out int nodeIndex)
+    {
+        while (true)
         {
-            Array.Clear(stripe.Slots);
-            Volatile.Write(ref stripe.Top, 0);
+            var observedHead = Volatile.Read(ref head);
+            nodeIndex = GetIndex(observedHead);
+            if (nodeIndex == EmptyIndex)
+                return false;
+
+            var nextIndex = Volatile.Read(ref nodes[nodeIndex].Next);
+            var updatedHead = NextHead(observedHead, nextIndex);
+            if (Interlocked.CompareExchange(ref head, updatedHead, observedHead) == observedHead)
+                return true;
         }
     }
+
+    private static void PublishNode(ref long head, Node[] nodes, int nodeIndex)
+    {
+        while (true)
+        {
+            var observedHead = Volatile.Read(ref head);
+            Volatile.Write(ref nodes[nodeIndex].Next, GetIndex(observedHead));
+            var updatedHead = NextHead(observedHead, nodeIndex);
+            if (Interlocked.CompareExchange(ref head, updatedHead, observedHead) == observedHead)
+                return;
+        }
+    }
+
+    private static long PackHead(int version, int index)
+        => ((long)version << 32) | (uint)index;
+
+    private static long NextHead(long observedHead, int index)
+        => PackHead(unchecked((int)(observedHead >> 32) + 1), index);
+
+    private static int GetIndex(long head)
+        => (int)head;
 
     private static int ComputeStripeCount(int capacity)
     {

--- a/tests/Dekaf.Tests.Unit/Internal/LockFreeStackTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/LockFreeStackTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Internal;
+using System.Collections.Concurrent;
 using System.Reflection;
 
 namespace Dekaf.Tests.Unit.Internal;
@@ -50,6 +51,39 @@ public class LockFreeStackTests
     }
 
     [Test]
+    public async Task TryPop_AfterPausedPushCompletes_ReturnsPublishedItem()
+    {
+        var pushPaused = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var resumePush = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stack = new LockFreeStack<Item>(1, () =>
+        {
+            pushPaused.SetResult();
+            resumePush.Task.GetAwaiter().GetResult();
+        });
+        var item = new Item { Value = 42 };
+        var pushTask = Task.Run(() => stack.TryPush(item));
+        bool poppedWhilePushPaused;
+
+        try
+        {
+            await pushPaused.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            poppedWhilePushPaused = stack.TryPop(out _);
+        }
+        finally
+        {
+            resumePush.TrySetResult();
+        }
+
+        var pushed = await pushTask.WaitAsync(TimeSpan.FromSeconds(10));
+        var poppedAfterPushCompleted = stack.TryPop(out var result);
+
+        await Assert.That(poppedWhilePushPaused).IsFalse();
+        await Assert.That(pushed).IsTrue();
+        await Assert.That(poppedAfterPushCompleted).IsTrue();
+        await Assert.That(result).IsSameReferenceAs(item);
+    }
+
+    [Test]
     public async Task Count_ReflectsStackState()
     {
         var stack = new LockFreeStack<Item>(4);
@@ -64,6 +98,29 @@ public class LockFreeStackTests
 
         stack.TryPop(out _);
         await Assert.That(stack.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TryPush_TryPop_DoNotAllocateInSteadyState()
+    {
+        var stack = new LockFreeStack<Item>(1);
+        var item = new Item { Value = 42 };
+
+        for (var i = 0; i < 100; i++)
+        {
+            stack.TryPush(item);
+            stack.TryPop(out _);
+        }
+
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 10_000; i++)
+        {
+            stack.TryPush(item);
+            stack.TryPop(out _);
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        await Assert.That(allocated).IsEqualTo(0);
     }
 
     [Test]
@@ -164,6 +221,8 @@ public class LockFreeStackTests
         var stack = new LockFreeStack<Item>(capacity);
         var pushCount = 0;
         var popCount = 0;
+        var duplicateCount = 0;
+        var poppedValues = new ConcurrentDictionary<int, byte>();
 
         var tasks = new Task[threadCount * 2];
 
@@ -188,8 +247,12 @@ public class LockFreeStackTests
             {
                 for (var j = 0; j < operationsPerThread; j++)
                 {
-                    if (stack.TryPop(out _))
+                    if (stack.TryPop(out var item))
+                    {
                         Interlocked.Increment(ref popCount);
+                        if (!poppedValues.TryAdd(item.Value, 0))
+                            Interlocked.Increment(ref duplicateCount);
+                    }
                 }
             });
         }
@@ -197,12 +260,18 @@ public class LockFreeStackTests
         await Task.WhenAll(tasks);
 
         // Drain remaining
-        while (stack.TryPop(out _))
+        while (stack.TryPop(out var item))
+        {
             Interlocked.Increment(ref popCount);
+            if (!poppedValues.TryAdd(item.Value, 0))
+                Interlocked.Increment(ref duplicateCount);
+        }
 
-        // Pop count + remaining must equal push count
+        // Every accepted item must be returned exactly once after producers quiesce.
         await Assert.That(popCount).IsGreaterThan(0);
-        await Assert.That(popCount).IsLessThanOrEqualTo(pushCount);
+        await Assert.That(popCount).IsEqualTo(pushCount);
+        await Assert.That(poppedValues.Count).IsEqualTo(pushCount);
+        await Assert.That(duplicateCount).IsEqualTo(0);
         await Assert.That(stack.Count).IsEqualTo(0);
     }
 


### PR DESCRIPTION
## Summary
- publish only fully initialized stack nodes through stamped CAS heads
- recycle a fixed per-stripe node set, preserving bounds and zero steady-state allocations
- cover paused publication deterministically and require exact concurrent push/pop accounting

## Testing
- `dotnet build src/Dekaf/Dekaf.csproj -c Release -f netstandard2.0 --no-restore`
- `dotnet build src/Dekaf/Dekaf.csproj -c Release -f net10.0 --no-restore`
- focused `LockFreeStackTests` and `BatchArrayReuseQueueTests` (19 passed)
- full `Dekaf.Tests.Unit` suite with 4-way parallelism (4,521 passed)

Closes #1679